### PR TITLE
Lua: Fix void return for non-void functions

### DIFF
--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -524,7 +524,7 @@ SWIGINTERN int SWIG_Lua_add_namespace_details(lua_State* L, swig_lua_namespace* 
 
   /* clear stack - remove metatble */
   lua_pop(L,1);
-
+  return 0;
 }
 
 /* helper function. creates namespace table and add it to module table */
@@ -555,6 +555,7 @@ SWIGINTERN int SWIG_Lua_namespace_register(lua_State* L, swig_lua_namespace* ns)
 
   lua_setmetatable(L,-2); /* set metatable */
   lua_rawset(L,-3); /* add namespace to module table */
+  return 0;
 }
 /* -----------------------------------------------------------------------------
  * global variable support code: classes


### PR DESCRIPTION
Fixes issue #93

Commit #c3f3880d caused the functions
SWIGINTERN int SWIG_Lua_add_namespace_details(lua_State\* L,
swig_lua_namespace\* ns)
and
SWIGINTERN int SWIG_Lua_namespace_register(lua_State\* L,
swig_lua_namespace\* ns)
to return void when int returns were expected resulting in the build
failures for plplot's lua bindings for example. This commit fixes the
issue.
