### PR TITLE
Added SWIG #define to call v8 garbage collector

### DIFF
--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -42,12 +42,14 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #endif
 
 #if (SWIG_V8_VERSION < 0x032224)
+#define SWIGV8_GC() v8::V8::IdleNotification()
 #define SWIGV8_ADJUST_MEMORY(size) v8::V8::AdjustAmountOfExternalAllocatedMemory(size)
 #define SWIGV8_CURRENT_CONTEXT() v8::Context::GetCurrent()
 #define SWIGV8_THROW_EXCEPTION(err) v8::ThrowException(err)
 #define SWIGV8_STRING_NEW(str) v8::String::New(str)
 #define SWIGV8_SYMBOL_NEW(sym) v8::String::NewSymbol(sym)
 #else
+#define SWIGV8_GC() v8::Isolate::GetCurrent()->IdleNotification()
 #define SWIGV8_ADJUST_MEMORY(size) v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(size)
 #define SWIGV8_CURRENT_CONTEXT() v8::Isolate::GetCurrent()->GetCurrentContext()
 #define SWIGV8_THROW_EXCEPTION(err) v8::Isolate::GetCurrent()->ThrowException(err)


### PR DESCRIPTION
The destructors in our nodeJS-wrapped C++ classes weren’t being invoked— even on termination.
v8 doesn’t guarantee gc— even on scope closing or program termination.
We need to call gc manually.
Adding a #define lets us call 1 SWIG function that will be maintained— instead of having many #ifdefs.
