### PR TITLE
Fix -python -O li_boost_shared_ptr_template

### DIFF
--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -220,7 +220,12 @@ class Allocate:public Dispatcher {
 		      if (!Swig_symbol_isoverloaded(n)) {
 			// Don't eliminate if an overloaded method as this hides the method
 			// in the scripting languages: the dispatch function will hide the base method if ignored.
-			SetFlag(n, "feature:ignore");
+                        if (!Getattr(b, "feature:smartptr")) {
+                          // Also don't ignore if the class uses
+                          // smart pointers as the swig run time type checker
+                          // can't deal with it unless they exist.
+			  SetFlag(n, "feature:ignore");
+                        }
 		      }
 	      } else {
 		// Some languages need to know about covariant return types


### PR DESCRIPTION
The %shared_ptr feature bypasses the normal swig type checking and counts on the smart pointer being converted on the C++ side to the template type.   This all works fine and dandy as long as swig always spits out C++ wrappers for every virtual function.

  When the -O switch is enabled virtual_elimination_mode is turned on in allocate.cxx.  Then allocate.cxx eliminates the duplicate virtual functions because for every single type that is not "smart" the python run time type checker can deal with casting to the correct type and having C++ dispatch things correctly.  But shared_ptr does not play along using the same rules.  So, the run time type checker has no clue how to follow the inheritance chain with derived classes.

  The following breaks when swig ignores Bar::x():

class Foo { virtual int x(); };
class Bar : public Foo { virtual int x(); };
%shared_ptr(Bar);

  This is because individually Foo::x() and Bar::x() know how to unmangle the special magic done by shared_ptr to convert the boost::shared_ptr<etc, etc, etc into a Foo * or a Bar *.  But swig itself has no idea how to cast between boost::shared_ptr<Foo> and boost::shared_ptr<Bar> so it treats them as seperate types (which they really are).

  This patch avoids the elimination of virtual functions for classes with feature:smartptr set.  Having individual virtual functions called by the scripting seems to be a key way the %shared_ptr feature operates.  All other classes benefit when virtual functions are eliminated.

  
