### PR TITLE
[Javascript] Fix SWIG_exception() macro

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -6,6 +6,10 @@ Version 3.0.11 (in progress)
 ============================
 
 2016-09-16: olly
+            [Javascript] Fix SWIG_exception() macro to return from the current
+            function.  Fixes #789, reported by Julien Dutriaux.
+
+2016-09-16: olly
             [PHP] Fix SWIG_exception() macro to return from the current function.
             Fixes #240, reported by Sergey Seroshtan.
 

--- a/Examples/test-suite/javascript/swig_exception_runme.js
+++ b/Examples/test-suite/javascript/swig_exception_runme.js
@@ -1,0 +1,30 @@
+var swig_exception = require("swig_exception");
+
+var c = new swig_exception.Circle(10);
+var s = new swig_exception.Square(10);
+
+if (swig_exception.Shape.nshapes != 2) {
+    throw "Shape.nshapes should be 2, actually " + swig_exception.Shape.nshapes;
+}
+
+// ----- Throw exception -----
+try {
+    c.throwException();
+    throw "Exception wasn't thrown";
+} catch (e) {
+    if (e.message != "OK") {
+	throw "Exception message should be \"OK\", actually \"" + e.message + "\"";
+    }
+}
+
+// ----- Delete everything -----
+
+c = null;
+s = null;
+e = null;
+
+/* FIXME: Garbage collection needs to happen before this check will work.
+if (swig_exception.Shape.nshapes != 0) {
+    throw "Shape.nshapes should be 0, actually " + swig_exception.Shape.nshapes;
+}
+*/

--- a/Lib/javascript/jsc/javascriptcode.swg
+++ b/Lib/javascript/jsc/javascriptcode.swg
@@ -32,6 +32,7 @@ static JSObjectRef $jswrapper(JSContextRef context, JSObjectRef ctorObject,
     size_t argc, const JSValueRef argv[], JSValueRef* exception)
 {
     SWIG_exception(SWIG_ERROR, "Class $jsname can not be instantiated");
+fail:
     return 0;
 }
 %}

--- a/Lib/javascript/jsc/javascripthelpers.swg
+++ b/Lib/javascript/jsc/javascripthelpers.swg
@@ -53,7 +53,7 @@ SWIGINTERN bool JS_veto_set_variable(JSContextRef context, JSObjectRef thisObjec
     } else {
       SWIG_exception(SWIG_ERROR, msg);
     }
-    
+fail:    
     return false;
 }
 

--- a/Lib/javascript/jsc/javascriptrun.swg
+++ b/Lib/javascript/jsc/javascriptrun.swg
@@ -4,7 +4,7 @@
  * ---------------------------------------------------------------------------*/
 
 #define SWIG_Error(code, msg)     SWIG_JSC_exception(context, exception, code, msg)
-#define SWIG_exception(code, msg) SWIG_JSC_exception(context, exception, code, msg)
+#define SWIG_exception(code, msg) do { SWIG_JSC_exception(context, exception, code, msg); SWIG_fail; } while (0)
 #define SWIG_fail                 goto fail
 
 SWIGRUNTIME void SWIG_Javascript_Raise(JSContextRef context, JSValueRef *exception, const char* type) {

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -36,6 +36,7 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
   SWIG_exception(SWIG_ERROR, "Class $jsname can not be instantiated");
+fail:
   SWIGV8_RETURN(SWIGV8_UNDEFINED());
 }
 %}

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -83,6 +83,7 @@ SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::String> property, v8::Local<
     } else {
       SWIG_exception(SWIG_ERROR, msg);
     }
+fail: ;
 }
 
 %} // v8_helper_functions

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -97,7 +97,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
  * ---------------------------------------------------------------------------*/
 
 #define SWIG_Error(code, msg)     SWIGV8_ErrorHandler.error(code, msg)
-#define SWIG_exception(code, msg) SWIGV8_ErrorHandler.error(code, msg)
+#define SWIG_exception(code, msg) do { SWIGV8_ErrorHandler.error(code, msg); SWIG_fail; } while (0)
 #define SWIG_fail                 goto fail
 #define SWIGV8_OVERLOAD false
 


### PR DESCRIPTION
Fix SWIG_exception() macro to return from the current function.
Fixes #789, reported by Julien Dutriaux.