### PR TITLE
Passing unit tests for -classic python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,10 +160,6 @@ matrix:
     # Not quite working yet
     - compiler: gcc
       os: linux
-      env: SWIGLANG=python SWIG_FEATURES=-classic
-    # Not quite working yet
-    - compiler: gcc
-      os: linux
       env: SWIGLANG=python SWIG_FEATURES=-O
     # Not quite working yet
     - compiler: gcc

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,18 @@ Version 3.0.9 (in progress)
 2016-01-27: steeve
             [Go] Ensure structs are properly packed between gc and GCC/clang.
 
+2016-01-25: ahnolds
+            [Python] Support the full Python test suite in -classic mode
+            * Convert long/unsigned long/long long/unsigned long long to PyInt
+              rather than PyLong when possible. Certain python functions like
+              len() require a PyInt when operating on old-style classes.
+            * Add support for static methods in classic mode, including support
+              for pythonappend, pythonprepend, and docstrings.
+            * Removing the use of __swig_getmethods__ for static member methods
+              since they will always be found by the standard argument lookup
+            * Fix a bug where the wrong type of exception was caught when
+              checking for new-style class support
+
 2016-01-23: ahnolds
             [Go] Enable support for the Go test-suite on OSX:
             * The linker on OSX requires that all symbols (even weak symbols)

--- a/Examples/python/import_packages/same_modnames1/runme.py
+++ b/Examples/python/import_packages/same_modnames1/runme.py
@@ -8,6 +8,12 @@ import pkg2.foo
 print "  Finished importing pkg2.foo"
 
 var2 = pkg2.foo.Pkg2_Foo()
-if str(type(var2)).find("'pkg2.foo.Pkg2_Foo'") == -1:
-    raise RuntimeError("failed type checking: " + str(type(var2)))
+
+classname = str(type(var2))
+# Check for an old-style class if swig was run in -classic mode
+if classname == "<type 'instance'>":
+    classname = str(var2.__class__)
+
+if classname.find("pkg2.foo.Pkg2_Foo") == -1:
+    raise RuntimeError("failed type checking: " + classname)
 print "  Successfully created object pkg2.foo.Pkg2_Foo"

--- a/Examples/python/import_packages/same_modnames2/runme.py
+++ b/Examples/python/import_packages/same_modnames2/runme.py
@@ -7,6 +7,12 @@ import pkg1.pkg2.foo
 print "  Finished importing pkg1.pkg2.foo"
 
 var2 = pkg1.pkg2.foo.Pkg2_Foo()
-if str(type(var2)).find("'pkg1.pkg2.foo.Pkg2_Foo'") == -1:
-    raise RuntimeError("failed type checking: " + str(type(var2)))
+
+classname = str(type(var2))
+# Check for an old-style class if swig was run in -classic mode
+if classname == "<type 'instance'>":
+    classname = str(var2.__class__)
+
+if classname.find("pkg1.pkg2.foo.Pkg2_Foo") == -1:
+    raise RuntimeError("failed type checking: " + classname)
 print "  Successfully created object pkg1.pkg2.foo.Pkg2_Foo"

--- a/Examples/test-suite/python/python_append_runme.py
+++ b/Examples/test-suite/python/python_append_runme.py
@@ -20,3 +20,10 @@ if grabpath() != os.path.dirname(mypath):
 
 if grabstaticpath() != os.path.basename(mypath):
     raise RuntimeError("grabstaticpath failed")
+
+clearstaticpath()
+if grabstaticpath() != None:
+    raise RuntimeError("Resetting staticfuncpath failed")
+Test.static_func()
+if grabstaticpath() != os.path.basename(mypath):
+    raise RuntimeError("grabstaticpath failed")

--- a/Examples/test-suite/python_append.i
+++ b/Examples/test-suite/python_append.i
@@ -12,6 +12,9 @@ def grabpath():
     return funcpath
 def grabstaticpath():
     return staticfuncpath
+def clearstaticpath():
+    global staticfuncpath
+    staticfuncpath = None
 %}
 
 %pythonappend Test::func %{

--- a/Lib/python/pyprimtypes.swg
+++ b/Lib/python/pyprimtypes.swg
@@ -67,7 +67,7 @@ SWIGINTERNINLINE PyObject*
 /* long */
 
 %fragment(SWIG_From_frag(long),"header") {
-  %define_as(SWIG_From_dec(long),           PyLong_FromLong)
+  %define_as(SWIG_From_dec(long),           PyInt_FromLong)
 }
 
 %fragment(SWIG_AsVal_frag(long),"header",
@@ -123,7 +123,7 @@ SWIGINTERNINLINE PyObject*
 SWIG_From_dec(unsigned long)(unsigned long value)
 {
   return (value > LONG_MAX) ?
-    PyLong_FromUnsignedLong(value) : PyLong_FromLong(%numeric_cast(value,long)); 
+    PyLong_FromUnsignedLong(value) : PyInt_FromLong(%numeric_cast(value,long));
 }
 }
 
@@ -186,7 +186,7 @@ SWIGINTERNINLINE PyObject*
 SWIG_From_dec(long long)(long long value)
 {
   return ((value < LONG_MIN) || (value > LONG_MAX)) ?
-    PyLong_FromLongLong(value) : PyLong_FromLong(%numeric_cast(value,long)); 
+    PyLong_FromLongLong(value) : PyInt_FromLong(%numeric_cast(value,long));
 }
 %#endif
 }
