### PR TITLE
Add checks for new fields in PyTypeObject and PyNumberMethods for Python version 3.4 and 3.5

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -435,6 +435,9 @@ SwigPyStaticVar_Type(void) {
 #if PY_VERSION_HEX >= 0x02060000
       0,                                        /* tp_version */
 #endif
+#if PY_VERSION_HEX >= 0x03040000
+      0,                                        /* tp_finalize */
+#endif
 #ifdef COUNT_ALLOCS
       0,0,0,0                                   /* tp_alloc -> tp_next */
 #endif

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -185,6 +185,9 @@ swig_varlink_type(void) {
 #if PY_VERSION_HEX >= 0x02060000
       0,                                  /* tp_version */
 #endif
+#if PY_VERSION_HEX >= 0x03040000
+      0,                                  /* tp_finalize */
+#endif
 #ifdef COUNT_ALLOCS
       0,0,0,0                             /* tp_alloc -> tp_next */
 #endif

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -724,7 +724,9 @@ SwigPyObject_TypeOnce(void) {
     (unaryfunc)SwigPyObject_oct,  /*nb_oct*/
     (unaryfunc)SwigPyObject_hex,  /*nb_hex*/
 #endif
-#if PY_VERSION_HEX >= 0x03000000 /* 3.0 */
+#if PY_VERSION_HEX >= 0x03050000 /* 3.5 */
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 /* nb_inplace_add -> nb_inplace_matrix_multiply */
+#elif PY_VERSION_HEX >= 0x03000000 /* 3.0 */
     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 /* nb_inplace_add -> nb_index, nb_inplace_divide removed */
 #elif PY_VERSION_HEX >= 0x02050000 /* 2.5.0 */
     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 /* nb_inplace_add -> nb_index */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -806,6 +806,9 @@ SwigPyObject_TypeOnce(void) {
 #if PY_VERSION_HEX >= 0x02060000
       0,                                    /* tp_version */
 #endif
+#if PY_VERSION_HEX >= 0x03040000
+      0,                                    /* tp_finalize */
+#endif
 #ifdef COUNT_ALLOCS
       0,0,0,0                               /* tp_alloc -> tp_next */
 #endif
@@ -984,6 +987,9 @@ SwigPyPacked_TypeOnce(void) {
 #endif
 #if PY_VERSION_HEX >= 0x02060000
       0,                                    /* tp_version */
+#endif
+#if PY_VERSION_HEX >= 0x03040000
+      0,                                    /* tp_finalize */
 #endif
 #ifdef COUNT_ALLOCS
       0,0,0,0                               /* tp_alloc -> tp_next */


### PR DESCRIPTION
The [tp_finalize field of PyTypeObjects](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_finalize) is new in Python v3.4
The [nb_matrix_multiply and nb_inplace_matrix_multiply fields of PyNumberMethods](https://docs.python.org/3/c-api/typeobj.html#number-object-structures) are new in Python v3.5

The existing code causes gcc/g++ to emit warnings if -Wmissing-field-initializers is enabled when building the swig-generated files - the patch ensures that the fields are properly defined