### PR TITLE
fix warnings from compiling generated python wrappers

### DIFF
--- a/Lib/cpointer.i
+++ b/Lib/cpointer.i
@@ -114,7 +114,7 @@ static NAME * frompointer(TYPE *t) {
 
 %define %pointer_functions(TYPE,NAME)
 %{
-static TYPE *new_##NAME() { %}
+static TYPE *new_##NAME(void) { %}
 #ifdef __cplusplus
 %{  return new TYPE(); %}
 #else
@@ -149,7 +149,7 @@ static TYPE NAME ##_value(TYPE *obj) {
 }
 %}
 
-TYPE *new_##NAME();
+TYPE *new_##NAME(void);
 TYPE *copy_##NAME(TYPE value);
 void  delete_##NAME(TYPE *obj);
 void  NAME##_assign(TYPE *obj, TYPE value);

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1337,7 +1337,7 @@ SWIG_Python_ConvertPacked(PyObject *obj, void *ptr, size_t sz, swig_type_info *t
 */
 
 SWIGRUNTIME PyObject* 
-SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
+SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this_value)
 {
 #if (PY_VERSION_HEX >= 0x02020000)
   PyObject *inst = 0;
@@ -1352,25 +1352,25 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
 	if (dict == NULL) {
 	  dict = PyDict_New();
 	  *dictptr = dict;
-	  PyDict_SetItem(dict, SWIG_This(), swig_this);
+	  PyDict_SetItem(dict, SWIG_This(), swig_this_value);
 	}
       }
 #else
       PyObject *key = SWIG_This();
-      PyObject_SetAttr(inst, key, swig_this);
+      PyObject_SetAttr(inst, key, swig_this_value);
 #endif
     }
   } else {
 #if PY_VERSION_HEX >= 0x03000000
     inst = ((PyTypeObject*) data->newargs)->tp_new((PyTypeObject*) data->newargs, Py_None, Py_None);
     if (inst) {
-      PyObject_SetAttr(inst, SWIG_This(), swig_this);
+      PyObject_SetAttr(inst, SWIG_This(), swig_this_value);
       Py_TYPE(inst)->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
     }
 #else
     PyObject *dict = PyDict_New();
     if (dict) {
-      PyDict_SetItem(dict, SWIG_This(), swig_this);
+      PyDict_SetItem(dict, SWIG_This(), swig_this_value);
       inst = PyInstance_NewRaw(data->newargs, dict);
       Py_DECREF(dict);
     }
@@ -1382,7 +1382,7 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
   PyObject *inst = 0;
   PyObject *dict = PyDict_New();
   if (dict) {
-    PyDict_SetItem(dict, SWIG_This(), swig_this);
+    PyDict_SetItem(dict, SWIG_This(), swig_this_value);
     inst = PyInstance_NewRaw(data->newargs, dict);
     Py_DECREF(dict);
   }
@@ -1405,14 +1405,14 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
 #ifdef Py_TPFLAGS_GC
   PyObject_GC_Init(inst);
 #endif
-  PyDict_SetItem(inst->in_dict, SWIG_This(), swig_this);
+  PyDict_SetItem(inst->in_dict, SWIG_This(), swig_this_value);
   return (PyObject *) inst;
 #endif
 #endif
 }
 
 SWIGRUNTIME void
-SWIG_Python_SetSwigThis(PyObject *inst, PyObject *swig_this)
+SWIG_Python_SetSwigThis(PyObject *inst, PyObject *swig_this_value)
 {
  PyObject *dict;
 #if (PY_VERSION_HEX >= 0x02020000) && !defined(SWIG_PYTHON_SLOW_GETSET_THIS)
@@ -1423,12 +1423,12 @@ SWIG_Python_SetSwigThis(PyObject *inst, PyObject *swig_this)
      dict = PyDict_New();
      *dictptr = dict;
    }
-   PyDict_SetItem(dict, SWIG_This(), swig_this);
+   PyDict_SetItem(dict, SWIG_This(), swig_this_value);
    return;
  }
 #endif
  dict = PyObject_GetAttrString(inst, (char*)"__dict__");
