### PR TITLE
cstrings.swg: fix function names inside comments

### DIFF
--- a/Lib/typemaps/cstrings.swg
+++ b/Lib/typemaps/cstrings.swg
@@ -203,7 +203,7 @@
  * This macro is used to return Character data along with a size
  * parameter.
  *
- *     %cstring_output_maxsize(Char *outx, int *max) {
+ *     %cstring_output_withsize(Char *outx, int *max) {
  *     void foo(Char *outx, int *max) {
  *         sprintf(outx,"blah blah\n");
  *         *max = strlen(outx);  
@@ -236,7 +236,7 @@
  * This macro is used to return Character data that was
  * allocated with new or malloc.
  *
- *     %cstring_output_allocated(Char **outx, free($1));
+ *     %cstring_output_allocate(Char **outx, free($1));
  *     void foo(Char **outx) {
  *         *outx = (Char *) malloc(512);
  *         sprintf(outx,"blah blah\n");
@@ -263,7 +263,7 @@
  * This macro is used to return Character data that was
  * allocated with new or malloc.
  *
- *     %cstring_output_allocated(Char **outx, int *sz, free($1));
+ *     %cstring_output_allocate_size(Char **outx, int *sz, free($1));
  *     void foo(Char **outx, int *sz) {
  *         *outx = (Char *) malloc(512);
  *         sprintf(outx,"blah blah\n");


### PR DESCRIPTION
3 typos, spotted after copy-pasting one of these lines.