### PR TITLE
Initialize C++ arrays created by array_functions' new_foo().

### DIFF
--- a/Lib/carrays.i
+++ b/Lib/carrays.i
@@ -22,7 +22,7 @@
 %{
 static TYPE *new_##NAME(int nelements) { %}
 #ifdef __cplusplus
-%{  return new TYPE[nelements]; %}
+%{  return new TYPE[nelements](); %}
 #else
 %{  return (TYPE *) calloc(nelements,sizeof(TYPE)); %}
 #endif


### PR DESCRIPTION
`array_functions(TYPE, NAME)` generates a `new_foo(size)` function that
allocates a new array of the given type.  When compiling in C, the array
is initialized with `calloc()`, which shows that the intent was to have
the array be zero-initialized.  When in C++, however, the array was not
getting initialized, so it could contain random garbage after creation,
when the type was a POD type.

This change makes `new_foo(size)` create a value-initialized array when
in C++, as per the C++ standard's 5.3.4.15 that says that adding a pair
of parentheses at the end of a new-expression does that.
