### PR TITLE
Escaped char values in enums

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,15 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.9 (in progress)
 ===========================
 
+2016-01-23: wsfulton
+	    [C#, Java, PHP] Fix generated code parsing enum values using char escape sequences
+            when these values appear in the C#/Java/PHP code such as:
+
+              enum X { x1 = '\n', x2 = '\1' };
+
+            Except C# does not support the octal escape sequences, so %csconstvalue
+            is still required to fix.
+
 2016-01-12: olly
 	    [Javascript] Look for "nodejs" as well as "node", as it's packaged
 	    as the former on Debian.

--- a/Examples/test-suite/chartest.i
+++ b/Examples/test-suite/chartest.i
@@ -12,4 +12,23 @@ char GetUnprintableChar() {
   return 0x7F;
 }
 
+static const char globchar0 = '\0';
+static const char globchar1 = '\1';
+static const char globchar2 = '\n';
+static const char globcharA = 'A';
+static const char globcharB = '\102'; // B
+static const char globcharC = '\x43'; // C
+static const char globcharD = 0x44; // D
+static const char globcharE = 69; // E
+
+struct CharTestClass {
+  static const char memberchar0 = '\0';
+  static const char memberchar1 = '\1';
+  static const char memberchar2 = '\n';
+  static const char membercharA = 'A';
+  static const char membercharB = '\102'; // B
+  static const char membercharC = '\x43'; // C
+  static const char membercharD = 0x44; // D
+  static const char membercharE = 69; // E
+};
 %}

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -378,6 +378,7 @@ CPP_TEST_CASES += \
 	static_array_member \
 	static_const_member \
 	static_const_member_2 \
+	string_constants \
 	struct_initialization_cpp \
 	struct_value \
 	symbol_clash \

--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -77,6 +77,10 @@
   // char
   char chartest1(char c = 'x') { return c; }
   char chartest2(char c = '\0') { return c; }
+  char chartest3(char c = '\1') { return c; }
+  char chartest4(char c = '\n') { return c; }
+  char chartest5(char c = '\102') { return c; } // 'B'
+  char chartest6(char c = '\x43') { return c; } // 'C'
 
   // namespaces
   namespace AType { 

--- a/Examples/test-suite/enum_thorough.i
+++ b/Examples/test-suite/enum_thorough.i
@@ -585,7 +585,50 @@ enum {
 };
 int globalDifferentTypesTest(int n) { return n; }
 }
+%}
 
+#if defined(SWIGJAVA)
+%javaconst(0) enumcharC;
+%javaconst(0) globalenumcharC;
+#elif defined(SWIGCSHARP)
+%csconstvalue("1") globalenumchar1;
+%csconstvalue("'B'") globalenumcharB;
+%csconstvalue("1") enumchar1;
+%csconstvalue("'B'") enumcharB;
+#endif
+%inline %{
+enum {
+  globalenumchar0 = '\0',
+  globalenumchar1 = '\1',
+  globalenumchar2 = '\n',
+  globalenumcharA = 'A',
+  globalenumcharB = '\102', // B
+  globalenumcharC = '\x43', // C
+  globalenumcharD = 0x44, // D
+  globalenumcharE = 69  // E
+};
+enum EnumChar {
+  enumchar0 = '\0',
+  enumchar1 = '\1',
+  enumchar2 = '\n',
+  enumcharA = 'A',
+  enumcharB = '\102', // B
+  enumcharC = '\x43', // C
+  enumcharD = 0x44, // D
+  enumcharE = 69 // E
+};
+struct EnumCharStruct {
+  enum EnumChar {
+    enumchar0 = '\0',
+    enumchar1 = '\1',
+    enumchar2 = '\n',
+    enumcharA = 'A',
+    enumcharB = '\102', // B
+    enumcharC = '\x43', // C
+    enumcharD = 0x44, // D
+    enumcharE = 69 // E
+  };
+};
 %}
 
 #if defined(SWIGJAVA)
@@ -614,5 +657,4 @@ enum {
   global_typedefaultint_noconst
 };
 }
-
 %}

--- a/Examples/test-suite/python/default_args_runme.py
+++ b/Examples/test-suite/python/default_args_runme.py
@@ -136,5 +136,23 @@ def run(module_name):
     if default_args.CDA().cdefaultargs_test2() != 1:
         raise RuntimeError
 
+    if default_args.chartest1() != 'x':
+        raise RuntimeError
+
+    if default_args.chartest2() != '\0':
+        raise RuntimeError
+
+    if default_args.chartest3() != '\1':
+        raise RuntimeError
+
+    if default_args.chartest4() != '\n':
+        raise RuntimeError
+
+    if default_args.chartest5() != 'B':
+        raise RuntimeError
+
+    if default_args.chartest6() != 'C':
+        raise RuntimeError
+
 if __name__ == "__main__":
     run('default_args')

