### PR TITLE
Fixed #1300 clang warning in SWIG_Python_ConvertPtrAndOwn.

### DIFF
--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -168,7 +168,7 @@ SWIGINTERNINLINE int SWIG_CheckState(int r) {
   return SWIG_IsOK(r) ? SWIG_CastRank(r) + 1 : 0; 
 }
 #else /* no cast-rank mode */
-#  define SWIG_AddCast(r) ((r)+0)
+#  define SWIG_AddCast(r) (r)
 #  define SWIG_CheckState(r) (SWIG_IsOK(r) ? 1 : 0)
 #endif
 


### PR DESCRIPTION
Hi,

See #1300 on sourceforge.

Cheers!
