### PR TITLE
Python examples pep8 whitespace cleanup

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -66,6 +66,9 @@ LIBCRYPT   = @LIBCRYPT@
 SYSLIBS    = $(LIBM) $(LIBC) $(LIBCRYPT)
 LIBPREFIX  =
 
+PEP8         = @PEP8@
+PEP8_FLAGS   = --ignore=E402,E501,E30,W291,W391
+
 # RUNTOOL is for use with runtime tools, eg set it to valgrind
 RUNTOOL    =
 # COMPILETOOL is a way to run the compiler under another tool, or more commonly just to stop the compiler executing
@@ -372,7 +375,7 @@ endif
 
 PY2TO3 = 2to3 `2to3 -l | grep -v -E "Available|import$$" | awk '{print "-f "$$0}'`
 
-python_run: $(PYSCRIPT)
+python_run: $(PYSCRIPT) python_check
 	export PYTHONPATH=".:$$PYTHONPATH"; \
 	$(RUNTOOL) $(PYTHON) $(PYSCRIPT) $(RUNPIPE)
 
@@ -384,6 +387,16 @@ endif
 $(RUNME)3.py: $(SRCDIR)$(RUNME).py
 	cp $< $@
 	$(PY2TO3) -w $@ >/dev/null 2>&1
+
+# -----------------------------------------------------------------
+# Run Python pep8 if it exists
+# -----------------------------------------------------------------
+
+python_check: $(PYSCRIPT)
+	+if [ -n "$(PEP8)" ]; then \
+		$(PEP8) $(PEP8_FLAGS) $(PYSCRIPT) || true;\
+	fi
+
 
 # -----------------------------------------------------------------
 # Version display

--- a/Examples/python/callback/runme.py
+++ b/Examples/python/callback/runme.py
@@ -2,14 +2,16 @@
 
 # This file illustrates the cross language polymorphism using directors.
 
-import example 
+import example
 
 
 class PyCallback(example.Callback):
-	def __init__(self):
-		example.Callback.__init__(self)
-	def run(self):
-		print "PyCallback.run()"
+
+    def __init__(self):
+        example.Callback.__init__(self)
+
+    def run(self):
+        print "PyCallback.run()"
 
 # Create an Caller instance
 
@@ -25,7 +27,7 @@ callback = example.Callback()
 callback.thisown = 0
 caller.setCallback(callback)
 caller.call()
-caller.delCallback();
+caller.delCallback()
 
 print
 print "Adding and calling a Python callback"
@@ -53,4 +55,3 @@ caller.delCallback()
 
 print
 print "python exit"
-

--- a/Examples/python/class/runme.py
+++ b/Examples/python/class/runme.py
@@ -3,7 +3,7 @@
 # This file illustrates the proxy class C++ interface generated
 # by SWIG.
 
-import example 
+import example
 
 # ----- Object creation -----
 
@@ -15,7 +15,7 @@ print "    Created square", s
 
 # ----- Access a static member -----
 
-print "\nA total of", example.cvar.Shape_nshapes,"shapes were created"
+print "\nA total of", example.cvar.Shape_nshapes, "shapes were created"
 
 # ----- Member data access -----
 
@@ -28,16 +28,16 @@ s.x = -10
 s.y = 5
 
 print "\nHere is their current position:"
-print "    Circle = (%f, %f)" % (c.x,c.y)
-print "    Square = (%f, %f)" % (s.x,s.y)
+print "    Circle = (%f, %f)" % (c.x, c.y)
+print "    Square = (%f, %f)" % (s.x, s.y)
 
 # ----- Call some methods -----
 
 print "\nHere are some properties of the shapes:"
-for o in [c,s]:
-      print "   ", o
-      print "        area      = ", o.area()
-      print "        perimeter = ", o.perimeter()
+for o in [c, s]:
+    print "   ", o
+    print "        area      = ", o.area()
+    print "        perimeter = ", o.perimeter()
 # prevent o from holding a reference to the last object looked at
 o = None
 
@@ -47,5 +47,5 @@ print "\nGuess I'll clean up now"
 del c
 del s
 
-print example.cvar.Shape_nshapes,"shapes remain"
+print example.cvar.Shape_nshapes, "shapes remain"
 print "Goodbye"

--- a/Examples/python/constants/runme.py
+++ b/Examples/python/constants/runme.py
@@ -8,7 +8,7 @@ print "CCONST  =", example.CCONST, "(should be 'x')"
 print "CCONST2 =", example.CCONST2, "(this should be on a new line)"
 print "SCONST  =", example.SCONST, "(should be 'Hello World')"
 print "SCONST2 =", example.SCONST2, "(should be '\"Hello World\"')"
-print "EXPR    =", example.EXPR,   "(should be 48.5484)"
+print "EXPR    =", example.EXPR, "(should be 48.5484)"
 print "iconst  =", example.iconst, "(should be 37)"
 print "fconst  =", example.fconst, "(should be 3.14)"
 

--- a/Examples/python/constants/runme.py
+++ b/Examples/python/constants/runme.py
@@ -1,6 +1,6 @@
 # file: runme.py
 
-import example 
+import example
 
 print "ICONST  =", example.ICONST, "(should be 42)"
 print "FCONST  =", example.FCONST, "(should be 2.1828)"
