### PR TITLE
Fix for Issue #646 Java with -DSWIGWORD64

### DIFF
--- a/Lib/java/arrays_java.i
+++ b/Lib/java/arrays_java.i
@@ -102,9 +102,13 @@ JAVA_ARRAYS_DECL(short, jshort, Short, Short)         /* short[] */
 JAVA_ARRAYS_DECL(unsigned short, jint, Int, Ushort)   /* unsigned short[] */
 JAVA_ARRAYS_DECL(int, jint, Int, Int)                 /* int[] */
 JAVA_ARRAYS_DECL(unsigned int, jlong, Long, Uint)     /* unsigned int[] */
+#if defined(SWIGWORDSIZE64)
+JAVA_ARRAYS_DECL(long, jlong, Long, Long)        /* long long[] */
+#else
 JAVA_ARRAYS_DECL(long, jint, Int, Long)               /* long[] */
 JAVA_ARRAYS_DECL(unsigned long, jlong, Long, Ulong)   /* unsigned long[] */
 JAVA_ARRAYS_DECL(jlong, jlong, Long, Longlong)        /* long long[] */
+#endif
 JAVA_ARRAYS_DECL(float, jfloat, Float, Float)         /* float[] */
 JAVA_ARRAYS_DECL(double, jdouble, Double, Double)     /* double[] */
 
@@ -126,9 +130,13 @@ JAVA_ARRAYS_IMPL(short, jshort, Short, Short)         /* short[] */
 JAVA_ARRAYS_IMPL(unsigned short, jint, Int, Ushort)   /* unsigned short[] */
 JAVA_ARRAYS_IMPL(int, jint, Int, Int)                 /* int[] */
 JAVA_ARRAYS_IMPL(unsigned int, jlong, Long, Uint)     /* unsigned int[] */
+#if defined(SWIGWORDSIZE64)
+JAVA_ARRAYS_IMPL(long, jlong, Long, Long)        /* long long[] */
+#else
 JAVA_ARRAYS_IMPL(long, jint, Int, Long)               /* long[] */
 JAVA_ARRAYS_IMPL(unsigned long, jlong, Long, Ulong)   /* unsigned long[] */
 JAVA_ARRAYS_IMPL(jlong, jlong, Long, Longlong)        /* long long[] */
+#endif
 JAVA_ARRAYS_IMPL(float, jfloat, Float, Float)         /* float[] */
 JAVA_ARRAYS_IMPL(double, jdouble, Double, Double)     /* double[] */
 
@@ -183,9 +191,13 @@ JAVA_ARRAYS_TYPEMAPS(short, short, jshort, Short, "[S")         /* short[ANY] */
 JAVA_ARRAYS_TYPEMAPS(unsigned short, int, jint, Ushort, "[I")   /* unsigned short[ANY] */
 JAVA_ARRAYS_TYPEMAPS(int, int, jint, Int, "[I")                 /* int[ANY] */
 JAVA_ARRAYS_TYPEMAPS(unsigned int, long, jlong, Uint, "[J")     /* unsigned int[ANY] */
+#if defined(SWIGWORDSIZE64)
+JAVA_ARRAYS_TYPEMAPS(long, long, jlong, Long, "[J")    /* long long[ANY] */
+#else
 JAVA_ARRAYS_TYPEMAPS(long, int, jint, Long, "[I")               /* long[ANY] */
 JAVA_ARRAYS_TYPEMAPS(unsigned long, long, jlong, Ulong, "[J")   /* unsigned long[ANY] */
 JAVA_ARRAYS_TYPEMAPS(long long, long, jlong, Longlong, "[J")    /* long long[ANY] */
+#endif
 JAVA_ARRAYS_TYPEMAPS(float, float, jfloat, Float, "[F")         /* float[ANY] */
 JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] */
 
@@ -203,21 +215,41 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
     short[ANY], short[]
     ""
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT32_ARRAY) /* Java int[] */
+    unsigned short[ANY], unsigned short[],
+    int[ANY], int[]    
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT32_ARRAY) /* Java int[] */
     unsigned short[ANY], unsigned short[],
     int[ANY], int[],
     long[ANY], long[]
     ""
