### PR TITLE
[Lua] Add error-locus information to SWIG error messages

### DIFF
--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -185,19 +185,20 @@ typedef struct {
 
 /* Contract support */
 #define SWIG_contract_assert(expr, msg)  \
-  if (!(expr)) { lua_pushstring(L, (char *) msg); goto fail; } else
+  if (!(expr)) { SWIG_Lua_pusherrstring(L, (char *) msg); goto fail; } else
+
 
 /* helper #defines */
 #define SWIG_fail {goto fail;}
 #define SWIG_fail_arg(func_name,argnum,type) \
-  {lua_pushfstring(L,"Error in %s (arg %d), expected '%s' got '%s'",\
+  {SWIG_Lua_pushferrstring(L,"Error in %s (arg %d), expected '%s' got '%s'",\
   func_name,argnum,type,SWIG_Lua_typename(L,argnum));\
   goto fail;}
 #define SWIG_fail_ptr(func_name,argnum,type) \
   SWIG_fail_arg(func_name,argnum,(type && type->str)?type->str:"void*")
 #define SWIG_check_num_args(func_name,a,b) \
   if (lua_gettop(L)<a || lua_gettop(L)>b) \
-  {lua_pushfstring(L,"Error in %s expected %d..%d args, got %d",func_name,a,b,lua_gettop(L));\
+  {SWIG_Lua_pushferrstring(L,"Error in %s expected %d..%d args, got %d",func_name,a,b,lua_gettop(L));\
   goto fail;}
 
 
@@ -250,8 +251,7 @@ SWIGINTERN int SWIG_Lua_set_immutable(lua_State* L)
 /*  there should be 1 param passed in: the new value */
 #ifndef SWIGLUA_IGNORE_SET_IMMUTABLE
   lua_pop(L,1);  /* remove it */
-  lua_pushstring(L,"This variable is immutable");
-  lua_error(L);
+  luaL_error(L,"This variable is immutable");
 #endif
     return 0;   /* should not return anything */
 }
@@ -786,9 +786,8 @@ SWIGRUNTIME void* SWIG_Lua_MustGetPtr(lua_State* L,int index,swig_type_info *typ
        int argnum,const char* func_name){
   void* result;
   if (!SWIG_IsOK(SWIG_ConvertPtr(L,index,&result,type,flags))){
-    lua_pushfstring(L,"Error in %s, expected a %s at argument number %d\n",
-      func_name,(type && type->str)?type->str:"void*",argnum);
-    lua_error(L);
+    luaL_error (L,"Error in %s, expected a %s at argument number %d\n",
+		func_name,(type && type->str)?type->str:"void*",argnum);
   }
   return result;
 }

--- a/Lib/lua/typemaps.i
+++ b/Lib/lua/typemaps.i
@@ -250,12 +250,12 @@ SWIGINTERN int SWIG_table_size(lua_State* L, int index)
 	SWIGINTERN TYPE* SWIG_get_##NAME##_num_array_fixed(lua_State* L, int index, int size){\
 		TYPE *array;\
 		if (!lua_istable(L,index) || SWIG_itable_size(L,index) != size) {\
-			lua_pushfstring(L,"expected a table of size %d",size);\
+			SWIG_Lua_pushferrstring(L,"expected a table of size %d",size);\
 			return 0;\
 		}\
 		array=SWIG_ALLOC_ARRAY(TYPE,size);\
 		if (!SWIG_read_##NAME##_num_array(L,index,array,size)){\
-			lua_pushstring(L,"table must contain numbers");\
+			SWIG_Lua_pusherrstring(L,"table must contain numbers");\
 			SWIG_FREE_ARRAY(array);\
 			return 0;\
 		}\
@@ -265,17 +265,17 @@ SWIGINTERN int SWIG_table_size(lua_State* L, int index)
 	{\
 		TYPE *array;\
 		if (!lua_istable(L,index)) {\
-			lua_pushstring(L,"expected a table");\
+			SWIG_Lua_pusherrstring(L,"expected a table");\
 			return 0;\
 		}\
 		*size=SWIG_itable_size(L,index);\
 		if (*size<1){\
-			lua_pushstring(L,"table appears to be empty");\
+			SWIG_Lua_pusherrstring(L,"table appears to be empty");\
 			return 0;\
 		}\
 		array=SWIG_ALLOC_ARRAY(TYPE,*size);\
 		if (!SWIG_read_##NAME##_num_array(L,index,array,*size)){\
-			lua_pushstring(L,"table must contain numbers");\
+			SWIG_Lua_pusherrstring(L,"table must contain numbers");\
 			SWIG_FREE_ARRAY(array);\
 			return 0;\
 		}\
@@ -451,12 +451,12 @@ SWIGINTERN int SWIG_read_ptr_array(lua_State* L,int index,void **array,int size,
 SWIGINTERN void** SWIG_get_ptr_array_fixed(lua_State* L, int index, int size,swig_type_info *type){
 	void **array;
 	if (!lua_istable(L,index) || SWIG_itable_size(L,index) != size) {
-		lua_pushfstring(L,"expected a table of size %d",size);
+		SWIG_Lua_pushferrstring(L,"expected a table of size %d",size);
 		return 0;
 	}
 	array=SWIG_ALLOC_ARRAY(void*,size);
 	if (!SWIG_read_ptr_array(L,index,array,size,type)){
-		lua_pushfstring(L,"table must contain pointers of type %s",type->name);
+		SWIG_Lua_pushferrstring(L,"table must contain pointers of type %s",type->name);
 		SWIG_FREE_ARRAY(array);
 		return 0;
 	}
@@ -465,17 +465,17 @@ SWIGINTERN void** SWIG_get_ptr_array_fixed(lua_State* L, int index, int size,swi
 SWIGINTERN void** SWIG_get_ptr_array_var(lua_State* L, int index, int* size,swig_type_info *type){
 	void **array;
 	if (!lua_istable(L,index)) {
-		lua_pushstring(L,"expected a table");
+		SWIG_Lua_pusherrstring(L,"expected a table");
 		return 0;
 	}
 	*size=SWIG_itable_size(L,index);
 	if (*size<1){
-		lua_pushstring(L,"table appears to be empty");
+		SWIG_Lua_pusherrstring(L,"table appears to be empty");
 		return 0;
 	}
 	array=SWIG_ALLOC_ARRAY(void*,*size);
 	if (!SWIG_read_ptr_array(L,index,array,*size,type)){
-		lua_pushfstring(L,"table must contain pointers of type %s",type->name);
+		SWIG_Lua_pushferrstring(L,"table must contain pointers of type %s",type->name);
 		SWIG_FREE_ARRAY(array);
 		return 0;
 	}

--- a/Lib/lua/wchar.i
+++ b/Lib/lua/wchar.i
@@ -31,7 +31,7 @@ wchar_t* str2wstr(const char *str, int len)
 %typemap(in, checkfn="SWIG_lua_isnilstring", fragment="SWIG_lua_isnilstring") wchar_t *
 %{
 $1 = str2wstr(lua_tostring( L, $input ),lua_rawlen( L, $input ));
-if ($1==0) {lua_pushfstring(L,"Error in converting to wchar (arg %d)",$input);goto fail;}
+if ($1==0) {SWIG_Lua_pushferrstring(L,"Error in converting to wchar (arg %d)",$input);goto fail;}
 %}
 
 %typemap(freearg) wchar_t *

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -811,7 +811,7 @@ public:
       Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
       Delete(fulldecl);
     } while ((sibl = Getattr(sibl, "sym:nextSibling")));
-    Printf(f->code, "lua_pushstring(L,\"Wrong arguments for overloaded function '%s'\\n\"\n"
+    Printf(f->code, "SWIG_Lua_pusherrstring(L,\"Wrong arguments for overloaded function '%s'\\n\"\n"
         "\"  Possible C/C++ prototypes are:\\n\"%s);\n",symname,protoTypes);
     Delete(protoTypes);
 


### PR DESCRIPTION
Standard Lua error messages include the source location of the innermost Lua call that resulted in the error, which makes debugging much easier.

This change adds the same information to errors raised from SWIG, using the standard Lua "luaL_where" function to identify and format the location.

One notable exception is errors resulting from exceptions, where the string seems to be content rather than informative.