@@ -21,7 +21,3 @@ try:
     print "FOO    = ", example.FOO, "(Arg! This shouldn't print anything)"
 except AttributeError:
     print "FOO isn't defined (good)"
-
-
-
-

--- a/Examples/python/contract/runme.py
+++ b/Examples/python/contract/runme.py
@@ -1,13 +1,13 @@
 # file: runme.py
 
-import example 
+import example
 
 # Call our gcd() function
 
 x = 42
 y = 105
-g = example.gcd(x,y)
-print "The gcd of %d and %d is %d" % (x,y,g)
+g = example.gcd(x, y)
+print "The gcd of %d and %d is %d" % (x, y, g)
 
 # Manipulate the Foo global variable
 
@@ -19,12 +19,3 @@ example.cvar.Foo = 3.1415926
 
 # See if the change took effect
 print "Foo = ", example.cvar.Foo
-
-
-
-
-
-
-
-
-

--- a/Examples/python/docstrings/runme.py
+++ b/Examples/python/docstrings/runme.py
@@ -1,6 +1,5 @@
 # file: runme.py
 
-import example 
+import example
 
 print "example.Foo.bar.__doc__  =", repr(example.Foo.bar.__doc__), "(Should be 'No comment')"
-

--- a/Examples/python/enum/runme.py
+++ b/Examples/python/enum/runme.py
@@ -20,7 +20,7 @@ print "\nTesting use of enums with functions\n"
 example.enum_test(example.RED, example.Foo.IMPULSE)
 example.enum_test(example.BLUE,  example.Foo.WARP)
 example.enum_test(example.GREEN, example.Foo.LUDICROUS)
-example.enum_test(1234,5678)
+example.enum_test(1234, 5678)
 
 print "\nTesting use of enum with class method"
 f = example.Foo()
@@ -28,4 +28,3 @@ f = example.Foo()
 f.enum_test(example.Foo.IMPULSE)
 f.enum_test(example.Foo.WARP)
 f.enum_test(example.Foo.LUDICROUS)
-

--- a/Examples/python/enum/runme.py
+++ b/Examples/python/enum/runme.py
@@ -18,7 +18,7 @@ print "    Foo_LUDICROUS =", example.Foo.LUDICROUS
 print "\nTesting use of enums with functions\n"
 
 example.enum_test(example.RED, example.Foo.IMPULSE)
-example.enum_test(example.BLUE,  example.Foo.WARP)
+example.enum_test(example.BLUE, example.Foo.WARP)
 example.enum_test(example.GREEN, example.Foo.LUDICROUS)
 example.enum_test(1234, 5678)
 

--- a/Examples/python/exception/runme.py
+++ b/Examples/python/exception/runme.py
@@ -6,38 +6,37 @@ import example
 
 t = example.Test()
 try:
-      t.unknown()
-except RuntimeError,e:
-      print "incomplete type", e.args[0]
+    t.unknown()
+except RuntimeError, e:
+    print "incomplete type", e.args[0]
 
 try:
-      t.simple()
-except RuntimeError,e:
-      print e.args[0]
+    t.simple()
+except RuntimeError, e:
+    print e.args[0]
 
 try:
-      t.message()
-except RuntimeError,e:
-      print e.args[0]
+    t.message()
+except RuntimeError, e:
+    print e.args[0]
 
 if not example.is_python_builtin():
-  try:
+    try:
         t.hosed()
-  except example.Exc,e:
+    except example.Exc, e:
         print e.code, e.msg
 else:
-  try:
+    try:
         t.hosed()
-  except BaseException,e:
-        # Throwing builtin classes as exceptions not supported (-builtin option)
+    except BaseException, e:
+        # Throwing builtin classes as exceptions not supported (-builtin
+        # option)
         print e
 
-for i in range(1,4):
-      try:
-            t.multi(i)
-      except RuntimeError,e:
-            print e.args[0]
-      except example.Exc,e:
-            print e.code, e.msg
-
-
+for i in range(1, 4):
+    try:
+        t.multi(i)
+    except RuntimeError, e:
+        print e.args[0]
+    except example.Exc, e:
+        print e.code, e.msg

--- a/Examples/python/exceptproxy/runme.py
+++ b/Examples/python/exceptproxy/runme.py
@@ -2,8 +2,8 @@
 import example
 
 if example.is_python_builtin():
-  print "Skipping example: -builtin option does not support %exceptionclass"
-  exit(0)
+    print "Skipping example: -builtin option does not support %exceptionclass"
+    exit(0)
 
 q = example.intQueue(10)
 
@@ -12,18 +12,18 @@ print "Inserting items into intQueue"
 print type(example.FullError)
 
 try:
-      for i in range(0,100):
-            q.enqueue(i)
-except example.FullError,e:
-      print "Maxsize is", e.maxsize
+    for i in range(0, 100):
+        q.enqueue(i)
+except example.FullError, e:
+    print "Maxsize is", e.maxsize
 
 print "Removing items"
 
 try:
-      while 1:
-            q.dequeue()
-except example.EmptyError,e:
-      pass
+    while 1:
+        q.dequeue()
+except example.EmptyError, e:
+    pass
 
 
 q = example.doubleQueue(1000)
