### PR TITLE
Add some generated example files to the .gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,6 @@ Examples/python/import_template/spam.py
 # Scilab generated files
 loader.sce
 
-# Pearl Examples generated files
+# Perl5 Examples generated files
 Examples/test-suite/perl5/*.pm
 Examples/test-suite/perl5/*.h

--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,36 @@ Examples/test-suite/octave/*.oct
 *.py[cod]
 */__pycache__/
 /__pycache__/
+Examples/python/*/example.py
+Examples/python/*/example_wrap.h
+Examples/python/import/bar.py
+Examples/python/import/base.py
+Examples/python/import/foo.py
+Examples/python/import/spam.py
+Examples/python/import_packages/from_init1/py2/pkg2/bar.py
+Examples/python/import_packages/from_init1/py2/pkg2/foo.py
+Examples/python/import_packages/from_init2/py2/pkg2/bar.py
+Examples/python/import_packages/from_init2/py2/pkg2/pkg3/foo.py
+Examples/python/import_packages/from_init3/py2/pkg2/bar.py
+Examples/python/import_packages/from_init3/py2/pkg2/pkg3/pkg4/foo.py
+Examples/python/import_packages/relativeimport1/py2/pkg2/bar.py
+Examples/python/import_packages/relativeimport1/py2/pkg2/pkg3/foo.py
+Examples/python/import_packages/relativeimport2/py2/pkg2/bar.py
+Examples/python/import_packages/relativeimport2/py2/pkg2/pkg3/pkg4/foo.py
+Examples/python/import_packages/relativeimport3/py2/pkg2/bar.py
+Examples/python/import_packages/relativeimport3/py2/pkg2/pkg3/foo.py
+Examples/python/import_packages/same_modnames1/pkg1/foo.py
+Examples/python/import_packages/same_modnames1/pkg2/foo.py
+Examples/python/import_packages/same_modnames2/pkg1/foo.py
+Examples/python/import_packages/same_modnames2/pkg1/pkg2/foo.py
+Examples/python/import_template/bar.py
+Examples/python/import_template/base.py
+Examples/python/import_template/foo.py
+Examples/python/import_template/spam.py
 
 # Scilab generated files
 loader.sce
 
+# Pearl Examples generated files
+Examples/test-suite/perl5/*.pm
+Examples/test-suite/perl5/*.h


### PR DESCRIPTION
After running make -k check I was left with a bunch of generated files showing up as untracked files.  Added some rules to .gitignore to deal with them for python and perl5 to reduce how many showed up