### PR TITLE
Removed golang stringing for signed/unsigned char

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,19 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.8 (in progress)
 ===========================
 
+2015-09-03: demi-rluddy
+            [Go] Removed golang stringing for signed/unsigned char
+
+            Changed default handling of signed char* and unsigned char* to be
+            opaque pointers rather than strings, similarly to how other
+            languages work.
+
+            Any existing code relying on treating signed char* or unsigned
+            char* as a string can restore the old behavior with typemaps.i by
+            using %apply to copy the [unchanged] char* behavior.
+
+            *** POTENTIAL INCOMPATIBILITY ***
+
 2015-08-07: talby
             [Perl] tidy -Wtautological-constant-out-of-range-compare warnings when building generated code under clang
 

--- a/Lib/go/go.swg
+++ b/Lib/go/go.swg
@@ -426,57 +426,41 @@
 /* Strings.  */
 
 %typemap(gotype)
-	char *, char *&, char[ANY], char[],
-	signed char *, signed char *&, signed char[ANY], signed char[],
-	unsigned char *, unsigned char *&, unsigned char[ANY], unsigned char[]
-"string"
+	char *, char *&, char[ANY], char[] "string"
 
 /* Needed to avoid confusion with the way the go module handles
    references.  */
-%typemap(gotype) char&, unsigned char& "*byte"
-%typemap(gotype) signed char& "*int8"
+%typemap(gotype) char& "*byte"
 
 %typemap(in)
-	char *, char[ANY], char[],
-	signed char *, signed char[ANY], signed char[],
-	unsigned char *, unsigned char[ANY], unsigned char[]
+	char *, char[ANY], char[]
 %{ $1 = ($1_ltype)$input.p; %}
 
-%typemap(in) char *&, signed char *&, unsigned char *&
+%typemap(in) char *&
 %{ $1 = ($1_ltype)$input.p; %}
 
 %typemap(out,fragment="AllocateString")
-	char *, char *&, char[ANY], char[],
-	signed char *, signed char *&, signed char[ANY], signed char[],
-	unsigned char *, unsigned char *&, unsigned char[ANY], unsigned char[]
+	char *, char *&, char[ANY], char[]
 %{ $result = Swig_AllocateString((char*)$1, $1 ? strlen((char*)$1) : 0); %}
 
 %typemap(goout,fragment="CopyString")
-	char *, char *&, char[ANY], char[],
-	signed char *, signed char *&, signed char[ANY], signed char[],
-	unsigned char *, unsigned char *&, unsigned char[ANY], unsigned char[]
+	char *, char *&, char[ANY], char[]
 %{ $result = swigCopyString($1) %}
 
 %typemap(directorin,fragment="AllocateString")
-	char *, char *&, char[ANY], char[],
-	signed char *, signed char *&, signed char[ANY], signed char[],
-	unsigned char *, unsigned char *&, unsigned char[ANY], unsigned char[]
+	char *, char *&, char[ANY], char[]
 %{
   $input = Swig_AllocateString((char*)$1, $1 ? strlen((char*)$1) : 0);
 %}
 
 %typemap(godirectorin,fragment="CopyString")
-	char *, char *&, char[ANY], char[],
-	signed char *, signed char *&, signed char[ANY], signed char[],
-	unsigned char *, unsigned char *&, unsigned char[ANY], unsigned char[]
+	char *, char *&, char[ANY], char[]
 %{
   $result = swigCopyString($input)
 %}
 
 %typemap(directorout)
-	char *, char *&, char[ANY], char[],
-	signed char *, signed char *&, signed char[ANY], signed char[],
-	unsigned char *, unsigned char *&, unsigned char[ANY], unsigned char[]
+	char *, char *&, char[ANY], char[]
 %{ $result = ($1_ltype)$input.p; %}
 
 /* String & length */

--- a/Lib/go/go.swg
+++ b/Lib/go/go.swg
@@ -430,7 +430,8 @@
 
 /* Needed to avoid confusion with the way the go module handles
    references.  */
-%typemap(gotype) char& "*byte"
+%typemap(gotype) char&, unsigned char& "*byte"
+%typemap(gotype) signed char& "*int8"
 
 %typemap(in)
 	char *, char[ANY], char[]


### PR DESCRIPTION
With this change, generated code for golang treats char* as a string but
treats signed char* and unsigned char* as normal pointers. This seems to
fit better with the expected behavior, as the latter are more often used
as non-string data.

Resolves #505 