### PR TITLE
Use core.atomic.atomicOp to mutate shared variables

### DIFF
--- a/Lib/d/dhead.swg
+++ b/Lib/d/dhead.swg
@@ -227,7 +227,8 @@ public:
 
     m_sPendingException = e;
     synchronized {
-      ++m_sPendingCount;
+      import core.atomic;
+      core.atomic.atomicOp!"+="(m_sPendingCount, 1);
     }
   }
 
@@ -238,7 +239,8 @@ public:
         e = m_sPendingException;
         m_sPendingException = null;
         synchronized {
-          --m_sPendingCount;
+          import core.atomic;
+          core.atomic.atomicOp!"-="(m_sPendingCount, 1);
         }
       }
     }


### PR DESCRIPTION
prevents deprecation warning since 2.066(rc):
Deprecation: Read-modify-write operations are not allowed for shared variables. Use core.atomic.atomicOp!"+="(m_sPendingCount, 1) instead.
