### PR TITLE
Fix dependency of SwigPySequence_Base fragment

### DIFF
--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -102,7 +102,7 @@ namespace swig {
 } 
 }
 
-%fragment("SwigPySequence_Base","header",fragment="<stddef.h>")
+%fragment("SwigPySequence_Base","header",fragment="StdTraits")
 {
 %#include <functional>
 


### PR DESCRIPTION
This fragment needs to depend on StdTraits fragment as it specializes the
template struct traits<> defined there and it could happen that the struct was
not declared before being specialized, resulting in compilation errors in the
generated code.

It doesn't seem to need to depend on stddef.h inclusion, however, so replace
it with the correct dependency instead of keeping both.

---

Unfortunately I can't provide a simple test case for the bug fixed by this change as it only arises when using multiple modules with `%template` declarations in both of them, but I hope this still can be applied as it seems to be "obviously correct" and just makes `SwigPySequence_Base` fragment consistent with the other fragments defined in the same file.