### PR TITLE
guile std_string test: run test in utf8 locale

### DIFF
--- a/Examples/test-suite/guile/li_std_string_runme.scm
+++ b/Examples/test-suite/guile/li_std_string_runme.scm
@@ -5,5 +5,5 @@
 ; Note: when working with non-ascii strings in guile 2
 ;       locale must be set explicitly
 ;       The setlocale call below takes care of that
-(setlocale LC_ALL "")
+(setlocale LC_ALL "en_US.utf8")
 (load "../schemerunme/li_std_string.scm")


### PR DESCRIPTION
Guile can't properly handle non-ascii strings in the default C locale
