### PR TITLE
[Coverity] fix issue reported for SWIG_Python_FixMethods

### DIFF
--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -306,9 +306,9 @@ SWIG_Python_FixMethods(PyMethodDef *methods,
 	  char *ndoc = (char*)malloc(ldoc + lptr + 10);
 	  if (ndoc) {
 	    char *buff = ndoc;
-	    strncpy(buff, methods[i].ml_doc, ldoc);
+	    memcpy(buff, methods[i].ml_doc, ldoc);
 	    buff += ldoc;
-	    strncpy(buff, "swig_ptr: ", 10);
+	    memcpy(buff, "swig_ptr: ", 10);
 	    buff += 10;
 	    SWIG_PackVoidPtr(buff, ptr, ty->name, lptr);
 	    methods[i].ml_doc = ndoc;


### PR DESCRIPTION
Fix Coverity issue reported for SWIG_Python_FixMethods:

"buffer_size: Calling strncpy with a source string whose length
(10 chars) is greater than or equal to the size argument (10)
will fail to null-terminate buff."

The issue is only reported for the "swig_ptr: " line, but for
consistency we replace both occurrences of strncpy with memcpy.