### PR TITLE
Add check-failing target to check that failing tests still do fail

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -713,6 +713,13 @@ check-cpp: $(CPP_TEST_CASES:=.cpptest)
 
 check-cpp11: $(CPP11_TEST_CASES:=.cpptest)
 
+check-failing-test = \
+	$(MAKE) -s $1.$2 >/dev/null 2>/dev/null && echo "Failing test $t passed."
+
+check-failing:
+	+-$(foreach t,$(FAILING_C_TESTS),$(call check-failing-test,$t,ctest);)
+	+-$(foreach t,$(FAILING_CPP_TESTS),$(call check-failing-test,$t,cpptest);)
+	+-$(foreach t,$(FAILING_MULTI_CPP_TESTS),$(call check-failing-test,$t,multicpptest);)
 endif
 
 # partialcheck target runs SWIG only, ie no compilation or running of tests (for a subset of languages)


### PR DESCRIPTION
This is useful to remove the tests which pass after the latest fixes from the
list of the failing tests.

---
I realized that I was running the shell one-liner doing the equivalent of this all the time, so I decided to add support for checking whether the failing tests still do fail to the makefile itself, this is quite convenient, because quite often several tests start to pass after fixing just one bug (which, IMHO, is a problem with the test suite itself, the tests should be more orthogonal, but I'm not about to propose changing this...).