### PR TITLE
updated info on lang-specific subdirs in Doc/Manual/Library.html

### DIFF
--- a/Doc/Manual/Library.html
+++ b/Doc/Manual/Library.html
@@ -66,18 +66,19 @@ Library files are included using the <tt>%include</tt> directive.
 When searching for files, directories are searched in the following order:
 </p>
 
-<ul>
+<ol>
 <li>The current directory
 <li>Directories specified with the <tt>-I</tt> command line option
 <li>.<tt>/swig_lib</tt>
 <li>SWIG library install location as reported by <tt>swig -swiglib</tt>, for example <tt>/usr/local/share/swig/1.3.30</tt>
 <li>On Windows, a directory <tt>Lib</tt> relative to the location of <tt>swig.exe</tt> is also searched.
-</ul>
+</ol>
 
 <p>
-Within each directory, SWIG first looks for a subdirectory corresponding to a target language (e.g., <tt>python</tt>,
-<tt>tcl</tt>, etc.).   If found, SWIG will search the language specific directory first.  This allows
-for language-specific implementations of library files.
+Within directories mentioned in points 3-5, SWIG first looks for a subdirectory
+corresponding to a target language (e.g., <tt>python</tt>, <tt>tcl</tt>, etc.).
+If found, SWIG will search the language specific directory first. This allows
+for language-specific implementations of library files. 
 </p>
 
 <p>


### PR DESCRIPTION
Hi,

the documentation chapter 8.1

http://swig.org/Doc2.0/SWIGDocumentation.html#Library_nn2 

states that for each search directory, also language-specific subdirectory is searched for interface files. This is not true. In fact, this applies only to "library" paths (system-wide and local ./swig_lib") and does not apply to local directory and directories defined with -I option. This could be potentially fixed by modifying "Source/Module/main.cxx", but it could introduce more troubles that advantages (think about those, who do not want lang-specific subdirs for -I and local dirs), so I propose this small change to the documentation.
