### PR TITLE
Don't hardcode C# type corresponding to size_t in vector typemaps

### DIFF
--- a/Lib/csharp/std_vector.i
+++ b/Lib/csharp/std_vector.i
@@ -70,7 +70,7 @@
     set {
       if (value < size())
         throw new global::System.ArgumentOutOfRangeException("Capacity");
-      reserve((uint)value);
+      reserve(($typemap(cstype, size_t))value);
     }
   }
 


### PR DESCRIPTION
The C# type corresponding to size_t may be changed by redefining its "cstype"
type typemap, but this broke compilation of the code using std::vector<> as
the typemap generating it assumed that size_t was always represented by uint
in C#. Make this work in all cases by explicitly looking up cstype of size_t
instead.

Notice that it may be quite useful, and even necessary, to map size_t to int
as when generating C# assembly for use with COM, via .NET interop, as some COM
clients, notably VBA-using ones, including all Microsoft Office applications,
don't support unsigned types and can't call methods using or returning uint in
C# at all.