### PR TITLE
BUGFIX: superclass name not lispy

### DIFF
--- a/Source/Modules/cffi.cxx
+++ b/Source/Modules/cffi.cxx
@@ -687,7 +687,7 @@ void CFFI::emit_class(Node *n) {
       if (!first)
   Printf(supers, " ");
       String *s = Getattr(i.item, "name");
-      Printf(supers, "%s", lispify_name(i.item, s, "'classname"));
+      Printf(supers, "%s", lispify_name(i.item, lispy_name(Char(s)), "'classname"));
     }
   } else {
     // Printf(supers,"ff:foreign-pointer");


### PR DESCRIPTION
The superclass names were not lispified correctly and so the class was inheriting
from erroneous class symbols.
