### PR TITLE
add @SuppressWarnings("unused") to constructors generated using SWIG_JAV...

### DIFF
--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1181,7 +1181,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(javabody) TYPE *, TYPE &, TYPE &&, TYPE [] %{
   private long swigCPtr;
 
-  PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean futureUse) {
+  PTRCTOR_VISIBILITY $javaclassname(long cPtr, @SuppressWarnings("unused") boolean futureUse) {
     swigCPtr = cPtr;
   }
 
@@ -1197,7 +1197,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(javabody) TYPE (CLASS::*) %{
   private String swigCMemberPtr;
 
-  PTRCTOR_VISIBILITY $javaclassname(String cMemberPtr, boolean futureUse) {
+  PTRCTOR_VISIBILITY $javaclassname(String cMemberPtr, @SuppressWarnings("unused") boolean futureUse) {
     swigCMemberPtr = cMemberPtr;
   }
 


### PR DESCRIPTION
...ABODY_TYPEWRAPPER macro