### PR TITLE
swiglabels.swg: added check if __GNUC__ is defined

### DIFF
--- a/Lib/swiglabels.swg
+++ b/Lib/swiglabels.swg
@@ -65,9 +65,11 @@
 #endif
 
 /* exporting methods */
-#if (__GNUC__ >= 4) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
-#  ifndef GCC_HASCLASSVISIBILITY
-#    define GCC_HASCLASSVISIBILITY
+#if defined(__GNUC__)
+#  if (__GNUC__ >= 4) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
+#    ifndef GCC_HASCLASSVISIBILITY
+#      define GCC_HASCLASSVISIBILITY
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
It makes sense to check if the preprocessor definition `__GNUC__` is defined before using it as a value.