### PR TITLE
Passing unit tests for Go on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,9 +162,6 @@ matrix:
     - compiler: gcc
       os: linux
       env: SWIGLANG=python SWIG_FEATURES=-O
-    - compiler: clang
-      os: osx
-      env: SWIGLANG=go
 before_install:
   - date -u
   - uname -a

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,15 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.9 (in progress)
 ===========================
 
+2016-01-23: ahnolds
+            [Go] Enable support for the Go test-suite on OSX:
+            * The linker on OSX requires that all symbols (even weak symbols)
+              are defined at link time. Because the function _cgo_topofstack is
+              only defined starting in Go version 1.4, we explicitly mark it as
+              undefined for older versions of Go on OSX.
+            * Avoid writing empty swigargs structs, since empty structs are not
+              allowed in extern "C" blocks.
+
 2016-01-12: olly
 	    [Javascript] Look for "nodejs" as well as "node", as it's packaged
 	    as the former on Debian.

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -54,7 +54,7 @@ INCLUDES = -I$(abs_top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)
 	  SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	  INCLUDES='$(INCLUDES)' SWIGOPT='$(SWIGOPT)' NOLINK=true \
 	  TARGET='$(TARGETPREFIX)$*$(TARGETSUFFIX)' INTERFACEDIR='$(INTERFACEDIR)' INTERFACE='$*.i' \
-	  $(LANGUAGE)$(VARIANT)_cpp_nocgo; \
+	  $(LANGUAGE)$(VARIANT)_cpp_nocgo && \
 	  $(run_testcase_cpp); \
 	fi
 
@@ -67,7 +67,7 @@ INCLUDES = -I$(abs_top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)
 	  SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	  INCLUDES='$(INCLUDES)' SWIGOPT='$(SWIGOPT)' NOLINK=true \
 	  TARGET='$(TARGETPREFIX)$*$(TARGETSUFFIX)' INTERFACEDIR='$(INTERFACEDIR)' INTERFACE='$*.i' \
-	  $(LANGUAGE)$(VARIANT)_nocgo; \
+	  $(LANGUAGE)$(VARIANT)_nocgo && \
 	  $(run_testcase); \
 	fi
 

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -11,6 +11,8 @@ GO12		= @GO12@
 GO13		= @GO13@
 GO15		= @GO15@
 GOC		= @GOC@
+GOVERSIONOPTION	= @GOVERSIONOPTION@
+host		= @host@
 SCRIPTSUFFIX	= _runme.go
 
 GOCOMPILEARG = `if $(GO15); then echo tool compile; elif $(GO1); then echo tool $(GOC:c=g); fi`
@@ -19,6 +21,8 @@ GOTOOL = `if $(GO1) ; then echo go tool; fi`
 GOPACK = `if $(GO1) ; then echo go tool pack; else echo gopack; fi`
 
 GOOBJEXT = `if $(GO15); then echo o; else echo $(GOC:c=); fi`
+
+OSXOLDGOLINKFLAGS	= `if [ -n "\`$(GO) $(GOVERSIONOPTION) | grep -E 'go1($|.0|.1|.2|.3)'\`" ] && [ -n "\`echo $(host) | grep darwin\`" ]; then echo "-Wl,-U,__cgo_topofstack"; fi`
 
 SO = @SO@
 
@@ -121,7 +125,7 @@ run_testcase = \
 	    $(COMPILETOOL) $(GCCGO) -o $*_runme $(SCRIPTPREFIX)$*_runme.@OBJEXT@ $*.a; \
 	  elif $(GO12) || $(GO13) || $(GO15); then \
 	    $(COMPILETOOL) $(GO) $(GOCOMPILEARG) -I . $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) && \
-	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -linkmode external -extld $(CC) -extldflags "$(CFLAGS)" -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
+	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -linkmode external -extld $(CC) -extldflags "$(CFLAGS) $(OSXOLDGOLINKFLAGS)" -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
 	  else \
 	    $(COMPILETOOL) $(GO) $(GOCOMPILEARG) -I . $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) && \
 	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -L . -r $${GOROOT:-`go env GOROOT`}/pkg/$${GOOS:-`go env GOOS`}_$${GOARCH:-`go env GOARCH`}:. -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
@@ -136,7 +140,7 @@ run_testcase_cpp = \
 	    $(COMPILETOOL) $(GCCGO) -o $*_runme $(SCRIPTPREFIX)$*_runme.@OBJEXT@ $*.a -lstdc++; \
 	  elif $(GO12) || $(GO13) || $(GO15); then \
 	    $(COMPILETOOL) $(GO) $(GOCOMPILEARG) -I . $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) && \
