### PR TITLE
Python: Fix mixed signedness warning for std::array

### DIFF
--- a/Lib/python/std_array.i
+++ b/Lib/python/std_array.i
@@ -45,11 +45,11 @@
       Difference jj = 0;
       swig::slice_adjust(i, j, step, size, ii, jj);
 
-      if (step == 1 && ii == 0 && jj == size) {
+      if (step == 1 && ii == 0 && static_cast<typename Sequence::size_type>(jj) == size) {
         Sequence *sequence = new Sequence();
         std::copy(self->begin(), self->end(), sequence->begin());
         return sequence;
-      } else if (step == -1 && ii == (size - 1) && jj == -1) {
+      } else if (step == -1 && static_cast<typename Sequence::size_type>(ii) == (size - 1) && jj == -1) {
         Sequence *sequence = new Sequence();
         std::copy(self->rbegin(), self->rend(), sequence->begin());
         return sequence;
@@ -67,9 +67,9 @@
       Difference jj = 0;
       swig::slice_adjust(i, j, step, size, ii, jj, true);
 
-      if (step == 1 && ii == 0 && jj == size) {
+      if (step == 1 && ii == 0 && static_cast<typename Sequence::size_type>(jj) == size) {
         std::copy(is.begin(), is.end(), self->begin());
-      } else if (step == -1 && ii == (size - 1) && jj == -1) {
+      } else if (step == -1 && static_cast<typename Sequence::size_type>(ii) == (size - 1) && jj == -1) {
         std::copy(is.rbegin(), is.rend(), self->begin());
       } else {
         throw std::invalid_argument("std::array object only supports setting a slice that is the size of the array");


### PR DESCRIPTION
This fixes warnings about mixed signedness in comparisons when using the std_array.i for Python, such as

```
include/Parameter/Parameter.swigwrap_23.cxx: In instantiation of 'std::array<_Tp, _Nm>* swig::getslice(const std::array<_Tp, _Nm>*, Difference, Difference, Py_ssize_t) [with T = double; long unsigned int N = 3ul; Difference = long int; Py_ssize_t = long int]':
include/Parameter/Parameter.swigwrap_23.cxx:5269:42:   required from here
include/Parameter/Parameter.swigwrap_23.cxx:5208:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (step == 1 && ii == 0 && jj == size) {
                                   ~~~^~~~~~~
include/Parameter/Parameter.swigwrap_23.cxx:5212:35: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       } else if (step == -1 && ii == (size - 1) && jj == -1) {
                                ~~~^~~~~~~~~~~~~
include/Parameter/Parameter.swigwrap_23.cxx: In instantiation of 'void swig::setslice(std::array<_Tp, _Nm>*, Difference, Difference, Py_ssize_t, const InputSeq&) [with T = double; long unsigned int N = 3ul; Difference = long int; InputSeq = std::array<double, 3ul>; Py_ssize_t = long int]':
include/Parameter/Parameter.swigwrap_23.cxx:5272:61:   required from here
include/Parameter/Parameter.swigwrap_23.cxx:5230:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (step == 1 && ii == 0 && jj == size) {
                                   ~~~^~~~~~~
include/Parameter/Parameter.swigwrap_23.cxx:5232:35: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       } else if (step == -1 && ii == (size - 1) && jj == -1) {
                                ~~~^~~~~~~~~~~~~
```