### PR TITLE
Fixed clang memset warning in Python

### DIFF
--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -139,7 +139,7 @@ namespace swig {
 	  %type_error(swig::type_name<Type>());
 	}
 	if (throw_error) throw std::invalid_argument("bad type");
-	memset(v_def,0,sizeof(Type));
+	memset((void*)v_def,0,sizeof(Type));
 	return *v_def;
       }
     }


### PR DESCRIPTION
A warning is created by the `memset` function in `traits_as<>::as` in Python when compiling with clang.  Adding a  `void*` cast fixes this warning.

(This is a replacement for pull request #658 that had too many commits)