### PR TITLE
Fix handling of "default" typemap in Python.

### DIFF
--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -114,6 +114,8 @@
 %rename(renamed2arg) Foo::renameme(int x) const;
 %rename(renamed1arg) Foo::renameme() const;
 
+%typemap(default) double* null_by_default "$1=0;";
+
 %inline %{
 
   // Define a class
@@ -139,6 +141,9 @@
       // test the method itself being renamed
       void oldname(int x = 1234) {}
       void renameme(int x = 1234, double d=123.4) const {}
+
+      int double_if_dbl_ptr_is_null(int n, double* null_by_default)
+        { return null_by_default ? n : 2*n; }
   };
   int Foo::bar = 1;
   int Foo::spam = 2;

--- a/Examples/test-suite/python/default_args_runme.py
+++ b/Examples/test-suite/python/default_args_runme.py
@@ -32,6 +32,12 @@ def run(module_name):
   f.newname(1)
 
 
+  if f.double_if_dbl_ptr_is_null(6, None) != 12:
+    raise RuntimeError
+
+  if f.double_if_dbl_ptr_is_null(7) != 14:
+    raise RuntimeError
+
   try:
     f = default_args.Foo(1)
     error = 1


### PR DESCRIPTION
Use "compact" arguments form for the function if "default" typemap is defined
for any of its arguments to allow omitting this argument when calling it from
Python.

Closes #330, #377.