### PR TITLE
fix Lib/std/std unordered containers

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -545,6 +545,7 @@ CPP11_TEST_CASES = \
 	cpp11_explicit_conversion_operators \
 	cpp11_final_override \
 	cpp11_function_objects \
+	cpp11_hash_tables \
 	cpp11_inheriting_constructors \
 	cpp11_initializer_list \
 	cpp11_initializer_list_extend \
@@ -572,7 +573,6 @@ CPP11_TEST_CASES = \
 
 # Broken C++11 test cases.
 CPP11_TEST_BROKEN = \
-#	cpp11_hash_tables \           # not fully implemented yet
 #	cpp11_variadic_templates \    # Broken for some languages (such as Java)
 #	cpp11_reference_wrapper \     # No typemaps
 

--- a/Examples/test-suite/cpp11_hash_tables.i
+++ b/Examples/test-suite/cpp11_hash_tables.i
@@ -4,19 +4,27 @@
 
 %inline %{
 #include <set>
-//#include <map>
+#include <map>
 #include <unordered_set>
-//#include <unordered_map>
+#include <unordered_map>
 %}
 
 %include "std_set.i"
-//%include "std_map.i"
+%include "std_multiset.i"
+%include "std_map.i"
+%include "std_multimap.i"
 %include "std_unordered_set.i"
-//%include "std_unordered_map.i"
+%include "std_unordered_multiset.i"
+%include "std_unordered_map.i"
+%include "std_unordered_multimap.i"
 %template (SetInt) std::set<int>;
-//%template (MapIntInt) std::map<int, int>;
+%template (MultiSetInt) std::multiset<int>;
+%template (MapIntInt) std::map<int, int>;
+%template (MultiMapIntInt) std::multimap<int, int>;
 %template (UnorderedSetInt) std::unordered_set<int>;
-//%template (UnorderedMapIntInt) std::unordered_map<int, int>;
+%template (UnorderedMultiSetInt) std::unordered_multiset<int>;
+%template (UnorderedMapIntInt) std::unordered_map<int, int>;
+%template (UnorderedMultiMapIntInt) std::unordered_multimap<int, int>;
 
 %inline %{
 using namespace std;
@@ -25,19 +33,19 @@ class MyClass {
 public:
   set<int> getSet() { return _set; }
   void addSet(int elt) { _set.insert(_set.begin(), elt); }
-//  map<int, int> getMap() { return _map; }
-//  void addMap(int elt1, int elt2) { _map.insert(make_pair(elt1, elt2)); }
+  map<int, int> getMap() { return _map; }
+  void addMap(int elt1, int elt2) { _map.insert(make_pair(elt1, elt2)); }
 
   unordered_set<int> getUnorderedSet() { return _unordered_set; }
   void addUnorderedSet(int elt) { _unordered_set.insert(_unordered_set.begin(), elt); }
-//  unordered_map<int, int> getUnorderedMap() { return _unordered_map; }
-//  void addUnorderedMap(int elt1, int elt2) { _unordered_map.insert(make_pair(elt1, elt2)); }
+  unordered_map<int, int> getUnorderedMap() { return _unordered_map; }
+  void addUnorderedMap(int elt1, int elt2) { _unordered_map.insert(make_pair(elt1, elt2)); }
 private:
   set<int> _set;
-//  map<int, int> _map;
+  map<int, int> _map;
 
   unordered_set<int> _unordered_set;
-//  unordered_map<int, int> _unordered_map;
+  unordered_map<int, int> _unordered_map;
 };
 %}
 

