### PR TITLE
Fix SWIG Python builtin custom exception

### DIFF
--- a/Examples/python/exception/runme.py
+++ b/Examples/python/exception/runme.py
@@ -20,17 +20,10 @@ try:
 except RuntimeError,e:
       print e.args[0]
 
-if not example.is_python_builtin():
-  try:
-        t.hosed()
-  except example.Exc,e:
-        print e.code, e.msg
-else:
-  try:
-        t.hosed()
-  except BaseException,e:
-        # Throwing builtin classes as exceptions not supported (-builtin option)
-        print e
+try:
+      t.hosed()
+except example.Exc,e:
+      print e.code, e.msg
 
 for i in range(1,4):
       try:

--- a/Examples/test-suite/python/exception_order_runme.py
+++ b/Examples/test-suite/python/exception_order_runme.py
@@ -1,10 +1,5 @@
 from exception_order import *
 
-# This test is expected to fail with -builtin option.
-# Throwing builtin classes as exceptions not supported
-if is_python_builtin():
-  exit(0)
-
 a = A()
 
 try:

--- a/Examples/test-suite/python/li_std_except_as_class_runme.py
+++ b/Examples/test-suite/python/li_std_except_as_class_runme.py
@@ -1,18 +1,9 @@
 from li_std_except_as_class import *
 
-# This test is expected to fail with -builtin option.
-# Throwing builtin classes as exceptions not supported
-if is_python_builtin():
-  try: test_domain_error()
-  except RuntimeError: pass
-  try: test_domain_error()
-  except RuntimeError: pass
-  try: test_domain_error()
-  except RuntimeError: pass
-else:
-  # std::domain_error hierarchy
-  try: test_domain_error()
-  except domain_error: pass
+try: test_domain_error()
+except domain_error: pass
+
+if not is_python_builtin():
   try: test_domain_error()
   except logic_error: pass
   try: test_domain_error()

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -301,11 +301,19 @@ SWIG_Python_CheckImplicit(swig_type_info *ty)
 
 SWIGRUNTIMEINLINE PyObject *
 SWIG_Python_ExceptionType(swig_type_info *desc) {
+  PyObject *ptr;
   SwigPyClientData *data = desc ? (SwigPyClientData *) desc->clientdata : 0;
-  PyObject *klass = data ? data->klass : 0;
-  return (klass ? klass : PyExc_RuntimeError);
+
+#ifdef SWIGPYTHON_BUILTIN
+  ptr = data ? (PyObject *) data->pytype : 0;
+#else
+  ptr = data ? data->klass : 0;
+#endif
+  return (ptr ? ptr : PyExc_RuntimeError);
 }
 
+
+#ifndef SWIGPYTHON_BUILTIN
 
 SWIGRUNTIME SwigPyClientData * 
 SwigPyClientData_New(PyObject* obj)
@@ -360,6 +368,8 @@ SwigPyClientData_New(PyObject* obj)
     return data;
   }
 }
+
+#endif
 
 SWIGRUNTIME void 
 SwigPyClientData_Del(SwigPyClientData *data) {


### PR DESCRIPTION
When builtin mode is enabled, triggering custom exception object didn't work
and always lead to SWIG_RuntimeError exception.

We can now enable the exception_order_runme test when using builtin.
