### PR TITLE
Zero-initialize swig_override in the director constructor.

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -198,6 +198,7 @@ CPP_TEST_CASES += \
 	director_protected \
 	director_protected_overloaded \
 	director_redefined \
+	director_ref \
 	director_smartptr \
 	director_thread \
 	director_unroll \

--- a/Examples/test-suite/director_ref.i
+++ b/Examples/test-suite/director_ref.i
@@ -1,0 +1,82 @@
+%module(directors="1") director_ref
+
+%{
+#include <string>
+
+class Foo {
+public:
+        Foo(int i = -1) : count(0) {}
+	virtual void OnDelete() {}
+	virtual ~Foo() {}
+	virtual std::string Msg(std::string msg = "default") { return "Foo-" + msg; }
+
+	std::string GetMsg() { return Msg(); }
+	std::string GetMsg(std::string msg) { return Msg(msg); }
+
+	void Ref() { ++count; }
+	void Unref() { --count; if (count == 0) { OnDelete(); delete this; } }
+	int GetRefCount() { return count; }
+private:
+	int count;
+};
+
+class FooPtr {
+public:
+        FooPtr(Foo* f = NULL) : my_f(f) { if (my_f) { my_f->Ref(); } }
+        ~FooPtr() { if (my_f) { my_f->Unref(); } }
+        void Reset(Foo* f = NULL) {
+		if (f) { f->Ref(); }
+		if (my_f) { my_f->Unref(); }
+		my_f = f;
+	}
+	int GetOwnedRefCount() {
+		if (my_f) { return my_f->GetRefCount(); }
+		return 0;
+	}
+
+private:
+        Foo* my_f;
+};
+
+%}
+
+%include <std_string.i>
+
+%feature("director") Foo;
+%feature("ref") Foo "$this->Ref();"
+%feature("unref") Foo "$this->Unref();"
+
+class Foo {
+public:
+        Foo(int i = -1) : count(0) {}
+	virtual void OnDelete() {}
+	virtual ~Foo() {}
+	virtual std::string Msg(std::string msg = "default") { return "Foo-" + msg; }
+
+	std::string GetMsg() { return Msg(); }
+	std::string GetMsg(std::string msg) { return Msg(msg); }
+
+	void Ref() { ++count; }
+	void Unref() { --count; if (count == 0) { OnDelete(); delete this; } }
+	int GetRefCount() { return count; }
+private:
+	int count;
+};
+
+class FooPtr {
+public:
+        FooPtr(Foo* f = NULL) : my_f(f) { if (my_f) { my_f->Ref(); } }
+        ~FooPtr() { if (my_f) { my_f->Unref(); } }
+        void Reset(Foo* f = NULL) {
+		if (f) { f->Ref(); }
+		if (my_f) { my_f->Unref(); }
+		my_f = f;
+	}
+	int GetOwnedRefCount() {
+		if (my_f) { return my_f->GetRefCount(); }
+		return 0;
+	}
+
+private:
+        Foo* my_f;
+};

