### PR TITLE
Renamed all operators beginning with underscore.

### DIFF
--- a/Examples/r/class/example.cxx
+++ b/Examples/r/class/example.cxx
@@ -19,8 +19,35 @@ double Circle::perimeter() {
   return 2*M_PI*radius;
 }
 
+Circle::Circle(double xx, double yy, double rr)
+  : radius(rr)
+{
+  x = xx;
+  y = yy;
+}
+
+bool Circle::operator==(const Circle & other)
+{
+  return x == other.x && y == other.y && radius == other.radius;
+}
+
+bool Circle::operator!=(const Circle & other)
+{
+  return !operator==(other);
+}
+
 double Square::area() {
   return width*width;
+}
+
+bool Square::operator==(const Square & other)
+{
+  return x == other.x && y == other.y && width == other.width;
+}
+
+bool Square::operator!=(const Square & other)
+{
+  return !operator==(other);
 }
 
 double Square::perimeter() {

--- a/Examples/r/class/example.h
+++ b/Examples/r/class/example.h
@@ -20,8 +20,12 @@ private:
   double radius;
 public:
   Circle(double r) : radius(r) { }
+  Circle(double xx, double yy, double rr);
   virtual double area();
   virtual double perimeter();
+
+  bool operator==(const Circle & other);
+  bool operator!=(const Circle & other);
 };
 
 class Square : public Shape {
@@ -31,4 +35,7 @@ public:
   Square(double w) : width(w) { }
   virtual double area();
   virtual double perimeter();
+
+  bool operator==(const Square & other);
+  bool operator!=(const Square & other);
 };

--- a/Examples/r/class/runme.R
+++ b/Examples/r/class/runme.R
@@ -31,6 +31,14 @@ print("Here is their current position:")
 sprintf("    Circle = (%f, %f)", circle$x,circle$y)
 sprintf("    Square = (%f, %f)", square$x,square$y)
 
+c2 <- Circle(1, 5, 15)
+c1 <- circle
+c1$move(1, 5)
+print(Circle_MemberEq(c1, c2))
+print(Circle_MemberNotEq(c1, c2))
+
+print(c1$MemberEq(c2))
+
 # ----- Call some methods -----
 
 print ("Here are some properties of the shapes:")

--- a/Lib/r/ropers.swg
+++ b/Lib/r/ropers.swg
@@ -1,42 +1,31 @@
 #ifdef __cplusplus
 
-// These are auto-supported by the Perl-module
-%rename(__plusplus__) *::operator++;
-%rename(__minmin__)   *::operator--;
-%rename(__add__)      *::operator+;
-%rename(__sub__)      *::operator-;
-%rename(__neg__)      *::operator-();
-%rename(__neg__)      *::operator-() const;
-%rename(__mul__)      *::operator*;
-%rename(__div__)      *::operator/;
-%rename(__eq__)       *::operator==;
-%rename(__ne__)       *::operator!=;
-%rename(__mod__)      *::operator%;
-%rename(__gt__)       *::operator>;
-%rename(__lt__)       *::operator<;
-%rename(__not__)      *::operator!;
-
-// These are renamed, but no 'use overload...' is added
-%rename(__lshift__)   *::operator<<;
-%rename(__rshift__)   *::operator>>;
-%rename(__and__)      *::operator&;
-%rename(__or__)       *::operator|;
-%rename(__xor__)      *::operator^;
-%rename(__invert__)   *::operator~;
-%rename(__le__)       *::operator<=;
-%rename(__ge__)       *::operator>=;
-%rename(__call__)     *::operator();
-%rename(__getitem__)  *::operator[];
-
-%rename(__seteq__)    *::operator=;
-
-
-%rename(__land__)       operator&&;
-%rename(__lor__)        operator||;
-%rename(__plusplus__)   *::operator++;
-%rename(__minusminus__) *::operator--;
-%rename(__arrowstar__)  *::operator->*;
-%rename(__index__)      *::operator[];
+%rename(MemberPlusPlus)     *::operator++;
+%rename(MemberMinMin)       *::operator--;
+%rename(MemberAdd)          *::operator+;
+%rename(MemberSub)          *::operator-;
+%rename(MemberNeg)          *::operator-();
+%rename(MemberNegConst)     *::operator-() const;
+%rename(MemberMul)          *::operator*;
+%rename(MemberDiv)          *::operator/;
+%rename(MemberEq)           *::operator==;
+%rename(MemberNotEq)        *::operator!=;
+%rename(MemberMod)          *::operator%;
+%rename(MemberGreater)      *::operator>;
+%rename(MemberLess)         *::operator<;
+%rename(MemberNot)          *::operator!;
+%rename(MemberLShift)       *::operator<<;
+%rename(MemberRShift)       *::operator>>;
+%rename(MemberAnd)          *::operator&;
+%rename(MemberOr)           *::operator|;
+%rename(MemberXor)          *::operator^;
+%rename(MemberInvert)       *::operator~;
+%rename(MemberLessOrEq)     *::operator<=;
+%rename(MemberGreaterOrEq)  *::operator>=;
+%rename(MemberCall)         *::operator();
+%rename(MemberGetItem)      *::operator[];
+%rename(MemberAssign)       *::operator=;
+%rename(MemberArrowStar)    *::operator->*;
 
 %rename(Equal) operator =;
 %rename(PlusEqual) operator +=;
@@ -65,6 +54,5 @@
 %rename(PlusPlusPostfix) operator++(int);
 %rename(MinusMinusPrefix) operator--();
 %rename(MinusMinusPostfix) operator--(int);
-
 
 #endif


### PR DESCRIPTION
Hello,

In R, identifier cannot start with an underscore. I renamed the operators.

FYI: This is my first time looking into swig, so be extra careful with the pull request - I am not sure how to verify the fix further.