--- a/Examples/test-suite/string_constants.i
+++ b/Examples/test-suite/string_constants.i
@@ -1,0 +1,44 @@
+%module string_constants
+// Test unusual string constants
+
+%warnfilter(SWIGWARN_TYPEMAP_CHARLEAK);
+
+#if defined(SWIGCSHARP)
+%csconst(1);
+%csconstvalue("\"AEIOU\\n\"") SS1;
+%csconstvalue("\"AEIOU\\n\"") SS2;
+#endif
+#if defined(SWIGJAVA)
+%javaconst(1);
+#endif
+%inline %{
+#define SS1 "ÆÎOU\n"
+#define AA1 "A\rB\nC"
+#define EE1 "\124\125\126"
+#define XX1 "\x57\x58\x59"
+#define ZS1 "\0"
+#define ES1 ""
+%}
+%constant SS2="ÆÎOU\n";
+%constant AA2="A\rB\nC";
+%constant EE2="\124\125\126";
+%constant XX2="\x57\x58\x59";
+%constant ZS2="\0";
+%constant ES2="";
+
+%inline %{
+static const char *SS3 = "ÆÎOU\n";
+static const char *AA3 = "A\rB\nC";
+static const char *EE3 = "\124\125\126";
+static const char *XX3 = "\x57\x58\x59";
+static const char *ZS3 = "\0";
+static const char *ES3 = "";
+struct things {
+  const char * defarguments1(const char *SS4 = "ÆÎOU\n") { return SS4; }
+  const char * defarguments2(const char *AA4 = "A\rB\nC") { return AA4; }
+  const char * defarguments3(const char *EE4 = "\124\125\126") { return EE4; }
+  const char * defarguments4(const char *XX4 = "\x57\x58\x59") { return XX4; }
+  const char * defarguments5(const char *ZS4 = "\0") { return ZS4; }
+  const char * defarguments6(const char *ES4 = "") { return ES4; }
+};
+%}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -5962,11 +5962,7 @@ valexpr        : exprnum { $$ = $1; }
 	       }
                | CHARCONST {
 		  $$.val = NewString($1);
-		  if (Len($$.val)) {
-		    $$.rawval = NewStringf("'%(escape)s'", $$.val);
-		  } else {
-		    $$.rawval = NewString("'\\0'");
-		  }
+		  $$.rawval = NewStringf("'%s'", $$.val);
 		  $$.type = T_CHAR;
 		  $$.bitfield = 0;
 		  $$.throws = 0;

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -5971,11 +5971,7 @@ valexpr        : exprnum { $$ = $1; }
 	       }
                | WCHARCONST {
 		  $$.val = NewString($1);
-		  if (Len($$.val)) {
-		    $$.rawval = NewStringf("L\'%s\'", $$.val);
-		  } else {
-		    $$.rawval = NewString("L'\\0'");
-		  }
+		  $$.rawval = NewStringf("L\'%s\'", $$.val);
 		  $$.type = T_WCHAR;
 		  $$.bitfield = 0;
 		  $$.throws = 0;

--- a/Source/Modules/cffi.cxx
+++ b/Source/Modules/cffi.cxx
@@ -1107,7 +1107,7 @@ String *CFFI::convert_literal(String *literal, String *type, bool try_to_split) 
     return num;
   } else if (SwigType_type(type) == T_CHAR) {
     /* Use CL syntax for character literals */
-    String* result = NewStringf("#\\%c", s[0]);
+    String* result = NewStringf("#\\%s", s);
     Delete(num);
     return result;
   } else if (SwigType_type(type) == T_STRING) {

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -600,17 +600,13 @@ int Language::constantDirective(Node *n) {
     if (!value) {
       value = Copy(name);
     } else {
-      /*      if (checkAttribute(n,"type","char")) {
-         value = NewString(value);
-         } else {
-         value = NewStringf("%(escape)s", value);
-         }
-       */
       Setattr(n, "rawvalue", value);
-      value = NewStringf("%(escape)s", value);
-      if (!Len(value))
-	Append(value, "\\0");
-      /*      Printf(stdout,"'%s' = '%s'\n", name, value); */
+      int swig_type = SwigType_type(Getattr(n, "type"));
+      if (swig_type == T_STRING || swig_type == T_WSTRING) {
+	value = NewStringf("%(escape)s", value);
+      } else {
+	value = NewStringf("%s", value);
+      }
     }
     Setattr(n, "value", value);
     this->constantWrapper(n);

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -1265,9 +1265,6 @@ static int look(Scanner *s) {
       if (c == '\'') {
 	Delitem(s->text, DOH_END);
 	return (SWIG_TOKEN_CHAR);
-      } else if (c == '\\') {
-	Delitem(s->text, DOH_END);
-	get_escape(s);
       }
       break;
 


### PR DESCRIPTION
[C#, Java, PHP] Fix generated code parsing enum values using char escape sequences
when these values appear in the C#/Java/PHP code such as:
```
  enum X { x1 = '\n', x2 = '\1' };
```
Except C# does not support the octal escape sequences, so %csconstvalue
is still required to fix.
