### PR TITLE
Redundant typedef fix

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,12 +7,16 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 3.0.12 (in progress)
 ============================
 
+2017-01-10: davedissian
+        Issue #838 - A typedef where the "name" matches the "type" no longer
+        causes symbol lookups to fail when generating code.
+
 2016-12-31: ajrheading1
-	    Issue #860 - Remove use of std::unary_function and std::binary_function
+        Issue #860 - Remove use of std::unary_function and std::binary_function
             which is deprecated in C++11.
 
 2016-12-30: olly
-	    [PHP7] Register internal 'swig_runtime_data_type_pointer' constant
-	    as "CONST_PERSISTENT" to avoid segmentation fault on module unload.
-	    Fixes https://github.com/swig/swig/issues/859 reported by Timotheus
-	    Pokorra - thanks also to Javier Torres for a minimal reproducer.
+        [PHP7] Register internal 'swig_runtime_data_type_pointer' constant
+        as "CONST_PERSISTENT" to avoid segmentation fault on module unload.
+        Fixes https://github.com/swig/swig/issues/859 reported by Timotheus
+        Pokorra - thanks also to Javier Torres for a minimal reproducer.

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -389,6 +389,7 @@ CPP_TEST_CASES += \
 	static_const_member_2 \
 	string_constants \
 	struct_initialization_cpp \
+	struct_redundant_typedef \
 	struct_value \
 	swig_exception \
 	symbol_clash \
@@ -656,6 +657,7 @@ C_TEST_CASES += \
 	sizeof_pointer \
 	sneaky1 \
 	string_simple \
+	struct_redundant_typedef \
 	struct_rename \
 	struct_initialization \
 	typedef_struct \

--- a/Examples/test-suite/java/struct_redundant_typedef_runme.java
+++ b/Examples/test-suite/java/struct_redundant_typedef_runme.java
@@ -1,0 +1,22 @@
+
+import struct_redundant_typedef.*;
+
+public class struct_redundant_typedef_runme {
+
+  static {
+    try {
+      System.loadLibrary("struct_redundant_typedef");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+    Foo foo = new Foo();
+    foo.setX(5);
+    if (struct_redundant_typedef.extract(foo) == 5) {
+      // All good!
+    }
+  }
+}

--- a/Examples/test-suite/struct_redundant_typedef.i
+++ b/Examples/test-suite/struct_redundant_typedef.i
@@ -1,0 +1,13 @@
+%module struct_redundant_typedef
+
+%inline %{
+
+typedef struct Foo Foo;
+
+struct Foo {
+   int x;
+};
+
+int extract(Foo* foo) { return foo->x; }
+
+%}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -3005,6 +3005,18 @@ c_decl  : storage_class type declarator initializer c_decl_tail {
 	      } else {
 		set_nextSibling($$,$5);
 	      }
+
+              /* If we encounter a redundant typedef (typedef struct Hello Hello;) - omit it from the AST */
+              if (Cmp($1,"typedef") == 0) {
+                String* type = Copy($2);
+                Replace(type,"struct ","",DOH_REPLACE_FIRST);
+                Replace(type,"union ","",DOH_REPLACE_FIRST);
+                Replace(type,"class ","",DOH_REPLACE_FIRST);
+                if (Strcmp($3.id, type) == 0) {
+                  Delete($$);
+                  $$ = 0;
+                }
+              }
            }
            /* Alternate function syntax introduced in C++11:
               auto funcName(int x, int y) -> int; */


### PR DESCRIPTION
This pull request fixes #838 

I determined that `Language::classLookup` seems to fail when there exists a `cdecl` in the symbol table where the name is identical to another struct/class in the symbol table. As SWIG doesn't have a tag namespace, a typedef such as `typedef struct Foo Foo` can simply be ignored at the parsing stage, which prevents the issue all together.

Added a test case which will attempt to compile some Java code and see if the proxy class is set up correctly.