### PR TITLE
Python3.5 destructor exception fix

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -58,6 +58,7 @@ CPP_TEST_CASES += \
 	primitive_types \
 	python_abstractbase \
 	python_append \
+	python_destructor_exception \
 	python_director \
 	python_docstring \
 	python_nondynamic \

--- a/Examples/test-suite/python/python_destructor_exception_runme.py
+++ b/Examples/test-suite/python/python_destructor_exception_runme.py
@@ -1,0 +1,14 @@
+import python_destructor_exception
+from StringIO import StringIO
+import sys
+
+#buffer = StringIO()
+#sys.stderr = buffer
+
+attributeErrorOccurred = False
+try:
+    python_destructor_exception.ClassWithThrowingDestructor().GetBlah()
+except AttributeError, e:
+    attributeErrorOccurred = True
+
+assert attributeErrorOccurred

--- a/Examples/test-suite/python_destructor_exception.i
+++ b/Examples/test-suite/python_destructor_exception.i
@@ -1,0 +1,17 @@
+/* File : example.i */
+%module python_destructor_exception
+%include exception.i
+
+%exception ClassWithThrowingDestructor::~ClassWithThrowingDestructor()
+{
+  $action
+  SWIG_exception(SWIG_RuntimeError, "I am the ClassWithThrowingDestructor dtor doing bad things");
+}
+
+%inline %{
+class ClassWithThrowingDestructor
+{
+};
+
+%}
+

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -536,23 +536,32 @@ SwigPyObject_dealloc(PyObject *v)
     if (destroy) {
       /* destroy is always a VARARGS method */
       PyObject *res;
+
+      /* PyObject_CallFunction() has the potential to silently drop
+         the active active exception.  In cases of unnamed temporary
+         variable or where we just finished iterating over a generator
+         StopIteration will be active right now, and this needs to
+         remain true upon return from SwigPyObject_dealloc.  So save
+         and restore. */
+      
+      PyObject *val = NULL, *type = NULL, *tb = NULL;
+      PyErr_Fetch(&val, &type, &tb);
+
       if (data->delargs) {
         /* we need to create a temporary object to carry the destroy operation */
         PyObject *tmp = SwigPyObject_New(sobj->ptr, ty, 0);
-        /* PyObject_CallFunction() has the potential to silently drop the active
-           active exception.  In cases where we just finished iterating over a
-           generator StopIteration will be active right now, and this needs to
-           remain true upon return from SwigPyObject_dealloc.  So save and restore. */
-        PyObject *val = NULL, *type = NULL, *tb = NULL;
-        PyErr_Fetch(&val, &type, &tb);
         res = SWIG_Python_CallFunctor(destroy, tmp);
-        PyErr_Restore(val, type, tb);
         Py_DECREF(tmp);
       } else {
         PyCFunction meth = PyCFunction_GET_FUNCTION(destroy);
         PyObject *mself = PyCFunction_GET_SELF(destroy);
         res = ((*meth)(mself, v));
       }
+      if (!res)
+        PyErr_WriteUnraisable(destroy);
+
+      PyErr_Restore(val, type, tb);
+
       Py_XDECREF(res);
     } 
 #if !defined(SWIG_PYTHON_SILENT_MEMLEAK)

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -537,14 +537,21 @@ SwigPyObject_dealloc(PyObject *v)
       /* destroy is always a VARARGS method */
       PyObject *res;
       if (data->delargs) {
-	/* we need to create a temporary object to carry the destroy operation */
-	PyObject *tmp = SwigPyObject_New(sobj->ptr, ty, 0);
-	res = SWIG_Python_CallFunctor(destroy, tmp);
-	Py_DECREF(tmp);
+        /* we need to create a temporary object to carry the destroy operation */
+        PyObject *tmp = SwigPyObject_New(sobj->ptr, ty, 0);
+        /* PyObject_CallFunction() has the potential to silently drop the active
+           active exception.  In cases where we just finished iterating over a
+           generator StopIteration will be active right now, and this needs to
+           remain true upon return from SwigPyObject_dealloc.  So save and restore. */
+        PyObject *val = NULL, *type = NULL, *tb = NULL;
+        PyErr_Fetch(&val, &type, &tb);
+        res = SWIG_Python_CallFunctor(destroy, tmp);
+        PyErr_Restore(val, type, tb);
+        Py_DECREF(tmp);
       } else {
-	PyCFunction meth = PyCFunction_GET_FUNCTION(destroy);
-	PyObject *mself = PyCFunction_GET_SELF(destroy);
-	res = ((*meth)(mself, v));
+        PyCFunction meth = PyCFunction_GET_FUNCTION(destroy);
+        PyObject *mself = PyCFunction_GET_SELF(destroy);
+        res = ((*meth)(mself, v));
       }
       Py_XDECREF(res);
     } 


### PR DESCRIPTION
Further improvements to the #560 pull request. 

Uses PyErr_WriteUnraisable to write error messages to sys.stderr when ```__del__``` raises a Python exception that can't be handled. This is an unlikely situation, but the standard python approach. 

Also adds a test case where this destructor problem is seen with unnamed temporary variables. 

Still need test cases for StopIteration type of problems to be sure this fixes those. 