### PR TITLE
Fix build on S390(x)-architecture

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,8 @@ then
 		 then CCSHARED="-fpic"
 		 else CCSHARED="+z"
 		 fi;;
+	s390x*-*-*) CCSHARED="-fpic" ;;
+	s390*-*-*) CCSHARED="-fPIC" ;;
 	*-*-linux*) CCSHARED="-fpic";;
 	*-*-freebsd* | *-*-openbsd*) CCSHARED="-fpic";;
 	*-*-netbsd*) CCSHARED="-fPIC";;


### PR DESCRIPTION
A simple patch to `configure.ac` for properly adding `-fPIC`-flag on S390(x)-arches.