### PR TITLE
"ignore" warning (2)

### DIFF
--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -463,20 +463,18 @@ static void add_symbols(Node *n) {
         SetFlag(n,"feature:ignore");
       }
     }
-    if (only_csymbol || GetFlag(n,"feature:ignore")) {
+    if (only_csymbol || GetFlag(n,"feature:ignore") || strncmp(Char(symname),"$ignore",7) == 0) {
       /* Only add to C symbol table and continue */
       Swig_symbol_add(0, n);
-      if (strncmp(Char(symname),"$ignore",7) == 0)
-	SetFlag(n,"feature:ignore");
-    } else if (strncmp(Char(symname),"$ignore",7) == 0) {
-      char *c = Char(symname)+7;
-      SetFlag(n,"feature:ignore");
-      if (strlen(c)) {
-	SWIG_WARN_NODE_BEGIN(n);
-	Swig_warning(0,Getfile(n), Getline(n), "%s\n",c+1);
-	SWIG_WARN_NODE_END(n);
+      if (strncmp(Char(symname),"$ignore",7) == 0) {
+        char *c = Char(symname) + 7;
+	SetFlag(n, "feature:ignore");
+	if (strlen(c)) {
+	  SWIG_WARN_NODE_BEGIN(n);
+	  Swig_warning(0,Getfile(n), Getline(n), "%s\n",c+1);
+	  SWIG_WARN_NODE_END(n);
+	}
       }
-      Swig_symbol_add(0, n);
     } else {
       Node *c;
       if ((wrn) && (Len(wrn))) {


### PR DESCRIPTION
refactoring: 2 ways of ignoring symbol in add_symbols() merged for clarity