### PR TITLE
[ruby] add simple assertion functions for tests.

### DIFF
--- a/Examples/test-suite/ruby/swig_assert.rb
+++ b/Examples/test-suite/ruby/swig_assert.rb
@@ -16,6 +16,21 @@ end
 
 
 #
+# simple assertions. strings are not needed as arguments.
+#
+def simple_assert_equal(a, b)
+  unless a == b
+    raise SwigRubyError.new("\n#{a} expected but was \n#{b}")
+  end
+end
+
+def simple_assert(a)
+  unless a
+    raise SwigRubyError.new("assertion falied.")
+  end
+end
+
+#
 # Asserts whether a and b are equal.
 #
 # scope - optional Binding where to run the code


### PR DESCRIPTION
Hi, using the current assertion functions in Examples/test-suite/ruby/swig_assert.rb is honestly painful. They require arguments to be given as strings. It also makes test codes less readable. This PR adds simple assertion functions that fail when they should.

Regards.