### PR TITLE
Fixed %unrefobject for inherited classes

### DIFF
--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -2758,7 +2758,7 @@ int Language::destructorDeclaration(Node *n) {
 
   if (!CurrentClass)
     return SWIG_NOWRAP;
-  if (cplus_mode != PUBLIC && !Getattr(CurrentClass, "feature:unref"))
+  if (cplus_mode != PUBLIC && !Swig_unref_call(CurrentClass))
     return SWIG_NOWRAP;
   if (ImportMode)
     return SWIG_NOWRAP;


### PR DESCRIPTION
Fixes the "unref" feature when used on derived classes with non-public
destructors.
I'm not sure if this is the correct method to be used, but this causes
the swig wrapper to check for a parent that supports the unref feature.