--- a/Examples/test-suite/ruby/cpp11_hash_tables_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_hash_tables_runme.rb
@@ -1,0 +1,44 @@
+require 'swig_assert'
+require 'cpp11_hash_tables'
+
+[Cpp11_hash_tables::MapIntInt.new({1=>7}),
+ Cpp11_hash_tables::MultiMapIntInt.new({1=>7}),
+ Cpp11_hash_tables::UnorderedMapIntInt.new({1=>7}),
+ Cpp11_hash_tables::UnorderedMultiMapIntInt.new({1=>7})].each{|x|
+  swig_assert_equal("x[1]", "7", binding)
+  swig_assert_equal("x[2]", "nil", binding)
+  x[2] = 9
+  swig_assert_equal("x[2]", "9", binding)
+  x.delete(2)
+  swig_assert_equal("x[2]", "nil", binding)
+  swig_assert_equal("x.empty?", "false", binding)
+  x.delete(1)
+  swig_assert_equal("x.empty?", "true", binding)
+  swig_assert_equal("x.include?(1)", "false", binding)
+}
+
+[Cpp11_hash_tables::MultiMapIntInt.new({1=>7}),
+ Cpp11_hash_tables::UnorderedMultiMapIntInt.new({1=>7})].each{|x|
+  x[1] = 9
+  swig_assert_equal("x[1].sort", "[7,9]", binding)
+}
+
+[Cpp11_hash_tables::SetInt.new([1]),
+ Cpp11_hash_tables::MultiSetInt.new([1]),
+ Cpp11_hash_tables::UnorderedSetInt.new([1]),
+ Cpp11_hash_tables::UnorderedMultiSetInt.new([1])].each{|x|
+  swig_assert_equal("x.include?(1)", "true", binding)
+  swig_assert_equal("x.include?(2)", "false", binding)
+  x << 2
+  swig_assert_equal("x.include?(2)", "true", binding)
+  x.erase(2)
+  swig_assert_equal("x.empty?", "false", binding)
+  x.erase(1)
+  swig_assert_equal("x.empty?", "true", binding)
+}
+
+[Cpp11_hash_tables::MultiSetInt.new([1]),
+ Cpp11_hash_tables::UnorderedMultiSetInt.new([1])].each{|x|
+  x << 1
+  swig_assert_equal("x.count(1)", "2", binding)
+}

