### PR TITLE
Don't use preinst-swig in the test suite makefile.

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -56,8 +56,8 @@ endif
 COMPILETOOL=
 SWIGTOOL   =
 
-SWIG       = $(SWIGTOOL) $(top_builddir)/preinst-swig
-SWIG_LIB   = $(top_srcdir)/Lib
+SWIG       = $(SWIGTOOL) $(top_builddir)/swig
+export SWIG_LIB   = $(top_srcdir)/Lib
 TEST_SUITE = test-suite
 EXAMPLES   = Examples
 CXXSRCS    = 


### PR DESCRIPTION
This is unnecessary if we export SWIG_LIB from this makefile instead and prevents SWIGTOOL=gdb from working as gdb can't be used to debug a shell script -- but only the real SWIG binary.