### PR TITLE
Fix integer overflow warning in python.cxx

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3401,7 +3401,7 @@ public:
     printSlot(f, getSlot(n, "feature:python:tp_dict"), "tp_dict");
     printSlot(f, getSlot(n, "feature:python:tp_descr_get"), "tp_descr_get", "descrgetfunc");
     printSlot(f, getSlot(n, "feature:python:tp_descr_set"), "tp_descr_set", "descrsetfunc");
-    Printf(f, "    (size_t)(((char*)&((SwigPyObject *) 64L)->dict) - (char*) 64L), /* tp_dictoffset */\n");
+    Printf(f, "    static_cast<Py_ssize_t>((size_t)(((char*)&((SwigPyObject *) 64L)->dict) - (char*) 64L)), /* tp_dictoffset */\n");
     printSlot(f, tp_init, "tp_init", "initproc");
     printSlot(f, getSlot(n, "feature:python:tp_alloc"), "tp_alloc", "allocfunc");
     printSlot(f, "0", "tp_new", "newfunc");


### PR DESCRIPTION
When compiling SWIG generated cxx file in c++11 mode ('-std=c++11') with '-Wc++11-narrowing' flag one will get an error (see the example below) since the 'tp_dictoffset' is basically 'unsigned long' to 'long', which could lead to integer overflow. Using 'static_cast<Py_ssize_t>(...)' can prevent this.

error example (with clang -std=c++11):
non-constant-expression cannot be narrowed from type 'size_t'
      (aka 'unsigned long') to 'Py_ssize_t' (aka 'long') in initializer list
      [-Wc++11-narrowing](size_t)(((char_)&((SwigPyObject *) 64L)->dict) - (char_) 64L), /*...
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
