### PR TITLE
Fix Go example in Go.html

### DIFF
--- a/Doc/Manual/Go.html
+++ b/Doc/Manual/Go.html
@@ -445,7 +445,7 @@ type MyClass interface {
   MyMethod() int
 }
 
-MyClassMyFactoryFunction() MyClass {
+func MyClassMyFactoryFunction() MyClass {
   // swig magic here
 }
 </pre>


### PR DESCRIPTION
Missing "func" keyword.