@@ -31,21 +31,15 @@ q = example.doubleQueue(1000)
 print "Inserting items into doubleQueue"
 
 try:
-      for i in range(0,10000):
-            q.enqueue(i*1.5)
-except example.FullError,e:
-      print "Maxsize is", e.maxsize
+    for i in range(0, 10000):
+        q.enqueue(i * 1.5)
+except example.FullError, e:
+    print "Maxsize is", e.maxsize
 
 print "Removing items"
 
 try:
-      while 1:
-            q.dequeue()
-except example.EmptyError,e:
-      pass
-
-
-
-
-
-      
+    while 1:
+        q.dequeue()
+except example.EmptyError, e:
+    pass

--- a/Examples/python/extend/runme.py
+++ b/Examples/python/extend/runme.py
@@ -2,16 +2,18 @@
 
 # This file illustrates the cross language polymorphism using directors.
 
-import example 
+import example
 
 
 # CEO class, which overrides Employee::getPosition().
 
 class CEO(example.Manager):
-	def __init__(self, name):
-		example.Manager.__init__(self, name)
-	def getPosition(self):
-		return "CEO"
+
+    def __init__(self, name):
+        example.Manager.__init__(self, name)
+
+    def getPosition(self):
+        return "CEO"
 
 
 # Create an instance of our employee extension class, CEO. The calls to
@@ -78,4 +80,3 @@ print "----------------------"
 # All done.
 
 print "python exit"
-

--- a/Examples/python/funcptr/runme.py
+++ b/Examples/python/funcptr/runme.py
@@ -1,6 +1,6 @@
 # file: runme.py
 
-import example 
+import example
 
 a = 37
 b = 42
@@ -10,9 +10,9 @@ b = 42
 print "Trying some C callback functions"
 print "    a        =", a
 print "    b        =", b
-print "    ADD(a,b) =", example.do_op(a,b,example.ADD)
-print "    SUB(a,b) =", example.do_op(a,b,example.SUB)
-print "    MUL(a,b) =", example.do_op(a,b,example.MUL)
+print "    ADD(a,b) =", example.do_op(a, b, example.ADD)
+print "    SUB(a,b) =", example.do_op(a, b, example.SUB)
+print "    MUL(a,b) =", example.do_op(a, b, example.MUL)
 
 print "Here is what the C callback function objects look like in Python"
 print "    ADD      =", example.ADD

--- a/Examples/python/funcptr2/runme.py
+++ b/Examples/python/funcptr2/runme.py
@@ -1,6 +1,6 @@
 # file: runme.py
 
-import example 
+import example
 
 a = 37
 b = 42
@@ -10,9 +10,9 @@ b = 42
 print "Trying some C callback functions"
 print "    a        =", a
 print "    b        =", b
-print "    ADD(a,b) =", example.do_op(a,b,example.ADD)
-print "    SUB(a,b) =", example.do_op(a,b,example.SUB)
-print "    MUL(a,b) =", example.do_op(a,b,example.MUL)
+print "    ADD(a,b) =", example.do_op(a, b, example.ADD)
+print "    SUB(a,b) =", example.do_op(a, b, example.SUB)
+print "    MUL(a,b) =", example.do_op(a, b, example.MUL)
 
 print "Here is what the C callback function objects look like in Python"
 print "    ADD      =", example.ADD
@@ -20,5 +20,5 @@ print "    SUB      =", example.SUB
 print "    MUL      =", example.MUL
 
 print "Call the functions directly..."
-print "    add(a,b) =", example.add(a,b)
-print "    sub(a,b) =", example.sub(a,b)
+print "    add(a,b) =", example.add(a, b)
+print "    sub(a,b) =", example.sub(a, b)

--- a/Examples/python/functor/runme.py
+++ b/Examples/python/functor/runme.py
@@ -8,10 +8,9 @@ b = example.doubleSum(100.0)
 # Use the objects.  They should be callable just like a normal
 # python function.
 
-for i in range(0,100):
+for i in range(0, 100):
     a(i)                # Note: function call
     b(math.sqrt(i))     # Note: function call
 
 print a.result()
 print b.result()
-

--- a/Examples/python/import/runme.py
+++ b/Examples/python/import/runme.py
@@ -81,31 +81,27 @@ x = d.toBase()
 print " Spam -> Base -> Foo : ",
 y = foo.Foo_fromBase(x)
 if y:
-      print "bad swig"
+    print "bad swig"
 else:
-      print "good swig"
+    print "good swig"
 
 print " Spam -> Base -> Bar : ",
 y = bar.Bar_fromBase(x)
 if y:
-      print "good swig"
+    print "good swig"
 else:
-      print "bad swig"
-      
+    print "bad swig"
+
 print " Spam -> Base -> Spam : ",
 y = spam.Spam_fromBase(x)
 if y:
-      print "good swig"
+    print "good swig"
 else:
-      print "bad swig"
+    print "bad swig"
 
 print " Foo -> Spam : ",
 y = spam.Spam_fromBase(b)
 if y:
-      print "bad swig"
+    print "bad swig"
 else:
-      print "good swig"
-
-
-
-
+    print "good swig"

