### PR TITLE
[ruby] make std container classes include Enumerable module

### DIFF
--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -14,6 +14,7 @@ CPP_TEST_CASES = \
 	li_cstring \
 	li_factory \
 	li_std_functors \
+	li_std_list \
 	li_std_multimap \
 	li_std_pair_lang_object \
 	li_std_queue \

--- a/Examples/test-suite/ruby/cpp11_hash_tables_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_hash_tables_runme.rb
@@ -5,6 +5,9 @@ require 'cpp11_hash_tables'
  Cpp11_hash_tables::MultiMapIntInt.new({1=>7}),
  Cpp11_hash_tables::UnorderedMapIntInt.new({1=>7}),
  Cpp11_hash_tables::UnorderedMultiMapIntInt.new({1=>7})].each{|x|
+
+  swig_assert_equal("x.find_all{|e,k| e == 1}", "[[1,7]]", binding)
+
   swig_assert_equal("x[1]", "7", binding)
   swig_assert_equal("x[2]", "nil", binding)
   x[2] = 9
@@ -27,6 +30,9 @@ require 'cpp11_hash_tables'
  Cpp11_hash_tables::MultiSetInt.new([1]),
  Cpp11_hash_tables::UnorderedSetInt.new([1]),
  Cpp11_hash_tables::UnorderedMultiSetInt.new([1])].each{|x|
+
+  swig_assert_equal("x.find_all{|e| e == 1}", "[1]", binding)
+
   swig_assert_equal("x.include?(1)", "true", binding)
   swig_assert_equal("x.include?(2)", "false", binding)
   x << 2
@@ -41,4 +47,14 @@ require 'cpp11_hash_tables'
  Cpp11_hash_tables::UnorderedMultiSetInt.new([1])].each{|x|
   x << 1
   swig_assert_equal("x.count(1)", "2", binding)
+}
+
+[Cpp11_hash_tables::MapIntInt,
+ Cpp11_hash_tables::MultiMapIntInt,
+ Cpp11_hash_tables::UnorderedMapIntInt,
+ Cpp11_hash_tables::UnorderedMultiMapIntInt,
+ Cpp11_hash_tables::SetInt,
+ Cpp11_hash_tables::UnorderedSetInt,
+ Cpp11_hash_tables::UnorderedMultiSetInt].each{|k|
+  swig_assert("k.include?(Enumerable)", binding)
 }

--- a/Examples/test-suite/ruby/cpp11_hash_tables_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_hash_tables_runme.rb
@@ -54,6 +54,7 @@ require 'cpp11_hash_tables'
  Cpp11_hash_tables::UnorderedMapIntInt,
  Cpp11_hash_tables::UnorderedMultiMapIntInt,
  Cpp11_hash_tables::SetInt,
+ Cpp11_hash_tables::MultiSetInt,
  Cpp11_hash_tables::UnorderedSetInt,
  Cpp11_hash_tables::UnorderedMultiSetInt].each{|k|
   swig_assert("k.include?(Enumerable)", binding)

--- a/Examples/test-suite/ruby/li_std_list_runme.rb
+++ b/Examples/test-suite/ruby/li_std_list_runme.rb
@@ -1,0 +1,8 @@
+require 'swig_assert'
+
+require 'li_std_list'
+
+include Li_std_list
+
+x = DoubleList.new([1,2,3])
+swig_assert_equal("[1.0]", "x.find_all{|e| e == 1 }", binding)

--- a/Lib/ruby/std_list.i
+++ b/Lib/ruby/std_list.i
@@ -27,6 +27,7 @@
 #define %swig_list_methods(Type...) %swig_sequence_methods(Type)
 #define %swig_list_methods_val(Type...) %swig_sequence_methods_val(Type);
 
+%mixin std::list "Enumerable";
 
 %rename("delete")     std::list::__delete__;
 %rename("reject!")    std::list::reject_bang;

--- a/Lib/ruby/std_multiset.i
+++ b/Lib/ruby/std_multiset.i
@@ -36,7 +36,7 @@
 
 #define %swig_multiset_methods(Set...) %swig_set_methods(Set)
 
-
+%mixin std::multiset "Enumerable";
 
 %rename("delete")     std::multiset::__delete__;
 %rename("reject!")    std::multiset::reject_bang;

--- a/Lib/ruby/std_unordered_map.i
+++ b/Lib/ruby/std_unordered_map.i
@@ -77,7 +77,7 @@
 %rename("include?")   std::unordered_map::__contains__ const;
 %rename("has_key?")   std::unordered_map::has_key const;
 
-%mixin std::map "Enumerable";
-%alias  std::unordered_map::push          "<<";
+%mixin std::unordered_map "Enumerable";
+%alias std::unordered_map::push          "<<";
 
 %include <std/std_unordered_map.i>

--- a/Lib/ruby/std_unordered_multiset.i
+++ b/Lib/ruby/std_unordered_multiset.i
@@ -36,6 +36,8 @@
 
 #define %swig_unordered_multiset_methods(Set...) %swig_unordered_set_methods(Set)
 
+%mixin std::unordered_multiset "Enumerable";
+
 %rename("delete")     std::unordered_multiset::__delete__;
 %rename("reject!")    std::unordered_multiset::reject_bang;
 %rename("map!")       std::unordered_multiset::map_bang;


### PR DESCRIPTION
Hi, this PR make std container classes include Enumerable module.

Some of the current std containers don't include Enumerable module, which I think is not intended. Container classes having `each` method usually include Enumerable module in Ruby. 

For example, Array and Hash, having `each` method, do include Enumerable. String class, not having `each` method, does not include it.

Regards.