### PR TITLE
fix missing package before &body in the Common Lisp backend

### DIFF
--- a/Lib/cffi/cffi.swg
+++ b/Lib/cffi/cffi.swg
@@ -152,7 +152,7 @@
 %insert("swiglisp") %{
 ;;;SWIG wrapper code starts here
 
-(cl:defmacro defanonenum (&body enums)
+(cl:defmacro defanonenum (cl:&body enums)
    "Converts anonymous enums to defconstants."
   `(cl:progn ,@(cl:loop for value in enums
                         for index = 0 then (cl:1+ index)


### PR DESCRIPTION
See issue https://github.com/swig/swig/issues/21 .
