### PR TITLE
[Python] octal default values for python 2 *and* 3

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2127,14 +2127,15 @@ public:
 		// This must have been a hex number, we can use it directly in Python,
 		// so nothing to do here.
 	      } else {
-		// This must have been an octal number, we have to change its prefix
-		// to be "0o" in Python 3 only (and as long as we still support Python
-		// 2.5, this can't be done unconditionally).
-		if (py3) {
-		  if (end - s > 1) {
-		    result = NewString("0o");
-		    Append(result, NewStringWithSize(s + 1, (int)(end - s - 1)));
-		  }
+		// This must have been an octal number. We will let python convert it
+		// to an int using base 8, since we would have to change its prefix
+		// to be "0o" in Python 3 only.
+		if (end - s > 1) {
+		  result = NewString("int('");
+		  String *octal_string = NewStringWithSize(s + 1, (int)(end - s - 1));
+		  Append(result, octal_string);
+		  Append(result, "', 8)");
+		  Delete(octal_string);
 		}
 	      }
 	    }


### PR DESCRIPTION
This allows handling of octal default argument values in a Python version independent way by writing an octal value, say '0644' as `int('644',8)`, instead of `0644` for Python 2 or `0o644` for Python 3.

Also, the newly allocated `NewStringWithSize` is now deleted, which was previously not done (this was a memory leak, right?).

The function `int(x, radix)` is indeed available since Python 2.0, see the 
[Python 2.0 docs](https://docs.python.org/release/2.0/lib/built-in-funcs.html#l2h-167).