### PR TITLE
Fix the division operator overload in Python 3 generated bindings.

### DIFF
--- a/Lib/python/pyopers.swg
+++ b/Lib/python/pyopers.swg
@@ -103,7 +103,7 @@
 %pybinoperator(__neg__,      *::operator-(),		unaryfunc, nb_negative);
 %pybinoperator(__neg__,      *::operator-() const,	unaryfunc, nb_negative);
 %pybinoperator(__mul__,      *::operator*,		binaryfunc, nb_multiply);
-%pybinoperator(__div__,      *::operator/,		binaryfunc, nb_div);
+%pybinoperator(__div__,      *::operator/,		binaryfunc, nb_divide);
 %pybinoperator(__mod__,      *::operator%,		binaryfunc, nb_remainder);
 %pybinoperator(__lshift__,   *::operator<<,		binaryfunc, nb_lshift);
 %pybinoperator(__rshift__,   *::operator>>,		binaryfunc, nb_rshift);
@@ -117,7 +117,7 @@
 %pycompare(__eq__,           *::operator==,		Py_EQ);
 %pycompare(__ne__,           *::operator!=,		Py_NE);
 
-%feature("python:slot", "nb_truediv", functype="binaryfunc") *::operator/;
+%feature("python:slot", "nb_true_divide", functype="binaryfunc") *::operator/;
 
 /* Special cases */
 %rename(__invert__)     *::operator~;
@@ -202,6 +202,7 @@ __bool__ = __nonzero__
 %pyinplaceoper(__ilshift__, *::operator <<=,	binaryfunc, nb_inplace_lshift);
 %pyinplaceoper(__irshift__, *::operator >>=,	binaryfunc, nb_inplace_rshift);
 
+%feature("python:slot", "nb_inplace_true_divide", functype="binaryfunc") *::operator/=;
 
 /* Finally, in python we need to mark the binary operations to fail as
  'maybecall' methods */


### PR DESCRIPTION
Fix the division operator overload under Python 3.
The complete test suite passes with this changes under Python 2.7.5+.

The test suite fails on Python 3.3 because of compliance issues in the test themselves (eg. print call missing parentheses, except issues, etc...). But the division operator works and the fairly large binding we use still works with no regression in our tests.