### PR TITLE
Prevent redefinition warnings when compiling with SWIG<module> defined

### DIFF
--- a/Source/Modules/allegrocl.cxx
+++ b/Source/Modules/allegrocl.cxx
@@ -1635,9 +1635,7 @@ int ALLEGROCL::top(Node *n) {
 
   Swig_banner(f_begin);
 
-  Printf(f_runtime, "\n");
-  Printf(f_runtime, "#define SWIGALLEGROCL\n");
-  Printf(f_runtime, "\n");
+  Printf(f_runtime, "\n\n#ifndef SWIGALLEGROCL\n#define SWIGALLEGROCL\n#endif\n\n");
 
   Swig_banner_target_lang(f_cl, ";;");
 

--- a/Source/Modules/cffi.cxx
+++ b/Source/Modules/cffi.cxx
@@ -174,9 +174,7 @@ int CFFI::top(Node *n) {
 
   Swig_banner(f_begin);
 
-  Printf(f_runtime, "\n");
-  Printf(f_runtime, "#define SWIGCFFI\n");
-  Printf(f_runtime, "\n");
+  Printf(f_runtime, "\n\n#ifndef SWIGCFFI\n#define SWIGCFFI\n#endif\n\n");
 
   Swig_banner_target_lang(f_lisp, ";;;");
 

--- a/Source/Modules/chicken.cxx
+++ b/Source/Modules/chicken.cxx
@@ -222,8 +222,7 @@ int CHICKEN::top(Node *n) {
 
   Swig_banner(f_begin);
 
-  Printf(f_runtime, "\n");
-  Printf(f_runtime, "#define SWIGCHICKEN\n");
+  Printf(f_runtime, "\n\n#ifndef SWIGCHICKEN\n#define SWIGCHICKEN\n#endif\n\n");
 
   if (no_collection)
     Printf(f_runtime, "#define SWIG_CHICKEN_NO_COLLECTION 1\n");

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -392,8 +392,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGCSHARP\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGCSHARP\n#define SWIGCSHARP\n#endif\n\n");
 
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");

--- a/Source/Modules/d.cxx
+++ b/Source/Modules/d.cxx
@@ -472,8 +472,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGD\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGD\n#define SWIGD\n#endif\n\n");
 
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");

--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -322,8 +322,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGGUILE\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGGUILE\n#define SWIGGUILE\n#endif\n\n");
 
     /* Write out directives and declarations */
 

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -425,7 +425,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n#define SWIGJAVA\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGJAVA\n#define SWIGJAVA\n#endif\n\n");
 
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -329,8 +329,7 @@ public:
     /* Standard stuff for the SWIG runtime section */
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGLUA\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGLUA\n#define SWIGLUA\n#endif\n\n");
 
     emitLuaFlavor(f_runtime);
 

--- a/Source/Modules/modula3.cxx
+++ b/Source/Modules/modula3.cxx
@@ -958,9 +958,7 @@ MODULA3():
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGMODULA3\n");
-    Printf(f_runtime, "\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGMODULA3\n#define SWIGMODULA3\n#endif\n\n");
 
     Swig_name_register("wrapper", "Modula3_%f");
     if (old_variable_names) {

--- a/Source/Modules/mzscheme.cxx
+++ b/Source/Modules/mzscheme.cxx
@@ -150,9 +150,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGMZSCHEME\n");
-    Printf(f_runtime, "\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGMZSCHEME\n#define SWIGMZSCHEME\n#endif\n\n");
 
     module = Getattr(n, "name");
 

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -269,8 +269,8 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGOCAML\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGOCAML\n#define SWIGOCAML\n#endif\n\n");
+
     Printf(f_runtime, "#define SWIG_MODULE \"%s\"\n", module);
     /* Module name */
     Printf(f_mlbody, "let module_name = \"%s\"\n", module);

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -194,8 +194,8 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGOCTAVE\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGOCTAVE\n#define SWIGOCTAVE\n#endif\n\n");
+
     Printf(f_runtime, "#define SWIG_name_d      \"%s\"\n", module);
     Printf(f_runtime, "#define SWIG_name        %s\n", module);
 

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -325,8 +325,8 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGPERL\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGPERL\n#define SWIGPERL\n#endif\n\n");
+
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");
     }

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -320,9 +320,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGPHP\n");
-    Printf(f_runtime, "\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGPHP\n#define SWIGPHP\n#endif\n\n");
 
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");

--- a/Source/Modules/pike.cxx
+++ b/Source/Modules/pike.cxx
@@ -149,9 +149,7 @@ public:
     /* Standard stuff for the SWIG runtime section */
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGPIKE\n");
-    Printf(f_runtime, "\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGPIKE\n#define SWIGPIKE\n#endif\n\n");
 
     Printf(f_header, "#define SWIG_init    pike_module_init\n");
     Printf(f_header, "#define SWIG_name    \"%s\"\n\n", module);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -659,8 +659,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGPYTHON\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGPYTHON\n#define SWIGPYTHON\n#endif\n\n");
 
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -793,9 +793,7 @@ int R::top(Node *n) {
 
   Swig_banner(f_begin);
 
-  Printf(f_runtime, "\n");
-  Printf(f_runtime, "#define SWIGR\n");
-  Printf(f_runtime, "\n");
+  Printf(f_runtime, "\n\n#ifndef SWIGR\n#define SWIGR\n#endif\n\n");
 
   
   Swig_banner_target_lang(s_init, "#");

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -1097,8 +1097,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGRUBY\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGRUBY\n#define SWIGRUBY\n#endif\n\n");
 
     if (directorsEnabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -195,8 +195,7 @@ public:
     /* Output module initialization code */
     Swig_banner(beginSection);
 
-    Printf(runtimeSection, "\n#define SWIGSCILAB\n");
-    Printf(runtimeSection, "\n");
+    Printf(runtimeSection, "\n\n#ifndef SWIGSCILAB\n#define SWIGSCILAB\n#endif\n\n");
 
     // Gateway header source merged with wrapper source in nobuilder mode
     if (!generateBuilder)

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -165,9 +165,7 @@ public:
 
     Swig_banner(f_begin);
 
-    Printf(f_runtime, "\n");
-    Printf(f_runtime, "#define SWIGTCL\n");
-    Printf(f_runtime, "\n");
+    Printf(f_runtime, "\n\n#ifndef SWIGTCL\n#define SWIGTCL\n#endif\n\n");
 
     /* Set the module name, namespace, and prefix */
 


### PR DESCRIPTION
Redefinition of `SWIG<module>` can generate warnings. This is not ok, as to generate nice bindings in some cases there is need for some language specific code which should be preferably hidden behind `SWIG<module>` and `SWIG<module>` should be given as a flag to the preprocessor when compiling as well as when SWIG is parsing the header.

Signed-off-by: Petre Eftime <petre.p.eftime@intel.com>