### PR TITLE
Fix for -python -O %feature nondynamic

### DIFF
--- a/Examples/test-suite/python/python_nondynamic_runme.py
+++ b/Examples/test-suite/python/python_nondynamic_runme.py
@@ -4,6 +4,11 @@ aa = python_nondynamic.A()
 
 aa.a = 1
 aa.b = 2
+
+# Sanity check to see if all the funky setattr methods make it into C.
+assert(python_nondynamic._python_nondynamic.A_a_get(aa) == 1)
+assert(python_nondynamic._python_nondynamic.A_b_get(aa) == 2)
+
 try:
     aa.c = 2
     err = 0
@@ -23,6 +28,11 @@ class B(python_nondynamic.A):
     pass
 
 bb = B()
+bb.a = 4
+bb.b = 5
+assert(bb.a == 4)
+assert(bb.b == 5)
+
 
 try:
     bb.c = 3


### PR DESCRIPTION
  This code uses metaclasses.  It did before my fix.  But the old code only worked for python2 meta classes.    The old code also did not pay any attention to the python properties switched on with the -O switch.

  This works with python2 and python3.  It may not work for python2 older than 2.7.  If that is the case, then someone who's brain can grapple with metaclasses and properties better than mine can take a shot at it.

  Otherwise, this fixes the tests to move forward for swig-3.1 in supporting python 2.7+

Mike