### PR TITLE
Fix gcc strict aliasing warnings with function pointers too.

### DIFF
--- a/Source/DOH/base.c
+++ b/Source/DOH/base.c
@@ -947,11 +947,12 @@ int DohGetmark(DOH *ho) {
 
 DOH *DohCall(DOH *func, DOH *args) {
   DOH *result;
-  DOH *(*builtin) (DOH *);
+  DohFuncPtr_t builtin;
 
-  *(void **)(&builtin) = GetVoid(func, "builtin");
-  if (!builtin)
+  builtin.p = GetVoid(func, "builtin");
+
+  if (!builtin.p)
     return 0;
-  result = (*builtin) (args);
+  result = (*builtin.func) (args);
   return result;
 }

--- a/Source/DOH/doh.h
+++ b/Source/DOH/doh.h
@@ -336,6 +336,12 @@ extern DOHList *DohSplit(DOHFile * input, char ch, int nsplits);
 extern DOHList *DohSplitLines(DOHFile * input);
 extern DOH *DohNone;
 
+/* Helper union for converting between function and object pointers. */
+typedef union DohFuncPtr {
+  void* p;
+  DOH *(*func)(DOH *);
+} DohFuncPtr_t;
+
 extern void DohMemoryDebug(void);
 
 #ifndef DOH_LONG_NAMES

--- a/Source/DOH/fio.c
+++ b/Source/DOH/fio.c
@@ -46,15 +46,19 @@ static int Writen(DOH *out, void *buffer, int len) {
  * ----------------------------------------------------------------------------- */
 
 void DohEncoding(const char *name, DOH *(*fn) (DOH *s)) {
+  DohFuncPtr_t fp;
+
   if (!encodings)
     encodings = NewHash();
-  Setattr(encodings, (void *) name, NewVoid(*(void **)&fn, 0));
+
+  fp.func = fn;
+  Setattr(encodings, (void *) name, NewVoid(fp.p, 0));
 }
 
 /* internal function for processing an encoding */
 static DOH *encode(char *name, DOH *s) {
   DOH *handle, *ns;
-  DOH *(*fn) (DOH *);
+  DohFuncPtr_t fp;
   long pos;
   char *cfmt = strchr(name, ':');
   DOH *tmp = 0;
@@ -72,8 +76,9 @@ static DOH *encode(char *name, DOH *s) {
     s = tmp;
   pos = Tell(s);
   Seek(s, 0, SEEK_SET);
-  *(void **)(&fn) = Data(handle);
-  ns = (*fn) (s);
+
+  fp.p = Data(handle);
+  ns = (*fp.func) (s);
   assert(pos != -1);
   (void)Seek(s, pos, SEEK_SET);
   if (tmp)


### PR DESCRIPTION
The commit 40bf877 fixed warnings about converting between function and object
pointers but introduced warnings about breaking strict-aliasing rules which
appear with -Wstrict-aliasing which is implicitly enabled by -O2.

Avoid these warnings as well by using an intermediate union for conversion
instead of casts trickery.
