### PR TITLE
Avoid collisions with the 'check' word on apple clang

### DIFF
--- a/Lib/octave/octcontainer.swg
+++ b/Lib/octave/octcontainer.swg
@@ -46,7 +46,7 @@ namespace swig {
   
   template <> 
   struct traits_check<octave_value, value_category> {
-    static bool check(const octave_value&) {
+    static bool swig_check_obj(const octave_value&) {
       return true;
     }
   };
@@ -400,13 +400,13 @@ namespace swig
       return const_reference(_seq, n);
     }
 
-    bool check(bool set_err = true) const
+    bool swig_check_obj(bool set_err = true) const
     {
       int s = size();
       for (int i = 0; i < s; ++i) {
 	//	swig::SwigVar_PyObject item = OctSequence_GetItem(_seq, i);
 	octave_value item; // * todo
-	if (!swig::check<value_type>(item)) {
+	if (!swig::swig_check_obj<value_type>(item)) {
 	  if (set_err) {
 	    char msg[1024];
 	    sprintf(msg, "in sequence element %d", i);
@@ -575,7 +575,7 @@ namespace swig {
 	    *seq = pseq;
 	    return SWIG_NEWOBJ;
 	  } else {
-	    return octseq.check() ? SWIG_OK : SWIG_ERROR;
+	    return octseq.swig_check_obj() ? SWIG_OK : SWIG_ERROR;
 	  }
 	} catch (std::exception& e) {
 	  if (seq&&!error_state)

--- a/Lib/octave/octstdcommon.swg
+++ b/Lib/octave/octstdcommon.swg
@@ -165,7 +165,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, value_category> {
-    static bool check(const octave_value& obj) {
+    static bool swig_check_obj(const octave_value& obj) {
       int res = asval(obj, (Type *)(0));
       return SWIG_IsOK(res) ? true : false;
     }
@@ -173,15 +173,15 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, pointer_category> {
-    static bool check(const octave_value& obj) {
+    static bool swig_check_obj(const octave_value& obj) {
       int res = asptr(obj, (Type **)(0));
       return SWIG_IsOK(res) ? true : false;
     }
   };
 
   template <class Type>
-  inline bool check(const octave_value& obj) {
-    return traits_check<Type, typename traits<Type>::category>::check(obj);
+  inline bool swig_check_obj(const octave_value& obj) {
+    return traits_check<Type, typename traits<Type>::category>::swig_check_obj(obj);
   }
 }
 }
@@ -208,7 +208,7 @@ namespace swig {
 
   template <> 
   struct traits_check<Type, value_category> {
-    static int check(const octave_value& obj) {
+    static int swig_check_obj(const octave_value& obj) {
       int res = Check(obj);
       return obj && res ? res : 0;
     }

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -54,7 +54,7 @@ namespace swig {
   
   template <> 
   struct traits_check<SwigPtr_PyObject, value_category> {
-    static bool check(SwigPtr_PyObject) {
+    static bool swig_check_obj(SwigPtr_PyObject) {
       return true;
     }
   };
@@ -87,7 +87,7 @@ namespace swig {
   
   template <> 
   struct traits_check<SwigVar_PyObject, value_category> {
-    static bool check(SwigVar_PyObject) {
+    static bool swig_check_obj(SwigVar_PyObject) {
       return true;
     }
   };
@@ -170,7 +170,7 @@ namespace swig {
 
   template <> 
   struct traits_check<PyObject *, value_category> {
-    static bool check(PyObject *) {
+    static bool swig_check_obj(PyObject *) {
       return true;
     }
   };
@@ -619,12 +619,12 @@ namespace swig
       return const_reference(_seq, n);
     }
 
-    bool check(bool set_err = true) const
+    bool swig_check_obj(bool set_err = true) const
     {
       int s = size();
       for (int i = 0; i < s; ++i) {
 	swig::SwigVar_PyObject item = PySequence_GetItem(_seq, i);
-	if (!swig::check<value_type>(item)) {
+	if (!swig::swig_check_obj<value_type>(item)) {
 	  if (set_err) {
 	    char msg[1024];
 	    sprintf(msg, "in sequence element %d", i);
@@ -957,7 +957,7 @@ namespace swig {
 	    *seq = pseq;
 	    return SWIG_NEWOBJ;
 	  } else {
-	    return swigpyseq.check() ? SWIG_OK : SWIG_ERROR;
+	    return swigpyseq.swig_check_obj() ? SWIG_OK : SWIG_ERROR;
 	  }
 	} catch (std::exception& e) {
 	  if (seq) {

--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -169,7 +169,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, value_category> {
-    static bool check(PyObject *obj) {
+    static bool swig_check_obj(PyObject *obj) {
       int res = obj ? asval(obj, (Type *)(0)) : SWIG_ERROR;
       return SWIG_IsOK(res) ? true : false;
     }
@@ -177,15 +177,15 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, pointer_category> {
-    static bool check(PyObject *obj) {
+    static bool swig_check_obj(PyObject *obj) {
       int res = obj ? asptr(obj, (Type **)(0)) : SWIG_ERROR;
       return SWIG_IsOK(res) ? true : false;
     }
   };
 
   template <class Type>
-  inline bool check(PyObject *obj) {
-    return traits_check<Type, typename traits<Type>::category>::check(obj);
+  inline bool swig_check_obj(PyObject *obj) {
+    return traits_check<Type, typename traits<Type>::category>::swig_check_obj(obj);
   }
 }
 }
@@ -241,7 +241,7 @@ namespace swig {
 
   template <> 
   struct traits_check<Type, value_category> {
-    static int check(PyObject *obj) {
+    static int swig_check_obj(PyObject *obj) {
       int res = Check(obj);
       return obj && res ? res : 0;
     }

--- a/Lib/r/rstdcommon.swg
+++ b/Lib/r/rstdcommon.swg
@@ -157,7 +157,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, value_category> {
-    static bool check(SWIG_Object obj) {
+    static bool swig_check_obj(SWIG_Object obj) {
       int res = obj ? asval(obj, (Type *)(0)) : SWIG_ERROR;
       return SWIG_IsOK(res) ? true : false;
     }
@@ -165,15 +165,15 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, pointer_category> {
-    static bool check(SWIG_Object obj) {
+    static bool swig_check_obj(SWIG_Object obj) {
       int res = obj ? asptr(obj, (Type **)(0)) : SWIG_ERROR;
       return SWIG_IsOK(res) ? true : false;
     }
   };
 
   template <class Type>
-  inline bool check(SWIG_Object obj) {
-    return traits_check<Type, typename traits<Type>::category>::check(obj);
+  inline bool swig_check_obj(SWIG_Object obj) {
+    return traits_check<Type, typename traits<Type>::category>::swig_check_obj(obj);
   }
 }
 }
@@ -200,7 +200,7 @@ namespace swig {
 
   template <> 
   struct traits_check<Type, value_category> {
-    static int check(SWIG_Object obj) {
+    static int swig_check_obj(SWIG_Object obj) {
       int res = Check(obj);
       return obj && res ? res : 0;
     }

--- a/Lib/ruby/rubyclasses.swg
+++ b/Lib/ruby/rubyclasses.swg
@@ -384,7 +384,7 @@ namespace swig {
   
   template <> 
   struct traits_check<GC_VALUE, value_category> {
-    static bool check(GC_VALUE) {
+    static bool swig_check_obj(GC_VALUE) {
       return true;
     }
   };

--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -393,12 +393,12 @@ namespace swig
       return const_reference(_seq, n);
     }
 
-    bool check(bool set_err = false) const
+    bool swig_check_obj(bool set_err = false) const
     {
       int s = (int) size();
       for (int i = 0; i < s; ++i) {
 	VALUE item = rb_ary_entry(_seq, i );
-	if (!swig::check<value_type>(item)) {
+	if (!swig::swig_check_obj<value_type>(item)) {
 	  if (set_err) {
 	    char msg[1024];
 	    sprintf(msg, "in sequence element %d", i);
@@ -993,7 +993,7 @@ namespace swig {
 	    *seq = pseq;
 	    return SWIG_NEWOBJ;
 	  } else {
-	    return rubyseq.check() ? SWIG_OK : SWIG_ERROR;
+	    return rubyseq.swig_check_obj() ? SWIG_OK : SWIG_ERROR;
 	  }
 	} catch (std::exception& e) {
 	  if (seq) {

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -179,7 +179,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, value_category> {
-    static bool check(VALUE obj) {
+    static bool swig_check_obj(VALUE obj) {
       int res = obj ? asval(obj, (Type *)(0)) : SWIG_ERROR;
       return SWIG_IsOK(res) ? true : false;
     }
@@ -187,15 +187,15 @@ namespace swig {
 
   template <class Type> 
   struct traits_check<Type, pointer_category> {
-    static bool check(VALUE obj) {
+    static bool swig_check_obj(VALUE obj) {
       int res = obj ? asptr(obj, (Type **)(0)) : SWIG_ERROR;
       return SWIG_IsOK(res) ? true : false;
     }
   };
 
   template <class Type>
-  inline bool check(VALUE obj) {
-    return traits_check<Type, typename traits<Type>::category>::check(obj);
+  inline bool swig_check_obj(VALUE obj) {
+    return traits_check<Type, typename traits<Type>::category>::swig_check_obj(obj);
   }
 }
 }

--- a/Lib/scilab/scicontainer.swg
+++ b/Lib/scilab/scicontainer.swg
@@ -378,7 +378,7 @@ namespace swig {
           }
       }
 
-      if (traits_as_sequence<value_type>::check(obj) == SWIG_OK)
+      if (traits_as_sequence<value_type>::swig_check_obj(obj) == SWIG_OK)
       {
         try
         {

--- a/Lib/scilab/scisequence.swg
+++ b/Lib/scilab/scisequence.swg
@@ -46,7 +46,7 @@
 namespace swig {
   // Error returned for sequence containers of default item type
   template <typename T> struct traits_as_sequence {
-    static int check(SwigSciObject obj) {
+    static int swig_check_obj(SwigSciObject obj) {
       SWIG_Error(SWIG_TypeError, type_name<T>());
     }
     static int get(SwigSciObject obj, void **sequence) {
@@ -67,7 +67,7 @@ namespace swig {
 
   // Support sequence containers of pointers
   template <typename T> struct traits_as_sequence<T*> {
-    static int check(SwigSciObject obj) {
+    static int swig_check_obj(SwigSciObject obj) {
       return SWIG_AsCheck_Sequence_dec(ptr)(obj);
     }
     static int get(SwigSciObject obj, void **sequence) {
@@ -99,7 +99,7 @@ namespace swig {
 
 namespace swig {
   template <> struct traits_as_sequence<CppType > {
-    static int check(SwigSciObject obj) {
+    static int swig_check_obj(SwigSciObject obj) {
       return SWIG_AsCheck_Sequence_dec(CppType)(obj);
     }
     static int get(SwigSciObject obj, void **sequence) {

--- a/Lib/scilab/scistdcommon.swg
+++ b/Lib/scilab/scistdcommon.swg
@@ -165,7 +165,7 @@ namespace swig {
 
   template <class Type>
   struct traits_check<Type, value_category> {
-    static bool check(const SwigSciObject& obj) {
+    static bool swig_check_obj(const SwigSciObject& obj) {
       int res = asval(obj, (Type *)(0));
       return SWIG_IsOK(res) ? true : false;
     }
@@ -173,15 +173,15 @@ namespace swig {
 
   template <class Type>
   struct traits_check<Type, pointer_category> {
-    static bool check(const SwigSciObject& obj) {
+    static bool swig_check_obj(const SwigSciObject& obj) {
       int res = asptr(obj, (Type **)(0));
       return SWIG_IsOK(res) ? true : false;
     }
   };
 
   template <class Type>
-  inline bool check(const SwigSciObject& obj) {
-    return traits_check<Type, typename traits<Type>::category>::check(obj);
+  inline bool swig_check_obj(const SwigSciObject& obj) {
+    return traits_check<Type, typename traits<Type>::category>::swig_check_obj(obj);
   }
 }
 }
@@ -208,7 +208,7 @@ namespace swig {
 
   template <>
   struct traits_check<Type, value_category> {
-    static int check(const SwigSciObject& obj) {
+    static int swig_check_obj(const SwigSciObject& obj) {
       int res = Check(obj);
       return obj && res ? res : 0;
     }


### PR DESCRIPTION
When compiling [Shogun](https://github.com/shogun-toolbox/shogun) with swig 3.0.5 on Mac OS X Yosemite with `clang -v`:

```
Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin14.0.0
Thread model: posix
```
a few compilation errors occur: 

```
.../modshogunPYTHON_wrap.cxx:7682:38: error: expected member name or ';' after declaration specifiers
    static bool check(PyObject *obj) {
```

After some research I found that it is due to the word 'check' used here that interferes with something else (apparently no symbol named 'check' is in the scope). Changing names of static member functions that check pyobjects helps to solve the problem and compile the wrapper. Maybe some simpler reproducing example is possible - please tell me whether it is needed.