### PR TITLE
#733 - wrong "override" calculation in import mode

### DIFF
--- a/Examples/test-suite/imports_a.h
+++ b/Examples/test-suite/imports_a.h
@@ -18,4 +18,12 @@ class A {
   virtual MemberEnum member_virtual_test(MemberEnum e) { return e; }
   virtual GlobalEnum global_virtual_test(GlobalEnum e) { return global_test(e); }
 };
+
+/* This class overrides nothing. Inherited classes should see base functions.
+*/
+class A_Intermediate : public A { 
+ public:
+  A_Intermediate(){}
+  ~A_Intermediate(){}
+};
 #endif

--- a/Examples/test-suite/imports_b.h
+++ b/Examples/test-suite/imports_b.h
@@ -1,6 +1,6 @@
 #include "imports_a.h"
 
-class B : public A 
+class B : public A_Intermediate
 { 
  public: 
   B() {};

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -197,15 +197,17 @@ class Allocate:public Dispatcher {
 	      // Found a polymorphic method.
 	      // Mark the polymorphic method, in case the virtual keyword was not used.
 	      Setattr(n, "storage", "virtual");
-
-	      if (both_have_public_access || both_have_protected_access) {
-		if (!is_non_public_base(inclass, b))
-		  Setattr(n, "override", base);	// Note C# definition of override, ie access must be the same
-	      } else if (!both_have_private_access) {
-		// Different access
-		if (this_wrapping_protected_members || base_wrapping_protected_members)
+	      if (!Getattr(b, "feature:interface")) { // interface implementation neither hides nor overrides
+		if (both_have_public_access || both_have_protected_access) {
 		  if (!is_non_public_base(inclass, b))
-		    Setattr(n, "hides", base);	// Note C# definition of hiding, ie hidden if access is different
+		    Setattr(n, "override", base);	// Note C# definition of override, ie access must be the same
+		}
+		else if (!both_have_private_access) {
+		  // Different access
+		  if (this_wrapping_protected_members || base_wrapping_protected_members)
+		    if (!is_non_public_base(inclass, b))
+		      Setattr(n, "hides", base);	// Note C# definition of hiding, ie hidden if access is different
+		}
 	      }
 	      // Try and find the most base's covariant return type
 	      SwigType *most_base_covariant_type = Getattr(base, "covariant");

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -2041,34 +2041,6 @@ public:
   }
 
   /* ----------------------------------------------------------------------
-   * calculateDirectBase()
-   * ---------------------------------------------------------------------- */
-
-  void calculateDirectBase(Node* n) {
-    Node* direct_base = 0;
-    // C++ inheritance
-    Node *attributes = NewHash();
-    SwigType *typemap_lookup_type = Getattr(n, "classtypeobj");
-    const String *pure_baseclass = typemapLookup(n, "csbase", typemap_lookup_type, WARN_NONE, attributes);
-    bool purebase_replace = GetFlag(attributes, "tmap:csbase:replace") ? true : false;
-    bool purebase_notderived = GetFlag(attributes, "tmap:csbase:notderived") ? true : false;
-    Delete(attributes);
-    if (!purebase_replace) {
-      if (List *baselist = Getattr(n, "bases")) {
-	Iterator base = First(baselist);
-	while (base.item && (GetFlag(base.item, "feature:ignore") || Getattr(base.item, "feature:interface")))
-	  base = Next(base);
-	direct_base = base.item;
-      }
-      if (!direct_base && purebase_notderived)
-	direct_base = symbolLookup(const_cast<String*>(pure_baseclass));
-    } else {
-      direct_base = symbolLookup(const_cast<String*>(pure_baseclass));
-    }
-    Setattr(n, "direct_base", direct_base);
-  }
-
-  /* ----------------------------------------------------------------------
    * classHandler()
    * ---------------------------------------------------------------------- */
 
@@ -2153,7 +2125,6 @@ public:
 	emitInterfaceDeclaration(n, interface_name, interface_class_code);
         Delete(output_directory);
       }
-      calculateDirectBase(n);
     }
 
     Language::classHandler(n);
@@ -2422,21 +2393,8 @@ public:
       Printf(function_code, "  %s ", methodmods);
       if (!is_smart_pointer()) {
 	// Smart pointer classes do not mirror the inheritance hierarchy of the underlying pointer type, so no virtual/override/new required.
-	if (Node *base_ovr = Getattr(n, "override")) {
-	  if (GetFlag(n, "isextendmember"))
+	if (Getattr(n, "override"))
 	    Printf(function_code, "override ");
-	  else {
-	    Node* base = parentNode(base_ovr);
-	    bool ovr = false;
-	    for (Node* direct_base = Getattr(parentNode(n), "direct_base"); direct_base; direct_base = Getattr(direct_base, "direct_base")) {
-	      if (direct_base == base) { // "override" only applies if the base was not discarded (e.g. in case of multiple inheritance or via "ignore")
-		ovr = true;
-		break;
-	      }
-	    }
-	    Printf(function_code, ovr ? "override " : "virtual ");
-	  }
-	}
 	else if (checkAttribute(n, "storage", "virtual"))
 	  Printf(function_code, "virtual ");
 	if (Getattr(n, "hides"))


### PR DESCRIPTION
"override" calculation in allocate.cxx should take into account interfaces.
"direct_base" attribute has no other use now, so it may be removed completely (it had some intended usage, but I can't remember what exactly)
