### PR TITLE
Doc/Manual/CSharp.html: remove irrelevant text

### DIFF
--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -1272,7 +1272,7 @@ the C# code can be generated into the intermediary class using the <tt>imclassco
   }
 
   // Note that SWIG detects any method calls named starting with
-  // SWIG_CSharpSetPendingException for warning 845
+  // SWIG_CSharpSetPendingException
   static void SWIG_CSharpSetPendingExceptionCustom(const char *msg) {
     customExceptionCallback(msg);
   }


### PR DESCRIPTION
The reference "for warning 845" does not make any sense in this
context.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>