+#endif
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT64_ARRAY) /* Java long[] */
+    unsigned int[ANY], unsigned int[],    
+    long[ANY], long[]
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT64_ARRAY) /* Java long[] */
     unsigned int[ANY], unsigned int[],
     unsigned long[ANY], unsigned long[],
     long long[ANY], long long[]
     ""
+#endif
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT128_ARRAY) /* Java BigInteger[] */
+    unsigned long[ANY], unsigned long[]
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT128_ARRAY) /* Java BigInteger[] */
     unsigned long long[ANY], unsigned long long[]
     ""
+#endif
 
 %typecheck(SWIG_TYPECHECK_FLOAT_ARRAY) /* Java float[] */
     float[ANY], float[]

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -63,10 +63,15 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(jni) unsigned short,     const unsigned short &     "jint"
 %typemap(jni) int,                const int &                "jint"
 %typemap(jni) unsigned int,       const unsigned int &       "jlong"
+#if defined(SWIGWORDSIZE64)
+%typemap(jni) long,          const long &          "jlong"
+%typemap(jni) unsigned long, const unsigned long & "jobject"
+#else
 %typemap(jni) long,               const long &               "jint"
 %typemap(jni) unsigned long,      const unsigned long &      "jlong"
 %typemap(jni) long long,          const long long &          "jlong"
 %typemap(jni) unsigned long long, const unsigned long long & "jobject"
+#endif
 %typemap(jni) float,              const float &              "jfloat"
 %typemap(jni) double,             const double &             "jdouble"
 %typemap(jni) void                                           "void"
@@ -79,10 +84,15 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(jtype) unsigned short,     const unsigned short &     "int"
 %typemap(jtype) int,                const int &                "int"
 %typemap(jtype) unsigned int,       const unsigned int &       "long"
+#if defined(SWIGWORDSIZE64)
+%typemap(jtype) long,          const long &          "long"
+%typemap(jtype) unsigned long, const unsigned long & "java.math.BigInteger"
+#else
 %typemap(jtype) long,               const long &               "int"
 %typemap(jtype) unsigned long,      const unsigned long &      "long"
 %typemap(jtype) long long,          const long long &          "long"
 %typemap(jtype) unsigned long long, const unsigned long long & "java.math.BigInteger"
+#endif
 %typemap(jtype) float,              const float &              "float"
 %typemap(jtype) double,             const double &             "double"
 %typemap(jtype) void                                           "void"
@@ -95,10 +105,15 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(jstype) unsigned short,     const unsigned short &     "int"
 %typemap(jstype) int,                const int &                "int"
 %typemap(jstype) unsigned int,       const unsigned int &       "long"
+#if defined(SWIGWORDSIZE64)
+%typemap(jstype) long,          const long &          "long"
+%typemap(jstype) unsigned long, const unsigned long & "java.math.BigInteger"
+#else
 %typemap(jstype) long,               const long &               "int"
 %typemap(jstype) unsigned long,      const unsigned long &      "long"
 %typemap(jstype) long long,          const long long &          "long"
 %typemap(jstype) unsigned long long, const unsigned long long & "java.math.BigInteger"
+#endif
 %typemap(jstype) float,              const float &              "float"
 %typemap(jstype) double,             const double &             "double"
 %typemap(jstype) void                                           "void"
@@ -242,9 +257,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(directorin, descriptor="I") unsigned short   "$input = (jint) $1;"
 %typemap(directorin, descriptor="I") int              "$input = (jint) $1;"
 %typemap(directorin, descriptor="J") unsigned int     "$input = (jlong) $1;"
+#if defined(SWIGWORDSIZE64)
+%typemap(directorin, descriptor="J") long        "$input = (jlong) $1;"
+#else
 %typemap(directorin, descriptor="I") long             "$input = (jint) $1;"
 %typemap(directorin, descriptor="J") unsigned long    "$input = (jlong) $1;"
 %typemap(directorin, descriptor="J") long long        "$input = (jlong) $1;"
+#endif
 %typemap(directorin, descriptor="F") float            "$input = (jfloat) $1;"
 %typemap(directorin, descriptor="D") double           "$input = (jdouble) $1;"
 
