### PR TITLE
Fixed SWIGWORDSIZE64 for csharp

### DIFF
--- a/Lib/csharp/arrays_csharp.i
+++ b/Lib/csharp/arrays_csharp.i
@@ -94,13 +94,15 @@ CSHARP_ARRAYS(short, short)
 CSHARP_ARRAYS(unsigned short, ushort)
 CSHARP_ARRAYS(int, int)
 CSHARP_ARRAYS(unsigned int, uint)
-// FIXME - on Unix 64 bit, long is 8 bytes but is 4 bytes on Windows 64 bit.
-//         How can this be handled sensibly?
-//         See e.g. http://www.xml.com/ldd/chapter/book/ch10.html
+#if defined(SWIGWORDSIZE64)
+CSHARP_ARRAYS(long, long)
+CSHARP_ARRAYS(unsigned long, ulong)
+#else
 CSHARP_ARRAYS(long, int)
 CSHARP_ARRAYS(unsigned long, uint)
 CSHARP_ARRAYS(long long, long)
 CSHARP_ARRAYS(unsigned long long, ulong)
+#endif
 CSHARP_ARRAYS(float, float)
 CSHARP_ARRAYS(double, double)
 CSHARP_ARRAYS(bool, bool)
@@ -129,10 +131,15 @@ CSHARP_ARRAYS_FIXED(short, short)
 CSHARP_ARRAYS_FIXED(unsigned short, ushort)
 CSHARP_ARRAYS_FIXED(int, int)
 CSHARP_ARRAYS_FIXED(unsigned int, uint)
+#if defined(SWIGWORDSIZE64)
+CSHARP_ARRAYS_FIXED(long, long)
+CSHARP_ARRAYS_FIXED(unsigned long, ulong)
+#else
 CSHARP_ARRAYS_FIXED(long, int)
 CSHARP_ARRAYS_FIXED(unsigned long, uint)
 CSHARP_ARRAYS_FIXED(long long, long)
 CSHARP_ARRAYS_FIXED(unsigned long long, ulong)
+#endif
 CSHARP_ARRAYS_FIXED(float, float)
 CSHARP_ARRAYS_FIXED(double, double)
 CSHARP_ARRAYS_FIXED(bool, bool)

--- a/Lib/csharp/csharp.swg
+++ b/Lib/csharp/csharp.swg
@@ -98,10 +98,15 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(imtype) unsigned short,     const unsigned short &     "ushort"
 %typemap(imtype) int,                const int &                "int"
 %typemap(imtype) unsigned int,       const unsigned int &       "uint"
+#if defined(SWIGWORDSIZE64)
+%typemap(imtype) long,               const long &               "long"
+%typemap(imtype) unsigned long,      const unsigned long &      "ulong"
+#else
 %typemap(imtype) long,               const long &               "int"
 %typemap(imtype) unsigned long,      const unsigned long &      "uint"
 %typemap(imtype) long long,          const long long &          "long"
 %typemap(imtype) unsigned long long, const unsigned long long & "ulong"
+#endif
 %typemap(imtype) float,              const float &              "float"
 %typemap(imtype) double,             const double &             "double"
 %typemap(imtype) void                                           "void"
@@ -114,10 +119,15 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(cstype) unsigned short,     const unsigned short &     "ushort"
 %typemap(cstype) int,                const int &                "int"
 %typemap(cstype) unsigned int,       const unsigned int &       "uint"
+#if defined(SWIGWORDSIZE64)
+%typemap(cstype) long,               const long &               "long"
+%typemap(cstype) unsigned long,      const unsigned long &      "ulong"
+#else
 %typemap(cstype) long,               const long &               "int"
 %typemap(cstype) unsigned long,      const unsigned long &      "uint"
 %typemap(cstype) long long,          const long long &          "long"
 %typemap(cstype) unsigned long long, const unsigned long long & "ulong"
+#endif
 %typemap(cstype) float,              const float &              "float"
 %typemap(cstype) double,             const double &             "double"
 %typemap(cstype) void                                           "void"
@@ -518,6 +528,27 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     const unsigned short &
     ""
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT32)
+    int,     
+    const int &    
+    ""
+
+%typecheck(SWIG_TYPECHECK_UINT32)
+    unsigned int,     
+    const unsigned int &    
+    ""
+
+%typecheck(SWIG_TYPECHECK_INT64)
+    long, 
+    const long &
+    ""
+
+%typecheck(SWIG_TYPECHECK_UINT64)
+    unsigned long,
+    const unsigned long &
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT32)
     int, 
     long, 
@@ -541,6 +572,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     unsigned long long,
     const unsigned long long &
     ""
+#endif
 
 %typecheck(SWIG_TYPECHECK_FLOAT)
     float,
@@ -657,6 +689,16 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     uint ret = $imcall;$excode
     return ret;
   }
