### PR TITLE
Fix ruby support for std::wstring

### DIFF
--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -19,6 +19,7 @@ CPP_TEST_CASES = \
 	li_std_queue \
 	li_std_set \
 	li_std_stack \
+	li_std_wstring \
 	primitive_types \
 	ruby_keywords \
 	ruby_minherit_shared_ptr \

--- a/Examples/test-suite/ruby/li_std_wstring_runme.rb
+++ b/Examples/test-suite/ruby/li_std_wstring_runme.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+require 'swig_assert'
+require 'li_std_wstring'
+
+x = "h"
+
+swig_assert_equal("Li_std_wstring.test_value(x)", "x", binding)
+
+
+x = "abc"
+
+swig_assert_equal("Li_std_wstring.test_value(x)", "x", binding)
+
+x = "hello"
+
+swig_assert_equal("Li_std_wstring.test_const_reference(x)", "x", binding)
+
+a = Li_std_wstring::A.new(x)
+
+swig_assert_equal("Li_std_wstring.test_value(a)", "x", binding)
+
+swig_assert_equal("Li_std_wstring.test_value(x)", "x", binding)

--- a/Lib/ruby/rubywstrings.swg
+++ b/Lib/ruby/rubywstrings.swg
@@ -1,13 +1,6 @@
 /* -----------------------------------------------------------------------------
  * rubywstrings.swg
  *
- * Currently, Ruby does not support Unicode or WChar properly, so these
- * are still treated as char arrays for now.
- * There are other libraries available that add support to this in
- * ruby including WString, FXString, etc.
- * ----------------------------------------------------------------------------- */
-
-/* ------------------------------------------------------------
  *  utility methods for wchar_t strings 
  * ------------------------------------------------------------ */
 
@@ -15,17 +8,11 @@
 SWIGINTERN int
 SWIG_AsWCharPtrAndSize(VALUE obj, wchar_t **cptr, size_t *psize, int *alloc)
 {
-  VALUE tmp;
+  VALUE tmp = rb_str_conv_enc(obj, rb_enc_get(obj),
+                                   rb_to_encoding(rb_str_new_cstr( SWIG_RUBY_WSTRING_ENCODING )) );
   *alloc = SWIG_NEWOBJ;
-  if(sizeof(wchar_t) == 4) {
-    tmp = rb_str_conv_enc(obj, rb_enc_get(obj), rb_to_encoding(rb_str_new_cstr("UTF-32")) );
-  } else if (sizeof(wchar_t) == 2) {
-    tmp = rb_str_conv_enc(obj, rb_enc_get(obj), rb_to_encoding(rb_str_new_cstr("UTF-16")) );
-  } else {
-    rb_raise(rb_eRuntimeError, "unsupported wchar_t size");
-  }
-  return SWIG_AsCharPtrAndSize( tmp, (char**)cptr, psize, alloc);
 
+  return SWIG_AsCharPtrAndSize(tmp, (char**)cptr, psize, alloc);
 }
 }
 
@@ -35,18 +22,13 @@ SWIG_FromWCharPtrAndSize(const wchar_t * carray, size_t size)
 {
   VALUE ret = SWIG_FromCharPtrAndSize( (const char*)carray, size);
   rb_encoding* enc = rb_default_internal_encoding();
-  if(sizeof(wchar_t) == 4) {
-    rb_enc_associate(ret, rb_to_encoding(rb_str_new_cstr("UTF-32")));
-  } else if (sizeof(wchar_t) == 2) {
-    rb_enc_associate(ret, rb_to_encoding(rb_str_new_cstr("UTF-16")));
-  } else {
-    rb_raise(rb_eRuntimeError, "unsupported wchar_t size");
-  }
+
+  rb_enc_associate(ret, rb_to_encoding(rb_str_new_cstr( SWIG_RUBY_WSTRING_ENCODING )) );
 
   if( !enc ) {
-    enc = rb_to_encoding(rb_str_new_cstr("UTF-8"));
+    enc = rb_to_encoding(rb_str_new_cstr( SWIG_RUBY_INTERNAL_ENCODING ));
   }
-  return rb_str_conv_enc(ret, rb_enc_get(ret), enc );
+  return rb_str_conv_enc(ret, rb_enc_get(ret), enc);
 }
 }
 

--- a/Lib/ruby/rubywstrings.swg
+++ b/Lib/ruby/rubywstrings.swg
@@ -15,38 +15,17 @@
 SWIGINTERN int
 SWIG_AsWCharPtrAndSize(VALUE obj, wchar_t **cptr, size_t *psize, int *alloc)
 {
-  return SWIG_AsCharPtrAndSize( obj, (char**)cptr, psize, alloc);
-//   VALUE tmp = 0;
-//   bool ok = false;
-//   if ( TYPE(obj) == T_STRING ) {
-//     if (cptr) {
-//       obj = tmp = SWIG_Unicode_FromObject(obj);
-//       ok = true;
-//     }
-//   }
-//   if (ok) {
-//     Py_ssize_t len = PyUnicode_GetSize(obj);
-//     rb_notimplement();
-//     if (cptr) {
-//       *cptr = %new_array(len + 1, wchar_t);
-//       SWIG_Unicode_AsWideChar((PyUnicodeObject *)obj, *cptr, len);
-//       (*cptr)[len] = 0;
-//     }
-//     if (psize) *psize = (size_t) len + 1;
-//     if (alloc) *alloc = cptr ? SWIG_NEWOBJ : 0;
-//     return SWIG_OK;
-//   } else {
-//     swig_type_info* pwchar_descriptor = SWIG_pwchar_descriptor();
-//     if (pwchar_descriptor) {
-//       void * vptr = 0;
-//       if (SWIG_ConvertPtr(obj, &vptr, pwchar_descriptor, 0) == SWIG_OK) {
-// 	if (cptr) *cptr = (wchar_t *)vptr;
-// 	if (psize) *psize = vptr ? (wcslen((wchar_t *)vptr) + 1) : 0;
-// 	return SWIG_OK;
-//       }
-//     }
-//   }
-//   return SWIG_TypeError;
+  VALUE tmp;
+  *alloc = SWIG_NEWOBJ;
+  if(sizeof(wchar_t) == 4) {
+    tmp = rb_str_conv_enc(obj, rb_enc_get(obj), rb_to_encoding(rb_str_new_cstr("UTF-32")) );
+  } else if (sizeof(wchar_t) == 2) {
+    tmp = rb_str_conv_enc(obj, rb_enc_get(obj), rb_to_encoding(rb_str_new_cstr("UTF-16")) );
+  } else {
+    rb_raise(rb_eRuntimeError, "unsupported wchar_t size");
+  }
+  return SWIG_AsCharPtrAndSize( tmp, (char**)cptr, psize, alloc);
+
 }
 }
 
