### PR TITLE
Take long, not int, in std::vector Java wrappers methods

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,12 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.9 (in progress)
 ===========================
 
+2016-04-28: vadz
+	    [Java] Take long, not int, in std::vector wrappers get() and set() methods.
+	    This allows to write vec.get(vec.size()-1) without casts.
+
+            *** POTENTIAL INCOMPATIBILITY ***
+
 2016-04-18: ianlancetaylor
 	    [Go] Fix use of goout typemap when calling base method by
 	    forcing the "type" attribute to the value we need.

--- a/Examples/test-suite/java/li_std_vector_runme.java
+++ b/Examples/test-suite/java/li_std_vector_runme.java
@@ -18,7 +18,9 @@ public class li_std_vector_runme {
     IntConstPtrVector v3 = li_std_vector.vecintconstptr(new IntConstPtrVector());
 
     v1.add(123);
+    v1.add(456);
     if (v1.get(0) != 123) throw new RuntimeException("v1 test failed");
+    if (v1.get(v1.size() - 1) != 456) throw new RuntimeException("v1[last] test failed");
 
     StructVector v4 = li_std_vector.vecstruct(new StructVector());
     StructPtrVector v5 = li_std_vector.vecstructptr(new StructPtrVector());

--- a/Lib/java/std_vector.i
+++ b/Lib/java/std_vector.i
@@ -27,16 +27,14 @@ namespace std {
         %rename(add) push_back;
         void push_back(const value_type& x);
         %extend {
-            const_reference get(int i) throw (std::out_of_range) {
-                int size = int(self->size());
-                if (i>=0 && i<size)
+            const_reference get(size_t i) throw (std::out_of_range) {
+                if (i < self->size())
                     return (*self)[i];
                 else
                     throw std::out_of_range("vector index out of range");
             }
-            void set(int i, const value_type& val) throw (std::out_of_range) {
-                int size = int(self->size());
-                if (i>=0 && i<size)
+            void set(size_t i, const value_type& val) throw (std::out_of_range) {
+                if (i < self->size())
                     (*self)[i] = val;
                 else
                     throw std::out_of_range("vector index out of range");
@@ -61,16 +59,14 @@ namespace std {
         %rename(add) push_back;
         void push_back(const value_type& x);
         %extend {
-            bool get(int i) throw (std::out_of_range) {
-                int size = int(self->size());
-                if (i>=0 && i<size)
+            bool get(size_t i) throw (std::out_of_range) {
+                if (i < self->size())
                     return (*self)[i];
                 else
                     throw std::out_of_range("vector index out of range");
             }
-            void set(int i, const value_type& val) throw (std::out_of_range) {
-                int size = int(self->size());
-                if (i>=0 && i<size)
+            void set(size_t i, const value_type& val) throw (std::out_of_range) {
+                if (i < self->size())
                     (*self)[i] = val;
                 else
                     throw std::out_of_range("vector index out of range");


### PR DESCRIPTION
The type of the argument of get() and set() was inconsistent with the return
type of size() (and, incidentally, that of C++ at() method) and writing

```
vec.get(vec.size() - 1)
```

unexpectedly didn't compile because of a type mismatch.

Fix this by taking size_t in get()/set() too.

---

As the changelog says, this is an incompatible change, but it's really annoying that you need a cast to compile the above currently.

The same should arguably be done in `java/std_array.i` too...
