### PR TITLE
Suppress unmessage at package load

### DIFF
--- a/Lib/r/r.swg
+++ b/Lib/r/r.swg
@@ -264,8 +264,8 @@ x
 setAs('ExternalReference', 'character',
 function(from) {if (!is.null(from$"__str__")) from$"__str__"()})
 
-suppressWarnings(setMethod('print', 'ExternalReference',
-function(x) {print(as(x, "character"))}))
+suppressMessages(suppressWarnings(setMethod('print', 'ExternalReference',
+function(x) {print(as(x, "character"))})))
 %}
 
 


### PR DESCRIPTION
The generated R 'packagename.R' file defines a 'print' method that overrides the base package
print, so 'ExternalReferences' can be printed. This is all just fine, but because a 'generic' function
is not defined for base::print(), an unnecessary informational message is printed at package load, so for example for the 'redland' R package:

```
Creating a generic function for ‘print’ from package ‘base’ in package 'redland'
```

In the interest of reducing unneeded messages at package load, I've introduced this PR to
simply suppress this message from being printed.