### PR TITLE
Class p1 fixes2

### DIFF
--- a/Examples/test-suite/lua/nspace_runme.lua
+++ b/Examples/test-suite/lua/nspace_runme.lua
@@ -70,6 +70,10 @@ assert(ns.Outer.Inner1.Color_colorStaticMethod == nil)
 
 -- Enums and static methods of class marked as %nonspace should have backward compatible name
 assert(ns.NoNSpacePlease_noNspaceStaticFunc() == 10)
--- assert(ns.NoNSpacePlease_NoNspace1 == 1)
--- assert(ns.NoNSpacePlease.NoNspace2 == 10)
+assert(ns.Outer.Inner2.NoNSpacePlease_NoNspace == nil)
+-- ReallyNoNSpaceEnum is wrapped into %nonspace and thus handled correctly.
+-- NoNSpaceEnum is not (although both of them are in %nonspace-wrapped class) and thus
+-- handled rather unexpectedly
+assert(ns.NoNSpacePlease_ReallyNoNspace1 == 1)
+assert(ns.NoNSpacePlease.ReallyNoNspace2 == 10)
 

--- a/Examples/test-suite/nspace.i
+++ b/Examples/test-suite/nspace.i
@@ -10,6 +10,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 
 %nspace;
 %nonspace Outer::Inner2::NoNSpacePlease;
+%nonspace Outer::Inner2::NoNSpacePlease::ReallyNoNSpaceEnum;
 
 %copyctor;
 %ignore Outer::Inner2::Color::Color();
@@ -70,6 +71,7 @@ namespace Outer {
     class NoNSpacePlease {
       public:
         enum NoNSpaceEnum { NoNspace1 = 1, NoNspace2 = 10 };
+        enum ReallyNoNSpaceEnum { ReallyNoNspace1 = 1, ReallyNoNspace2 = 10 };
         static int noNspaceStaticFunc() { return 10; }
     };
   } // Inner2

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -1165,9 +1165,20 @@ public:
   virtual int enumDeclaration(Node *n) {
     current[STATIC_CONST] = true;
     current[ENUM_CONST] = true;
+    // There is some slightly specific behaviour with enums. Basically,
+    // their NSpace may be tracked separately. The code below tries to work around
+    // this issue to some degree.
+    // The idea is the same as in classHandler - to drop old names generation if
+    // enum is in class in namespace.
+    const int v2_compat_names_generation_old = v2_compat_names_generation;
+    if (getNSpace() ||
+        ( Getattr(n, "sym:nspace") != 0 && Len(Getattr(n, "sym:nspace")) > 0 ) ) {
+      v2_compat_names_generation = 0;
+    }
     int result = Language::enumDeclaration(n);
     current[STATIC_CONST] = false;
     current[ENUM_CONST] = false;
+    v2_compat_names_generation = v2_compat_names_generation_old;
     return result;
   }
 


### PR DESCRIPTION
1. Disabled backward compatible names for enums in NSpace
2. Getattribute->GetFlag
