### PR TITLE
Lua: Fix "'snprintf': identifier not found"

### DIFF
--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -15,6 +15,12 @@ extern "C" {
 #include <stdlib.h>  /* for malloc */
 #include <assert.h>  /* for a few sanity tests */
 
+#if defined(_MSC_VER) || defined(__BORLANDC__) || defined(_WATCOM)
+# ifndef snprintf
+#  define snprintf _snprintf
+# endif
+#endif
+
 /* -----------------------------------------------------------------------------
  * Lua flavors
  * ----------------------------------------------------------------------------- */


### PR DESCRIPTION
Was receiving "'snprintf': identifier not found" compiler error when compiling with Lua bindings generated with SWIG version 3.0.0 on Windows. This fixes the issue. It is also the same fix used in chickenrun.swg.
