### PR TITLE
Implement the operator overload test suite for Python.

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -292,11 +292,7 @@ PYTHON_SO     = @PYTHON_SO@
 ifeq (,$(PY3))
   SWIGPYTHON = $(SWIG) -python
 else
-  ifeq (,$(PY3BUILTIN))
-    SWIGPYTHON = $(SWIG) -python -py3
-  else
-    SWIGPYTHON = $(SWIG) -python -py3 -builtin
-  endif
+  SWIGPYTHON = $(SWIG) -python -py3
 endif
 
 # ----------------------------------------------------------------

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -292,7 +292,11 @@ PYTHON_SO     = @PYTHON_SO@
 ifeq (,$(PY3))
   SWIGPYTHON = $(SWIG) -python
 else
-  SWIGPYTHON = $(SWIG) -python -py3
+  ifeq (,$(PY3BUILTIN))
+    SWIGPYTHON = $(SWIG) -python -py3
+  else
+    SWIGPYTHON = $(SWIG) -python -py3 -builtin
+  endif
 endif
 
 # ----------------------------------------------------------------

--- a/Examples/test-suite/operator_overload.i
+++ b/Examples/test-suite/operator_overload.i
@@ -114,11 +114,11 @@ public:
     return *this;
   }
   // +=,-=... are member fns
-  void operator+=(const Op& o){ i+=o.i;}
-  void operator-=(const Op& o){ i-=o.i;}
-  void operator*=(const Op& o){ i*=o.i;}
-  void operator/=(const Op& o){ i/=o.i;}
-  void operator%=(const Op& o){ i%=o.i;}
+  Op &operator+=(const Op& o){ i+=o.i; return *this; }
+  Op &operator-=(const Op& o){ i-=o.i; return *this; }
+  Op &operator*=(const Op& o){ i*=o.i; return *this; }
+  Op &operator/=(const Op& o){ i/=o.i; return *this; }
+  Op &operator%=(const Op& o){ i%=o.i; return *this; }
   // the +,-,*,... are friends
   // (just to make life harder)
   friend Op operator+(const Op& a,const Op& b){return Op(a.i+b.i);}

--- a/Examples/test-suite/python/operator_overload_runme.py
+++ b/Examples/test-suite/python/operator_overload_runme.py
@@ -3,7 +3,7 @@ from operator_overload import *
 # first check all the operators are implemented correctly from pure C++ code
 Op_sanity_check()
 
-pop = Op(6)/Op(3)  # breaks in Python3 with or without -builtin
+pop = Op(6)/Op(3)
 
 # test routine:
 a=Op()
@@ -40,7 +40,7 @@ if not b>=d:
 e=Op(3)
 e+=d
 if not e==b:
-  raise RuntimeError("e==b (%s==%s)" % (str(e), str(b)))
+  raise RuntimeError("e==b (%s==%s)" % (e.i, b.i))
 e-=c
 if not e==a:
   raise RuntimeError("e==a")
@@ -74,12 +74,6 @@ if not -a==a:
   raise RuntimeError("-a==a")
 if not -b==Op(-5):
   raise RuntimeError("-b==Op(-5)")
