### PR TITLE
Ignore locally installed ccache when running CCache unit tests

### DIFF
--- a/CCache/test.sh
+++ b/CCache/test.sh
@@ -15,6 +15,12 @@ else
  SWIG=swig
 fi
 
+# fix: Remove ccache from $PATH if it exists
+#      as it will influence the unit tests
+PATH="`echo $PATH | \
+ awk -v RS=: -v ORS=: '/\/usr\/lib(64|)\/ccache(:|)/ {next} {print}' | \
+ sed 's/:*$//'`"
+
 CCACHE=../ccache-swig
 TESTDIR=test.$$
 

--- a/CCache/test.sh
+++ b/CCache/test.sh
@@ -18,8 +18,7 @@ fi
 # fix: Remove ccache from $PATH if it exists
 #      as it will influence the unit tests
 PATH="`echo $PATH | \
- awk -v RS=: -v ORS=: '/\/usr\/lib(64|)\/ccache(:|)/ {next} {print}' | \
- sed 's/:*$//'`"
+ sed -e 's!:/usr\(/local\)*/lib\([0-9]\)*/ccache\(/\)*!!g'`"
 
 CCACHE=../ccache-swig
 TESTDIR=test.$$


### PR DESCRIPTION
Some small improvement for running the testsuite, if ccache is installed and found in $PATH.
***
original patch by David Sommerseth <davids@redhat.com>