### PR TITLE
replacement for enumR2015 - tidied and rebased

### DIFF
--- a/Examples/test-suite/r/Makefile.in
+++ b/Examples/test-suite/r/Makefile.in
@@ -5,7 +5,7 @@
 LANGUAGE     = r
 SCRIPTSUFFIX = _runme.R
 WRAPSUFFIX   = .R
-RUNR         = R CMD BATCH --no-save --no-restore
+RUNR         = R CMD BATCH --no-save --no-restore '--args $(SCRIPTDIR)'
 
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
@@ -43,6 +43,7 @@ include $(srcdir)/../common.mk
 	$(setup)
 	+$(swig_and_compile_multi_cpp)
 	$(run_multitestcase)
+
 
 # Runs the testcase.
 #

--- a/Examples/test-suite/r/arrays_dimensionless_runme.R
+++ b/Examples/test-suite/r/arrays_dimensionless_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("arrays_dimensionless", .Platform$dynlib.ext, sep=""))
 source("arrays_dimensionless.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/funcptr_runme.R
+++ b/Examples/test-suite/r/funcptr_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("funcptr", .Platform$dynlib.ext, sep=""))
 source("funcptr.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/ignore_parameter_runme.R
+++ b/Examples/test-suite/r/ignore_parameter_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("ignore_parameter", .Platform$dynlib.ext, sep=""))
 source("ignore_parameter.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/integers_runme.R
+++ b/Examples/test-suite/r/integers_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("integers", .Platform$dynlib.ext, sep=""))
 source("integers.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/overload_method_runme.R
+++ b/Examples/test-suite/r/overload_method_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("overload_method", .Platform$dynlib.ext, sep=""))
 source("overload_method.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/preproc_constants_runme.R
+++ b/Examples/test-suite/r/preproc_constants_runme.R
@@ -1,0 +1,11 @@
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
+dyn.load(paste("preproc_constants", .Platform$dynlib.ext, sep=""))
+source("preproc_constants.R")
+cacheMetaData(1)
+
+v <- enumToInteger('kValue', '_MyEnum')
+print(v)
+unittest(v,4)
+q(save="no")

--- a/Examples/test-suite/r/r_copy_struct_runme.R
+++ b/Examples/test-suite/r/r_copy_struct_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("r_copy_struct", .Platform$dynlib.ext, sep=""))
 source("r_copy_struct.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/r_legacy_runme.R
+++ b/Examples/test-suite/r/r_legacy_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("r_legacy", .Platform$dynlib.ext, sep=""))
 source("r_legacy.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/r_sexp_runme.R
+++ b/Examples/test-suite/r/r_sexp_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("r_sexp", .Platform$dynlib.ext, sep=""))
 source("r_sexp.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/rename_simple_runme.R
+++ b/Examples/test-suite/r/rename_simple_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("rename_simple", .Platform$dynlib.ext, sep=""))
 source("rename_simple.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/simple_array_runme.R
+++ b/Examples/test-suite/r/simple_array_runme.R
@@ -1,4 +1,5 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
 dyn.load(paste("simple_array", .Platform$dynlib.ext, sep=""))
 source("simple_array.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/unions_runme.R
+++ b/Examples/test-suite/r/unions_runme.R
@@ -1,4 +1,5 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
 dyn.load(paste("unions", .Platform$dynlib.ext, sep=""))
 source("unions.R")
 cacheMetaData(1)

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -12,11 +12,11 @@
  * ----------------------------------------------------------------------------- */
 
 #include "swigmod.h"
+#include <limits.h>
 
 static const double DEFAULT_NUMBER = .0000123456712312312323;
 
-static String* replaceInitialDash(const String *name)
-{
+static String *replaceInitialDash(const String *name) {
   String *retval;
   if (!Strncmp(name, "_", 1)) {
     retval = Copy(name);
@@ -27,42 +27,57 @@ static String* replaceInitialDash(const String *name)
   return retval;
 }
 
-static String * getRTypeName(SwigType *t, int *outCount = NULL) {
+static String *getRTypeName(SwigType *t, int *outCount = NULL) {
   String *b = SwigType_base(t);
   List *els = SwigType_split(t);
   int count = 0;
   int i;
-  
-  if(Strncmp(b, "struct ", 7) == 0) 
+
+  if (Strncmp(b, "struct ", 7) == 0)
     Replace(b, "struct ", "", DOH_REPLACE_FIRST);
-  
+
   /* Printf(stdout, "<getRTypeName> %s,base = %s\n", t, b);
-     for(i = 0; i < Len(els); i++) 
+     for(i = 0; i < Len(els); i++)
      Printf(stdout, "%d) %s, ", i, Getitem(els,i));
      Printf(stdout, "\n"); */
-  
-  for(i = 0; i < Len(els); i++) {
+
+  for (i = 0; i < Len(els); i++) {
     String *el = Getitem(els, i);
-    if(Strcmp(el, "p.") == 0 || Strncmp(el, "a(", 2) == 0) {
+    if (Strcmp(el, "p.") == 0 || Strncmp(el, "a(", 2) == 0) {
       count++;
       Append(b, "Ref");
     }
   }
-  if(outCount)
+  if (outCount)
     *outCount = count;
-  
+
   String *tmp = NewString("");
   char *retName = Char(SwigType_manglestr(t));
   Insert(tmp, 0, retName);
   return tmp;
-  
+
   /*
-  if(count)
-    return(b);
-  
-  Delete(b);
-  return(NewString(""));
-  */
+     if(count)
+     return(b);
+
+     Delete(b);
+     return(NewString(""));
+   */
+}
+
+static String *getNamespacePrefix(const String *enumRef) {
+  // for use from enumDeclaration.
+  // returns the namespace part of a string
+  // Do we have any "::"?
+  String *name = NewString(enumRef);
+
+  while (Strstr(name, "::")) {
+    name = NewStringf("%s", Strchr(name, ':') + 2);
+  }
+  String *result = NewStringWithSize(enumRef, Len(enumRef) - Len(name));
+
+  Delete(name);
+  return (result);
 }
 
 /*********************
@@ -71,16 +86,16 @@ static String * getRTypeName(SwigType *t, int *outCount = NULL) {
   Now handles arrays, i.e. struct A[2]
 ****************/
 
-static String *getRClassName(String *retType, int /*addRef*/ = 1, int upRef=0) {
+static String *getRClassName(String *retType, int /*addRef */  = 1, int upRef = 0) {
   String *tmp = NewString("");
   SwigType *resolved = SwigType_typedef_resolve_all(retType);
   char *retName = Char(SwigType_manglestr(resolved));
   if (upRef) {
     Printf(tmp, "_p%s", retName);
-  } else{
+  } else {
     Insert(tmp, 0, retName);
   }
-  
+
   return tmp;
 /*
 #if 1
@@ -89,33 +104,33 @@ static String *getRClassName(String *retType, int /*addRef*/ = 1, int upRef=0) {
   if(!l || n == 0) {
 #ifdef R_SWIG_VERBOSE
     if (debugMode)
-      Printf(stdout, "SwigType_split return an empty list for %s\n", 
-	     retType);
+      Printf(stdout, "SwigType_split return an empty list for %s\n",
+             retType);
 #endif
     return(tmp);
   }
-  
-  
+
+
   String *el = Getitem(l, n-1);
   char *ptr = Char(el);
   if(strncmp(ptr, "struct ", 7) == 0)
     ptr += 7;
-  
+
   Printf(tmp, "%s", ptr);
-  
+
   if(addRef) {
     for(int i = 0; i < n; i++) {
-      if(Strcmp(Getitem(l, i), "p.") == 0 || 
-	 Strncmp(Getitem(l, i), "a(", 2) == 0)
-	Printf(tmp, "Ref");
+      if(Strcmp(Getitem(l, i), "p.") == 0 ||
+         Strncmp(Getitem(l, i), "a(", 2) == 0)
+        Printf(tmp, "Ref");
     }
   }
-  
+
 #else
   char *retName = Char(SwigType_manglestr(retType));
   if(!retName)
     return(tmp);
-  
+
   if(addRef) {
     while(retName && strlen(retName) > 1 && strncmp(retName, "_p", 2) == 0)  {
       retName += 2;
@@ -126,7 +141,7 @@ static String *getRClassName(String *retType, int /*addRef*/ = 1, int upRef=0) {
     retName ++;
   Insert(tmp, 0, retName);
 #endif
-  
+
   return tmp;
 */
 }
@@ -137,50 +152,47 @@ static String *getRClassName(String *retType, int /*addRef*/ = 1, int upRef=0) {
   Now handles arrays, i.e. struct A[2]
 ****************/
 
-static String * getRClassNameCopyStruct(String *retType, int addRef) {
+static String *getRClassNameCopyStruct(String *retType, int addRef) {
   String *tmp = NewString("");
-  
+
 #if 1
   List *l = SwigType_split(retType);
   int n = Len(l);
-  if(!l || n == 0) {
+  if (!l || n == 0) {
 #ifdef R_SWIG_VERBOSE
     Printf(stdout, "SwigType_split return an empty list for %s\n", retType);
 #endif
-    return(tmp);
+    return (tmp);
   }
-  
-  
-  String *el = Getitem(l, n-1);
+
+
+  String *el = Getitem(l, n - 1);
   char *ptr = Char(el);
-  if(strncmp(ptr, "struct ", 7) == 0)
+  if (strncmp(ptr, "struct ", 7) == 0)
     ptr += 7;
-  
+
   Printf(tmp, "%s", ptr);
-  
-  if(addRef) {
-    for(int i = 0; i < n; i++) {
-      if(Strcmp(Getitem(l, i), "p.") == 0 || 
-	 Strncmp(Getitem(l, i), "a(", 2) == 0)
-	Printf(tmp, "Ref");
+
+  if (addRef) {
+    for (int i = 0; i < n; i++) {
+      if (Strcmp(Getitem(l, i), "p.") == 0 || Strncmp(Getitem(l, i), "a(", 2) == 0)
+        Printf(tmp, "Ref");
     }
   }
-  
 #else
   char *retName = Char(SwigType_manglestr(retType));
-  if(!retName)
-    return(tmp);
-  
-  if(addRef) {
-    while(retName && strlen(retName) > 1 && 
-	  strncmp(retName, "_p", 2) == 0)  {
+  if (!retName)
+    return (tmp);
+
+  if (addRef) {
+    while (retName && strlen(retName) > 1 && strncmp(retName, "_p", 2) == 0) {
       retName += 2;
       Printf(tmp, "Ref");
     }
   }
-  
-  if(retName[0] == '_')
-    retName ++;
+
+  if (retName[0] == '_')
+    retName++;
   Insert(tmp, 0, retName);
 #endif
 
@@ -197,11 +209,8 @@ static String * getRClassNameCopyStruct(String *retType, int addRef) {
 
 static void writeListByLine(List *l, File *out, bool quote = 0) {
   int i, n = Len(l);
-  for(i = 0; i < n; i++) 
-    Printf(out, "%s%s%s%s%s\n", tab8, 
-	   quote ? "\"" :"",  
-	   Getitem(l, i), 
-	   quote ? "\"" :"", i < n-1 ? "," : "");
+  for (i = 0; i < n; i++)
+    Printf(out, "%s%s%s%s%s\n", tab8, quote ? "\"" : "", Getitem(l, i), quote ? "\"" : "", i < n - 1 ? "," : "");
 }
 
 
@@ -231,10 +240,13 @@ static void showUsage() {
 }
 
 static bool expandTypedef(SwigType *t) {
-  if (SwigType_isenum(t)) return false;
+  if (SwigType_isenum(t))
+    return false;
   String *prefix = SwigType_prefix(t);
-  if (Strncmp(prefix, "f", 1)) return false;
-  if (Strncmp(prefix, "p.f", 3)) return false;
+  if (Strncmp(prefix, "f", 1))
+    return false;
+  if (Strncmp(prefix, "p.f", 3))
+    return false;
   return true;
 }
 
@@ -246,11 +258,11 @@ static bool expandTypedef(SwigType *t) {
 static int addCopyParameter(SwigType *type) {
   int ok = 0;
   ok = Strncmp(type, "struct ", 7) == 0 || Strncmp(type, "p.struct ", 9) == 0;
-  if(!ok) {
+  if (!ok) {
     ok = Strncmp(type, "p.", 2);
   }
 
-  return(ok);
+  return (ok);
 }
 
 static void replaceRClass(String *tm, SwigType *type) {
@@ -260,25 +272,28 @@ static void replaceRClass(String *tm, SwigType *type) {
   Replaceall(tm, "$R_class", tmp);
   Replaceall(tm, "$*R_class", tmp_base);
   Replaceall(tm, "$&R_class", tmp_ref);
-  Delete(tmp); Delete(tmp_base); Delete(tmp_ref);
+  Delete(tmp);
+  Delete(tmp_base);
+  Delete(tmp_ref);
 }
 
 static double getNumber(String *value) {
   double d = DEFAULT_NUMBER;
-  if(Char(value)) {
-    if(sscanf(Char(value), "%lf", &d) != 1)
-      return(DEFAULT_NUMBER);
+  if (Char(value)) {
+    if (sscanf(Char(value), "%lf", &d) != 1)
+      return (DEFAULT_NUMBER);
   }
-  return(d);
+  return (d);
 }
 
-class R : public Language {
+
+class R:public Language {
 public:
   R();
   void registerClass(Node *n);
   void main(int argc, char *argv[]);
   int top(Node *n);
-  
+
   void dispatchFunction(Node *n);
   int functionWrapper(Node *n);
   int constantWrapper(Node *n);
@@ -290,99 +305,90 @@ public:
   int membervariableHandler(Node *n);
 
   int typedefHandler(Node *n);
-  static List *Swig_overload_rank(Node *n,
-			   bool script_lang_wrapping);
+  static List *Swig_overload_rank(Node *n, bool script_lang_wrapping);
 
   int memberfunctionHandler(Node *n) {
     if (debugMode)
-      Printf(stdout, "<memberfunctionHandler> %s %s\n", 
-	     Getattr(n, "name"),
-	     Getattr(n, "type"));
+      Printf(stdout, "<memberfunctionHandler> %s %s\n", Getattr(n, "name"), Getattr(n, "type"));
     member_name = Getattr(n, "sym:name");
     processing_class_member_function = 1;
-    int status = Language::memberfunctionHandler(n);    
-    processing_class_member_function = 0;
-    return status;
+    int status = Language::memberfunctionHandler(n);
+     processing_class_member_function = 0;
+     return status;
   }
-
-  /* Grab the name of the current class being processed so that we can 
-     deal with members of that class. */
-  int classHandler(Node *n){
-    if(!ClassMemberTable) 
+  /* Grab the name of the current class being processed so that we can
+     deal with members of that class. */ int classHandler(Node *n) {
+    if (!ClassMemberTable)
       ClassMemberTable = NewHash();
-    
+
     class_name = Getattr(n, "name");
     int status = Language::classHandler(n);
-    
+
     class_name = NULL;
     return status;
   }
 
   // Not used:
   String *runtimeCode();
-  
+
 protected:
   int addRegistrationRoutine(String *rname, int nargs);
   int outputRegistrationRoutines(File *out);
-  
+
   int outputCommandLineArguments(File *out);
-  int generateCopyRoutines(Node *n); 
+  int generateCopyRoutines(Node *n);
   int DumpCode(Node *n);
-  
+
   int OutputMemberReferenceMethod(String *className, int isSet, List *el, File *out);
   int OutputArrayMethod(String *className, List *el, File *out);
   int OutputClassMemberTable(Hash *tb, File *out);
   int OutputClassMethodsTable(File *out);
   int OutputClassAccessInfo(Hash *tb, File *out);
-  
+
   int defineArrayAccessors(SwigType *type);
-  
+
   void addNamespaceFunction(String *name) {
-    if(!namespaceFunctions)
+    if (!namespaceFunctions)
       namespaceFunctions = NewList();
     Append(namespaceFunctions, name);
   }
 
   void addNamespaceMethod(String *name) {
-    if(!namespaceMethods)
+    if (!namespaceMethods)
       namespaceMethods = NewList();
     Append(namespaceMethods, name);
   }
-  
-  String* processType(SwigType *t, Node *n, int *nargs = NULL);
+
+  String *processType(SwigType *t, Node *n, int *nargs = NULL);
   String *createFunctionPointerHandler(SwigType *t, Node *n, int *nargs);
   int addFunctionPointerProxy(String *name, Node *n, SwigType *t, String *s_paramTypes) {
     /*XXX Do we need to put the t in there to get the return type later. */
-    if(!functionPointerProxyTable) 
+    if (!functionPointerProxyTable)
       functionPointerProxyTable = NewHash();
-    
+
     Setattr(functionPointerProxyTable, name, n);
-    
+
     Setattr(SClassDefs, name, name);
-    Printv(s_classes, "setClass('", 
-	   name,
-	   "',\n", tab8, 
-	   "prototype = list(parameterTypes = c(", s_paramTypes, "),\n",
-	   tab8, tab8, tab8,
-	   "returnType = '", SwigType_manglestr(t), "'),\n", tab8, 
-	   "contains = 'CRoutinePointer')\n\n##\n", NIL);
-    
+    Printv(s_classes, "setClass('",
+           name,
+           "',\n", tab8,
+           "prototype = list(parameterTypes = c(", s_paramTypes, "),\n",
+           tab8, tab8, tab8, "returnType = '", SwigType_manglestr(t), "'),\n", tab8, "contains = 'CRoutinePointer')\n\n##\n", NIL);
+
     return SWIG_OK;
   }
-  
 
-  void addSMethodInfo(String *name, 
-		      String *argType, int nargs);
-  // Simple initialization such as constant strings that can be reused. 
-  void init(); 
-  
-  
-  void addAccessor(String *memberName, Wrapper *f, 
-		   String *name, int isSet = -1);
-  
+
+  void addSMethodInfo(String *name, String *argType, int nargs);
+  // Simple initialization such as constant strings that can be reused.
+  void init();
+
+
+  void addAccessor(String *memberName, Wrapper *f, String *name, int isSet = -1);
+
   static int getFunctionPointerNumArgs(Node *n, SwigType *tt);
 
-protected: 
+protected:
   bool copyStruct;
   bool memoryProfile;
   bool aggressiveGc;
@@ -400,95 +406,88 @@ protected:
   String *s_init;
   String *s_init_routine;
   String *s_namespace;
-  
-  // State variables that carry information across calls to functionWrapper() 
-  // from  member accessors and class declarations. 
+
+  // State variables that carry information across calls to functionWrapper()
+  // from  member accessors and class declarations.
   String *opaqueClassDeclaration;
   int processing_variable;
   int processing_member_access_function;
   String *member_name;
   String *class_name;
-  
-  
+
+
   int processing_class_member_function;
   List *class_member_functions;
   List *class_member_set_functions;
-  
+
   /* */
   Hash *ClassMemberTable;
   Hash *ClassMethodsTable;
   Hash *SClassDefs;
   Hash *SMethodInfo;
-  
-  // Information about routines that are generated and to be registered with 
-  // R for dynamic lookup. 
+
+  // Information about routines that are generated and to be registered with
+  // R for dynamic lookup.
   Hash *registrationTable;
   Hash *functionPointerProxyTable;
-  
+
   List *namespaceFunctions;
   List *namespaceMethods;
-  List *namespaceClasses; // Probably can do this from ClassMemberTable.
-  
-  
-  // Store a copy of the command line. 
-  // Need only keep a string that has it formatted. 
+  List *namespaceClasses;       // Probably can do this from ClassMemberTable.
+
+
+  // Store a copy of the command line.
+  // Need only keep a string that has it formatted.
   char **Argv;
-  int    Argc;
+  int Argc;
   bool inCPlusMode;
-  
+
   // State variables that we remember from the command line settings
   // potentially that govern the code we generate.
   String *DllName;
   String *Rpackage;
-  bool    noInitializationCode;
-  bool    outputNamespaceInfo;
-  
+  bool noInitializationCode;
+  bool outputNamespaceInfo;
+
   String *UnProtectWrapupCode;
 
   // Static members
   static bool debugMode;
 };
 
-R::R() :
-  copyStruct(false),
-  memoryProfile(false),
-  aggressiveGc(false),
-  sfile(0),
-  f_init(0),
-  s_classes(0),
-  f_begin(0),
-  f_runtime(0),
-  f_wrapper(0),
-  s_header(0),
-  f_wrappers(0),
-  s_init(0),
-  s_init_routine(0),
-  s_namespace(0),
-  opaqueClassDeclaration(0),
-  processing_variable(0),
-  processing_member_access_function(0),
-  member_name(0),
-  class_name(0),
-  processing_class_member_function(0),
-  class_member_functions(0),
-  class_member_set_functions(0),
-  ClassMemberTable(0),
-  ClassMethodsTable(0),
-  SClassDefs(0),
-  SMethodInfo(0),
-  registrationTable(0),
-  functionPointerProxyTable(0),
-  namespaceFunctions(0),
-  namespaceMethods(0),
-  namespaceClasses(0),
-  Argv(0),
-  Argc(0),
-  inCPlusMode(false),
-  DllName(0),
-  Rpackage(0),
-  noInitializationCode(false),
-  outputNamespaceInfo(false),
-  UnProtectWrapupCode(0) {
+R::R():
+copyStruct(false),
+memoryProfile(false),
+aggressiveGc(false),
+sfile(0),
+f_init(0),
+s_classes(0),
+f_begin(0),
+f_runtime(0),
+f_wrapper(0),
+s_header(0),
+f_wrappers(0),
+s_init(0),
+s_init_routine(0),
+s_namespace(0),
+opaqueClassDeclaration(0),
+processing_variable(0),
+processing_member_access_function(0),
+member_name(0),
+class_name(0),
+processing_class_member_function(0),
+class_member_functions(0),
+class_member_set_functions(0),
+ClassMemberTable(0),
+ClassMethodsTable(0),
+SClassDefs(0),
+SMethodInfo(0),
+registrationTable(0),
+functionPointerProxyTable(0),
+namespaceFunctions(0),
+namespaceMethods(0),
+namespaceClasses(0),
+Argv(0), Argc(0), inCPlusMode(false), DllName(0), Rpackage(0), noInitializationCode(false), outputNamespaceInfo(false), UnProtectWrapupCode(0) {
 }
 
 bool R::debugMode = false;
@@ -508,43 +507,44 @@ int R::getFunctionPointerNumArgs(Node *n, SwigType *tt) {
 
 void R::addSMethodInfo(String *name, String *argType, int nargs) {
   (void) argType;
-  
-  if(!SMethodInfo)
+
+  if (!SMethodInfo)
     SMethodInfo = NewHash();
   if (debugMode)
     Printf(stdout, "[addMethodInfo] %s\n", name);
 
   Hash *tb = Getattr(SMethodInfo, name);
 
-  if(!tb) {
+  if (!tb) {
     tb = NewHash();
     Setattr(SMethodInfo, name, tb);
   }
 
   String *str = Getattr(tb, "max");
   int max = -1;
-  if(str)
+  if (str)
     max = atoi(Char(str));
-  if(max < nargs) {
-    if(str)  Delete(str);
+  if (max < nargs) {
+    if (str)
+      Delete(str);
     str = NewStringf("%d", max);
     Setattr(tb, "max", str);
   }
 }
- 
+
 /*
 Returns the name of the new routine.
 */
-String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
+String *R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   String *funName = SwigType_manglestr(t);
-  
+
   /* See if we have already processed this one. */
-  if(functionPointerProxyTable && Getattr(functionPointerProxyTable, funName))
+  if (functionPointerProxyTable && Getattr(functionPointerProxyTable, funName))
     return funName;
-  
+
   if (debugMode)
-    Printf(stdout, "<createFunctionPointerHandler> Defining %s\n",  t);
-  
+    Printf(stdout, "<createFunctionPointerHandler> Defining %s\n", t);
+
   SwigType *rettype = Copy(Getattr(n, "type"));
   SwigType *funcparams = SwigType_functionpointer_decompose(rettype);
   String *rtype = SwigType_str(rettype, 0);
@@ -558,13 +558,13 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
     Printf(stdout, "Type: %s\n", t);
     Printf(stdout, "Return type: %s\n", SwigType_base(t));
   }
-  
+
   bool isVoidType = Strcmp(rettype, "void") == 0;
   if (debugMode)
     Printf(stdout, "%s is void ? %s  (%s)\n", funName, isVoidType ? "yes" : "no", rettype);
-  
+
   Wrapper *f = NewWrapper();
-  
+
   /* Go through argument list, attach lnames for arguments */
   int i = 0;
   Parm *p = parms;
@@ -573,14 +573,14 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
     String *lname;
 
     if (!arg && Cmp(Getattr(p, "type"), "void")) {
-      lname = NewStringf("s_arg%d", i+1);
+      lname = NewStringf("s_arg%d", i + 1);
       Setattr(p, "name", lname);
     } else
       lname = arg;
 
     Setattr(p, "lname", lname);
   }
-  
+
   Swig_typemap_attach_parms("out", parms, f);
   Swig_typemap_attach_parms("scoerceout", parms, f);
   Swig_typemap_attach_parms("scheck", parms, f);
@@ -595,9 +595,9 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   Wrapper_add_local(f, "r_swig_cb_data", "RCallbackFunctionData *r_swig_cb_data = R_SWIG_getCallbackFunctionData()");
   String *lvar = NewString("r_swig_cb_data");
 
-  Wrapper_add_local(f, "r_tmp", "SEXP r_tmp"); // for use in converting arguments to R objects for call.
-  Wrapper_add_local(f, "r_nprotect", "int r_nprotect = 0"); // for use in converting arguments to R objects for call.
-  Wrapper_add_local(f, "r_vmax", "char * r_vmax= 0"); // for use in converting arguments to R objects for call.
+  Wrapper_add_local(f, "r_tmp", "SEXP r_tmp");  // for use in converting arguments to R objects for call.
+  Wrapper_add_local(f, "r_nprotect", "int r_nprotect = 0");     // for use in converting arguments to R objects for call.
+  Wrapper_add_local(f, "r_vmax", "char * r_vmax= 0");   // for use in converting arguments to R objects for call.
 
   // Add local for error code in return value.  This is not in emit_return_variable because that assumes an out typemap
   // whereas the type makes are reverse
@@ -605,136 +605,125 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
 
   p = parms;
   int nargs = ParmList_len(parms);
-  if(numArgs) {
+  if (numArgs) {
     *numArgs = nargs;
     if (debugMode)
       Printf(stdout, "Setting number of parameters to %d\n", *numArgs);
-  } 
+  }
   String *setExprElements = NewString("");
-  
+
   String *s_paramTypes = NewString("");
-  for(i = 0; p; i++) {
+  for (i = 0; p; i++) {
     SwigType *tt = Getattr(p, "type");
     SwigType *name = Getattr(p, "name");
     String *tm = Getattr(p, "tmap:out");
-    Printf(f->def,  "%s %s", SwigType_str(tt, 0), name);
-     if(tm) {
+    Printf(f->def, "%s %s", SwigType_str(tt, 0), name);
+    if (tm) {
       Replaceall(tm, "$1", name);
       if (SwigType_isreference(tt)) {
-	String *tmp = NewString("");
+        String *tmp = NewString("");
         Append(tmp, "*");
-	Append(tmp, name);
-	Replaceall(tm, tmp, name);
+        Append(tmp, name);
+        Replaceall(tm, tmp, name);
       }
       Replaceall(tm, "$result", "r_tmp");
-      replaceRClass(tm, Getattr(p,"type"));
-      Replaceall(tm,"$owner", "R_SWIG_EXTERNAL");
-    } 
-    
+      replaceRClass(tm, Getattr(p, "type"));
+      Replaceall(tm, "$owner", "R_SWIG_EXTERNAL");
+    }
+
     Printf(setExprElements, "%s\n", tm);
     Printf(setExprElements, "SETCAR(r_swig_cb_data->el, %s);\n", "r_tmp");
     Printf(setExprElements, "r_swig_cb_data->el = CDR(r_swig_cb_data->el);\n\n");
-    
+
     Printf(s_paramTypes, "'%s'", SwigType_manglestr(tt));
-    
-    
+
+
     p = nextSibling(p);
-    if(p) {
+    if (p) {
       Printf(f->def, ", ");
       Printf(s_paramTypes, ", ");
     }
   }
-  
-  Printf(f->def,  ") {\n");
-  
+
+  Printf(f->def, ") {\n");
+
   Printf(f->code, "Rf_protect(%s->expr = Rf_allocVector(LANGSXP, %d));\n", lvar, nargs + 1);
   Printf(f->code, "r_nprotect++;\n");
   Printf(f->code, "r_swig_cb_data->el = r_swig_cb_data->expr;\n\n");
-  
+
   Printf(f->code, "SETCAR(r_swig_cb_data->el, r_swig_cb_data->fun);\n");
   Printf(f->code, "r_swig_cb_data->el = CDR(r_swig_cb_data->el);\n\n");
-  
+
   Printf(f->code, "%s\n\n", setExprElements);
-  
-  Printv(f->code, "r_swig_cb_data->retValue = R_tryEval(", 
-	 "r_swig_cb_data->expr,",
-	 " R_GlobalEnv,",
-	 " &r_swig_cb_data->errorOccurred",
-	 ");\n", 
-	 NIL);
-  
+
+  Printv(f->code, "r_swig_cb_data->retValue = R_tryEval(", "r_swig_cb_data->expr,", " R_GlobalEnv,", " &r_swig_cb_data->errorOccurred", ");\n", NIL);
+
   Printv(f->code, "\n",
-	 "if(r_swig_cb_data->errorOccurred) {\n",
-	 "R_SWIG_popCallbackFunctionData(1);\n",
-	 "Rf_error(\"error in calling R function as a function pointer (",
-	 funName,
-	 ")\");\n",
-	 "}\n",
-	 NIL);
-   
-   
-   
-  if(!isVoidType) {
-    /* Need to deal with the return type of the function pointer, not the function pointer itself. 
+         "if(r_swig_cb_data->errorOccurred) {\n",
+         "R_SWIG_popCallbackFunctionData(1);\n", "Rf_error(\"error in calling R function as a function pointer (", funName, ")\");\n", "}\n", NIL);
+
+
+
+  if (!isVoidType) {
+    /* Need to deal with the return type of the function pointer, not the function pointer itself.
        So build a new node that has the relevant pieces.
        XXX  Have to be a little more clever so that we can deal with struct A * - the * is getting lost.
        Is this still true? If so, will a SwigType_push() solve things?
-    */
+     */
     Parm *bbase = NewParmNode(rettype, n);
     String *returnTM = Swig_typemap_lookup("in", bbase, Swig_cresult_name(), f);
-    if(returnTM) {
+    if (returnTM) {
       String *tm = returnTM;
-      Replaceall(tm,"$input", "r_swig_cb_data->retValue");
-      Replaceall(tm,"$target", Swig_cresult_name());
+      Replaceall(tm, "$input", "r_swig_cb_data->retValue");
+      Replaceall(tm, "$target", Swig_cresult_name());
       replaceRClass(tm, rettype);
-      Replaceall(tm,"$owner", "R_SWIG_EXTERNAL");
-      Replaceall(tm,"$disown","0");
+      Replaceall(tm, "$owner", "R_SWIG_EXTERNAL");
+      Replaceall(tm, "$disown", "0");
       Printf(f->code, "%s\n", tm);
     }
     Delete(bbase);
   }
-  
+
   Printv(f->code, "R_SWIG_popCallbackFunctionData(1);\n", NIL);
   Printv(f->code, "\n", UnProtectWrapupCode, NIL);
 
-  if (SwigType_isreference(rettype)) {  
-    Printv(f->code,  "return *", Swig_cresult_name(), ";\n", NIL);
-  } else if(!isVoidType)
-    Printv(f->code,  "return ", Swig_cresult_name(), ";\n", NIL);
-  
+  if (SwigType_isreference(rettype)) {
+    Printv(f->code, "return *", Swig_cresult_name(), ";\n", NIL);
+  } else if (!isVoidType)
+    Printv(f->code, "return ", Swig_cresult_name(), ";\n", NIL);
+
   Printv(f->code, "\n}\n", NIL);
   Replaceall(f->code, "SWIG_exception_fail", "SWIG_exception_noreturn");
-  
+
   /* To coerce correctly in S, we really want to have an extra/intermediate
-     function that handles the scoerceout. 
+     function that handles the scoerceout.
      We need to check if any of the argument types have an entry in
      that map. If none do, the ignore and call the function straight.
      Otherwise, generate the a marshalling function.
      Need to be able to find it in S. Or use an entirely generic one
      that evaluates the expressions.
      Handle errors in the evaluation of the function by restoring
-     the stack, if there is one in use for this function (i.e. no 
+     the stack, if there is one in use for this function (i.e. no
      userData).
-  */
-  
+   */
+
   Wrapper_print(f, f_wrapper);
-  
+
   addFunctionPointerProxy(funName, n, t, s_paramTypes);
   Delete(s_paramTypes);
   Delete(rtype);
   Delete(rettype);
   Delete(funcparams);
   DelWrapper(f);
-  
+
   return funName;
 }
 
 void R::init() {
-  UnProtectWrapupCode =  
-    NewStringf("%s", "vmaxset(r_vmax);\nif(r_nprotect)  Rf_unprotect(r_nprotect);\n\n");
-  
+  UnProtectWrapupCode = NewStringf("%s", "vmaxset(r_vmax);\nif(r_nprotect)  Rf_unprotect(r_nprotect);\n\n");
+
   SClassDefs = NewHash();
-  
+
   sfile = NewString("");
   f_init = NewString("");
   s_header = NewString("");
@@ -761,18 +750,18 @@ int R::cDeclaration(Node *n) {
 
 /**
    Method from Language that is called to start the entire
-   processing off, i.e. the generation of the code. 
+   processing off, i.e. the generation of the code.
    It is called after the input has been read and parsed.
    Here we open the output streams and generate the code.
 ***/
 int R::top(Node *n) {
   String *module = Getattr(n, "name");
-  if(!Rpackage) 
+  if (!Rpackage)
     Rpackage = Copy(module);
-  if(!DllName)
+  if (!DllName)
     DllName = Copy(module);
 
-  if(outputNamespaceInfo) {
+  if (outputNamespaceInfo) {
     s_namespace = NewString("");
     Swig_register_filebyname("snamespace", s_namespace);
     Printf(s_namespace, "useDynLib(%s)\n", DllName);
@@ -797,7 +786,7 @@ int R::top(Node *n) {
   Printf(f_runtime, "#define SWIGR\n");
   Printf(f_runtime, "\n");
 
-  
+
   Swig_banner_target_lang(s_init, "#");
   outputCommandLineArguments(s_init);
 
@@ -812,17 +801,17 @@ int R::top(Node *n) {
   Printf(f_wrapper, "#endif\n");
 
   String *type_table = NewString("");
-  SwigType_emit_type_table(f_runtime,f_wrapper);
+  SwigType_emit_type_table(f_runtime, f_wrapper);
   Delete(type_table);
 
-  if(ClassMemberTable) {
+  if (ClassMemberTable) {
     //XXX OutputClassAccessInfo(ClassMemberTable, sfile);
     Delete(ClassMemberTable);
     ClassMemberTable = NULL;
   }
 
-  Printf(f_init,"}\n");
-  if(registrationTable)
+  Printf(f_init, "}\n");
+  if (registrationTable)
     outputRegistrationRoutines(f_init);
 
   /* Now arrange to write the 2 files - .S and .c. */
@@ -848,35 +837,35 @@ int R::top(Node *n) {
 ****************************************************/
 int R::DumpCode(Node *n) {
   String *output_filename = NewString("");
-  
-  
+
+
   /* The name of the file in which we will generate the S code. */
   Printf(output_filename, "%s%s.R", SWIG_output_directory(), Rpackage);
-  
+
 #ifdef R_SWIG_VERBOSE
   Printf(stdout, "Writing S code to %s\n", output_filename);
 #endif
-  
+
   File *scode = NewFile(output_filename, "w", SWIG_output_files());
   if (!scode) {
     FileErrorDisplay(output_filename);
     SWIG_exit(EXIT_FAILURE);
   }
   Delete(output_filename);
-  
-  
+
+
   Printf(scode, "%s\n\n", s_init);
   Printf(scode, "%s\n\n", s_classes);
   Printf(scode, "%s\n", sfile);
-  
+
   Delete(scode);
-  String *outfile = Getattr(n,"outfile");
-  File *runtime = NewFile(outfile,"w", SWIG_output_files());
+  String *outfile = Getattr(n, "outfile");
+  File *runtime = NewFile(outfile, "w", SWIG_output_files());
   if (!runtime) {
     FileErrorDisplay(outfile);
     SWIG_exit(EXIT_FAILURE);
   }
-  
+
   Printf(runtime, "%s", f_begin);
   Printf(runtime, "%s\n", f_runtime);
   Printf(runtime, "%s\n", s_header);
@@ -885,7 +874,7 @@ int R::DumpCode(Node *n) {
 
   Delete(runtime);
 
-  if(outputNamespaceInfo) {
+  if (outputNamespaceInfo) {
     output_filename = NewString("");
     Printf(output_filename, "%sNAMESPACE", SWIG_output_directory());
     File *ns = NewFile(output_filename, "w", SWIG_output_files());
@@ -894,7 +883,7 @@ int R::DumpCode(Node *n) {
       SWIG_exit(EXIT_FAILURE);
     }
     Delete(output_filename);
-   
+
     Printf(ns, "%s\n", s_namespace);
 
     Printf(ns, "\nexport(\n");
@@ -913,7 +902,7 @@ int R::DumpCode(Node *n) {
 
 
 /*
-  We may need to do more.... so this is left as a 
+  We may need to do more.... so this is left as a
   stub for the moment.
 */
 int R::OutputClassAccessInfo(Hash *tb, File *out) {
@@ -925,28 +914,28 @@ int R::OutputClassAccessInfo(Hash *tb, File *out) {
 /************************************************************************
   Currently this just writes the information collected about the
   different methods of the C++ classes that have been processed
-  to the console. 
+  to the console.
   This will be used later to define S4 generics and methods.
 **************************************************************************/
 int R::OutputClassMethodsTable(File *) {
   Hash *tb = ClassMethodsTable;
-  
-  if(!tb)
+
+  if (!tb)
     return SWIG_OK;
-  
+
   List *keys = Keys(tb);
   String *key;
   int i, n = Len(keys);
   if (debugMode) {
-    for(i = 0; i < n ; i++ ) {
+    for (i = 0; i < n; i++) {
       key = Getitem(keys, i);
       Printf(stdout, "%d) %s\n", i, key);
       List *els = Getattr(tb, key);
       int nels = Len(els);
       Printf(stdout, "\t");
-      for(int j = 0; j < nels; j+=2) {
-	Printf(stdout, "%s%s", Getitem(els, j), j < nels - 1 ? ", " : "");
-	Printf(stdout, "%s\n", Getitem(els, j+1));
+      for (int j = 0; j < nels; j += 2) {
+        Printf(stdout, "%s%s", Getitem(els, j), j < nels - 1 ? ", " : "");
+        Printf(stdout, "%s\n", Getitem(els, j + 1));
       }
       Printf(stdout, "\n");
     }
@@ -957,89 +946,88 @@ int R::OutputClassMethodsTable(File *) {
 
 
 /*
-  Iterate over the <class name>_set and <>_get 
+  Iterate over the <class name>_set and <>_get
   elements and generate the $ and $<- functions
   that provide constrained access to the member
   fields in these elements.
 
   tb - a hash table that is built up in functionWrapper
   as we process each membervalueHandler.
-  The entries are indexed by <class name>_set and 
+  The entries are indexed by <class name>_set and
   <class_name>_get. Each entry is a List *.
-   
+
   out - the stram where the code is to be written. This is the S
   code stream as we generate only S code here..
 */
 int R::OutputClassMemberTable(Hash *tb, File *out) {
   List *keys = Keys(tb), *el;
-  
+
   String *key;
   int i, n = Len(keys);
   /* Loop over all the  <Class>_set and <Class>_get entries in the table. */
-  
-  if(n && outputNamespaceInfo) {
+
+  if (n && outputNamespaceInfo) {
     Printf(s_namespace, "exportClasses(");
   }
-  for(i = 0; i < n; i++) {
+  for (i = 0; i < n; i++) {
     key = Getitem(keys, i);
     el = Getattr(tb, key);
-    
+
     String *className = Getitem(el, 0);
     char *ptr = Char(key);
     ptr = &ptr[Len(key) - 3];
     int isSet = strcmp(ptr, "set") == 0;
-    
-    //        OutputArrayMethod(className, el, out);        
+
+    //        OutputArrayMethod(className, el, out);
     OutputMemberReferenceMethod(className, isSet, el, out);
-    
-    if(outputNamespaceInfo) 
-      Printf(s_namespace, "\"%s\"%s", className, i < n-1 ? "," : "");
+
+    if (outputNamespaceInfo)
+      Printf(s_namespace, "\"%s\"%s", className, i < n - 1 ? "," : "");
   }
-  if(n && outputNamespaceInfo) { 
+  if (n && outputNamespaceInfo) {
     Printf(s_namespace, ")\n");
   }
-  
+
   return n;
 }
 
 /*******************************************************************
- Write the methods for $ or $<- for accessing a member field in an 
+ Write the methods for $ or $<- for accessing a member field in an
  struct or union (or class).
  className - the name of the struct or union (e.g. Bar for struct Bar)
- isSet - a logical value indicating whether the method is for 
+ isSet - a logical value indicating whether the method is for
            modifying ($<-) or accessing ($) the member field.
  el - a list of length  2 * # accessible member elements  + 1.
-      The first element is the name of the class. 
+      The first element is the name of the class.
       The other pairs are  member name and the name of the R function to access it.
  out - the stream where we write the code.
 ********************************************************************/
-int R::OutputMemberReferenceMethod(String *className, int isSet, 
-				   List *el, File *out) {
+int R::OutputMemberReferenceMethod(String *className, int isSet, List *el, File *out) {
   int numMems = Len(el), j;
   int varaccessor = 0;
-  if (numMems == 0) 
+  if (numMems == 0)
     return SWIG_OK;
-  
+
   Wrapper *f = NewWrapper(), *attr = NewWrapper();
-  
+
   Printf(f->def, "function(x, name%s)", isSet ? ", value" : "");
   Printf(attr->def, "function(x, i, j, ...%s)", isSet ? ", value" : "");
-  
+
   Printf(f->code, "{\n");
   Printf(f->code, "%saccessorFuns = list(", tab8);
 
   Node *itemList = NewHash();
   bool has_prev = false;
-  for(j = 0; j < numMems; j+=3) {
+  for (j = 0; j < numMems; j += 3) {
     String *item = Getitem(el, j);
-    if (Getattr(itemList, item)) 
+    if (Getattr(itemList, item))
       continue;
     Setattr(itemList, item, "1");
-    
+
     String *dup = Getitem(el, j + 1);
     char *ptr = Char(dup);
     ptr = &ptr[Len(dup) - 3];
-    
+
     if (!strcmp(ptr, "get"))
       varaccessor++;
 
@@ -1055,7 +1043,7 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     } else {
       pitem = Copy(item);
     }
-    if (has_prev) 
+    if (has_prev)
       Printf(f->code, ", ");
     Printf(f->code, "'%s' = %s", pitem, dup);
     has_prev = true;
@@ -1063,114 +1051,102 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   }
   Delete(itemList);
   Printf(f->code, ");\n");
-  
+
   if (!isSet && varaccessor > 0) {
     Printf(f->code, "%svaccessors = c(", tab8);
     int vcount = 0;
-    for(j = 0; j < numMems; j+=3) {
+    for (j = 0; j < numMems; j += 3) {
       String *item = Getitem(el, j);
       String *dup = Getitem(el, j + 1);
       char *ptr = Char(dup);
       ptr = &ptr[Len(dup) - 3];
-      
+
       if (!strcmp(ptr, "get")) {
-	vcount++;
-	Printf(f->code, "'%s'%s", item, vcount < varaccessor ? ", " : "");
+        vcount++;
+        Printf(f->code, "'%s'%s", item, vcount < varaccessor ? ", " : "");
       }
     }
     Printf(f->code, ");\n");
   }
-  
-  
+
+
   /*    Printv(f->code, tab8,
-	"idx = pmatch(name, names(accessorFuns))\n",
-	tab8,
-	"if(is.na(idx)) {\n",
-	tab8, tab4, 
-	"stop(\"No ", (isSet ? "modifiable" : "accessible"), " field named \", name, \" in ", className,
-	": fields are \", paste(names(accessorFuns), sep = \", \")", 
-	")", "\n}\n", NIL); */
-  Printv(f->code, ";", tab8,
-	 "idx = pmatch(name, names(accessorFuns));\n",
-	 tab8,
-	 "if(is.na(idx)) \n",
-	 tab8, tab4, NIL);
-  Printf(f->code, "return(callNextMethod(x, name%s));\n",
-	 isSet ? ", value" : "");
+     "idx = pmatch(name, names(accessorFuns))\n",
+     tab8,
+     "if(is.na(idx)) {\n",
+     tab8, tab4,
+     "stop(\"No ", (isSet ? "modifiable" : "accessible"), " field named \", name, \" in ", className,
+     ": fields are \", paste(names(accessorFuns), sep = \", \")",
+     ")", "\n}\n", NIL); */
+  Printv(f->code, ";", tab8, "idx = pmatch(name, names(accessorFuns));\n", tab8, "if(is.na(idx)) \n", tab8, tab4, NIL);
+  Printf(f->code, "return(callNextMethod(x, name%s));\n", isSet ? ", value" : "");
   Printv(f->code, tab8, "f = accessorFuns[[idx]];\n", NIL);
-  if(isSet) {
+  if (isSet) {
     Printv(f->code, tab8, "f(x, value);\n", NIL);
     Printv(f->code, tab8, "x;\n", NIL); // make certain to return the S value.
   } else {
     if (varaccessor) {
-      Printv(f->code, tab8,
-	     "if (is.na(match(name, vaccessors))) function(...){f(x, ...)} else f(x);\n", NIL);
+      Printv(f->code, tab8, "if (is.na(match(name, vaccessors))) function(...){f(x, ...)} else f(x);\n", NIL);
     } else {
       Printv(f->code, tab8, "function(...){f(x, ...)};\n", NIL);
     }
   }
   Printf(f->code, "}\n");
-  
-  
+
+
   Printf(out, "# Start of accessor method for %s\n", className);
-  Printf(out, "setMethod('$%s', '_p%s', ",
-	 isSet ? "<-" : "", 
-	 getRClassName(className)); 
+  Printf(out, "setMethod('$%s', '_p%s', ", isSet ? "<-" : "", getRClassName(className));
   Wrapper_print(f, out);
   Printf(out, ");\n");
-  
-  if(isSet) {
-    Printf(out, "setMethod('[[<-', c('_p%s', 'character'),", 
-	   getRClassName(className)); 
+
+  if (isSet) {
+    Printf(out, "setMethod('[[<-', c('_p%s', 'character'),", getRClassName(className));
     Insert(f->code, 2, "name = i;\n");
     Printf(attr->code, "%s", f->code);
     Wrapper_print(attr, out);
     Printf(out, ");\n");
   }
-  
+
   DelWrapper(attr);
   DelWrapper(f);
-  
+
   Printf(out, "# end of accessor method for %s\n", className);
-  
+
   return SWIG_OK;
 }
 
 /*******************************************************************
- Write the methods for [ or [<- for accessing a member field in an 
+ Write the methods for [ or [<- for accessing a member field in an
  struct or union (or class).
  className - the name of the struct or union (e.g. Bar for struct Bar)
  el - a list of length  2 * # accessible member elements  + 1.
-      The first element is the name of the class. 
+      The first element is the name of the class.
       The other pairs are  member name and the name of the R function to access it.
  out - the stream where we write the code.
 ********************************************************************/
 int R::OutputArrayMethod(String *className, List *el, File *out) {
   int numMems = Len(el), j;
-  
-  if(!el || numMems == 0)
-    return(0);
-  
+
+  if (!el || numMems == 0)
+    return (0);
+
   Printf(out, "# start of array methods for %s\n", className);
-  for(j = 0; j < numMems; j+=3) {
+  for (j = 0; j < numMems; j += 3) {
     String *item = Getitem(el, j);
     String *dup = Getitem(el, j + 1);
     if (!Strcmp(item, "__getitem__")) {
-      Printf(out, 
-	     "setMethod('[', '_p%s', function(x, i, j, ..., drop =TRUE) ", 
-	     getRClassName(className));
+      Printf(out, "setMethod('[', '_p%s', function(x, i, j, ..., drop =TRUE) ", getRClassName(className));
       Printf(out, "  sapply(i, function (n)  %s(x, as.integer(n-1))))\n\n", dup);
     }
     if (!Strcmp(item, "__setitem__")) {
-      Printf(out, "setMethod('[<-', '_p%s', function(x, i, j, ..., value)", 
-	     getRClassName(className));
+      Printf(out, "setMethod('[<-', '_p%s', function(x, i, j, ..., value)", getRClassName(className));
       Printf(out, "  sapply(1:length(i), function(n) %s(x, as.integer(i[n]-1), value[n])))\n\n", dup);
     }
-    
+
   }
-  
+
   Printf(out, "# end of array methods for %s\n", className);
-  
+
   return SWIG_OK;
 }
 
@@ -1183,51 +1159,129 @@ int R::OutputArrayMethod(String *className, List *el, File *out) {
 int R::enumDeclaration(Node *n) {
   String *name = Getattr(n, "name");
   String *tdname = Getattr(n, "tdname");
-  
+
+  if (cplus_mode != PUBLIC) {
+    return (SWIG_NOWRAP);
+  }
+
   /* Using name if tdname is empty. */
-  
-  if(Len(tdname) == 0)
+
+  if (Len(tdname) == 0)
     tdname = name;
 
-
-  if(!tdname || Strcmp(tdname, "") == 0) {
+  if (!tdname || Strcmp(tdname, "") == 0) {
     Language::enumDeclaration(n);
     return SWIG_OK;
   }
-  
+
   String *mangled_tdname = SwigType_manglestr(tdname);
   String *scode = NewString("");
-  
-  Printv(scode, "defineEnumeration('", mangled_tdname, "'", 
-	 ",\n",  tab8, tab8, tab4, ".values = c(\n", NIL);
-  
+  String *possiblescode = NewString("");
+
+  // Need to create some C code to return the enum values.
+  // Presumably a C function for each element of the enum..
+  // There is probably some sneaky way to use the
+  // standard methods of variable/constant access, but I can't see
+  // it yet.
+  // Need to fetch the namespace part of the enum in tdname, so
+  // that we can address the correct enum. Perhaps there is already an
+  // attribute that has this info, but I can't find it. That leaves
+  // searching for ::. Obviously needs to work if there is no nesting.
+  //
+  // One issue is that swig is generating defineEnumeration calls for
+  // enums in the private part of classes. This usually isn't a
+  // problem, but the model in which some C code returns the
+  // underlying value won't compile because it is accessing a private
+  // type.
+  //
+  // It will be best to turn off binding to private parts of
+  // classes.
+
+  String *cppcode = NewString("");
+  // this is the namespace that will get used inside the functions
+  // returning enumerations.
+  String *namespaceprefix = getNamespacePrefix(tdname);
+  Wrapper *eW = NewWrapper();
+  Node *kk;
+
+  for (kk = firstChild(n); kk; kk = nextSibling(kk)) {
+    String *ename = Getattr(kk, "name");
+    String *fname = NewString("");
+    String *cfunctname = NewStringf("R_swigenum_%s_%s", mangled_tdname, ename);
+    String *rfunctname = NewStringf("R_swigenum_%s_%s_get", mangled_tdname, ename);
+    Printf(fname, "%s(void){", cfunctname);
+    Printf(cppcode, "SWIGEXPORT SEXP \n%s\n", fname);
+    Printf(cppcode, "int result;\n");
+    Printf(cppcode, "SEXP r_ans = R_NilValue;\n");
+    Printf(cppcode, "result = (int)%s%s;\n", namespaceprefix, ename);
+    Printf(cppcode, "r_ans = Rf_ScalarInteger(result);\n");
+    Printf(cppcode, "return(r_ans);\n}\n");
+
+    // Now emit the r binding functions
+    Printf(possiblescode, "`%s` = function(.copy=FALSE) {\n", rfunctname);
+    Printf(possiblescode, ".Call(\'%s\', as.logical(.copy), PACKAGE=\'%s\')\n}\n\n", cfunctname, Rpackage);
+    Printf(possiblescode, "attr(`%s`, \'returnType\')=\'integer\'\n", rfunctname);
+    Printf(possiblescode, "class(`%s`) = c(\"SWIGfunction\", class(\'%s\'))\n\n", rfunctname, rfunctname);
+    Delete(ename);
+    Delete(fname);
+    Delete(cfunctname);
+    Delete(rfunctname);
+  }
+
+  Printv(cppcode, "", NIL);
+
+  Printf(eW->code, "%s", cppcode);
+  Delete(cppcode);
+
+  Delete(namespaceprefix);
+
+  Printv(scode, "defineEnumeration('", mangled_tdname, "'", ",\n", tab8, tab8, tab4, ".values = c(\n", NIL);
+
   Node *c;
-  int value = -1; // First number is zero
+  int value = -1;               // First number is zero
+  bool needenumfunc = false;    // Track whether we need runtime C
+                                // calls to deduce correct enum values
   for (c = firstChild(n); c; c = nextSibling(c)) {
     //      const char *tag = Char(nodeType(c));
-    //      if (Strcmp(tag,"cdecl") == 0) {        
+    //      if (Strcmp(tag,"cdecl") == 0) {
     name = Getattr(c, "name");
+    // This needs to match the version earlier - could have stored it.
+    String *rfunctname = NewStringf("R_swigenum_%s_%s_get()", mangled_tdname, name);
     String *val = Getattr(c, "enumvalue");
-    if(val && Char(val)) {
-      int inval = (int) getNumber(val);
-      if(inval == DEFAULT_NUMBER) 
-	value++;
-      else 
-	value = inval;
-    } else
+    String *numstring = NewString("");
+
+    if (val && Char(val)) {
+      double inval = getNumber(val);
+      if (inval == DEFAULT_NUMBER) {
+        // This should indicate there is some fancy text there
+        // so we want to call the special R functions
+        needenumfunc = true;
+        Printf(numstring, "%s", rfunctname);
+      } else {
+        value = (int) inval;
+        Printf(numstring, "%d", value);
+
+      }
+    } else {
       value++;
-    
-    Printf(scode, "%s%s%s'%s' = %d%s\n", tab8, tab8, tab8, name, value,
-	   nextSibling(c) ? ", " : "");
-    //      }
+      Printf(numstring, "%d", value);
+    }
+    Printf(scode, "%s%s%s'%s' = %s%s\n", tab8, tab8, tab8, name, numstring, nextSibling(c) ? ", " : "");
+    Delete(rfunctname);
+    Delete(numstring);
   }
-  
+
   Printv(scode, "))", NIL);
+
+  if (needenumfunc) {
+    Wrapper_print(eW, f_wrapper);
+    Printf(sfile, "%s\n", possiblescode);
+  }
   Printf(sfile, "%s\n", scode);
-  
+
   Delete(scode);
+  Delete(possiblescode);
   Delete(mangled_tdname);
-  
   return SWIG_OK;
 }
 
@@ -1236,30 +1290,28 @@ int R::enumDeclaration(Node *n) {
 **************************************************************/
 int R::variableWrapper(Node *n) {
   String *name = Getattr(n, "sym:name");
-  
+
   processing_variable = 1;
   Language::variableWrapper(n); // Force the emission of the _set and _get function wrappers.
   processing_variable = 0;
-  
-  
+
+
   SwigType *ty = Getattr(n, "type");
   int addCopyParam = addCopyParameter(ty);
-  
+
   //XXX
   processType(ty, n);
-  
-  if(!SwigType_isconst(ty)) {
+
+  if (!SwigType_isconst(ty)) {
     Wrapper *f = NewWrapper();
-    Printf(f->def, "%s = \nfunction(value%s)\n{\n", 
-	   name, addCopyParam ? ", .copy = FALSE" : "");
-    Printv(f->code, "if(missing(value)) {\n", 
-	   name, "_get(", addCopyParam ? ".copy" : "", ")\n}", NIL);
-    Printv(f->code, " else {\n", 
-	   name, "_set(value)\n}\n}", NIL);
-    
+    Printf(f->def, "%s = \nfunction(value%s)\n{\n", name, addCopyParam ? ", .copy = FALSE" : "");
+    Printv(f->code, "if(missing(value)) {\n", name, "_get(", addCopyParam ? ".copy" : "", ")\n}", NIL);
+    Printv(f->code, " else {\n", name, "_set(value)\n}\n}", NIL);
+
     Wrapper_print(f, sfile);
     DelWrapper(f);
   } else {
+    Printf(sfile, "## constant in variableWrapper\n");
     Printf(sfile, "%s = %s_get\n", name, name);
   }
 
@@ -1267,27 +1319,27 @@ int R::variableWrapper(Node *n) {
 }
 
 
-void R::addAccessor(String *memberName, Wrapper *wrapper, String *name, 
-		    int isSet) {
-  if(isSet < 0) {
+
+void R::addAccessor(String *memberName, Wrapper *wrapper, String *name, int isSet) {
+  if (isSet < 0) {
     int n = Len(name);
     char *ptr = Char(name);
-    isSet = Strcmp(NewString(&ptr[n-3]), "set") == 0;
+    isSet = Strcmp(NewString(&ptr[n - 3]), "set") == 0;
   }
-  
+
   List *l = isSet ? class_member_set_functions : class_member_functions;
-  
-  if(!l) {
+
+  if (!l) {
     l = NewList();
-    if(isSet)
+    if (isSet)
       class_member_set_functions = l;
     else
       class_member_functions = l;
   }
-  
+
   Append(l, memberName);
   Append(l, name);
-  
+
   String *tmp = NewString("");
   Wrapper_print(wrapper, tmp);
   Append(l, tmp);
@@ -1299,237 +1351,235 @@ void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
 #define MAX_OVERLOAD 256
 
 struct Overloaded {
-  Node      *n;          /* Node                               */
-  int        argc;       /* Argument count                     */
-  ParmList  *parms;      /* Parameters used for overload check */
-  int        error;      /* Ambiguity error                    */
+  Node *n;                      /* Node                               */
+  int argc;                     /* Argument count                     */
+  ParmList *parms;              /* Parameters used for overload check */
+  int error;                    /* Ambiguity error                    */
 };
 
 
-List * R::Swig_overload_rank(Node *n, 
-				 bool script_lang_wrapping) {
-  Overloaded  nodes[MAX_OVERLOAD];
-  int         nnodes = 0;
-  Node *o = Getattr(n,"sym:overloaded");
+List *R::Swig_overload_rank(Node *n, bool script_lang_wrapping) {
+  Overloaded nodes[MAX_OVERLOAD];
+  int nnodes = 0;
+  Node *o = Getattr(n, "sym:overloaded");
 
 
-  if (!o) return 0;
+  if (!o)
+    return 0;
 
   Node *c = o;
   while (c) {
-    if (Getattr(c,"error")) {
-      c = Getattr(c,"sym:nextSibling");
+    if (Getattr(c, "error")) {
+      c = Getattr(c, "sym:nextSibling");
       continue;
     }
     /*    if (SmartPointer && Getattr(c,"cplus:staticbase")) {
-	  c = Getattr(c,"sym:nextSibling");
-	  continue;
-	  } */
+       c = Getattr(c,"sym:nextSibling");
+       continue;
+       } */
 
     /* Make a list of all the declarations (methods) that are overloaded with
      * this one particular method name */
 
-    if (Getattr(c,"wrap:name")) {
+    if (Getattr(c, "wrap:name")) {
       nodes[nnodes].n = c;
-      nodes[nnodes].parms = Getattr(c,"wrap:parms");
+      nodes[nnodes].parms = Getattr(c, "wrap:parms");
       nodes[nnodes].argc = emit_num_required(nodes[nnodes].parms);
       nodes[nnodes].error = 0;
       nnodes++;
     }
-    c = Getattr(c,"sym:nextSibling");
+    c = Getattr(c, "sym:nextSibling");
   }
-  
+
   /* Sort the declarations by required argument count */
   {
-    int i,j;
+    int i, j;
     for (i = 0; i < nnodes; i++) {
-      for (j = i+1; j < nnodes; j++) {
-	if (nodes[i].argc > nodes[j].argc) {
-	  Overloaded t = nodes[i];
-	  nodes[i] = nodes[j];
-	  nodes[j] = t;
-	}
+      for (j = i + 1; j < nnodes; j++) {
+        if (nodes[i].argc > nodes[j].argc) {
+          Overloaded t = nodes[i];
+          nodes[i] = nodes[j];
+          nodes[j] = t;
+        }
       }
     }
   }
 
   /* Sort the declarations by argument types */
   {
-    int i,j;
-    for (i = 0; i < nnodes-1; i++) {
-      if (nodes[i].argc == nodes[i+1].argc) {
-	for (j = i+1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
-	  Parm *p1 = nodes[i].parms;
-	  Parm *p2 = nodes[j].parms;
-	  int   differ = 0;
-	  int   num_checked = 0;
-	  while (p1 && p2 && (num_checked < nodes[i].argc)) {
-	    if (debugMode) {
-	      Printf(stdout,"p1 = '%s', p2 = '%s'\n", Getattr(p1,"type"), Getattr(p2,"type"));
-	    }
-	    if (checkAttribute(p1,"tmap:in:numinputs","0")) {
-	      p1 = Getattr(p1,"tmap:in:next");
-	      continue;
-	    }
-	    if (checkAttribute(p2,"tmap:in:numinputs","0")) {
-	      p2 = Getattr(p2,"tmap:in:next");
-	      continue;
-	    }
-	    String *t1 = Getattr(p1,"tmap:typecheck:precedence");
-	    String *t2 = Getattr(p2,"tmap:typecheck:precedence");
-	    if (debugMode) {
-	      Printf(stdout,"t1 = '%s', t2 = '%s'\n", t1, t2);
-	    }
-	    if ((!t1) && (!nodes[i].error)) {
-	      Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
-			   "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-			   Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
-	      nodes[i].error = 1;
-	    } else if ((!t2) && (!nodes[j].error)) {
-	      Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
-			   "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-			   Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
-	      nodes[j].error = 1;
-	    }
-	    if (t1 && t2) {
-	      int t1v, t2v;
-	      t1v = atoi(Char(t1));
-	      t2v = atoi(Char(t2));
-	      differ = t1v-t2v;
-	    }
-	    else if (!t1 && t2) differ = 1;
-	    else if (t1 && !t2) differ = -1;
-	    else if (!t1 && !t2) differ = -1;
-	    num_checked++;
-	    if (differ > 0) {
-	      Overloaded t = nodes[i];
-	      nodes[i] = nodes[j];
-	      nodes[j] = t;
-	      break;
-	    } else if ((differ == 0) && (Strcmp(t1,"0") == 0)) {
-	      t1 = Getattr(p1,"ltype");
-	      if (!t1) {
-		t1 = SwigType_ltype(Getattr(p1,"type"));
-		if (Getattr(p1,"tmap:typecheck:SWIGTYPE")) {
-		  SwigType_add_pointer(t1);
-		}
-		Setattr(p1,"ltype",t1);
-	      }
-	      t2 = Getattr(p2,"ltype");
-	      if (!t2) {
-		t2 = SwigType_ltype(Getattr(p2,"type"));
-		if (Getattr(p2,"tmap:typecheck:SWIGTYPE")) {
-		  SwigType_add_pointer(t2);
-		}
-		Setattr(p2,"ltype",t2);
-	      }
+    int i, j;
+    for (i = 0; i < nnodes - 1; i++) {
+      if (nodes[i].argc == nodes[i + 1].argc) {
+        for (j = i + 1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
+          Parm *p1 = nodes[i].parms;
+          Parm *p2 = nodes[j].parms;
+          int differ = 0;
+          int num_checked = 0;
+          while (p1 && p2 && (num_checked < nodes[i].argc)) {
+            if (debugMode) {
+              Printf(stdout, "p1 = '%s', p2 = '%s'\n", Getattr(p1, "type"), Getattr(p2, "type"));
+            }
+            if (checkAttribute(p1, "tmap:in:numinputs", "0")) {
+              p1 = Getattr(p1, "tmap:in:next");
+              continue;
+            }
+            if (checkAttribute(p2, "tmap:in:numinputs", "0")) {
+              p2 = Getattr(p2, "tmap:in:next");
+              continue;
+            }
+            String *t1 = Getattr(p1, "tmap:typecheck:precedence");
+            String *t2 = Getattr(p2, "tmap:typecheck:precedence");
+            if (debugMode) {
+              Printf(stdout, "t1 = '%s', t2 = '%s'\n", t1, t2);
+            }
+            if ((!t1) && (!nodes[i].error)) {
+              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
+                           "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
+                           Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
+              nodes[i].error = 1;
+            } else if ((!t2) && (!nodes[j].error)) {
+              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
+                           "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
+                           Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
+              nodes[j].error = 1;
+            }
+            if (t1 && t2) {
+              int t1v, t2v;
+              t1v = atoi(Char(t1));
+              t2v = atoi(Char(t2));
+              differ = t1v - t2v;
+            } else if (!t1 && t2)
+              differ = 1;
+            else if (t1 && !t2)
+              differ = -1;
+            else if (!t1 && !t2)
+              differ = -1;
+            num_checked++;
+            if (differ > 0) {
+              Overloaded t = nodes[i];
+              nodes[i] = nodes[j];
+              nodes[j] = t;
+              break;
+            } else if ((differ == 0) && (Strcmp(t1, "0") == 0)) {
+              t1 = Getattr(p1, "ltype");
+              if (!t1) {
+                t1 = SwigType_ltype(Getattr(p1, "type"));
+                if (Getattr(p1, "tmap:typecheck:SWIGTYPE")) {
+                  SwigType_add_pointer(t1);
+                }
+                Setattr(p1, "ltype", t1);
+              }
+              t2 = Getattr(p2, "ltype");
+              if (!t2) {
+                t2 = SwigType_ltype(Getattr(p2, "type"));
+                if (Getattr(p2, "tmap:typecheck:SWIGTYPE")) {
+                  SwigType_add_pointer(t2);
+                }
+                Setattr(p2, "ltype", t2);
+              }
 
-	      /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
+              /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
                  order */
 
-	      if (SwigType_issubtype(t2,t1)) {
-		Overloaded t = nodes[i];
-		nodes[i] = nodes[j];
-		nodes[j] = t;
-	      }
+              if (SwigType_issubtype(t2, t1)) {
+                Overloaded t = nodes[i];
+                nodes[i] = nodes[j];
+                nodes[j] = t;
+              }
 
-	      if (Strcmp(t1,t2) != 0) {
-		differ = 1;
-		break;
-	      }
-	    } else if (differ) {
-	      break;
-	    }
-	    if (Getattr(p1,"tmap:in:next")) {
-	      p1 = Getattr(p1,"tmap:in:next");
-	    } else {
-	      p1 = nextSibling(p1);
-	    }
-	    if (Getattr(p2,"tmap:in:next")) {
-	      p2 = Getattr(p2,"tmap:in:next");
-	    } else {
-	      p2 = nextSibling(p2);
-	    }
-	  }
-	  if (!differ) {
-	    /* See if declarations differ by const only */
-	    String *d1 = Getattr(nodes[i].n, "decl");
-	    String *d2 = Getattr(nodes[j].n, "decl");
-	    if (d1 && d2) {
-	      String *dq1 = Copy(d1);
-	      String *dq2 = Copy(d2);
-	      if (SwigType_isconst(d1)) {
-		Delete(SwigType_pop(dq1));
-	      }
-	      if (SwigType_isconst(d2)) {
-		Delete(SwigType_pop(dq2));
-	      }
-	      if (Strcmp(dq1, dq2) == 0) {
+              if (Strcmp(t1, t2) != 0) {
+                differ = 1;
+                break;
+              }
+            } else if (differ) {
+              break;
+            }
+            if (Getattr(p1, "tmap:in:next")) {
+              p1 = Getattr(p1, "tmap:in:next");
+            } else {
+              p1 = nextSibling(p1);
+            }
+            if (Getattr(p2, "tmap:in:next")) {
+              p2 = Getattr(p2, "tmap:in:next");
+            } else {
+              p2 = nextSibling(p2);
+            }
+          }
+          if (!differ) {
+            /* See if declarations differ by const only */
+            String *d1 = Getattr(nodes[i].n, "decl");
+            String *d2 = Getattr(nodes[j].n, "decl");
+            if (d1 && d2) {
+              String *dq1 = Copy(d1);
+              String *dq2 = Copy(d2);
+              if (SwigType_isconst(d1)) {
+                Delete(SwigType_pop(dq1));
+              }
+              if (SwigType_isconst(d2)) {
+                Delete(SwigType_pop(dq2));
+              }
+              if (Strcmp(dq1, dq2) == 0) {
 
-		if (SwigType_isconst(d1) && !SwigType_isconst(d2)) {
-		  if (script_lang_wrapping) {
-		    // Swap nodes so that the const method gets ignored (shadowed by the non-const method)
-		    Overloaded t = nodes[i];
-		    nodes[i] = nodes[j];
-		    nodes[j] = t;
-		  }
-		  differ = 1;
-		  if (!nodes[j].error) {
-		    if (script_lang_wrapping) {
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-				   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-				   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
-		    } else {
-		      if (!Getattr(nodes[j].n, "overload:ignore"))
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-				     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-				     "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		    }
-		  }
-		  nodes[j].error = 1;
-		} else if (!SwigType_isconst(d1) && SwigType_isconst(d2)) {
-		  differ = 1;
-		  if (!nodes[j].error) {
-		    if (script_lang_wrapping) {
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-				   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-				   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
-		    } else {
-		      if (!Getattr(nodes[j].n, "overload:ignore"))
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-				     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-				     "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		    }
-		  }
-		  nodes[j].error = 1;
-		}
-	      }
-	      Delete(dq1);
-	      Delete(dq2);
-	    }
-	  }
-	  if (!differ) {
-	    if (!nodes[j].error) {
-	      if (script_lang_wrapping) {
-		Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
-			     "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
-		Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
-			     "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
-	      } else {
-		if (!Getattr(nodes[j].n, "overload:ignore"))
-		  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-			       "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-			       "using %s instead.\n", Swig_name_decl(nodes[i].n));
-	      }
-	      nodes[j].error = 1;
-	    }
-	  }
-	}
+                if (SwigType_isconst(d1) && !SwigType_isconst(d2)) {
+                  if (script_lang_wrapping) {
+                    // Swap nodes so that the const method gets ignored (shadowed by the non-const method)
+                    Overloaded t = nodes[i];
+                    nodes[i] = nodes[j];
+                    nodes[j] = t;
+                  }
+                  differ = 1;
+                  if (!nodes[j].error) {
+                    if (script_lang_wrapping) {
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                    } else {
+                      if (!Getattr(nodes[j].n, "overload:ignore"))
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                    }
+                  }
+                  nodes[j].error = 1;
+                } else if (!SwigType_isconst(d1) && SwigType_isconst(d2)) {
+                  differ = 1;
+                  if (!nodes[j].error) {
+                    if (script_lang_wrapping) {
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                    } else {
+                      if (!Getattr(nodes[j].n, "overload:ignore"))
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                    }
+                  }
+                  nodes[j].error = 1;
+                }
+              }
+              Delete(dq1);
+              Delete(dq2);
+            }
+          }
+          if (!differ) {
+            if (!nodes[j].error) {
+              if (script_lang_wrapping) {
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
+                             "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n), "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
+              } else {
+                if (!Getattr(nodes[j].n, "overload:ignore"))
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                               "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
+              }
+              nodes[j].error = 1;
+            }
+          }
+        }
       }
     }
   }
@@ -1539,7 +1589,7 @@ List * R::Swig_overload_rank(Node *n,
     for (i = 0; i < nnodes; i++) {
       if (nodes[i].error)
         Setattr(nodes[i].n, "overload:ignore", "1");
-      Append(result,nodes[i].n);
+      Append(result, nodes[i].n);
       //      Printf(stdout,"[ %d ] %s\n", i, ParmList_errorstr(nodes[i].parms));
       //      Swig_print_node(nodes[i].n);
     }
@@ -1551,37 +1601,33 @@ void R::dispatchFunction(Node *n) {
   Wrapper *f = NewWrapper();
   String *symname = Getattr(n, "sym:name");
   String *nodeType = Getattr(n, "nodeType");
-  bool constructor = (!Cmp(nodeType, "constructor")); 
+  bool constructor = (!Cmp(nodeType, "constructor"));
 
   String *sfname = NewString(symname);
 
   if (constructor)
     Replace(sfname, "new_", "", DOH_REPLACE_FIRST);
 
-  Printf(f->def,
-	 "`%s` <- function(...) {", sfname);
+  Printf(f->def, "`%s` <- function(...) {", sfname);
   if (debugMode) {
     Swig_print_node(n);
   }
   List *dispatch = Swig_overload_rank(n, true);
-  int   nfunc = Len(dispatch);
-  Printv(f->code, 
-	 "argtypes <- mapply(class, list(...));\n",
-	 "argv <- list(...);\n",
-	 "argc <- length(argtypes);\n", NIL );
+  int nfunc = Len(dispatch);
+  Printv(f->code, "argtypes <- mapply(class, list(...));\n", "argv <- list(...);\n", "argc <- length(argtypes);\n", NIL);
 
   Printf(f->code, "# dispatch functions %d\n", nfunc);
   int cur_args = -1;
   bool first_compare = true;
-  for (int i=0; i < nfunc; i++) {
-    Node *ni = Getitem(dispatch,i);
-    Parm *pi = Getattr(ni,"wrap:parms");
+  for (int i = 0; i < nfunc; i++) {
+    Node *ni = Getitem(dispatch, i);
+    Parm *pi = Getattr(ni, "wrap:parms");
     int num_arguments = emit_num_arguments(pi);
 
-    String *overname = Getattr(ni,"sym:overname");      
+    String *overname = Getattr(ni, "sym:overname");
     if (cur_args != num_arguments) {
       if (cur_args != -1) {
-	Printv(f->code, "} else ", NIL);
+        Printv(f->code, "} else ", NIL);
       }
       Printf(f->code, "if (argc == %d) {", num_arguments);
       cur_args = num_arguments;
@@ -1591,67 +1637,52 @@ void R::dispatchFunction(Node *n) {
     int j;
     if (num_arguments > 0) {
       if (!first_compare) {
-	Printv(f->code, " else ", NIL);
+        Printv(f->code, " else ", NIL);
       } else {
-	first_compare = false;
+        first_compare = false;
       }
       Printv(f->code, "if (", NIL);
-      for (p =pi, j = 0 ; j < num_arguments ; j++) {
-	if (debugMode) {
-	  Swig_print_node(p);
-	}
-	String *tm = Swig_typemap_lookup("rtype", p, "", 0);
-	if(tm) {
-	  replaceRClass(tm, Getattr(p, "type"));
-	}
+      for (p = pi, j = 0; j < num_arguments; j++) {
+        if (debugMode) {
+          Swig_print_node(p);
+        }
+        String *tm = Swig_typemap_lookup("rtype", p, "", 0);
+        if (tm) {
+          replaceRClass(tm, Getattr(p, "type"));
+        }
 
-	String *tmcheck = Swig_typemap_lookup("rtypecheck", p, "", 0);
-	if (tmcheck) {
-	  String *tmp = NewString("");
-	  Printf(tmp, "argv[[%d]]", j+1);
-	  Replaceall(tmcheck, "$arg", tmp);
-	  Printf(tmp, "argtype[%d]", j+1);
-	  Replaceall(tmcheck, "$argtype", tmp);
-	  if (tm) {
-	    Replaceall(tmcheck, "$rtype", tm);
-	  }
-	  if (debugMode) {
-	    Printf(stdout, "<rtypecheck>%s\n", tmcheck);
-	  }
-	  Printf(f->code, "%s(%s)",
-		 j == 0? "" : " && ",
-		 tmcheck);
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
-	if (tm) {
-	  if (Strcmp(tm,"numeric")==0) {
-	    Printf(f->code, "%sis.numeric(argv[[%d]])",
-		j == 0 ? "" : " && ",
-		j+1);
-	  }
-	  else if (Strcmp(tm,"integer")==0) {
-	    Printf(f->code, "%s(is.integer(argv[[%d]]) || is.numeric(argv[[%d]]))",
-		j == 0 ? "" : " && ",
-		j+1, j+1);
-	  }
-	  else if (Strcmp(tm,"character")==0) {
-	    Printf(f->code, "%sis.character(argv[[%d]])",
-		j == 0 ? "" : " && ",
-		j+1);
-	  }
-	  else {
-	    Printf(f->code, "%sextends(argtypes[%d], '%s')",
-		j == 0 ? "" : " && ",
-		j+1,
-		tm);
-	  }
-	}
-	if (!SwigType_ispointer(Getattr(p, "type"))) {
-	  Printf(f->code, " && length(argv[[%d]]) == 1",
-	      j+1);
-	}
-	p = Getattr(p, "tmap:in:next");
+        String *tmcheck = Swig_typemap_lookup("rtypecheck", p, "", 0);
+        if (tmcheck) {
+          String *tmp = NewString("");
+          Printf(tmp, "argv[[%d]]", j + 1);
+          Replaceall(tmcheck, "$arg", tmp);
+          Printf(tmp, "argtype[%d]", j + 1);
+          Replaceall(tmcheck, "$argtype", tmp);
+          if (tm) {
+            Replaceall(tmcheck, "$rtype", tm);
+          }
+          if (debugMode) {
+            Printf(stdout, "<rtypecheck>%s\n", tmcheck);
+          }
+          Printf(f->code, "%s(%s)", j == 0 ? "" : " && ", tmcheck);
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
+        if (tm) {
+          if (Strcmp(tm, "numeric") == 0) {
+            Printf(f->code, "%sis.numeric(argv[[%d]])", j == 0 ? "" : " && ", j + 1);
+          } else if (Strcmp(tm, "integer") == 0) {
+            Printf(f->code, "%s(is.integer(argv[[%d]]) || is.numeric(argv[[%d]]))", j == 0 ? "" : " && ", j + 1, j + 1);
+          } else if (Strcmp(tm, "character") == 0) {
+            Printf(f->code, "%sis.character(argv[[%d]])", j == 0 ? "" : " && ", j + 1);
+          } else {
+            Printf(f->code, "%sextends(argtypes[%d], '%s')", j == 0 ? "" : " && ", j + 1, tm);
+          }
+        }
+        if (!SwigType_ispointer(Getattr(p, "type"))) {
+          Printf(f->code, " && length(argv[[%d]]) == 1", j + 1);
+        }
+        p = Getattr(p, "tmap:in:next");
       }
       Printf(f->code, ") { f <- %s%s; }\n", sfname, overname);
     } else {
@@ -1659,10 +1690,7 @@ void R::dispatchFunction(Node *n) {
     }
   }
   if (cur_args != -1) {
-    Printf(f->code, "} else {\n"
-	   "stop(\"cannot find overloaded function for %s with argtypes (\","
-	   "toString(argtypes),\")\");\n"
-	   "}", sfname);
+    Printf(f->code, "} else {\n" "stop(\"cannot find overloaded function for %s with argtypes (\"," "toString(argtypes),\")\");\n" "}", sfname);
   }
   Printv(f->code, ";\nf(...)", NIL);
   Printv(f->code, ";\n}", NIL);
@@ -1677,86 +1705,77 @@ void R::dispatchFunction(Node *n) {
 int R::functionWrapper(Node *n) {
   String *fname = Getattr(n, "name");
   String *iname = Getattr(n, "sym:name");
-  String *type = Getattr(n, "type"); 
-  
+  String *type = Getattr(n, "type");
+
   if (debugMode) {
-    Printf(stdout, 
-	   "<functionWrapper> %s %s %s\n", fname, iname, type);
+    Printf(stdout, "<functionWrapper> %s %s %s\n", fname, iname, type);
   }
   String *overname = 0;
   String *nodeType = Getattr(n, "nodeType");
-  bool constructor = (!Cmp(nodeType, "constructor")); 
-  bool destructor = (!Cmp(nodeType, "destructor")); 
-  
+  bool constructor = (!Cmp(nodeType, "constructor"));
+  bool destructor = (!Cmp(nodeType, "destructor"));
+
   String *sfname = NewString(iname);
-  
+
   if (constructor)
     Replace(sfname, "new_", "", DOH_REPLACE_FIRST);
-  
-  if (Getattr(n,"sym:overloaded")) {
-    overname = Getattr(n,"sym:overname");      
+
+  if (Getattr(n, "sym:overloaded")) {
+    overname = Getattr(n, "sym:overname");
     Append(sfname, overname);
   }
-  
-  if (debugMode) 
-    Printf(stdout, 
-	   "<functionWrapper> processing parameters\n");
-  
-  
+
+  if (debugMode)
+    Printf(stdout, "<functionWrapper> processing parameters\n");
+
+
   ParmList *l = Getattr(n, "parms");
   Parm *p;
   String *tm;
-  
+
   p = l;
-  while(p) {
+  while (p) {
     SwigType *resultType = Getattr(p, "type");
-    if (expandTypedef(resultType) && 
-	SwigType_istypedef(resultType)) {
-      SwigType *resolved =
-	SwigType_typedef_resolve_all(resultType);
+    if (expandTypedef(resultType) && SwigType_istypedef(resultType)) {
+      SwigType *resolved = SwigType_typedef_resolve_all(resultType);
       if (expandTypedef(resolved)) {
-	Setattr(p, "type", Copy(resolved));
+        Setattr(p, "type", Copy(resolved));
       }
     }
     p = nextSibling(p);
-  } 
+  }
 
-  String *unresolved_return_type = 
-    Copy(type);
-  if (expandTypedef(type) &&
-      SwigType_istypedef(type)) {
-    SwigType *resolved = 
-      SwigType_typedef_resolve_all(type);
+  String *unresolved_return_type = Copy(type);
+  if (expandTypedef(type) && SwigType_istypedef(type)) {
+    SwigType *resolved = SwigType_typedef_resolve_all(type);
     if (expandTypedef(resolved)) {
       type = Copy(resolved);
       Setattr(n, "type", type);
     }
   }
-  if (debugMode) 
-    Printf(stdout, "<functionWrapper> unresolved_return_type %s\n",
-	   unresolved_return_type);
-  if(processing_member_access_function) {
+  if (debugMode)
+    Printf(stdout, "<functionWrapper> unresolved_return_type %s\n", unresolved_return_type);
+  if (processing_member_access_function) {
     if (debugMode)
-      Printf(stdout, "<functionWrapper memberAccess> '%s' '%s' '%s' '%s'\n", 
-	     fname, iname, member_name, class_name);
-    
-    if(opaqueClassDeclaration)
+      Printf(stdout, "<functionWrapper memberAccess> '%s' '%s' '%s' '%s'\n", fname, iname, member_name, class_name);
+
+    if (opaqueClassDeclaration)
       return SWIG_OK;
-      
-      
-    /* Add the name of this member to a list for this class_name. 
+
+
+    /* Add the name of this member to a list for this class_name.
        We will dump all these at the end. */
-    
+
     int n = Len(iname);
     char *ptr = Char(iname);
-    bool isSet(Strcmp(NewString(&ptr[n-3]), "set") == 0);
-    
-    
+    bool isSet(Strcmp(NewString(&ptr[n - 3]), "set") == 0);
+
+
     String *tmp = NewString("");
     Printf(tmp, "%s_%s", class_name, isSet ? "set" : "get");
-    
+
     List *memList = Getattr(ClassMemberTable, tmp);
-    if(!memList) {
+    if (!memList) {
       memList = NewList();
       Append(memList, class_name);
       Setattr(ClassMemberTable, tmp, memList);
@@ -1765,29 +1784,29 @@ int R::functionWrapper(Node *n) {
     Append(memList, member_name);
     Append(memList, iname);
   }
-  
+
   int i;
   int nargs;
-  
+
   String *wname = Swig_name_wrapper(iname);
   Replace(wname, "_wrap", "R_swig", DOH_REPLACE_FIRST);
-  if(overname) 
+  if (overname)
     Append(wname, overname);
-  Setattr(n,"wrap:name", wname);
+  Setattr(n, "wrap:name", wname);
 
   Wrapper *f = NewWrapper();
   Wrapper *sfun = NewWrapper();
-  
+
   int isVoidReturnType = (Strcmp(type, "void") == 0);
-  // Need to use the unresolved return type since 
-  // typedef resolution removes the const which causes a 
+  // Need to use the unresolved return type since
+  // typedef resolution removes the const which causes a
   // mismatch with the function action
   emit_return_variable(n, unresolved_return_type, f);
 
   SwigType *rtype = Getattr(n, "type");
   int addCopyParam = 0;
 
-  if(!isVoidReturnType) 
+  if (!isVoidReturnType)
     addCopyParam = addCopyParameter(rtype);
 
 
@@ -1796,15 +1815,14 @@ int R::functionWrapper(Node *n) {
 
   //    if(addCopyParam)
   if (debugMode)
-    Printf(stdout, "Adding a .copy argument to %s for %s = %s\n", 
-	   iname, type, addCopyParam ? "yes" : "no");
+    Printf(stdout, "Adding a .copy argument to %s for %s = %s\n", iname, type, addCopyParam ? "yes" : "no");
 
   Printv(f->def, "SWIGEXPORT SEXP\n", wname, " ( ", NIL);
 
-  Printf(sfun->def, "# Start of %s\n", iname);         
+  Printf(sfun->def, "# Start of %s\n", iname);
   Printv(sfun->def, "\n`", sfname, "` = function(", NIL);
 
-  if(outputNamespaceInfo) //XXX Need to be a little more discriminating
+  if (outputNamespaceInfo)      //XXX Need to be a little more discriminating
     addNamespaceFunction(iname);
 
   Swig_typemap_attach_parms("scoercein", l, f);
@@ -1812,8 +1830,8 @@ int R::functionWrapper(Node *n) {
   Swig_typemap_attach_parms("scheck", l, f);
 
   emit_parameter_variables(l, f);
-  emit_attach_parmmaps(l,f);
-  Setattr(n,"wrap:parms",l);
+  emit_attach_parmmaps(l, f);
+  Setattr(n, "wrap:parms", l);
 
   nargs = emit_num_arguments(l);
 
@@ -1829,7 +1847,7 @@ int R::functionWrapper(Node *n) {
   bool inFirstArg = true;
   bool inFirstType = true;
   Parm *curP;
-  for (p =l, i = 0 ; i < nargs ; i++) {
+  for (p = l, i = 0; i < nargs; i++) {
 
     while (checkAttribute(p, "tmap:in:numinputs", "0")) {
       p = Getattr(p, "tmap:in:next");
@@ -1840,26 +1858,26 @@ int R::functionWrapper(Node *n) {
     String *funcptr_name = processType(tt, p, &nargs);
 
     //      SwigType *tp = Getattr(p, "type");
-    String   *name  = Getattr(p,"name");
-    String   *lname  = Getattr(p,"lname");
+    String *name = Getattr(p, "name");
+    String *lname = Getattr(p, "lname");
 
     // R keyword renaming
     if (name) {
       if (Swig_name_warning(p, 0, name, 0)) {
-	name = 0;
+        name = 0;
       } else {
-	/* If we have a :: in the parameter name because we are accessing a static member of a class, say, then
-	   we need to remove that prefix. */
-	while (Strstr(name, "::")) {
-	  //XXX need to free.
-	  name = NewStringf("%s", Strchr(name, ':') + 2);
-	  if (debugMode)
-	    Printf(stdout, "+++  parameter name with :: in it %s\n", name);
-	}
+        /* If we have a :: in the parameter name because we are accessing a static member of a class, say, then
+           we need to remove that prefix. */
+        while (Strstr(name, "::")) {
+          //XXX need to free.
+          name = NewStringf("%s", Strchr(name, ':') + 2);
+          if (debugMode)
+            Printf(stdout, "+++  parameter name with :: in it %s\n", name);
+        }
       }
     }
     if (!name || Len(name) == 0)
-      name = NewStringf("s_arg%d", i+1);
+      name = NewStringf("s_arg%d", i + 1);
 
     name = replaceInitialDash(name);
 
@@ -1867,13 +1885,13 @@ int R::functionWrapper(Node *n) {
       name = Copy(name);
       Insert(name, 0, "s_");
     }
-      
-    if(processing_variable) {
+
+    if (processing_variable) {
       name = Copy(name);
       Insert(name, 0, "s_");
     }
 
-    if(!Strcmp(name, fname)) {
+    if (!Strcmp(name, fname)) {
       name = Copy(name);
       Insert(name, 0, "s_");
     }
@@ -1881,79 +1899,73 @@ int R::functionWrapper(Node *n) {
     Printf(sargs, "%s, ", name);
 
     String *tm;
-    if((tm = Getattr(p, "tmap:scoercein"))) {
+    if ((tm = Getattr(p, "tmap:scoercein"))) {
       Replaceall(tm, "$input", name);
       replaceRClass(tm, Getattr(p, "type"));
 
-      if(funcptr_name) {
-	//XXX need to get this to return non-zero
-	if(nargs == -1)
-	  nargs = getFunctionPointerNumArgs(p, tt);
+      if (funcptr_name) {
+        //XXX need to get this to return non-zero
+        if (nargs == -1)
+          nargs = getFunctionPointerNumArgs(p, tt);
 
-	String *snargs = NewStringf("%d", nargs);
-	Printv(sfun->code, "if(is.function(", name, ")) {", "\n",
-	       "assert('...' %in% names(formals(", name, 
-	       ")) || length(formals(", name, ")) >= ", snargs, ");\n} ", NIL);
-	Delete(snargs);
+        String *snargs = NewStringf("%d", nargs);
+        Printv(sfun->code, "if(is.function(", name, ")) {", "\n",
+               "assert('...' %in% names(formals(", name, ")) || length(formals(", name, ")) >= ", snargs, ");\n} ", NIL);
+        Delete(snargs);
 
-	Printv(sfun->code, "else {\n",
-	       "if(is.character(", name, ")) {\n",
-	       name, " = getNativeSymbolInfo(", name, ");",
-	       "\n};\n",
-	       "if(is(", name, ", \"NativeSymbolInfo\")) {\n",
-	       name, " = ", name, "$address", ";\n}\n",
-	       "if(is(", name, ", \"ExternalReference\")) {\n",
-	       name, " = ", name, "@ref;\n}\n",
-	       "}; \n",
-	       NIL);
+        Printv(sfun->code, "else {\n",
+               "if(is.character(", name, ")) {\n",
+               name, " = getNativeSymbolInfo(", name, ");",
+               "\n};\n",
+               "if(is(", name, ", \"NativeSymbolInfo\")) {\n",
+               name, " = ", name, "$address", ";\n}\n", "if(is(", name, ", \"ExternalReference\")) {\n", name, " = ", name, "@ref;\n}\n", "}; \n", NIL);
       } else {
-	Printf(sfun->code, "%s\n", tm);
+        Printf(sfun->code, "%s\n", tm);
       }
     }
 
     Printv(sfun->def, inFirstArg ? "" : ", ", name, NIL);
 
-    if ((tm = Getattr(p,"tmap:scheck"))) {
+    if ((tm = Getattr(p, "tmap:scheck"))) {
 
-      Replaceall(tm,"$target", lname);
-      Replaceall(tm,"$source", name);
-      Replaceall(tm,"$input", name);
+      Replaceall(tm, "$target", lname);
+      Replaceall(tm, "$source", name);
+      Replaceall(tm, "$input", name);
       replaceRClass(tm, Getattr(p, "type"));
-      Printf(sfun->code,"%s\n",tm);
+      Printf(sfun->code, "%s\n", tm);
     }
 
 
 
     curP = p;
-    if ((tm = Getattr(p,"tmap:in"))) {
+    if ((tm = Getattr(p, "tmap:in"))) {
 
-      Replaceall(tm,"$target", lname);
-      Replaceall(tm,"$source", name);
-      Replaceall(tm,"$input", name);
+      Replaceall(tm, "$target", lname);
+      Replaceall(tm, "$source", name);
+      Replaceall(tm, "$input", name);
 
-      if (Getattr(p,"wrap:disown") || (Getattr(p,"tmap:in:disown"))) {
-	Replaceall(tm,"$disown","SWIG_POINTER_DISOWN");
+      if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
+        Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
       } else {
-	Replaceall(tm,"$disown","0");
+        Replaceall(tm, "$disown", "0");
       }
 
-      if(funcptr_name) {
-	/* have us a function pointer */
-	Printf(f->code, "if(TYPEOF(%s) != CLOSXP) {\n", name);
-	Replaceall(tm,"$R_class", "");
+      if (funcptr_name) {
+        /* have us a function pointer */
+        Printf(f->code, "if(TYPEOF(%s) != CLOSXP) {\n", name);
+        Replaceall(tm, "$R_class", "");
       } else {
-	replaceRClass(tm, Getattr(p, "type"));
+        replaceRClass(tm, Getattr(p, "type"));
       }
 
 
-      Printf(f->code,"%s\n",tm);
-      if(funcptr_name) 
-	Printf(f->code, "} else {\n%s = %s;\nR_SWIG_pushCallbackFunctionData(%s, NULL);\n}\n", 
-	       lname, funcptr_name, name);
+      Printf(f->code, "%s\n", tm);
+      if (funcptr_name)
+        Printf(f->code, "} else {\n%s = %s;\nR_SWIG_pushCallbackFunctionData(%s, NULL);\n}\n", lname, funcptr_name, name);
       Printv(f->def, inFirstArg ? "" : ", ", "SEXP ", name, NIL);
-      if (Len(name) != 0) 
-	inFirstArg = false;
-      p = Getattr(p,"tmap:in:next");
+      if (Len(name) != 0)
+        inFirstArg = false;
+      p = Getattr(p, "tmap:in:next");
 
     } else {
       p = nextSibling(p);
@@ -1961,18 +1973,18 @@ int R::functionWrapper(Node *n) {
 
 
     tm = Swig_typemap_lookup("rtype", curP, "", 0);
-    if(tm) {
+    if (tm) {
       replaceRClass(tm, Getattr(curP, "type"));
     }
     Printf(s_inputTypes, "%s'%s'", inFirstType ? "" : ", ", tm);
     Printf(s_inputMap, "%s%s='%s'", inFirstType ? "" : ", ", name, tm);
     inFirstType = false;
 
-    if(funcptr_name) 
+    if (funcptr_name)
       Delete(funcptr_name);
-  } /* end of looping over parameters. */
+  }                             /* end of looping over parameters. */
 
-  if(addCopyParam) {
+  if (addCopyParam) {
     Printf(sfun->def, "%s.copy = FALSE", nargs > 0 ? ", " : "");
     Printf(f->def, "%sSEXP s_swig_copy", nargs > 0 ? ", " : "");
 
@@ -1997,21 +2009,21 @@ int R::functionWrapper(Node *n) {
 
   String *outargs = NewString("");
   int numOutArgs = isVoidReturnType ? -1 : 0;
-  for(p = l, i = 0; p; i++) {
-    if((tm = Getattr(p, "tmap:argout"))) {
+  for (p = l, i = 0; p; i++) {
+    if ((tm = Getattr(p, "tmap:argout"))) {
       //       String *lname =  Getattr(p, "lname");
       numOutArgs++;
       String *pos = NewStringf("%d", numOutArgs);
-      Replaceall(tm,"$source", Getattr(p, "lname"));
-      Replaceall(tm,"$result", "r_ans");
-      Replaceall(tm,"$n", pos); // The position into which to store the answer.
-      Replaceall(tm,"$arg", Getattr(p, "emit:input"));
-      Replaceall(tm,"$input", Getattr(p, "emit:input"));
-      Replaceall(tm,"$owner", "R_SWIG_EXTERNAL");
+      Replaceall(tm, "$source", Getattr(p, "lname"));
+      Replaceall(tm, "$result", "r_ans");
+      Replaceall(tm, "$n", pos);        // The position into which to store the answer.
+      Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+      Replaceall(tm, "$input", Getattr(p, "emit:input"));
+      Replaceall(tm, "$owner", "R_SWIG_EXTERNAL");
 
 
       Printf(outargs, "%s\n", tm);
-      p = Getattr(p,"tmap:argout:next");
+      p = Getattr(p, "tmap:argout:next");
     } else
       p = nextSibling(p);
   }
@@ -2019,60 +2031,57 @@ int R::functionWrapper(Node *n) {
   String *actioncode = emit_action(n);
 
   /* Deal with the explicit return value. */
-  if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) { 
+  if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
     SwigType *retType = Getattr(n, "type");
-    //Printf(stdout, "Return Value for %s, array? %s\n", retType, SwigType_isarray(retType) ? "yes" : "no");     
+    //Printf(stdout, "Return Value for %s, array? %s\n", retType, SwigType_isarray(retType) ? "yes" : "no");
     /*      if(SwigType_isarray(retType)) {
-	    defineArrayAccessors(retType);
-	    } */
+       defineArrayAccessors(retType);
+       } */
 
 
-    Replaceall(tm,"$1", Swig_cresult_name());
-    Replaceall(tm,"$result", "r_ans");
+    Replaceall(tm, "$1", Swig_cresult_name());
+    Replaceall(tm, "$result", "r_ans");
     replaceRClass(tm, retType);
 
-    if (GetFlag(n,"feature:new")) {
+    if (GetFlag(n, "feature:new")) {
       Replaceall(tm, "$owner", "R_SWIG_OWNER");
     } else {
-      Replaceall(tm,"$owner", "R_SWIG_EXTERNAL");
+      Replaceall(tm, "$owner", "R_SWIG_EXTERNAL");
     }
 
 #if 0
-    if(addCopyParam) {
+    if (addCopyParam) {
       Printf(f->code, "if(LOGICAL(s_swig_copy)[0]) {\n");
       Printf(f->code, "/* Deal with returning a reference. */\nr_ans = R_NilValue;\n");
       Printf(f->code, "}\n else {\n");
-    } 
+    }
 #endif
     Printf(f->code, "%s\n", tm);
 #if 0
-    if(addCopyParam) 
-      Printf(f->code, "}\n"); /* end of if(s_swig_copy) ... else { ... } */
+    if (addCopyParam)
+      Printf(f->code, "}\n");   /* end of if(s_swig_copy) ... else { ... } */
 #endif
 
   } else {
-    Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number,
-		 "Unable to use return type %s in function %s.\n", SwigType_str(type, 0), fname);
+    Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(type, 0), fname);
   }
 
 
-  if(Len(outargs)) {
+  if (Len(outargs)) {
     Wrapper_add_local(f, "R_OutputValues", "SEXP R_OutputValues");
 
     String *tmp = NewString("");
-    if(!isVoidReturnType)
+    if (!isVoidReturnType)
       Printf(tmp, "Rf_protect(r_ans);\n");
 
-    Printf(tmp, "Rf_protect(R_OutputValues = Rf_allocVector(VECSXP,%d));\nr_nprotect += %d;\n", 
-	   numOutArgs + !isVoidReturnType, 
-	   isVoidReturnType ? 1 : 2);
+    Printf(tmp, "Rf_protect(R_OutputValues = Rf_allocVector(VECSXP,%d));\nr_nprotect += %d;\n", numOutArgs + !isVoidReturnType, isVoidReturnType ? 1 : 2);
 
-    if(!isVoidReturnType)
+    if (!isVoidReturnType)
       Printf(tmp, "SET_VECTOR_ELT(R_OutputValues, 0, r_ans);\n");
     Printf(tmp, "r_ans = R_OutputValues;\n");
 
     Insert(outargs, 0, tmp);
-    Delete(tmp); 
+    Delete(tmp);
 
 
 
@@ -2088,7 +2097,7 @@ int R::functionWrapper(Node *n) {
   /* Look to see if there is any newfree cleanup code */
   if (GetFlag(n, "feature:new")) {
     if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-      Replaceall(tm, "$source", Swig_cresult_name());	/* deprecated */
+      Replaceall(tm, "$source", Swig_cresult_name());   /* deprecated */
       Printf(f->code, "%s\n", tm);
     }
   }
@@ -2097,26 +2106,23 @@ int R::functionWrapper(Node *n) {
 
   /*If the user gave us something to convert the result in  */
   if ((tm = Swig_typemap_lookup("scoerceout", n, Swig_cresult_name(), sfun))) {
-    Replaceall(tm,"$source","ans");
-    Replaceall(tm,"$result","ans");
+    Replaceall(tm, "$source", "ans");
+    Replaceall(tm, "$result", "ans");
     replaceRClass(tm, Getattr(n, "type"));
     Chop(tm);
   }
 
 
-  Printv(sfun->code, ";", (Len(tm) ? "ans = " : ""), ".Call('", wname, 
-	 "', ", sargs, "PACKAGE='", Rpackage, "');\n", NIL);
-  if(Len(tm))
-    {
-      Printf(sfun->code, "%s\n\n", tm); 
-      if (constructor)
-	{ 
-	  String *finalizer = NewString(iname);
-	  Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
-	  Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s)\n", finalizer);
-	}                                                                      
-      Printf(sfun->code, "ans\n");
+  Printv(sfun->code, ";", (Len(tm) ? "ans = " : ""), ".Call('", wname, "', ", sargs, "PACKAGE='", Rpackage, "');\n", NIL);
+  if (Len(tm)) {
+    Printf(sfun->code, "%s\n\n", tm);
+    if (constructor) {
+      String *finalizer = NewString(iname);
+      Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
+      Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s)\n", finalizer);
     }
+    Printf(sfun->code, "ans\n");
+  }
 
   if (destructor)
     Printv(f->code, "R_ClearExternalPtr(self);\n", NIL);
@@ -2125,27 +2131,23 @@ int R::functionWrapper(Node *n) {
   Printv(sfun->code, "\n}", NIL);
 
   /* Substitute the function name */
-  Replaceall(f->code,"$symname",iname);
+  Replaceall(f->code, "$symname", iname);
 
   Wrapper_print(f, f_wrapper);
   Wrapper_print(sfun, sfile);
 
   Printf(sfun->code, "\n# End of %s\n", iname);
   tm = Swig_typemap_lookup("rtype", n, "", 0);
-  if(tm) {
+  if (tm) {
     SwigType *retType = Getattr(n, "type");
     replaceRClass(tm, retType);
-  }  
-    
-  Printv(sfile, "attr(`", sfname, "`, 'returnType') = '", 
-	 isVoidReturnType ? "void" : (tm ? tm : ""), 
-	 "'\n", NIL); 
-    
-  if(nargs > 0)
-    Printv(sfile, "attr(`", sfname, "`, \"inputTypes\") = c(",
-	   s_inputTypes, ")\n", NIL);
-  Printv(sfile, "class(`", sfname, "`) = c(\"SWIGFunction\", class('", 
-	 sfname, "'))\n\n", NIL); 
+  }
+
+  Printv(sfile, "attr(`", sfname, "`, 'returnType') = '", isVoidReturnType ? "void" : (tm ? tm : ""), "'\n", NIL);
+
+  if (nargs > 0)
+    Printv(sfile, "attr(`", sfname, "`, \"inputTypes\") = c(", s_inputTypes, ")\n", NIL);
+  Printv(sfile, "class(`", sfname, "`) = c(\"SWIGFunction\", class('", sfname, "'))\n\n", NIL);
 
   if (memoryProfile) {
     Printv(sfile, "memory.profile()\n", NIL);
@@ -2153,26 +2155,24 @@ int R::functionWrapper(Node *n) {
   if (aggressiveGc) {
     Printv(sfile, "gc()\n", NIL);
   }
-
   // Printv(sfile, "setMethod('", name, "', '", name, "', ", iname, ")\n\n\n");
 
 
 
-  /* If we are dealing with a method in an C++ class, then 
-     add the name of the R function and its definition. 
+  /* If we are dealing with a method in an C++ class, then
+     add the name of the R function and its definition.
      XXX need to figure out how to store the Wrapper if possible in the hash/list.
      Would like to be able to do this so that we can potentially insert
-  */
-  if(processing_member_access_function || processing_class_member_function) {
+   */
+  if (processing_member_access_function || processing_class_member_function) {
     addAccessor(member_name, sfun, iname);
   }
 
-  if (Getattr(n, "sym:overloaded") &&
-      !Getattr(n, "sym:nextSibling")) {
+  if (Getattr(n, "sym:overloaded") && !Getattr(n, "sym:nextSibling")) {
     dispatchFunction(n);
   }
 
-  addRegistrationRoutine(wname, addCopyParam ? nargs +1 : nargs);
+  addRegistrationRoutine(wname, addCopyParam ? nargs + 1 : nargs);
 
   DelWrapper(f);
   DelWrapper(sfun);
@@ -2193,21 +2193,20 @@ int R::constantWrapper(Node *n) {
 }
 
 /*****************************************************
- Add the specified routine name to the collection of 
+ Add the specified routine name to the collection of
  generated routines that are called from R functions.
- This is used to register the routines with R for 
+ This is used to register the routines with R for
  resolving symbols.
 
  rname - the name of the routine
- nargs - the number of arguments it expects. 
+ nargs - the number of arguments it expects.
 ******************************************************/
 int R::addRegistrationRoutine(String *rname, int nargs) {
-  if(!registrationTable) 
+  if (!registrationTable)
     registrationTable = NewHash();
 
-  String *el = 
-    NewStringf("{\"%s\", (DL_FUNC) &%s, %d}", rname, rname, nargs);
-  
+  String *el = NewStringf("{\"%s\", (DL_FUNC) &%s, %d}", rname, rname, nargs);
+
   Setattr(registrationTable, rname, el);
 
   return SWIG_OK;
@@ -2220,30 +2219,30 @@ int R::addRegistrationRoutine(String *rname, int nargs) {
 ******************************************************/
 int R::outputRegistrationRoutines(File *out) {
   int i, n;
-  if(!registrationTable) 
-    return(0);
-  if(inCPlusMode) 
+  if (!registrationTable)
+    return (0);
+  if (inCPlusMode)
     Printf(out, "#ifdef __cplusplus\nextern \"C\" {\n#endif\n\n");
 
   Printf(out, "#include <R_ext/Rdynload.h>\n\n");
-  if(inCPlusMode) 
+  if (inCPlusMode)
     Printf(out, "#ifdef __cplusplus\n}\n#endif\n\n");
 
   Printf(out, "SWIGINTERN R_CallMethodDef CallEntries[] = {\n");
-    
+
   List *keys = Keys(registrationTable);
   n = Len(keys);
-  for(i = 0; i < n; i++)
+  for (i = 0; i < n; i++)
     Printf(out, "   %s,\n", Getattr(registrationTable, Getitem(keys, i)));
 
   Printf(out, "   {NULL, NULL, 0}\n};\n\n");
 
-  if(!noInitializationCode) {
+  if (!noInitializationCode) {
     if (inCPlusMode)
       Printv(out, "extern \"C\" ", NIL);
     Printf(out, "SWIGEXPORT void R_init_%s(DllInfo *dll) {\n", Rpackage);
     Printf(out, "%sR_registerRoutines(dll, NULL, CallEntries, NULL, NULL);\n", tab4);
-    if(Len(s_init_routine)) {
+    if (Len(s_init_routine)) {
       Printf(out, "\n%s\n", s_init_routine);
     }
     Printf(out, "}\n");
@@ -2257,60 +2256,58 @@ int R::outputRegistrationRoutines(File *out) {
 /****************************************************************************
   Process a struct, union or class declaration in the source code,
   or an anonymous typedef struct
- 
+
 *****************************************************************************/
-//XXX What do we need to do here - 
+//XXX What do we need to do here -
 // Define an S4 class to refer to this.
 
 void R::registerClass(Node *n) {
-  String *name = Getattr(n, "name");    
-  String *kind = Getattr(n, "kind");    
+  String *name = Getattr(n, "name");
+  String *kind = Getattr(n, "kind");
 
   if (debugMode)
     Swig_print_node(n);
   String *sname = NewStringf("_p%s", SwigType_manglestr(name));
-  if(!Getattr(SClassDefs, sname)) {
+  if (!Getattr(SClassDefs, sname)) {
     Setattr(SClassDefs, sname, sname);
     String *base;
 
-    if(Strcmp(kind, "class") == 0) {
+    if (Strcmp(kind, "class") == 0) {
       base = NewString("");
       List *l = Getattr(n, "bases");
-      if(Len(l)) {
-	Printf(base, "c(");
-	for(int i = 0; i < Len(l); i++) {
-	  registerClass(Getitem(l, i));
-	  Printf(base, "'_p%s'%s", 
-		 SwigType_manglestr(Getattr(Getitem(l, i), "name")), 
-		 i < Len(l)-1 ? ", " : "");                
-	}
-	Printf(base, ")");
+      if (Len(l)) {
+        Printf(base, "c(");
+        for (int i = 0; i < Len(l); i++) {
+          registerClass(Getitem(l, i));
+          Printf(base, "'_p%s'%s", SwigType_manglestr(Getattr(Getitem(l, i), "name")), i < Len(l) - 1 ? ", " : "");
+        }
+        Printf(base, ")");
       } else {
-	base = NewString("'C++Reference'");
+        base = NewString("'C++Reference'");
       }
-    } else 
+    } else
       base = NewString("'ExternalReference'");
 
     Printf(s_classes, "setClass('%s', contains = %s)\n", sname, base);
     Delete(base);
   }
-  
+
 }
 
 int R::classDeclaration(Node *n) {
 
-  String *name = Getattr(n, "name");    
-  String *kind = Getattr(n, "kind");    
+  String *name = Getattr(n, "name");
+  String *kind = Getattr(n, "kind");
 
   if (debugMode)
     Swig_print_node(n);
   registerClass(n);
 
-    
+
   /* If we have a typedef union { ... } U, then we never get to see the typedef
      via a regular call to typedefHandler. Instead, */
-  if(Getattr(n, "unnamed") && Getattr(n, "storage") && Strcmp(Getattr(n, "storage"), "typedef") == 0
-     && Getattr(n, "tdname") && Strcmp(Getattr(n, "tdname"), name) == 0) {
+  if (Getattr(n, "unnamed") && Getattr(n, "storage") && Strcmp(Getattr(n, "storage"), "typedef") == 0
+      && Getattr(n, "tdname") && Strcmp(Getattr(n, "tdname"), name) == 0) {
     if (debugMode)
       Printf(stdout, "Typedef in the class declaration for %s\n", name);
     //        typedefHandler(n);
@@ -2318,7 +2315,7 @@ int R::classDeclaration(Node *n) {
 
   bool opaque = GetFlag(n, "feature:opaque") ? true : false;
 
-  if(opaque)
+  if (opaque)
     opaqueClassDeclaration = name;
 
   int status = Language::classDeclaration(n);
@@ -2326,76 +2323,72 @@ int R::classDeclaration(Node *n) {
   opaqueClassDeclaration = NULL;
 
 
-  // OutputArrayMethod(name, class_member_functions, sfile);        
+  // OutputArrayMethod(name, class_member_functions, sfile);
   if (class_member_functions)
     OutputMemberReferenceMethod(name, 0, class_member_functions, sfile);
   if (class_member_set_functions)
     OutputMemberReferenceMethod(name, 1, class_member_set_functions, sfile);
 
-  if(class_member_functions) {
+  if (class_member_functions) {
     Delete(class_member_functions);
     class_member_functions = NULL;
   }
-  if(class_member_set_functions) {
+  if (class_member_set_functions) {
     Delete(class_member_set_functions);
     class_member_set_functions = NULL;
   }
   if (Getattr(n, "has_destructor")) {
-    Printf(sfile, "setMethod('delete', '_p%s', function(obj) {delete%s(obj)})\n",
-	   getRClassName(Getattr(n, "name")),
-	   getRClassName(Getattr(n, "name")));
+    Printf(sfile, "setMethod('delete', '_p%s', function(obj) {delete%s(obj)})\n", getRClassName(Getattr(n, "name")), getRClassName(Getattr(n, "name")));
 
   }
-  if(!opaque && !Strcmp(kind, "struct") && copyStruct) {
+  if (!opaque && !Strcmp(kind, "struct") && copyStruct) {
 
-    String *def = 
-      NewStringf("setClass(\"%s\",\n%srepresentation(\n", name, tab4);
+    String *def = NewStringf("setClass(\"%s\",\n%srepresentation(\n", name, tab4);
     bool firstItem = true;
 
-    for(Node *c = firstChild(n); c; ) {
+    for (Node *c = firstChild(n); c;) {
       String *elName;
       String *tp;
 
       elName = Getattr(c, "name");
- 
+
       String *elKind = Getattr(c, "kind");
       if (!Equal(elKind, "variable")) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
       if (!Len(elName)) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
 #if 0
       tp = getRType(c);
 #else
       tp = Swig_typemap_lookup("rtype", c, "", 0);
-      if(!tp) {
-	c = nextSibling(c);
-	continue;
+      if (!tp) {
+        c = nextSibling(c);
+        continue;
       }
       if (Strstr(tp, "R_class")) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
-      if (Strcmp(tp, "character") &&
-	  Strstr(Getattr(c, "decl"), "p.")) {
-	c = nextSibling(c);
-	continue;
+      if (Strcmp(tp, "character") && Strstr(Getattr(c, "decl"), "p.")) {
+        c = nextSibling(c);
+        continue;
       }
 
       if (!firstItem) {
-	Printf(def, ",\n");
-      } 
-      //	    else 
+        Printf(def, ",\n");
+      }
+      //            else
       //XXX How can we tell if this is already done.
-      //	      SwigType_push(elType, elDecl);
-	    
-	    
+      //              SwigType_push(elType, elDecl);
+
+
       // returns ""  tp = processType(elType, c, NULL);
-      //	    Printf(stdout, "<classDeclaration> elType %p\n", elType);
-      //	    tp = getRClassNameCopyStruct(Getattr(c, "type"), 1);
+      //            Printf(stdout, "<classDeclaration> elType %p\n", elType);
+      //            tp = getRClassNameCopyStruct(Getattr(c, "type"), 1);
 #endif
       String *elNameT = replaceInitialDash(elName);
       Printf(def, "%s%s = \"%s\"", tab8, elNameT, tp);
@@ -2431,13 +2424,13 @@ int R::classDeclaration(Node *n) {
 int R::generateCopyRoutines(Node *n) {
   Wrapper *copyToR = NewWrapper();
   Wrapper *copyToC = NewWrapper();
-  
+
   String *name = Getattr(n, "name");
   String *tdname = Getattr(n, "tdname");
   String *kind = Getattr(n, "kind");
   String *type;
 
-  if(Len(tdname)) {
+  if (Len(tdname)) {
     type = Copy(tdname);
   } else {
     type = NewStringf("%s %s", kind, name);
@@ -2448,14 +2441,12 @@ int R::generateCopyRoutines(Node *n) {
   if (debugMode)
     Printf(stdout, "generateCopyRoutines:  name = %s, %s\n", name, type);
 
-  Printf(copyToR->def, "CopyToR%s = function(value, obj = new(\"%s\"))\n{\n", 
-	 mangledName, name);
-  Printf(copyToC->def, "CopyToC%s = function(value, obj)\n{\n", 
-	 mangledName);
+  Printf(copyToR->def, "CopyToR%s = function(value, obj = new(\"%s\"))\n{\n", mangledName, name);
+  Printf(copyToC->def, "CopyToC%s = function(value, obj)\n{\n", mangledName);
 
   Node *c = firstChild(n);
 
-  for(; c; c = nextSibling(c)) {
+  for (; c; c = nextSibling(c)) {
     String *elName = Getattr(c, "name");
     if (!Len(elName)) {
       continue;
@@ -2466,14 +2457,13 @@ int R::generateCopyRoutines(Node *n) {
     }
 
     String *tp = Swig_typemap_lookup("rtype", c, "", 0);
-    if(!tp) {
+    if (!tp) {
       continue;
     }
     if (Strstr(tp, "R_class")) {
       continue;
     }
-    if (Strcmp(tp, "character") &&
-	Strstr(Getattr(c, "decl"), "p.")) {
+    if (Strcmp(tp, "character") && Strstr(Getattr(c, "decl"), "p.")) {
       continue;
     }
 
@@ -2485,26 +2475,25 @@ int R::generateCopyRoutines(Node *n) {
     Delete(elNameT);
   }
   Printf(copyToR->code, "obj;\n}\n\n");
-  String *rclassName = getRClassNameCopyStruct(type, 0); // without the Ref.
-  Printf(sfile, "# Start definition of copy functions & methods for %s\n", rclassName);  
-  
+  String *rclassName = getRClassNameCopyStruct(type, 0);        // without the Ref.
+  Printf(sfile, "# Start definition of copy functions & methods for %s\n", rclassName);
+
   Wrapper_print(copyToR, sfile);
   Printf(copyToC->code, "obj\n}\n\n");
   Wrapper_print(copyToC, sfile);
-  
-  
-  Printf(sfile, "# Start definition of copy methods for %s\n", rclassName);  
-  Printf(sfile, "setMethod('copyToR', '_p_%s', CopyToR%s);\n", rclassName, 
-	 mangledName);
-  Printf(sfile, "setMethod('copyToC', '%s', CopyToC%s);\n\n", rclassName, 
-	 mangledName);
-  
-  Printf(sfile, "# End definition of copy methods for %s\n", rclassName);  
-  Printf(sfile, "# End definition of copy functions & methods for %s\n", rclassName);  
-      
+
+
+  Printf(sfile, "# Start definition of copy methods for %s\n", rclassName);
+  Printf(sfile, "setMethod('copyToR', '_p_%s', CopyToR%s);\n", rclassName, mangledName);
+  Printf(sfile, "setMethod('copyToC', '%s', CopyToC%s);\n\n", rclassName, mangledName);
+
+  Printf(sfile, "# End definition of copy methods for %s\n", rclassName);
+  Printf(sfile, "# End definition of copy functions & methods for %s\n", rclassName);
+
   String *m = NewStringf("%sCopyToR", name);
   addNamespaceMethod(m);
-  char *tt = Char(m);  tt[Len(m)-1] = 'C';
+  char *tt = Char(m);
+  tt[Len(m) - 1] = 'C';
   addNamespaceMethod(m);
   Delete(m);
   Delete(rclassName);
@@ -2518,9 +2507,9 @@ int R::generateCopyRoutines(Node *n) {
 
 
 /*****
-      Called when there is a typedef to be invoked. 
+      Called when there is a typedef to be invoked.
 
-      XXX Needs to be enhanced or split to handle the case where we have a 
+      XXX Needs to be enhanced or split to handle the case where we have a
       typedef within a classDeclaration emission because the struct/union/etc.
       is anonymous.
 ******/
@@ -2532,14 +2521,13 @@ int R::typedefHandler(Node *n) {
 
   processType(tp, n);
 
-  if(Strncmp(type, "struct ", 7) == 0) {
+  if (Strncmp(type, "struct ", 7) == 0) {
     String *name = Getattr(n, "name");
     char *trueName = Char(type);
     trueName += 7;
     if (debugMode)
       Printf(stdout, "<typedefHandler> Defining S class %s\n", trueName);
-    Printf(s_classes, "setClass('_p%s', contains = 'ExternalReference')\n", 
-	   SwigType_manglestr(name));
+    Printf(s_classes, "setClass('_p%s', contains = 'ExternalReference')\n", SwigType_manglestr(name));
   }
 
   return Language::typedefHandler(n);
@@ -2550,21 +2538,20 @@ int R::typedefHandler(Node *n) {
 /*********************
   Called when processing a field in a "class", i.e. struct, union or
   actual class.  We set a state variable so that we can correctly
-  interpret the resulting functionWrapper() call and understand that 
+  interpret the resulting functionWrapper() call and understand that
   it is for a field element.
 **********************/
 int R::membervariableHandler(Node *n) {
   SwigType *t = Getattr(n, "type");
   processType(t, n, NULL);
   processing_member_access_function = 1;
-  member_name = Getattr(n,"sym:name");
+  member_name = Getattr(n, "sym:name");
   if (debugMode)
-    Printf(stdout, "<membervariableHandler> name = %s, sym:name = %s\n", 
-	   Getattr(n, "name"), member_name);
+    Printf(stdout, "<membervariableHandler> name = %s, sym:name = %s\n", Getattr(n, "name"), member_name);
 
   int status(Language::membervariableHandler(n));
 
-  if(!opaqueClassDeclaration && debugMode)
+  if (!opaqueClassDeclaration && debugMode)
     Printf(stdout, "<membervariableHandler> %s %s\n", Getattr(n, "name"), Getattr(n, "type"));
 
   processing_member_access_function = 0;
@@ -2577,7 +2564,7 @@ int R::membervariableHandler(Node *n) {
 /*
   This doesn't seem to get used so leave it out for the moment.
 */
-String * R::runtimeCode() {
+String *R::runtimeCode() {
   String *s = Swig_include_sys("rrun.swg");
   if (!s) {
     Printf(stdout, "*** Unable to open 'rrun.swg'\n");
@@ -2588,7 +2575,7 @@ String * R::runtimeCode() {
 
 
 /**
-   Called when SWIG wants to initialize this 
+   Called when SWIG wants to initialize this
    We initialize anythin we want here.
    Most importantly, tell SWIG where to find the files (e.g. r.swg) for this module.
    Use Swig_mark_arg() to tell SWIG that it is understood and not to throw an error.
@@ -2610,41 +2597,41 @@ void R::main(int argc, char *argv[]) {
   this->Argc = argc;
   this->Argv = argv;
 
-  allow_overloading();// can we support this?    
+  allow_overloading();          // can we support this?
 
-  for(int i = 0; i < argc; i++) {
-    if(strcmp(argv[i], "-package") == 0) {
+  for (int i = 0; i < argc; i++) {
+    if (strcmp(argv[i], "-package") == 0) {
       Swig_mark_arg(i);
       i++;
       Swig_mark_arg(i);
       Rpackage = argv[i];
-    } else if(strcmp(argv[i], "-dll") == 0) {
+    } else if (strcmp(argv[i], "-dll") == 0) {
       Swig_mark_arg(i);
       i++;
       Swig_mark_arg(i);
       DllName = argv[i];
-    } else if(strcmp(argv[i], "-help") == 0) {
+    } else if (strcmp(argv[i], "-help") == 0) {
       showUsage();
-    } else if(strcmp(argv[i], "-namespace") == 0) {
+    } else if (strcmp(argv[i], "-namespace") == 0) {
       outputNamespaceInfo = true;
       Swig_mark_arg(i);
-    } else if(!strcmp(argv[i], "-no-init-code")) {
+    } else if (!strcmp(argv[i], "-no-init-code")) {
       noInitializationCode = true;
       Swig_mark_arg(i);
-    } else if(!strcmp(argv[i], "-c++")) {
+    } else if (!strcmp(argv[i], "-c++")) {
       inCPlusMode = true;
       Swig_mark_arg(i);
       Printf(s_classes, "setClass('C++Reference', contains = 'ExternalReference')\n");
-    } else if(!strcmp(argv[i], "-debug")) {
+    } else if (!strcmp(argv[i], "-debug")) {
       debugMode = true;
       Swig_mark_arg(i);
-    }  else if (!strcmp(argv[i],"-cppcast")) {
+    } else if (!strcmp(argv[i], "-cppcast")) {
       cppcast = true;
       Swig_mark_arg(i);
-    } else if (!strcmp(argv[i],"-nocppcast")) {
+    } else if (!strcmp(argv[i], "-nocppcast")) {
       cppcast = false;
       Swig_mark_arg(i);
-    } else if (!strcmp(argv[i],"-copystruct")) {
+    } else if (!strcmp(argv[i], "-copystruct")) {
       copyStruct = true;
       Swig_mark_arg(i);
     } else if (!strcmp(argv[i], "-nocopystruct")) {
@@ -2683,13 +2670,12 @@ void R::main(int argc, char *argv[]) {
   Could make this work for String or File and then just store the resulting string
   rather than the collection of arguments and argc.
 */
-int R::outputCommandLineArguments(File *out)
-{
-  if(Argc < 1 || !Argv || !Argv[0])
-    return(-1);
+int R::outputCommandLineArguments(File *out) {
+  if (Argc < 1 || !Argv || !Argv[0])
+    return (-1);
 
   Printf(out, "\n##   Generated via the command line invocation:\n##\t");
-  for(int i = 0; i < Argc ; i++) {
+  for (int i = 0; i < Argc; i++) {
     Printf(out, " %s", Argv[i]);
   }
   Printf(out, "\n\n\n");
@@ -2699,10 +2685,9 @@ int R::outputCommandLineArguments(File *out)
 
 
 
-/* How SWIG instantiates an object from this module. 
+/* How SWIG instantiates an object from this module.
    See swigmain.cxx */
-extern "C" 
-Language *swig_r(void) {
+extern "C" Language *swig_r(void) {
   return new R();
 }
 
@@ -2713,55 +2698,50 @@ Language *swig_r(void) {
 /*
   Needs to be reworked.
 */
-String * R::processType(SwigType *t, Node *n, int *nargs) {
+String *R::processType(SwigType *t, Node *n, int *nargs) {
   //XXX Need to handle typedefs, e.g.
   //  a type which is a typedef  to a function pointer.
 
   SwigType *tmp = Getattr(n, "tdname");
   if (debugMode)
     Printf(stdout, "processType %s (tdname = %s)\n", Getattr(n, "name"), tmp);
-  
+
   SwigType *td = t;
-  if (expandTypedef(t) &&
-      SwigType_istypedef(t)) {
-    SwigType *resolved = 
-      SwigType_typedef_resolve_all(t);
+  if (expandTypedef(t) && SwigType_istypedef(t)) {
+    SwigType *resolved = SwigType_typedef_resolve_all(t);
     if (expandTypedef(resolved)) {
       td = Copy(resolved);
     }
   }
 
-  if(!td) {
+  if (!td) {
     int count = 0;
     String *b = getRTypeName(t, &count);
-    if(count && b && !Getattr(SClassDefs, b)) {
+    if (count && b && !Getattr(SClassDefs, b)) {
       if (debugMode)
-	Printf(stdout, "<processType> Defining class %s\n",  b);
+        Printf(stdout, "<processType> Defining class %s\n", b);
 
-      Printf(s_classes, "setClass('%s', contains = 'ExternalReference')\n", b);       
+      Printf(s_classes, "setClass('%s', contains = 'ExternalReference')\n", b);
       Setattr(SClassDefs, b, b);
     }
-     
+
   }
 
 
-  if(td)
+  if (td)
     t = td;
 
-  if(SwigType_isfunctionpointer(t)) {
+  if (SwigType_isfunctionpointer(t)) {
     if (debugMode)
-      Printf(stdout, 
-	     "<processType> Defining pointer handler %s\n",  t);
-       
+      Printf(stdout, "<processType> Defining pointer handler %s\n", t);
+
     String *tmp = createFunctionPointerHandler(t, n, nargs);
     return tmp;
   }
-
 #if 0
   SwigType_isfunction(t) && SwigType_ispointer(t)
 #endif
-
-    return NULL;
+      return NULL;
 }
 
 
@@ -2773,8 +2753,3 @@ String * R::processType(SwigType *t, Node *n, int *nargs) {
 
 
 /*************************************************************************************/
-
-
-
-
-


### PR DESCRIPTION
This is a modification to support use of tricky enumerations in R. Itincludes the addition of a _runme for an existing test - preproc_constants
that was previously not run. That tests includes a preprocessor based
setting of an enumeration which is ignored by the existing r enumeration
infrastructure. The new version correctly reports the enumeration value
as 4 - previous versions set it to 0. Traditional enumerations are unchanged.

The approach used to deal with these enumerations is similar to that of
other languages, and requires a call to a C function at runtime to return
the enumeration value. The previous approach figured out the values statically
and this is still used where possible. The need for a runtime call leads to
changes in when swig code is used in packages - see below.

One test that previously passed now fails - namely the R sourcing of
preproc_constants.R, as the enumeration code requires the shared library,
which isn't loaded by that script.

There is also a modification to the way the R _runme.R files are used.
The call to R CMD BATCH now includes a --args option that indicates
the source folder for the unittest.R file, and the first couple
of lines of the _runme.R files deal with correctly locating this.
Out of source tests now run.

This work was motivated by problems generating the SimpleITK binding,
specifically with some of the more complex enumerations.

This approach does have some issues wrt to code in packages, but I can't
see an alternative. The problem with packages is that the R code setting
up the enumeration structures requires the shared library so that the C
functions returning enumeration values can be called. The enumeration
setup code thus needs to be moved to the package initialisation section.
For SimpleITK I do this using an R script, which I think is an acceptable
solution. The core part of the process is the following function. I dump
all the enumeration stuff into a .onload function. This is only necessary
if some of the enumerations are tricky.

splitSwigFile <- function(filename, onloadfile, mainfile)
{
p1 <- parse(file=filename)

getdefineEnum <- function(X)
{
return (is.call(X) & (X[[1]]=="defineEnumeration"))
}

dd <- sapply(p1, getdefineEnum)

enums <- p1[dd]
enums <- unlist(lapply(enums, deparse))

enums <- c(".onLoad <- function(libname, pkgname) {", enums, "}")

everythingelse <- p1[!dd]
everythingelse <- unlist(lapply(everythingelse, deparse))
writeLines(everythingelse, mainfile)
writeLines(enums, onloadfile)

}