### PR TITLE
Fix python global object constants

### DIFF
--- a/Examples/test-suite/python/constant_directive_runme.py
+++ b/Examples/test-suite/python/constant_directive_runme.py
@@ -1,0 +1,21 @@
+import constant_directive
+
+if type(constant_directive.TYPE1_CONSTANT1) != constant_directive.Type1:
+  print("TYPE1_CONSTANT1    type: {}".format(type(constant_directive.TYPE1_CONSTANT1)))
+  raise RuntimeError("fail");
+if type(constant_directive.getType1Instance()) != constant_directive.Type1:
+  print("getType1Instance() type: {}".format(type(constant_directive.getType1Instance())))
+  raise RuntimeError("fail");
+
+if constant_directive.TYPE1_CONSTANT1.val != 1:
+  print "constant_directive.TYPE1_CONSTANT1.val != 1"
+  print "constant_directive.TYPE1_CONSTANT1.val is %r" % constant_directive.TYPE1_CONSTANT1.val
+  raise RuntimeError("fail")
+if constant_directive.TYPE1_CONSTANT2.val != 2:
+  print "constant_directive.TYPE1_CONSTANT2.val != 2"
+  print "constant_directive.TYPE1_CONSTANT2.val is %r" % constant_directive.TYPE1_CONSTANT2.val
+  raise RuntimeError("fail")
+if constant_directive.TYPE1_CONSTANT3.val != 3:
+  print "constant_directive.TYPE1_CONSTANT3.val != 3"
+  print "constant_directive.TYPE1_CONSTANT3.val is %r" % constant_directive.TYPE1_CONSTANT3.val
+  raise RuntimeError("fail")

--- a/Examples/test-suite/python/constant_directive_runme.py
+++ b/Examples/test-suite/python/constant_directive_runme.py
@@ -1,8 +1,8 @@
 import constant_directive
 
-if type(constant_directive.TYPE1_CONSTANT1) != constant_directive.Type1:
+if not isinstance(constant_directive.TYPE1_CONSTANT1,constant_directive.Type1):
   raise RuntimeError("Failure: TYPE1_CONSTANT1 type: {}".format(type(constant_directive.TYPE1_CONSTANT1)))
-if type(constant_directive.getType1Instance()) != constant_directive.Type1:
+if not isinstance(constant_directive.getType1Instance(),constant_directive.Type1):
   raise RuntimeError("Failure: getType1Instance() type: {}".format(type(constant_directive.getType1Instance())))
 
 if constant_directive.TYPE1_CONSTANT1.val != 1:

--- a/Examples/test-suite/python/constant_directive_runme.py
+++ b/Examples/test-suite/python/constant_directive_runme.py
@@ -1,21 +1,15 @@
 import constant_directive
 
 if type(constant_directive.TYPE1_CONSTANT1) != constant_directive.Type1:
-  print("TYPE1_CONSTANT1    type: {}".format(type(constant_directive.TYPE1_CONSTANT1)))
-  raise RuntimeError("fail");
+  raise RuntimeError("Failure: TYPE1_CONSTANT1 type: {}".format(type(constant_directive.TYPE1_CONSTANT1)))
 if type(constant_directive.getType1Instance()) != constant_directive.Type1:
-  print("getType1Instance() type: {}".format(type(constant_directive.getType1Instance())))
-  raise RuntimeError("fail");
+  raise RuntimeError("Failure: getType1Instance() type: {}".format(type(constant_directive.getType1Instance())))
 
 if constant_directive.TYPE1_CONSTANT1.val != 1:
-  print "constant_directive.TYPE1_CONSTANT1.val != 1"
-  print "constant_directive.TYPE1_CONSTANT1.val is %r" % constant_directive.TYPE1_CONSTANT1.val
-  raise RuntimeError("fail")
+  raise RuntimeError("constant_directive.TYPE1_CONSTANT1.val is %r (should be 1)" % constant_directive.TYPE1_CONSTANT1.val)
+
 if constant_directive.TYPE1_CONSTANT2.val != 2:
-  print "constant_directive.TYPE1_CONSTANT2.val != 2"
-  print "constant_directive.TYPE1_CONSTANT2.val is %r" % constant_directive.TYPE1_CONSTANT2.val
-  raise RuntimeError("fail")
+  raise RuntimeError("constant_directive.TYPE1_CONSTANT2.val is %r (should be 2)" % constant_directive.TYPE1_CONSTANT2.val)
+
 if constant_directive.TYPE1_CONSTANT3.val != 3:
