### PR TITLE
Fix intgosize arg documentation

### DIFF
--- a/Doc/Manual/Go.html
+++ b/Doc/Manual/Go.html
@@ -94,9 +94,9 @@ swig -go -help
 </tr>
 
 <tr>
-<td>-intgo-type-size %lt;s%gt;</td>
+<td>-intgosize &lt;s&gt;</td>
 <td>Set the size for the Go type <tt>int</tt>.  This controls the size
-  that the C/C++ code expects to see.  The %lt;s%gt; argument should
+  that the C/C++ code expects to see.  The &lt;s&gt; argument should
   be 32 or 64.  This option is currently required during the
   transition from Go 1.0 to Go 1.1, as the size of <tt>int</tt> on
   64-bit x86 systems changes between those releases (from 32 bits to


### PR DESCRIPTION
it was misnamed, and brackets were shown as plaintext lt; gt;
