### PR TITLE
Implement argout, freearg, and check for CFFI.

### DIFF
--- a/Source/Modules/cffi.cxx
+++ b/Source/Modules/cffi.cxx
@@ -61,6 +61,11 @@ public:
   virtual int classHandler(Node *n);
 
 private:
+  static void checkConstraints(ParmList *parms, Wrapper *f);
+  static void argout(ParmList *parms, Wrapper *f);
+  static String *freearg(ParmList *parms);
+  static void cleanupFunction(Node *n, Wrapper *f, ParmList *parms);
+
   void emit_defun(Node *n, String *name);
   void emit_defmethod(Node *n);
   void emit_initialize_instance(Node *n);
@@ -364,6 +369,77 @@ int CFFI::membervariableHandler(Node *n) {
   return Language::membervariableHandler(n);
 }
 
+
+void CFFI::checkConstraints(ParmList *parms, Wrapper *f) {
+  Parm *p = parms;
+  while (p) {
+    String *tm = Getattr(p, "tmap:check");
+    if (!tm) {
+      p = nextSibling(p);
+    } else {
+      tm = Copy(tm);
+      Replaceall(tm, "$input", Getattr(p, "emit:input"));
+      Printv(f->code, tm, "\n\n", NULL);
+      Delete(tm);
+      p = Getattr(p, "tmap:check:next");
+    }
+  }
+}
+
+void CFFI::argout(ParmList *parms, Wrapper *f) {
+  Parm *p = parms;
+  while (p) {
+    String *tm = Getattr(p, "tmap:argout");
+    if (!tm) {
+      p = nextSibling(p);
+    } else {
+      tm = Copy(tm);
+      Replaceall(tm, "$result", Swig_cresult_name());
+      Replaceall(tm, "$input", Getattr(p, "emit:input"));
+      Printv(f->code, tm, "\n", NULL);
+      Delete(tm);
+      p = Getattr(p, "tmap:argout:next");
+    }
+  }
+}
+
+String *CFFI::freearg(ParmList *parms) {
+  String *ret = NewString("");
+  Parm *p = parms;
+  while (p) {
+    String *tm = Getattr(p, "tmap:freearg");
+    if (!tm) {
+      p = nextSibling(p);
+    } else {
+      tm = Copy(tm);
+      Replaceall(tm, "$input", Getattr(p, "emit:input"));
+      Printv(ret, tm, "\n", NULL);
+      Delete(tm);
+      p = Getattr(p, "tmap:freearg:next");
+    }
+  }
+  return ret;
+}
+
+void CFFI::cleanupFunction(Node *n, Wrapper *f, ParmList *parms) {
+  String *cleanup = freearg(parms);
+  Printv(f->code, cleanup, NULL);
+
+  if (GetFlag(n, "feature:new")) {
+    String *tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0);
+    if (tm) {
+      Replaceall(tm, "$source", Swig_cresult_name());
+      Printv(f->code, tm, "\n", NULL);
+      Delete(tm);
+    }
+  }
+
+  Replaceall(f->code, "$cleanup", cleanup);
+  Delete(cleanup);
+
+  Replaceall(f->code, "$symname", Getattr(n, "sym:name"));
+}
+
 int CFFI::functionWrapper(Node *n) {
 
   ParmList *parms = Getattr(n, "parms");
@@ -451,6 +527,9 @@ int CFFI::functionWrapper(Node *n) {
   // Emit the function definition
   String *signature = SwigType_str(return_type, name_and_parms);
   Printf(f->def, "EXPORT %s {", signature);
+
+  checkConstraints(parms, f);
+
   Printf(f->code, "  try {\n");
 
   String *actioncode = emit_action(n);
@@ -459,9 +538,17 @@ int CFFI::functionWrapper(Node *n) {
   if (result_convert) {
     Replaceall(result_convert, "$result", "lresult");
     Printf(f->code, "%s\n", result_convert);
-    if(!is_void_return) Printf(f->code, "    return lresult;\n");
-    Delete(result_convert);
   }
+  Delete(result_convert);
+
+  argout(parms, f);
+
+  cleanupFunction(n, f, parms);
+
+  if (!is_void_return) {
+    Printf(f->code, "    return lresult;\n");
+  }
+
   emit_return_variable(n, Getattr(n, "type"), f);
 
   Printf(f->code, "  } catch (...) {\n");


### PR DESCRIPTION
Implement missing typemap methods---argout, freearg, and check---for CFFI. The implementation is cribbed from the Go module.