-
-# plus add some code to check the __str__ fn
-if not str(Op(1))=='Op(1)':
-  raise RuntimeError("str(Op(1))=='Op(1)'")
-if not str(Op(-3))=='Op(-3)':
-  raise RuntimeError("str(Op(-3))=='Op(-3)'")
 
 """
 /* Sample test code in C++

--- a/Examples/test-suite/python/operator_overload_runme.py
+++ b/Examples/test-suite/python/operator_overload_runme.py
@@ -1,0 +1,162 @@
+from operator_overload import *
+
+# first check all the operators are implemented correctly from pure C++ code
+Op_sanity_check()
+
+pop = Op(6)/Op(3)  # breaks in Python3 with or without -builtin
+
+# test routine:
+a=Op()
+b=Op(5)
+c=Op(b) # copy construct
+d=Op(2)
+dd=d # assignment operator
+
+# test equality
+if not a!=b:
+  raise RuntimeError("a!=b")
+if not b==c:
+  raise RuntimeError("b==c")
+if not a!=d:
+  raise RuntimeError("a!=d")
+if not d==dd:
+  raise RuntimeError("d==dd")
+
+# test <
+if not a<b:
+  raise RuntimeError("a<b")
+if not a<=b:
+  raise RuntimeError("a<=b")
+if not b<=c:
+  raise RuntimeError("b<=c")
+if not b>=c:
+  raise RuntimeError("b>=c")
+if not b>d:
+  raise RuntimeError("b>d")
+if not b>=d:
+  raise RuntimeError("b>=d")
+
+# test +=
+e=Op(3)
+e+=d
+if not e==b:
+  raise RuntimeError("e==b (%s==%s)" % (str(e), str(b)))
+e-=c
+if not e==a:
+  raise RuntimeError("e==a")
+e=Op(1)
+e*=b
+if not e==c:
+  raise RuntimeError("e==c")
+e/=d
+if not e==d:
+  raise RuntimeError("e==d")
+e%=c;
+if not e==d:
+  raise RuntimeError("e==d")
+
+# test +
+f=Op(1)
+g=Op(1)
+if not f+g==Op(2):
+  raise RuntimeError("f+g==Op(2)")
+if not f-g==Op(0):
+  raise RuntimeError("f-g==Op(0)")
+if not f*g==Op(1):
+  raise RuntimeError("f*g==Op(1)")
+if not f/g==Op(1):
+  raise RuntimeError("f/g==Op(1)")
+if not f%g==Op(0):
+  raise RuntimeError("f%g==Op(0)")
+
+# test unary operators
+if not -a==a:
+  raise RuntimeError("-a==a")
+if not -b==Op(-5):
+  raise RuntimeError("-b==Op(-5)")
+
+# plus add some code to check the __str__ fn
+if not str(Op(1))=='Op(1)':
+  raise RuntimeError("str(Op(1))=='Op(1)'")
+if not str(Op(-3))=='Op(-3)':
+  raise RuntimeError("str(Op(-3))=='Op(-3)'")
+
+"""
+/* Sample test code in C++
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(int argc,char** argv)
+{
+	// test routine:
+	Op a;
+	Op b=5;
+	Op c=b;	// copy construct
+	Op d=2;
+
+	// test equality
+	assert(a!=b);
+	assert(b==c);
+	assert(a!=d);
+
+	// test <
+	assert(a<b);
+	assert(a<=b);
+	assert(b<=c);
+	assert(b>=c);
+	assert(b>d);
+	assert(b>=d);
+
+	// test +=
+	Op e=3;
+	e+=d;
+	assert(e==b);
+	e-=c;
+	assert(e==a);
+	e=Op(1);
+	e*=b;
+	assert(e==c);
+	e/=d;
+	assert(e==d);
+	e%=c;
+	assert(e==d);
+
+	// test +
+	Op f(1),g(1);
+	assert(f+g==Op(2));
+	assert(f-g==Op(0));
+	assert(f*g==Op(1));
+	assert(f/g==Op(1));
+	assert(f%g==Op(0));
+
+	// test unary operators
+	assert(!a==true);
+	assert(!b==false);
+	assert(-a==a);
+	assert(-b==Op(-5));
+
+	// test []
+	Op h=3;
+	assert(h[0]==3);
+	assert(h[1]==0);
+	h[0]=2;	// set
+	assert(h[0]==2);
+	h[1]=2;	// ignored
+	assert(h[0]==2);
+	assert(h[1]==0);
+
+	// test ()
+	Op i=3;
+	assert(i()==3);
+	assert(i(1)==4);
+	assert(i(1,2)==6);
+
+	// plus add some code to check the __str__ fn
+	//assert(str(Op(1))=="Op(1)");
+	//assert(str(Op(-3))=="Op(-3)");
+
+	printf("ok\n");
+}
+*/
+"""

--- a/Lib/python/pyopers.swg
+++ b/Lib/python/pyopers.swg
@@ -103,7 +103,11 @@
 %pybinoperator(__neg__,      *::operator-(),		unaryfunc, nb_negative);
 %pybinoperator(__neg__,      *::operator-() const,	unaryfunc, nb_negative);
 %pybinoperator(__mul__,      *::operator*,		binaryfunc, nb_multiply);
+#if defined(SWIGPYTHON_PY3)
+%pybinoperator(__truediv__,  *::operator/,		binaryfunc, nb_divide);
+#else
 %pybinoperator(__div__,      *::operator/,		binaryfunc, nb_divide);
+#endif
 %pybinoperator(__mod__,      *::operator%,		binaryfunc, nb_remainder);
 %pybinoperator(__lshift__,   *::operator<<,		binaryfunc, nb_lshift);
 %pybinoperator(__rshift__,   *::operator>>,		binaryfunc, nb_rshift);
@@ -192,7 +196,11 @@ __bool__ = __nonzero__
 %pyinplaceoper(__iadd__   , *::operator +=,	binaryfunc, nb_inplace_add);
 %pyinplaceoper(__isub__   , *::operator -=,	binaryfunc, nb_inplace_subtract);
 %pyinplaceoper(__imul__   , *::operator *=,	binaryfunc, nb_inplace_multiply);
+#if defined(SWIGPYTHON_PY3)
+%pyinplaceoper(__itruediv__   , *::operator /=,	binaryfunc, nb_inplace_divide);
+#else
 %pyinplaceoper(__idiv__   , *::operator /=,	binaryfunc, nb_inplace_divide);
+#endif
 %pyinplaceoper(__imod__   , *::operator %=,	binaryfunc, nb_inplace_remainder);
 %pyinplaceoper(__iand__   , *::operator &=,	binaryfunc, nb_inplace_and);
 %pyinplaceoper(__ior__    , *::operator |=,	binaryfunc, nb_inplace_or);

--- a/Lib/python/pyopers.swg
+++ b/Lib/python/pyopers.swg
@@ -103,7 +103,7 @@
 %pybinoperator(__neg__,      *::operator-(),		unaryfunc, nb_negative);
 %pybinoperator(__neg__,      *::operator-() const,	unaryfunc, nb_negative);
 %pybinoperator(__mul__,      *::operator*,		binaryfunc, nb_multiply);
-%pybinoperator(__div__,      *::operator/,		binaryfunc, nb_div);
+%pybinoperator(__div__,      *::operator/,		binaryfunc, nb_divide);
 %pybinoperator(__mod__,      *::operator%,		binaryfunc, nb_remainder);
 %pybinoperator(__lshift__,   *::operator<<,		binaryfunc, nb_lshift);
 %pybinoperator(__rshift__,   *::operator>>,		binaryfunc, nb_rshift);
@@ -116,8 +116,6 @@
 %pycompare(__ge__,           *::operator>=,		Py_GE);
 %pycompare(__eq__,           *::operator==,		Py_EQ);
 %pycompare(__ne__,           *::operator!=,		Py_NE);
-
-%feature("python:slot", "nb_truediv", functype="binaryfunc") *::operator/;
 
 /* Special cases */
 %rename(__invert__)     *::operator~;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -517,6 +517,7 @@ public:
 	  fputs(usage3, stdout);
 	} else if (strcmp(argv[i], "-py3") == 0) {
 	  py3 = 1;
+	  Preprocessor_define("SWIGPYTHON_PY3", 0);
 	  Swig_mark_arg(i);
 	} else if (strcmp(argv[i], "-builtin") == 0) {
 	  builtin = 1;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3716,9 +3716,9 @@ public:
     printSlot(f, getSlot(n, "feature:python:nb_inplace_xor"), "nb_inplace_xor", "binaryfunc");
     printSlot(f, getSlot(n, "feature:python:nb_inplace_or"), "nb_inplace_or", "binaryfunc");
     printSlot(f, getSlot(n, "feature:python:nb_floor_divide"), "nb_floor_divide", "binaryfunc");
-    printSlot(f, getSlot(n, "feature:python:nb_true_divide"), "nb_true_divide", "binaryfunc");
+    printSlot(f, getSlot(n, "feature:python:nb_divide"), "nb_true_divide", "binaryfunc");
     printSlot(f, getSlot(n, "feature:python:nb_inplace_floor_divide"), "nb_inplace_floor_divide", "binaryfunc");
-    printSlot(f, getSlot(n, "feature:python:nb_inplace_true_divide"), "nb_inplace_true_divide", "binaryfunc");
+    printSlot(f, getSlot(n, "feature:python:nb_inplace_divide"), "nb_inplace_true_divide", "binaryfunc");
     Printv(f, "#if PY_VERSION_HEX >= 0x02050000\n", NIL);
     printSlot(f, getSlot(n, "feature:python:nb_index"), "nb_index", "unaryfunc");
     Printv(f, "#endif\n", NIL);


### PR DESCRIPTION
The suite fails on Python 3 (with and without -builtin) due to the following issues:

- Operator / is mapped to the div slot which is now truediv in Python3 (see PR #136 for a WIP fix).
- Operators +=, -=, *= and probably others assign the method return type (void) to the object they are applied on. A workaround is to return *this from the affected operators.

Also included in this patch is support for the PY3BUILTIN flag to run the test suite with the -builtin SWIG option (`make PY3=1 PY3BUILTIN=1 operator_overload.cpptest` from `swig/Examples/test-suite/python`).