### PR TITLE
Fixed potential null pointer dereference in Python binding

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2542,7 +2542,7 @@ public:
     if (!fastunpack) {
       Wrapper_add_local(f, "ii", "Py_ssize_t ii");
       if (maxargs - (add_self ? 1 : 0) > 0)
-	Append(f->code, "if (!PyTuple_Check(args)) SWIG_fail;\n");
+	Append(f->code, "if (args && !PyTuple_Check(args)) SWIG_fail;\n");
       Append(f->code, "argc = args ? PyObject_Length(args) : 0;\n");
       if (add_self)
 	Append(f->code, "argv[0] = self;\n");


### PR DESCRIPTION
There is no check as to whether args is null. 

Right below this line, a check is performed.
This check is also performed on line 2932.