### PR TITLE
Create an actual copy during director pass-by-value.

### DIFF
--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -635,9 +635,16 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 #endif
 
 %typemap(directorin,descriptor="L$packagepath/$&javaclassname;") SWIGTYPE 
-%{ $input = 0;
-   *(($&1_ltype*)&$input) = &$1; %}
-%typemap(javadirectorin) SWIGTYPE "new $&javaclassname($jniinput, false)"
+#ifdef __cplusplus
+%{ *($&1_ltype*)&$input = new $1_ltype((const $1_ltype &)$1); %}
+#else
+{
+  $&1_ltype $1ptr = ($&1_ltype) malloc(sizeof($1_ltype));
+  memmove($1ptr, &$1, sizeof($1_type));
+  *($&1_ltype*)&$input = $1ptr;
+}
+#endif
+%typemap(javadirectorin) SWIGTYPE "new $&javaclassname($jniinput, true)"
 %typemap(javadirectorout) SWIGTYPE "$&javaclassname.getCPtr($javacall)"
 
 /* Generic pointers and references */


### PR DESCRIPTION
Handle arguments passed by value into a director class the same way as arguments outputted by value: Make a copy of them that Java can own.

It would be nice if the new object could be move-initialized, but in the interest of compatibility I have not attempted this. Is there a policy on how move semantics can be exploited in SWIG without breaking compatibility?

Objects passed by value are only valid for the duration of the call, so the previous approach made sense from a C++ perspective; however, in C++ you could save the argument by copying or moving it. In Java it's more natural to save a reference to the object instead. This approach allows this to work.

Perhaps ironically, pass-by-reference still results in an object that Java cannot safely safe a reference to, because objects passed by reference might not be copy-constructable.