### PR TITLE
Fix infinite recursion in Python tests makefile

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -155,7 +155,7 @@ convert_testcase = \
 	  $(MAKE) $(SCRIPTDIR)/$(py_runme); \
 	fi
 
-$(SCRIPTDIR)/$(SCRIPTPREFIX)%$(SCRIPTSUFFIX): $(srcdir)/$(SCRIPTPREFIX)%$(PY2SCRIPTSUFFIX)
+$(SCRIPTDIR)/$(SCRIPTPREFIX)%$(SCRIPTSUFFIX): $(abspath $(srcdir)/$(SCRIPTPREFIX)%$(PY2SCRIPTSUFFIX))
 	test x$< = x$@ || cp $< $@ || exit 1
 	test x$(PY3) = x || $(PY2TO3) -w $@ >/dev/null 2>&1 || exit 1
 


### PR DESCRIPTION
$(srcdir)/%_runme.py could match the rule for ./%_runme.py in which it
appeared as a dependency when srcdir started with a period.

It is not clear why this didn't happen before and doesn't happen for all the
files even now, yet the problem does happen with both GNU make 3.81 and 4.0
and this workaround fixes it in both cases.

---

Somehow, running `make check-python-test-suite` with the latest master now results in errors due to an apparent recursion in the makefile. The exact error message is best seen when running make directly in the `Examples/test-suite/python` directory, see the block at the end (I put it there because it is so long).

This is crazy because it didn't happen before and yet I can't find any recent commit introducing the problem and now I see it even when trying very old commits which definitely worked for me before. It clearly has something to do with building outside of the source directory and using relative paths to it, i.e. I run `../../../src/3rdparty/swig/configure` (which, I think, it still required for C#/Java tests at least) as I do, but I don't understand how can it happen nor why didn't it happen before. But I already spent almost an hour on this and I don't think it makes sense to continue, hopefully the workaround can be applied even if things are not totally clear as it should be harmless and it does fix the problem for me under two different machines.

Here is the error message, which can also be seen by directly making `./argcargvtest_runme.py`. On this machine (Debian Jessie, GNU make 4.0) it seems to happen for all the files. On the other machine (Debian Wheezy, GNU make 3.81) it only happens for some of them which is even less understandable :-(

```
% make argcargvtest.cpptest
if [ -f ../../../../../../src/3rdparty/swig/Examples/test-suite/python/argcargvtest_runme.py ]; then make ./argcargvtest_runme.py; fi
make[1]: Entering directory '/home/zeitlin/build/swig/master/Examples/test-suite/python'
make[1]: stat: ../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/argcargvtest_runme.py: File name too long
make[1]: *** No rule to make target '../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/argcargvtest_runme.py', needed by '../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/../../../../../../src/3rdparty/swig/Examples/test-suite/python/argcargvtest_runme.py'.  Stop.
make[1]: Leaving directory '/home/zeitlin/build/swig/master/Examples/test-suite/python'
Makefile:103: recipe for target 'argcargvtest.cpptest' failed
make: *** [argcargvtest.cpptest] Error 2
```
