### PR TITLE
Remove inheritance from std::unary_function and std::binary_function,

### DIFF
--- a/Lib/octave/octcontainer.swg
+++ b/Lib/octave/octcontainer.swg
@@ -68,7 +68,7 @@ namespace swig {
 
 namespace std {
   template <>
-  struct less <octave_value>: public binary_function<octave_value, octave_value, bool>
+  struct less <octave_value>
   {
     bool
     operator()(const octave_value& v, const octave_value& w) const

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -108,7 +108,7 @@ namespace swig {
 
 namespace std {
   template <>
-  struct less <PyObject *>: public binary_function<PyObject *, PyObject *, bool>
+  struct less <PyObject *>
   {
     bool
     operator()(PyObject * v, PyObject *w) const
@@ -133,7 +133,7 @@ namespace std {
   };
 
   template <>
-  struct less <swig::SwigPtr_PyObject>: public binary_function<swig::SwigPtr_PyObject, swig::SwigPtr_PyObject, bool>
+  struct less <swig::SwigPtr_PyObject>
   {
     bool
     operator()(const swig::SwigPtr_PyObject& v, const swig::SwigPtr_PyObject& w) const
@@ -143,7 +143,7 @@ namespace std {
   };
 
   template <>
-  struct less <swig::SwigVar_PyObject>: public binary_function<swig::SwigVar_PyObject, swig::SwigVar_PyObject, bool>
+  struct less <swig::SwigVar_PyObject>
   {
     bool
     operator()(const swig::SwigVar_PyObject& v, const swig::SwigVar_PyObject& w) const

--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -38,7 +38,7 @@
 
 namespace swig {
   template < class T >
-  struct yield : public std::unary_function< T, bool >
+  struct yield
   {
     bool
     operator()( const T& v ) const

--- a/Lib/ruby/rubystdfunctors.swg
+++ b/Lib/ruby/rubystdfunctors.swg
@@ -90,7 +90,7 @@ namespace swig {
   static ID call_id = rb_intern("call");
 
   template <class _T = GC_VALUE, class _DefaultFunc = std::less<GC_VALUE> >
-  struct BinaryPredicate : GC_VALUE, std::binary_function< _T, _T, bool >
+  struct BinaryPredicate : GC_VALUE
   {
     BinaryPredicate(VALUE obj = Qnil) : GC_VALUE(obj) { }
     bool operator()(_T a, _T b) const
@@ -109,7 +109,7 @@ namespace swig {
   };
 
   template <class _T = GC_VALUE, class _DefaultFunc = std::less< _T > >
-  struct BinaryFunction : GC_VALUE, std::binary_function< _T, _T, _T >
+  struct BinaryFunction : GC_VALUE
   {
     BinaryFunction(VALUE obj = Qnil) : GC_VALUE(obj) { }
     _T operator()(_T a, _T b) const
@@ -128,7 +128,7 @@ namespace swig {
   };
 
   template< class _T = GC_VALUE >
-  struct UnaryPredicate : GC_VALUE, std::unary_function< _T, bool >
+  struct UnaryPredicate : GC_VALUE
   {
     UnaryPredicate(VALUE obj = Qnil) : GC_VALUE(obj) { }
     bool operator()(_T a) const
@@ -142,7 +142,7 @@ namespace swig {
   };
 
   template< class _T = GC_VALUE >
-  struct UnaryFunction : GC_VALUE, std::unary_function< _T, _T >
+  struct UnaryFunction : GC_VALUE
   {
     UnaryFunction(VALUE obj = Qnil) : GC_VALUE(obj) { }
     _T operator()(_T a) const


### PR DESCRIPTION
they are deprecated in C++11 and already removed in Visual C++ '15'
running with /std:c++latest

http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3145.html