### PR TITLE
Remove unused support for typemap scopes

### DIFF
--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -409,8 +409,6 @@ extern int        ParmList_is_compactdefargs(ParmList *p);
 
   extern String *Swig_typemap_lookup(const_String_or_char_ptr tmap_method, Node *n, const_String_or_char_ptr lname, Wrapper *f);
   extern String *Swig_typemap_lookup_out(const_String_or_char_ptr tmap_method, Node *n, const_String_or_char_ptr lname, Wrapper *f, String *actioncode);
-  extern void Swig_typemap_new_scope(void);
-  extern Hash *Swig_typemap_pop_scope(void);
 
   extern void Swig_typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList *parms, Wrapper *f);
 


### PR DESCRIPTION
While debugging some typemap problem, I noticed that the code in `typemap.c` was unnecessarily complicated as it supported typemap scopes which are, in fact, never used, so I've just removed them to simplify it.