### PR TITLE
Python: Fix property access with director

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -172,6 +172,7 @@ CPP_TEST_CASES += \
 	director_abstract \
 	director_alternating \
 	director_basic \
+	director_property \
 	director_binary_string \
 	director_classes \
 	director_classic \

--- a/Examples/test-suite/director_property.i
+++ b/Examples/test-suite/director_property.i
@@ -1,0 +1,151 @@
+%module(directors="1") director_property
+
+%warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) MyClass::pmethod;
+
+%{
+ #include <string>
+
+ class Foo {
+ private:
+   std::string a;
+ public:
+   virtual ~Foo() {}
+   virtual std::string ping() { return "Foo::ping()"; }
+   virtual std::string pong() { return "Foo::pong();" + ping(); }
+   virtual std::string getA() { return this->a; }
+   virtual void setA(std::string a) { this->a = a; }
+
+   static Foo* get_self(Foo *slf) {return slf;}
+   
+ };
+
+ %}
+
+ %include <std_string.i>
+
+ %feature("director") Foo;
+
+
+ class Foo {
+ public:
+   virtual ~Foo();
+   virtual std::string ping();
+   virtual std::string pong();
+   virtual std::string getA();
+   virtual void setA(std::string a);
+   
+   static Foo* get_self(Foo *slf);
+   
+ };
+
+ %{
+ #include <complex> 
+ %}
+ %feature("director") A;
+
+ // basic renaming
+ %rename(rg) A::gg;
+ %feature("nodirector") hi::A1::gg;
+
+ %inline %{
+
+ struct A{
+     A(std::complex<int> i, double d=0.0) {}
+     A(int i, bool j=false) {}
+     virtual ~A() {}
+
+     virtual int f(int i=0) {return i;}
+     virtual int gg(int i=0) {return i;}
+ };
+
+ namespace hi  {
+
+   struct A1 : public A {
+     A1(std::complex<int> i, double d=0.0) : A(i, d) {}
+     A1(int i, bool j=false) : A(i, j) {}
+
+     virtual int ff(int i = 0) {return i;}  
+   };
+ }
+
+
+ %}
+
+
+ %feature("director") MyClass;
+
+ %inline %{
+
+ typedef void VoidType;
+
+  struct Bar
+  {
+    int x;
+    Bar(int _x = 0) : x(_x)
+    {
+    }
+ };
+ 
+ 
+
+class MyClass {
+public:
+  MyClass(int a = 0) 
+  {
+  }
+  
+  virtual void method(VoidType *)
+  {
+  }
+  
+  virtual ~MyClass()
+  {
+  }
+
+  virtual Bar vmethod(Bar b)
+  {
+    b.x += 13;
+    return b;
+  }  
+
+  virtual Bar* pmethod(Bar *b)
+  {
+    b->x += 12;
+    return b;
+  }  
+
+  Bar cmethod(const Bar &b)
+  {
+    return vmethod(b);
+  }  
+
+  static MyClass *get_self(MyClass *c) 
+  {
+    return c;
+  }
+
+  static Bar * call_pmethod(MyClass *myclass, Bar *b) {
+    return myclass->pmethod(b);
+  }
+};
+
+template<class T>
+class MyClassT {
+public:
+  MyClassT(int a = 0) 
+  {
+  }
+  
+  virtual void method(VoidType *)
+  {
+  }
+  
+  virtual ~MyClassT()
+  {
+  }
+  
+};
+
+%}
+
+%template(MyClassT_i) MyClassT<int>;

--- a/Examples/test-suite/python/director_property_runme.py
+++ b/Examples/test-suite/python/director_property_runme.py
@@ -1,0 +1,18 @@
+import director_property
+
+class PyFoo(director_property.Foo):
+	a = property(director_property.Foo.getA, director_property.Foo.setA)
+
+	def ping(self):
+		return "PyFoo::ping()"
+
+
+foo = PyFoo()
+
+foo.setA("BLABLA")
+if foo.getA() != "BLABLA":
+	raise RuntimeError
+
+foo.a = "BIBI"
+if foo.a != "BIBI":
+	raise RuntimeError

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -871,16 +871,21 @@ public:
 #else
 	       tab4, "if (not static):\n",
 #endif
-	       tab4, tab4, "self.__dict__[name] = value\n",
+	       tab4, tab4, "object.__setattr__(self, name, value)\n",
 	       tab4, "else:\n",
 	       tab4, tab4, "raise AttributeError(\"You cannot add attributes to %s\" % self)\n\n",
 	        "\n", "def _swig_setattr(self, class_type, name, value):\n", tab4, "return _swig_setattr_nondynamic(self, class_type, name, value, 0)\n\n", NIL);
 
 	Printv(f_shadow,
-	        "\n", "def _swig_getattr(self, class_type, name):\n",
+	       "\n", "def _swig_getattr_nondynamic(self, class_type, name, static=1):\n",
 	       tab4, "if (name == \"thisown\"):\n", tab8, "return self.this.own()\n",
 	       tab4, "method = class_type.__swig_getmethods__.get(name, None)\n",
-	       tab4, "if method:\n", tab8, "return method(self)\n", tab4, "raise AttributeError(name)\n\n", NIL);
+	       tab4, "if method:\n", tab8, "return method(self)\n",
+	       tab4, "if (not static):\n",
+	       tab4, tab4, "return object.__getattr__(self, name)\n",
+	       tab4, "else:\n",
+	       tab4, tab4, "raise AttributeError(name)\n\n",
+	       "def _swig_getattr(self, class_type, name):\n", tab4, "return _swig_getattr_nondynamic(self, class_type, name, 0)\n\n", NIL);
 
 	Printv(f_shadow,
 	        "\n", "def _swig_repr(self):\n",


### PR DESCRIPTION
When adding a property in a class extending a directory class, we can't set/read property correctly.
Here the fix, and the test
