### PR TITLE
Add new but ignored warning option -Wdate-time.

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -661,6 +661,8 @@ MULTI_CPP_TEST_CASES += \
 
 # Custom tests - tests with additional commandline options
 wallkw.cpptest: SWIGOPT += -Wallkw
+wdate_time.ctest: SWIGOPT += -Wdate-time
+
 preproc_include.ctest: SWIGOPT += -includeall
 
 

--- a/Examples/test-suite/python/wdate_time_runme.py
+++ b/Examples/test-suite/python/wdate_time_runme.py
@@ -1,0 +1,5 @@
+import wdate_time
+
+print "__TIME__:", wdate_time.macro_time
+print "__DATE__:", wdate_time.macro_date
+print "__TIMESTAMP__:", wdate_time.macro_timestamp

--- a/Examples/test-suite/wdate_time.i
+++ b/Examples/test-suite/wdate_time.i
@@ -1,0 +1,26 @@
+%module wdate_time
+
+/* No actual source code, just to test the -Wdate-time command line option.
+   As SWIG does not replace __TIME__, __DATE__ and __TIMESTAMP__ it has no
+   effect for SWIG processing. */
+
+%{
+/* Provide timestamps as macros for the (realistic?) case that they are not
+   provided by the C preprocessor. */
+
+#ifndef __TIME__
+#define __TIME__  "23:37:02"
+#endif
+#ifndef __DATE__
+#define __TIME__  "Aug 28 2015"
+#endif
+#ifndef __TIMESTAMP__
+#define __TIMESTAMP__  "Fri Aug 28 23:37:02 2015"
+#endif
+%}
+
+%inline %{
+const char macro_time[] = __TIME__;
+const char macro_date[] = __DATE__;
+const char macro_timestamp[] = __TIMESTAMP__;
+%}

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -145,6 +145,7 @@ static const char *usage4 = (const char *) "\
      -Wallkw         - Enable keyword warnings for all the supported languages\n\
      -Werror         - Treat warnings as errors\n\
      -Wextra         - Adds the following additional warnings: " EXTRA_WARNINGS "\n\
+     -Wdate-time     - Ignored for the time being since __DATE__ and __TIME__ are not replaced\n\
      -w<list>        - Suppress/add warning messages, eg -w401,+321 - see Warnings.html\n\
      -xmlout <file>  - Write XML version of the parse tree to <file> after normal processing\n\
 \n\
@@ -764,6 +765,9 @@ void SWIG_getoptions(int argc, char *argv[]) {
 	Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-Werror") == 0) {
 	werror = 1;
+	Swig_mark_arg(i);
+      } else if (strcmp(argv[i], "-Wdate-time") == 0) {
+        /* no effect for SWIG, see https://gcc.gnu.org/onlinedocs/gcc-4.9.3/gcc/Warning-Options.html#Warning-Options */
 	Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-Wextra") == 0) {
 	Swig_mark_arg(i);


### PR DESCRIPTION
Rationale: This would be helpful for the Debian reproducible builds
effort, described at https://wiki.debian.org/ReproducibleBuilds

Basically, the warning is used to detect where the time macros
`__TIME__`, `__DATE__` etc. are used, but this makes SWIG fail because
of the unrecognized option.

Please see my email on swig-devel and [this feature request](https://bugs.debian.org/790102) for more background.