### PR TITLE
Issue #508: Classprefix handling in the parser

### DIFF
--- a/Examples/test-suite/nested_class.i
+++ b/Examples/test-suite/nested_class.i
@@ -55,6 +55,10 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
+namespace bar {
+    int foo();
+}
+
 struct Outer {
   typedef int Integer;
   ///////////////////////////////////////////
@@ -129,9 +133,13 @@ struct Outer {
     Integer x;
   } InnerClass4Typedef;
 
+  int Outer::foo(){ return 1; } // should correctly ignore qualification here (#508)
+
   typedef struct {
     Integer x;
   } InnerStruct4Typedef;
+
+  friend int bar::foo(); // should parse correctly (#508)
 
   typedef union {
     Integer x;

--- a/Examples/test-suite/nested_class.i
+++ b/Examples/test-suite/nested_class.i
@@ -56,7 +56,7 @@
 #endif
 
 namespace bar {
-    int foo();
+    int foo() { return 0; }
 }
 
 struct Outer {

--- a/Examples/test-suite/nested_class.i
+++ b/Examples/test-suite/nested_class.i
@@ -133,7 +133,9 @@ struct Outer {
     Integer x;
   } InnerClass4Typedef;
 
+#ifdef _MSC_VER
   int Outer::foo(){ return 1; } // should correctly ignore qualification here (#508)
+#endif
 
   typedef struct {
     Integer x;

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -2925,8 +2925,8 @@ c_decl  : storage_class type declarator initializer c_decl_tail {
                    matches that of the declaration, then we will allow it. Otherwise, delete. */
                 String *p = Swig_scopename_prefix($3.id);
 		if (p) {
-		  if ((Namespaceprefix && Strcmp(p,Namespaceprefix) == 0) ||
-		      (inclass && Strcmp(p,Classprefix) == 0)) {
+		  if ((Namespaceprefix && Strcmp(p, Namespaceprefix) == 0) ||
+		      (Classprefix && Strcmp(p, Classprefix) == 0)) {
 		    String *lstr = Swig_scopename_last($3.id);
 		    Setattr($$,"name",lstr);
 		    Delete(lstr);
@@ -2981,8 +2981,8 @@ c_decl  : storage_class type declarator initializer c_decl_tail {
 	      if (Strstr($3.id,"::")) {
                 String *p = Swig_scopename_prefix($3.id);
 		if (p) {
-		  if ((Namespaceprefix && Strcmp(p,Namespaceprefix) == 0) ||
-		      (inclass && Strcmp(p,Classprefix) == 0)) {
+		  if ((Namespaceprefix && Strcmp(p, Namespaceprefix) == 0) ||
+		      (Classprefix && Strcmp(p, Classprefix) == 0)) {
 		    String *lstr = Swig_scopename_last($3.id);
 		    Setattr($$,"name",lstr);
 		    Delete(lstr);
@@ -3618,6 +3618,7 @@ cpp_class_decl  : storage_class cpptype idcolon inherit LBRACE {
 		   Swig_symbol_setscope(cscope);
 		   Delete(Namespaceprefix);
 		   Namespaceprefix = Swig_symbol_qualifiedscopename(0);
+		   Classprefix = currentOuterClass ? Getattr(currentOuterClass, "Classprefix") : 0;
 	       }
 
 /* An unnamed struct, possibly with a typedef */
@@ -3654,7 +3655,7 @@ cpp_class_decl  : storage_class cpptype idcolon inherit LBRACE {
 	       cparse_start_line = cparse_line;
 	       currentOuterClass = $<node>$;
 	       inclass = 1;
-	       Classprefix = NewStringEmpty();
+	       Classprefix = 0;
 	       Delete(Namespaceprefix);
 	       Namespaceprefix = Swig_symbol_qualifiedscopename(0);
 	       /* save the structure declaration to make a typedef for it later*/
@@ -3765,6 +3766,7 @@ cpp_class_decl  : storage_class cpptype idcolon inherit LBRACE {
 		 Delete($$);
 		 $$ = $6; /* pass member list to outer class/namespace (instead of self)*/
 	       }
+	       Classprefix = currentOuterClass ? Getattr(currentOuterClass, "Classprefix") : 0;
               }
              ;
 


### PR DESCRIPTION
Classprefix is not always restored after nested structures processing. Also, Classprefix is incorrectly checked in some places.