### PR TITLE
Complain if any new shift/reduce conflicts are introduced in the grammar.

### DIFF
--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -13,11 +13,9 @@
  * some point.  Beware.
  * ----------------------------------------------------------------------------- */
 
-/*
-Removed until we know more about the min versions of Bison and Yacc required for this
-to work, see Byacc man page: http://invisible-island.net/byacc/manpage/yacc.html
+/* There are 6 known shift-reduce conflicts in this file, fail compilation if any
+   more are introduced. */
 %expect 6
-*/
 
 %{
 #define yylex yylex


### PR DESCRIPTION
Currently there are 6 of them, suppress warning about them but do complain if
any new ones are introduced.

----

This basically formalizes what you wrote in a comment to PR #170.