### PR TITLE
Error thrown from overloaded constructor now throws the specified error.

### DIFF
--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -106,11 +106,15 @@ fail:
     self = $jswrapper(args, errorHandler);
     if(errorHandler.err.IsEmpty()) {
       SWIGV8_ESCAPE(self);
+    } else {
+      goto fail;
     }
 #else
     $jswrapper(args, errorHandler);
     if(errorHandler.err.IsEmpty()) {
       return;
+    } else {
+      goto fail;
     }
 #endif
   }


### PR DESCRIPTION
When an error was thrown from an overloaded constructor, SWIGV8_ESCAPE
would not get called, which is correct. However, the program would then
carry on and get the error message overridden by a general error message
"Illegal arguments for construction of...". Adding an "else goto fail"
skips this line and returns the error that was thrown.