### PR TITLE
[javascript][node] incorrect exception handing with function overload

### DIFF
--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -334,9 +334,13 @@ fail:
 #else
     $jswrapper(args, errorHandler);
     if(errorHandler.err.IsEmpty()) {
-      return;
+      SWIGV8_RETURN(jsresult);
+    }
+    else {
+      SWIGV8_RETURN(SWIGV8_UNDEFINED());
     }
 #endif
+    SWIGV8_RETURN(SWIGV8_UNDEFINED());
   }
 %}
 


### PR DESCRIPTION
this fix https://github.com/swig/swig/issues/519:

in generated code,
swig uses  args.Length() to dispatch different overloaded functions, but when exception occurs, 

```
    if(errorHandler.err.IsEmpty()) {
      return;
    }
```

and the execution falls to 

```
  SWIG_exception_fail(SWIG_ERROR, "Illegal arguments for function xxxx");
```

therefore, when ever exceptions thrown, it's always  "Illegal arguments" .
