### PR TITLE
Corrected generation of "set" methods for R.

### DIFF
--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -989,9 +989,10 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
     int klen = Len(key);
     int isSet = 0;
     if (klen > 4) {
-      ptr = &ptr[Len(key) - 4];
+      ptr = &ptr[klen - 4];
       isSet = strcmp(ptr, "_set") == 0;
     }
+
     //        OutputArrayMethod(className, el, out);        
     OutputMemberReferenceMethod(className, isSet, el, out);
     
@@ -1278,7 +1279,9 @@ void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
   if(isSet < 0) {
     int n = Len(name);
     char *ptr = Char(name);
-    isSet = Strcmp(NewString(&ptr[n-3]), "set") == 0;
+    if (n>4) {
+      isSet = Strcmp(NewString(&ptr[n-4]), "_set") == 0;
+    }
   }
   
   List *l = isSet ? class_member_set_functions : class_member_functions;
@@ -1758,7 +1761,8 @@ int R::functionWrapper(Node *n) {
     
     int n = Len(iname);
     char *ptr = Char(iname);
-    bool isSet(Strcmp(NewString(&ptr[n-3]), "set") == 0);
+    bool isSet(0);
+    if (n > 4) isSet = Strcmp(NewString(&ptr[n-4]), "_set") == 0;
     
     
     String *tmp = NewString("");

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -974,7 +974,9 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
   String *key;
   int i, n = Len(keys);
   /* Loop over all the  <Class>_set and <Class>_get entries in the table. */
-  
+  /* This function checks for names ending in _set - perhaps it should */
+  /* use attributes of some other form, as it potentially clashes with */
+  /* methods ending in _set */
   if(n && outputNamespaceInfo) {
     Printf(s_namespace, "exportClasses(");
   }
@@ -984,9 +986,12 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
     
     String *className = Getitem(el, 0);
     char *ptr = Char(key);
-    ptr = &ptr[Len(key) - 3];
-    int isSet = strcmp(ptr, "set") == 0;
-    
+    int klen = Len(key);
+    int isSet = 0;
+    if (klen > 4) {
+      ptr = &ptr[Len(key) - 4];
+      isSet = strcmp(ptr, "_set") == 0;
+    }
     //        OutputArrayMethod(className, el, out);        
     OutputMemberReferenceMethod(className, isSet, el, out);
     


### PR DESCRIPTION
The function "OutputClassMemberTable" tags methods generated
for a class for R wrapper code supporting syntax like:

WrappedClass$VarName <- value

The comments in the function indicate that it is looking for
method names ending in "_set", but in fact it was searching for
methods ending in just "set", This was resulting in class methods
ending in set (names like GetOffset, SetOffset etc) being placed
in the wrong accessor functions and thus not being available in
the normal way.

There is probably a more appropriate way to tag the _set functions
when they are being created, which is a future step. This
patch makes the behaviour conform to the original intention.