### PR TITLE
Fix unitialized variable warning

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2378,7 +2378,7 @@ public:
     Printv(f->def, linkage, builtin_ctor ? "int " : "PyObject *", wname, "(PyObject *self, PyObject *args) {", NIL);
 
     Wrapper_add_local(f, "argc", "int argc");
-    Printf(tmp, "PyObject *argv[%d]", maxargs + 1);
+    Printf(tmp, "PyObject *argv[%d] = {}", maxargs + 1);
     Wrapper_add_local(f, "argv", tmp);
 
     if (!fastunpack) {


### PR DESCRIPTION
Fix for GCC warning about uninitialized variable in overload functions dispatcher (#453)