### PR TITLE
Relax Java preproc_line_file unit test to pass in a separate build directory.

### DIFF
--- a/Examples/test-suite/java/preproc_line_file_runme.java
+++ b/Examples/test-suite/java/preproc_line_file_runme.java
@@ -11,8 +11,17 @@ public class preproc_line_file_runme {
     }
   }
 
-  public static String FILENAME_WINDOWS = "..\\..\\..\\..\\Examples\\test-suite\\preproc_line_file.i";
-  public static String FILENAME_UNIX = "../../../../Examples/test-suite/preproc_line_file.i";
+  private static void test_file(String file, String suffix) throws Throwable
+  {
+      String FILENAME_WINDOWS = "Examples\\test-suite\\preproc_line_file.i";
+      String FILENAME_UNIX = "Examples/test-suite/preproc_line_file.i";
+
+      // We don't test for exact equality here because the file names are relative to the build directory, which can be different from the source directory,
+      // under Unix. But they do need to end with the same path components.
+      if (!file.endsWith(FILENAME_UNIX + suffix) && !file.endsWith(FILENAME_WINDOWS + suffix))
+          throw new RuntimeException("file \"" + file + "\" doesn't end with " + FILENAME_UNIX + suffix);
+  }
+
   public static void main(String argv[]) throws Throwable
   {
     int myline = preproc_line_file.MYLINE;
@@ -22,13 +31,8 @@ public class preproc_line_file_runme {
     if (myline + 100 + 1 != myline_adjusted)
       throw new RuntimeException("preproc failure");
 
-    String myfile = preproc_line_file.MYFILE;
-    String myfile_adjusted = preproc_line_file.MYFILE_ADJUSTED;
-    if (!(myfile.equals(FILENAME_UNIX) || myfile.equals(FILENAME_WINDOWS)))
-      throw new RuntimeException("preproc failure");
-
-    if (!(myfile_adjusted.equals(FILENAME_UNIX + ".bak") || myfile_adjusted.equals(FILENAME_WINDOWS + ".bak")))
-      throw new RuntimeException("preproc failure");
+    test_file(preproc_line_file.MYFILE, "");
+    test_file(preproc_line_file.MYFILE_ADJUSTED, ".bak");
 
     if (!preproc_line_file.MY_STRINGNUM_A.equals("my15"))
       throw new RuntimeException("preproc failed MY_STRINGNUM_A");
@@ -57,9 +61,7 @@ public class preproc_line_file_runme {
     if (preproc_line_file.INLINE_LINE != 87)
       throw new RuntimeException("preproc failure");
 
-    String inlineFile = preproc_line_file.INLINE_FILE;
-    if (!(inlineFile.equals(FILENAME_UNIX) || inlineFile.equals(FILENAME_WINDOWS)))
-      throw new RuntimeException("preproc failure");
+    test_file(preproc_line_file.INLINE_FILE, "");
 
     if (Slash.LINE_NUM != 93)
       throw new RuntimeException("preproc failure");


### PR DESCRIPTION
Exact paths comparison doesn't work when SWIG is built in a directory
different from the source one, so check whether the path just ends with the
expected path components instead.

This allows all Java tests to pass in this build configuration.
