### PR TITLE
[Java] Call super in finalize override.

### DIFF
--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1233,8 +1233,12 @@ SWIG_JAVABODY_PROXY(protected, protected, SWIGTYPE)
 SWIG_JAVABODY_TYPEWRAPPER(protected, protected, protected, SWIGTYPE)
 
 %typemap(javafinalize) SWIGTYPE %{
-  protected void finalize() {
-    delete();
+  protected void finalize() throws Throwable {
+    try {
+      delete();
+    } finally {
+      super.finalize();
+    }
   }
 %}
 


### PR DESCRIPTION
Zealous static analysers complain about the missing call to `super.finalize()`. We address their complaint by changing the generated `finalize` override to call super.