### PR TITLE
[Go] Do not start getters with Get

### DIFF
--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -637,8 +637,10 @@ private:
       bool is_set = Strcmp(Char(name) + Len(name) - 4, "_set") == 0;
       assert(is_set || Strcmp(Char(name) + Len(name) - 4, "_get") == 0);
 
-      // Start with Set or Get.
-      go_name = NewString(is_set ? "Set" : "Get");
+      // If this is a setter, start the Go name with Set
+      // If this is a getter, use it directly.
+      // See http://golang.org/doc/effective_go.html#Getters
+      go_name = NewString(is_set ? "Set" : "");
 
       // If this is a static variable, put in the class name,
       // capitalized.


### PR DESCRIPTION
Removes the `Get` prefix from getters in Go.

From their style guide: http://golang.org/doc/effective_go.html#Getters

> Go doesn't provide automatic support for getters and setters. There's nothing wrong with providing getters and setters yourself, and it's often appropriate to do so, but it's neither idiomatic nor necessary to put Get into the getter's name. If you have a field called owner (lower case, unexported), the getter method should be called Owner (upper case, exported), not GetOwner. The use of upper-case names for export provides the hook to discriminate the field from the method. A setter function, if needed, will ikely be called SetOwner. Both names read well in practice: