### PR TITLE
Fixed JSClassRef declaration not using the static one

### DIFF
--- a/Lib/javascript/jsc/javascriptcode.swg
+++ b/Lib/javascript/jsc/javascriptcode.swg
@@ -354,7 +354,7 @@ static JSStaticFunction $jsmangledname_functions[] = {
   $jsmangledname_objectDefinition.staticValues = $jsmangledname_values;
   $jsmangledname_objectDefinition.staticFunctions = $jsmangledname_functions;
   $jsclass_inheritance
-  JSClassRef $jsmangledname_classRef = JSClassCreate(&$jsmangledname_objectDefinition);
+  $jsmangledname_classRef = JSClassCreate(&$jsmangledname_objectDefinition);
   SWIGTYPE_$jsmangledtype->clientdata = $jsmangledname_classRef;
 %}
 


### PR DESCRIPTION
The class descriptor is not assigned to the static variable but to a local one, which makes the global variable unused.
