### PR TITLE
Travis uses rvm, use it to install ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,9 +100,7 @@ matrix:
       env: SWIGLANG=ruby
     - compiler: gcc
       os: linux
-      env: SWIGLANG=ruby VER=2.3
-      sudo: required
-      dist: trusty
+      env: SWIGLANG=ruby VER=2.3.0
     - compiler: gcc
       os: linux
       env: SWIGLANG=scilab

--- a/Tools/travis-linux-install.sh
+++ b/Tools/travis-linux-install.sh
@@ -93,12 +93,7 @@ case "$SWIGLANG" in
 		;;
 	"ruby")
 		if [[ "$VER" ]]; then
-			sudo apt-get -qq install python-software-properties
-			sudo add-apt-repository -y ppa:brightbox/ruby-ng
-			sudo apt-get -qq update
-			sudo apt-get -qq install ruby2.3 ruby2.3-dev
-#			sudo gem pristine --all # Results in: You don't have write permissions for the /var/lib/gems/2.3.0 directory
-			WITHLANG=$SWIGLANG=$SWIGLANG$VER
+			rvm install $VER
 		fi
 		;;
 	"scilab")


### PR DESCRIPTION
Travis uses rvm to handle it's ruby versions (see [here](https://docs.travis-ci.com/user/ci-environment/#Ruby-(aka-common)-VM-images) and [here](https://docs.travis-ci.com/user/languages/ruby/#Supported-Ruby-Versions) for more details, and [here](http://rubies.travis-ci.org/) for a complete list of available ruby versions).  Rather than using apt-get to install ruby2.3 from a different repository as in 42c14005 and forcing builds on to Trusty as d06f2c9e does, instead just install the right version of ruby using rvm.  This has the added bonus of avoiding the "gem pristine" warnings generated if you install a version of ruby outside of the rvm structure.