### PR TITLE
[ruby] upcasting shared_ptr within std containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,11 @@ matrix:
       dist: trusty
     - compiler: gcc
       os: linux
+      env: SWIGLANG=octave SWIGJOBS=-j2 VER=4.2 CPP11=1
+      sudo: required
+      dist: trusty
+    - compiler: gcc
+      os: linux
       env: SWIGLANG=perl5
       sudo: required
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,11 +87,6 @@ matrix:
       dist: trusty
     - compiler: gcc
       os: linux
-      env: SWIGLANG=octave SWIGJOBS=-j2 VER=4.2 CPP11=1
-      sudo: required
-      dist: trusty
-    - compiler: gcc
-      os: linux
       env: SWIGLANG=perl5
       sudo: required
       dist: trusty
@@ -298,6 +293,12 @@ matrix:
     - compiler: gcc
       os: linux
       env: SWIGLANG=python SWIG_FEATURES=-O
+      sudo: required
+      dist: trusty
+    # Has started to fail at package install time
+    - compiler: gcc
+      os: linux
+      env: SWIGLANG=octave SWIGJOBS=-j2 VER=4.2 CPP11=1
       sudo: required
       dist: trusty
 before_install:

--- a/Examples/test-suite/cpp11_shared_ptr_upcast.i
+++ b/Examples/test-suite/cpp11_shared_ptr_upcast.i
@@ -9,9 +9,9 @@
 #include <vector>
 %}
 
