### PR TITLE
Add support for case conversion characters in regex substitutions.

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,10 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 2.0.11 (in progress)
 ============================
 
+2013-08-30: vadz
+            Allow using \l, \L, \u, \U and \E in the substitution part of %(regex:/pattern/subst/)
+            inside %rename to change the case of the text being replaced.
+
 2013-08-30: wsfulton
             [Lua] Pull Git patch #81: Include Lua error locus in SWIG error messages.  
             This is standard information in Lua error messages, and makes it much

--- a/Doc/Manual/SWIG.html
+++ b/Doc/Manual/SWIG.html
@@ -1888,11 +1888,22 @@ and a more descriptive one, but the two functions are otherwise equivalent:
     <i>pattern</i> part is a regular expression in Perl syntax (as supported
     by the <a href="http://www.pcre.org/">Perl Compatible Regular Expressions (PCRE)</a>)
     library and the <i>subst</i> string
-    can contain back-references introduced by <tt>'\'</tt> or, as backslashes need
-    to be escaped in C strings, rather by <tt>"\\"</tt>. For example, to remove
-    any alphabetic prefix before an underscore you could use the following directive:
-    <tt>%rename("regex:/(\\w+)_(.*)/\\2/")</tt></td>
-    <td><tt>Prefix_Print</tt></td><td><tt>Print</tt></td>
+    can contain back-references of the form <tt>\N</tt> where <tt>N</tt> is a digit
+    from 0 to 9, or one of the following escape sequences: <tt>\l</tt>, <tt>\L</tt>,
+    <tt>\u</tt>, <tt>\U</tt> or <tt>\E</tt>. The back-references are replaced with the
+    contents of the corresponding capture group while the escape sequences perform the
+    case conversion in the substitution string: <tt>\l</tt> and <tt>\L</tt> convert to
+    the lower case, while <tt>\u</tt> and <tt>\U</tt> convert to the upper case. The
+    difference between the elements of each pair is that <tt>\l</tt> and <tt>\u</tt>
+    change the case of the next character only, while <tt>\L</tt> and <tt>\U</tt> do
+    it for all the remaining characters or until <tt>\E</tt> is encountered.
+
+    Finally please notice that backslashes need to be escaped in C strings, so in
+    practice <tt>"\\"</tt> must be used in all these escape sequences. For example,
+    to remove any alphabetic prefix before an underscore and capitalize the remaining
+    part you could use the following directive:
+    <tt>%rename("regex:/(\\w+)_(.*)/\\u\\2/")</tt></td>
+    <td><tt>prefix_print</tt></td><td><tt>Print</tt></td>
 </tr>
 <tr>
     <td><tt>command:cmd</tt></td>

--- a/Examples/test-suite/csharp/rename_pcre_encoder_runme.cs
+++ b/Examples/test-suite/csharp/rename_pcre_encoder_runme.cs
@@ -4,9 +4,12 @@ using rename_pcre_encoderNamespace;
 public class runme {
   static void Main() {
     SomeWidget w = new SomeWidget();
-    w.putBorderWidth(17);
-    if ( w.getBorderWidth() != 17 )
+    w.put_borderWidth(17);
+    if ( w.get_borderWidth() != 17 )
       throw new Exception(String.Format("Border with should be 17, not {0}",
-                                        w.getBorderWidth()));
+                                        w.get_borderWidth()));
+
+    if ( rename_pcre_encoder.StartINSAneAndUNSAvoryTraNSAtlanticRaNSAck() != 42 )
+      throw new Exception("Unexpected result of renamed function call");
   }
 }

--- a/Examples/test-suite/java/rename_pcre_encoder_runme.java
+++ b/Examples/test-suite/java/rename_pcre_encoder_runme.java
@@ -6,9 +6,11 @@ public class rename_pcre_encoder_runme {
   public static void main(String argv[])
   {
     SomeWidget w = new SomeWidget();
-    w.putBorderWidth(17);
-    if ( w.getBorderWidth() != 17 )
+    w.put_borderWidth(17);
+    if ( w.get_borderWidth() != 17 )
       throw new RuntimeException(String.format("Border with should be 17, not %d",
-                                               w.getBorderWidth()));
+                                               w.get_borderWidth()));
+    if ( rename_pcre_encoder.StartINSAneAndUNSAvoryTraNSAtlanticRaNSAck() != 42 )
+      throw new RuntimeException("Unexpected result of renamed function call");
   }
 }

--- a/Examples/test-suite/python/rename_pcre_encoder_runme.py
+++ b/Examples/test-suite/python/rename_pcre_encoder_runme.py
@@ -1,13 +1,16 @@
 from rename_pcre_encoder import *
 
 s = SomeWidget()
-s.putBorderWidth(3)
-if s.getBorderWidth() != 3:
-    raise RuntimeError("Border should be 3, not %d" % (s.getBorderWidth(),))
+s.put_borderWidth(3)
+if s.get_borderWidth() != 3:
+    raise RuntimeError("Border should be 3, not %d" % (s.get_borderWidth(),))
 
-s.putSize(4, 5)
+s.put_size(4, 5)
 a = AnotherWidget()
 a.DoSomething()
 
 evt = wxEVTSomeEvent()
 t   = xUnchangedName()
+
+if StartINSAneAndUNSAvoryTraNSAtlanticRaNSAck() != 42:
+    raise RuntimeError("Unexpected result of renamed function call")

--- a/Examples/test-suite/rename_pcre_encoder.i
+++ b/Examples/test-suite/rename_pcre_encoder.i
@@ -3,9 +3,14 @@
 // strip the wx prefix from all identifiers except those starting with wxEVT
 %rename("%(regex:/wx(?!EVT)(.*)/\\1/)s") "";
 
-// Replace "Set" and "Get" prefixes with "put" and "get" respectively.
-%rename("%(regex:/^Set(.*)/put\\1/)s", %$isfunction) "";
-%rename("%(regex:/^Get(.*)/get\\1/)s", %$isfunction) "";
+// Change "{Set,Get}Foo" naming convention to "{put,get}_foo" one.
+%rename("%(regex:/^Set(.*)/put_\\l\\1/)s", %$isfunction) "";
+%rename("%(regex:/^Get(.*)/get_\\l\\1/)s", %$isfunction) "";
+
+// Make some words stand out (unfortunately we don't have "global" flag): we
+// use \U to capitalize the second capture group and then \E to preserve the
+// case of the rest.
+%rename("%(regex:/(.*?)(nsa)(.*?)\\2(.*?)\\2(.*?)\\2(.*)/\\1\\U\\2\\E\\3\\U\\2\\E\\4\\U\\2\\E\\5\\U\\2\\E\\6/)s") "";
 
 %inline %{
 
@@ -27,5 +32,7 @@ class wxEVTSomeEvent {
 
 class xUnchangedName {
 };
+
+inline int StartInsaneAndUnsavoryTransatlanticRansack() { return 42; }
 
 %}


### PR DESCRIPTION
Allow using Perl-like \l, \L, \u, \U and \E escape sequences in the
substitution string used with %rename("%(regex:/pattern/subst/)s").
This is useful for e.g. title casing all string after removing some prefix.
