### PR TITLE
[ruby] must not do a null check for VALUE obj

### DIFF
--- a/Examples/test-suite/ruby/std_containers_runme.rb
+++ b/Examples/test-suite/ruby/std_containers_runme.rb
@@ -13,6 +13,8 @@ require 'swig_assert'
 require 'std_containers'
 include Std_containers
 
+swig_assert_equal("[true, false]", "videntb([true, false])")
+
 swig_assert_each_line(<<'EOF', binding)
 
 cube = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]

--- a/Examples/test-suite/std_containers.i
+++ b/Examples/test-suite/std_containers.i
@@ -115,6 +115,10 @@
     return v;
   }
 
+  std::vector<bool> videntb(const std::vector<bool>& v)
+  {
+    return v;
+  }
 
   int get_elem(const std::vector<int>& v, int index)
   {

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -246,7 +246,7 @@ typedef struct {
 SWIGRUNTIME swig_ruby_owntype
 SWIG_Ruby_AcquirePtr(VALUE obj, swig_ruby_owntype own) {
   swig_ruby_owntype oldown = {0, 0};
-  if (obj) {
+  if (TYPE(obj) == T_DATA) {
     oldown.datafree = RDATA(obj)->dfree;
     RDATA(obj)->dfree = own.datafree;
   }

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -117,7 +117,7 @@ namespace swig {
     static Type as(VALUE obj, bool throw_error) {
       Type v;
       int res = asval(obj, &v);
-      if (!obj || !SWIG_IsOK(res)) {
+      if (!SWIG_IsOK(res)) {
 	if (throw_error) throw std::invalid_argument("bad type");
 	VALUE lastErr = rb_gv_get("$!");
 	if (lastErr == Qnil) {
@@ -132,7 +132,7 @@ namespace swig {
   struct traits_as<Type, pointer_category> {
     static Type as(VALUE obj, bool throw_error) {
       Type *v = 0;      
-      int res = (obj ? traits_asptr<Type>::asptr(obj, &v) : SWIG_ERROR);
+      int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res) && v) {
 	if (SWIG_IsNewObj(res)) {
 	  Type r(*v);
@@ -159,7 +159,7 @@ namespace swig {
   struct traits_as<Type*, pointer_category> {
     static Type* as(VALUE obj, bool throw_error) {
       Type *v = 0;      
-      int res = (obj ? traits_asptr<Type>::asptr(obj, &v) : SWIG_ERROR);
+      int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res)) {
 	return v;
       } else {
@@ -181,7 +181,7 @@ namespace swig {
   template <class Type> 
   struct traits_check<Type, value_category> {
     static bool check(VALUE obj) {
-      int res = obj ? asval(obj, (Type *)(0)) : SWIG_ERROR;
+      int res = asval(obj, (Type *)(0));
       return SWIG_IsOK(res) ? true : false;
     }
   };
@@ -189,7 +189,7 @@ namespace swig {
   template <class Type> 
   struct traits_check<Type, pointer_category> {
     static bool check(VALUE obj) {
-      int res = obj ? asptr(obj, (Type **)(0)) : SWIG_ERROR;
+      int res = asptr(obj, (Type **)(0));
       return SWIG_IsOK(res) ? true : false;
     }
   };


### PR DESCRIPTION
Doing a null check for `VALUE obj` is inappropriate. `VALUE obj` can be `0x0 == Qfalse`, which is a valid Ruby object. 

In the current master, calling `func([false])` in Ruby for `func(const std::vector<bool>&)` always causes TypeError. This PR fixes it.

Regards.