### PR TITLE
[Go] Updated Go documentation (examples, runtime.SetFinalizer, object ow...

### DIFF
--- a/Doc/Manual/Go.html
+++ b/Doc/Manual/Go.html
@@ -77,7 +77,7 @@ borne in mind when reading the rest of the SWIG documentation.
 Working examples can be found here:
 </p>
 <ul>
-<li><a href="https://github.com/golang/go/tree/master/misc/swig">Examples from the Go source tree</a>
+<li><a href="https://golang.org/misc/swig">Examples from the Go source tree</a>
 <li><a href="https://github.com/swig/swig/tree/master/Examples/go">Examples from the SWIG source tree</a>
 </ul>
 


### PR DESCRIPTION
...nership).
- Fixes swig/swig#266.
- Added links to working examples.
- Added link to runtime.SetFinalizer documentation.
- Added recommendation to read the runtime.SetFinalizer documentation before using it.
- Clarified that C++ objects ownership is not tracked and thus objects need to be freed manually.