-	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -linkmode external -extld $(CXX) -extldflags "$(CXXFLAGS)" -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
+	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -linkmode external -extld $(CXX) -extldflags "$(CXXFLAGS) $(OSXOLDGOLINKFLAGS)" -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
 	  else \
 	    $(COMPILETOOL) $(GO) $(GOCOMPILEARG) -I . $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) && \
 	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -L . -r $${GOROOT:-`go env GOROOT`}/pkg/$${GOOS:-`go env GOOS`}_$${GOARCH:-`go env GOARCH`}:. -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
@@ -152,7 +156,7 @@ run_multi_testcase = \
 	    $(COMPILETOOL) $(GCCGO) -o $*_runme $(SCRIPTPREFIX)$*_runme.@OBJEXT@ `for f in $$files; do echo $$f.a; done` -lstdc++; \
 	  elif $(GO12) || $(GO13) || $(GO15); then \
 	    $(COMPILETOOL) $(GO) $(GOCOMPILEARG) -I . $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) && \
-	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -L . -linkmode external -extld $(CXX) -extldflags "$(CXXFLAGS)" -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
+	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -L . -linkmode external -extld $(CXX) -extldflags "$(CXXFLAGS) $(OSXOLDGOLINKFLAGS)" -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \
 	  else \
 	    $(COMPILETOOL) $(GO) $(GOCOMPILEARG) -I . $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) && \
 	    $(COMPILETOOL) $(GOTOOL) $(GOLD) -L . -r $${GOROOT:-`go env GOROOT`}/pkg/$${GOOS:-`go env GOOS`}_$${GOARCH:-`go env GOARCH`}:. -o $*_runme $(SCRIPTPREFIX)$*_runme.$(GOOBJEXT); \

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -2112,6 +2112,7 @@ private:
     emit_attach_parmmaps(parms, f);
     int parm_count = emit_num_arguments(parms);
     int required_count = emit_num_required(parms);
+    bool needs_swigargs = false;
 
     emit_return_variable(n, result, f);
 
@@ -2125,6 +2126,7 @@ private:
     String *swigargs = NewString("\tstruct swigargs {\n");
 
     if (parm_count > required_count) {
+      needs_swigargs = true;
       Printv(swigargs, "\t\tintgo _swig_optargc;\n", NULL);
     }
 
@@ -2136,6 +2138,7 @@ private:
       SwigType *pt = Getattr(p, "type");
       String *ct = gcCTypeForGoValue(p, pt, ln);
       Printv(swigargs, "\t\t\t", ct, ";\n", NULL);
+      needs_swigargs = true;
       Delete(ct);
 
       String *gn = NewStringf("_swig_go_%d", i);
@@ -2152,6 +2155,7 @@ private:
       String *ct = gcCTypeForGoValue(n, result, ln);
       Delete(ln);
       Printv(swigargs, "\t\t", ct, ";\n", NULL);
+      needs_swigargs = true;
       Delete(ct);
 
       ln = NewString("_swig_go_result");
@@ -2208,7 +2212,10 @@ private:
 
     cleanupFunction(n, f, parms);
 
-    Printv(f->locals, swigargs, NULL);
+    if (needs_swigargs)
+    {
+      Printv(f->locals, swigargs, NULL);
+    }
 
     Printv(f->code, "}\n", NULL);
 


### PR DESCRIPTION
This patches two unrelated bugs that were causing the Go unit tests to fail on OSX:

* Apparently, the linker on OSX requires that symbols be defined at link time, even if they are marked with the weak/weak_import attribute. This is different from the behavior of ld on Linux, which just marks the symbols as weak in the binary. I've found two possible solutions to this problem:
  1. Explicitly tell the linker that it's ok for the symbol in question to be undefined with the `-U` linker flag. This is the approach I took in this patch since it's much simpler, although it does result in the symbol being marked as undefined in the binary rather than weak. It looks like the undefined symbol is still resolved at runtime though (possibly with a slight performance penalty?), so I don't think this matters.
  2. Write and compile a dummy .dylib that exports the symbol in question, and weak link against it with the `-weak_library` linker flag. This is more complicated since you need to create a dummy library to link against. Some sources also suggest you need to also use the `-flat_namespace` linker command to allow the symbol to be loaded from a library with a different name at runtime.
* Calling a C/C++ function creates a swigargs struct intended for passing arguments and getting the return value. However, if the function takes no arguments and returns void, the resulting struct is empty. Empty structs are not allowed in C, so clang warns about empty structs in `extern "C"` blocks when -Wall is active. The solution here is to only create the swigargs struct if it isn't empty, since if it's empty it's also not used.