--- a/Examples/python/import_packages/from_init1/runme.py
+++ b/Examples/python/import_packages/from_init1/runme.py
@@ -5,9 +5,9 @@ import os.path
 testname = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 print "Testing " + testname + " - %module(package=...) + python 'import' in __init__.py"
 
-if sys.version_info < (3,0):
-  import py2.pkg2
-  print "  Finished importing py2.pkg2"
+if sys.version_info < (3, 0):
+    import py2.pkg2
+    print "  Finished importing py2.pkg2"
 else:
-  import py3.pkg2
-  print "  Finished importing py3.pkg2"
+    import py3.pkg2
+    print "  Finished importing py3.pkg2"

--- a/Examples/python/import_packages/from_init2/runme.py
+++ b/Examples/python/import_packages/from_init2/runme.py
@@ -5,9 +5,9 @@ import os.path
 testname = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 print "Testing " + testname + " - %module(package=...) + python 'import' in __init__.py"
 
-if sys.version_info < (3,0):
-  import py2.pkg2
-  print "  Finished importing py2.pkg2"
+if sys.version_info < (3, 0):
+    import py2.pkg2
+    print "  Finished importing py2.pkg2"
 else:
-  import py3.pkg2
-  print "  Finished importing py3.pkg2"
+    import py3.pkg2
+    print "  Finished importing py3.pkg2"

--- a/Examples/python/import_packages/from_init3/runme.py
+++ b/Examples/python/import_packages/from_init3/runme.py
@@ -5,9 +5,9 @@ import os.path
 testname = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 print "Testing " + testname + " - %module(package=...) + python 'import' in __init__.py"
 
-if sys.version_info < (3,0):
-  import py2.pkg2
-  print "  Finished importing py2.pkg2"
+if sys.version_info < (3, 0):
+    import py2.pkg2
+    print "  Finished importing py2.pkg2"
 else:
-  import py3.pkg2
-  print "  Finished importing py3.pkg2"
+    import py3.pkg2
+    print "  Finished importing py3.pkg2"

--- a/Examples/python/import_packages/relativeimport1/runme.py
+++ b/Examples/python/import_packages/relativeimport1/runme.py
@@ -5,9 +5,9 @@ import os.path
 testname = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 print "Testing " + testname + " - %module(package=...) with -relativeimport"
 
-if sys.version_info < (3,0):
-  import py2.pkg2.bar
-  print "  Finished importing py2.pkg2.bar"
+if sys.version_info < (3, 0):
+    import py2.pkg2.bar
+    print "  Finished importing py2.pkg2.bar"
 else:
-  import py3.pkg2.bar
-  print "  Finished importing py3.pkg2.bar"
+    import py3.pkg2.bar
+    print "  Finished importing py3.pkg2.bar"

--- a/Examples/python/import_packages/relativeimport2/runme.py
+++ b/Examples/python/import_packages/relativeimport2/runme.py
@@ -5,9 +5,9 @@ import os.path
 testname = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 print "Testing " + testname + " - %module(package=...) + python 'import' in __init__.py"
 
-if sys.version_info < (3,0):
-  import py2.pkg2.bar
-  print "  Finished importing py2.pkg2.bar"
+if sys.version_info < (3, 0):
+    import py2.pkg2.bar
+    print "  Finished importing py2.pkg2.bar"
 else:
-  import py3.pkg2.bar
-  print "  Finished importing py3.pkg2.bar"
+    import py3.pkg2.bar
+    print "  Finished importing py3.pkg2.bar"

--- a/Examples/python/import_packages/relativeimport3/runme.py
+++ b/Examples/python/import_packages/relativeimport3/runme.py
@@ -5,9 +5,9 @@ import os.path
 testname = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 print "Testing " + testname + " - %module(package=...) with -relativeimport"
 
-if sys.version_info < (3,0):
-  import py2.pkg2.bar
-  print "  Finished importing py2.pkg2.bar"
+if sys.version_info < (3, 0):
+    import py2.pkg2.bar
+    print "  Finished importing py2.pkg2.bar"
 else:
-  import py3.pkg2.bar
-  print "  Finished importing py3.pkg2.bar"
+    import py3.pkg2.bar
+    print "  Finished importing py3.pkg2.bar"

--- a/Examples/python/import_packages/same_modnames1/runme.py
+++ b/Examples/python/import_packages/same_modnames1/runme.py
@@ -9,5 +9,5 @@ print "  Finished importing pkg2.foo"
 
 var2 = pkg2.foo.Pkg2_Foo()
 if str(type(var2)).find("'pkg2.foo.Pkg2_Foo'") == -1:
-  raise RuntimeError("failed type checking: " + str(type(var2)))
+    raise RuntimeError("failed type checking: " + str(type(var2)))
 print "  Successfully created object pkg2.foo.Pkg2_Foo"

--- a/Examples/python/import_packages/same_modnames2/runme.py
+++ b/Examples/python/import_packages/same_modnames2/runme.py
@@ -6,7 +6,7 @@ print "Testing " + testname + " - %module(package=...) + python 'import' in __in
 import pkg1.pkg2.foo
 print "  Finished importing pkg1.pkg2.foo"
 
