### PR TITLE
Allow configuration of behaviour when there is a Director Error in Python

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -3078,6 +3078,27 @@ Swig::DirectorMethodException is thrown, Python will register the
 exception as soon as the C wrapper function returns.
 </p>
 
+<p>
+If it gets into trouble running a method implemented in Python, Swig will use
+exceptions derived from Swig::DirectorException.  In some environments an
+alternate mechanism may be desired for handling these errors. This could be the
+case in environments that disallow C++ exceptions, for instance.  This
+customization can be performed by placing code into %section("director_error").
+Any code placed in that section will be run when an error occurs, replacing the
+default code which simply throws an exception.  The string $exception can be
+used to refer to the exception object that would normally have been thrown.
+</p>
+
+<div class="code">
+<pre>
+%section("director_error")
+%{
+    printf("Director error: %s\n", $exception.what());
+    exit(100);
+%}
+</pre>
+</div>
+
 <H3><a name="Python_nn37"></a>36.5.5 Overhead and code bloat</H3>
 
 

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -3083,7 +3083,7 @@ If it gets into trouble running a method implemented in Python, Swig will use
 exceptions derived from Swig::DirectorException.  In some environments an
 alternate mechanism may be desired for handling these errors. This could be the
 case in environments that disallow C++ exceptions, for instance.  This
-customization can be performed by placing code into %section("director_error").
+customization can be performed by placing code into %insert("director_error").
 Any code placed in that section will be run when an error occurs, replacing the
 default code which simply throws an exception.  The string $exception can be
 used to refer to the exception object that would normally have been thrown.
@@ -3091,7 +3091,7 @@ used to refer to the exception object that would normally have been thrown.
 
 <div class="code">
 <pre>
-%section("director_error")
+%insert("director_error")
 %{
     printf("Director error: %s\n", $exception.what());
     exit(100);

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -59,6 +59,7 @@ CPP_TEST_CASES += \
 	python_abstractbase \
 	python_append \
 	python_director \
+	python_director_error \
 	python_nondynamic \
 	python_overload_simple_cast \
 	python_richcompare \

--- a/Examples/test-suite/python/python_director_error_runme.py
+++ b/Examples/test-suite/python/python_director_error_runme.py
@@ -1,0 +1,29 @@
+import python_director_error
+
+class MyException(Exception):
+  pass
+
+go_called_count = 0
+class Derived(python_director_error.Foo):
+  def go(self):
+    global go_called_count
+    go_called_count += 1
+    raise MyException
+
+if go_called_count != 0:
+  raise RuntimeError, "go_called_count before"
+if python_director_error.GetExceptionCount() != 0:
+  raise RuntimeError, "GetExceptionCount() before"
+
+f = Derived()
+try:
+  python_director_error.CallGo(f);
+  raise RuntimeError # Callee should have exited with an exception.
+except MyException:
+  pass
+
+if go_called_count != 1:
+  raise RuntimeError, "go_called_count after"
+if python_director_error.GetExceptionCount() != 1:
+  raise RuntimeError, "GetExceptionCount() after: %i" % python_director_error.GetExceptionCount()
+

--- a/Examples/test-suite/python_director_error.i
+++ b/Examples/test-suite/python_director_error.i
@@ -1,0 +1,43 @@
+%module(directors="1") python_director_error
+%insert("director_error")
+%{
+  exception_count++;
+  throw $exception;
+%}
+
+%exception {
+  try { $action }
+  catch (Swig::DirectorException &e) { SWIG_fail; }
+}
+
+%{
+#include <string>
+
+class Foo {
+public:
+  virtual void go() = 0;
+  virtual ~Foo() {};
+};
+
+static int exception_count;
+
+int GetExceptionCount() {
+  return exception_count;
+}
+
+void CallGo(Foo *foo) {
+  foo->go();
+}
+
+%}
+
+%feature("director") Foo;
+
+class Foo {
+public:
+  virtual ~Foo();
+  virtual void go() = 0;
+};
+
+int GetExceptionCount();
+void CallGo(Foo *foo);

--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -171,6 +171,9 @@ namespace Swig {
     Type *_ptr;
   };
 
+  template <class ExceptionType>
+  void ThrowDirectorException(const ExceptionType &exception);
+
   /* base class for director exceptions */
   class DirectorException : public std::exception {
   protected:
@@ -201,7 +204,7 @@ namespace Swig {
     }
 
     static void raise(PyObject *error, const char *msg) {
-      throw DirectorException(error, msg);
+      ThrowDirectorException(DirectorException(error, msg));
     }
 
     static void raise(const char *msg) {
@@ -261,11 +264,11 @@ namespace Swig {
     }
 
     static void raise(PyObject *error, const char *msg) {
-      throw DirectorTypeMismatchException(error, msg);
+      ThrowDirectorException(DirectorTypeMismatchException(error, msg));
     }
 
     static void raise(const char *msg) {
-      throw DirectorTypeMismatchException(msg);
+      ThrowDirectorException(DirectorTypeMismatchException(msg));
     }
   };
 
@@ -277,7 +280,7 @@ namespace Swig {
     }
 
     static void raise(const char *msg) {
-      throw DirectorMethodException(msg);
+      ThrowDirectorException(DirectorMethodException(msg));
     }
   };
 


### PR DESCRIPTION
This changeset allows directors to be used in Python without using C++ exceptions by allowing the user to indicate which action to take when a DirectorException is raised.

I am not entirely satisfied with my use of %insert to describe the action to take on exception and am open to comments on how to do it better. Using %feature would be nice, and I will happily make that change if somebody points me to an example of a %feature that only applies globally. Alternatively, using a #define similar to SWIG_DIRECTOR_UEH would also work for me. (Except that that macro would expand to whatever error handling code you want rather than just be a flag.)