### PR TITLE
[ruby] With %newobject, the wrong error message of an overloaded function is created

### DIFF
--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -2110,13 +2110,11 @@ public:
     // Generate prototype list, go to first node
     Node *sibl = n;
 
-    String* type = SwigType_str(Getattr(sibl,"type"),NULL);
-
     while (Getattr(sibl, "sym:previousSibling"))
       sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
 
     // Constructors will be treated specially
-    const bool isCtor = Cmp(Getattr(sibl,"feature:new"), "1") == 0;
+    const bool isCtor = (!Cmp(Getattr(sibl, "nodeType"), "constructor"));
     const bool isMethod = ( Cmp(Getattr(sibl, "ismember"), "1") == 0 &&
 			    (!isCtor) );
 
@@ -2138,7 +2136,7 @@ public:
     String *protoTypes = NewString("");
     do {
       Append( protoTypes, "\n\"    ");
-      if ( !isCtor )  Printv( protoTypes, type, " ", NIL );
+      if ( !isCtor )  Printv( protoTypes, SwigType_str(Getattr(sibl,"type"), NULL), " ", NIL );
       Printv(protoTypes, methodName, NIL );
       Parm* p = Getattr(sibl, "wrap:parms");
       if (p && (current == MEMBER_FUNC || current == MEMBER_VAR || 
@@ -2159,7 +2157,6 @@ public:
     Append(f->code, "\nreturn Qnil;\n");
 
     Delete(methodName);
-    Delete(type);
     Delete(protoTypes);
 
     Printv(f->code, "}\n", NIL);


### PR DESCRIPTION
Hi,
When creating a c++ wrapper for ruby, with %newobject, the wrong error message of an overloaded function is created. For example, 

````
%module sample

%newobject f;
void f();
int* f(int);
````
then 

````
$ swig -c++ -ruby sample.i
````
will create sample_wrap.cxx in which

````
  Ruby_Format_OverloadedError( argc, 1, "f.new", 
    "    f.new()\n"
    "    f.new(int)\n");
````
".new" is appended to the function names.

I hope this patch would help your development.
Regards.