### PR TITLE
[Python] fix issue 691 (relative C extension module import when using `-builtin`)

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -859,21 +859,19 @@ public:
       Printv(f_shadow, "else:\n", NULL);
       Printf(f_shadow, tab4 "import %s\n", module);
 
+      if (builtin) {
+        /* The C extension module may have been imported as a package submodule above.
+         * In that case, we need to use a relative import here, too. */
+        Printv(f_shadow, "if __name__.rpartition('.')[0] != '' and version_info >= (2, 7, 0):\n", NULL);
+        Printf(f_shadow, tab4 "from .%s import *\n", module);
+        Printv(f_shadow, "else:\n", NULL);
+        Printf(f_shadow, tab4 "from %s import *\n", module);
+      }
+
       /* Delete the version_info symbol since we don't use it elsewhere in the
        * module. */
       Printv(f_shadow, "del version_info\n", NULL);
 
-      if (builtin) {
-        /*
-         * Python3 removes relative imports.  So 'from _foo import *'
-         * will only work for non-package modules.
-         */
-        Printv(f_shadow, "if __name__.rpartition('.')[0] != '':\n", NULL);
-        Printf(f_shadow, tab4 "from %s%s import *\n", (py3 ? "." : ""),
-          module);
-        Printv(f_shadow, "else:\n", NULL);
-        Printf(f_shadow, tab4 "from %s import *\n", module);
-      }
       if (modern || !classic) {
 	Printv(f_shadow, "try:\n", tab4, "_swig_property = property\n", "except NameError:\n", tab4, "pass  # Python < 2.2 doesn't have 'property'.\n\n", NULL);
       }


### PR DESCRIPTION
It turns out #691 has a simple fix, so I wrote a PR for it.

@mromberg, please have a quick look.

The point is that when using `-builtin`, we want to import `*` form the C extension module `_module`. This should be done using a relative import if the C extension is a submodule of a package. For this, the syntax

    from ._module import *

must be used for Python 3, and may be used for Python >= 2.7. Otherwise,

    from _module import *

may be used.

Notes:

* The syntax `from ._module import *` was used only when invoking swig with the `-py3` option. This is not correct, since even without this option, the wrapper code should be compatible under python 3. The `-py3` option may only break backwards compatibility.

* The old code to include C extension modules, which is currently used for python < 2.7, actually imports the extension module as a global module (well, sometimes it does, sometimes it doesn't...). In either case, the syntax

        from _module import *

    will work, and therefore, for this case this syntax should be used.

Tl;dr
---
The case distinction between python 2 and python 3 syntax for relative imports should be handled in the python code, not in the C++ code relying on the `-py3` swig option.