### PR TITLE
Add anon namespace.

### DIFF
--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -4638,6 +4638,7 @@ public:
 
     directorDeclaration(n);
 
+    Printf(f_directors_h, "namespace {\n");
     Printf(f_directors_h, "%s {\n", Getattr(n, "director:decl"));
     Printf(f_directors_h, "\npublic:\n");
     Printf(f_directors_h, "    void swig_connect_director(JNIEnv *jenv, jobject jself, jclass jcls, bool swig_mem_own, bool weak_global);\n");
@@ -4788,7 +4789,8 @@ public:
       Printf(f_directors_h, "    }\n");
     }
 
-    Printf(f_directors_h, "};\n\n");
+    Printf(f_directors_h, "};\n");
+    Printf(f_directors_h, "}  // namespace\n\n");
     Printf(w->code, "}\n");
     Printf(w->code, "}\n");
 


### PR DESCRIPTION
Wrap SwigDirector_* classes generated for Java in an anonymous namespace.

When two C++ classes live in different namespaces, and are mapped to Java classes in different packages, but otherwise have the same name, previously the SwigDirector_* classes would collide. By wrapping them in an anonymous namespace, we allow them to peacefully coexist so long as they're in different swig invocations.