### PR TITLE
[Coverity] fix issue reported for setslice (pycontainer.swg)

### DIFF
--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -351,7 +351,7 @@ namespace swig {
         typename Sequence::const_iterator isit = is.begin();
         typename Sequence::iterator it = self->begin();
         std::advance(it,ii);
-        for (size_t rc=0; rc<replacecount; ++rc) {
+        for (size_t rc=0; rc<replacecount && it != self->end(); ++rc) {
           *it++ = *isit++;
           for (Py_ssize_t c=0; c<(step-1) && it != self->end(); ++c)
             it++;
@@ -367,7 +367,7 @@ namespace swig {
       typename Sequence::const_iterator isit = is.begin();
       typename Sequence::reverse_iterator it = self->rbegin();
       std::advance(it,size-ii-1);
-      for (size_t rc=0; rc<replacecount; ++rc) {
+      for (size_t rc=0; rc<replacecount && it != self->rend(); ++rc) {
         *it++ = *isit++;
         for (Py_ssize_t c=0; c<(-step-1) && it != self->rend(); ++c)
           it++;


### PR DESCRIPTION
Fix Coverity issue reported for setslice (pycontainer.swg):

"CID 11151 (#3-1 of 3): Using invalid iterator (INVALIDATE_ITERATOR)18.
increment_iterator: Incrementing iterator it though it is already past
the end of its container."

Coverity does not understand 'replace_count', so warns that we may go
past self->end() (or self->rend() I guess). Because after each slice
step, it depends on the correctness of 'replace_count' if we iterate
further (which we probably won't, but still).