### PR TITLE
Add a space between literal and string macro

### DIFF
--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -1722,7 +1722,7 @@ public:
 	      Printf(output, "\t\t\treturn new %s%s($r);\n", prefix, Getattr(classLookup(d), "sym:name"));
 	    } else {
 	      Printf(output, "\t\t\t$c = new stdClass();\n");
-	      Printf(output, "\t\t\t$c->"SWIG_PTR" = $r;\n");
+	      Printf(output, "\t\t\t$c->" SWIG_PTR " = $r;\n");
 	      Printf(output, "\t\t\treturn $c;\n");
 	    }
 	    Printf(output, "\t\t}\n\t\treturn $r;\n");


### PR DESCRIPTION
In C++11 a space between a literal and string macro is required.

This was pointed out by the following gcc warning when trying to build in C++11 mode:
Source/Modules/php.cxx:1736:23: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
        Printf(output, "\t\t\t$c->"SWIG_PTR" = $r;\n");