### PR TITLE
[Coverity] fix issue reported for wrapper argument checking

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2541,9 +2541,14 @@ public:
 
     if (!fastunpack) {
       Wrapper_add_local(f, "ii", "Py_ssize_t ii");
-      if (maxargs - (add_self ? 1 : 0) > 0)
-	Append(f->code, "if (!PyTuple_Check(args)) SWIG_fail;\n");
-      Append(f->code, "argc = args ? PyObject_Length(args) : 0;\n");
+
+      if (maxargs - (add_self ? 1 : 0) > 0) {
+        Append(f->code, "if (!PyTuple_Check(args)) SWIG_fail;\n");
+        Append(f->code, "argc = PyObject_Length(args);\n");
+      } else {
+        Append(f->code, "argc = args ? PyObject_Length(args) : 0;\n");
+      }
+
       if (add_self)
 	Append(f->code, "argv[0] = self;\n");
       Printf(f->code, "for (ii = 0; (ii < %d) && (ii < argc); ii++) {\n", add_self ? maxargs - 1 : maxargs);


### PR DESCRIPTION
Fix Coverity issue reported for wrapper argument checking:

"Null-checking args suggests that it may be null, but it has already
been dereferenced on all paths leading to the check."

So 'args' is null checked, but after dereferencing it with
PyTuple_Check(args).

If we assume that args may be null (else why check for it), then we
need to avoid dereferencing null.