### PR TITLE
[Go] Ensure structs are properly packed between 8c and GCC/clang

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,9 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.6 (in progress)
 ===========================
 
+2014-02-13: steeve
+            [Go] Ensure structs are properly packed between 8/6c and GCC/clang.
+
 2015-02-09: wsfulton
             [Guile] Fix generated code for static const char member variables when
             defined and declared inline.

--- a/Lib/go/goruntime.swg
+++ b/Lib/go/goruntime.swg
@@ -36,6 +36,24 @@ typedef size_t uintgo;
 %}
 #endif
 
+#ifndef SWIGGO_GCCGO
+// Set the host compiler struct attribute that will be
+// used to match 6c/8c/5c's struct layout. For example, on 386 Windows,
+// gcc wants to 8-align int64s, but 8c does not.
+// Use __gcc_struct__ to work around http://gcc.gnu.org/PR52991 on x86,
+// and http://golang.org/issue/5603.
+// See: https://code.google.com/p/go/source/browse/src/cmd/cgo/out.go?r=22b0839c6cd425dc61f20c34977bc85fb3d7d475#614
+%insert(runtime) %{
+# if !defined(__clang__) && (defined(__i386__) || defined(__x86_64__))
+#   define SWIGSTRUCTPACKED __attribute__((__packed__, __gcc_struct__))
+# else
+#   define SWIGSTRUCTPACKED __attribute__((__packed__))
+# endif
+%}
+#else
+# define SWIGSTRUCTPACKED
+#endif
+
 %insert(runtime) %{
 
 typedef struct { char *p; intgo n; } _gostring_;
@@ -82,7 +100,7 @@ static void *_swig_goallocate(size_t len) {
   struct {
     size_t len;
     void *ret;
-  } a;
+  } SWIGSTRUCTPACKED a;
   a.len = len;
   crosscall2(_cgo_allocate, &a, (int) sizeof a);
   return a.ret;
@@ -91,7 +109,7 @@ static void *_swig_goallocate(size_t len) {
 static void _swig_gopanic(const char *p) {
   struct {
     const char *p;
-  } a;
+  } SWIGSTRUCTPACKED a;
   a.p = p;
   crosscall2(_cgo_panic, &a, (int) sizeof a);
 }

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1524,7 +1524,7 @@ private:
       Delete(ct);
       Delete(ln);
     }
-    Printv(swigargs, "\t} *swig_a = (struct swigargs *) swig_v;\n", NULL);
+    Printv(swigargs, "\t} SWIGSTRUCTPACKED *swig_a = (struct swigargs *) swig_v;\n", NULL);
 
     // Copy the input arguments out of the structure into the Go local
     // variables.
@@ -3217,7 +3217,7 @@ private:
     Printv(f_c_directors, director_sig, NULL);
 
     if (!gccgo_flag) {
-      Printv(f_c_directors, "  struct { void *p; } a;\n", NULL);
+      Printv(f_c_directors, "  struct { void *p; } SWIGSTRUCTPACKED a;\n", NULL);
       Printv(f_c_directors, "  a.p = go_val;\n", NULL);
       Printv(f_c_directors, "  crosscall2(", wname, ", &a, (int) sizeof a);\n", NULL);
 
@@ -4127,7 +4127,7 @@ private:
 	Delete(rname);
       }
 
-      Printv(w->code, "  } swig_a;\n", NULL);
+      Printv(w->code, "  } SWIGSTRUCTPACKED swig_a;\n", NULL);
       Printv(w->code, "  swig_a.go_val = go_val;\n", NULL);
 
       p = parms;


### PR DESCRIPTION
Ensure SWIG generated structs are properly packed.
Without this fix, crashes are seen on windows/386 when calling functions with int64 arguments.

It also mimics what CGO itself [1] does.

[1] https://code.google.com/p/go/source/browse/src/cmd/cgo/out.go?r=22b0839c6cd425dc61f20c34977bc85fb3d7d475#614