### PR TITLE
Ignore another pep8 error.

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -11,7 +11,7 @@ endif
 LANGUAGE     = python
 PYTHON       = $(PYBIN)
 PEP8         = @PEP8@
-PEP8_FLAGS   = --ignore=E501,E30,W291,W391
+PEP8_FLAGS   = --ignore=E402,E501,E30,W291,W391
 
 #*_runme.py for Python 2.x, *_runme3.py for Python 3.x
 PY2SCRIPTSUFFIX = _runme.py


### PR DESCRIPTION
While working on #170 I hadn't initially noticed that we were using fixed 1.5.7 version of pep8 and so tested with its latest master (pre-1.6.0), which gives at least one new error for SWIG-generated code, so I fixed it to make the test suite pass for me.

This is not really urgent to merge right now as this pep8 version is not released yet, but OTOH it shouldn't do any harm. And having a separate `PEP8_FLAGS` will make adding (or removing?) other warnings to it easier in the future.
