### PR TITLE
fix #453

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2385,7 +2385,12 @@ public:
     Printv(f->def, linkage, builtin_ctor ? "int " : "PyObject *", wname, "(PyObject *self, PyObject *args) {", NIL);
 
     Wrapper_add_local(f, "argc", "int argc");
-    Printf(tmp, "PyObject *argv[%d]", maxargs + 1);
+    String *zeros = NewString("0");
+    for (int i = 0; i < maxargs; ++ i) {
+      Append(zeros, ", 0");
+    }
+    Printf(tmp, "PyObject *argv[%d] = {%s}", maxargs + 1, zeros);
+    Delete(zeros);
     Wrapper_add_local(f, "argv", tmp);
 
     if (!fastunpack) {


### PR DESCRIPTION
and add the right number of zeros, seems Wrapper_add_local adds unexpected eols between braces, but it's valid:
```
WIGINTERN PyObject *_wrap_new_Box(PyObject *self, PyObject *args) {
 9622   int argc;
 9623   PyObject *argv[2] = {
 9624     0, 0
 9625   };
 9626   int ii;
 9627 
 9628   if (!PyTuple
```