### PR TITLE
Writing R extensions says:

### DIFF
--- a/Lib/r/rrun.swg
+++ b/Lib/r/rrun.swg
@@ -1,15 +1,4 @@
 
-#ifdef __cplusplus
-#include <exception>
-extern "C" {
-#endif
-
-/* for raw pointer */
-#define SWIG_ConvertPtr(obj, pptr, type, flags)         SWIG_R_ConvertPtr(obj, pptr, type, flags)
-#define SWIG_ConvertPtrAndOwn(obj,pptr,type,flags,own)  SWIG_R_ConvertPtr(obj, pptr, type, flags)
-#define SWIG_NewPointerObj(ptr, type, flags)            SWIG_R_NewPointerObj(ptr, type, flags)
-
-
 /* Remove global namespace pollution */
 #if !defined(SWIG_NO_R_NO_REMAP)
 # define R_NO_REMAP
@@ -20,6 +9,17 @@ extern "C" {
 
 #include <Rdefines.h>
 #include <Rversion.h>
+
+#ifdef __cplusplus
+#include <exception>
+extern "C" {
+#endif
+
+/* for raw pointer */
+#define SWIG_ConvertPtr(obj, pptr, type, flags)         SWIG_R_ConvertPtr(obj, pptr, type, flags)
+#define SWIG_ConvertPtrAndOwn(obj,pptr,type,flags,own)  SWIG_R_ConvertPtr(obj, pptr, type, flags)
+#define SWIG_NewPointerObj(ptr, type, flags)            SWIG_R_NewPointerObj(ptr, type, flags)
+
 #include <stdlib.h>
 #include <assert.h>
 


### PR DESCRIPTION
The "Writing R extensions" manual says:

"Most R header files can be included within C++ programs but they should
not be included within an extern "C" block (as they include system headers)."

This has started to cause compilation errors for swig generated R code under OSX.

This patch moves the Rdefines.h and Rversion.h outside the extern block.

I have tested with R 2.15.3 and 3.3.1 and the swig test suite passes 505 tests in both cases