### PR TITLE
Fixes #230: shared_ptr breaks with C++ class inheritance by making swigCMemOwn private

### DIFF
--- a/Lib/java/boost_shared_ptr.i
+++ b/Lib/java/boost_shared_ptr.i
@@ -146,7 +146,7 @@
 // Base proxy classes
 %typemap(javabody) TYPE %{
   private transient long swigCPtr;
-  private transient boolean swigCMemOwn;
+  protected transient boolean swigCMemOwn;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;


### PR DESCRIPTION
Fixes this issue: https://github.com/swig/swig/issues/230