--- a/Lib/ruby/std_multimap.i
+++ b/Lib/ruby/std_multimap.i
@@ -90,12 +90,11 @@
 
   %extend {
     VALUE __getitem__(const key_type& key) const {
-      MultiMap::const_iterator i = self->find(key);
-      if ( i != self->end() )
+      std::pair<MultiMap::const_iterator, MultiMap::const_iterator > r = $self->equal_range(key);
+      if ( r.first != r.second )
 	{
-	  MultiMap::const_iterator e = $self->upper_bound(key);
 	  VALUE ary = rb_ary_new();
-	  for ( ; i != e; ++i )
+	  for (MultiMap::const_iterator i = r.first ; i != r.second; ++i )
 	    {
 	      rb_ary_push( ary, swig::from<MultiMap::mapped_type>( i->second ) );
 	    }

--- a/Lib/ruby/std_unordered_map.i
+++ b/Lib/ruby/std_unordered_map.i
@@ -1,0 +1,83 @@
+//
+//   Maps
+//
+%include <std_map.i>
+
+%fragment("StdUnorderedMapTraits","header",fragment="StdMapCommonTraits")
+{
+  namespace swig {
+    template <class RubySeq, class K, class T >
+    inline void
+    assign(const RubySeq& rubyseq, std::unordered_map<K,T > *map) {
+      typedef typename std::unordered_map<K,T>::value_type value_type;
+      typename RubySeq::const_iterator it = rubyseq.begin();
+      for (;it != rubyseq.end(); ++it) {
+	map->insert(value_type(it->first, it->second));
+      }
+    }
+
+    template <class K, class T>
+    struct traits_asptr<std::unordered_map<K,T> >  {
+      typedef std::unordered_map<K,T> map_type;
+      static int asptr(VALUE obj, map_type **val) {
+	int res = SWIG_ERROR;
+	if ( TYPE(obj) == T_HASH ) {
+	  static ID id_to_a = rb_intern("to_a");
+	  VALUE items = rb_funcall(obj, id_to_a, 0);
+	  res = traits_asptr_stdseq<std::unordered_map<K,T>, std::pair<K, T> >::asptr(items, val);
+	} else {
+	  map_type *p;
+	  swig_type_info *descriptor = swig::type_info<map_type>();
+	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
+	  if (SWIG_IsOK(res) && val)  *val = p;
+	}
+	return res;
+      }
+    };
+
+    template <class K, class T >
+    struct traits_from<std::unordered_map<K,T> >  {
+      typedef std::unordered_map<K,T> map_type;
+      typedef typename map_type::const_iterator const_iterator;
+      typedef typename map_type::size_type size_type;
+
+      static VALUE from(const map_type& map) {
+	swig_type_info *desc = swig::type_info<map_type>();
+	if (desc && desc->clientdata) {
+	  return SWIG_NewPointerObj(new map_type(map), desc, SWIG_POINTER_OWN);
+	} else {
+	  size_type size = map.size();
+	  int rubysize = (size <= (size_type) INT_MAX) ? (int) size : -1;
+	  if (rubysize < 0) {
+	    SWIG_RUBY_THREAD_BEGIN_BLOCK;
+	    rb_raise( rb_eRuntimeError, "map size not valid in Ruby");
+	    SWIG_RUBY_THREAD_END_BLOCK;
+	    return Qnil;
+	  }
+	  VALUE obj = rb_hash_new();
+	  for (const_iterator i= map.begin(); i!= map.end(); ++i) {
+	    VALUE key = swig::from(i->first);
+	    VALUE val = swig::from(i->second);
+	    rb_hash_aset(obj, key, val);
+	  }
+	  return obj;
+	}
+      }
+    };
+  }
+}
+
+#define %swig_unordered_map_common(Map...) %swig_map_common(Map)
+#define %swig_unordered_map_methods(Map...) %swig_map_methods(Map)
+
+%rename("delete")     std::unordered_map::__delete__;
+%rename("reject!")    std::unordered_map::reject_bang;
+%rename("map!")       std::unordered_map::map_bang;
+%rename("empty?")     std::unordered_map::empty;
+%rename("include?")   std::unordered_map::__contains__ const;
+%rename("has_key?")   std::unordered_map::has_key const;
+
+%mixin std::map "Enumerable";
+%alias  std::unordered_map::push          "<<";
+
+%include <std/std_unordered_map.i>

--- a/Lib/ruby/std_unordered_multimap.i
+++ b/Lib/ruby/std_unordered_multimap.i
@@ -1,0 +1,102 @@
+/*
+  Multimaps
+*/
+%include <std_multimap.i>
+
+%fragment("StdUnorderedMultimapTraits","header",fragment="StdMapCommonTraits")
+{
+  namespace swig {
+    template <class RubySeq, class K, class T >
+    inline void
+    assign(const RubySeq& rubyseq, std::unordered_multimap<K,T > *multimap) {
+      typedef typename std::unordered_multimap<K,T>::value_type value_type;
+      typename RubySeq::const_iterator it = rubyseq.begin();
+      for (;it != rubyseq.end(); ++it) {
+	multimap->insert(value_type(it->first, it->second));
+      }
+    }
+
+    template <class K, class T>
+    struct traits_asptr<std::unordered_multimap<K,T> >  {
+      typedef std::unordered_multimap<K,T> multimap_type;
+      static int asptr(VALUE obj, std::unordered_multimap<K,T> **val) {
+	int res = SWIG_ERROR;
+	if ( TYPE(obj) == T_HASH ) {
+	  static ID id_to_a = rb_intern("to_a");
+	  VALUE items = rb_funcall(obj, id_to_a, 0);
+	  return traits_asptr_stdseq<std::unordered_multimap<K,T>, std::pair<K, T> >::asptr(items, val);
+	} else {
+	  multimap_type *p;
+	  res = SWIG_ConvertPtr(obj,(void**)&p,swig::type_info<multimap_type>(),0);
+	  if (SWIG_IsOK(res) && val)  *val = p;
+	}
+	return res;
+      }
+    };
+
+    template <class K, class T >
+    struct traits_from<std::unordered_multimap<K,T> >  {
+      typedef std::unordered_multimap<K,T> multimap_type;
+      typedef typename multimap_type::const_iterator const_iterator;
+      typedef typename multimap_type::size_type size_type;
+
+      static VALUE from(const multimap_type& multimap) {
+	swig_type_info *desc = swig::type_info<multimap_type>();
+	if (desc && desc->clientdata) {
+	  return SWIG_NewPointerObj(new multimap_type(multimap), desc, SWIG_POINTER_OWN);
+	} else {
+	  size_type size = multimap.size();
+	  int rubysize = (size <= (size_type) INT_MAX) ? (int) size : -1;
+	  if (rubysize < 0) {
+	    SWIG_RUBY_THREAD_BEGIN_BLOCK;
+	    rb_raise(rb_eRuntimeError,
+		     "multimap_ size not valid in Ruby");
+	    SWIG_RUBY_THREAD_END_BLOCK;
+	    return Qnil;
+	  }
+	  VALUE obj = rb_hash_new();
+	  for (const_iterator i= multimap.begin(); i!= multimap.end(); ++i) {
+	    VALUE key = swig::from(i->first);
+	    VALUE val = swig::from(i->second);
+
+	    VALUE oldval = rb_hash_aref( obj, key );
+	    if ( oldval == Qnil )
+	      rb_hash_aset(obj, key, val);
+	    else {
+	      // Multiple values for this key, create array if needed
+	      // and add a new element to it.
+	      VALUE ary;
+	      if ( TYPE(oldval) == T_ARRAY )
+		ary = oldval;
+	      else
+		{
+		  ary = rb_ary_new2(2);
+		  rb_ary_push( ary, oldval );
+		  rb_hash_aset( obj, key, ary );
+		}
+	      rb_ary_push( ary, val );
+	    }
+
+	  }
+	  return obj;
+	}
+      }
+    };
+  }
+}
+
+#define %swig_unordered_multimap_methods(MultiMap...) %swig_multimap_methods(MultiMap)
+
+%mixin std::unordered_multimap "Enumerable";
+
+%rename("delete")     std::unordered_multimap::__delete__;
+%rename("reject!")    std::unordered_multimap::reject_bang;
+%rename("map!")       std::unordered_multimap::map_bang;
+%rename("empty?")     std::unordered_multimap::empty;
+%rename("include?" )  std::unordered_multimap::__contains__ const;
+%rename("has_key?" )  std::unordered_multimap::has_key const;
+
+%alias  std::unordered_multimap::push          "<<";
+
+%include <std/std_unordered_multimap.i>
+

--- a/Lib/ruby/std_unordered_multiset.i
+++ b/Lib/ruby/std_unordered_multiset.i
@@ -1,0 +1,50 @@
+/*
+  Multisets
+*/
+
+%include <std_unordered_set.i>
+
+%fragment("StdUnorderedMultisetTraits","header",fragment="StdSequenceTraits")
+%{
+  namespace swig {
+    template <class RubySeq, class T>
+    inline void
+    assign(const RubySeq& rubyseq, std::unordered_multiset<T>* seq) {
+      // seq->insert(rubyseq.begin(), rubyseq.end()); // not used as not always implemented
+      typedef typename RubySeq::value_type value_type;
+      typename RubySeq::const_iterator it = rubyseq.begin();
+      for (;it != rubyseq.end(); ++it) {
+	seq->insert(seq->end(),(value_type)(*it));
+      }
+    }
+
+    template <class T>
+    struct traits_asptr<std::unordered_multiset<T> >  {
+      static int asptr(VALUE obj, std::unordered_multiset<T> **m) {
+	return traits_asptr_stdseq<std::unordered_multiset<T> >::asptr(obj, m);
+      }
+    };
+
+    template <class T>
+    struct traits_from<std::unordered_multiset<T> > {
+      static VALUE from(const std::unordered_multiset<T>& vec) {
+	return traits_from_stdseq<std::unordered_multiset<T> >::from(vec);
+      }
+    };
+  }
+%}
+
+#define %swig_unordered_multiset_methods(Set...) %swig_unordered_set_methods(Set)
+
+
+
+%rename("delete")     std::unordered_multiset::__delete__;
+%rename("reject!")    std::unordered_multiset::reject_bang;
+%rename("map!")       std::unordered_multiset::map_bang;
+%rename("empty?")     std::unordered_multiset::empty;
+%rename("include?")  std::unordered_multiset::__contains__ const;
+%rename("has_key?")  std::unordered_multiset::has_key const;
+
+%alias  std::unordered_multiset::push          "<<";
+
+%include <std/std_unordered_multiset.i>

--- a/Lib/ruby/std_unordered_set.i
+++ b/Lib/ruby/std_unordered_set.i
@@ -1,0 +1,54 @@
+/*
+  Sets
+*/
+
+%include <std_set.i>
+
+%fragment("StdUnorderedSetTraits","header",fragment="<stddef.h>",fragment="StdSequenceTraits")
+%{
+  namespace swig {
+    template <class RubySeq, class T>
+    inline void
+    assign(const RubySeq& rubyseq, std::unordered_set<T>* seq) {
+      // seq->insert(rubyseq.begin(), rubyseq.end()); // not used as not always implemented
+      typedef typename RubySeq::value_type value_type;
+      typename RubySeq::const_iterator it = rubyseq.begin();
+      for (;it != rubyseq.end(); ++it) {
+	seq->insert(seq->end(),(value_type)(*it));
+      }
+    }
+
+    template <class T>
+    struct traits_asptr<std::unordered_set<T> >  {
+      static int asptr(VALUE obj, std::unordered_set<T> **s) {
+	return traits_asptr_stdseq<std::unordered_set<T> >::asptr(obj, s);
+      }
+    };
+
+    template <class T>
+    struct traits_from<std::unordered_set<T> > {
+      static VALUE from(const std::unordered_set<T>& vec) {
+	return traits_from_stdseq<std::unordered_set<T> >::from(vec);
+      }
+    };
+  }
+%}
+
+#define %swig_unordered_set_methods(set...) %swig_set_methods(set)
+
+%mixin std::unordered_set "Enumerable";
+
+
+
+%rename("delete")     std::unordered_set::__delete__;
+%rename("reject!")    std::unordered_set::reject_bang;
+%rename("map!")       std::unordered_set::map_bang;
+%rename("empty?")     std::unordered_set::empty;
+%rename("include?" )  std::unordered_set::__contains__ const;
+%rename("has_key?" )  std::unordered_set::has_key const;
+
+%alias  std::unordered_set::push          "<<";
+
+
+%include <std/std_unordered_set.i>
+

--- a/Lib/std/std_container.i
+++ b/Lib/std/std_container.i
@@ -26,16 +26,18 @@
   class const_iterator;
   iterator begin();
   iterator end();
+  #endif
 
-  #if !defined(SWIG_NO_REVERSE_ITERATOR_METHODS)
+%enddef
+
+%define %std_container_methods_reverse_iterators(container...)
+
+  #ifdef SWIG_EXPORT_ITERATOR_METHODS
   class reverse_iterator;
   class const_reverse_iterator;
   reverse_iterator rbegin();
   reverse_iterator rend();
   #endif
-
-  #endif
-
 
 %enddef
 

--- a/Lib/std/std_container.i
+++ b/Lib/std/std_container.i
@@ -26,18 +26,16 @@
   class const_iterator;
   iterator begin();
   iterator end();
-  #endif
 
-%enddef
-
-%define %std_container_methods_reverse_iterators(container...)
-
-  #ifdef SWIG_EXPORT_ITERATOR_METHODS
+  #if !defined(SWIG_NO_REVERSE_ITERATOR_METHODS)
   class reverse_iterator;
   class const_reverse_iterator;
   reverse_iterator rbegin();
   reverse_iterator rend();
   #endif
+
+  #endif
+
 
 %enddef
 

--- a/Lib/std/std_unordered_map.i
+++ b/Lib/std/std_unordered_map.i
@@ -4,7 +4,7 @@
 // operator--() and constructor(compare function) not available for unordered_
 // types
 //
-
+#define SWIG_NO_REVERSE_ITERATOR_METHODS
 %include <std_pair.i>
 %include <std_container.i>
 
@@ -22,8 +22,6 @@
 }
 
   iterator find(const key_type& x);
-  iterator lower_bound(const key_type& x);
-  iterator upper_bound(const key_type& x);
 #endif
 %enddef
 
@@ -68,7 +66,7 @@
 
 namespace std {
 
-  template<class _Key, class _Tp, class _Compare = std::less< _Key >,
+  template<class _Key, class _Tp, class _Hash = std::hash< _Key >, class _Pred = std::equal_to< _Key >,
 	   class _Alloc = allocator<std::pair< const _Key, _Tp > > >
   class unordered_map {
   public:
@@ -101,29 +99,28 @@ namespace std {
       }
     }
 
-    %fragment(SWIG_Traits_frag(std::unordered_map< _Key, _Tp, _Compare, _Alloc >), "header",
+    %fragment(SWIG_Traits_frag(std::unordered_map< _Key, _Tp, _Hash, _Pred, _Alloc >), "header",
 	      fragment=SWIG_Traits_frag(std::pair< _Key, _Tp >),
-	      fragment="StdMapTraits") {
+	      fragment="StdUnorderedMapTraits") {
       namespace swig {
-	template <>  struct traits<std::unordered_map< _Key, _Tp, _Compare, _Alloc > > {
+	template <>  struct traits<std::unordered_map< _Key, _Tp, _Hash, _Pred, _Alloc > > {
 	  typedef pointer_category category;
 	  static const char* type_name() {
-	    return "std::unordered_map<" #_Key "," #_Tp "," #_Compare "," #_Alloc " >";
+	    return "std::unordered_map<" #_Key "," #_Tp "," #_Hash "," #_Pred "," #_Alloc " >";
 	  }
 	};
       }
     }
 
-    %typemap_traits_ptr(SWIG_TYPECHECK_MAP, std::unordered_map< _Key, _Tp, _Compare, _Alloc >);
-
-    unordered_map( const _Compare& );
+    %typemap_traits_ptr(SWIG_TYPECHECK_MAP, std::unordered_map< _Key, _Tp, _Hash, _Pred, _Alloc >);
 
 #ifdef %swig_unordered_map_methods
     // Add swig/language extra methods
-    %swig_unordered_map_methods(std::unordered_map< _Key, _Tp, _Compare, _Alloc >);
+    %swig_unordered_map_methods(std::unordered_map< _Key, _Tp, _Hash, _Pred, _Alloc >);
 #endif
   
     %std_unordered_map_methods(unordered_map);
   };
 
 }
+#undef SWIG_NO_REVERSE_ITERATOR_METHODS

--- a/Lib/std/std_unordered_map.i
+++ b/Lib/std/std_unordered_map.i
@@ -4,12 +4,11 @@
 // operator--() and constructor(compare function) not available for unordered_
 // types
 //
-#define SWIG_NO_REVERSE_ITERATOR_METHODS
 %include <std_pair.i>
 %include <std_container.i>
 
 %define %std_unordered_map_methods_common(unordered_map...)
-  %std_container_methods(unordered_map);
+  %std_container_methods_without_reverse_iterators(unordered_map);
 
   size_type erase(const key_type& x);
   size_type count(const key_type& x) const;
@@ -123,4 +122,3 @@ namespace std {
   };
 
 }
-#undef SWIG_NO_REVERSE_ITERATOR_METHODS

--- a/Lib/std/std_unordered_multimap.i
+++ b/Lib/std/std_unordered_multimap.i
@@ -6,10 +6,10 @@
 //
 
 %include <std_unordered_map.i>
-
+#define SWIG_NO_REVERSE_ITERATOR_METHODS
 
 %define %std_unordered_multimap_methods(mmap...)
-  %std_map_methods_common(mmap);
+  %std_unordered_map_methods_common(mmap);
 
 #ifdef SWIG_EXPORT_ITERATOR_METHODS
   std::pair<iterator,iterator> equal_range(const key_type& x);
@@ -44,7 +44,7 @@
 
 
 namespace std {
-  template<class _Key, class _Tp, class _Compare = std::less< _Key >,
+  template<class _Key, class _Tp, class _Hash = std::hash< _Key >, class _Pred = std::equal_to< _Key >,
 	   class _Alloc = allocator<std::pair< const _Key, _Tp > > >
   class unordered_multimap {
   public:
@@ -63,28 +63,27 @@ namespace std {
     %traits_swigtype(_Key);
     %traits_swigtype(_Tp);	    
 
-    %fragment(SWIG_Traits_frag(std::unordered_multimap< _Key, _Tp, _Compare, _Alloc >), "header",
+    %fragment(SWIG_Traits_frag(std::unordered_multimap< _Key, _Tp, _Hash, _Pred, _Alloc >), "header",
 	      fragment=SWIG_Traits_frag(std::pair< _Key, _Tp >),
-	      fragment="StdMultimapTraits") {
+	      fragment="StdUnorderedMultimapTraits") {
       namespace swig {
-	template <>  struct traits<std::unordered_multimap< _Key, _Tp, _Compare, _Alloc > > {
+	template <>  struct traits<std::unordered_multimap< _Key, _Tp, _Hash, _Pred, _Alloc > > {
 	  typedef pointer_category category;
 	  static const char* type_name() {
-	    return "std::unordered_multimap<" #_Key "," #_Tp "," #_Compare "," #_Alloc " >";
+	    return "std::unordered_multimap<" #_Key "," #_Tp "," #_Hash "," #_Pred "," #_Alloc " >";
 	  }
 	};
       }
     }
 
-    %typemap_traits_ptr(SWIG_TYPECHECK_MULTIMAP, std::unordered_multimap< _Key, _Tp, _Compare, _Alloc >);
+    %typemap_traits_ptr(SWIG_TYPECHECK_MULTIMAP, std::unordered_multimap< _Key, _Tp, _Hash, _Pred, _Alloc >);
   
-    unordered_multimap( const _Compare& );
-
 #ifdef %swig_unordered_multimap_methods
     // Add swig/language extra methods
-    %swig_unordered_multimap_methods(std::unordered_multimap< _Key, _Tp, _Compare, _Alloc >);
+    %swig_unordered_multimap_methods(std::unordered_multimap< _Key, _Tp, _Hash, _Pred, _Alloc >);
 #endif
 
     %std_unordered_multimap_methods(unordered_multimap);
   };
 }
+#undef SWIG_NO_REVERSE_ITERATOR_METHODS

--- a/Lib/std/std_unordered_multimap.i
+++ b/Lib/std/std_unordered_multimap.i
@@ -6,7 +6,6 @@
 //
 
 %include <std_unordered_map.i>
-#define SWIG_NO_REVERSE_ITERATOR_METHODS
 
 %define %std_unordered_multimap_methods(mmap...)
   %std_unordered_map_methods_common(mmap);
@@ -86,4 +85,3 @@ namespace std {
     %std_unordered_multimap_methods(unordered_multimap);
   };
 }
-#undef SWIG_NO_REVERSE_ITERATOR_METHODS

--- a/Lib/std/std_unordered_multiset.i
+++ b/Lib/std/std_unordered_multiset.i
@@ -43,7 +43,8 @@ namespace std {
 
   //unordered_multiset
 
-  template <class _Key, class _Compare = std::less< _Key >,
+  template <class _Key, class _Hash = std::hash< _Key >,
+            class _Compare = std::equal_to< _Key >,
 	    class _Alloc = allocator< _Key > >
   class unordered_multiset {
   public:
@@ -59,26 +60,24 @@ namespace std {
 
     %traits_swigtype(_Key);
 
-    %fragment(SWIG_Traits_frag(std::unordered_multiset< _Key, _Compare, _Alloc >), "header",
+    %fragment(SWIG_Traits_frag(std::unordered_multiset< _Key, _Hash, _Compare, _Alloc >), "header",
 	      fragment=SWIG_Traits_frag(_Key),
 	      fragment="StdMultisetTraits") {
       namespace swig {
-	template <>  struct traits<std::unordered_multiset< _Key, _Compare, _Alloc > > {
+	template <>  struct traits<std::unordered_multiset< _Key, _Hash, _Compare, _Alloc > > {
 	  typedef pointer_category category;
 	  static const char* type_name() {
-	    return "std::unordered_multiset<" #_Key "," #_Compare "," #_Alloc " >";
+	    return "std::unordered_multiset<" #_Key "," #_Hash "," #_Compare "," #_Alloc " >";
 	  }
 	};
       }
     }
 
-    %typemap_traits_ptr(SWIG_TYPECHECK_MULTISET, std::unordered_multiset< _Key, _Compare, _Alloc >);
-
-    unordered_multiset( const _Compare& );
+    %typemap_traits_ptr(SWIG_TYPECHECK_MULTISET, std::unordered_multiset< _Key, _Hash, _Compare, _Alloc >);
 
 #ifdef %swig_unordered_multiset_methods
     // Add swig/language extra methods
-    %swig_unordered_multiset_methods(std::unordered_multiset< _Key, _Compare, _Alloc >);
+    %swig_unordered_multiset_methods(std::unordered_multiset< _Key, _Hash, _Compare, _Alloc >);
 #endif
   
     %std_unordered_multiset_methods(unordered_multiset);

--- a/Lib/std/std_unordered_multiset.i
+++ b/Lib/std/std_unordered_multiset.i
@@ -62,7 +62,7 @@ namespace std {
 
     %fragment(SWIG_Traits_frag(std::unordered_multiset< _Key, _Hash, _Compare, _Alloc >), "header",
 	      fragment=SWIG_Traits_frag(_Key),
-	      fragment="StdMultisetTraits") {
+	      fragment="StdUnorderedMultisetTraits") {
       namespace swig {
 	template <>  struct traits<std::unordered_multiset< _Key, _Hash, _Compare, _Alloc > > {
 	  typedef pointer_category category;

--- a/Lib/std/std_unordered_set.i
+++ b/Lib/std/std_unordered_set.i
@@ -110,8 +110,6 @@ namespace std {
 
     %typemap_traits_ptr(SWIG_TYPECHECK_SET, std::unordered_set< _Key, _Hash, _Compare, _Alloc >);
 
-    unordered_set( const _Compare& );
-
 #ifdef %swig_unordered_set_methods
     // Add swig/language extra methods
     %swig_unordered_set_methods(std::unordered_set< _Key, _Hash, _Compare, _Alloc >);


### PR DESCRIPTION
This patch fixes Lib/std/std unordered containers.

1. unordered containers do not have reverse_iterator. so we have introduced SWIG_NO_REVERSE_ITERATOR_METHODS flag.

2. fix the arguments of templates.

3. remove declarations of constructors which do not exist.