### PR TITLE
Make string encoding explitic

### DIFF
--- a/Examples/test-suite/ruby/char_constant_runme.rb
+++ b/Examples/test-suite/ruby/char_constant_runme.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-#
+#Encoding: ASCII-8BIT
 # Put description here
 #
 # 


### PR DESCRIPTION
Ruby 2.0 enforces explicit string encodings. The char_constant
testcase fails because the internal (SWIG_FromCharPtrAndSize, using
rb_str_new) defaults to ASCII-8BIT while the test-suite file defaults
to the current shell LOCALE setting.

This patch sets the char_constant_runme.rb encoding to ASCII-8BIT.
