### PR TITLE
Minor fix to Octave autodoc generation for functions returning structs

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,9 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 2.0.10 (in progress)
 ============================
 
+2013-02-17: kwwette
+            [Octave] Minor fix to autodoc generation: get the right type for functions returning structs.
+
 2013-02-09: wsfulton
             [CFFI] Apply patch #22 - Fix missing package before &body
 

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -355,14 +355,10 @@ public:
 
       SwigType *type = Getattr(n, "type");
       if (type && Strcmp(type, "void")) {
-	type = SwigType_base(type);
-	Node *lookup = Swig_symbol_clookup(type, 0);
-	if (lookup)
-	  type = Getattr(lookup, "sym:name");
+	Node *nn = classLookup(Getattr(n, "type"));
+	String *type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
 	Append(decl_info, "@var{retval} = ");
-	String *type_str = NewString("");
-	Printf(type_str, "@var{retval} is of type %s. ", type);
-	Append(args_str, type_str);
+	Printf(args_str, "%s@var{retval} is of type %s. ", args_str, type_str);
 	Delete(type_str);
       }
 


### PR DESCRIPTION
This patch is a minor fix to Octave autodoc generation for functions returning structs. It fixes SF bug #1226: http://sourceforge.net/p/swig/bugs/1226/
