### PR TITLE
correct example in enum class docs

### DIFF
--- a/Doc/Manual/CPlusPlus11.html
+++ b/Doc/Manual/CPlusPlus11.html
@@ -525,19 +525,19 @@ class Color {
 <p>A workaround is to write these as a series of separate classes containing anonymous enums:</p>
 
 <div class="code"><pre>
-class PrintingColors {
+struct PrintingColors {
   enum : unsigned int {
     Cyan, Magenta, Yellow, Black
   };
 };
 
-class BasicColors {
+struct BasicColors {
   enum : unsigned int {
     Red, Green, Blue
   };
 };
 
-class AllColors {
+struct AllColors {
   enum : unsigned int {
     Yellow, Orange, Red, Magenta, Blue, Cyan, Green, Pink, Black, White
   };


### PR DESCRIPTION
I found that the workaround example provided for enum class effectively does nothing useful (when generating python code). I suppose it's so because class compounds are private by default and swig does not generate  enum values, just empty classes `PrintingColors` etc.. Changing `class` to `struct` seems to fix the issue. This was seen and verified on swig `3.0.2`.
