### PR TITLE
[ruby] dependency bug of unordered_set containers.

### DIFF
--- a/Examples/test-suite/cpp11_std_unordered_map.i
+++ b/Examples/test-suite/cpp11_std_unordered_map.i
@@ -1,0 +1,5 @@
+%module cpp11_std_unordered_map
+
+%include <std_unordered_map.i>
+
+%template(UnorderedMapIntInt) std::unordered_map<int, int>;

--- a/Examples/test-suite/cpp11_std_unordered_multimap.i
+++ b/Examples/test-suite/cpp11_std_unordered_multimap.i
@@ -1,0 +1,7 @@
+%module cpp11_std_unordered_multimap
+
+%include <std_pair.i>
+%include <std_unordered_multimap.i>
+
+%template(PairIntInt) std::pair<int,int>;
+%template(UnorderedMultiMapIntInt) std::unordered_multimap<int, int>;

--- a/Examples/test-suite/cpp11_std_unordered_multiset.i
+++ b/Examples/test-suite/cpp11_std_unordered_multiset.i
@@ -1,0 +1,5 @@
+%module cpp11_std_unordered_multiset
+
+%include <std_unordered_multiset.i>
+
+%template(UnorderedMultiSetInt) std::unordered_multiset<int>;

--- a/Examples/test-suite/cpp11_std_unordered_set.i
+++ b/Examples/test-suite/cpp11_std_unordered_set.i
@@ -1,0 +1,5 @@
+%module cpp11_std_unordered_set
+
+%include <std_unordered_set.i>
+
+%template(UnorderedSetInt) std::unordered_set<int>;

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -35,6 +35,10 @@ CPP11_TEST_CASES = \
 	cpp11_hash_tables \
 	cpp11_shared_ptr_upcast \
 	cpp11_shared_ptr_const \
+	cpp11_std_unordered_map \
+	cpp11_std_unordered_multimap \
+	cpp11_std_unordered_set \
+	cpp11_std_unordered_multiset
 
 C_TEST_CASES += \
 	li_cstring \

--- a/Lib/ruby/std_unordered_multiset.i
+++ b/Lib/ruby/std_unordered_multiset.i
@@ -4,7 +4,7 @@
 
 %include <std_unordered_set.i>
 
-%fragment("StdUnorderedMultisetTraits","header",fragment="StdSequenceTraits")
+%fragment("StdUnorderedMultisetTraits","header",fragment="StdUnorderedSetTraits")
 %{
   namespace swig {
     template <class RubySeq, class T>

--- a/Lib/ruby/std_unordered_set.i
+++ b/Lib/ruby/std_unordered_set.i
@@ -4,7 +4,7 @@
 
 %include <std_set.i>
 
-%fragment("StdUnorderedSetTraits","header",fragment="<stddef.h>",fragment="StdSequenceTraits")
+%fragment("StdUnorderedSetTraits","header",fragment="<stddef.h>",fragment="StdSetTraits")
 %{
   namespace swig {
     template <class RubySeq, class T>


### PR DESCRIPTION
My previous merged PR needs some fixes. Sorry.

Putting all the tests of containers into one file makes it impossible to find a dependency bug like this. Should we split Examples/test-suite/cpp11_hash_tables.i into separated tests, or add some additional tests?

Regards.