### PR TITLE
Fixing python attribute lookup

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -897,15 +897,11 @@ public:
 	        "\n", "def _swig_setattr(self, class_type, name, value):\n", tab4, "return _swig_setattr_nondynamic(self, class_type, name, value, 0)\n\n", NIL);
 
 	Printv(f_shadow,
-	       "\n", "def _swig_getattr_nondynamic(self, class_type, name, static=1):\n",
+	       "\n", "def _swig_getattr(self, class_type, name):\n",
 	       tab4, "if (name == \"thisown\"):\n", tab8, "return self.this.own()\n",
 	       tab4, "method = class_type.__swig_getmethods__.get(name, None)\n",
 	       tab4, "if method:\n", tab8, "return method(self)\n",
-	       tab4, "if (not static):\n",
-	       tab4, tab4, "return object.__getattr__(self, name)\n",
-	       tab4, "else:\n",
-	       tab4, tab4, "raise AttributeError(name)\n\n",
-	       "def _swig_getattr(self, class_type, name):\n", tab4, "return _swig_getattr_nondynamic(self, class_type, name, 0)\n\n", NIL);
+	       tab4, "raise AttributeError(\"'%s' object has no attribute '%s'\" % (class_type.__name__, name))\n\n", NIL);
 
 	Printv(f_shadow,
 	        "\n", "def _swig_repr(self):\n",


### PR DESCRIPTION
Cleans up patch #232
Fixes misleading error messages from #588

If \_\_getattr\_\_ is called, this means that normal attribute lookup has failed.
  If checking thisown and \_\_swig_getmethods\_\_ fails, then give up and raise
  AttributeError instead of calling the non-existent object.\_\_getattr\_\_.
  Note that in practice the result is essentially the same, since trying to
  access object.\_\_getattr\_\_ fails and raises AttributeError, just with a
  misleading message.
In addition, there's no point in having nondynamic attribute lookup.