### PR TITLE
Set OCAMLC to empty if Ocaml compiler not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1891,7 +1891,7 @@ else
 
     AC_MSG_CHECKING(for Ocaml compiler)
 	if test -z "$OCAMLC"; then
-	AC_CHECK_PROGS(OCAMLC, ocamlc, :)
+	AC_CHECK_PROGS(OCAMLC, ocamlc, )
     fi
 
     AC_MSG_CHECKING(for Ocaml toplevel creator)


### PR DESCRIPTION
OCAMLC is tested for 'empty string' when setting SKIP_OCAML
(configure.ac:2677), setting it to ':' will not skip ocaml.