-var2 = pkg1.pkg2.foo.Pkg2_Foo();
+var2 = pkg1.pkg2.foo.Pkg2_Foo()
 if str(type(var2)).find("'pkg1.pkg2.foo.Pkg2_Foo'") == -1:
-  raise RuntimeError("failed type checking: " + str(type(var2)))
+    raise RuntimeError("failed type checking: " + str(type(var2)))
 print "  Successfully created object pkg1.pkg2.foo.Pkg2_Foo"

--- a/Examples/python/import_template/runme.py
+++ b/Examples/python/import_template/runme.py
@@ -81,31 +81,27 @@ x = d.toBase()
 print " Spam -> Base -> Foo : ",
 y = foo.intFoo_fromBase(x)
 if y:
-      print "bad swig"
+    print "bad swig"
 else:
-      print "good swig"
+    print "good swig"
 
 print " Spam -> Base -> Bar : ",
 y = bar.intBar_fromBase(x)
 if y:
-      print "good swig"
+    print "good swig"
 else:
-      print "bad swig"
-      
+    print "bad swig"
+
 print " Spam -> Base -> Spam : ",
 y = spam.intSpam_fromBase(x)
 if y:
-      print "good swig"
+    print "good swig"
 else:
-      print "bad swig"
+    print "bad swig"
 
 print " Foo -> Spam : ",
 y = spam.intSpam_fromBase(b)
 if y:
-      print "bad swig"
+    print "bad swig"
 else:
-      print "good swig"
-
-
-
-
+    print "good swig"

--- a/Examples/python/java/runme.py
+++ b/Examples/python/java/runme.py
@@ -6,11 +6,11 @@ JvAttachCurrentThread(None, None)
 e1 = Example(1)
 e2 = Example(2)
 
-print e1.Add(1,2)
-print e1.Add(1.0,2.0)
-e3 = e1.Add(e1,e2)
+print e1.Add(1, 2)
+print e1.Add(1.0, 2.0)
+e3 = e1.Add(e1, e2)
 print e3.mPublicInt
 
-print e1.Add("1","2")
+print e1.Add("1", "2")
 
 JvDetachCurrentThread()

--- a/Examples/python/multimap/runme.py
+++ b/Examples/python/multimap/runme.py
@@ -1,16 +1,16 @@
 # file: runme.py
 
-import example 
+import example
 
 # Call our gcd() function
 
 x = 42
 y = 105
-g = example.gcd(x,y)
-print "The gcd of %d and %d is %d" % (x,y,g)
+g = example.gcd(x, y)
+print "The gcd of %d and %d is %d" % (x, y, g)
 
 # Call the gcdmain() function
-example.gcdmain(["gcdmain","42","105"])
+example.gcdmain(["gcdmain", "42", "105"])
 
 # Call the count function
 print example.count("Hello World", "l")
@@ -18,10 +18,3 @@ print example.count("Hello World", "l")
 # Call the capitalize function
 
 print example.capitalize("hello world")
-
-
-
-
-
-
-

--- a/Examples/python/operator/runme.py
+++ b/Examples/python/operator/runme.py
@@ -1,21 +1,20 @@
 # Operator overloading example
 import example
 
-a = example.Complex(2,3)
-b = example.Complex(-5,10)
+a = example.Complex(2, 3)
+b = example.Complex(-5, 10)
 
-print "a   =",a
-print "b   =",b
+print "a   =", a
+print "b   =", b
 
 c = a + b
-print "c   =",c
-print "a*b =",a*b
-print "a-c =",a-c
+print "c   =", c
+print "a*b =", a * b
+print "a-c =", a - c
 
-e = example.ComplexCopy(a-c)
-print "e   =",e
+e = example.ComplexCopy(a - c)
+print "e   =", e
 
 # Big expression
-f = ((a+b)*(c+b*e)) + (-a)
-print "f   =",f
-
+f = ((a + b) * (c + b * e)) + (-a)
+print "f   =", f

--- a/Examples/python/performance/constructor/runme.py
+++ b/Examples/python/performance/constructor/runme.py
@@ -2,8 +2,9 @@ import sys
 sys.path.append('..')
 import harness
 
-def proc (mod) :
-    for i in range(1000000) :
+
+def proc(mod):
+    for i in range(1000000):
         x = mod.MyClass()
 
 harness.run(proc)

--- a/Examples/python/performance/func/runme.py
+++ b/Examples/python/performance/func/runme.py
@@ -2,9 +2,10 @@ import sys
 sys.path.append('..')
 import harness
 
-def proc (mod) :
+
+def proc(mod):
     x = mod.MyClass()
-    for i in range(10000000) :
+    for i in range(10000000):
         x.func()
 
 harness.run(proc)

--- a/Examples/python/performance/harness.py
+++ b/Examples/python/performance/harness.py
@@ -3,9 +3,10 @@ import time
 import imp
 from subprocess import *
 
-def run (proc) :
 
-    try :
+def run(proc):
+
+    try:
         mod = imp.find_module(sys.argv[1])
         mod = imp.load_module(sys.argv[1], *mod)
 
@@ -14,15 +15,18 @@ def run (proc) :
         t2 = time.clock()
         print "%s took %f seconds" % (mod.__name__, t2 - t1)
 
