### PR TITLE
remove __pycache__ directories when cleaning python test cases

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -320,6 +320,7 @@ runme3.py: runme.py
 # -----------------------------------------------------------------
 
 python_clean:
+	rm -rf __pycache__
 	rm -f *_wrap* *~ .~* mypython@EXEEXT@ *.pyc
 	rm -f core @EXTRA_CLEAN@
 	rm -f *.@OBJEXT@ *@SO@ *@PYTHON_SO@
@@ -372,6 +373,7 @@ octave_run: $(OCTSCRIPT)
 # -----------------------------------------------------------------
 
 octave_clean:
+	rm -rf __pycache__
 	rm -f *_wrap* *~ .~* myoctave@EXEEXT@ *.pyc
 	rm -f core @EXTRA_CLEAN@
 	rm -f *.@OBJEXT@ *@SO@ *@OCTAVE_SO@


### PR DESCRIPTION
The python3 generates`__pycache__` directories to store *.pyc file within. They should be removed during clean.
##### Before patch:

```
ptomulik@node00$ make -k -j16 PY3=y check-python-examples; (cd Examples/test-suite/python/ && make -s -k -j16 PY3=y check);
[...]
ptomulik@node00$ make clean;
ptomulik@node00$ find . -name '*.pyc'
./Examples/test-suite/python/__pycache__/enum_forward.cpython-32.pyc
./Examples/test-suite/python/__pycache__/array_member.cpython-32.pyc
./Examples/test-suite/python/__pycache__/li_std_pair_using.cpython-32.pyc
./Examples/test-suite/python/__pycache__/nested_workaround.cpython-32.pyc
./Examples/test-suite/python/__pycache__/abstract_typedef2.cpython-32.pyc
./Examples/test-suite/python/__pycache__/using_extend.cpython-32.pyc
./Examples/test-suite/python/__pycache__/li_cwstring.cpython-32.pyc
./Examples/test-suite/python/__pycache__/kwargs_feature.cpython-32.pyc
./Examples/test-suite/python/__pycache__/preproc.cpython-32.pyc
./Examples/test-suite/python/__pycache__/class_scope_weird.cpython-32.pyc
./Examples/test-suite/python/__pycache__/import_nomodule.cpython-32.pyc
[...]
```
##### After patch:

```
ptomulik@node00$ make -k -j16 PY3=y check-python-examples; (cd Examples/test-suite/python/ && make -s -k -j16 PY3=y check);
[...]
ptomulik@node00$ make clean;
ptomulik@node00$ find . -name '*.pyc'
```
