### PR TITLE
Fix handling of non-first arguments default values in Python.

### DIFF
--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -13,6 +13,12 @@
 %inline %{
   #include <string>
 
+  // All kinds of numbers: hex, octal (which pose special problems to Python), negative...
+  void lots_of_args(int pos = -1, unsigned rgb = 0xabcdef, int mode = 0644) { }
+
+  // Long long arguments are not handled at Python level currently but still work.
+  void seek(long long offset = 0LL) {}
+
   // Anonymous arguments
   int anonymous(int = 7771);
   int anonymous(int x) { return x; }

--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -199,6 +199,7 @@ namespace Space {
 struct Klass {
   int val;
   Klass(int val = -1) : val(val) {}
+  static Klass inc(int n = 1, const Klass& k = Klass()) { return Klass(k.val + n); }
 };
 Klass constructorcall(const Klass& k = Klass()) { return k; }
 

--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -35,6 +35,12 @@
       bool blah(speed s = FAST, flavor f = SWEET) { return (s == FAST && f == SWEET); };
   };
 
+  // using base class enum in a derived class
+  class DerivedEnumClass : public EnumClass {
+  public:
+    void accelerate(speed s = SLOW) { }
+  };
+
   // casts
   const char * casts1(const char *m = (const char *) NULL) {
     char *ret = NULL; 

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1946,12 +1946,15 @@ public:
     if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
       return SwigType_ispointer(t) ? NewString("None") : NewString("0");
 
-    // This could also be an enum type, default value of which is perfectly
-    // representable in Python.
-    Node *lookup = Swig_symbol_clookup(v, 0);
-    if (lookup) {
-      if (Cmp(Getattr(lookup, "nodeType"), "enumitem") == 0)
-	return Getattr(lookup, "sym:name");
+    // This could also be an enum type, default value of which could be
+    // representable in Python if it doesn't include any scope (which could,
+    // but currently is not, translated).
+    if (!Strchr(s, ':')) {
+      Node *lookup = Swig_symbol_clookup(v, 0);
+      if (lookup) {
+	if (Cmp(Getattr(lookup, "nodeType"), "enumitem") == 0)
+	  return Getattr(lookup, "sym:name");
+      }
     }
 
     return NIL;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1861,15 +1861,19 @@ public:
     Parm *pnext;
 
     for (p = plist; p; p = pnext) {
+      pnext = NIL;
       String *tm = Getattr(p, "tmap:in");
       if (tm) {
 	pnext = Getattr(p, "tmap:in:next");
 	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
 	  continue;
 	}
-      } else {
+      }
+
+      if (!pnext) {
 	pnext = nextSibling(p);
       }
+
       if (String *value = Getattr(p, "value")) {
 	String *type = Getattr(p, "type");
 	if (!convertValue(value, type))


### PR DESCRIPTION
This fixes the bug reported in the "Default argument not being added to wrapped Python .py File" mailing list thread.

Please review as I don't really understand the semantics of `tmap:in:next`. I hadn't touched this code at all in the commit that broke it (15b3690) exactly because of this, even though it did seem suspicious to me, but it turns out that it's more than suspicious and simply wrong, as in the case of the new unit test this result in simply not checking the second parameter at all because `tmap:in:next` is null and so we exit the loop in `is_representable_as_pyargs()` after the first iteration.

Unfortunately I don't know where does this code come from, it appears in git since 3d8ddfc4, but this commit ("Python 3.0 branch merge") is too huge to be able to extract anything useful from it.

Also notice that there is another instance of the same code in `make_autodocParmList()`, but fixing it there in the same way broke `autodoc` and `char_binary` tests, so I didn't touch it. It's worrisome that the code which seems clearly wrong to me is needed to make the tests work currently though...

Commit message:

---
Since 15b3690, non-first arguments with default values of non-primitive types
were not used in Python wrappers, resulting in invalid Python code if the
preceding arguments did have default values.

This happened because is_representable_as_pyargs() didn't check any arguments
except the first one at all in most cases because it used tmap:in:next
unconditionally, but it is usually null. Fall back on the next argument in the
function parameter list now to fix this.