### PR TITLE
fix handling of function pointers by %constant directive

### DIFF
--- a/Examples/test-suite/constant_directive.i
+++ b/Examples/test-suite/constant_directive.i
@@ -1,28 +1,41 @@
 %module constant_directive
 
 // %constant and struct
+
+%inline %{
+struct Type1 {
+  Type1(int val = 0) : val(val) {}
+  int val;
+};
+/* Typedefs for const Type and its pointer */
+typedef const Type1 Type1Const;
+typedef const Type1* Type1Cptr;
+
+/* Typedefs for function pointers returning Type1 */
+typedef Type1 (*Type1Fptr)();
+typedef Type1 (* const Type1Cfptr)();
+
+/* Function returning an instance of Type1 */
+Type1 getType1Instance() { return Type1(111); }
+%}
+
 %{
-  struct Type1 {
-    Type1(int val = 0) : val(val) {} 
-    int val;
-  };
   static Type1 TYPE1_CONSTANT1(1);
   static Type1 TYPE1_CONST2(2);
   static Type1 TYPE1_CONST3(3);
 %}
 
-struct Type1 {
-  Type1(int val = 0) : val(val) {} 
-  int val;
-};
-
-%inline %{
-Type1 getType1Instance() { return Type1(111); }
-%}
-
 %constant Type1 TYPE1_CONSTANT1;
 %constant Type1 TYPE1_CONSTANT2 = TYPE1_CONST2;
 %constant Type1 *TYPE1_CONSTANT3 = &TYPE1_CONST3;
-
+/* Typedef'ed types */
+%constant Type1Const* TYPE1CONST_CONSTANT1 = &TYPE1_CONSTANT1;
+%constant Type1Cptr TYPE1CPTR_CONSTANT1 = &TYPE1_CONSTANT1;
+/* Function pointers */
+%constant Type1 (*TYPE1FPTR1_CONSTANT1)() = getType1Instance;
+%constant Type1 (* const TYPE1CFPTR1_CONSTANT1)() = getType1Instance;
+/* Typedef'ed function pointers */
+%constant Type1Fptr TYPE1FPTR1DEF_CONSTANT1 = getType1Instance;
+%constant Type1Cfptr TYPE1CFPTR1DEF_CONSTANT1 = getType1Instance;
+/* Regular constant */
 %constant int TYPE_INT = 0;
-

--- a/Examples/test-suite/java/constant_directive_runme.java
+++ b/Examples/test-suite/java/constant_directive_runme.java
@@ -18,5 +18,9 @@ public class constant_directive_runme {
       throw new RuntimeException("fail");
     if (constant_directive.TYPE1_CONSTANT3.getVal() != 3)
       throw new RuntimeException("fail");
+    if (constant_directive.TYPE1CONST_CONSTANT1.getVal() != 1)
+      throw new RuntimeException("fail");
+    if (constant_directive.TYPE1CPTR_CONSTANT1.getVal() != 1)
+      throw new RuntimeException("fail");
   }
 }

--- a/Examples/test-suite/python/constant_directive_runme.py
+++ b/Examples/test-suite/python/constant_directive_runme.py
@@ -18,3 +18,11 @@ if constant_directive.TYPE1_CONSTANT2.val != 2:
 if constant_directive.TYPE1_CONSTANT3.val != 3:
     raise RuntimeError("constant_directive.TYPE1_CONSTANT3.val is %r (should be 3)" %
                        constant_directive.TYPE1_CONSTANT3.val)
+
+if constant_directive.TYPE1CONST_CONSTANT1.val != 1:
+    raise RuntimeError("constant_directive.TYPE1CONST_CONSTANT1.val is %r (should be 1)" %
+                       constant_directive.TYPE1CONST_CONSTANT1.val)
+
+if constant_directive.TYPE1CPTR_CONSTANT1.val != 1:
+    raise RuntimeError("constant_directive.TYPE1CPTR_CONSTANT1.val is %r (should be 1)" %
+                       constant_directive.TYPE1CPTR_CONSTANT1.val)

--- a/Lib/python/pytypemaps.swg
+++ b/Lib/python/pytypemaps.swg
@@ -79,10 +79,12 @@
 
 /* Consttab, needed for callbacks, it should be removed later */
 
-%typemap(consttab) SWIGTYPE ((*)(ANY))  
+%typemap(consttab) SWIGTYPE ((*)(ANY))
 { SWIG_PY_POINTER, (char*)"$symname", 0, 0, (void *)($value), &$descriptor }
+%typemap(consttab) SWIGTYPE ((* const)(ANY)) = SWIGTYPE ((*)(ANY));
 
 %typemap(constcode) SWIGTYPE ((*)(ANY)) "";
+%typemap(constcode) SWIGTYPE ((* const)(ANY)) = SWIGTYPE ((*)(ANY));
 
 
 /* Smart Pointers */

--- a/Lib/typemaps/swigtype.swg
+++ b/Lib/typemaps/swigtype.swg
@@ -625,6 +625,7 @@
 %typemap(constcode, noblock=1) SWIGTYPE ((*)(ANY)){
   %set_constant("$symname", SWIG_NewFunctionPtrObj((void *)$value, $descriptor));
 }
+%typemap(constcode) SWIGTYPE ((* const)(ANY)) = SWIGTYPE ((*)(ANY));
 
 #if defined(SWIG_DIRECTOR_TYPEMAPS)
 


### PR DESCRIPTION
With this fix, ``%constant`` directive correctly handles function pointers. I believe, this fixes the issue with ``std::endl`` etc. mentioned by @wsfulton  [here](https://github.com/swig/swig/pull/631#issuecomment-198248842) in PR #631.