- PyDict_SetItem(dict, SWIG_This(), swig_this);
+ PyDict_SetItem(dict, SWIG_This(), swig_this_value);
  Py_DECREF(dict);
 } 
 

--- a/Lib/typemaps/cpointer.swg
+++ b/Lib/typemaps/cpointer.swg
@@ -105,7 +105,7 @@ typedef struct {
 
 %define %pointer_functions(TYPE,NAME)
 %{
-  static TYPE *new_##NAME() { 
+  static TYPE *new_##NAME(void) { 
     return %new_instance(TYPE);
   }
   
@@ -126,7 +126,7 @@ typedef struct {
   }
 %}
 
-TYPE *new_##NAME();
+TYPE *new_##NAME(void);
 TYPE *copy_##NAME(TYPE value);
 void  delete_##NAME(TYPE *obj);
 void  NAME##_assign(TYPE *obj, TYPE value);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2522,6 +2522,9 @@ public:
 
     Printv(f->def, linkage, builtin_ctor ? "int " : "PyObject *", wname, "(PyObject *self, PyObject *args) {", NIL);
 
+    /* Avoid warning if the self parameter is not used.  */
+    Append(f->code, "(void) self;\n");
+
     Wrapper_add_local(f, "argc", "Py_ssize_t argc");
     Printf(tmp, "PyObject *argv[%d] = {0}", maxargs + 1);
     Wrapper_add_local(f, "argv", tmp);
@@ -2746,6 +2749,12 @@ public:
       }
       Printv(f->def, linkage, wrap_return, wname, "(PyObject *", self_param, ", PyObject *args, PyObject *kwargs) {", NIL);
     }
+
+    /* Avoid warning if the self parameter is not used.  */
+    Append(f->code, "(void) ");
+    Append(f->code, self_param);
+    Append(f->code, ";\n");
+
     if (!builtin || !in_class || tuple_arguments > 0) {
       if (!allow_kwargs) {
 	Append(parse_args, "    if (!PyArg_ParseTuple(args,(char *)\"");

--- a/Tools/testflags.py
+++ b/Tools/testflags.py
@@ -32,7 +32,7 @@ def get_cflags(language, std, compiler):
 def get_cxxflags(language, std, compiler):
     if std == None or len(std) == 0:
         std = "c++98"
-    cxx_common = "-fdiagnostics-show-option -std=" + std + " -Wno-long-long -Wreturn-type -Wmissing-field-initializers -Wshadow -Wstrict-prototypes"
+    cxx_common = "-fdiagnostics-show-option -std=" + std + " -Wno-long-long -Wreturn-type -Wmissing-field-initializers -Wshadow"
     cxxflags = {
         "csharp":"-Werror " + cxx_common,
              "d":"-Werror " + cxx_common,

--- a/Tools/testflags.py
+++ b/Tools/testflags.py
@@ -3,7 +3,7 @@
 def get_cflags(language, std, compiler):
     if std == None or len(std) == 0:
         std = "gnu89"
-    c_common = "-fdiagnostics-show-option -std=" + std + " -Wno-long-long -Wreturn-type -Wdeclaration-after-statement -Wmissing-field-initializers"
+    c_common = "-fdiagnostics-show-option -std=" + std + " -Wno-long-long -Wreturn-type -Wdeclaration-after-statement -Wmissing-field-initializers -Wshadow -Wstrict-prototypes"
     cflags = {
         "csharp":"-Werror " + c_common,
              "d":"-Werror " + c_common,
@@ -32,7 +32,7 @@ def get_cflags(language, std, compiler):
 def get_cxxflags(language, std, compiler):
     if std == None or len(std) == 0:
         std = "c++98"
-    cxx_common = "-fdiagnostics-show-option -std=" + std + " -Wno-long-long -Wreturn-type -Wmissing-field-initializers"
+    cxx_common = "-fdiagnostics-show-option -std=" + std + " -Wno-long-long -Wreturn-type -Wmissing-field-initializers -Wshadow -Wstrict-prototypes"
     cxxflags = {
         "csharp":"-Werror " + cxx_common,
              "d":"-Werror " + cxx_common,


### PR DESCRIPTION
I'm trying to reduce the number of warnings that are emitted when compiling the SWIG-generated wrapper code.
