### PR TITLE
Deal with Apple's deprecated 'AssertMacros.h' from Carbon-framework

### DIFF
--- a/Lib/swiglabels.swg
+++ b/Lib/swiglabels.swg
@@ -106,3 +106,7 @@
 # define _SCL_SECURE_NO_DEPRECATE
 #endif
 
+/* Deal with Apple's deprecated 'AssertMacros.h' from Carbon-framework */
+#if defined(__APPLE__) && !defined(__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES)
+# define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
+#endif


### PR DESCRIPTION
As suggested by @ojwb in https://github.com/swig/swig/pull/324#issuecomment-73623121.