### PR TITLE
[Python] improved wrapping of division operators

### DIFF
--- a/Lib/python/pyopers.swg
+++ b/Lib/python/pyopers.swg
@@ -103,11 +103,6 @@
 %pybinoperator(__neg__,      *::operator-(),		unaryfunc, nb_negative);
 %pybinoperator(__neg__,      *::operator-() const,	unaryfunc, nb_negative);
 %pybinoperator(__mul__,      *::operator*,		binaryfunc, nb_multiply);
-#if defined(SWIGPYTHON_PY3)
-%pybinoperator(__truediv__,  *::operator/,		binaryfunc, nb_divide);
-#else
-%pybinoperator(__div__,      *::operator/,		binaryfunc, nb_divide);
-#endif
 %pybinoperator(__mod__,      *::operator%,		binaryfunc, nb_remainder);
 %pybinoperator(__lshift__,   *::operator<<,		binaryfunc, nb_lshift);
 %pybinoperator(__rshift__,   *::operator>>,		binaryfunc, nb_rshift);
@@ -129,6 +124,7 @@
 
 #if defined(SWIGPYTHON_BUILTIN)
 %pybinoperator(__nonzero__,   *::operator bool,		inquiry, nb_nonzero);
+%pybinoperator(__truediv__,   *::operator/    ,		binaryfunc, nb_divide);
 #else
 %feature("shadow")      *::operator bool %{
 def __nonzero__(self):
@@ -136,6 +132,13 @@ def __nonzero__(self):
 __bool__ = __nonzero__
 %};
 %rename(__nonzero__)    *::operator bool;
+%feature("shadow")      *::operator/ %{
+def __truediv__(self, *args):
+    return $action(self, *args)
+__div__ = __truediv__
+%};
+%rename(__truediv__)    *::operator/;
+%pythonmaybecall        *::operator/;
 #endif
 
 /* Ignored operators */
@@ -202,11 +205,6 @@ __bool__ = __nonzero__
 %pyinplaceoper(__iadd__   , *::operator +=,	binaryfunc, nb_inplace_add);
 %pyinplaceoper(__isub__   , *::operator -=,	binaryfunc, nb_inplace_subtract);
 %pyinplaceoper(__imul__   , *::operator *=,	binaryfunc, nb_inplace_multiply);
-#if defined(SWIGPYTHON_PY3)
-%pyinplaceoper(__itruediv__   , *::operator /=,	binaryfunc, nb_inplace_divide);
-#else
-%pyinplaceoper(__idiv__   , *::operator /=,	binaryfunc, nb_inplace_divide);
-#endif
 %pyinplaceoper(__imod__   , *::operator %=,	binaryfunc, nb_inplace_remainder);
 %pyinplaceoper(__iand__   , *::operator &=,	binaryfunc, nb_inplace_and);
 %pyinplaceoper(__ior__    , *::operator |=,	binaryfunc, nb_inplace_or);
@@ -214,6 +212,19 @@ __bool__ = __nonzero__
 %pyinplaceoper(__ilshift__, *::operator <<=,	binaryfunc, nb_inplace_lshift);
 %pyinplaceoper(__irshift__, *::operator >>=,	binaryfunc, nb_inplace_rshift);
 
+/* Special cases */
+#if defined(SWIGPYTHON_BUILTIN)
+%pyinplaceoper(__itruediv__   , *::operator /=,	binaryfunc, nb_inplace_divide);
+#else
+%delobject *::operator /=;
+%newobject *::operator /=;
+%feature("shadow")      *::operator /= %{
+def __itruediv__(self, *args):
+    return $action(self, *args)
+__idiv__ = __itruediv__
+%};
+%rename(__itruediv__)    *::operator /=;
+#endif
 
 /* Finally, in python we need to mark the binary operations to fail as
  'maybecall' methods */
@@ -228,6 +239,7 @@ __bool__ = __nonzero__
 %pybinopermaybecall(neg);
 %pybinopermaybecall(mul);
 %pybinopermaybecall(div);
+%pybinopermaybecall(truediv);
 %pybinopermaybecall(mod);
 %pybinopermaybecall(lshift);
 %pybinopermaybecall(rshift);


### PR DESCRIPTION
This changes the way the division operators `operator /` and `operator /=` are wrapped in the case that `-builtin` is _not_ used (for `-builtin` everything stays the same, except that the operators are renamed to `__truediv__` and `__itruediv__`, but the same slots `nb_divide` and `nb_inplace_divide` are used).

The division operators are now always wrapped as `__truediv__` and `__itruediv__`, with alias methods
`__div__` and `__idiv__` generated for compatibility with Python 2. The same technique was already used for the wrapping of `operator bool` as `__nonzero__` and `__bool__`.

This allows correct wrapping for Python 2 and 3 **independent of the `-py3` flag**, and fixes these operators for Python 2 when using `from __future__ import division` (this was broken).
