### PR TITLE
Work around gcc warning about function pointers conversions.

### DIFF
--- a/Source/DOH/base.c
+++ b/Source/DOH/base.c
@@ -949,7 +949,7 @@ DOH *DohCall(DOH *func, DOH *args) {
   DOH *result;
   DOH *(*builtin) (DOH *);
 
-  builtin = (DOH *(*)(DOH *)) GetVoid(func, "builtin");
+  *(void **)(&builtin) = GetVoid(func, "builtin");
   if (!builtin)
     return 0;
   result = (*builtin) (args);

--- a/Source/DOH/fio.c
+++ b/Source/DOH/fio.c
@@ -48,7 +48,7 @@ static int Writen(DOH *out, void *buffer, int len) {
 void DohEncoding(const char *name, DOH *(*fn) (DOH *s)) {
   if (!encodings)
     encodings = NewHash();
-  Setattr(encodings, (void *) name, NewVoid((void *) fn, 0));
+  Setattr(encodings, (void *) name, NewVoid(*(void **)&fn, 0));
 }
 
 /* internal function for processing an encoding */
@@ -72,7 +72,7 @@ static DOH *encode(char *name, DOH *s) {
     s = tmp;
   pos = Tell(s);
   Seek(s, 0, SEEK_SET);
-  fn = (DOH *(*)(DOH *)) Data(handle);
+  *(void **)(&fn) = Data(handle);
   ns = (*fn) (s);
   assert(pos != -1);
   (void)Seek(s, pos, SEEK_SET);


### PR DESCRIPTION
I got finally tired of seeing

```
Source/DOH/fio.c: In function 'DohEncoding':
Source/DOH/fio.c:51: warning: ISO C forbids conversion of function pointer to object pointer type
Source/DOH/fio.c: In function 'encode':
Source/DOH/fio.c:75: warning: ISO C forbids conversion of object pointer to function pointer type
Source/DOH/base.c: In function 'DohCall':
Source/DOH/base.c:952: warning: ISO C forbids conversion of object pointer to function pointer type
```

every time I build SWIG, so I've made a patch to work around them. The code should be exactly equivalent to the old version but doesn't result in these gcc warnings (didn't test with clang though).
