### PR TITLE
[Python] improved default argument handling

### DIFF
--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -14,14 +14,20 @@
   #include <string>
 
   // All kinds of numbers: hex, octal (which pose special problems to Python), negative...
-  void trickyvalue1(int first, int pos = -1) {}
-  void trickyvalue2(int first, unsigned rgb = 0xabcdef) {}
-  void trickyvalue3(int first, int mode = 0644) {}
+
+  class TrickyInPython {
+  public:
+    int value_m1(int first, int pos = -1) { return pos; }
+    unsigned value_0xabcdef(int first, unsigned rgb = 0xabcdef) { return rgb; }
+    int value_0644(int first, int mode = 0644) { return mode; }
+    int value_perm(int first, int mode = 0640 | 0004) { return mode; }
+    int value_m01(int first, int val = -01) { return val; }
+    bool booltest2(bool x = 0 | 1) { return x; }
+  };
 
   void doublevalue1(int first, double num = 0.0e-1) {}
   void doublevalue2(int first, double num = -0.0E2) {}
 
-  // Long long arguments are not handled at Python level currently but still work.
   void seek(long long offset = 0LL) {}
   void seek2(unsigned long long offset = 0ULL) {}
   void seek3(long offset = 0L) {}

--- a/Examples/test-suite/python/default_args_runme.py
+++ b/Examples/test-suite/python/default_args_runme.py
@@ -113,14 +113,38 @@ def run(module_name):
     if Klass_inc().val != 0:
         raise RuntimeError("Klass::inc failed")
 
-    default_args.trickyvalue1(10)
-    default_args.trickyvalue1(10, 10)
-    default_args.trickyvalue2(10)
-    default_args.trickyvalue2(10, 10)
-    default_args.trickyvalue3(10)
-    default_args.trickyvalue3(10, 10)
+    tricky_failure = False
+    tricky = default_args.TrickyInPython()
+    if tricky.value_m1(10) != -1:
+        print "trickyvalue_m1 failed"
+        tricky_failure = True
+    if tricky.value_m1(10, 10) != 10:
+        print "trickyvalue_m1 failed"
+        tricky_failure = True
+    if tricky.value_0xabcdef(10) != 0xabcdef:
+        print "trickyvalue_0xabcdef failed"
+        tricky_failure = True
+    if tricky.value_0644(10) != 420:
+        print "trickyvalue_0644 failed"
+        tricky_failure = True
+    if tricky.value_perm(10) != 420:
+        print "trickyvalue_perm failed"
+        tricky_failure = True
+    if tricky.value_m01(10) != -1:
+        print "trickyvalue_m01 failed"
+        tricky_failure = True
+    if not tricky.booltest2():
+        print "booltest2 failed"
+        tricky_failure = True
+
+    if tricky_failure:
+        raise RuntimeError
+
     default_args.seek()
     default_args.seek(10)
+
+    if not default_args.booltest():
+        raise RuntimeError("booltest failed")
 
     if default_args.slightly_off_square(10) != 102:
         raise RuntimeError

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2131,9 +2131,9 @@ public:
     if (!result) {
       result = convertDoubleValue(v);
       if (!result) {
-        if (Strcmp(v, "true") == 0 || Strcmp(v, "TRUE") == 0)
+        if (Strcmp(v, "true") == 0)
           result = NewString("True");
-        else if (Strcmp(v, "false") == 0 || Strcmp(v, "FALSE") == 0)
+        else if (Strcmp(v, "false") == 0)
           result = NewString("False");
         else if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
           result = SwigType_ispointer(resolved_type) ? NewString("None") : NewString("0");

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2127,14 +2127,15 @@ public:
 		// This must have been a hex number, we can use it directly in Python,
 		// so nothing to do here.
 	      } else {
-		// This must have been an octal number, we have to change its prefix
-		// to be "0o" in Python 3 only (and as long as we still support Python
-		// 2.5, this can't be done unconditionally).
-		if (py3) {
-		  if (end - s > 1) {
-		    result = NewString("0o");
-		    Append(result, NewStringWithSize(s + 1, (int)(end - s - 1)));
-		  }
+		// This must have been an octal number. We will let python convert it
+		// to an int using base 8, since we would have to change its prefix
+		// to be "0o" in Python 3 only.
+		if (end - s > 1) {
+		  result = NewString("int('");
+		  String *octal_string = NewStringWithSize(s + 1, (int)(end - s - 1));
+		  Append(result, octal_string);
+		  Append(result, "', 8)");
+		  Delete(octal_string);
 		}
 	      }
 	    }


### PR DESCRIPTION
The current SWIG handling of default arguments for python has several issues:
- Tangled code.
- Incorrect handling of several cases:
  1. Negative octals. Currently not handled correctly when `-py3` given (unusual case, but incorrect).
  2. Arguments of type "octal + something" (e.g. `0640 | 04`). Currently drops everything after the first octal. Nasty!
  3. Bool arguments "0 + something" (e.g. `0 | 1`) are always "False" (unusual case, but incorrect).
- Test cases test only for correct _syntax_, not for correctness of the converted value.
- Different handling of octal literals for Python 2 and Python 3 based on `-py3` switch.

This PR addresses all of the above issues. Here are some comments:
- The relevant conversion code is refactored and should be much more clear now.
- Test cases including some new tests are (slightly) improved (but still only test for corner cases)
- Identical code generated for Python 2 and Python 3. This now writes octals such as `0644` as `int('0644', 8)` (available in Python >= 2.0, propagates to long integer as of 2.3).
- There have always been issues with integer literals exceeding 32 bit on Python <= 2.2. These issues remain.
- Tests now pass with Python 2 and Python 3.

Note that this is a much improved version of the previous PR #699.
