### PR TITLE
Added support for guile's native pointer type

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,7 +5,7 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.11 (in progress)
 ============================
 
-2016-09-18  bcaine
+2016-09-18  briancaine
             [Guile] Patch #744 Added support for Guile's native pointer functionality
 
 2016-06-26: wkalinin

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,9 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.11 (in progress)
 ============================
 
+2016-09-18  bcaine
+            [Guile] Patch #744 Added support for Guile's native pointer functionality
+
 2016-06-26: wkalinin
             [Java, C#] Patch #681 Fix seg fault when ignoring nested classes.
 

--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -907,14 +907,14 @@
 <li><a href="Guile.html#Guile_nn14">Smobs</a>
 <li><a href="Guile.html#Guile_nn15">Garbage Collection</a>
 </ul>
-<li><a href="Guile.html#Guile_nn12">Native Guile pointers</a>
-<li><a href="Guile.html#Guile_nn16">Exception Handling</a>
-<li><a href="Guile.html#Guile_nn17">Procedure documentation</a>
-<li><a href="Guile.html#Guile_nn18">Procedures with setters</a>
-<li><a href="Guile.html#Guile_nn19">GOOPS Proxy Classes</a>
+<li><a href="Guile.html#Guile_nn16">Native Guile pointers</a>
+<li><a href="Guile.html#Guile_nn17">Exception Handling</a>
+<li><a href="Guile.html#Guile_nn18">Procedure documentation</a>
+<li><a href="Guile.html#Guile_nn19">Procedures with setters</a>
+<li><a href="Guile.html#Guile_nn20">GOOPS Proxy Classes</a>
 <ul>
-<li><a href="Guile.html#Guile_nn20">Naming Issues</a>
-<li><a href="Guile.html#Guile_nn21">Linking</a>
+<li><a href="Guile.html#Guile_nn21">Naming Issues</a>
+<li><a href="Guile.html#Guile_nn22">Linking</a>
 </ul>
 </ul>
 </div>

--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -907,6 +907,7 @@
 <li><a href="Guile.html#Guile_nn14">Smobs</a>
 <li><a href="Guile.html#Guile_nn15">Garbage Collection</a>
 </ul>
+<li><a href="Guile.html#Guile_nn12">Native Guile pointers</a>
 <li><a href="Guile.html#Guile_nn16">Exception Handling</a>
 <li><a href="Guile.html#Guile_nn17">Procedure documentation</a>
 <li><a href="Guile.html#Guile_nn18">Procedures with setters</a>

--- a/Doc/Manual/Guile.html
+++ b/Doc/Manual/Guile.html
@@ -30,6 +30,7 @@
 <li><a href="#Guile_nn14">Smobs</a>
 <li><a href="#Guile_nn15">Garbage Collection</a>
 </ul>
+<li><a href="#Guile_nn12">Native Guile pointers</a>
 <li><a href="#Guile_nn16">Exception Handling</a>
 <li><a href="#Guile_nn17">Procedure documentation</a>
 <li><a href="#Guile_nn18">Procedures with setters</a>
@@ -453,13 +454,14 @@ is exactly like described in <a href="Customization.html#Customization_ownership
 Object ownership and %newobject</a> in the SWIG manual.  All typemaps use an $owner var, and
 the guile module replaces $owner with 0 or 1 depending on feature:new.</p>
 
-<H2><a name="Guile_nn12">24.7 Native Guile pointers</a></H2>
+<H2><a name="Guile_nn12">24.8 Native Guile pointers</a></H2>
+
 
 <p>
 In addition to SWIG smob pointers, <a href="https://www.gnu.org/software/guile/manual/html_node/Foreign-Pointers.html">Guile's native pointer type</a> are accepted as arguments to wrapped SWIG functions. This can be useful for passing <a href="https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html#">pointers to bytevector data</a> to wrapped functions.
 </p>
 
-<H2><a name="Guile_nn16">24.8 Exception Handling</a></H2>
+<H2><a name="Guile_nn16">24.9 Exception Handling</a></H2>
 
 
 <p>
@@ -485,7 +487,7 @@ mapping:
 The default when not specified here is to use "swig-error".
 See Lib/exception.i for details.
 
-<H2><a name="Guile_nn17">24.9 Procedure documentation</a></H2>
+<H2><a name="Guile_nn17">24.10 Procedure documentation</a></H2>
 
 
 <p>If invoked with the command-line option <code>-procdoc
@@ -520,7 +522,7 @@ like this:
 typemap argument <code>doc</code>. See <code>Lib/guile/typemaps.i</code> for
 details.
 
-<H2><a name="Guile_nn18">24.10 Procedures with setters</a></H2>
+<H2><a name="Guile_nn18">24.11 Procedures with setters</a></H2>
 
 
 <p>For global variables, SWIG creates a single wrapper procedure
@@ -548,7 +550,7 @@ struct members, the procedures <code>(<var>struct</var>-<var>member</var>-get
 pointer)</code> and <code>(<var>struct-member</var>-set pointer
 value)</code> are <em>not</em> generated.
 
-<H2><a name="Guile_nn19">24.11 GOOPS Proxy Classes</a></H2>
+<H2><a name="Guile_nn19">24.12 GOOPS Proxy Classes</a></H2>
 
 
 <p>SWIG can also generate classes and generic functions for use with
@@ -694,7 +696,7 @@ Notice that &lt;Foo&gt; is used before it is defined.  The fix is to just put th
 <code>%import "foo.h"</code> before the <code>%inline</code> block.
 </p>
 
-<H3><a name="Guile_nn20">24.11.1 Naming Issues</a></H3>
+<H3><a name="Guile_nn20">24.12.1 Naming Issues</a></H3>
 
 
 <p>As you can see in the example above, there are potential naming conflicts.  The default exported
@@ -731,7 +733,7 @@ guile-modules.  For example,</p>
 (use-modules ((Test) #:renamer (symbol-prefix-proc 'goops:)))
 </pre></div>
 
-<H3><a name="Guile_nn21">24.11.2 Linking</a></H3>
+<H3><a name="Guile_nn21">24.12.2 Linking</a></H3>
 
 
 <p>The guile-modules generated above all need to be linked together.  GOOPS support requires

--- a/Doc/Manual/Guile.html
+++ b/Doc/Manual/Guile.html
@@ -30,7 +30,6 @@
 <li><a href="#Guile_nn14">Smobs</a>
 <li><a href="#Guile_nn15">Garbage Collection</a>
 </ul>
-<li><a href="#Guile_nn12">Native Guile pointers</a>
 <li><a href="#Guile_nn16">Exception Handling</a>
 <li><a href="#Guile_nn17">Procedure documentation</a>
 <li><a href="#Guile_nn18">Procedures with setters</a>
@@ -454,14 +453,13 @@ is exactly like described in <a href="Customization.html#Customization_ownership
 Object ownership and %newobject</a> in the SWIG manual.  All typemaps use an $owner var, and
 the guile module replaces $owner with 0 or 1 depending on feature:new.</p>
 
-<H2><a name="Guile_nn12">24.8 Native Guile pointers</a></H2>
-
+<H2><a name="Guile_nn12">24.7 Native Guile pointers</a></H2>
 
 <p>
-In addition to SWIG smob pointers, <a href="https://www.gnu.org/software/guile/manual/html_node/Foreign-Pointers.html">Guile's native pointer type</a> are accepted as arguments to wrapped SWIG functions. This can be useful for passing <a href="https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html#">pointers to bytevector data</a> to native functions.
+In addition to SWIG smob pointers, <a href="https://www.gnu.org/software/guile/manual/html_node/Foreign-Pointers.html">Guile's native pointer type</a> are accepted as arguments to wrapped SWIG functions. This can be useful for passing <a href="https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html#">pointers to bytevector data</a> to wrapped functions.
 </p>
 
-<H2><a name="Guile_nn16">24.9 Exception Handling</a></H2>
+<H2><a name="Guile_nn16">24.8 Exception Handling</a></H2>
 
 
 <p>
@@ -487,7 +485,7 @@ mapping:
 The default when not specified here is to use "swig-error".
 See Lib/exception.i for details.
 
-<H2><a name="Guile_nn17">24.10 Procedure documentation</a></H2>
+<H2><a name="Guile_nn17">24.9 Procedure documentation</a></H2>
 
 
 <p>If invoked with the command-line option <code>-procdoc
@@ -522,7 +520,7 @@ like this:
 typemap argument <code>doc</code>. See <code>Lib/guile/typemaps.i</code> for
 details.
 
-<H2><a name="Guile_nn18">24.11 Procedures with setters</a></H2>
+<H2><a name="Guile_nn18">24.10 Procedures with setters</a></H2>
 
 
 <p>For global variables, SWIG creates a single wrapper procedure
@@ -550,7 +548,7 @@ struct members, the procedures <code>(<var>struct</var>-<var>member</var>-get
 pointer)</code> and <code>(<var>struct-member</var>-set pointer
 value)</code> are <em>not</em> generated.
 
-<H2><a name="Guile_nn19">24.12 GOOPS Proxy Classes</a></H2>
+<H2><a name="Guile_nn19">24.11 GOOPS Proxy Classes</a></H2>
 
 
 <p>SWIG can also generate classes and generic functions for use with
@@ -696,7 +694,7 @@ Notice that &lt;Foo&gt; is used before it is defined.  The fix is to just put th
 <code>%import "foo.h"</code> before the <code>%inline</code> block.
 </p>
 
-<H3><a name="Guile_nn20">24.12.1 Naming Issues</a></H3>
+<H3><a name="Guile_nn20">24.11.1 Naming Issues</a></H3>
 
 
 <p>As you can see in the example above, there are potential naming conflicts.  The default exported
@@ -733,7 +731,7 @@ guile-modules.  For example,</p>
 (use-modules ((Test) #:renamer (symbol-prefix-proc 'goops:)))
 </pre></div>
 
-<H3><a name="Guile_nn21">24.12.2 Linking</a></H3>
+<H3><a name="Guile_nn21">24.11.2 Linking</a></H3>
 
 
 <p>The guile-modules generated above all need to be linked together.  GOOPS support requires

--- a/Doc/Manual/Guile.html
+++ b/Doc/Manual/Guile.html
@@ -30,6 +30,7 @@
 <li><a href="#Guile_nn14">Smobs</a>
 <li><a href="#Guile_nn15">Garbage Collection</a>
 </ul>
+<li><a href="#Guile_nn12">Native Guile pointers</a>
 <li><a href="#Guile_nn16">Exception Handling</a>
 <li><a href="#Guile_nn17">Procedure documentation</a>
 <li><a href="#Guile_nn18">Procedures with setters</a>
@@ -453,7 +454,14 @@ is exactly like described in <a href="Customization.html#Customization_ownership
 Object ownership and %newobject</a> in the SWIG manual.  All typemaps use an $owner var, and
 the guile module replaces $owner with 0 or 1 depending on feature:new.</p>
 
-<H2><a name="Guile_nn16">24.8 Exception Handling</a></H2>
+<H2><a name="Guile_nn12">24.8 Native Guile pointers</a></H2>
+
+
+<p>
+In addition to SWIG smob pointers, <a href="https://www.gnu.org/software/guile/manual/html_node/Foreign-Pointers.html">Guile's native pointer type</a> are accepted as arguments to wrapped SWIG functions. This can be useful for passing <a href="https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html#">pointers to bytevector data</a> to native functions.
+</p>
+
+<H2><a name="Guile_nn16">24.9 Exception Handling</a></H2>
 
 
 <p>
@@ -479,7 +487,7 @@ mapping:
 The default when not specified here is to use "swig-error".
 See Lib/exception.i for details.
 
-<H2><a name="Guile_nn17">24.9 Procedure documentation</a></H2>
+<H2><a name="Guile_nn17">24.10 Procedure documentation</a></H2>
 
 
 <p>If invoked with the command-line option <code>-procdoc
@@ -514,7 +522,7 @@ like this:
 typemap argument <code>doc</code>. See <code>Lib/guile/typemaps.i</code> for
 details.
 
-<H2><a name="Guile_nn18">24.10 Procedures with setters</a></H2>
+<H2><a name="Guile_nn18">24.11 Procedures with setters</a></H2>
 
 
 <p>For global variables, SWIG creates a single wrapper procedure
@@ -542,7 +550,7 @@ struct members, the procedures <code>(<var>struct</var>-<var>member</var>-get
 pointer)</code> and <code>(<var>struct-member</var>-set pointer
 value)</code> are <em>not</em> generated.
 
-<H2><a name="Guile_nn19">24.11 GOOPS Proxy Classes</a></H2>
+<H2><a name="Guile_nn19">24.12 GOOPS Proxy Classes</a></H2>
 
 
 <p>SWIG can also generate classes and generic functions for use with
@@ -688,7 +696,7 @@ Notice that &lt;Foo&gt; is used before it is defined.  The fix is to just put th
 <code>%import "foo.h"</code> before the <code>%inline</code> block.
 </p>
 
-<H3><a name="Guile_nn20">24.11.1 Naming Issues</a></H3>
+<H3><a name="Guile_nn20">24.12.1 Naming Issues</a></H3>
 
 
 <p>As you can see in the example above, there are potential naming conflicts.  The default exported
@@ -725,7 +733,7 @@ guile-modules.  For example,</p>
 (use-modules ((Test) #:renamer (symbol-prefix-proc 'goops:)))
 </pre></div>
 
-<H3><a name="Guile_nn21">24.11.2 Linking</a></H3>
+<H3><a name="Guile_nn21">24.12.2 Linking</a></H3>
 
 
 <p>The guile-modules generated above all need to be linked together.  GOOPS support requires

--- a/Doc/Manual/Guile.html
+++ b/Doc/Manual/Guile.html
@@ -30,14 +30,14 @@
 <li><a href="#Guile_nn14">Smobs</a>
 <li><a href="#Guile_nn15">Garbage Collection</a>
 </ul>
-<li><a href="#Guile_nn12">Native Guile pointers</a>
-<li><a href="#Guile_nn16">Exception Handling</a>
-<li><a href="#Guile_nn17">Procedure documentation</a>
-<li><a href="#Guile_nn18">Procedures with setters</a>
-<li><a href="#Guile_nn19">GOOPS Proxy Classes</a>
+<li><a href="#Guile_nn16">Native Guile pointers</a>
+<li><a href="#Guile_nn17">Exception Handling</a>
+<li><a href="#Guile_nn18">Procedure documentation</a>
+<li><a href="#Guile_nn19">Procedures with setters</a>
+<li><a href="#Guile_nn20">GOOPS Proxy Classes</a>
 <ul>
-<li><a href="#Guile_nn20">Naming Issues</a>
-<li><a href="#Guile_nn21">Linking</a>
+<li><a href="#Guile_nn21">Naming Issues</a>
+<li><a href="#Guile_nn22">Linking</a>
 </ul>
 </ul>
 </div>
@@ -454,14 +454,14 @@ is exactly like described in <a href="Customization.html#Customization_ownership
 Object ownership and %newobject</a> in the SWIG manual.  All typemaps use an $owner var, and
 the guile module replaces $owner with 0 or 1 depending on feature:new.</p>
 
-<H2><a name="Guile_nn12">24.8 Native Guile pointers</a></H2>
+<H2><a name="Guile_nn16">24.8 Native Guile pointers</a></H2>
 
 
 <p>
 In addition to SWIG smob pointers, <a href="https://www.gnu.org/software/guile/manual/html_node/Foreign-Pointers.html">Guile's native pointer type</a> are accepted as arguments to wrapped SWIG functions. This can be useful for passing <a href="https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html#">pointers to bytevector data</a> to wrapped functions.
 </p>
 
-<H2><a name="Guile_nn16">24.9 Exception Handling</a></H2>
+<H2><a name="Guile_nn17">24.9 Exception Handling</a></H2>
 
 
 <p>
@@ -487,7 +487,7 @@ mapping:
 The default when not specified here is to use "swig-error".
 See Lib/exception.i for details.
 
-<H2><a name="Guile_nn17">24.10 Procedure documentation</a></H2>
+<H2><a name="Guile_nn18">24.10 Procedure documentation</a></H2>
 
 
 <p>If invoked with the command-line option <code>-procdoc
@@ -522,7 +522,7 @@ like this:
 typemap argument <code>doc</code>. See <code>Lib/guile/typemaps.i</code> for
 details.
 
-<H2><a name="Guile_nn18">24.11 Procedures with setters</a></H2>
+<H2><a name="Guile_nn19">24.11 Procedures with setters</a></H2>
 
 
 <p>For global variables, SWIG creates a single wrapper procedure
@@ -550,7 +550,7 @@ struct members, the procedures <code>(<var>struct</var>-<var>member</var>-get
 pointer)</code> and <code>(<var>struct-member</var>-set pointer
 value)</code> are <em>not</em> generated.
 
-<H2><a name="Guile_nn19">24.12 GOOPS Proxy Classes</a></H2>
+<H2><a name="Guile_nn20">24.12 GOOPS Proxy Classes</a></H2>
 
 
 <p>SWIG can also generate classes and generic functions for use with
@@ -696,7 +696,7 @@ Notice that &lt;Foo&gt; is used before it is defined.  The fix is to just put th
 <code>%import "foo.h"</code> before the <code>%inline</code> block.
 </p>
 
-<H3><a name="Guile_nn20">24.12.1 Naming Issues</a></H3>
+<H3><a name="Guile_nn21">24.12.1 Naming Issues</a></H3>
 
 
 <p>As you can see in the example above, there are potential naming conflicts.  The default exported
@@ -733,7 +733,7 @@ guile-modules.  For example,</p>
 (use-modules ((Test) #:renamer (symbol-prefix-proc 'goops:)))
 </pre></div>
 
-<H3><a name="Guile_nn21">24.12.2 Linking</a></H3>
+<H3><a name="Guile_nn22">24.12.2 Linking</a></H3>
 
 
 <p>The guile-modules generated above all need to be linked together.  GOOPS support requires

--- a/Examples/test-suite/guile/argout_runme.scm
+++ b/Examples/test-suite/guile/argout_runme.scm
@@ -1,0 +1,16 @@
+;; tests support for native guile pointers
+;; https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html
+(dynamic-call "scm_init_argout_module" (dynamic-link "./libargout"))
+
+(use-modules (srfi srfi-4) (system foreign))
+
+(define initial-value 42)
+(define some-s32-data (s32vector initial-value))
+
+(if (not (= (incp (bytevector->pointer some-s32-data)) initial-value))
+    (error "Didn't read s32 data" initial-value some-s32-data))
+
+(if (not (= (s32vector-ref some-s32-data 0) (+ initial-value 1)))
+    (error "Failed to increment s32 data" some-s32-data))
+
+(exit 0)

--- a/Examples/test-suite/guile/argout_runme.scm
+++ b/Examples/test-suite/guile/argout_runme.scm
@@ -7,7 +7,7 @@
 
 ;; if we're running guile 1.8, then bytevector->pointer won't exist and this
 ;; test is useless
-(if (module-variable (resolve-module '(system foreign)) 'bytevector->pointer)
+(if (>= (string->number (major-version)) 2)
     (begin
       (use-modules (srfi srfi-4) (system foreign))
 

--- a/Examples/test-suite/guile/argout_runme.scm
+++ b/Examples/test-suite/guile/argout_runme.scm
@@ -2,15 +2,19 @@
 ;; https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html
 (dynamic-call "scm_init_argout_module" (dynamic-link "./libargout"))
 
-(use-modules (srfi srfi-4) (system foreign))
-
 (define initial-value 42)
 (define some-s32-data (s32vector initial-value))
 
-(if (not (= (incp (bytevector->pointer some-s32-data)) initial-value))
-    (error "Didn't read s32 data" initial-value some-s32-data))
+;; if we're running guile 1.8, then bytevector->pointer won't exist and this
+;; test is useless
+(if (module-variable (resolve-module '(system foreign)) 'bytevector->pointer)
+    (begin
+      (use-modules (srfi srfi-4) (system foreign))
 
-(if (not (= (s32vector-ref some-s32-data 0) (+ initial-value 1)))
-    (error "Failed to increment s32 data" some-s32-data))
+      (if (not (= (incp (bytevector->pointer some-s32-data)) initial-value))
+          (error "Didn't read s32 data" initial-value some-s32-data))
+
+      (if (not (= (s32vector-ref some-s32-data 0) (+ initial-value 1)))
+          (error "Failed to increment s32 data" some-s32-data))))
 
 (exit 0)

--- a/Lib/guile/guile_scm_run.swg
+++ b/Lib/guile/guile_scm_run.swg
@@ -176,7 +176,7 @@ SWIG_Guile_ConvertPtr(SCM s, void **result, swig_type_info *type, int flags)
   if (SCM_NULLP(smob)) {
     *result = NULL;
     return SWIG_OK;
-  } if (SCM_POINTER_P(s)) {
+  } else if (SCM_POINTER_P(s)) {
     *result = SCM_POINTER_VALUE(s);
     return SWIG_OK;
   } else if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {

--- a/Lib/guile/guile_scm_run.swg
+++ b/Lib/guile/guile_scm_run.swg
@@ -176,11 +176,11 @@ SWIG_Guile_ConvertPtr(SCM s, void **result, swig_type_info *type, int flags)
   if (SCM_NULLP(smob)) {
     *result = NULL;
     return SWIG_OK;
-#if defined(SCM_POINTER_P) && defined(SCM_POINTER_VALUE)
+#if SCM_MAJOR_VERSION >= 2
   } else if (SCM_POINTER_P(s)) {
     *result = SCM_POINTER_VALUE(s);
     return SWIG_OK;
-#endif /* if defined(SCM_POINTER_P) && defined(SCM_POINTER_VALUE) */
+#endif /* if SCM_MAJOR_VERSION >= 2 */
   } else if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {
     /* we do not accept smobs representing destroyed pointers */
     from = (swig_type_info *) SCM_CELL_WORD_2(smob);

--- a/Lib/guile/guile_scm_run.swg
+++ b/Lib/guile/guile_scm_run.swg
@@ -176,6 +176,9 @@ SWIG_Guile_ConvertPtr(SCM s, void **result, swig_type_info *type, int flags)
   if (SCM_NULLP(smob)) {
     *result = NULL;
     return SWIG_OK;
+  } if (SCM_POINTER_P(s)) {
+    *result = SCM_POINTER_VALUE(s);
+    return SWIG_OK;
   } else if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {
     /* we do not accept smobs representing destroyed pointers */
     from = (swig_type_info *) SCM_CELL_WORD_2(smob);

--- a/Lib/guile/guile_scm_run.swg
+++ b/Lib/guile/guile_scm_run.swg
@@ -176,9 +176,11 @@ SWIG_Guile_ConvertPtr(SCM s, void **result, swig_type_info *type, int flags)
   if (SCM_NULLP(smob)) {
     *result = NULL;
     return SWIG_OK;
+#if defined(SCM_POINTER_P) && defined(SCM_POINTER_VALUE)
   } else if (SCM_POINTER_P(s)) {
     *result = SCM_POINTER_VALUE(s);
     return SWIG_OK;
+#endif /* if defined(SCM_POINTER_P) && defined(SCM_POINTER_VALUE) */
   } else if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {
     /* we do not accept smobs representing destroyed pointers */
     from = (swig_type_info *) SCM_CELL_WORD_2(smob);


### PR DESCRIPTION
I believe the guile exit currently represents swig pointers as [tagged smobs](https://www.gnu.org/software/guile/manual/html_node/Smobs.html). Guile also has a [native pointer type](https://www.gnu.org/software/guile/manual/html_node/Void-Pointers-and-Byte-Access.html#Void-Pointers-and-Byte-Access) that works with strings, numeric arrays and the low-level FFI.

The guile exit only accepts swig pointers right now. This patch changes it to accept native pointers as well.
