### PR TITLE
Fix broken tests for python3 -relativeimport and no -py3

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -5680,8 +5680,9 @@ class M2(pkg2.mod3.M3): pass
 <p>By default, SWIG would generate <tt>mod2.py</tt> proxy file with
 <tt>import</tt> directive as in point 1. This can be changed with the
 <tt>-relativeimport</tt> command line option. The <tt>-relativeimport</tt> instructs
-SWIG to organize imports as in point 2 (for Python 2.x) or as in point 4 (for
-Python 3, that is when the -py3 command line option is enabled). In short, if you have
+SWIG to organize imports as in point 2 (for Python < 2.7.0) or as in point 4
+for Python 2.7.0 and newer. This is a check done at the time the module is
+imported. In short, if you have
 <tt>mod2.i</tt> and <tt>mod3.i</tt> as above, then without
 <tt>-relativeimport</tt> SWIG will write</p>
 
@@ -5695,21 +5696,15 @@ import pkg1.pkg2.mod3
 write</p>
 
 <div class="targetlang">
-<pre>
-import pkg2.mod3
+  <pre>
+import sys
+if sys.version_info >= (2, 7, 0):
+    from . import pkg2
+    import pkg1.pkg2.mod3
+else:
+    import pkg2.mod3
 </pre>
 </div>
-
-<p>if <tt>-py3</tt> is not used, or</p>
-
-<div class="targetlang">
-<pre>
-from . import pkg2
-import pkg1.pkg2.mod3
-</pre>
-</div>
-
-<p>when <tt>-py3</tt> is used.</p>
 
 <p>You should avoid using relative imports and use absolute ones whenever
 possible. There are some cases, however, when relative imports may be

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1251,13 +1251,14 @@ public:
       Printf(out, "import %s%s%s%s\n", apkg, *Char(apkg) ? "." : "", pfx, mod);
       Delete(apkg);
     } else {
-      if (py3) {
-        if (py3_rlen1)
-	  Printf(out, "from . import %.*s\n", py3_rlen1, rpkg);
-        Printf(out, "from .%s import %s%s\n", rpkg, pfx, mod);
-      } else {
-        Printf(out, "import %s%s%s%s\n", rpkg, *Char(rpkg) ? "." : "", pfx, mod);
-      }
+      Printf(out, "import sys\n");
+      Printf(out, "if sys.version_info > (2, 7, 0):\n");
+      if (py3_rlen1)
+          Printf(out, tab4 "from . import %.*s\n", py3_rlen1, rpkg);
+      Printf(out, tab4 "from .%s import %s%s\n", rpkg, pfx, mod);
+      Printf(out, "else:\n");
+      Printf(out, tab4 "import %s%s%s%s\n", rpkg, *Char(rpkg) ? "." : "",
+        pfx, mod);
       Delete(rpkg);
     }
     return out;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1252,7 +1252,7 @@ public:
       Delete(apkg);
     } else {
       Printf(out, "import sys\n");
-      Printf(out, "if sys.version_info > (2, 7, 0):\n");
+      Printf(out, "if sys.version_info >= (2, 7, 0):\n");
       if (py3_rlen1)
           Printf(out, tab4 "from . import %.*s\n", py3_rlen1, rpkg);
       Printf(out, tab4 "from .%s import %s%s\n", rpkg, pfx, mod);


### PR DESCRIPTION
Converts the test for python3 support from a swigtime check of py3 to a runtime check of the python version number.  The exact same import syntax is still used.  But now the test for python3 is done at the time the module is imported.

  This allows the .py file to work (with the -relativeimport switch) with both python2 and python3.