### PR TITLE
Fix test failure on PPC{64} where the char is unsigned by default

### DIFF
--- a/Examples/test-suite/li_boost_array.i
+++ b/Examples/test-suite/li_boost_array.i
@@ -31,7 +31,7 @@ namespace boost {
 
 %inline %{
 boost::array<int, 6> arrayOutVal() {
-  const char carray[] = { -2, -1, 0, 0, 1, 2 };
+  const signed char carray[] = { -2, -1, 0, 0, 1, 2 };
   boost::array<int, 6> myarray;
   for (size_t i=0; i<6; ++i) {
     myarray[i] = carray[i];


### PR DESCRIPTION
This fixes a test failure on PPC, PPC64 and PPC64LE.