### PR TITLE
clean all .py files generated by python-test-suite

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -58,7 +58,7 @@ CPP_TEST_CASES += \
 	li_std_wstream \
 	li_std_wstring \
 	primitive_types \
-        python_abstractbase \
+  python_abstractbase \
 	python_append \
 	python_director \
 	python_nondynamic \
@@ -165,6 +165,9 @@ endif
 clean:
 	$(MAKE) -f $(top_builddir)/$(EXAMPLES)/Makefile python_clean
 	rm -f hugemod.h hugemod_a.i hugemod_b.i hugemod_a.py hugemod_b.py hugemod_runme.py
+	rm -f clientdata_prop_a.py clientdata_prop_b.py import_stl_a.py import_stl_b.py
+	rm -f imports_a.py imports_b.py mod_a.py mod_b.py multi_import_a.py 
+	rm -f multi_import_b.py packageoption_a.py packageoption_b.py packageoption_c.py
 
 cvsignore:
 	@echo '*wrap* *.pyc *.so *.dll *.exp *.lib'


### PR DESCRIPTION
After `make && make check-python-test-suite && make clean` some generated files are left in `Examples/test-suite/python`:

```
ptomulik@barakus:$ git status
# On branch tests_clean
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#       Examples/test-suite/python/clientdata_prop_a.py
#       Examples/test-suite/python/clientdata_prop_b.py
#       Examples/test-suite/python/import_stl_a.py
#       Examples/test-suite/python/import_stl_b.py
#       Examples/test-suite/python/imports_a.py
#       Examples/test-suite/python/imports_b.py
#       Examples/test-suite/python/mod_a.py
#       Examples/test-suite/python/mod_b.py
#       Examples/test-suite/python/multi_import_a.py
#       Examples/test-suite/python/multi_import_b.py
#       Examples/test-suite/python/packageoption_a.py
#       Examples/test-suite/python/packageoption_b.py
#       Examples/test-suite/python/packageoption_c.py
nothing added to commit but untracked files present (use "git add" to track)
```

This patch adds these files to clean target.
