### PR TITLE
Make (char*, size_t) typemap usable for strings of other types in Java.

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -4,3 +4,7 @@ See the RELEASENOTES file for a summary of changes in each release.
 
 Version 3.0.8 (in progress)
 ===========================
+
+2015-08-05: vadz
+            [Java] Make (char* STRING, size_t LENGTH) typemaps usable for
+            strings of other types, e.g. "unsigned char*".

--- a/Examples/test-suite/char_binary.i
+++ b/Examples/test-suite/char_binary.i
@@ -5,10 +5,14 @@ A test case for testing non null terminated char pointers.
 %module char_binary
 
 %apply (char *STRING, size_t LENGTH) { (const char *str, size_t len) }
+%apply (char *STRING, size_t LENGTH) { (const unsigned char *str, size_t len) }
 
 %inline %{
 struct Test {
   size_t strlen(const char *str, size_t len) {
+    return len;
+  }
+  size_t ustrlen(const unsigned char *str, size_t len) {
     return len;
   }
 };

--- a/Examples/test-suite/java/char_binary_runme.java
+++ b/Examples/test-suite/java/char_binary_runme.java
@@ -20,5 +20,11 @@ public class char_binary_runme {
 
     if (t.strlen(hil0) != 4)
       throw new RuntimeException("bad multi-arg typemap");
+
+    if (t.ustrlen(hile) != 4)
+      throw new RuntimeException("bad multi-arg typemap");
+
+    if (t.ustrlen(hil0) != 4)
+      throw new RuntimeException("bad multi-arg typemap");
   }
 }

--- a/Examples/test-suite/javascript/char_binary_runme.js
+++ b/Examples/test-suite/javascript/char_binary_runme.js
@@ -5,8 +5,15 @@ if (t.strlen('hile') != 4) {
   print(t.strlen('hile'));
   throw("bad multi-arg typemap 1");
 }
+if (t.ustrlen('hile') != 4) {
+  print(t.ustrlen('hile'));
+  throw("bad multi-arg typemap 1");
+}
 
 if (t.strlen('hil\0') != 4) {
+  throw("bad multi-arg typemap 2");
+}
+if (t.ustrlen('hil\0') != 4) {
   throw("bad multi-arg typemap 2");
 }
 
@@ -22,6 +29,9 @@ char_binary.pchar_setitem(pc, 4, 0);
 
 
 if (t.strlen(pc) != 4) {
+  throw("bad multi-arg typemap (3)");
+}
+if (t.ustrlen(pc) != 4) {
   throw("bad multi-arg typemap (3)");
 }
 

--- a/Examples/test-suite/perl5/char_binary_runme.pl
+++ b/Examples/test-suite/perl5/char_binary_runme.pl
@@ -1,14 +1,16 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 10;
 BEGIN { use_ok('char_binary') }
 require_ok('char_binary');
 
 my $t = char_binary::Test->new();
 
 is($t->strlen('hile'), 4, "string typemap");
+is($t->ustrlen('hile'), 4, "unsigned string typemap");
 
 is($t->strlen("hil\0"), 4, "string typemap");
+is($t->ustrlen("hil\0"), 4, "unsigned string typemap");
 
 #
 # creating a raw char*
@@ -22,6 +24,7 @@ char_binary::pchar_setitem($pc, 4, 0);
 
 
 is($t->strlen($pc), 4, "string typemap");
+is($t->ustrlen($pc), 4, "unsigned string typemap");
 
 $char_binary::var_pchar = $pc;
 is($char_binary::var_pchar, "hola", "pointer case");

--- a/Examples/test-suite/python/char_binary_runme.py
+++ b/Examples/test-suite/python/char_binary_runme.py
@@ -4,8 +4,13 @@ t = Test()
 if t.strlen('hile') != 4:
     print t.strlen('hile')
     raise RuntimeError, "bad multi-arg typemap"
+if t.ustrlen('hile') != 4:
+    print t.ustrlen('hile')
+    raise RuntimeError, "bad multi-arg typemap"
 
 if t.strlen('hil\0') != 4:
+    raise RuntimeError, "bad multi-arg typemap"
+if t.ustrlen('hil\0') != 4:
     raise RuntimeError, "bad multi-arg typemap"
 
 #
@@ -20,6 +25,8 @@ pchar_setitem(pc, 4, 0)
 
 
 if t.strlen(pc) != 4:
+    raise RuntimeError, "bad multi-arg typemap"
+if t.ustrlen(pc) != 4:
     raise RuntimeError, "bad multi-arg typemap"
 
 cvar.var_pchar = pc

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1330,8 +1330,8 @@ SWIG_PROXY_CONSTRUCTOR(true, true, SWIGTYPE)
 %typemap(freearg) (char *STRING, size_t LENGTH) ""
 %typemap(in)      (char *STRING, size_t LENGTH) {
   if ($input) {
-    $1 = (char *) JCALL2(GetByteArrayElements, jenv, $input, 0);
-    $2 = (size_t) JCALL1(GetArrayLength, jenv, $input);
+    $1 = ($1_ltype) JCALL2(GetByteArrayElements, jenv, $input, 0);
+    $2 = ($2_type) JCALL1(GetArrayLength, jenv, $input);
   } else {
     $1 = 0;
     $2 = 0;


### PR DESCRIPTION
Notably it now works for "unsigned char*" strings.

Add a test to check that it now works in Java and also showing that it already
worked for the other languages with support for this typemap.

---
Note that I didn't find any other way to get rid of `const` than using `$1_basetype*`: if I used just `$1_type`, we had problems with `const T*` as `$1_type` had const while the actual type of the local variable did not (wrongly?).