### PR TITLE
Use "(void)" instead of "()" when wrapping no-argument extension functions.

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,10 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 2.0.10 (in progress)
 ============================
 
+2013-02-17: kwwette
+            When generating functions which wrap C extension code, use "(void)" for no-argument functions
+            instead of "()". This prevents warnings when compiling with "gcc -Wstrict-prototypes".
+
 2013-02-09: wsfulton
             [CFFI] Apply patch #22 - Fix missing package before &body
 

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -807,7 +807,7 @@ void Swig_replace_special_variables(Node *n, Node *parentnode, String *code) {
  * ----------------------------------------------------------------------------- */
 static String *extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus, const String *self) {
   String *parms_str = cplusplus ? ParmList_str_defaultargs(parms) : ParmList_str(parms);
-  String *sig = NewStringf("%s(%s)", function_name, parms_str);
+  String *sig = NewStringf("%s(%s)", function_name, (cplusplus || Len(parms_str)) ? parms_str : "void");
   String *rt_sig = SwigType_str(return_type, sig);
   String *body = NewStringf("SWIGINTERN %s", rt_sig);
   Printv(body, code, "\n", NIL);


### PR DESCRIPTION
This small patch modifies SWIG so that, when generating functions which wrap extension code, it uses "(void)" for no-argument functions instead of "()". This prevents warnings when compiling with "gcc -Wstrict-prototypes".
