### PR TITLE
[Java] Fix compilation problems with cMemOwnDerived

### DIFF
--- a/Lib/java/boost_shared_ptr.i
+++ b/Lib/java/boost_shared_ptr.i
@@ -161,11 +161,11 @@
 // Derived proxy classes
 %typemap(javabody_derived) TYPE %{
   private transient long swigCPtr;
-  private boolean swigCMemOwnDerived;
+  private transient boolean swigCMemOwn;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
-    swigCMemOwnDerived = cMemoryOwn;
+    swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
@@ -186,15 +186,14 @@
 
 %typemap(javadestruct_derived, methodname="delete", methodmodifiers="public synchronized") TYPE {
     if (swigCPtr != 0) {
-      if (swigCMemOwnDerived) {
-        swigCMemOwnDerived = false;
+      if (swigCMemOwn) {
+        swigCMemOwn = false;
         $jnicall;
       }
       swigCPtr = 0;
     }
     super.delete();
   }
-
 
 %template() SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >;
 %enddef

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1228,8 +1228,9 @@ SWIG_JAVABODY_PROXY(protected, protected, SWIGTYPE)
 SWIG_JAVABODY_TYPEWRAPPER(protected, protected, protected, SWIGTYPE)
 
 %typemap(javafinalize) SWIGTYPE %{
-  protected void finalize() {
+  protected void finalize() throws Throwable {
     delete();
+    super.finalize();
   }
 %}
 


### PR DESCRIPTION
This pull request fixes the compilation problems with the cMemOwned vs cMemOwnDerived problems when using boost shared pointers and directors.

I tried to keep the original idea of introducing a new variable in the derived class for that purpose, but avoided compilation problems by simply keeping the old name. This leverages from the need to introduce new mapping rules for derived classes. Java takes care of selecting the correct variable. So far, I did not observer any problems with it. All tests are passed.

Moreover, Java complains about missing calls to super in the finalize. This has been fixed by calling super.finalize and adding an exception that is defined by Object.
