### PR TITLE
Win64 ptrdiff t

### DIFF
--- a/Examples/test-suite/primitive_types.i
+++ b/Examples/test-suite/primitive_types.i
@@ -368,6 +368,17 @@ macro(size_t,             pfx, sizet)
   virtual const char* pfx##_##str(type x) { return "name"; }
 %enddef
 
+/* checking size_t and ptrdiff_t typemaps */
+%include "stdint.i"
+%inline {
+  size_t    get_size_min()    { return 0; }
+  size_t    get_size_max()    { return SIZE_MAX; }
+  ptrdiff_t get_ptrdiff_min() { return PTRDIFF_MIN; }
+  ptrdiff_t get_ptrdiff_max() { return PTRDIFF_MAX; }
+
+  size_t    size_echo   (size_t val)    { return val; }
+  ptrdiff_t ptrdiff_echo(ptrdiff_t val) { return val; }
+}
 
 %inline {
   struct Foo

--- a/Examples/test-suite/primitive_types.i
+++ b/Examples/test-suite/primitive_types.i
@@ -369,6 +369,10 @@ macro(size_t,             pfx, sizet)
 %enddef
 
 /* checking size_t and ptrdiff_t typemaps */
+%begin %{
+// Must be defined before Python.h is included, since this may indirectly include stdint.h
+#define __STDC_LIMIT_MACROS
+%}
 %include "stdint.i"
 %inline {
   size_t    get_size_min()    { return 0; }

--- a/Examples/test-suite/python/primitive_types_runme.py
+++ b/Examples/test-suite/python/primitive_types_runme.py
@@ -573,3 +573,34 @@ if val_double(sys.maxint + 1) != float(sys.maxint + 1):
     raise RuntimeError, "bad double typemap"
 if val_double(-sys.maxint - 2) != float(-sys.maxint - 2):
     raise RuntimeError, "bad double typemap"
+
+
+# Check the minimum and maximum values that fit in ptrdiff_t and size_t
+def checkType(name, maxfunc, maxval, minfunc, minval, echofunc):
+    if maxfunc() != maxval:
+        raise RuntimeError, "bad " + name + " typemap"
+    if minfunc() != minval:
+        raise RuntimeError, "bad " + name + " typemap"
+    if echofunc(maxval) != maxval:
+        raise RuntimeError, "bad " + name + " typemap"
+    if echofunc(minval) != minval:
+        raise RuntimeError, "bad " + name + " typemap"
+    error = 0
+    try:
+        echofunc(maxval + 1)
+        error = 1
+    except OverflowError:
+        pass
+    if error == 1:
+        raise RuntimeError, "bad " + name + " typemap"
+    try:
+        echofunc(minval - 1)
+        error = 1
+    except OverflowError:
+        pass
+    if error == 1:
+        raise RuntimeError, "bad " + name + " typemap"
+
+# sys.maxsize is the largest value supported by Py_ssize_t, which should be the same as ptrdiff_t
+checkType("ptrdiff_t", get_ptrdiff_max, sys.maxsize,           get_ptrdiff_min, -(sys.maxsize + 1), ptrdiff_echo)
+checkType("size_t",    get_size_max,    (2 * sys.maxsize) + 1, get_size_min,    0,                  size_echo)

--- a/Lib/javascript/jsc/javascriptprimtypes.swg
+++ b/Lib/javascript/jsc/javascriptprimtypes.swg
@@ -98,18 +98,21 @@ SWIG_AsVal_dec(unsigned long)(JSValueRef obj, unsigned long *val)
 
 %fragment(SWIG_From_frag(long long),"header",
     fragment=SWIG_From_frag(long),
-    fragment="<limits.h>") {
+    fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE JSValueRef
 SWIG_From_dec(long long)(long long value)
 {
   return JSValueMakeNumber(context, value);
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(long long),"header",
     fragment=SWIG_AsVal_frag(long),
     fragment="SWIG_CanCastAsInteger",
-    fragment="<limits.h>") {
+    fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(long long)(JSValueRef obj, long long* val)
 {
@@ -120,6 +123,7 @@ SWIG_AsVal_dec(long long)(JSValueRef obj, long long* val)
 
   return SWIG_OK;
 }
+%#endif
 }
 
 /* unsigned long long */
@@ -127,19 +131,22 @@ SWIG_AsVal_dec(long long)(JSValueRef obj, long long* val)
 
 %fragment(SWIG_From_frag(unsigned long long),"header",
 	  fragment=SWIG_From_frag(long long),
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN JSValueRef
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
   return (value > LONG_MAX) ?
     JSValueMakeNumber(context, value) : JSValueMakeNumber(context, %numeric_cast(value,long));
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long long),"header",
     fragment=SWIG_AsVal_frag(unsigned long),
     fragment="SWIG_CanCastAsInteger",
-    fragment="<limits.h>") {
+   fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(unsigned long long)(JSValueRef obj, unsigned long long *val)
 {
@@ -158,6 +165,7 @@ SWIG_AsVal_dec(unsigned long long)(JSValueRef obj, unsigned long long *val)
 
   return SWIG_OK;
 }
+%#endif
 }
 
 /* double */

--- a/Lib/javascript/v8/javascriptprimtypes.swg
+++ b/Lib/javascript/v8/javascriptprimtypes.swg
@@ -112,18 +112,21 @@ int SWIG_AsVal_dec(unsigned long)(v8::Handle<v8::Value> obj, unsigned long *val)
 
 %fragment(SWIG_From_frag(long long),"header",
     fragment=SWIG_From_frag(long),
-    fragment="<limits.h>") {
+    fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE
 v8::Handle<v8::Value> SWIG_From_dec(long long)(long long value)
 {
   return SWIGV8_NUMBER_NEW(value);
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(long long),"header",
     fragment=SWIG_AsVal_frag(long),
     fragment="SWIG_CanCastAsInteger",
-    fragment="<limits.h>") {
+    fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN
 int SWIG_AsVal_dec(long long)(v8::Handle<v8::Value> obj, long long* val)
 {
@@ -134,6 +137,7 @@ int SWIG_AsVal_dec(long long)(v8::Handle<v8::Value> obj, long long* val)
 
   return SWIG_OK;
 }
+%#endif
 }
 
 /* unsigned long long */
@@ -141,19 +145,22 @@ int SWIG_AsVal_dec(long long)(v8::Handle<v8::Value> obj, long long* val)
 
 %fragment(SWIG_From_frag(unsigned long long),"header",
     fragment=SWIG_From_frag(long long),
-    fragment="<limits.h>") {
+    fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE
 v8::Handle<v8::Value> SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
   return (value > LONG_MAX) ?
     SWIGV8_INTEGER_NEW_UNS(value) : SWIGV8_INTEGER_NEW(%numeric_cast(value,long));
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long long),"header",
     fragment=SWIG_AsVal_frag(unsigned long),
     fragment="SWIG_CanCastAsInteger",
-    fragment="<limits.h>") {
+    fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN
 int SWIG_AsVal_dec(unsigned long long)(v8::Handle<v8::Value> obj, unsigned long long *val)
 {
@@ -171,6 +178,7 @@ int SWIG_AsVal_dec(unsigned long long)(v8::Handle<v8::Value> obj, unsigned long 
 
   return SWIG_OK;
 }
+%#endif
 }
 
 /* double */

--- a/Lib/octave/octprimtypes.swg
+++ b/Lib/octave/octprimtypes.swg
@@ -97,15 +97,20 @@ SWIG_AsVal_dec(bool)(const octave_value& ov, bool *val)
 
 // long long
 
-%fragment(SWIG_From_frag(long long),"header") {
+%fragment(SWIG_From_frag(long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
   SWIGINTERNINLINE octave_value SWIG_From_dec(long long)  (long long value)
     {    
       return octave_int64(value);
     }
+%#endif
 }
 
 
-%fragment(SWIG_AsVal_frag(long long),"header") {
+%fragment(SWIG_AsVal_frag(long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
   SWIGINTERN int SWIG_AsVal_dec(long long)(const octave_value& ov, long long* val)
     {
       if (!ov.is_scalar_type())
@@ -127,16 +132,22 @@ SWIG_AsVal_dec(bool)(const octave_value& ov, bool *val)
       }
       return SWIG_OK;
     }
+%#endif
 }
 
-%fragment(SWIG_From_frag(unsigned long long),"header") {
+%fragment(SWIG_From_frag(unsigned long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
   SWIGINTERNINLINE octave_value SWIG_From_dec(unsigned long long)  (unsigned long long value)
     {    
       return octave_uint64(value);
     }
+%#endif
 }
 
-%fragment(SWIG_AsVal_frag(unsigned long long),"header") {
+%fragment(SWIG_AsVal_frag(unsigned long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
   SWIGINTERN int SWIG_AsVal_dec(unsigned long long)(const octave_value& ov, unsigned long long* val)
     {
       if (!ov.is_scalar_type())
@@ -171,6 +182,7 @@ SWIG_AsVal_dec(bool)(const octave_value& ov, bool *val)
       }
       return SWIG_OK;
     }
+%#endif
 }
 
 // double

--- a/Lib/perl5/perlprimtypes.swg
+++ b/Lib/perl5/perlprimtypes.swg
@@ -167,8 +167,9 @@ SWIG_AsVal_dec(unsigned long)(SV *obj, unsigned long *val)
 /* long long */
 
 %fragment(SWIG_From_frag(long long),"header",
-	  fragment=SWIG_From_frag(long),
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdio.h>") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE SV *
 SWIG_From_dec(long long)(long long value)
 {
@@ -183,13 +184,14 @@ SWIG_From_dec(long long)(long long value)
   }
   return sv_2mortal(sv);
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(long long),"header",
-	  fragment="<limits.h>",
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdlib.h>",
 	  fragment="SWIG_CanCastAsInteger") {
-
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(long long)(SV *obj, long long *val)
 {
@@ -239,13 +241,15 @@ SWIG_AsVal_dec(long long)(SV *obj, long long *val)
   }
   return SWIG_TypeError; 
 }
+%#endif
 }
 
 /* unsigned long long */
 
 %fragment(SWIG_From_frag(unsigned long long),"header",
-	  fragment=SWIG_From_frag(long long),
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdio.h>") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE SV *
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
@@ -260,12 +264,14 @@ SWIG_From_dec(unsigned long long)(unsigned long long value)
   }
   return sv_2mortal(sv);
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long long),"header",
-	  fragment="<limits.h>",
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdlib.h>",
 	  fragment="SWIG_CanCastAsInteger") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(unsigned long long)(SV *obj, unsigned long long *val)
 {
@@ -312,6 +318,7 @@ SWIG_AsVal_dec(unsigned long long)(SV *obj, unsigned long long *val)
   }
   return SWIG_TypeError;
 }
+%#endif
 }
 
 /* double */

--- a/Lib/python/pyprimtypes.swg
+++ b/Lib/python/pyprimtypes.swg
@@ -180,20 +180,22 @@ SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
 /* long long */
 
 %fragment(SWIG_From_frag(long long),"header",
-	  fragment=SWIG_From_frag(long),
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE PyObject* 
 SWIG_From_dec(long long)(long long value)
 {
   return ((value < LONG_MIN) || (value > LONG_MAX)) ?
     PyLong_FromLongLong(value) : PyLong_FromLong(%numeric_cast(value,long)); 
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(long long),"header",
 	  fragment=SWIG_AsVal_frag(long),
 	  fragment="SWIG_CanCastAsInteger",
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(long long)(PyObject *obj, long long *val)
 {
@@ -230,25 +232,28 @@ SWIG_AsVal_dec(long long)(PyObject *obj, long long *val)
 %#endif
   return res;
 }
+%#endif
 }
 
 /* unsigned long long */
 
 %fragment(SWIG_From_frag(unsigned long long),"header",
-	  fragment=SWIG_From_frag(long long),
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE PyObject* 
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
   return (value > LONG_MAX) ?
     PyLong_FromUnsignedLongLong(value) : PyLong_FromLong(%numeric_cast(value,long)); 
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long long),"header",
 	  fragment=SWIG_AsVal_frag(unsigned long),
 	  fragment="SWIG_CanCastAsInteger",
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(unsigned long long)(PyObject *obj, unsigned long long *val)
 {
@@ -284,6 +289,7 @@ SWIG_AsVal_dec(unsigned long long)(PyObject *obj, unsigned long long *val)
 %#endif
   return res;
 }
+%#endif
 }
 
 /* double */

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -44,21 +44,27 @@ SWIG_AsVal_dec(long)(SEXP obj, long *val)
 }
 
 
-%fragment(SWIG_From_frag(long long),"header") {
+%fragment(SWIG_From_frag(long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(long long)(long long value)
 {
 	return Rf_ScalarInteger((int)value);
 }
+%#endif
 }
 
-%fragment(SWIG_AsVal_frag(long long),"header") {
+%fragment(SWIG_AsVal_frag(long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE  int
 SWIG_AsVal_dec(long long)(SEXP obj, long long *val)
 {
    if (val) *val = Rf_asInteger(obj);
    return SWIG_OK;
 }
+%#endif
 }
 
 %fragment(SWIG_From_frag(unsigned long),"header") {
@@ -80,22 +86,28 @@ SWIG_AsVal_dec(unsigned long)(SEXP obj, unsigned long *val)
 }
 
 
-%fragment(SWIG_From_frag(unsigned long long),"header") {
+%fragment(SWIG_From_frag(unsigned long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
 	return Rf_ScalarInteger((int)value);
 }
+%#endif
 }
 
 
-%fragment(SWIG_AsVal_frag(unsigned long long),"header") {
+%fragment(SWIG_AsVal_frag(unsigned long long),"header",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE  int
 SWIG_AsVal_dec(unsigned long long)(SEXP obj, unsigned long long *val)
 {
    if (val) *val = Rf_asInteger(obj);
    return SWIG_OK;
 }
+%#endif
 }
 
 %fragment(SWIG_From_frag(double),"header") {

--- a/Lib/ruby/rubyprimtypes.swg
+++ b/Lib/ruby/rubyprimtypes.swg
@@ -124,15 +124,20 @@ SWIG_AsVal_dec(unsigned long)(VALUE obj, unsigned long *val)
 
 %fragment(SWIG_From_frag(long long),"header",
 	  fragment=SWIG_From_frag(long),
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE VALUE 
 SWIG_From_dec(long long)(long long value)
 {
   return LL2NUM(value);
 }
+%#endif
 }
 
-%fragment(SWIG_AsVal_frag(long long),"header",fragment="SWIG_ruby_failed") {
+%fragment(SWIG_AsVal_frag(long long),"header",
+	  fragment="SWIG_ruby_failed",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 %ruby_aux_method(long long, NUM2LL, type == T_FIXNUM ? NUM2LL(obj) : rb_big2ll(obj))
 
 SWIGINTERN int
@@ -151,21 +156,26 @@ SWIG_AsVal_dec(long long)(VALUE obj, long long *val)
   }
   return SWIG_TypeError;
 }
+%#endif
 }
 
 /* unsigned long long */
 
 %fragment(SWIG_From_frag(unsigned long long),"header",
-	  fragment=SWIG_From_frag(long long),
-	  fragment="<limits.h>") {
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE VALUE 
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
   return ULL2NUM(value);
 }
+%#endif
 }
 
-%fragment(SWIG_AsVal_frag(unsigned long long),"header",fragment="SWIG_ruby_failed") {
+%fragment(SWIG_AsVal_frag(unsigned long long),"header",
+	  fragment="SWIG_ruby_failed",
+	  fragment="SWIG_LongLongAvailable") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 %ruby_aux_method(long long, NUM2ULL,  type == T_FIXNUM ? NUM2ULL(obj) : rb_big2ull(obj))
 
 SWIGINTERN int
@@ -184,6 +194,7 @@ SWIG_AsVal_dec(unsigned long long)(VALUE obj, unsigned long long *val)
   }
   return SWIG_TypeError;
 }
+%#endif
 }
 
 /* double */

--- a/Lib/tcl/tclprimtypes.swg
+++ b/Lib/tcl/tclprimtypes.swg
@@ -112,8 +112,9 @@ SWIG_AsVal_dec(unsigned long)(Tcl_Obj *obj, unsigned long *val) {
 
 %fragment(SWIG_From_frag(long long),"header",
 	  fragment=SWIG_From_frag(long),
-	  fragment="<limits.h>",
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdio.h>") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE Tcl_Obj* 
 SWIG_From_dec(long long)(long long value)
 {
@@ -125,11 +126,13 @@ SWIG_From_dec(long long)(long long value)
     return Tcl_NewStringObj(temp,-1);
   }
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(long long),"header",
-	  fragment="<limits.h>",
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdlib.h>") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(long long)(Tcl_Obj *obj, long long *val)
 {
@@ -160,14 +163,16 @@ SWIG_AsVal_dec(long long)(Tcl_Obj *obj, long long *val)
   }
   return SWIG_TypeError;
 }
+%#endif
 }
 
 /* unsigned long long */
 
 %fragment(SWIG_From_frag(unsigned long long),"header",
 	  fragment=SWIG_From_frag(long long),
-	  fragment="<limits.h>",
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdio.h>") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERNINLINE Tcl_Obj* 
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
@@ -179,12 +184,14 @@ SWIG_From_dec(unsigned long long)(unsigned long long value)
     return Tcl_NewStringObj(temp,-1);
   }
 }
+%#endif
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long long),"header",
 	  fragment=SWIG_AsVal_frag(unsigned long),
-	  fragment="<limits.h>",
+	  fragment="SWIG_LongLongAvailable",
 	  fragment="<stdlib.h>") {
+%#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_dec(unsigned long long)(Tcl_Obj *obj, unsigned long long *val)
 {
@@ -216,6 +223,7 @@ SWIG_AsVal_dec(unsigned long long)(Tcl_Obj *obj, unsigned long long *val)
   }
   return SWIG_TypeError;
 }
+%#endif
 }
 
 /* double */

--- a/Lib/typemaps/primtypes.swg
+++ b/Lib/typemaps/primtypes.swg
@@ -148,6 +148,12 @@ SWIG_AsVal_dec(bool)(SWIG_Object obj, bool *val)
 
 /* long long/unsigned long long */
 
+%fragment("SWIG_LongLongAvailable","header", fragment="<limits.h>") %{
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+%}
+
 %ensure_type_fragments(long long)
 %ensure_type_fragments(unsigned long long)
 
@@ -157,42 +163,82 @@ SWIG_AsVal_dec(bool)(SWIG_Object obj, bool *val)
 
 /* size_t */
 
-%fragment(SWIG_From_frag(size_t),"header",fragment=SWIG_From_frag(unsigned long)) {
+%fragment(SWIG_From_frag(size_t),"header",fragment=SWIG_From_frag(unsigned long),fragment=SWIG_From_frag(unsigned long long)) {
 SWIGINTERNINLINE SWIG_Object
 SWIG_From_dec(size_t)(size_t value)
 {    
-  return SWIG_From(unsigned long)(%numeric_cast(value, unsigned long));
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+%#endif
+    return SWIG_From(unsigned long)(%numeric_cast(value, unsigned long));
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else {
+    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
+    return SWIG_From(unsigned long long)(%numeric_cast(value, unsigned long long));
+  }
+%#endif
 }
 }
 
-%fragment(SWIG_AsVal_frag(size_t),"header",fragment=SWIG_AsVal_frag(unsigned long)) {
+%fragment(SWIG_AsVal_frag(size_t),"header",fragment=SWIG_AsVal_frag(unsigned long),fragment=SWIG_AsVal_frag(unsigned long long)) {
 SWIGINTERNINLINE int
 SWIG_AsVal_dec(size_t)(SWIG_Object obj, size_t *val)
 {
-  unsigned long v;
-  int res = SWIG_AsVal(unsigned long)(obj, val ? &v : 0);
-  if (SWIG_IsOK(res) && val) *val = %numeric_cast(v, size_t);
+  int res = SWIG_TypeError;
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+%#endif
+    unsigned long v;
+    res = SWIG_AsVal(unsigned long)(obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = %numeric_cast(v, size_t);
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else if (sizeof(size_t) <= sizeof(unsigned long long)) {
+    unsigned long long v;
+    res = SWIG_AsVal(unsigned long long)(obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = %numeric_cast(v, size_t);
+  }
+%#endif
   return res;
 }
 }
 
 /* ptrdiff_t */
 
-%fragment(SWIG_From_frag(ptrdiff_t),"header",fragment=SWIG_From_frag(long)) {
+%fragment(SWIG_From_frag(ptrdiff_t),"header",fragment=SWIG_From_frag(long),fragment=SWIG_From_frag(long long)) {
 SWIGINTERNINLINE SWIG_Object
 SWIG_From_dec(ptrdiff_t)(ptrdiff_t value)
 {    
-  return SWIG_From(long)(%numeric_cast(value,long));
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(ptrdiff_t) <= sizeof(long)) {
+%#endif
+    return SWIG_From(long)(%numeric_cast(value, long));
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else {
+    /* assume sizeof(ptrdiff_t) <= sizeof(long long) */
+    return SWIG_From(long long)(%numeric_cast(value, long long));
+  }
+%#endif
 }
 }
 
-%fragment(SWIG_AsVal_frag(ptrdiff_t),"header",fragment=SWIG_AsVal_frag(long)) {
+%fragment(SWIG_AsVal_frag(ptrdiff_t),"header",fragment=SWIG_AsVal_frag(long),fragment=SWIG_AsVal_frag(long long)) {
 SWIGINTERNINLINE int
 SWIG_AsVal_dec(ptrdiff_t)(SWIG_Object obj, ptrdiff_t *val)
 {
-  long v;
-  int res = SWIG_AsVal(long)(obj, val ? &v : 0);
-  if (SWIG_IsOK(res) && val) *val = %numeric_cast(v, ptrdiff_t);
+  int res = SWIG_TypeError;
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(ptrdiff_t) <= sizeof(long)) {
+%#endif
+    long v;
+    res = SWIG_AsVal(long)(obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = %numeric_cast(v, ptrdiff_t);
+%#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else if (sizeof(ptrdiff_t) <= sizeof(long long)) {
+    long long v;
+    res = SWIG_AsVal(long long)(obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = %numeric_cast(v, ptrdiff_t);
+  }
+%#endif
   return res;
 }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,6 @@ environment:
     VER: 35
     PY3: 1
 
-matrix:
-  allow_failures:
-    - platform: x64
-      SWIGLANG: python
-      VSVER: 12
-      VER: 27
-
 install:
 - date /T & time /T
 - set PATH=C:\cygwin\bin;%PATH%


### PR DESCRIPTION
Adds support for ptrdiff_t on 64-bit Windows platforms where `sizeof(ptrdiff_t) == 64` and `sizeof(long) == 32`.  Previously this caused problems because in Python slice notation given the index [NUM:], the second index is set to PTRDIFF_MAX, which is greater than LONG_MAX on LLP64 platforms like 64-bit Windows.

This (should) now pass the previously failure-allowed Appveyor build for Python 2 on x64 Windows.