### PR TITLE
Improve Python docstring indentation handling

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,17 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.7 (in progress)
 ===========================
 
+2015-07-28: wsfulton
+            [Python] Fix #475. Improve docstring indentation handling.
+            
+            SWIG-3.0.5 and earlier sometimes truncated text provided in the docstring feature.
+            This occurred when the indentation (whitespace) in the docstring was less in the
+            second or later lines when compared to the first line.
+            SWIG-3.0.6 gave a 'Line indented less than expected' error instead of truncating
+            the docstring text.
+            Now the indentation for the 'docstring' feature is smarter and is appropriately
+            adjusted so that no truncation occurs.
+
 2015-07-22: wsfulton
             Support for special variable expansion in typemap attributes. Example usage expansion
             in the 'out' attribute (C# specific):

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,30 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.7 (in progress)
 ===========================
 
+2015-07-29: wsfulton
+            [Python] Improve indentation warning and error messages for code in the following directives:
+
+              %pythonprepend
+              %pythonappend
+              %pythoncode
+              %pythonbegin
+              %feature("shadow")
+
+            Old error example:
+              Error: Line indented less than expected (line 3 of pythoncode)
+
+            New error example:
+              Error: Line indented less than expected (line 3 of %pythoncode or %insert("python") block)
+              as no line should be indented less than the indentation in line 1
+
+            Old warning example:
+              Warning 740: Whitespace prefix doesn't match (line 2 of %pythoncode or %insert("python") block)
+
+            New warning example:
+              Warning 740: Whitespace indentation is inconsistent compared to earlier lines (line 3 of
+              %pythoncode or %insert("python") block)
+
+            
 2015-07-28: wsfulton
             [Python] Fix #475. Improve docstring indentation handling.
             

--- a/Examples/test-suite/errors/swig_pythoncode_bad.stderr
+++ b/Examples/test-suite/errors/swig_pythoncode_bad.stderr
@@ -1,1 +1,1 @@
-swig_pythoncode_bad.i:7: Error: Line indented less than expected (line 2 of pythoncode)
+swig_pythoncode_bad.i:7: Error: Line indented less than expected (line 2 of %pythoncode or %insert("python") block) as no line should be indented less than the indentation in line 1

--- a/Examples/test-suite/errors/swig_pythoncode_bad2.stderr
+++ b/Examples/test-suite/errors/swig_pythoncode_bad2.stderr
@@ -1,1 +1,1 @@
-swig_pythoncode_bad2.i:13: Error: Line indented less than expected (line 3 of pythoncode)
+swig_pythoncode_bad2.i:13: Error: Line indented less than expected (line 3 of %pythoncode or %insert("python") block) as no line should be indented less than the indentation in line 1

--- a/Examples/test-suite/errors/swig_pythoncode_bad3.i
+++ b/Examples/test-suite/errors/swig_pythoncode_bad3.i
@@ -1,0 +1,7 @@
+%module xxx
+
+%pythoncode %{
+  def extra():
+  	print "extra a" # indentation is 2 spaces then tab
+	  print "extra b" # indentation is tab then 2 spaces
+%}

--- a/Examples/test-suite/errors/swig_pythoncode_bad3.stderr
+++ b/Examples/test-suite/errors/swig_pythoncode_bad3.stderr
@@ -1,0 +1,1 @@
+swig_pythoncode_bad3.i:7: Warning 740: Whitespace indentation is inconsistent compared to earlier lines (line 3 of %pythoncode or %insert("python") block)

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -59,6 +59,7 @@ CPP_TEST_CASES += \
 	python_abstractbase \
 	python_append \
 	python_director \
+	python_docstring \
 	python_nondynamic \
 	python_overload_simple_cast \
 	python_pythoncode \

--- a/Examples/test-suite/python/python_docstring_runme.py
+++ b/Examples/test-suite/python/python_docstring_runme.py
@@ -1,0 +1,100 @@
+from python_docstring import *
+import inspect
+
+def check(got, expected):
+    expected_list = expected.split("\n")
+    got_list = got.split("\n")
+
+    if expected_list != got_list:
+        raise RuntimeError("\n" + "Expected: " + str(expected_list) + "\n" + "Got     : " + str(got_list))
+
+# When getting docstrings, use inspect.getdoc(x) instead of x.__doc__ otherwise the different options
+# such as -O, -builtin, -classic produce different initial indentation.
+
+check(inspect.getdoc(DocStrings.docstring1),
+    "  line 1\n"
+    "line 2\n"
+    "\n"
+    "\n"
+    "\n"
+    "line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstring2),
+    "line 1\n"
+    "  line 2\n"
+    "\n"
+    "\n"
+    "\n"
+    "  line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstring3),
+    "line 1\n"
+    "  line 2\n"
+    "\n"
+    "\n"
+    "\n"
+    "  line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstring4),
+    "line 1\n"
+    "  line 2\n"
+    "\n"
+    "\n"
+    "\n"
+    "  line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstring5),
+    "line 1\n"
+    "  line 2\n"
+    "\n"
+    "\n"
+    "\n"
+    "  line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstring6),
+    "line 1\n"
+    "  line 2\n"
+    "\n"
+    "\n"
+    "\n"
+    "  line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstring7),
+    "line 1\n"
+    "line 2\n"
+    "line 3"
+    )
+
+check(inspect.getdoc(DocStrings.docstringA),
+    "first line\n"
+    "second line"
+    )
+
+check(inspect.getdoc(DocStrings.docstringB),
+    "first line\n"
+    "second line"
+    )
+
+check(inspect.getdoc(DocStrings.docstringC),
+    "first line\n"
+    "second line"
+    )
+
+# One line doc special case, use __doc__
+check(DocStrings.docstringX.__doc__,
+    "  one line docs"
+    )
+
+check(inspect.getdoc(DocStrings.docstringX),
+    "one line docs"
+    )
+
+check(inspect.getdoc(DocStrings.docstringY),
+    "one line docs"
+    )

--- a/Examples/test-suite/python_docstring.i
+++ b/Examples/test-suite/python_docstring.i
@@ -1,0 +1,98 @@
+%module python_docstring
+
+// Test indentation when using the docstring feature.
+// Checks tabs and spaces as input for indentation.
+
+%feature("docstring") docstring1 %{
+  line 1
+line 2
+
+  
+    
+line 3
+%}
+
+%feature("docstring") docstring2 %{
+line 1
+  line 2
+  
+      
+    
+  line 3
+  %}
+
+%feature("docstring") docstring3 %{
+    line 1
+      line 2
+
+          
+        
+      line 3
+      %}
+
+%feature("docstring") docstring4 %{
+	line 1
+	  line 2
+	
+	      
+	    
+	  line 3
+	  %}
+
+%feature("docstring") docstring5
+%{	line 1
+	  line 2
+	
+	      
+	    
+	  line 3
+	  %}
+
+%feature("docstring") docstring6
+{
+	line 1
+	  line 2
+	
+	      
+	    
+	  line 3
+}
+
+%feature("docstring") docstring7
+{
+line 1
+line 2
+line 3
+}
+
+%feature("docstring") docstringA
+%{    first line
+    second line%}
+
+%feature("docstring") docstringB
+%{		first line
+		second line%}
+
+%feature("docstring") docstringC
+%{  first line
+  second line%}
+
+%feature("docstring") docstringX "  one line docs"
+%feature("docstring") docstringY "one line docs"
+
+%inline %{
+struct DocStrings {
+  void docstring1() {}
+  void docstring2() {}
+  void docstring3() {}
+  void docstring4() {}
+  void docstring5() {}
+  void docstring6() {}
+  void docstring7() {}
+  void docstringA() {}
+  void docstringB() {}
+  void docstringC() {}
+  void docstringX() {}
+  void docstringY() {}
+};
+%}

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1300,7 +1300,7 @@ public:
 
   /* ------------------------------------------------------------
    * import_name_string()
-   *  ------------------------------------------------------------ */
+   * ------------------------------------------------------------ */
 
   static String *import_name_string(const String *mainpkg, const String *mainmod, const String *pkg, const String *mod, const String *sym) {
     if (!relativeimport) {
@@ -1346,9 +1346,10 @@ public:
 
   /* ------------------------------------------------------------
    * funcCall()
-   *    Emit shadow code to call a function in the extension
-   *    module. Using proper argument and calling style for
-   *    given node n.
+   *
+   * Emit shadow code to call a function in the extension
+   * module. Using proper argument and calling style for
+   * given node n.
    * ------------------------------------------------------------ */
   String *funcCall(String *name, String *parms) {
     String *str = NewString("");
@@ -1574,8 +1575,9 @@ public:
 
   /* ------------------------------------------------------------
    * have_docstring()
-   *    Check if there is a docstring directive and it has text,
-   *    or there is an autodoc flag set
+   *
+   * Check if there is a docstring directive and it has text,
+   * or there is an autodoc flag set
    * ------------------------------------------------------------ */
 
   bool have_docstring(Node *n) {
@@ -1585,9 +1587,10 @@ public:
 
   /* ------------------------------------------------------------
    * docstring()
-   *    Get the docstring text, stripping off {} if neccessary,
-   *    and enclose in triple double quotes.  If autodoc is also
-   *    set then it will build a combined docstring.
+   *
+   * Get the docstring text, stripping off {} if neccessary,
+   * and enclose in triple double quotes.  If autodoc is also
+   * set then it will build a combined docstring.
    * ------------------------------------------------------------ */
 
   String *docstring(Node *n, autodoc_t ad_type, const String *indent, bool use_triple = true) {
@@ -1650,8 +1653,9 @@ public:
 
   /* ------------------------------------------------------------
    * cdocstring()
-   *    Get the docstring text as it would appear in C-language
-   *	source code.
+   *
+   * Get the docstring text as it would appear in C-language
+   * source code.
    * ------------------------------------------------------------ */
 
   String *cdocstring(Node *n, autodoc_t ad_type)
@@ -1680,7 +1684,8 @@ public:
 
   /* -----------------------------------------------------------------------------
    * addMissingParameterNames()
-   *  For functions that have not had nameless parameters set in the Language class.
+   *
+   * For functions that have not had nameless parameters set in the Language class.
    *
    * Inputs: 
    *   plist - entire parameter list
@@ -1705,8 +1710,9 @@ public:
 
   /* ------------------------------------------------------------
    * make_autodocParmList()
-   *   Generate the documentation for the function parameters
-   *   Parameters:
+   *
+   * Generate the documentation for the function parameters
+   * Parameters:
    *    func_annotation: Function annotation support
    * ------------------------------------------------------------ */
 
@@ -1813,12 +1819,13 @@ public:
 
   /* ------------------------------------------------------------
    * make_autodoc()
-   *    Build a docstring for the node, using parameter and other
-   *    info in the parse tree.  If the value of the autodoc
-   *    attribute is "0" then do not include parameter types, if
-   *    it is "1" (the default) then do.  If it has some other
-   *    value then assume it is supplied by the extension writer
-   *    and use it directly.
+   *
+   * Build a docstring for the node, using parameter and other
+   * info in the parse tree.  If the value of the autodoc
+   * attribute is "0" then do not include parameter types, if
+   * it is "1" (the default) then do.  If it has some other
+   * value then assume it is supplied by the extension writer
+   * and use it directly.
    * ------------------------------------------------------------ */
 
   String *make_autodoc(Node *n, autodoc_t ad_type) {
@@ -1957,9 +1964,10 @@ public:
   }
 
   /* ------------------------------------------------------------
-   *  convertDoubleValue()
-   *    Check if the given string looks like a decimal floating point constant
-   *    and return it if it does, otherwise return NIL.
+   * convertDoubleValue()
+   *
+   * Check if the given string looks like a decimal floating point constant
+   * and return it if it does, otherwise return NIL.
    * ------------------------------------------------------------ */
   String *convertDoubleValue(String *v) {
     const char *const s = Char(v);
@@ -2001,8 +2009,9 @@ public:
 
   /* ------------------------------------------------------------
    * convertValue()
-   *    Check if string v can be a Python value literal or a
-   *    constant. Return NIL if it isn't.
+   *
+   * Check if string v can be a Python value literal or a
+   * constant. Return NIL if it isn't.
    * ------------------------------------------------------------ */
   String *convertValue(String *v, SwigType *type) {
     const char *const s = Char(v);
@@ -2124,12 +2133,13 @@ public:
 
   /* ------------------------------------------------------------
    * is_representable_as_pyargs()
-   *    Check if the function parameters default argument values
-   *    can be represented in Python.
    *
-   *    If this method returns false, the parameters will be translated
-   *    to a generic "*args" which allows us to deal with default values
-   *    at C++ code level where they can always be handled.
+   * Check if the function parameters default argument values
+   * can be represented in Python.
+   *
+   * If this method returns false, the parameters will be translated
+   * to a generic "*args" which allows us to deal with default values
+   * at C++ code level where they can always be handled.
    * ------------------------------------------------------------ */
   bool is_representable_as_pyargs(Node *n) {
     ParmList *plist = CopyParmList(Getattr(n, "parms"));
@@ -2171,9 +2181,10 @@ public:
 
   /* ------------------------------------------------------------
    * is_real_overloaded()
-   *   Check if the function is overloaded, but not just have some
-   *   siblings generated due to the original function have 
-   *   default arguments.
+   *
+   * Check if the function is overloaded, but not just have some
+   * siblings generated due to the original function have 
+   * default arguments.
    * ------------------------------------------------------------ */
   bool is_real_overloaded(Node *n) {
     Node *h = Getattr(n, "sym:overloaded");
@@ -2197,8 +2208,9 @@ public:
 
   /* ------------------------------------------------------------
    * make_pyParmList()
-   *    Generate parameter list for Python functions or methods,
-   *    reuse make_autodocParmList() to do so.
+   *
+   * Generate parameter list for Python functions or methods,
+   * reuse make_autodocParmList() to do so.
    * ------------------------------------------------------------ */
   String *make_pyParmList(Node *n, bool in_class, bool is_calling, int kw) {
     /* Get the original function for a defaultargs copy, 
@@ -2244,7 +2256,8 @@ public:
 
   /* ------------------------------------------------------------
    * have_pythonprepend()
-   *    Check if there is a %pythonprepend directive and it has text
+   *
+   * Check if there is a %pythonprepend directive and it has text
    * ------------------------------------------------------------ */
 
   bool have_pythonprepend(Node *n) {
@@ -2254,7 +2267,8 @@ public:
 
   /* ------------------------------------------------------------
    * pythonprepend()
-   *    Get the %pythonprepend code, stripping off {} if neccessary
+   *
+   * Get the %pythonprepend code, stripping off {} if neccessary
    * ------------------------------------------------------------ */
 
   String *pythonprepend(Node *n) {
@@ -2269,7 +2283,8 @@ public:
 
   /* ------------------------------------------------------------
    * have_pythonappend()
-   *    Check if there is a %pythonappend directive and it has text
+   *
+   * Check if there is a %pythonappend directive and it has text
    * ------------------------------------------------------------ */
 
   bool have_pythonappend(Node *n) {
@@ -2281,7 +2296,8 @@ public:
 
   /* ------------------------------------------------------------
    * pythonappend()
-   *    Get the %pythonappend code, stripping off {} if neccessary
+   *
+   * Get the %pythonappend code, stripping off {} if neccessary
    * ------------------------------------------------------------ */
 
   String *pythonappend(Node *n) {
@@ -2299,7 +2315,8 @@ public:
 
   /* ------------------------------------------------------------
    * have_addtofunc()
-   *    Check if there is a %addtofunc directive and it has text
+   *
+   * Check if there is a %addtofunc directive and it has text
    * ------------------------------------------------------------ */
 
   bool have_addtofunc(Node *n) {
@@ -2309,8 +2326,9 @@ public:
 
   /* ------------------------------------------------------------
    * returnTypeAnnotation()
-   *    Helper function for constructing the function annotation
-   *    of the returning type, return a empty string for Python 2.x
+   *
+   * Helper function for constructing the function annotation
+   * of the returning type, return a empty string for Python 2.x
    * ------------------------------------------------------------ */
   String *returnTypeAnnotation(Node *n) {
     String *ret = 0;
@@ -2343,9 +2361,10 @@ public:
 
   /* ------------------------------------------------------------
    * emitFunctionShadowHelper()
-   *    Refactoring some common code out of functionWrapper and
-   *    dispatchFunction that writes the proxy code for non-member
-   *    functions.
+   *
+   * Refactoring some common code out of functionWrapper and
+   * dispatchFunction that writes the proxy code for non-member
+   * functions.
    * ------------------------------------------------------------ */
 
   void emitFunctionShadowHelper(Node *n, File *f_dest, String *name, int kw) {
@@ -2374,7 +2393,8 @@ public:
 
   /* ------------------------------------------------------------
    * check_kwargs()
-   *    check if using kwargs is allowed for this Node
+   *
+   * check if using kwargs is allowed for this Node
    * ------------------------------------------------------------ */
 
   int check_kwargs(Node *n) const {


### PR DESCRIPTION
SWIG-3.0.5 and earlier sometimes truncated text provided in the docstring feature.
SWIG-3.0.6 gave a 'Line indented less than expected' error instead of truncating the docstring text.
Now the indentation for the 'docstring' feature is smarter and is adjusted so that no truncation occurs.
Also Improve the indentation warning and error messages.

Pull request to fix #475.
