### PR TITLE
[ruby] call swig::from with casting shared_ptr<const Type> to shared_ptr<Type>

### DIFF
--- a/Examples/test-suite/cpp11_shared_ptr_const.i
+++ b/Examples/test-suite/cpp11_shared_ptr_const.i
@@ -1,0 +1,47 @@
+%module cpp11_shared_ptr_const
+
+%{
+
+#include <memory>
+#include <vector>
+
+class Foo
+{
+public:
+  Foo(int i) : m(i) {}
+  int get_m() { return m;}
+  int m;
+};
+
+std::vector<std::shared_ptr<Foo> > foo_vec() {
+    std::vector<std::shared_ptr<Foo> > result;
+    result.push_back( std::shared_ptr<Foo>(new Foo(7)) );
+    return result;
+}
+
+std::vector<std::shared_ptr<const Foo> > const_foo_vec() {
+  std::vector<std::shared_ptr<const Foo> > result;
+  result.push_back( std::shared_ptr<Foo>(new Foo(7)) );
+  return result;
+}
+
+%}
+
+%include <std_shared_ptr.i>
+%include <std_vector.i>
+
+%shared_ptr(Foo);
+
+%template (FooVector) std::vector<std::shared_ptr<Foo> >;
+%template (FooConstVector) std::vector<std::shared_ptr<Foo const> >;
+
+std::vector<std::shared_ptr<Foo> > foo_vec() const;
+std::vector<std::shared_ptr<const Foo> > const_foo_vec() const;
+
+class Foo
+{
+public:
+  Foo(int i);
+  int get_m();
+  int m;
+};

--- a/Examples/test-suite/cpp11_shared_ptr_const.i
+++ b/Examples/test-suite/cpp11_shared_ptr_const.i
@@ -13,15 +13,23 @@ public:
   int m;
 };
 
-std::vector<std::shared_ptr<Foo> > foo_vec() {
+std::shared_ptr<Foo> foo(Foo v) {
+  return std::shared_ptr<Foo>(new Foo(v));
+}
+
+std::shared_ptr<const Foo> const_foo(Foo v) {
+  return std::shared_ptr<const Foo>(new Foo(v));
+}
+
+std::vector<std::shared_ptr<Foo> > foo_vec(Foo v) {
     std::vector<std::shared_ptr<Foo> > result;
-    result.push_back( std::shared_ptr<Foo>(new Foo(7)) );
+    result.push_back( std::shared_ptr<Foo>(new Foo(v)) );
     return result;
 }
 
-std::vector<std::shared_ptr<const Foo> > const_foo_vec() {
+std::vector<std::shared_ptr<const Foo> > const_foo_vec(Foo v) {
   std::vector<std::shared_ptr<const Foo> > result;
-  result.push_back( std::shared_ptr<Foo>(new Foo(7)) );
+  result.push_back( std::shared_ptr<Foo>(new Foo(v)) );
   return result;
 }
 
@@ -35,8 +43,10 @@ std::vector<std::shared_ptr<const Foo> > const_foo_vec() {
 %template (FooVector) std::vector<std::shared_ptr<Foo> >;
 %template (FooConstVector) std::vector<std::shared_ptr<Foo const> >;
 
-std::vector<std::shared_ptr<Foo> > foo_vec() const;
-std::vector<std::shared_ptr<const Foo> > const_foo_vec() const;
+std::shared_ptr<Foo> foo(Foo v);
+std::shared_ptr<const Foo> const_foo(Foo v);
+std::vector<std::shared_ptr<Foo> > foo_vec(Foo v) const;
+std::vector<std::shared_ptr<const Foo> > const_foo_vec(Foo v) const;
 
 class Foo
 {

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -31,6 +31,7 @@ CPP_TEST_CASES = \
 
 CPP11_TEST_CASES = \
 	cpp11_hash_tables \
+	cpp11_shared_ptr_const
 
 C_TEST_CASES += \
 	li_cstring \

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_const_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_const_runme.rb
@@ -3,5 +3,7 @@ require "cpp11_shared_ptr_const"
 
 include Cpp11_shared_ptr_const
 
-simple_assert_equal(7, foo_vec()[0].get_m )
-simple_assert_equal(7, const_foo_vec()[0].get_m )
+simple_assert_equal(1,           foo( Foo.new(1) ).get_m )
+simple_assert_equal(7,     const_foo( Foo.new(7) ).get_m )
+simple_assert_equal(7,       foo_vec( Foo.new(7) )[0].get_m )
+simple_assert_equal(8, const_foo_vec( Foo.new(8) )[0].get_m )

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_const_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_const_runme.rb
@@ -1,0 +1,7 @@
+require "swig_assert"
+require "cpp11_shared_ptr_const"
+
+include Cpp11_shared_ptr_const
+
+simple_assert_equal(7, foo_vec()[0].get_m )
+simple_assert_equal(7, const_foo_vec()[0].get_m )

--- a/Examples/test-suite/ruby/swig_assert.rb
+++ b/Examples/test-suite/ruby/swig_assert.rb
@@ -16,6 +16,21 @@ end
 
 
 #
+# simple assertions. strings are not needed as arguments.
+#
+def simple_assert_equal(a, b)
+  unless a == b
+    raise SwigRubyError.new("\n#{a} expected but was \n#{b}")
+  end
+end
+
+def simple_assert(a)
+  unless a
+    raise SwigRubyError.new("assertion falied.")
+  end
+end
+
+#
 # Asserts whether a and b are equal.
 #
 # scope - optional Binding where to run the code

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -7,6 +7,8 @@
 %fragment("StdTraits","header",fragment="StdTraitsCommon")
 {
 
+%#define SWIG_RUBYSTDCOMMON
+
 namespace swig {  
   /*
     Traits that provides the from method

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -1,2 +1,17 @@
 #define SWIG_SHARED_PTR_NAMESPACE std
 %include <boost_shared_ptr.i>
+
+
+%wrapper %{
+#ifdef SWIG_RUBYSTDCOMMON
+namespace swig {
+  template<class Type>
+  struct traits_from<std::shared_ptr<const Type> > {
+    static VALUE from(const std::shared_ptr<const Type>& val) {
+      std::shared_ptr<Type> p = std::const_pointer_cast<Type>(val);
+      return swig::from(p);
+    }
+  };
+};
+#endif
+%}


### PR DESCRIPTION
Crashing due to `std::shared_ptr<const Type>` is reported on #586 for Ruby, on #753 for Python. This PR fixes it for Ruby. The same solution might be applied to Python.

The root cause of this issue is the lacking of `%template` treating constness properly, which turns into  `SWIG_TypeQuery("std::shared_ptr<const Type>") == NULL`. 

In this PR, by using template specialization for `swig::from`, we remove the const qualifier of `std::shared_ptr<const Type>`  with `std::const_pointer_cast`, then call `swig::from` for the cast value.

This PR may conflict with #930 when merging. I will rebase and edit if needed.

Regards.