### PR TITLE
[Issue 905] Add recognition for `throw (.+) final|override` in parser.y

### DIFF
--- a/Examples/test-suite/cpp11_final_override.i
+++ b/Examples/test-suite/cpp11_final_override.i
@@ -16,6 +16,8 @@ struct Base {
   virtual void finaloverride2() {}
   virtual void finaloverride3() {}
   virtual void finaloverride4() const {}
+  virtual void finaloverride5() {}
+  virtual void finaloverride6() const {}
   virtual ~Base() {}
 };
 
@@ -31,6 +33,8 @@ struct Derived /*final*/ : Base {
   virtual void finaloverride2() override final {}
   virtual void finaloverride3() noexcept override final {}
   virtual void finaloverride4() const noexcept override final {}
+  virtual void finaloverride5() throw(int) override final {}
+  virtual void finaloverride6() const throw(int) override final {}
   virtual ~Derived() override final {}
 };
 void Derived::override2() const noexcept {}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -6397,6 +6397,11 @@ exception_specification : THROW LPAREN parms RPAREN {
                     $$.throwf = 0;
                     $$.nexcept = 0;
 	       }
+	       | THROW LPAREN parms RPAREN virt_specifier_seq {
+                    $$.throws = $3;
+                    $$.throwf = NewString("1");
+                    $$.nexcept = 0;
+	       }
 	       | NOEXCEPT virt_specifier_seq {
                     $$.throws = 0;
                     $$.throwf = 0;


### PR DESCRIPTION
PROBLEM:
 There is a small ommission in parser.y, which will lead
 to syntax errors in cases when non-empty throw declaration is
 followed by `override`, `final` or both. E.g. in cases like:

       void finalOverriden() throw(std::exception) final override;

SOLUTION:
 - Add a `THROW LPAREN parms RPAREN virt_specifier_seq` to
   exception_specification in Source/CParse/parser.y
 - Add several methods in test-suite/cpp11_final_override.i
   to verify the fix works.