-    except IndexError :
-        proc = Popen([sys.executable, 'runme.py', 'Simple_baseline'], stdout=PIPE)
+    except IndexError:
+        proc = Popen(
+            [sys.executable, 'runme.py', 'Simple_baseline'], stdout=PIPE)
         (stdout, stderr) = proc.communicate()
         print stdout
 
-        proc = Popen([sys.executable, 'runme.py', 'Simple_optimized'], stdout=PIPE)
+        proc = Popen(
+            [sys.executable, 'runme.py', 'Simple_optimized'], stdout=PIPE)
         (stdout, stderr) = proc.communicate()
         print stdout
 
-        proc = Popen([sys.executable, 'runme.py', 'Simple_builtin'], stdout=PIPE)
+        proc = Popen(
+            [sys.executable, 'runme.py', 'Simple_builtin'], stdout=PIPE)
         (stdout, stderr) = proc.communicate()
         print stdout

--- a/Examples/python/performance/hierarchy/runme.py
+++ b/Examples/python/performance/hierarchy/runme.py
@@ -2,9 +2,10 @@ import sys
 sys.path.append('..')
 import harness
 
-def proc (mod) :
+
+def proc(mod):
     x = mod.H()
-    for i in range(10000000) :
+    for i in range(10000000):
         x.func()
 
 harness.run(proc)

--- a/Examples/python/performance/hierarchy_operator/runme.py
+++ b/Examples/python/performance/hierarchy_operator/runme.py
@@ -2,9 +2,10 @@ import sys
 sys.path.append('..')
 import harness
 
-def proc (mod) :
+
+def proc(mod):
     x = mod.H()
-    for i in range(10000000) :
+    for i in range(10000000):
         x += i
 
 harness.run(proc)

--- a/Examples/python/performance/operator/runme.py
+++ b/Examples/python/performance/operator/runme.py
@@ -2,9 +2,10 @@ import sys
 sys.path.append('..')
 import harness
 
-def proc (mod) :
+
+def proc(mod):
     x = mod.MyClass()
-    for i in range(10000000) :
+    for i in range(10000000):
         x = x + i
 
 harness.run(proc)

--- a/Examples/python/pointer/runme.py
+++ b/Examples/python/pointer/runme.py
@@ -1,25 +1,25 @@
 # file: runme.py
 
-import example;
+import example
 
 # First create some objects using the pointer library.
-print "Testing the pointer library";
-a = example.new_intp();
-b = example.new_intp();
-c = example.new_intp();
-example.intp_assign(a,37);
-example.intp_assign(b,42);
+print "Testing the pointer library"
+a = example.new_intp()
+b = example.new_intp()
+c = example.new_intp()
+example.intp_assign(a, 37)
+example.intp_assign(b, 42)
 
-print "     a =",a
-print "     b =",b
-print "     c =",c
+print "     a =", a
+print "     b =", b
+print "     c =", c
 
 # Call the add() function with some pointers
-example.add(a,b,c)
+example.add(a, b, c)
 
 # Now get the result
 r = example.intp_value(c)
-print "     37 + 42 =",r
+print "     37 + 42 =", r
 
 # Clean up the pointers
 example.delete_intp(a)
@@ -30,15 +30,12 @@ example.delete_intp(c)
 # This should be much easier. Now how it is no longer
 # necessary to manufacture pointers.
 
-print "Trying the typemap library";
-r = example.sub(37,42)
-print "     37 - 42 =",r
+print "Trying the typemap library"
+r = example.sub(37, 42)
+print "     37 - 42 =", r
 
 # Now try the version with multiple return values
 
-print "Testing multiple return values";
-q,r = example.divide(42,37)
-print "     42/37 = %d remainder %d" % (q,r)
-
-
-
+print "Testing multiple return values"
+q, r = example.divide(42, 37)
+print "     42/37 = %d remainder %d" % (q, r)

--- a/Examples/python/reference/runme.py
+++ b/Examples/python/reference/runme.py
@@ -7,22 +7,22 @@ import example
 # ----- Object creation -----
 
 print "Creating some objects:"
-a = example.Vector(3,4,5)
-b = example.Vector(10,11,12)
+a = example.Vector(3, 4, 5)
+b = example.Vector(10, 11, 12)
 
-print "    Created",a.cprint()
-print "    Created",b.cprint()
+print "    Created", a.cprint()
+print "    Created", b.cprint()
 
 # ----- Call an overloaded operator -----
 
 # This calls the wrapper we placed around
 #
-#      operator+(const Vector &a, const Vector &) 
+#      operator+(const Vector &a, const Vector &)
 #
 # It returns a new allocated object.
 
 print "Adding a+b"
-c = example.addv(a,b)
+c = example.addv(a, b)
 print "    a+b =", c.cprint()
 
 # Note: Unless we free the result, a memory leak will occur
@@ -33,25 +33,25 @@ del c
 # Note: Using the high-level interface here
 print "Creating an array of vectors"
 va = example.VectorArray(10)
-print "    va = ",va
+print "    va = ", va
 
 # ----- Set some values in the array -----
 
 # These operators copy the value of $a and $b to the vector array
-va.set(0,a)
-va.set(1,b)
+va.set(0, a)
+va.set(1, b)
 