-  print "constant_directive.TYPE1_CONSTANT3.val != 3"
-  print "constant_directive.TYPE1_CONSTANT3.val is %r" % constant_directive.TYPE1_CONSTANT3.val
-  raise RuntimeError("fail")
+  raise RuntimeError("constant_directive.TYPE1_CONSTANT3.val is %r (should be 3)" % constant_directive.TYPE1_CONSTANT3.val)

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3171,25 +3171,25 @@ public:
       Replaceall(tm, "$value", value);
       if (!builtin && (shadow) && (!(shadow & PYSHADOW_MEMBER)) && (!in_class || !Getattr(n, "feature:python:callback"))) {
         // Generate method which registers the new constant
-        Printf(f_wrappers, "SWIGINTERN PyObject* %s_swigregister(PyObject* SWIGUNUSEDPARM(self), PyObject* args) {\n", iname);
-        Printf(f_wrappers, tab2 "PyObject *m;\n", tm);
+        Printf(f_wrappers, "SWIGINTERN PyObject *%s_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", iname);
+        Printf(f_wrappers, tab2 "PyObject *module;\n", tm);
 	if (modernargs) {
 	  if (fastunpack) {
-	    Printf(f_wrappers, tab2 "if (!SWIG_Python_UnpackTuple(args,(char*)\"swigregister\", 1, 1,&m)) return NULL;\n");
+	    Printf(f_wrappers, tab2 "if (!SWIG_Python_UnpackTuple(args,(char*)\"swigconstant\", 1, 1,&module)) return NULL;\n");
 	  } else {
-	    Printf(f_wrappers, tab2 "if (!PyArg_UnpackTuple(args,(char*)\"swigregister\", 1, 1,&m)) return NULL;\n");
+	    Printf(f_wrappers, tab2 "if (!PyArg_UnpackTuple(args,(char*)\"swigconstant\", 1, 1,&module)) return NULL;\n");
 	  }
 	} else {
-	  Printf(f_wrappers, tab2 "if (!PyArg_ParseTuple(args,(char*)\"O:swigregister\", &m)) return NULL;\n");
+	  Printf(f_wrappers, tab2 "if (!PyArg_ParseTuple(args,(char*)\"O:swigconstant\", &module)) return NULL;\n");
 	}
-        Printf(f_wrappers, tab2 "PyObject* d = PyModule_GetDict(m);\n");
-        Printf(f_wrappers, tab2 "if(!d) return NULL;\n");
+        Printf(f_wrappers, tab2 "PyObject *d = PyModule_GetDict(module);\n");
+        Printf(f_wrappers, tab2 "if (!d) return NULL;\n");
         Printf(f_wrappers, tab2 "%s\n", tm);
         Printf(f_wrappers, tab2 "return SWIG_Py_Void();\n");
         Printf(f_wrappers, "}\n\n\n");
 
         // Register the method in SwigMethods array
-	String *cname = NewStringf("%s_swigregister", iname);
+	String *cname = NewStringf("%s_swigconstant", iname);
 	add_method(cname, cname, 0);
 	Delete(cname);
       } else {
@@ -3210,14 +3210,12 @@ public:
     if (!builtin && (shadow) && (!(shadow & PYSHADOW_MEMBER))) {
       if (!in_class) {
 	Printv(f_shadow, "\n",NIL);
-	Printv(f_shadow, module, ".", iname, "_swigregister(",module,")\n", NIL);
-	Printv(f_shadow, iname, "_swigregister = ", module, ".", iname, "_swigregister\n", NIL);
+	Printv(f_shadow, module, ".", iname, "_swigconstant(",module,")\n", NIL);
 	Printv(f_shadow, iname, " = ", module, ".", iname, "\n", NIL);
       } else {
 	if (!(Getattr(n, "feature:python:callback"))) {
 	  Printv(f_shadow_stubs, "\n",NIL);
-	  Printv(f_shadow_stubs, module, ".", iname, "_swigregister(", module, ")\n", NIL);
-	  Printv(f_shadow_stubs, iname, "_swigregister = ", module, ".", iname, "_swigregister\n", NIL);
+	  Printv(f_shadow_stubs, module, ".", iname, "_swigconstant(", module, ")\n", NIL);
 	  Printv(f_shadow_stubs, iname, " = ", module, ".", iname, "\n", NIL);
 	}
       }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3169,7 +3169,32 @@ public:
       Replaceall(tm, "$source", value);
       Replaceall(tm, "$target", name);
       Replaceall(tm, "$value", value);
-      Printf(f_init, "%s\n", tm);
+      if (!builtin && (shadow) && (!(shadow & PYSHADOW_MEMBER)) && (!in_class || !Getattr(n, "feature:python:callback"))) {
+        // Generate method which registers the new constant
+        Printf(f_wrappers, "SWIGINTERN PyObject* %s_swigregister(PyObject* SWIGUNUSEDPARM(self), PyObject* args) {\n", iname);
+        Printf(f_wrappers, tab2 "PyObject *m;\n", tm);
+	if (modernargs) {
+	  if (fastunpack) {
+	    Printf(f_wrappers, tab2 "if (!SWIG_Python_UnpackTuple(args,(char*)\"swigregister\", 1, 1,&m)) return NULL;\n");
+	  } else {
+	    Printf(f_wrappers, tab2 "if (!PyArg_UnpackTuple(args,(char*)\"swigregister\", 1, 1,&m)) return NULL;\n");
+	  }
+	} else {
+	  Printf(f_wrappers, tab2 "if (!PyArg_ParseTuple(args,(char*)\"O:swigregister\", &m)) return NULL;\n");
+	}
+        Printf(f_wrappers, tab2 "PyObject* d = PyModule_GetDict(m);\n");
+        Printf(f_wrappers, tab2 "if(!d) return NULL;\n");
+        Printf(f_wrappers, tab2 "%s\n", tm);
+        Printf(f_wrappers, tab2 "return SWIG_Py_Void();\n");
+        Printf(f_wrappers, "}\n\n\n");
+
+        // Register the method in SwigMethods array
+	String *cname = NewStringf("%s_swigregister", iname);
+	add_method(cname, cname, 0);
+	Delete(cname);
+      } else {
+        Printf(f_init, "%s\n", tm);
+      }
       Delete(tm);
       have_tm = 1;
     }
@@ -3184,9 +3209,15 @@ public:
 
     if (!builtin && (shadow) && (!(shadow & PYSHADOW_MEMBER))) {
       if (!in_class) {
+	Printv(f_shadow, "\n",NIL);
+	Printv(f_shadow, module, ".", iname, "_swigregister(",module,")\n", NIL);
+	Printv(f_shadow, iname, "_swigregister = ", module, ".", iname, "_swigregister\n", NIL);
 	Printv(f_shadow, iname, " = ", module, ".", iname, "\n", NIL);
       } else {
 	if (!(Getattr(n, "feature:python:callback"))) {
+	  Printv(f_shadow_stubs, "\n",NIL);
+	  Printv(f_shadow_stubs, module, ".", iname, "_swigregister(", module, ")\n", NIL);
+	  Printv(f_shadow_stubs, iname, "_swigregister = ", module, ".", iname, "_swigregister\n", NIL);
 	  Printv(f_shadow_stubs, iname, " = ", module, ".", iname, "\n", NIL);
 	}
       }


### PR DESCRIPTION
With current swig the following simple test case

```swig
%module object_constants

struct Type1 { };
%constant Type1 t1;

%{
  struct Type1 {};
  Type1 t1;
%}
```

does not compile, when generated with ``-builtin`` option. The compilation error is:

```console
swig -python -c++ -builtin -o object_constants_wrap.cxx object_constants.i
g++ -o object_constants_wrap.o -c -fpic -I.  -I/usr/include/python2.7 object_constants_wrap.cxx 
object_constants_wrap.cxx: In function ‘void init_object_constants()’:
object_constants_wrap.cxx:1170:83: error: ‘self’ was not declared in this scope
 #define SWIG_NewPointerObj(ptr, type, flags)            SWIG_Python_NewPointerObj(self, ptr, type, flags)
                                                                                   ^
object_constants_wrap.cxx:4530:70: note: in expansion of macro ‘SWIG_NewPointerObj’
   SWIG_Python_SetConstant(d, d == md ? public_interface : NULL, "t1",SWIG_NewPointerObj(SWIG_as_voidptr(&t1),SWIGTYPE_p_Type1, 0 ));
```

This patch fixes the problem.

**Advice needed**: I've set ``self`` to ``m`` (module) but maybe it should be ``NULL``? Please advise.