### PR TITLE
Remove callback function from autodoc unit test.

### DIFF
--- a/Examples/test-suite/autodoc.i
+++ b/Examples/test-suite/autodoc.i
@@ -114,12 +114,6 @@
   }
 %}
 
-%callback("%(uppercase)s_CALLBACK") func_cb;
-
-%inline {
-  int func_cb(int c, int d) { return c; }
-}
-
 // Bug 3310528
 %feature("autodoc","1") banana; // names + types
 %inline %{

--- a/Examples/test-suite/callback.i
+++ b/Examples/test-suite/callback.i
@@ -1,10 +1,18 @@
 %module callback
 
+// Not specifying the callback name is only possible in Python.
+#ifdef SWIGPYTHON
 %callback(1) foo;
 %callback(1) foof;
 %callback(1) A::bar;
 %callback(1) A::foom;
-%callback("%s_Cb_Ptr") foo_T;  // old style, still works.
+#else
+%callback("%s") foo;
+%callback("%s") foof;
+%callback("%s") A::bar;
+%callback("%s") A::foom;
+#endif
+%callback("%s_Cb_Ptr") foo_T;  // this works in Python too
 
 %inline %{
 

--- a/Examples/test-suite/callback.i
+++ b/Examples/test-suite/callback.i
@@ -12,7 +12,7 @@
 %callback("%s") A::bar;
 %callback("%s") A::foom;
 #endif
-%callback("%s_Cb_Ptr") foo_T;  // this works in Python too
+%callback("%(uppercase)s_Cb_Ptr") foo_T;  // this works in Python too
 
 %inline %{
 

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -10,6 +10,7 @@ top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@
 
 CPP_TEST_CASES += \
+	callback \
 	php_iterator \
 	php_namewarn_rename \
 

--- a/Examples/test-suite/php/autodoc_runme.php
+++ b/Examples/test-suite/php/autodoc_runme.php
@@ -1,9 +1,0 @@
-<?php
-
-require "tests.php";
-require "autodoc.php";
-// In 2.0.6 and earlier, the constant was misnamed.
-if (gettype(autodoc::FUNC_CB_CALLBACK) !== 'resource') die("autodoc::FUNC_CB_CALLBACK not a resource\n");
-
-check::done();
-?>

--- a/Examples/test-suite/php/callback_runme.php
+++ b/Examples/test-suite/php/callback_runme.php
@@ -1,0 +1,9 @@
+<?php
+
+require "tests.php";
+require "callback.php";
+// In 2.0.6 and earlier, the constant was misnamed.
+if (gettype(callback::FOO_I_Cb_Ptr) !== 'resource') die("callback::foo_T<int> not a resource\n");
+
+check::done();
+?>


### PR DESCRIPTION
It doesn't seem to belong there at all, there is a dedicated callback unit
test for it and it was added to the initial version of autodoc.i back in
124253d69828b4323f939bf118254ee96aefcdc7 without any explanation, so just
remove it.

----
I'm submitting this separately, it's one of commits from my COM branch and is needed there to allow the COM test suite to pass the autodoc test as it doesn't have callbacks (yet), but it also just seems to globally make sense.