-va.set(2,example.addv(a,b))
+va.set(2, example.addv(a, b))
 
 # Get some values from the array
 
 print "Getting some array values"
-for i in range(0,5):
+for i in range(0, 5):
     print "    va(%d) = %s" % (i, va.get(i).cprint())
 
 # Watch under resource meter to check on this
 print "Making sure we don't leak memory."
-for i in xrange(0,1000000):
+for i in xrange(0, 1000000):
     c = va.get(i % 10)
 
 # ----- Clean up -----
@@ -60,4 +60,3 @@ print "Cleaning up"
 del va
 del a
 del b
-

--- a/Examples/python/simple/runme.py
+++ b/Examples/python/simple/runme.py
@@ -1,13 +1,13 @@
 # file: runme.py
 
-import example 
+import example
 
 # Call our gcd() function
 
 x = 42
 y = 105
-g = example.gcd(x,y)
-print "The gcd of %d and %d is %d" % (x,y,g)
+g = example.gcd(x, y)
+print "The gcd of %d and %d is %d" % (x, y, g)
 
 # Manipulate the Foo global variable
 
@@ -19,12 +19,3 @@ example.cvar.Foo = 3.1415926
 
 # See if the change took effect
 print "Foo = ", example.cvar.Foo
-
-
-
-
-
-
-
-
-

--- a/Examples/python/smartptr/runme.py
+++ b/Examples/python/smartptr/runme.py
@@ -3,7 +3,7 @@
 # This file illustrates the proxy class C++ interface generated
 # by SWIG.
 
-import example 
+import example
 
 # ----- Object creation -----
 
@@ -17,7 +17,7 @@ print "    Created square", s
 
 # ----- Access a static member -----
 
-print "\nA total of", example.cvar.Shape_nshapes,"shapes were created"
+print "\nA total of", example.cvar.Shape_nshapes, "shapes were created"
 
 # ----- Member data access -----
 
@@ -30,16 +30,16 @@ s.x = -10
 s.y = 5
 
 print "\nHere is their current position:"
-print "    Circle = (%f, %f)" % (c.x,c.y)
-print "    Square = (%f, %f)" % (s.x,s.y)
+print "    Circle = (%f, %f)" % (c.x, c.y)
+print "    Square = (%f, %f)" % (s.x, s.y)
 
 # ----- Call some methods -----
 
 print "\nHere are some properties of the shapes:"
-for o in [c,s]:
-      print "   ", o
-      print "        area      = ", o.area()
-      print "        perimeter = ", o.perimeter()
+for o in [c, s]:
+    print "   ", o
+    print "        area      = ", o.area()
+    print "        perimeter = ", o.perimeter()
 
 print "\nGuess I'll clean up now"
 
@@ -50,6 +50,5 @@ del cc
 del ss
 
 s = 3
-print example.cvar.Shape_nshapes,"shapes remain"
+print example.cvar.Shape_nshapes, "shapes remain"
 print "Goodbye"
-

--- a/Examples/python/std_map/runme.py
+++ b/Examples/python/std_map/runme.py
@@ -7,8 +7,6 @@ pmap["hi"] = 1
 pmap["hello"] = 2
 
 
-
-
 dmap = {}
 dmap["hello"] = 1.0
 dmap["hi"] = 2.0
@@ -28,8 +26,8 @@ for i in dmap.iterkeys():
 for i in dmap.itervalues():
     print "val", i
 
-for k,v in dmap.iteritems():
-    print "item", k,v
+for k, v in dmap.iteritems():
+    print "item", k, v
 
 dmap = example.DoubleMap()
 dmap["hello"] = 1.0
@@ -41,8 +39,8 @@ for i in dmap.iterkeys():
 for i in dmap.itervalues():
     print "val", i
 
-for k,v in dmap.iteritems():
-    print "item", k,v
+for k, v in dmap.iteritems():
+    print "item", k, v
 
 
 print dmap.items()
@@ -52,7 +50,6 @@ print dmap.values()
 hmap = example.halfd(dmap)
 print hmap.keys()
 print hmap.values()
-
 
 
 dmap = {}
@@ -76,7 +73,7 @@ for i in dmap.itervalues():
 for i in dmap.iteritems():
     print "item", i
 
-for k,v in dmap.iteritems():
-    print "item", k,v
+for k, v in dmap.iteritems():
+    print "item", k, v
 
 print dmap

--- a/Examples/python/std_vector/runme.py
+++ b/Examples/python/std_vector/runme.py
@@ -4,13 +4,13 @@ import example
 
 # Call average with a Python list...
 
-print example.average([1,2,3,4])
+print example.average([1, 2, 3, 4])
 
 # ... or a wrapped std::vector<int>
 
 v = example.IntVector(4)
 for i in range(len(v)):
-      v[i] = i+1
+    v[i] = i + 1
 print example.average(v)
 
 
@@ -22,8 +22,8 @@ print example.half((1.0, 1.5, 2.0, 2.5, 3.0))
 # ... or a wrapped std::vector<double>
 
 v = example.DoubleVector()
-for i in [1,2,3,4]:
-      v.append(i)
+for i in [1, 2, 3, 4]:
+    v.append(i)
 print example.half(v)
 
 
@@ -31,6 +31,5 @@ print example.half(v)
 
 example.halve_in_place(v)
 for i in range(len(v)):
