### PR TITLE
octave: allow examples/test suite to be run out of source tree

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -21,6 +21,10 @@
 #      'method' describes what is being built.
 #---------------------------------------------------------------
 
+# Regenerate Makefile if Makefile.in or config.status have changed.
+Makefile: @srcdir@/Makefile.in ../config.status
+	$(SHELL) ../config.status
+
 TARGET     =
 CC         = @CC@
 CXX        = @CXX@
@@ -29,7 +33,7 @@ CXXFLAGS   = @BOOST_CPPFLAGS@ @PLATCXXFLAGS@
 prefix     = @prefix@
 exec_prefix= @exec_prefix@
 SRCS       =
-INCLUDES   =
+INCLUDES   = -I$(EXSRCDIR)
 LIBS       =
 INTERFACE  =
 INTERFACEDIR  =
@@ -53,9 +57,9 @@ RUNPIPE=
 RUNME = runme
 
 IWRAP      = $(INTERFACE:.i=_wrap.i)
-ISRCS      = $(IWRAP:.i=.c)
-ICXXSRCS   = $(IWRAP:.i=.cxx)
-IOBJS      = $(IWRAP:.i=.@OBJEXT@)
+ISRCS      = $(notdir $(IWRAP:.i=.c))
+ICXXSRCS   = $(notdir $(IWRAP:.i=.cxx))
+IOBJS      = $(notdir $(IWRAP:.i=.@OBJEXT@))
 
 ##################################################################
 # Some options for silent output
@@ -103,7 +107,7 @@ CXXSHARED=      @CXXSHARED@
 # compilers.   If it doesn't work,  comment it out.
 @TRYLINKINGWITHCXX@
 
-OBJS      = $(SRCS:.c=.@OBJEXT@) $(CXXSRCS:.cxx=.@OBJEXT@)
+OBJS      = $(notdir $(SRCS:.c=.@OBJEXT@) $(CXXSRCS:.cxx=.@OBJEXT@))
 
 distclean:
 	rm -f Makefile
@@ -385,7 +389,7 @@ OCTAVE_CXX    = $(DEFS) @OCTAVE_CPPFLAGS@ @OCTAVE_CXXFLAGS@
 OCTAVE_DLNK   = @OCTAVE_LDFLAGS@
 OCTAVE_SO     = @OCTAVE_SO@
 
-OCTAVE_SCRIPT = $(RUNME).m
+OCTAVE_SCRIPT = $(EXSRCDIR)/$(RUNME).m
 
 # ----------------------------------------------------------------
 # Build a C dynamically loadable module
@@ -393,7 +397,7 @@ OCTAVE_SCRIPT = $(RUNME).m
 # ----------------------------------------------------------------
 
 octave: $(SRCS)
-	$(SWIG) -octave $(SWIGOPT) $(INTERFACEPATH)
+	$(SWIG) -octave $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
 	$(CXX) -g -c $(CCSHARED) $(CXXFLAGS) $(ICXXSRCS) $(INCLUDES) $(OCTAVE_CXX)
 	$(CC) -g -c $(CCSHARED) $(CFLAGS) $(SRCS) $(CSRCS) $(INCLUDES)
 	$(LDSHARED) $(CFLAGS) $(OBJS) $(IOBJS) $(OCTAVE_DLNK) $(LIBS) -o $(LIBPREFIX)$(TARGET)$(OCTAVE_SO)
@@ -403,7 +407,7 @@ octave: $(SRCS)
 # -----------------------------------------------------------------
 
 octave_cpp: $(SRCS)
-	$(SWIG) -c++ -octave $(SWIGOPT) $(INTERFACEPATH)
+	$(SWIG) -c++ -octave $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
 	$(CXX) -g -c $(CCSHARED) $(CXXFLAGS) $(ICXXSRCS) $(SRCS) $(CXXSRCS) $(INCLUDES) $(OCTAVE_CXX)
 	$(CXXSHARED) -g $(CXXFLAGS) $(OBJS) $(IOBJS) $(OCTAVE_DLNK) $(LIBS) $(CPP_DLLIBS) -o $(LIBPREFIX)$(TARGET)$(OCTAVE_SO)
 

