### PR TITLE
Fix memory leak in std::pair Python binding

### DIFF
--- a/Lib/python/std_pair.i
+++ b/Lib/python/std_pair.i
@@ -68,10 +68,18 @@
 	  value_type *vp = %new_instance(std::pair<T,U>);
 	  T *pfirst = &(vp->first);
 	  int res1 = swig::asval((PyObject*)first, pfirst);
-	  if (!SWIG_IsOK(res1)) return res1;
+	  if (!SWIG_IsOK(res1))
+	  {
+	    %delete(vp);
+	    return res1;
+	  }
 	  U *psecond = &(vp->second);
 	  int res2 = swig::asval((PyObject*)second, psecond);
-	  if (!SWIG_IsOK(res2)) return res2;
+	  if (!SWIG_IsOK(res2))
+	  {
+	    %delete(vp);
+	    return res2;
+	  }
 	  *val = vp;
 	  return SWIG_AddNewMask(res1 > res2 ? res1 : res2);
 	} else {


### PR DESCRIPTION
A new instance of std::pair is created, but if there is an issue with creating the values for first or second item in the pair, the method returns without freeing memory.

This logic was enabled when I used the options -modern and -fastunpack. 