--- a/Examples/test-suite/java/director_ref_runme.java
+++ b/Examples/test-suite/java/director_ref_runme.java
@@ -1,0 +1,71 @@
+
+import director_ref.*;
+
+public class director_ref_runme {
+
+  static {
+    try {
+      System.loadLibrary("director_ref");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+    director_ref_MyFoo a = new director_ref_MyFoo();
+    if (a.GetRefCount() != 1) {
+      throw new RuntimeException ( "Refcount test 1 failed." );
+    }
+    
+    // Make sure director logic still works.
+    if (!a.GetMsg().equals("director_ref_MyFoo-default")) {
+      throw new RuntimeException ( "Test 1 failed" );
+    }
+    if (!a.GetMsg("boo").equals("director_ref_MyFoo-boo")) {
+      throw new RuntimeException ( "Test 2 failed" );
+    }
+
+    a.delete();  // should delete the object.
+    if (a.cppDeleted != true) {
+      throw new RuntimeException ( "Unref test 1 failed." );
+    }
+
+    a = new director_ref_MyFoo();
+    FooPtr p = new FooPtr(a);
+    if (a.GetRefCount() != 2) {
+      throw new RuntimeException ( "Refcount test 2 failed." );
+    }
+    a.delete();  // Shouldn't actually delete the underlying object
+    if (a.cppDeleted) {
+      throw new RuntimeException ( "Unref test 2 failed." );
+    }
+    if (p.GetOwnedRefCount() != 1) {
+      throw new RuntimeException ( "Unref test 3 failed." );
+    }
+    p.Reset();  // Now it should be deleted on the cpp side.
+    // We can't check cppDeleted because the director will stop
+    // working after a delete() call.
+    if (p.GetOwnedRefCount() != 0) {
+      throw new RuntimeException ( "Unref test 4 failed." );
+    }
+  }
+}
+
+class director_ref_MyFoo extends Foo {
+    public director_ref_MyFoo() {
+      super();
+    }
+    public director_ref_MyFoo(int i) {
+      super(i);
+    }
+    public String Msg(String msg) { 
+      return "director_ref_MyFoo-" + msg; 
+    }
+    public void OnDelete() {
+      cppDeleted = true;
+    }
+
+    public boolean cppDeleted = false;
+}
+

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -4301,8 +4301,6 @@ public:
       }
     }
 
-    int n_methods = curr_class_dmethod - first_class_dmethod;
-
     /* insert jenv prefix argument */
     parms = CopyParmList(superparms);
 
@@ -4323,9 +4321,7 @@ public:
 	String *classtype = SwigType_namestr(Getattr(n, "name"));
 
 	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
-	if (n_methods) {
-	  Printf(f_directors, "  memset(swig_override, 0, sizeof(swig_override));\n");
-	}
+	Printf(f_directors, "  memset(swig_override, 0, sizeof(swig_override));\n");
 	Printf(f_directors, "}\n\n");
 
 	Delete(classtype);
@@ -4359,12 +4355,8 @@ public:
     String *dirClassName = directorClassName(n);
     Wrapper *w = NewWrapper();
 
-    int n_methods = curr_class_dmethod - first_class_dmethod;
-
     Printf(w->def, "%s::%s(JNIEnv *jenv) : %s {", dirClassName, dirClassName, Getattr(n, "director:ctor"));
-    if (n_methods) {
-      Printf(w->code, "  memset(swig_override, 0, sizeof(swig_override));\n");
-    }
+    Printf(w->code, "  memset(swig_override, 0, sizeof(swig_override));\n");
     Printf(w->code, "}\n");
     Wrapper_print(w, f_directors);
 
@@ -4539,6 +4531,8 @@ public:
       Printf(f_directors_h, "    bool swig_overrides(int n) {\n");
       Printf(f_directors_h, "      return false;\n");
       Printf(f_directors_h, "    }\n");
+      Printf(f_directors_h, "protected:\n");
+      Printf(f_directors_h, "    bool swig_override[1];  // Unused\n");
     }
 
     Printf(f_directors_h, "};\n\n");

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -4301,6 +4301,8 @@ public:
       }
     }
 
+    int n_methods = curr_class_dmethod - first_class_dmethod;
+
     /* insert jenv prefix argument */
     parms = CopyParmList(superparms);
 
@@ -4321,7 +4323,9 @@ public:
 	String *classtype = SwigType_namestr(Getattr(n, "name"));
 
 	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
-	Printf(f_directors, "  memset(swig_override, 0, sizeof(swig_override));\n");
+	if (n_methods) {
+	  Printf(f_directors, "  memset(swig_override, 0, sizeof(swig_override));\n");
+	}
 	Printf(f_directors, "}\n\n");
 
 	Delete(classtype);
@@ -4355,8 +4359,12 @@ public:
     String *dirClassName = directorClassName(n);
     Wrapper *w = NewWrapper();
 
+    int n_methods = curr_class_dmethod - first_class_dmethod;
+
     Printf(w->def, "%s::%s(JNIEnv *jenv) : %s {", dirClassName, dirClassName, Getattr(n, "director:ctor"));