--- a/Examples/octave/callback/Makefile
+++ b/Examples/octave/callback/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-CXXSRCS    = example.cxx
+CXXSRCS    = $(EXSRCDIR)/example.cxx
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/class/Makefile
+++ b/Examples/octave/class/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-CXXSRCS    = example.cxx
+CXXSRCS    = $(EXSRCDIR)/example.cxx
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/constants/Makefile
+++ b/Examples/octave/constants/Makefile
@@ -2,7 +2,7 @@ TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
 CXXSRCS    =
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/contract/Makefile
+++ b/Examples/octave/contract/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Examples/octave/enum/Makefile
+++ b/Examples/octave/enum/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-CXXSRCS    = example.cxx
+CXXSRCS    = $(EXSRCDIR)/example.cxx
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/extend/Makefile
+++ b/Examples/octave/extend/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-CXXSRCS    = example.cxx
+CXXSRCS    = $(EXSRCDIR)/example.cxx
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/funcptr/Makefile
+++ b/Examples/octave/funcptr/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Examples/octave/funcptr2/Makefile
+++ b/Examples/octave/funcptr2/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Examples/octave/functor/Makefile
+++ b/Examples/octave/functor/Makefile
@@ -2,7 +2,7 @@ TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
 CXXSRCS    =
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/module_load/Makefile
+++ b/Examples/octave/module_load/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Examples/octave/operator/Makefile
+++ b/Examples/octave/operator/Makefile
@@ -2,7 +2,7 @@ TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
 CXXSRCS    =
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/pointer/Makefile
+++ b/Examples/octave/pointer/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Examples/octave/reference/Makefile
+++ b/Examples/octave/reference/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-CXXSRCS    = example.cxx
+CXXSRCS    = $(EXSRCDIR)/example.cxx
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/simple/Makefile
+++ b/Examples/octave/simple/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Examples/octave/template/Makefile
+++ b/Examples/octave/template/Makefile
@@ -2,7 +2,7 @@ TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
 CXXSRCS    =
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 LIBS       = -lm
 SWIGOPT    =
 

--- a/Examples/octave/variables/Makefile
+++ b/Examples/octave/variables/Makefile
@@ -1,8 +1,8 @@
 TOP        = ../..
 SWIG       = $(TOP)/../preinst-swig
-SRCS       = example.c
+SRCS       = $(EXSRCDIR)/example.c
 TARGET     = swigexample
-INTERFACE  = example.i
+INTERFACE  = $(EXSRCDIR)/example.i
 
 check: build
 	$(MAKE) -f $(TOP)/Makefile octave_run

--- a/Makefile.in
+++ b/Makefile.in
@@ -99,7 +99,7 @@ skip-errors	= test -n ""
 ACTION = check
 NOSKIP =
 
-chk-set-swiglib		= SWIG_LIB=@ROOT_DIR@/Lib
+chk-set-swiglib		= SWIG_LIB=@ROOT_DIR@/@srcdir@/Lib
 chk-set-swig		= SWIG=@ROOT_DIR@/$(TARGET)
 chk-set-env = $(chk-set-swiglib) $(chk-set-swig)
 
@@ -239,7 +239,9 @@ check-%-examples :
 # individual example
 %.actionexample:
 	@echo $(ACTION)ing Examples/$(LANGUAGE)/$*
-	@(cd Examples/$(LANGUAGE)/$* && $(MAKE) $(FLAGS) $(chk-set-env) $(ACTION) RUNPIPE=$(RUNPIPE))
+	@mkdir -p Examples/$(LANGUAGE)/$*
+	@EXSRCDIR="../../../$(srcdir)/Examples/$(LANGUAGE)/$*"; \
+	(cd Examples/$(LANGUAGE)/$* && $(MAKE) -f "$${EXSRCDIR}/Makefile" EXSRCDIR="$${EXSRCDIR}" $(FLAGS) $(chk-set-env) $(ACTION) RUNPIPE=$(RUNPIPE))
 
 # gcj individual example
 java.actionexample:


### PR DESCRIPTION
- facilitates testing SWIG against multiple Octave versions
