### PR TITLE
Fix Examples/php/pointer to work with PHP 5.5

### DIFF
--- a/Examples/php/pointer/runme.php
+++ b/Examples/php/pointer/runme.php
@@ -15,7 +15,7 @@
 	print "	c = $c\n";
 
 	# Call the add() function wuth some pointers
-	add(&$a,&$b,&$c);
+	add($a,$b,$c);
 
 	print "	$a + $b = $c\n";
 

--- a/Lib/php/phppointers.i
+++ b/Lib/php/phppointers.i
@@ -1,5 +1,5 @@
 %define %pass_by_ref( TYPE, CONVERT_IN, CONVERT_OUT )
-%typemap(in) TYPE *REF ($*1_ltype tmp),
+%typemap(in, byref=1) TYPE *REF ($*1_ltype tmp),
              TYPE &REF ($*1_ltype tmp)
 %{
   /* First Check for SWIG wrapped type */

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -90,6 +90,7 @@ static String *s_vinit;		// varinit initialization code.
 static String *s_vdecl;
 static String *s_cinit;		// consttab initialization code.
 static String *s_oinit;
+static String *s_arginfo;
 static String *s_entry;
 static String *cs_entry;
 static String *all_cs_entry;
@@ -517,6 +518,9 @@ public:
     Printf(f_h, "PHP_RSHUTDOWN_FUNCTION(%s);\n", module);
     Printf(f_h, "PHP_MINFO_FUNCTION(%s);\n\n", module);
 
+    /* start the arginfo section */
+    s_arginfo = NewString("/* arginfo subsection */\n");
+
     /* start the function entry section */
     s_entry = NewString("/* entry subsection */\n");
 
@@ -643,7 +647,7 @@ public:
       Dump(f_directors, f_begin);
     }
     Printv(f_begin, s_vdecl, s_wrappers, NIL);
-    Printv(f_begin, all_cs_entry, "\n\n", s_entry,
+    Printv(f_begin, all_cs_entry, "\n\n", s_arginfo, "\n\n", s_entry,
 	" SWIG_ZEND_NAMED_FE(swig_", module, "_alter_newobject,_wrap_swig_", module, "_alter_newobject,NULL)\n"
 	" SWIG_ZEND_NAMED_FE(swig_", module, "_get_newobject,_wrap_swig_", module, "_get_newobject,NULL)\n"
 	"{NULL, NULL, NULL}\n};\n\n", NIL);
@@ -654,6 +658,7 @@ public:
     Delete(s_vdecl);
     Delete(all_cs_entry);
     Delete(s_entry);
+    Delete(s_arginfo);
     Delete(f_runtime);
     Delete(f_begin);
 
@@ -672,12 +677,25 @@ public:
   }
 
   /* Just need to append function names to function table to register with PHP. */
-  void create_command(String *cname, String *iname) {
+  void create_command(String *cname, String *iname, Node *n) {
     // This is for the single main zend_function_entry record
     Printf(f_h, "ZEND_NAMED_FUNCTION(%s);\n", iname);
     String * s = cs_entry;
     if (!s) s = s_entry;
-    Printf(s, " SWIG_ZEND_NAMED_FE(%(lower)s,%s,NULL)\n", cname, iname);
+    Printf(s, " SWIG_ZEND_NAMED_FE(%(lower)s,%s,swig_arginfo_%(lower)s)\n", cname, iname, cname);
+
+    // This is the above referenced arginfo structure.
+    ParmList *l = Getattr(n, "parms");
+    Printf(s_arginfo, "ZEND_BEGIN_ARG_INFO_EX(swig_arginfo_%(lower)s, 0, 0, 0)\n", cname);
+    for (Parm *p = l; p; p = Getattr(p, "tmap:in:next")) {
+      /* Ignored parameters */
+      if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+	continue;
+      }
+      int byref = GetFlag(p, "tmap:in:byref");
+      Printf(s_arginfo, " ZEND_ARG_PASS_INFO(%d)\n", byref);
+    }
+    Printf(s_arginfo, "ZEND_END_ARG_INFO()\n");
   }
 
   /* ------------------------------------------------------------
@@ -700,7 +718,7 @@ public:
     String *symname = Getattr(n, "sym:name");
     String *wname = Swig_name_wrapper(symname);
 
-    create_command(symname, wname);
+    create_command(symname, wname, n);
     Printv(f->def, "ZEND_NAMED_FUNCTION(", wname, ") {\n", NIL);
 
     Wrapper_add_local(f, "argc", "int argc");
@@ -790,16 +808,16 @@ public:
     String *outarg = NewStringEmpty();
     String *cleanup = NewStringEmpty();
 
-    // Not issued for overloaded functions.
-    if (!overloaded) {
-      create_command(iname, wname);
-    }
     Printv(f->def, "ZEND_NAMED_FUNCTION(", wname, ") {\n", NIL);
 
     emit_parameter_variables(l, f);
     /* Attach standard typemaps */
 
     emit_attach_parmmaps(l, f);
+    // Not issued for overloaded functions.
+    if (!overloaded) {
+      create_command(iname, wname, n);
+    }
 
     // wrap:parms is used by overload resolution.
     Setattr(n, "wrap:parms", l);


### PR DESCRIPTION
With this, all examples work with PHP 5.5.5 for me. Also checked with
PHP 5.3.17, hopefully no ifdefs are needed for backward compatibility.