@@ -54,18 +33,20 @@ SWIG_AsWCharPtrAndSize(VALUE obj, wchar_t **cptr, size_t *psize, int *alloc)
 SWIGINTERNINLINE VALUE 
 SWIG_FromWCharPtrAndSize(const wchar_t * carray, size_t size)
 {
-  return SWIG_FromCharPtrAndSize( (const char*)carray, size);
-//   if (carray) {
-//     if (size > INT_MAX) {
-//       swig_type_info* pwchar_descriptor = SWIG_pwchar_descriptor();
-//       return pwchar_descriptor ? 
-// 	SWIG_NewPointerObj(%const_cast(carray,wchar_t *), pwchar_descriptor, 0) : Qnil;
-//     } else {
-//       return SWIG_Unicode_FromWideChar(carray, %numeric_cast(size,int));
-//     }
-//   } else {
-//     return Qnil;
-//   }
+  VALUE ret = SWIG_FromCharPtrAndSize( (const char*)carray, size);
+  rb_encoding* enc = rb_default_internal_encoding();
+  if(sizeof(wchar_t) == 4) {
+    rb_enc_associate(ret, rb_to_encoding(rb_str_new_cstr("UTF-32")));
+  } else if (sizeof(wchar_t) == 2) {
+    rb_enc_associate(ret, rb_to_encoding(rb_str_new_cstr("UTF-16")));
+  } else {
+    rb_raise(rb_eRuntimeError, "unsupported wchar_t size");
+  }
+
+  if( !enc ) {
+    enc = rb_to_encoding(rb_str_new_cstr("UTF-8"));
+  }
+  return rb_str_conv_enc(ret, rb_enc_get(ret), enc );
 }
 }
 

--- a/Lib/ruby/std_basic_string.i
+++ b/Lib/ruby/std_basic_string.i
@@ -55,6 +55,10 @@ SWIGINTERNINLINE VALUE
 
 #if !defined(SWIG_STD_WSTRING)
 
+%traits_swigtype(std::basic_string<wchar_t>);
+%fragment(SWIG_Traits_frag(std::basic_string<wchar_t>));
+
+
 %fragment(SWIG_AsPtr_frag(std::basic_string<wchar_t>),"header",
 	  fragment="SWIG_AsWCharPtrAndSize") {
 SWIGINTERN int

--- a/Lib/ruby/std_wstring.i
+++ b/Lib/ruby/std_wstring.i
@@ -7,6 +7,31 @@ extern "C" {
 #include "ruby/encoding.h"
 #endif
 
+/**
+ *  The internal encoding of std::wstring is defined based on
+ *  the size of wchar_t. If it is not appropriate for your library,
+ *  SWIG_RUBY_WSTRING_ENCODING must be given when compiling.
+ */
+#ifndef SWIG_RUBY_WSTRING_ENCODING
+
+#if WCHAR_MAX == 0x7fff || WCHAR_MAX == 0xffff
+#define SWIG_RUBY_WSTRING_ENCODING "UTF-16"
+#elif WCHAR_MAX == 0x7fffffff || WCHAR_MAX == 0xffffffff
+#define SWIG_RUBY_WSTRING_ENCODING "UTF-32"
+#else
+#error unsupported wchar_t size. SWIG_RUBY_WSTRING_ENCODING must be given.
+#endif
+
+#endif
+
+/**
+ *  If Encoding.default_internal is nil, this encoding will be used
+ *  when coverting from std::wstring to String object in Ruby.
+ */
+#ifndef SWIG_RUBY_INTERNAL_ENCODING
+#define SWIG_RUBY_INTERNAL_ENCODING "UTF-8"
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/ruby/std_wstring.i
+++ b/Lib/ruby/std_wstring.i
@@ -1,3 +1,17 @@
+%{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAVE_RUBY_ENCODING_H
+#include "ruby/encoding.h"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+%}
+
 %include <rubywstrings.swg>
 %include <typemaps/std_wstring.swg>
 


### PR DESCRIPTION
Hi, this PR fixes ruby support for std::wstring, which is completely broken now. 

I am not sure how to treat wchar_t as portable. I understand portability has high priority for SWIG. This PR may not satisfy you at that point.

At least, this PR clarifies how to convert the encoding of string in Ruby C API.  `make check-ruby-test-suite` has passed.

Regards.