-      print v[i], "; ",
+    print v[i], "; ",
 print
-

--- a/Examples/python/template/runme.py
+++ b/Examples/python/template/runme.py
@@ -3,32 +3,30 @@
 import example
 
 # Call some templated functions
-print example.maxint(3,7)
-print example.maxdouble(3.14,2.18)
+print example.maxint(3, 7)
+print example.maxdouble(3.14, 2.18)
 
 # Create some class
 
 iv = example.vecint(100)
 dv = example.vecdouble(1000)
 
-for i in range(0,100):
-      iv.setitem(i,2*i)
+for i in range(0, 100):
+    iv.setitem(i, 2 * i)
 
-for i in range(0,1000):
-      dv.setitem(i, 1.0/(i+1))
+for i in range(0, 1000):
+    dv.setitem(i, 1.0 / (i + 1))
 
 sum = 0
-for i in range(0,100):
-      sum = sum + iv.getitem(i)
+for i in range(0, 100):
+    sum = sum + iv.getitem(i)
 
 print sum
 
 sum = 0.0
-for i in range(0,1000):
-      sum = sum + dv.getitem(i)
+for i in range(0, 1000):
+    sum = sum + dv.getitem(i)
 print sum
 
 del iv
 del dv
-
-      

--- a/Examples/python/varargs/runme.py
+++ b/Examples/python/varargs/runme.py
@@ -1,13 +1,13 @@
 # file: runme.py
 
 import sys
-import example 
+import example
 
 # Call printf
 example.printf("Hello World. I'm printf\n")
 
 # Note: We call printf, but use *python* string formatting
-for i in range(0,10):
+for i in range(0, 10):
     example.printf("i is %d\n" % i)
 
 # This will probably be garbled because %d is interpreted by C
@@ -15,21 +15,13 @@ example.printf("The value is %d\n")
 
 stdout = example.stdout_stream()
 # Call fprintf
-example.fprintf(stdout,"Hello World. I'm fprintf\n")
-for i in range(0,10):
-    example.fprintf(stdout,"i is %d\n" % i)
+example.fprintf(stdout, "Hello World. I'm fprintf\n")
+for i in range(0, 10):
+    example.fprintf(stdout, "i is %d\n" % i)
 
 # This won't be garbled since %d is not interpreted
-example.fprintf(stdout,"The value is %d\n")
+example.fprintf(stdout, "The value is %d\n")
 
 # This function calls our NULL-terminated function
 
-example.printv("Hello","World","this","is","a","test.")
-
-
-
-
-
-
-
-
+example.printv("Hello", "World", "this", "is", "a", "test.")

--- a/Examples/python/variables/runme.py
+++ b/Examples/python/variables/runme.py
@@ -4,21 +4,21 @@ import example
 
 # Try to set the values of some global variables
 
-example.cvar.ivar   =  42
-example.cvar.svar   = -31000
-example.cvar.lvar   =  65537
-example.cvar.uivar  =  123456
-example.cvar.usvar  =  61000
-example.cvar.ulvar  =  654321
-example.cvar.scvar  =  -13
-example.cvar.ucvar  =  251
-example.cvar.cvar   =  "S"
-example.cvar.fvar   =  3.14159
-example.cvar.dvar   =  2.1828
-example.cvar.strvar =  "Hello World"
-example.cvar.iptrvar= example.new_int(37)
-example.cvar.ptptr  = example.new_Point(37,42)
-example.cvar.name   = "Bill"
+example.cvar.ivar = 42
+example.cvar.svar = -31000
+example.cvar.lvar = 65537
+example.cvar.uivar = 123456
+example.cvar.usvar = 61000
+example.cvar.ulvar = 654321
+example.cvar.scvar = -13
+example.cvar.ucvar = 251
+example.cvar.cvar = "S"
+example.cvar.fvar = 3.14159
+example.cvar.dvar = 2.1828
+example.cvar.strvar = "Hello World"
+example.cvar.iptrvar = example.new_int(37)
+example.cvar.ptptr = example.new_Point(37, 42)
+example.cvar.name = "Bill"
 
 # Now print out the values of the variables
 
@@ -46,16 +46,16 @@ print "\nVariables (values printed from C)"
 
 example.print_vars()
 
-print "\nNow I'm going to try and modify some read only variables";
+print "\nNow I'm going to try and modify some read only variables"
 
-print "     Tring to set 'path'";
+print "     Tring to set 'path'"
 try:
     example.cvar.path = "Whoa!"
     print "Hey, what's going on?!?! This shouldn't work"
 except:
     print "Good."
 
-print "     Trying to set 'status'";
+print "     Trying to set 'status'"
 try:
     example.cvar.status = 0
     print "Hey, what's going on?!?! This shouldn't work"
@@ -70,6 +70,3 @@ example.cvar.pt = example.cvar.ptptr
 print "The new value is"
 example.pt_print()
 print "You should see the value", example.Point_print(example.cvar.ptptr)
-
-
-


### PR DESCRIPTION
Added pep8 checking to the python examples as warning

Used the same --exclude list as is currently used for the Examples/test-suite/python/ files
ran autopep8 for the bulk clean-up of the python example files.