-%include std_vector.i
-%include std_map.i
-%include std_shared_ptr.i
+%include <std_vector.i>
+%include <std_map.i>
+%include <std_shared_ptr.i>
 
 %{
 

--- a/Examples/test-suite/cpp11_shared_ptr_upcast.i
+++ b/Examples/test-suite/cpp11_shared_ptr_upcast.i
@@ -1,0 +1,97 @@
+%module cpp11_shared_ptr_upcast
+
+%{
+#include <set>
+#include <map>
+#include <memory>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+%}
+
+%include std_vector.i
+%include std_map.i
+%include std_shared_ptr.i
+
+%{
+
+class Base {
+public:
+  Base() : m(-1) {}
+  Base(int i) : m(i) {}
+  int get_m() { return m; }
+  int m;
+};
+
+class Derived : public Base {
+public:
+  Derived() : n(-2) {}
+  Derived(int i) : n(i) {}
+  int get_n() { return n; }
+  int n;
+};
+
+ typedef std::shared_ptr<Base>    BasePtr;
+ typedef std::shared_ptr<Derived> DerivedPtr;
+
+ int derived_num(DerivedPtr v) {
+   return (*v).get_n();
+ }
+
+ int derived_num(std::vector<DerivedPtr> v) {
+   return (*v[0]).get_n();
+ }
+
+ int derived_num(std::map<int, DerivedPtr> v) {
+   return (*v[0]).get_n();
+ }
+
+ int base_num(BasePtr v) {
+   return (*v).get_m();
+ }
+
+ int base_num(std::vector<BasePtr > v) {
+   return (*v[0]).get_m();
+ }
+
+ int base_num(std::map<int, BasePtr > v) {
+   return (*v[0]).get_m();
+ }
+
+%}
+
+
+%shared_ptr(Base);
+%shared_ptr(Derived);
+
+%template(BaseList) std::vector<std::shared_ptr<Base> >;
+%template(DerivedList) std::vector<std::shared_ptr<Derived> >;
+
+%template(BaseMap) std::map<int, std::shared_ptr<Base> >;
+%template(DerivedMap) std::map<int, std::shared_ptr<Derived> >;
+
+class Base {
+public:
+  Base();
+  int get_m();
+  int m;
+};
+
+class Derived : public Base {
+public:
+  Derived();
+  Derived(int i);
+  int get_n();
+  int n;
+};
+
+typedef std::shared_ptr<Base>    BasePtr;
+typedef std::shared_ptr<Derived> DerivedPtr;
+
+int derived_num(DerivedPtr);
+int derived_num(std::vector<std::shared_ptr<Derived> > v);
+int derived_num(std::map<int, DerivedPtr> v);
+int base_num(BasePtr);
+int base_num(std::vector<std::shared_ptr<Base> > v);
+int base_num(std::map<int, BasePtr > v);
+

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -31,6 +31,7 @@ CPP_TEST_CASES = \
 
 CPP11_TEST_CASES = \
 	cpp11_hash_tables \
+	cpp11_shared_ptr_upcast
 
 C_TEST_CASES += \
 	li_cstring \

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_upcast_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_upcast_runme.rb
@@ -1,0 +1,12 @@
+require 'swig_assert'
+require 'cpp11_shared_ptr_upcast'
+
+
+include Cpp11_shared_ptr_upcast
+
+simple_assert_equal( 7, derived_num(Derived.new(7)) )
+simple_assert_equal( 7, derived_num([Derived.new(7)]) )
+simple_assert_equal( 7, derived_num({0 => Derived.new(7)}) )
+simple_assert_equal(-1, base_num(Derived.new(7)) )
+simple_assert_equal(-1, base_num([Derived.new(7)]) )
+simple_assert_equal(-1, base_num({0 => Derived.new(7)}) )

--- a/Examples/test-suite/ruby/swig_assert.rb
+++ b/Examples/test-suite/ruby/swig_assert.rb
@@ -16,6 +16,21 @@ end
 
 
 #
+# simple assertions. strings are not needed as arguments.
+#
+def simple_assert_equal(a, b)
+  unless a == b
+    raise SwigRubyError.new("\n#{a} expected but was \n#{b}")
+  end
+end
+
+def simple_assert(a)
+  unless a
+    raise SwigRubyError.new("assertion falied.")
+  end
+end
+
+#
 # Asserts whether a and b are equal.
 #
 # scope - optional Binding where to run the code

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -3,11 +3,10 @@
  * The Ruby classes, for C++
  * ------------------------------------------------------------ */
 %include <rubyclasses.swg>
+%include <rubystdcommon_forward.swg>
 
-%fragment("StdTraits","header",fragment="StdTraitsCommon")
+%fragment("StdTraits","header",fragment="StdTraitsCommon",fragment="StdTraitsForwardDeclaration")
 {
-
-%#define SWIG_RUBYSTDCOMMON
 
 namespace swig {  
   /*

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -198,6 +198,79 @@ namespace swig {
   inline bool check(VALUE obj) {
     return traits_check<Type, typename traits<Type>::category>::check(obj);
   }
-}
+
+  template <class Type>
+  struct traits_asptr<std::shared_ptr<Type> > {
+    static int asptr(VALUE obj, std::shared_ptr<Type> **val) {
+      std::shared_ptr<Type> *p=0;
+      swig_type_info *descriptor = type_info<std::shared_ptr<Type> >();
+      swig_ruby_owntype newmem = {0, 0};
+      int res = descriptor ? SWIG_ConvertPtrAndOwn(obj, (void **)&p, descriptor, 0, &newmem) : SWIG_ERROR;
+      if (SWIG_IsOK(res) && p) {
+	if (val && *val) **val = *p;
+        if (newmem.own & SWIG_CAST_NEW_MEMORY) delete p;
+        return SWIG_OK;
+      } else {
+        return SWIG_ERROR;
+      }
+    }
+  };
+
+  template <class Type>
+  struct traits_asval<std::shared_ptr<Type> > {
+    static int asval(VALUE obj, std::shared_ptr<Type> *val) {
+      if (val) {
+        std::shared_ptr<Type> ret;
+	std::shared_ptr<Type> *p=&ret;
+	int res = traits_asptr<std::shared_ptr<Type> >::asptr(obj, &p);
+	if (!SWIG_IsOK(res)) return res;
+        if (val) *val = ret;
+        return SWIG_OK;
+      } else {
+	return traits_asptr<std::shared_ptr<Type> >::asptr(obj, (std::shared_ptr<Type> **)(0));
+      }
+    }
+  };
+
+  template <class Type>
+    struct traits_asval<std::shared_ptr<Type>*> {
+    static int asval(VALUE obj, std::shared_ptr<Type> **val) {
+      if (val && *val) {
+        typedef typename noconst_traits<std::shared_ptr<Type> >::noconst_type noconst_type;
+        noconst_type ret;
+        noconst_type *p = &ret;
+        int res = traits_asptr<noconst_type>::asptr(obj,  &p);
+        if (SWIG_IsOK(res)) {
+          **(const_cast<noconst_type**>(val)) = ret;
+	}
+	return res;
+      } else {
+	return traits_asptr<std::shared_ptr<Type> >::asptr(obj, (std::shared_ptr<Type> **)(0));
+      }
+    }
+  };
+
+  template <class Type>
+  struct traits_as<std::shared_ptr<Type>, pointer_category> {
+    static std::shared_ptr<Type> as(VALUE obj, bool throw_error) {
+      std::shared_ptr<Type> ret;
+      std::shared_ptr<Type> *v = &ret;
+      int res = (obj ? traits_asptr<std::shared_ptr<Type> >::asptr(obj, &v) : SWIG_ERROR);
+      if (SWIG_IsOK(res)) {
+	  return ret;
+      } else {
+	// Uninitialized return value, no Type() constructor required.
+	if (throw_error) throw std::invalid_argument("bad type");
+	VALUE lastErr = rb_gv_get("$!");
+	if (lastErr == Qnil) {
+	  SWIG_Error(SWIG_TypeError,  swig::type_name<std::shared_ptr<Type> >());
+	}
+	static std::shared_ptr<Type> *v_def = (std::shared_ptr<Type>*) malloc(sizeof(std::shared_ptr<Type>));
+	memset(v_def,0,sizeof(std::shared_ptr<Type>));
+	return *v_def;
+      }
+    }
+  };
 }
 
+}

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -7,6 +7,8 @@
 %fragment("StdTraits","header",fragment="StdTraitsCommon")
 {
 
+%#define SWIG_RUBYSTDCOMMON
+
 namespace swig {  
   /*
     Traits that provides the from method
@@ -198,79 +200,6 @@ namespace swig {
   inline bool check(VALUE obj) {
     return traits_check<Type, typename traits<Type>::category>::check(obj);
   }
-
-  template <class Type>
-  struct traits_asptr<std::shared_ptr<Type> > {
-    static int asptr(VALUE obj, std::shared_ptr<Type> **val) {
-      std::shared_ptr<Type> *p=0;
-      swig_type_info *descriptor = type_info<std::shared_ptr<Type> >();
-      swig_ruby_owntype newmem = {0, 0};
-      int res = descriptor ? SWIG_ConvertPtrAndOwn(obj, (void **)&p, descriptor, 0, &newmem) : SWIG_ERROR;
-      if (SWIG_IsOK(res) && p) {
-	if (val && *val) **val = *p;
-        if (newmem.own & SWIG_CAST_NEW_MEMORY) delete p;
-        return SWIG_OK;
-      } else {
-        return SWIG_ERROR;
-      }
-    }
-  };
-
-  template <class Type>
-  struct traits_asval<std::shared_ptr<Type> > {
-    static int asval(VALUE obj, std::shared_ptr<Type> *val) {
-      if (val) {
-        std::shared_ptr<Type> ret;
-	std::shared_ptr<Type> *p=&ret;
-	int res = traits_asptr<std::shared_ptr<Type> >::asptr(obj, &p);
-	if (!SWIG_IsOK(res)) return res;
-        if (val) *val = ret;
-        return SWIG_OK;
-      } else {
-	return traits_asptr<std::shared_ptr<Type> >::asptr(obj, (std::shared_ptr<Type> **)(0));
-      }
-    }
-  };
-
-  template <class Type>
-    struct traits_asval<std::shared_ptr<Type>*> {
-    static int asval(VALUE obj, std::shared_ptr<Type> **val) {
-      if (val && *val) {
-        typedef typename noconst_traits<std::shared_ptr<Type> >::noconst_type noconst_type;
-        noconst_type ret;
-        noconst_type *p = &ret;
-        int res = traits_asptr<noconst_type>::asptr(obj,  &p);
-        if (SWIG_IsOK(res)) {
-          **(const_cast<noconst_type**>(val)) = ret;
-	}
-	return res;
-      } else {
-	return traits_asptr<std::shared_ptr<Type> >::asptr(obj, (std::shared_ptr<Type> **)(0));
-      }
-    }
-  };
-
-  template <class Type>
-  struct traits_as<std::shared_ptr<Type>, pointer_category> {
-    static std::shared_ptr<Type> as(VALUE obj, bool throw_error) {
-      std::shared_ptr<Type> ret;
-      std::shared_ptr<Type> *v = &ret;
-      int res = (obj ? traits_asptr<std::shared_ptr<Type> >::asptr(obj, &v) : SWIG_ERROR);
-      if (SWIG_IsOK(res)) {
-	  return ret;
-      } else {
-	// Uninitialized return value, no Type() constructor required.
-	if (throw_error) throw std::invalid_argument("bad type");
-	VALUE lastErr = rb_gv_get("$!");
-	if (lastErr == Qnil) {
-	  SWIG_Error(SWIG_TypeError,  swig::type_name<std::shared_ptr<Type> >());
-	}
-	static std::shared_ptr<Type> *v_def = (std::shared_ptr<Type>*) malloc(sizeof(std::shared_ptr<Type>));
-	memset(v_def,0,sizeof(std::shared_ptr<Type>));
-	return *v_def;
-      }
-    }
-  };
+}
 }
 
-}

--- a/Lib/ruby/rubystdcommon_forward.swg
+++ b/Lib/ruby/rubystdcommon_forward.swg
@@ -1,0 +1,14 @@
+%fragment("StdTraitsForwardDeclaration","header")
+{
+namespace swig {
+  template <class Type> struct traits_asptr;
+  template <class Type> struct traits_asval;
+  struct pointer_category;
+  template <class Type, class Category> struct traits_as;
+  template<class Type> struct traits_from;
+  template <class Type> struct noconst_traits;
+  template <class Type> swig_type_info* type_info();
+  template <class Type> const char* type_name();
+  template <class Type> VALUE from(const Type& val);
+}
+}

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -3,9 +3,10 @@
 
 
  /*
-  * We want to put the folloing code after the fragment "StdTraits" at rubystdcommon.swg.
-  * This code is needed if and only if "StdTraits" and this std_shared_ptr.i are included at the same time.
-  * They don't always require each other. So specifying the dependecy by using %fragment does not work.
+  * We want to put the following code after the fragment "StdTraits" at rubystdcommon.swg.
+  * This code is needed if and only if the fragment and this std_shared_ptr.i are included at the same time.
+  * They don't always require each other. The order of including them is not predetermined either.
+  * So specifying the dependecy by using %fragment does not work.
   */
 %wrapper %{
 #ifdef SWIG_RUBYSTDCOMMON

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -67,9 +67,9 @@ namespace swig {
     static std::shared_ptr<Type> as(VALUE obj, bool throw_error) {
       std::shared_ptr<Type> ret;
       std::shared_ptr<Type> *v = &ret;
-      int res = (obj ? traits_asptr<std::shared_ptr<Type> >::asptr(obj, &v) : SWIG_ERROR);
+      int res = traits_asptr<std::shared_ptr<Type> >::asptr(obj, &v);
       if (SWIG_IsOK(res)) {
-	  return ret;
+	return ret;
       } else {
 	// Uninitialized return value, no Type() constructor required.
 	if (throw_error) throw std::invalid_argument("bad type");
@@ -82,7 +82,7 @@ namespace swig {
 	return *v_def;
       }
     }
-    };
+  };
  }
 #endif
 %}

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -1,16 +1,15 @@
 #define SWIG_SHARED_PTR_NAMESPACE std
 %include <boost_shared_ptr.i>
+%include <rubystdcommon_forward.swg>
 
 
- /*
-  * We want to put the following code after the fragment "StdTraits" at rubystdcommon.swg.
-  * This code is needed if and only if the fragment and this std_shared_ptr.i are included at the same time.
-  * They don't always require each other. The order of including them is not predetermined either.
-  * So specifying the dependecy by using %fragment does not work.
-  */
-%wrapper %{
-#ifdef SWIG_RUBYSTDCOMMON
+%fragment("StdSharedPtrTraits","header",fragment="StdTraitsForwardDeclaration")
+{
 namespace swig {
+  /*
+   template specialization for functions defined in rubystdcommon.swg.
+   here we should treat smart pointers in a way different from the way we treat raw pointers.
+  */
   template <class Type>
   struct traits_asptr<std::shared_ptr<Type> > {
     static int asptr(VALUE obj, std::shared_ptr<Type> **val) {
@@ -84,6 +83,11 @@ namespace swig {
     }
   };
 
+  /*
+   we have to remove the const qualifier to work around a BUG
+   SWIG_TypeQuery("std::shared_ptr<const Type>") == NULL,
+   which is caused by %template treating const qualifiers not properly.
+  */
   template<class Type>
   struct traits_from<std::shared_ptr<const Type> > {
     static VALUE from(const std::shared_ptr<const Type>& val) {
@@ -92,5 +96,7 @@ namespace swig {
     }
   };
 }
-#endif
-%}
+}
+
+//force the fragment.
+%fragment("StdSharedPtrTraits");

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -1,2 +1,87 @@
 #define SWIG_SHARED_PTR_NAMESPACE std
 %include <boost_shared_ptr.i>
+
+
+ /*
+  * We want to put the folloing code after the fragment "StdTraits" at rubystdcommon.swg.
+  * This code is needed if and only if "StdTraits" and this std_shared_ptr.i are included at the same time.
+  * They don't always require each other. So specifying the dependecy by using %fragment does not work.
+  */
+%wrapper %{
+#ifdef SWIG_RUBYSTDCOMMON
+namespace swig {
+  template <class Type>
+  struct traits_asptr<std::shared_ptr<Type> > {
+    static int asptr(VALUE obj, std::shared_ptr<Type> **val) {
+      std::shared_ptr<Type> *p=0;
+      swig_type_info *descriptor = type_info<std::shared_ptr<Type> >();
+      swig_ruby_owntype newmem = {0, 0};
+      int res = descriptor ? SWIG_ConvertPtrAndOwn(obj, (void **)&p, descriptor, 0, &newmem) : SWIG_ERROR;
+      if (SWIG_IsOK(res) && p) {
+	if (val && *val) **val = *p;
+        if (newmem.own & SWIG_CAST_NEW_MEMORY) delete p;
+        return SWIG_OK;
+      } else {
+        return SWIG_ERROR;
+      }
+    }
+  };
+
+  template <class Type>
+  struct traits_asval<std::shared_ptr<Type> > {
+    static int asval(VALUE obj, std::shared_ptr<Type> *val) {
+      if (val) {
+        std::shared_ptr<Type> ret;
+	std::shared_ptr<Type> *p=&ret;
+	int res = traits_asptr<std::shared_ptr<Type> >::asptr(obj, &p);
+	if (!SWIG_IsOK(res)) return res;
+        if (val) *val = ret;
+        return SWIG_OK;
+      } else {
+	return traits_asptr<std::shared_ptr<Type> >::asptr(obj, (std::shared_ptr<Type> **)(0));
+      }
+    }
+  };
+
+  template <class Type>
+    struct traits_asval<std::shared_ptr<Type>*> {
+    static int asval(VALUE obj, std::shared_ptr<Type> **val) {
+      if (val && *val) {
+        typedef typename noconst_traits<std::shared_ptr<Type> >::noconst_type noconst_type;
+        noconst_type ret;
+        noconst_type *p = &ret;
+        int res = traits_asptr<noconst_type>::asptr(obj,  &p);
+        if (SWIG_IsOK(res)) {
+          **(const_cast<noconst_type**>(val)) = ret;
+	}
+	return res;
+      } else {
+	return traits_asptr<std::shared_ptr<Type> >::asptr(obj, (std::shared_ptr<Type> **)(0));
+      }
+    }
+  };
+
+  template <class Type>
+  struct traits_as<std::shared_ptr<Type>, pointer_category> {
+    static std::shared_ptr<Type> as(VALUE obj, bool throw_error) {
+      std::shared_ptr<Type> ret;
+      std::shared_ptr<Type> *v = &ret;
+      int res = (obj ? traits_asptr<std::shared_ptr<Type> >::asptr(obj, &v) : SWIG_ERROR);
+      if (SWIG_IsOK(res)) {
+	  return ret;
+      } else {
+	// Uninitialized return value, no Type() constructor required.
+	if (throw_error) throw std::invalid_argument("bad type");
+	VALUE lastErr = rb_gv_get("$!");
+	if (lastErr == Qnil) {
+	  SWIG_Error(SWIG_TypeError,  swig::type_name<std::shared_ptr<Type> >());
+	}
+	static std::shared_ptr<Type> *v_def = (std::shared_ptr<Type>*) malloc(sizeof(std::shared_ptr<Type>));
+	memset(v_def,0,sizeof(std::shared_ptr<Type>));
+	return *v_def;
+      }
+    }
+    };
+ }
+#endif
+%}


### PR DESCRIPTION
An issue about std_shared_ptr.i mentioned in #731 and #773 also exists for Ruby. This PR fixes it. 

When upcasting `Derived*` to `Base*`, it is sufficient that `Base*` is allocated on stack, which is done by allocating `Type *p` on stack in the current `traits_asval::asval` for example. 

But when upcasting from `std::shared_ptr<Derived>` to `std::shared_ptr<Base>`,  `std::shared_ptr<Base>` needs to be allocated somewhere. In other words, when `Type = std::shared_ptr<Base>`,  we need `Type p`,  instead of `Type *p`, on stack. In the current  `Lib/ruby/rubystdcommon.swg`, `traits_asptr::asptr` does not treat the latter case properly.

In this PR, by using template specialization, a new `traits_asptr::asptr` that treats the above cases properly is defined.  The same solution might be applied to python.

Notice that in new `traits_asptr::asptr`, we call `**val = *p`.  In other words,  `**val` is assumed to be already allocated when `traits_asptr::asptr` called.  New `traits_asval::asval`s properly allocate it. I am not sure this change is acceptable.  Anyway I think this PR is a good place to start fixing this issue.

Regards.