### PR TITLE
Add missing #include <cmath> for std::isfinite

### DIFF
--- a/Lib/typemaps/fragments.swg
+++ b/Lib/typemaps/fragments.swg
@@ -172,6 +172,7 @@
 # if defined(isfinite)
 #  define SWIG_isfinite(X) (isfinite(X))
 # elif defined __cplusplus && __cplusplus >= 201103L
+#  include <cmath>
 #  define SWIG_isfinite(X) (std::isfinite(X))
 # elif defined(_MSC_VER)
 #  define SWIG_isfinite(X) (_finite(X))


### PR DESCRIPTION
Using `std::isfinite()` requires `#include <cmath>`, which doesn't exist in surrounding code. This results, for instance, in build failure of [ZNC](http://znc.in/) on FreeBSD 11.x (clang 3.8, libc++):

```
modperl/ZNC.cpp:2573:9: error: no member named 'isfinite' in namespace 'std'; did you mean simply 'isfinite'?
    if (SWIG_Float_Overflow_Check(v)) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
modperl/ZNC.cpp:2561:73: note: expanded from macro 'SWIG_Float_Overflow_Check'
# define SWIG_Float_Overflow_Check(X) ((X < -FLT_MAX || X > FLT_MAX) && SWIG_isfinite(X))
                                                                        ^~~~~~~~~~~~~~~~
modperl/ZNC.cpp:2549:29: note: expanded from macro 'SWIG_isfinite'
#  define SWIG_isfinite(X) (std::isfinite(X))
                            ^~~~~
/usr/include/c++/v1/math.h:380:1: note: 'isfinite' declared here
isfinite(_A1 __lcpp_x) _NOEXCEPT
^
2 warnings and 1 error generated.
```

full log: http://beefy1.nyi.freebsd.org/data/110i386-quarterly/421620/logs/errors/znc-1.6.3.log
