### PR TITLE
csharp: give -namespace meaning to the generated c++ wrapper code

### DIFF
--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -415,11 +415,19 @@ public:
     }
 
     Printf(f_runtime, "\n");
+    if (namespce) {
+        String *wrapper_name = NewStringf("");
+        Printf(wrapper_name, "CSharp_%s_%%f", namespce);
+        Swig_name_register("wrapper", wrapper_name);
+        Delete(wrapper_name);
+    }
+    else {
+	    Swig_name_register("wrapper", "CSharp_%f");
+    }
 
-    Swig_name_register("wrapper", "CSharp_%f");
     if (old_variable_names) {
-      Swig_name_register("set", "set_%n%v");
-      Swig_name_register("get", "get_%n%v");
+        Swig_name_register("set", "set_%n%v");
+      	Swig_name_register("get", "get_%n%v");
     }
 
     Printf(f_wrappers, "\n#ifdef __cplusplus\n");


### PR DESCRIPTION
When people use the -namespace option, they often intend for the input to swig to wrap a particular namespace in a single module. This option should also have an effect on how C++ wrapper function names are mangled, and not just the C# proxy code.

This fix solves many issues related to duplicate symbols when linking the source from multiple swig modules into one shared library. When -c++ and -namespace are used together, global symbols that might be placed in the namespace specified with the -namespace argument is a rare occurrence and simple to fix. 