### PR TITLE
Octave: use correct mkoctfile executable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1030,7 +1030,7 @@ fi
 
 if test -n "$OCTAVE"; then
    AC_MSG_CHECKING([for mkoctfile])
-   mkoctfile="`dirname ${OCTAVE}`/mkoctfile"
+   mkoctfile="$(dirname $OCTAVE)/$(basename $OCTAVE | sed -e 's/octave/mkoctfile/')"
    AS_IF([test -x "${mkoctfile}"],[
       AC_MSG_RESULT([${mkoctfile}])
    ],[


### PR DESCRIPTION
Allow a versioned Octave executable to be configured via --with-octave
and the correct corresponding mkoctfile executable to be used.