### PR TITLE
[ruby] avoid crashing due to std::shared_ptr of const Type.

### DIFF
--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -172,7 +172,7 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
   VALUE klass;
   VALUE obj;
   
-  if (!ptr)
+  if (!ptr || !type)
     return Qnil;
   
   if (type->clientdata) {


### PR DESCRIPTION
By adding a null check, we can avoid crashing as like mentioned in #586.
Or should we use assert here? 

Regards.