### PR TITLE
[Python] Fix import in frozen app for Python 2.6

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -5,6 +5,10 @@ See the RELEASENOTES file for a summary of changes in each release.
 Version 3.0.11 (in progress)
 ============================
 
+2016-09-09: olly
+            [Python] Fix import handling for Python 2.6 to work in a frozen
+            application.  Fixes #145, reported by Thomas Kluyver.
+
 2016-09-02: smarchetto
             [Scilab] Pointers are mapped to mlist instead of tlist
             (mlist better for scilab overloading)

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -861,12 +861,13 @@ public:
       /* At here, the module may already loaded, so simply import it. */
       Printf(f_shadow, tab4 tab8 "import %s\n", module);
       Printf(f_shadow, tab4 tab8 "return %s\n", module);
-      Printv(f_shadow, tab8 "if fp is not None:\n", NULL);
-      Printv(f_shadow, tab4 tab8 "try:\n", NULL);
-      Printf(f_shadow, tab8 tab8 "_mod = imp.load_module('%s', fp, pathname, description)\n", module);
-      Printv(f_shadow, tab4 tab8, "finally:\n", NULL);
+      Printv(f_shadow, tab8 "try:\n", NULL);
+      /* imp.load_module() handles fp being None. */
+      Printf(f_shadow, tab4 tab8 "_mod = imp.load_module('%s', fp, pathname, description)\n", module);
+      Printv(f_shadow, tab8, "finally:\n", NULL);
+      Printv(f_shadow, tab4 tab8 "if fp is not None:\n", NULL);
       Printv(f_shadow, tab8 tab8, "fp.close()\n", NULL);
-      Printv(f_shadow, tab4 tab8, "return _mod\n", NULL);
+      Printv(f_shadow, tab8, "return _mod\n", NULL);
       Printf(f_shadow, tab4 "%s = swig_import_helper()\n", module);
       Printv(f_shadow, tab4, "del swig_import_helper\n", NULL);
       Printv(f_shadow, "else:\n", NULL);


### PR DESCRIPTION
Fix import handling for Python 2.6 to work in a frozen application.
Fixes #145, reported by Thomas Kluyver.