### PR TITLE
Support $descriptor() macro in fragments

### DIFF
--- a/Examples/test-suite/python/special_variable_macros_runme.py
+++ b/Examples/test-suite/python/special_variable_macros_runme.py
@@ -9,6 +9,8 @@ if special_variable_macros.testJill(name) != "jilly":
   raise "test failed"
 if special_variable_macros.testMary(name) != "SWIGTYPE_p_NameWrap":
   raise "test failed"
+if special_variable_macros.testJames(name) != "SWIGTYPE_Name":
+  raise "test failed"
 if special_variable_macros.testJim(name) != "multiname num":
   raise "test failed"
 if special_variable_macros.testJohn(special_variable_macros.PairIntBool(10, False)) != 123:

--- a/Examples/test-suite/special_variable_macros.i
+++ b/Examples/test-suite/special_variable_macros.i
@@ -62,6 +62,14 @@ private:
   /*%typemap(in) NameWrap *NAMEWRAP end */
 %}
 
+// check $descriptor gets expanded properly when used in a fragment
+%fragment("nameDescriptor", "header")
+%{
+/*%fragment("getNameDescriptor", "header") start */
+static const char *nameDescriptor = "$descriptor(Name)";
+/*%fragment("getNameDescriptor", "header") end */
+%}
+
 
 //////////////////////////////////////////////////////////////////////////////////////
 
@@ -86,6 +94,14 @@ $typemap(in, NameWrap *NAMEWRAP)
 // %typemap(in) Name *mary end
 }
 
+%typemap(in, fragment="nameDescriptor") Name *james (Name temp) {
+  // %typemap(in) Name *james start
+  temp = Name(nameDescriptor);
+  (void)$input;
+  $1 = &temp;
+  // %typemap(in) Name *james end
+}
+
 %inline %{
 const char * testFred(Name *fred) {
   return fred->getName();
@@ -98,6 +114,9 @@ const char * testJill(Name *jill) {
 }
 const char * testMary(Name *mary) {
   return mary->getName();
+}
+const char * testJames(Name *james) {
+  return james->getName();
 }
 %}
 

--- a/Source/Swig/fragment.c
+++ b/Source/Swig/fragment.c
@@ -60,6 +60,8 @@ void Swig_fragment_register(Node *fragment) {
       }
       Setfile(ccode, Getfile(fragment));
       Setline(ccode, Getline(fragment));
+      /* Replace $descriptor() macros */
+      Swig_cparse_replace_descriptor(ccode);
       Setattr(fragments, name, ccode);
       if (debug)
 	Printf(stdout, "registering fragment %s %s\n", name, section);


### PR DESCRIPTION
Per our earlier discussion, adds $descriptor() macro expansion inside fragments, and also added a python test case for it. The test successfully passes.

Cheers,
