### PR TITLE
[CI] Fix Octave 4.2 CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -305,12 +305,6 @@ matrix:
       env: SWIGLANG=python SWIG_FEATURES=-O
       sudo: required
       dist: trusty
-    # Has started to fail at package install time
-    - compiler: gcc
-      os: linux
-      env: SWIGLANG=octave SWIGJOBS=-j2 VER=4.2 CPP11=1
-      sudo: required
-      dist: trusty
 before_install:
   - date -u
   - uname -a

--- a/Tools/travis-linux-install.sh
+++ b/Tools/travis-linux-install.sh
@@ -63,6 +63,14 @@ case "$SWIGLANG" in
 		travis_retry sudo apt-get -qq install ocaml ocaml-findlib
 		;;
 	"octave")
+		# Travis adds external PPAs which contain newer versions of packages
+		# than in baseline trusty. These newer packages prevent some of the
+		# Octave packages in ppa:kwwette/octave, which rely on the older
+		# packages in trusty, from installing. To prevent these kind of
+		# interactions arising, clean out all external PPAs added by Travis
+		# before installing Octave
+		travis_retry sudo rm -rf /etc/apt/sources.list.d/*
+		travis_retry sudo apt-get -qq update
 		if [[ -z "$VER" ]]; then
 			travis_retry sudo apt-get -qq install liboctave-dev
 		else


### PR DESCRIPTION
- Travis adds external PPAs which contain newer versions of packages
  than in baseline trusty. These newer packages prevent some of the
  Octave packages in ppa:kwwette/octave, which rely on the older
  packages in trusty, from installing. To prevent these kind of
  interactions arising, clean out all external PPAs added by Travis
  before installing Octave.