+#if defined(SWIGWORDSIZE64)
+%typemap(csout, excode=SWIGEXCODE) long,          const long &          {
+    long ret = $imcall;$excode
+    return ret;
+  }
+%typemap(csout, excode=SWIGEXCODE) unsigned long, const unsigned long & {
+    ulong ret = $imcall;$excode
+    return ret;
+  }
+#else
 %typemap(csout, excode=SWIGEXCODE) long,               const long &               {
     int ret = $imcall;$excode
     return ret;
@@ -673,6 +715,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     ulong ret = $imcall;$excode
     return ret;
   }
+#endif
 %typemap(csout, excode=SWIGEXCODE) float,              const float &              {
     float ret = $imcall;$excode
     return ret;
@@ -763,6 +806,18 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
       uint ret = $imcall;$excode
       return ret;
     } %}
+#if defined(SWIGWORDSIZE64)
+%typemap(csvarout, excode=SWIGEXCODE2) long,          const long &          %{
+    get {
+      long ret = $imcall;$excode
+      return ret;
+    } %}
+%typemap(csvarout, excode=SWIGEXCODE2) unsigned long, const unsigned long & %{
+    get {
+      ulong ret = $imcall;$excode
+      return ret;
+    } %}
+#else
 %typemap(csvarout, excode=SWIGEXCODE2) long,               const long &               %{
     get {
       int ret = $imcall;$excode
@@ -783,6 +838,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
       ulong ret = $imcall;$excode
       return ret;
     } %}
+#endif
 %typemap(csvarout, excode=SWIGEXCODE2) float,              const float &              %{
     get {
       float ret = $imcall;$excode

--- a/Lib/csharp/typemaps.i
+++ b/Lib/csharp/typemaps.i
@@ -74,10 +74,15 @@ INPUT_TYPEMAP(short,              short,                short)
 INPUT_TYPEMAP(unsigned short,     unsigned short,       ushort)
 INPUT_TYPEMAP(int,                int,                  int)
 INPUT_TYPEMAP(unsigned int,       unsigned int,         uint)
+#if defined(SWIGWORDSIZE64)
+INPUT_TYPEMAP(long,               long,                 long)
+INPUT_TYPEMAP(unsigned long,      unsigned long,        ulong)
+#else
 INPUT_TYPEMAP(long,               long,                 int)
 INPUT_TYPEMAP(unsigned long,      unsigned long,        uint)
 INPUT_TYPEMAP(long long,          long long,            long)
 INPUT_TYPEMAP(unsigned long long, unsigned long long,   ulong)
+#endif
 INPUT_TYPEMAP(float,              float,                float)
 INPUT_TYPEMAP(double,             double,               double)
 
@@ -153,10 +158,15 @@ OUTPUT_TYPEMAP(short,              short,                short,    INT16_PTR)
 OUTPUT_TYPEMAP(unsigned short,     unsigned short,       ushort,   UINT16_PTR)
 OUTPUT_TYPEMAP(int,                int,                  int,      INT32_PTR)
 OUTPUT_TYPEMAP(unsigned int,       unsigned int,         uint,     UINT32_PTR)
+#if defined(SWIGWORDSIZE64)
+OUTPUT_TYPEMAP(long,               long,                 long,     INT64_PTR)
+OUTPUT_TYPEMAP(unsigned long,      unsigned long,        ulong,    UINT64_PTR)
+#else
 OUTPUT_TYPEMAP(long,               long,                 int,      INT32_PTR)
 OUTPUT_TYPEMAP(unsigned long,      unsigned long,        uint,     UINT32_PTR)
 OUTPUT_TYPEMAP(long long,          long long,            long,     INT64_PTR)
 OUTPUT_TYPEMAP(unsigned long long, unsigned long long,   ulong,    UINT64_PTR)
+#endif
 OUTPUT_TYPEMAP(float,              float,                float,    FLOAT_PTR)
 OUTPUT_TYPEMAP(double,             double,               double,   DOUBLE_PTR)
 
@@ -242,10 +252,15 @@ INOUT_TYPEMAP(short,              short,                short,    INT16_PTR)
 INOUT_TYPEMAP(unsigned short,     unsigned short,       ushort,   UINT16_PTR)
 INOUT_TYPEMAP(int,                int,                  int,      INT32_PTR)
 INOUT_TYPEMAP(unsigned int,       unsigned int,         uint,     UINT32_PTR)
+#if defined(SWIGWORDSIZE64)
+INOUT_TYPEMAP(long,               long,                 long,     INT64_PTR)
+INOUT_TYPEMAP(unsigned long,      unsigned long,        ulong,    UINT64_PTR)
+#else
 INOUT_TYPEMAP(long,               long,                 int,      INT32_PTR)
 INOUT_TYPEMAP(unsigned long,      unsigned long,        uint,     UINT32_PTR)
 INOUT_TYPEMAP(long long,          long long,            long,     INT64_PTR)
 INOUT_TYPEMAP(unsigned long long, unsigned long long,   ulong,    UINT64_PTR)
+#endif
 INOUT_TYPEMAP(float,              float,                float,    FLOAT_PTR)
 INOUT_TYPEMAP(double,             double,               double,   DOUBLE_PTR)
 


### PR DESCRIPTION
This is a similar fix to  #646 for C#.  It turns out C# had the same problem as Java with gcc 64-bit. This patch needs to be fully tested.