@@ -244,7 +244,7 @@ SWIGINTERNINLINE PyObject*
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
   return (value > LONG_MAX) ?
-    PyLong_FromUnsignedLongLong(value) : PyLong_FromLong(%numeric_cast(value,long)); 
+    PyLong_FromUnsignedLongLong(value) : PyInt_FromLong(%numeric_cast(value,long));
 }
 %#endif
 }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -912,17 +912,12 @@ public:
 	       tab4, "try:\n", tab8, "strthis = \"proxy of \" + self.this.__repr__()\n",
 	       tab4, "except __builtin__.Exception:\n", tab8, "strthis = \"\"\n", tab4, "return \"<%s.%s; %s >\" % (self.__class__.__module__, self.__class__.__name__, strthis,)\n\n", NIL);
 
-	if (!classic) {
-	  /* Usage of types.ObjectType is deprecated.
-	   * But don't sure wether this would broken old Python?
-	   */
+	if (!classic && !modern) {
 	  Printv(f_shadow,
-//               "import types\n",
 		 "try:\n",
-//               "    _object = types.ObjectType\n",
-		 tab4, "_object = object\n", tab4, "_newclass = 1\n", "except AttributeError:\n", tab4, "class _object:\n", tab8, "pass\n", tab4, "_newclass = 0\n",
-//                 "del types\n", 
-		 "\n\n", NIL);
+		 tab4, "_object = object\n", tab4, "_newclass = 1\n",
+		 "except __builtin__.Exception:\n",
+		 tab4, "class _object:\n", tab8, "pass\n", tab4, "_newclass = 0\n\n", NIL);
 	}
       }
       if (modern) {

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1002,7 +1002,7 @@ public:
 
     if (shadow) {
       Swig_banner_target_lang(f_shadow_py, "#");
-      if (!modern) {
+      if (!modern && !classic) {
 	Printv(f_shadow, "# This file is compatible with both classic and new-style classes.\n", NIL);
       }
       Printv(f_shadow_py, "\n", f_shadow_begin, "\n", NIL);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4727,16 +4727,7 @@ public:
 	  Printv(f_shadow, tab8, "return ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n\n", NIL);
 	}
 	Printv(f_shadow, tab4, symname, " = staticmethod(", symname, ")\n", NIL);
-
-	if (!modern) {
-	  Printv(f_shadow, tab4, "__swig_getmethods__[\"", symname, "\"] = lambda x: ", symname, "\n", NIL);
-	}
-
       } else {
-	if (!modern) {
-	  Printv(f_shadow, tab4, "__swig_getmethods__[\"", symname, "\"] = lambda x: ", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname), "\n",
-		 NIL);
-	}
 	if (!classic) {
 	  if (!modern)
 	    Printv(f_shadow, tab4, "if _newclass:\n", tab4, NIL);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4745,6 +4745,11 @@ public:
 	  Printv(f_shadow, tab4, symname, " = staticmethod(", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname),
 		 ")\n", NIL);
 	}
+	if (classic || !modern) {
+	  if (!classic)
+	    Printv(f_shadow, tab4, "else:\n", tab4, NIL);
+	  Printv(f_shadow, tab4, symname, " = ", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname), "\n", NIL);
+	}
       }
     }
     return SWIG_OK;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4710,7 +4710,7 @@ public:
     }
 
     if (shadow) {
-      if (!classic && !Getattr(n, "feature:python:callback") && have_addtofunc(n)) {
+      if (!Getattr(n, "feature:python:callback") && have_addtofunc(n)) {
 	int kw = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
 	String *parms = make_pyParmList(n, false, false, kw);
 	String *callParms = make_pyParmList(n, false, true, kw);
@@ -4726,8 +4726,6 @@ public:
 	} else {
 	  Printv(f_shadow, tab8, "return ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n\n", NIL);
 	}
-	if (!modern)
-	  Printv(f_shadow, tab4, "if _newclass:\n", tab4, NIL);
 	Printv(f_shadow, tab4, symname, " = staticmethod(", symname, ")\n", NIL);
 
 	if (!modern) {


### PR DESCRIPTION
Support the full Python test suite in -classic mode.  The following are substantive changes:
* Convert long/unsigned long/long long/unsigned long long to PyInt rather than PyLong when possible. Certain python functions like len() require a PyInt when operating on old-style classes.
* Add support for static methods in classic mode, including support for pythonappend, pythonprepend, and docstrings.
* Removing the use of \_\_swig_getmethods\_\_ for static member methods since they will always be found by the standard argument lookup.
* Fix a bug where the wrong type of exception was caught when checking for new-style class support

The following cosmetic changes were made:
* Don't print a banner claiming compatibility with new-style classes when running in -classic mode

The following changes were made to the Python examples and test-suite:
* Support checking names of old-style classes in the import_packages example
* Add a check calling a static method with pythonappend/pythonprepend (previously the pythonappend/pythonprepend blocks were dropped for static methods in -classic mode)