### PR TITLE
Implement an %abstractdirector feature for java

### DIFF
--- a/Examples/test-suite/java/java_abstract_directors_runme.java
+++ b/Examples/test-suite/java/java_abstract_directors_runme.java
@@ -1,4 +1,7 @@
 import java_abstract_directors.*;
+import java.lang.reflect.*;
+import java.util.HashSet;
+import java.util.Set;
 
 public class java_abstract_directors_runme {
   static {
@@ -10,7 +13,81 @@ public class java_abstract_directors_runme {
     }
   }
 
-  public static void main(String argv[]) {
+  static void throwIfFalse(boolean b) throws Exception {
+    if (!b) throw new Exception();
+  }
 
+  public static void main(String argv[]) {
+    Class[] empty = (Class[]) null;
+    String reason = "no reason";
+
+    try {
+      reason = "Director1::Method1 abstract director failed";
+      throwIfFalse(Modifier.isAbstract(Director1.class.getDeclaredMethod("Method1", empty).getModifiers()));
+
+      reason = "Director1::Method2 abstract director failed";
+      throwIfFalse(!Modifier.isAbstract(Director1.class.getDeclaredMethod("Method2", empty).getModifiers()));
+
+      reason = "Director1.Director1 abstract director failed";
+      throwIfFalse(Modifier.isAbstract(Director1.class.getModifiers()));
+
+      reason = "Director2::Method1 abstract director failed";
+      throwIfFalse(Modifier.isAbstract(Director2.class.getDeclaredMethod("Method1", empty).getModifiers()));
+
+      reason = "Director2::Method2 abstract director failed";
+      throwIfFalse(!Modifier.isAbstract(Director2.class.getDeclaredMethod("Method2", empty).getModifiers()));
+
+      reason = "Director2.Director2 abstract director failed";
+      throwIfFalse(Modifier.isAbstract(Director2.class.getModifiers()));
+
+      reason = "Director3::Method1 abstract director failed";
+      throwIfFalse(!Modifier.isAbstract(Director3.class.getDeclaredMethod("Method1", empty).getModifiers()));
+
+      reason = "Director3::Method2 abstract director failed";
+      throwIfFalse(!Modifier.isAbstract(Director3.class.getDeclaredMethod("Method2", empty).getModifiers()));
+
+      reason = "Director3.Director3 abstract director failed";
+      throwIfFalse(!Modifier.isAbstract(Director3.class.getModifiers()));
+
+      reason = "Director4::Method1 abstract director failed";
+      throwIfFalse(Modifier.isAbstract(Director4.class.getDeclaredMethod("Method1", empty).getModifiers()));
+
+      reason = "Director4::Method2 abstract director failed";
+      throwIfFalse(!Modifier.isAbstract(Director4.class.getDeclaredMethod("Method2", empty).getModifiers()));
+
+      reason = "Director4.Director4 abstract director failed";
+      throwIfFalse(Modifier.isAbstract(Director4.class.getModifiers()));
+
+      Set<String> names = new HashSet<String>();
+      for (Method m : java_abstract_directorsJNI.class.getDeclaredMethods()) {
+        names.add(m.getName());
+      }
+
+      reason = "java_abstract_directorsJNI.Director1_Method1 abstract director failed";
+      throwIfFalse(!names.contains("Director1_Method1"));
+
+      reason = "java_abstract_directorsJNI.Director1_Method2 abstract director failed";
+      throwIfFalse(names.contains("Director1_Method2"));
+
+      reason = "java_abstract_directorsJNI.Director2_Method1 abstract director failed";
+      throwIfFalse(!names.contains("Director2_Method1"));
+
+      reason = "java_abstract_directorsJNI.Director2_Method2 abstract director failed";
+      throwIfFalse(names.contains("Director2_Method2"));
+
+      reason = "java_abstract_directorsJNI.Director3_Method1 abstract director failed";
+      throwIfFalse(names.contains("Director3_Method1"));
+
+      reason = "java_abstract_directorsJNI.Director3_Method2 abstract director failed";
+      throwIfFalse(names.contains("Director3_Method2"));
+
+      reason = "java_abstract_directorsJNI.Director4_Method1 abstract director failed";
+      throwIfFalse(!names.contains("Director4_Method1"));
+
+      reason = "java_abstract_directorsJNI.Director4_Method2 abstract director failed";
+      throwIfFalse(names.contains("Director4_Method2"));
+    } catch (Exception e) {
+      throw new RuntimeException(reason);
+    }
   }
 }

--- a/Examples/test-suite/java/java_abstract_directors_runme.java
+++ b/Examples/test-suite/java/java_abstract_directors_runme.java
@@ -1,0 +1,16 @@
+import java_abstract_directors.*;
+
+public class java_abstract_directors_runme {
+  static {
+    try {
+      System.loadLibrary("java_abstract_directors");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+
+  }
+}

--- a/Examples/test-suite/java_abstract_directors.i
+++ b/Examples/test-suite/java_abstract_directors.i
@@ -1,1 +1,62 @@
 %module(directors="1") java_abstract_directors
+
+%feature("director") Director1;
+
+%inline %{
+class Director0 {
+ public:
+  virtual ~Director0() {}
+  virtual void Method1() = 0;
+  virtual void Method2() {};
+};
+%}
+
+%feature("director") Director1;
+
+%abstractdirector Director1::Method1;
+
+%inline %{
+class Director1 {
+ public:
+  virtual ~Director1() {}
+  virtual void Method1() = 0;
+  virtual void Method2() {};
+};
+%}
+
+%feature("director") Director2;
+
+%abstractdirector Director2;
+
+%inline %{
+class Director2 {
+ public:
+  virtual ~Director2() {}
+  virtual void Method1() = 0;
+  virtual void Method2() {};
+};
+%}
+
+%feature("director") Director3;
+
+%inline %{
+class Director3 {
+ public:
+  virtual ~Director3() {}
+  virtual void Method1() = 0;
+  virtual void Method2() {};
+};
+%}
+
+%feature("director") Director4;
+
+%abstractdirector;
+
+%inline %{
+class Director4 {
+ public:
+  virtual ~Director4() {}
+  virtual void Method1() = 0;
+  virtual void Method2() {};
+};
+%}

--- a/Examples/test-suite/java_abstract_directors.i
+++ b/Examples/test-suite/java_abstract_directors.i
@@ -1,0 +1,1 @@
+%module(directors="1") java_abstract_directors

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1304,6 +1304,11 @@ SWIG_PROXY_CONSTRUCTOR(true, true, SWIGTYPE)
 #define %nojavaexception            %feature("except","0",throws="")
 #define %clearjavaexception         %feature("except","",throws="")
 
+/* Use to control if pure virtual methods should be abstract java methods. */
+#define %abstractdirector      %feature("java:abstractdirector")
+#define %noabstractdirector    %feature("java:abstractdirector","0")
+#define %clearabstractdirector %feature("java:abstractdirector","")
+
 %pragma(java) jniclassclassmodifiers="public class"
 %pragma(java) moduleclassmodifiers="public class"
 


### PR DESCRIPTION
The abstract directors feature will on demand turn C++ classes with pure virtual functions into abstract Java classes with abstract methods.