@@ -284,15 +303,23 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(out) unsigned short %{ $result = (jint)$1; %}
 %typemap(out) int            %{ $result = (jint)$1; %}
 %typemap(out) unsigned int   %{ $result = (jlong)$1; %}
+#if defined(SWIGWORDSIZE64)
+%typemap(out) long      %{ $result = (jlong)$1; %}
+#else
 %typemap(out) long           %{ $result = (jint)$1; %}
 %typemap(out) unsigned long  %{ $result = (jlong)$1; %}
 %typemap(out) long long      %{ $result = (jlong)$1; %}
+#endif
 %typemap(out) float          %{ $result = (jfloat)$1; %}
 %typemap(out) double         %{ $result = (jdouble)$1; %}
 
 /* unsigned long long */
 /* Convert from BigInteger using the toByteArray member function */
+#if defined(SWIGWORDSIZE64)
+%typemap(in) unsigned long { 
+#else
 %typemap(in) unsigned long long { 
+#endif
   jclass clazz;
   jmethodID mid;
   jbyteArray ba;
@@ -319,7 +346,11 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
   JCALL3(ReleaseByteArrayElements, jenv, ba, bae, 0);
 }
 
+#if defined(SWIGWORDSIZE64)
+%typemap(directorout) unsigned long { 
+#else
 %typemap(directorout) unsigned long long { 
+#endif
   jclass clazz;
   jmethodID mid;
   jbyteArray ba;
@@ -348,7 +379,11 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 
 
 /* Convert to BigInteger - byte array holds number in 2's complement big endian format */
+#if defined(SWIGWORDSIZE64)
+%typemap(out) unsigned long { 
+#else
 %typemap(out) unsigned long long { 
+#endif
   jbyteArray ba = JCALL1(NewByteArray, jenv, 9);
   jbyte* bae = JCALL2(GetByteArrayElements, jenv, ba, 0);
   jclass clazz = JCALL1(FindClass, jenv, "java/math/BigInteger");
@@ -367,7 +402,11 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 }
 
 /* Convert to BigInteger (see out typemap) */
+#if defined(SWIGWORDSIZE64)
+%typemap(directorin, descriptor="Ljava/math/BigInteger;") unsigned long, const unsigned long & {
+#else
 %typemap(directorin, descriptor="Ljava/math/BigInteger;") unsigned long long, const unsigned long long & {
+#endif
   jbyteArray ba = JCALL1(NewByteArray, jenv, 9);
   jbyte* bae = JCALL2(GetByteArrayElements, jenv, ba, 0);
   jclass clazz = JCALL1(FindClass, jenv, "java/math/BigInteger");
@@ -385,8 +424,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
   $input = bigint;
 }
 
+#if defined(SWIGWORDSIZE64)
+%typemap(javadirectorin) unsigned long "$jniinput"
+%typemap(javadirectorout) unsigned long "$javacall"
+#else
 %typemap(javadirectorin) unsigned long long "$jniinput"
 %typemap(javadirectorout) unsigned long long "$javacall"
+#endif
 
 /* char * - treat as String */
 %typemap(in, noblock=1) char * {
@@ -488,9 +532,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(directorin, descriptor="I") const unsigned short & "$input = (jint)$1;"
 %typemap(directorin, descriptor="I") const int &            "$input = (jint)$1;"
 %typemap(directorin, descriptor="J") const unsigned int &   "$input = (jlong)$1;"
+#if defined(SWIGWORDSIZE64)
+%typemap(directorin, descriptor="J") const long &           "$input = (jlong)$1;"
+#else
 %typemap(directorin, descriptor="I") const long &           "$input = (jint)$1;"
 %typemap(directorin, descriptor="J") const unsigned long &  "$input = (jlong)$1;"
 %typemap(directorin, descriptor="J") const long long &      "$input = (jlong)$1;"
+#endif
 %typemap(directorin, descriptor="F") const float &          "$input = (jfloat)$1;"
 %typemap(directorin, descriptor="D") const double &         "$input = (jdouble)$1;"
 
@@ -531,15 +579,23 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(out) const unsigned short & %{ $result = (jint)*$1; %}
 %typemap(out) const int &            %{ $result = (jint)*$1; %}
 %typemap(out) const unsigned int &   %{ $result = (jlong)*$1; %}
+#if defined(SWIGWORDSIZE64)
+%typemap(out) const long &           %{ $result = (jlong)*$1; %}
+#else
 %typemap(out) const long &           %{ $result = (jint)*$1; %}
 %typemap(out) const unsigned long &  %{ $result = (jlong)*$1; %}
 %typemap(out) const long long &      %{ $result = (jlong)*$1; %}
+#endif
 %typemap(out) const float &          %{ $result = (jfloat)*$1; %}
 %typemap(out) const double &         %{ $result = (jdouble)*$1; %}
 
 /* const unsigned long long & */
 /* Similar to unsigned long long */
+#if defined(SWIGWORDSIZE64)
+%typemap(in) const unsigned long & ($*1_ltype temp) {
+#else
 %typemap(in) const unsigned long long & ($*1_ltype temp) { 
+#endif
   jclass clazz;
   jmethodID mid;
   jbyteArray ba;
@@ -567,7 +623,11 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
   JCALL3(ReleaseByteArrayElements, jenv, ba, bae, 0);
 }
 
+#if defined(SWIGWORDSIZE64)
+%typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const unsigned long & {
+#else
 %typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const unsigned long long & { 
+#endif
   static $*1_ltype temp;
   jclass clazz;
   jmethodID mid;
@@ -596,7 +656,11 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
   JCALL3(ReleaseByteArrayElements, jenv, ba, bae, 0);
 }
 
+#if defined(SWIGWORDSIZE64)
+%typemap(out) const unsigned long & {
+#else
 %typemap(out) const unsigned long long & { 
+#endif
   jbyteArray ba = JCALL1(NewByteArray, jenv, 9);
   jbyte* bae = JCALL2(GetByteArrayElements, jenv, ba, 0);
   jclass clazz = JCALL1(FindClass, jenv, "java/math/BigInteger");
@@ -614,8 +678,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
   $result = bigint;
 }
 
+#if defined(SWIGWORDSIZE64)
+%typemap(javadirectorin) const unsigned long & "$jniinput"
+%typemap(javadirectorout) const unsigned long & "$javacall"
+#else
 %typemap(javadirectorin) const unsigned long long & "$jniinput"
 %typemap(javadirectorout) const unsigned long long & "$javacall"
+#endif
 
 /* Default handling. Object passed by value. Convert to a pointer */
 %typemap(in) SWIGTYPE ($&1_type argp)
@@ -908,6 +977,15 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     const short &
     ""
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT32) /* Java int */
+    jint,
+    unsigned short, 
+    int,     
+    const unsigned short &, 
+    const int &    
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT32) /* Java int */
     jint,
     unsigned short, 
@@ -917,7 +995,17 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     const int &, 
     const long &
     ""
+#endif
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT64) /* Java long */
+    jlong,
+    unsigned int,     
+    long, 
+    const unsigned int &,    
+    const long &
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT64) /* Java long */
     jlong,
     unsigned int, 
@@ -927,11 +1015,19 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     const unsigned long &, 
     const long long &
     ""
+#endif
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT128) /* Java BigInteger */
+    unsigned long,
+    const unsigned long &
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT128) /* Java BigInteger */
     unsigned long long,
     const unsigned long long &
     ""
+#endif
 
 %typecheck(SWIG_TYPECHECK_FLOAT) /* Java float */
     jfloat,

--- a/Lib/java/javahead.swg
+++ b/Lib/java/javahead.swg
@@ -29,12 +29,23 @@
 #   define JCALL7(func, jenv, ar1, ar2, ar3, ar4, ar5, ar6, ar7) (*jenv)->func(jenv, ar1, ar2, ar3, ar4, ar5, ar6, ar7)
 #endif
 
+#if defined(SWIGWORDSIZE64)
+%insert(runtime) %{
+/* Fix for jlong on some versions of gcc on Windows */
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
+  typedef long __int64;
+#endif
+%}
+#else
 %insert(runtime) %{
 /* Fix for jlong on some versions of gcc on Windows */
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER)
   typedef long long __int64;
 #endif
+%}
+#endif
 
+%insert(runtime) %{
 /* Fix for jlong on 64-bit x86 Solaris */
 #if defined(__x86_64)
 # ifdef _LP64

--- a/Lib/java/typemaps.i
+++ b/Lib/java/typemaps.i
@@ -80,10 +80,15 @@ INPUT_TYPEMAP(short, jshort, short, "S");
 INPUT_TYPEMAP(unsigned short, jint, int, "I");
 INPUT_TYPEMAP(int, jint, int, "I");
 INPUT_TYPEMAP(unsigned int, jlong, long, "J");
+#if defined(SWIGWORDSIZE64)
+INPUT_TYPEMAP(long, jlong, long, "J");
+INPUT_TYPEMAP(unsigned long, jobject, java.math.BigInteger, "Ljava/math/BigInteger;");
+#else
 INPUT_TYPEMAP(long, jint, int, "I");
 INPUT_TYPEMAP(unsigned long, jlong, long, "J");
 INPUT_TYPEMAP(long long, jlong, long, "J");
 INPUT_TYPEMAP(unsigned long long, jobject, java.math.BigInteger, "Ljava/math/BigInteger;");
+#endif
 INPUT_TYPEMAP(float, jfloat, float, "F");
 INPUT_TYPEMAP(double, jdouble, double, "D");
 
@@ -91,7 +96,11 @@ INPUT_TYPEMAP(double, jdouble, double, "D");
 
 /* Convert from BigInteger using the toByteArray member function */
 /* Overrides the typemap in the INPUT_TYPEMAP macro */
+#if defined(SWIGWORDSIZE64)
+%typemap(in) unsigned long *INPUT($*1_ltype temp), unsigned long &INPUT($*1_ltype temp) {
+#else
 %typemap(in) unsigned long long *INPUT($*1_ltype temp), unsigned long long &INPUT($*1_ltype temp) {
+#endif
   jclass clazz;
   jmethodID mid;
   jbyteArray ba;
@@ -220,11 +229,16 @@ OUTPUT_TYPEMAP(unsigned char, jshort, short, Short, "[Ljava/lang/Short;", jshort
 OUTPUT_TYPEMAP(short, jshort, short, Short, "[Ljava/lang/Short;", jshortArray);              
 OUTPUT_TYPEMAP(unsigned short, jint, int, Int, "[Ljava/lang/Integer;", jintArray);                
 OUTPUT_TYPEMAP(int, jint, int, Int, "[Ljava/lang/Integer;", jintArray);                
-OUTPUT_TYPEMAP(unsigned int, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);               
+OUTPUT_TYPEMAP(unsigned int, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);
+#if defined(SWIGWORDSIZE64)
+OUTPUT_TYPEMAP(long, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);               
+OUTPUT_TYPEMAP(unsigned long, jobject, java.math.BigInteger, NOTUSED, "[Ljava/lang/BigInteger;", SWIGBIGINTEGERARRAY);
+#else
 OUTPUT_TYPEMAP(long, jint, int, Int, "[Ljava/lang/Integer;", jintArray);                
 OUTPUT_TYPEMAP(unsigned long, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);               
 OUTPUT_TYPEMAP(long long, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);               
 OUTPUT_TYPEMAP(unsigned long long, jobject, java.math.BigInteger, NOTUSED, "[Ljava/lang/BigInteger;", SWIGBIGINTEGERARRAY);
+#endif
 OUTPUT_TYPEMAP(float, jfloat, float, Float, "[Ljava/lang/Float;", jfloatArray);              
 OUTPUT_TYPEMAP(double, jdouble, double, Double, "[Ljava/lang/Double;", jdoubleArray);             
 
@@ -247,7 +261,11 @@ OUTPUT_TYPEMAP(double, jdouble, double, Double, "[Ljava/lang/Double;", jdoubleAr
 /* Convert to BigInteger - byte array holds number in 2's complement big endian format */
 /* Use first element in BigInteger array for output */
 /* Overrides the typemap in the OUTPUT_TYPEMAP macro */
+#if defined(SWIGWORDSIZE64)
+%typemap(argout) unsigned long *OUTPUT, unsigned long &OUTPUT { 
+#else
 %typemap(argout) unsigned long long *OUTPUT, unsigned long long &OUTPUT { 
+#endif
   jbyteArray ba = JCALL1(NewByteArray, jenv, 9);
   jbyte* bae = JCALL2(GetByteArrayElements, jenv, ba, 0);
   jclass clazz = JCALL1(FindClass, jenv, "java/math/BigInteger");
@@ -359,11 +377,16 @@ INOUT_TYPEMAP(unsigned char, jshort, short, Short, "[Ljava/lang/Short;", jshortA
 INOUT_TYPEMAP(short, jshort, short, Short, "[Ljava/lang/Short;", jshortArray);
 INOUT_TYPEMAP(unsigned short, jint, int, Int, "[Ljava/lang/Integer;", jintArray); 
 INOUT_TYPEMAP(int, jint, int, Int, "[Ljava/lang/Integer;", jintArray);
-INOUT_TYPEMAP(unsigned int, jlong, long, Long, "[Ljava/lang/Long;", jlongArray); 
+INOUT_TYPEMAP(unsigned int, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);
+#if defined(SWIGWORDSIZE64)
+INOUT_TYPEMAP(long, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);
+INOUT_TYPEMAP(unsigned long, jobject, java.math.BigInteger, NOTUSED, "[Ljava.math.BigInteger;", SWIGBIGINTEGERARRAY);
+#else
 INOUT_TYPEMAP(long, jint, int, Int, "[Ljava/lang/Integer;", jintArray);
 INOUT_TYPEMAP(unsigned long, jlong, long, Long, "[Ljava/lang/Long;", jlongArray); 
 INOUT_TYPEMAP(long long, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);
 INOUT_TYPEMAP(unsigned long long, jobject, java.math.BigInteger, NOTUSED, "[Ljava.math.BigInteger;", SWIGBIGINTEGERARRAY);
+#endif
 INOUT_TYPEMAP(float, jfloat, float, Float, "[Ljava/lang/Float;", jfloatArray);
 INOUT_TYPEMAP(double, jdouble, double, Double, "[Ljava/lang/Double;", jdoubleArray); 
 
@@ -391,7 +414,11 @@ INOUT_TYPEMAP(double, jdouble, double, Double, "[Ljava/lang/Double;", jdoubleArr
 }
 
 /* Override the typemap in the INOUT_TYPEMAP macro for unsigned long long */
+#if defined(SWIGWORDSIZE64)
+%typemap(in) unsigned long *INOUT ($*1_ltype temp), unsigned long &INOUT ($*1_ltype temp) { 
+#else
 %typemap(in) unsigned long long *INOUT ($*1_ltype temp), unsigned long long &INOUT ($*1_ltype temp) { 
+#endif
   jobject bigint;
   jclass clazz;
   jmethodID mid;
@@ -428,6 +455,10 @@ INOUT_TYPEMAP(double, jdouble, double, Double, "[Ljava/lang/Double;", jdoubleArr
   JCALL3(ReleaseByteArrayElements, jenv, ba, bae, 0);
   $1 = &temp;
 }
-
+#if defined(SWIGWORDSIZE64)
+%typemap(argout) unsigned long *INOUT = unsigned long *OUTPUT;
+%typemap(argout) unsigned long &INOUT = unsigned long &OUTPUT;
+#else
 %typemap(argout) unsigned long long *INOUT = unsigned long long *OUTPUT;
 %typemap(argout) unsigned long long &INOUT = unsigned long long &OUTPUT;
+#endif


### PR DESCRIPTION
This patch will fix the issues with word size #646 on Linux 64-bit that requires the use of -DSWIGWORD64 .  This has only been tested against my software which may not be an exhaustive test. Further testing should be done before accepting this patch.  Note that users may also want to add:

```
#if defined(SWIGWORDSIZE64)
%apply unsigned int { size_t };
%apply const unsigned int & { const size_t & };
#endif
```

after including any STL structures to maintain the same Java size_t type for both architectures. Otherwise `size_t` will be `long` on 32-bit and `BigInteger` on 64-bit.  Note that Java `long` is 64-bit anyway so the loss of precision should be negligible. 
