### PR TITLE
Enum r2015 d

### DIFF
--- a/Examples/test-suite/r/Makefile.in
+++ b/Examples/test-suite/r/Makefile.in
@@ -5,7 +5,7 @@
 LANGUAGE     = r
 SCRIPTSUFFIX = _runme.R
 WRAPSUFFIX   = .R
-RUNR         = R CMD BATCH --no-save --no-restore
+RUNR         = R CMD BATCH --no-save --no-restore '--args $(SCRIPTDIR)'
 
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
@@ -43,6 +43,7 @@ include $(srcdir)/../common.mk
 	$(setup)
 	+$(swig_and_compile_multi_cpp)
 	$(run_multitestcase)
+
 
 # Runs the testcase.
 #

--- a/Examples/test-suite/r/arrays_dimensionless_runme.R
+++ b/Examples/test-suite/r/arrays_dimensionless_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("arrays_dimensionless", .Platform$dynlib.ext, sep=""))
 source("arrays_dimensionless.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/funcptr_runme.R
+++ b/Examples/test-suite/r/funcptr_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("funcptr", .Platform$dynlib.ext, sep=""))
 source("funcptr.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/ignore_parameter_runme.R
+++ b/Examples/test-suite/r/ignore_parameter_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("ignore_parameter", .Platform$dynlib.ext, sep=""))
 source("ignore_parameter.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/integers_runme.R
+++ b/Examples/test-suite/r/integers_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("integers", .Platform$dynlib.ext, sep=""))
 source("integers.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/overload_method_runme.R
+++ b/Examples/test-suite/r/overload_method_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("overload_method", .Platform$dynlib.ext, sep=""))
 source("overload_method.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/preproc_constants_runme.R
+++ b/Examples/test-suite/r/preproc_constants_runme.R
@@ -1,0 +1,11 @@
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
+dyn.load(paste("preproc_constants", .Platform$dynlib.ext, sep=""))
+source("preproc_constants.R")
+cacheMetaData(1)
+
+v <- enumToInteger('kValue', '_MyEnum')
+print(v)
+unittest(v,4)
+q(save="no")

--- a/Examples/test-suite/r/r_copy_struct_runme.R
+++ b/Examples/test-suite/r/r_copy_struct_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("r_copy_struct", .Platform$dynlib.ext, sep=""))
 source("r_copy_struct.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/r_legacy_runme.R
+++ b/Examples/test-suite/r/r_legacy_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("r_legacy", .Platform$dynlib.ext, sep=""))
 source("r_legacy.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/r_sexp_runme.R
+++ b/Examples/test-suite/r/r_sexp_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("r_sexp", .Platform$dynlib.ext, sep=""))
 source("r_sexp.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/rename_simple_runme.R
+++ b/Examples/test-suite/r/rename_simple_runme.R
@@ -1,4 +1,6 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
 dyn.load(paste("rename_simple", .Platform$dynlib.ext, sep=""))
 source("rename_simple.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/simple_array_runme.R
+++ b/Examples/test-suite/r/simple_array_runme.R
@@ -1,4 +1,5 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
 dyn.load(paste("simple_array", .Platform$dynlib.ext, sep=""))
 source("simple_array.R")
 cacheMetaData(1)

--- a/Examples/test-suite/r/unions_runme.R
+++ b/Examples/test-suite/r/unions_runme.R
@@ -1,4 +1,5 @@
-source("unittest.R")
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
 dyn.load(paste("unions", .Platform$dynlib.ext, sep=""))
 source("unions.R")
 cacheMetaData(1)


### PR DESCRIPTION
 This is a modification to support use of tricky enumerations in R. It
includes the addition of a _runme for an existing test - preproc_constants
that was previously not run. That test includes a preprocessor based
setting of an enumeration which is ignored by the existing r enumeration
infrastructure. The new version correctly reports the enumeration value
as 4 - previous versions set it to 0. Traditional enumerations are unchanged.

The approach used to deal with these enumerations is similar to that of
other languages, and requires a call to a C function at runtime to return
the enumeration value. The previous approach figured out the values statically
and this is still used where possible. The need for a runtime call leads to
changes in when swig code is used in packages - see below.

Several tests that previously passed now fail- such as the R sourcing of
preproc_constants.R, as the enumeration code requires the shared library,
which isn't loaded by that script. Old style enumerations always looked like this - 
with assignments using statically determined literals:
defineEnumeration("_itk__simple__KernelEnum", .values = c(sitkAnnulus = 0, 
    sitkBall = 1, sitkBox = 2, sitkCross = 3, sitkPolygon3 = 4, 
    sitkPolygon4 = 5, sitkPolygon5 = 6, sitkPolygon6 = 7, sitkPolygon7 = 8, 
    sitkPolygon8 = 9, sitkPolygon9 = 10))

New ones can look like this - with values determined using function calls to the wrapped code :
defineEnumeration('_MyEnum',
                    .values = c(
                        'kValue' = R_swigenum__MyEnum_kValue_get()
))

This kind of call will fail if the library isn't loaded, which is the case for the failing tests.

---

There is also a modification to the way the R _runme.R files are used.
The call to R CMD BATCH now includes a --args option that indicates
the source folder for the unittest.R file, and the first couple
of lines of the _runme.R files deal with correctly locating this.
Out of source tests now run correctly.

This work was motivated by problems generating the SimpleITK binding,
specifically with some of the more complex enumerations.

This approach does have some issues wrt to code in packages, but I can't
see an alternative. The problem with packages is that the R code setting
up the enumeration structures requires the shared library so that the C
functions returning enumeration values can be called. The enumeration
setup code thus needs to be moved to the package initialisation section.
For SimpleITK I do this using an R script, which I think is an acceptable
solution. The core part of the process is the following function. I dump
all the enumeration stuff into a .onload function. This is only necessary
if some of the enumerations are tricky.

splitSwigFile <- function(filename, onloadfile, mainfile)
{
p1 <- parse(file=filename)

getdefineEnum <- function(X)
{
return (is.call(X) & (X[[1]]=="defineEnumeration"))
}

dd <- sapply(p1, getdefineEnum)

enums <- p1[dd]
enums <- unlist(lapply(enums, deparse))

enums <- c(".onLoad <- function(libname, pkgname) {", enums, "}")

everythingelse <- p1[!dd]
everythingelse <- unlist(lapply(everythingelse, deparse))
writeLines(everythingelse, mainfile)
writeLines(enums, onloadfile)

}
