### PR TITLE
do not resolve full template declarations

### DIFF
--- a/Examples/test-suite/duplicate_class_name_in_ns.i
+++ b/Examples/test-suite/duplicate_class_name_in_ns.i
@@ -1,0 +1,21 @@
+%module a;
+
+namespace A
+{
+    class Foo {
+    public:
+        Foo(){};
+    };
+}
+
+namespace B
+{
+    template<typename T, typename U>
+        class Foo : public A::Foo {
+    public:
+        Foo(){};
+        int foo();
+    };
+    
+    %template(B) Foo<int, double>;
+}

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -558,9 +558,13 @@ class TypePass:private Dispatcher {
     String *name = Getattr(n, "name");
     String *ttype = Getattr(n, "templatetype");
     if (Strcmp(ttype, "class") == 0) {
-      String *rname = SwigType_typedef_resolve_all(name);
-      SwigType_typedef_class(rname);
-      Delete(rname);
+      if(Checkattr(n, "specialization", "1")) {
+        String *rname = SwigType_typedef_resolve_all(name);
+        SwigType_typedef_class(rname);
+        Delete(rname);
+      } else {
+        SwigType_typedef_class(name);
+      }
     } else if (Strcmp(ttype, "classforward") == 0) {
       String *rname = SwigType_typedef_resolve_all(name);
       SwigType_typedef_class(rname);


### PR DESCRIPTION
The symbol resolution is only needed for (partial) template specializations. This is because they can have template parameters and can be defined in a different scope/namespace.

However, a normal (full) template declaration can never have its home anywhere else than in the current scope/namespace. For such normal (full), first-time template declarations the resolution will incorrectly find classes if such exist with the same name but in different namespace.

I tested this with my own very complex, templated code which is full of namespaces. Unfortunately I have no small reproducer.
