### PR TITLE
Octave: fix bugs in output of cleanup code

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,12 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 2.0.10 (in progress)
 ============================
 
+2013-04-15: kwwette
+            [octave] Fix bugs in output of cleanup code.
+            - Cleanup code is now written also after the "fail:" label, so it will be called if
+              a SWIG_exception is raised by the wrapping function, consistent with other modules.
+            - Octave module now also recognises the "$cleanup" special variable, if needed.
+
 2013-04-08: kwwette
             Add -MP option to SWIG for generating phony targets for all dependencies.
             - Prevents make from complaining if header files have been deleted before

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -744,9 +744,14 @@ public:
       Delete(tm);
     }
 
-    Printf(f->code, "fail:\n");	// we should free locals etc if this happens
     Printf(f->code, "return _out;\n");
+    Printf(f->code, "fail:\n");	// we should free locals etc if this happens
+    Printv(f->code, cleanup, NIL);
+    Printf(f->code, "return octave_value_list();\n");
     Printf(f->code, "}\n");
+
+    /* Substitute the cleanup code */
+    Replaceall(f->code, "$cleanup", cleanup);
 
     Replaceall(f->code, "$symname", iname);
     Wrapper_print(f, f_wrappers);


### PR DESCRIPTION
This minor patch fixes some Octave bugs related to the output of cleanup code, e.g. freearg typemaps. Consistent with other language modules, the cleanup code is now also included after the "fail:" goto label, so it is invoked if the wrapping function raises a SWIG_exception. The patch also adds support for the "$cleanup" special variable.

Passes Octave test suite for versions 3.0.5, 3.2.4, 3.4.3, 3.6.3.
