### PR TITLE
lua: push characters as unformatted 1-character strings

### DIFF
--- a/Examples/test-suite/chartest.i
+++ b/Examples/test-suite/chartest.i
@@ -1,0 +1,15 @@
+%module chartest
+
+%inline %{
+char printable_global_char = 'a';
+char unprintable_global_char = 0x7F;
+
+char GetPrintableChar() {
+  return 'a';
+}
+
+char GetUnprintableChar() {
+  return 0x7F;
+}
+
+%}

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -138,6 +138,7 @@ CPP_TEST_CASES += \
 	casts \
 	char_binary \
 	char_strings \
+	chartest \
 	class_forward \
 	class_ignore \
 	class_scope_weird \

--- a/Examples/test-suite/lua/chartest_runme.lua
+++ b/Examples/test-suite/lua/chartest_runme.lua
@@ -1,0 +1,14 @@
+require("import")   -- the import fn
+import("chartest")   -- import code
+
+function char_assert(char, code)
+  assert(type(char) == 'string')
+  assert(char:len() == 1)
+  assert(char:byte() == code)
+end
+
+char_assert(chartest.GetPrintableChar(), 0x61)
+char_assert(chartest.GetUnprintableChar(), 0x7F)
+
+char_assert(chartest.printable_global_char, 0x61)
+char_assert(chartest.unprintable_global_char, 0x7F)

--- a/Lib/lua/lua.swg
+++ b/Lib/lua/lua.swg
@@ -185,7 +185,7 @@ use %include <std_except.i> instead
 
 // char is changed to a string
 %typemap(throws) char
-%{lua_pushfstring(L,"%c",$1);SWIG_fail;%}
+%{lua_pushlstring(L,&$1,1);SWIG_fail;%}
 
 /*
 Throwing object is a serious problem:

--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -1841,7 +1841,10 @@ SWIG_Lua_InstallConstants(lua_State *L, swig_lua_const_info constants[]) {
       break;
     case SWIG_LUA_CHAR:
       lua_pushstring(L,constants[i].name);
-      lua_pushfstring(L,"%c",(char)constants[i].lvalue);
+      {
+        char c = constants[i].lvalue;
+        lua_pushlstring(L,&c,1);
+      }
       lua_rawset(L,-3);
       break;
     case SWIG_LUA_STRING:

--- a/Lib/lua/luatypemaps.swg
+++ b/Lib/lua/luatypemaps.swg
@@ -122,14 +122,14 @@ SWIGINTERN int SWIG_lua_isnilstring(lua_State *L, int idx) {
 %{$1 = (lua_tostring(L, $input))[0];%}
 
 %typemap(out) char
-%{  lua_pushfstring(L,"%c",$1); SWIG_arg++;%}
+%{  lua_pushlstring(L, &$1, 1); SWIG_arg++;%}
 
 // by const ref
 %typemap(in,checkfn="SWIG_lua_isnilstring",fragment="SWIG_lua_isnilstring") const char& (char temp)
 %{temp = (lua_tostring(L, $input))[0]; $1=&temp;%}
 
 %typemap(out) const char&
-%{  lua_pushfstring(L,"%c",*$1); SWIG_arg++;%}
+%{  lua_pushlstring(L, $1, 1); SWIG_arg++;%}
 
 // pointers and references
 // under SWIG rules, it is ok, to have a pass in a lua nil,


### PR DESCRIPTION
Since Lua 5.3 the "%c" format character in lua_pushfstring will produce
the string "<\XXX>" (XXX being a decimal code sequence) when
given unprintable characters.

Use lua_pushlstring instead to reproduce the old behavior.