### PR TITLE
Fix link additional text in doxygen

### DIFF
--- a/Source/DoxygenTranslator/src/JavaDocConverter.cpp
+++ b/Source/DoxygenTranslator/src/JavaDocConverter.cpp
@@ -646,6 +646,7 @@ string JavaDocConverter::convertLink(string linkObject)
   string paramsStr = linkObject.substr(lbracePos + 1,
       rbracePos - lbracePos - 1);
   // strip the params, to fill them later
+  string additionalObject = linkObject.substr(rbracePos + 1, string::npos);
   linkObject = linkObject.substr(0, lbracePos);
 
   // find all the params
@@ -720,7 +721,7 @@ string JavaDocConverter::convertLink(string linkObject)
   }
   linkObject += ")";
 
-  return linkObject;
+  return linkObject + additionalObject;
 }
 
 void JavaDocConverter::handleTagLink(DoxygenEntity& tag,


### PR DESCRIPTION
\link Abcd#setEfg() this is a link\endlink works, it provides a linkon the text "this is a link"
But if we add an an object as argument
\link Abcd#setEfg(bool) this is a link\endlink it fails. it just provides a link on  the function.
This patch gets the text after the closing bracket and appends it at the end of  JavaDocConverter::convertLink function