-    Printf(w->code, "  memset(swig_override, 0, sizeof(swig_override));\n");
+    if (n_methods) {
+      Printf(w->code, "  memset(swig_override, 0, sizeof(swig_override));\n");
+    }
     Printf(w->code, "}\n");
     Wrapper_print(w, f_directors);
 

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -4321,6 +4321,7 @@ public:
 	String *classtype = SwigType_namestr(Getattr(n, "name"));
 
 	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
+	Printf(f_directors, "  memset(swig_override, 0, sizeof(swig_override));\n");
 	Printf(f_directors, "}\n\n");
 
 	Delete(classtype);
@@ -4355,6 +4356,7 @@ public:
     Wrapper *w = NewWrapper();
 
     Printf(w->def, "%s::%s(JNIEnv *jenv) : %s {", dirClassName, dirClassName, Getattr(n, "director:ctor"));
+    Printf(w->code, "  memset(swig_override, 0, sizeof(swig_override));\n");
     Printf(w->code, "}\n");
     Wrapper_print(w, f_directors);
 

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -435,6 +435,7 @@ public:
       Printf(f_directors_h, "\n");
       Printf(f_directors_h, "#ifndef SWIG_%s_WRAP_H_\n", module_class_name);
       Printf(f_directors_h, "#define SWIG_%s_WRAP_H_\n\n", module_class_name);
+      Printf(f_directors_h, "#include <bitset>\n");
 
       Printf(f_directors, "\n\n");
       Printf(f_directors, "/* ---------------------------------------------------\n");
@@ -4321,7 +4322,6 @@ public:
 	String *classtype = SwigType_namestr(Getattr(n, "name"));
 
 	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
-	Printf(f_directors, "  memset(swig_override, 0, sizeof(swig_override));\n");
 	Printf(f_directors, "}\n\n");
 
 	Delete(classtype);
@@ -4356,7 +4356,6 @@ public:
     Wrapper *w = NewWrapper();
 
     Printf(w->def, "%s::%s(JNIEnv *jenv) : %s {", dirClassName, dirClassName, Getattr(n, "director:ctor"));
-    Printf(w->code, "  memset(swig_override, 0, sizeof(swig_override));\n");
     Printf(w->code, "}\n");
     Wrapper_print(w, f_directors);
 
@@ -4485,13 +4484,13 @@ public:
     int n_methods = curr_class_dmethod - first_class_dmethod;
 
     if (n_methods) {
-      /* Emit the swig_overrides() method and the swig_override array */
+      /* Emit the swig_overrides() method and the swig_override bitset */
       Printf(f_directors_h, "public:\n");
       Printf(f_directors_h, "    bool swig_overrides(int n) {\n");
       Printf(f_directors_h, "      return (n < %d ? swig_override[n] : false);\n", n_methods);
       Printf(f_directors_h, "    }\n");
       Printf(f_directors_h, "protected:\n");
-      Printf(f_directors_h, "    bool swig_override[%d];\n", n_methods);
+      Printf(f_directors_h, "    std::bitset<%d> swig_override;\n", n_methods);
 
       /* Emit the code to look up the class's methods, initialize the override array */
 
@@ -4531,8 +4530,6 @@ public:
       Printf(f_directors_h, "    bool swig_overrides(int n) {\n");
       Printf(f_directors_h, "      return false;\n");
       Printf(f_directors_h, "    }\n");
-      Printf(f_directors_h, "protected:\n");
-      Printf(f_directors_h, "    bool swig_override[1];  // Unused\n");
     }
 
     Printf(f_directors_h, "};\n\n");


### PR DESCRIPTION
This pull request addresses https://github.com/swig/swig/issues/402, allowing feature("director") and feature("ref") to work together in C++ to Java mode.

In short, the director feature constructs the C++ object and then hooks up the director as two separate steps in Java. Until that second JNI call to set up the director, the swig_override array is uninitialized. Meanwhile, the ref feature specifies a method to call immediately after construction before control returns to Java; the method called is the generated director method, which tries to consult the uninitialized array.

By zero-initializing the swig_override array, we ensure that the method specified by the "ref" feature always calls the C++ method. There is no possibility of it calling an overriding Java method with this design; however, with "ref", that's probably not what you want anyway.