### PR TITLE
Implemented JSC SetModule / GetModule - allow type sharing across modules

### DIFF
--- a/Lib/javascript/jsc/javascriptinit.swg
+++ b/Lib/javascript/jsc/javascriptinit.swg
@@ -24,7 +24,7 @@ SWIG_JSC_GetModule(void *clientdata) {
     JSObjectRef globalObject = JSContextGetGlobalObject(context);
     JSStringRef moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
 
-    if(JSObjectHasProperty(context, globalObject, moduleName) == false){
+    if(JSObjectHasProperty(context, globalObject, moduleName) == false) {
         JSStringRelease(moduleName);
         return 0;
     }

--- a/Lib/javascript/jsc/javascriptinit.swg
+++ b/Lib/javascript/jsc/javascriptinit.swg
@@ -1,15 +1,26 @@
 %insert(init) %{
 SWIGRUNTIME void
 SWIG_JSC_SetModule(void *clientdata, swig_module_info *swig_module) {
-    JSGlobalContextRef context = (JSGlobalContextRef)clientdata;
+    JSGlobalContextRef context;
+    JSObjectRef globalObject;
+    JSStringRef moduleName;
+    JSClassDefinition classDef;
+    JSClassRef classRef;
+    JSObjectRef object;
 
-    JSObjectRef globalObject = JSContextGetGlobalObject(context);
-    JSStringRef moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
+    if(clientdata == 0){
+        return;
+    }
 
-    JSClassDefinition classDef  = kJSClassDefinitionEmpty;
-    JSClassRef classRef = JSClassCreate(&classDef);
+    context = (JSGlobalContextRef)clientdata;
 
-    JSObjectRef object = JSObjectMake(context, classRef, NULL);
+    globalObject = JSContextGetGlobalObject(context);
+    moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
+
+    classDef  = kJSClassDefinitionEmpty;
+    classRef = JSClassCreate(&classDef);
+
+    object = JSObjectMake(context, classRef, NULL);
     JSObjectSetPrivate(object, (void*)swig_module);
 
     JSObjectSetProperty(context, globalObject, moduleName, object, kJSPropertyAttributeNone, NULL);
@@ -19,23 +30,31 @@ SWIG_JSC_SetModule(void *clientdata, swig_module_info *swig_module) {
 }
 SWIGRUNTIME swig_module_info *
 SWIG_JSC_GetModule(void *clientdata) {
-    JSGlobalContextRef context = (JSGlobalContextRef)clientdata;
+    JSGlobalContextRef context;
+    JSObjectRef globalObject;
+    JSStringRef moduleName;
+    JSValueRef value;
+    JSObjectRef object;
 
-    JSObjectRef globalObject = JSContextGetGlobalObject(context);
-    JSStringRef moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
+    if(clientdata == 0){
+        return 0;
+    }
+
+    context = (JSGlobalContextRef)clientdata;
+
+    globalObject = JSContextGetGlobalObject(context);
+    moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
 
     if(JSObjectHasProperty(context, globalObject, moduleName) == false) {
         JSStringRelease(moduleName);
         return 0;
     }
 
-    JSValueRef value = JSObjectGetProperty(context, globalObject, moduleName, NULL);
-
-    JSObjectRef object = JSValueToObject(context, value, NULL);
-    swig_module_info *swig_module = (swig_module_info*)JSObjectGetPrivate(object);
-
+    value = JSObjectGetProperty(context, globalObject, moduleName, NULL);
+    object = JSValueToObject(context, value, NULL);
     JSStringRelease(moduleName);
-    return swig_module;
+
+    return (swig_module_info*)JSObjectGetPrivate(object);
 }
 
 #define SWIG_GetModule(clientdata)                SWIG_JSC_GetModule(clientdata)

--- a/Lib/javascript/jsc/javascriptinit.swg
+++ b/Lib/javascript/jsc/javascriptinit.swg
@@ -1,14 +1,45 @@
 %insert(init) %{
 SWIGRUNTIME void
-SWIG_JSC_SetModule(swig_module_info *swig_module) {}
+SWIG_JSC_SetModule(void *clientdata, swig_module_info *swig_module) {
+    JSGlobalContextRef context = (JSGlobalContextRef)clientdata;
 
+    JSObjectRef globalObject = JSContextGetGlobalObject(context);
+    JSStringRef moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
+
+    JSClassDefinition classDef  = kJSClassDefinitionEmpty;
+    JSClassRef classRef = JSClassCreate(&classDef);
+
+    JSObjectRef object = JSObjectMake(context, classRef, NULL);
+    JSObjectSetPrivate(object, (void*)swig_module);
+
+    JSObjectSetProperty(context, globalObject, moduleName, object, NULL, NULL);
+
+    JSClassRelease(classRef);
+    JSStringRelease(moduleName);
+}
 SWIGRUNTIME swig_module_info *
-SWIG_JSC_GetModule(void) {
-  return 0;
+SWIG_JSC_GetModule(void *clientdata) {
+    JSGlobalContextRef context = (JSGlobalContextRef)clientdata;
+
+    JSObjectRef globalObject = JSContextGetGlobalObject(context);
+    JSStringRef moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
+
+    if(JSObjectHasProperty(context, globalObject, moduleName) == false){
+        JSStringRelease(moduleName);
+        return 0;
+    }
+
+    JSValueRef value = JSObjectGetProperty(context, globalObject, moduleName, NULL);
+
+    JSObjectRef object = JSValueToObject(context, value, NULL);
+    swig_module_info *swig_module = (swig_module_info*)JSObjectGetPrivate(object);
+
+    JSStringRelease(moduleName);
+    return swig_module;
 }
 
-#define SWIG_GetModule(clientdata)                SWIG_JSC_GetModule()
-#define SWIG_SetModule(clientdata, pointer)       SWIG_JSC_SetModule(pointer)
+#define SWIG_GetModule(clientdata)                SWIG_JSC_GetModule(clientdata)
+#define SWIG_SetModule(clientdata, pointer)       SWIG_JSC_SetModule(clientdata, pointer)
 %}
 
 %insert(init) "swiginit.swg"
@@ -26,7 +57,7 @@ extern "C" {
 #endif
 
 bool SWIGJSC_INIT (JSGlobalContextRef context, JSObjectRef *exports) {
-    SWIG_InitializeModule(0);
+    SWIG_InitializeModule((void*)context);
 %}
 
 /* -----------------------------------------------------------------------------

--- a/Lib/javascript/jsc/javascriptinit.swg
+++ b/Lib/javascript/jsc/javascriptinit.swg
@@ -12,7 +12,7 @@ SWIG_JSC_SetModule(void *clientdata, swig_module_info *swig_module) {
     JSObjectRef object = JSObjectMake(context, classRef, NULL);
     JSObjectSetPrivate(object, (void*)swig_module);
 
-    JSObjectSetProperty(context, globalObject, moduleName, object, NULL, NULL);
+    JSObjectSetProperty(context, globalObject, moduleName, object, kJSPropertyAttributeNone, NULL);
 
     JSClassRelease(classRef);
     JSStringRelease(moduleName);


### PR DESCRIPTION
Adds an object named "swig_module_info_data" to the global object/context which holds private data to swig_module_info. Follows the same pattern as V8 implementation.
