### PR TITLE
R character vector support

### DIFF
--- a/Examples/test-suite/li_std_vector.i
+++ b/Examples/test-suite/li_std_vector.i
@@ -130,3 +130,13 @@ namespace aa {
 std::vector< ::aa::Holder > vec1(std::vector< ::aa::Holder > x) { return x; }
 %}
 #endif
+
+// exercising vectors of strings
+%inline %{
+std::vector<std::string> RevStringVec (const std::vector<std::string> &In)
+  {
+    std::vector<std::string> result(In);
+    std::reverse(result.begin(), result.end());
+    return(result);
+  }
+%}

--- a/Examples/test-suite/r/li_std_vector_runme.R
+++ b/Examples/test-suite/r/li_std_vector_runme.R
@@ -9,6 +9,10 @@ testvec <- c(1, 2, 3)
 
 unittest(half(testvec), testvec/2)
 unittest(average(testvec), mean(testvec))
+## string vector test
+vlen <- 13
+stringvec <- paste(letters[1:vlen], as.character(rnorm(vlen)))
+unittest(rev(stringvec), RevStringVec(stringvec))
 q(save="no")
 
 

--- a/Lib/r/std_vector.i
+++ b/Lib/r/std_vector.i
@@ -870,15 +870,25 @@
 %typemap("scoercein") std::vector<int> , std::vector<int> const, std::vector<int> const& "$input = as.integer($input);";
 
 // strings
-%typemap("rtype") std::vector< std::basic_string<char> >,  std::vector< std::basic_string<char> > *,
-   std::vector< std::basic_string<char> > & "character";
+%typemap("rtype") std::vector< std::basic_string<char> >,  
+std::vector< std::basic_string<char> > *,
+   std::vector< std::basic_string<char> > & "character"
 
-%typemap("scoercein") std::vector< std::basic_string<char> >,  std::vector< std::basic_string<char> > *,
+%typemap("rtypecheck") std::vector< std::basic_string<char> >,  
+std::vector< std::basic_string<char> > *,
+   std::vector< std::basic_string<char> > &
+   %{ is.character($arg) %}
+
+%typemap("scoercein") std::vector< std::basic_string<char> >,  
+std::vector< std::basic_string<char> > *,
    std::vector< std::basic_string<char> > & "$input = as.character($input);";
 
-%typemap("scoerceout") std::vector< std::basic_string<char> >,  std::vector< std::basic_string<char> > *,
+%typemap("scoerceout") std::vector< std::basic_string<char> >,  
+std::vector< std::basic_string<char> > *,
    std::vector< std::basic_string<char> > & 
 %{    %}
+
+%apply std::vector< std::basic_string<char> > { std::vector< std::string> };
 
 // all the related integer vectors
 // signed

--- a/Lib/r/std_vector.i
+++ b/Lib/r/std_vector.i
@@ -192,7 +192,6 @@
           }
         UNPROTECT(1);
         return(result);
-        //return SWIG_R_NewPointerObj(val, type_info< std::vector<T > >(), owner);
       }
     };
     
@@ -208,7 +207,6 @@
            }
         UNPROTECT(1);
         return(result);
-        //return SWIG_R_NewPointerObj(val, type_info< std::vector<T > >(), owner);
       }
     };
 
@@ -506,6 +504,31 @@
       for (unsigned pos = 0; pos < p->size(); pos++)
         {
           (*p)[pos] = static_cast<bool>(S[pos]);
+        }
+      int res = SWIG_OK;
+      if (SWIG_IsOK(res)) {
+        if (val) *val = p;
+      }
+      UNPROTECT(1);
+      return res;
+    }
+  };
+
+    template <>
+      struct traits_asptr < std::vector<std::basic_string<char> > > {
+      static int asptr(SEXP obj, std::vector<std::basic_string<char> > **val) {
+	std::vector<std::basic_string<char> > *p;
+      // R character vectors are STRSXP containing CHARSXP
+      // access a CHARSXP using STRING_ELT
+      int sexpsz = Rf_length(obj);
+      p = new std::vector<std::basic_string<char> >(sexpsz);
+      SEXP coerced;
+      PROTECT(coerced = Rf_coerceVector(obj, STRSXP));
+      //SEXP *S = CHARACTER_POINTER(coerced);
+      for (unsigned pos = 0; pos < p->size(); pos++)
+        {
+	  const char * thecstring = CHAR(STRING_ELT(coerced, pos));
+          (*p)[pos] = std::basic_string<char>(thecstring);
         }
       int res = SWIG_OK;
       if (SWIG_IsOK(res)) {
@@ -845,6 +868,17 @@
 
 %typemap("rtype") std::vector<int> "integer"
 %typemap("scoercein") std::vector<int> , std::vector<int> const, std::vector<int> const& "$input = as.integer($input);";
+
+// strings
+%typemap("rtype") std::vector< std::basic_string<char> >,  std::vector< std::basic_string<char> > *,
+   std::vector< std::basic_string<char> > & "character";
+
+%typemap("scoercein") std::vector< std::basic_string<char> >,  std::vector< std::basic_string<char> > *,
+   std::vector< std::basic_string<char> > & "$input = as.character($input);";
+
+%typemap("scoerceout") std::vector< std::basic_string<char> >,  std::vector< std::basic_string<char> > *,
+   std::vector< std::basic_string<char> > & 
+%{    %}
 
 // all the related integer vectors
 // signed


### PR DESCRIPTION
Existing support for transparent conversion between R string vectors and c++ ```std::vector<std::string>``` was incomplete. std::strings were imported, but incorrect tags remained. This patch corrects
the types and adds support for exporting to ```std::vector<std::string>```. There is also a simple
run test that compares a c++ reverse of strings (not string contents) to the R equivalent.