### PR TITLE
Csharp: CLS compliance - keyword rename

### DIFF
--- a/Lib/csharp/csharpkw.swg
+++ b/Lib/csharp/csharpkw.swg
@@ -2,9 +2,9 @@
 #define CSHARP_CSHARPKW_SWG_
 
 /* Warnings for C# keywords */
-#define CSHARPKW(x) %keywordwarn("'" `x` "' is a C# keyword, renaming to '_" `x` "'",rename="_%s")  `x`
+#define CSHARPKW(x) %keywordwarn("'" `x` "' is a C# keyword, renaming to '" `x` "_'",rename="%s_")  `x`
 
-#define CSHARPCLASSKW(x) %keywordwarn("'" `x` "' is a special method name used in the C# wrapper classes, class renamed to '_" `x` "'",%$isclass,rename="_%s") `x`
+#define CSHARPCLASSKW(x) %keywordwarn("'" `x` "' is a special method name used in the C# wrapper classes, class renamed to '" `x` "_'",%$isclass,rename="%s_") `x`
 
 /*
    from


### PR DESCRIPTION
Closes #532

SWIG C# can be used to wrap native libraries as common language
interface compatible assemblies.
If you want to use the assemblies with other languages like
Visual Basic these assemblies should comply to the
Common Language Specification (CLS).

Lib/csharp/csharpkw.swg defines rename rules to avoid collisions
with keywords. Unfortunately these rules prepend an underscore.
Parameters starting with underscores are not CLS compliant.

Hence the rules should be changed to append the underscore
instead of prepending it.

Tested with
make check-csharp-test-suite

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Cc: Olly Betts <olly@survex.com>