### PR TITLE
apply SF Patch #350 and add testcase

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,9 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.3 (in progress)
 ===========================
 
+2014-08-15: talby
+            [Perl] Include guard fix for nested modules from Anthony Heading (SF Patch #350).
+
 2014-08-04: wsfulton
             [C#] Merge patch #200 from gpetrou - Changed CSharp license header to include auto-generated
             tag so that StyleCop ignores the files.

--- a/Examples/test-suite/director_nestedmodule.i
+++ b/Examples/test-suite/director_nestedmodule.i
@@ -1,0 +1,29 @@
+%module(directors="1") "director::nestedmodule"
+
+%{
+#include <string>
+
+class Foo {
+  public:
+    virtual ~Foo() {}
+    virtual std::string ping() { return "Foo::ping()"; }
+    virtual std::string pong() { return "Foo::pong();" + ping(); }
+
+    static Foo* get_self(Foo *slf) {return slf;}
+};
+
+%}
+
+%include <std_string.i>
+
+%feature("director") Foo;
+
+
+class Foo {
+  public:
+    virtual ~Foo();
+    virtual std::string ping();
+    virtual std::string pong();
+
+    static Foo* get_self(Foo *slf);
+};

--- a/Examples/test-suite/perl5/Makefile.in
+++ b/Examples/test-suite/perl5/Makefile.in
@@ -17,6 +17,7 @@ CPP_TEST_CASES += \
 	li_cstring \
 	li_cdata_carrays \
 	li_reference \
+	director_nestedmodule \
 
 C_TEST_CASES += \
 	li_cdata \

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -342,11 +342,18 @@ public:
     Node *options = Getattr(mod, "options");
     module = Copy(Getattr(n,"name"));
 
+    String *underscore_module = Copy(module);
+    Replaceall(underscore_module,":","_");
+
+    if (verbose > 0) {
+      fprintf(stdout, "top: using namespace_module: %s\n", Char(namespace_module));
+    }
+
     if (directorsEnabled()) {
       Swig_banner(f_directors_h);
       Printf(f_directors_h, "\n");
-      Printf(f_directors_h, "#ifndef SWIG_%s_WRAP_H_\n", module);
-      Printf(f_directors_h, "#define SWIG_%s_WRAP_H_\n\n", module);
+      Printf(f_directors_h, "#ifndef SWIG_%s_WRAP_H_\n", underscore_module);
+      Printf(f_directors_h, "#define SWIG_%s_WRAP_H_\n\n", underscore_module);
       if (dirprot_mode()) {
 	Printf(f_directors_h, "#include <map>\n");
 	Printf(f_directors_h, "#include <string>\n\n");
@@ -379,13 +386,6 @@ public:
 	fprintf(stdout, "top: No package found\n");
       }
     }
-    String *underscore_module = Copy(module);
-    Replaceall(underscore_module,":","_");
-
-    if (verbose > 0) {
-      fprintf(stdout, "top: using namespace_module: %s\n", Char(namespace_module));
-    }
-
     /* If we're in blessed mode, change the package name to "packagec" */
 
     if (blessed) {


### PR DESCRIPTION
The test-suite file is only included in Perl5 tests because other languages did not like "::" in module names either.  Java seemed to have the same problem as Perl with the include guard having invalid characters, but after fixing that in Source/Modules/java.cxx deeper problems surfaced.
