### PR TITLE
In preprocessor, replace multiple macro arguments "at once" via placeholders

### DIFF
--- a/Examples/test-suite/preproc_macro_arg_order.i
+++ b/Examples/test-suite/preproc_macro_arg_order.i
@@ -1,0 +1,2 @@
+#define TAG( a, b ) a | b
+enum Bug { BUG = TAG( 'b', 'x' ) };


### PR DESCRIPTION
This avoids an issue where argument replacement with a string that contains the name of another argument can cause arguments to be replaced in text that wasn't meant to contain macro arguments.

Example:
    #define TAG( a, b ) a | b
    enum Bug { BUG = TAG( 'b', 'x' ) };

Ie. `a | b` becomes `'b' | b`, then `''x'' | 'x'`. Desired was `'b' | 'x'`.

The patch instead goes `\006 0 \007 | \006 1 \007`, then replaces `\006 0 \007` with `'b'` and `\006 1 \007` with `'x'`.

Fixes #737.
