### PR TITLE
[Ruby] fix crashing when using shared_ptr.i and directors.

### DIFF
--- a/Examples/test-suite/cpp11_shared_ptr_director.i
+++ b/Examples/test-suite/cpp11_shared_ptr_director.i
@@ -5,28 +5,54 @@
 %}
 
 %include "std_shared_ptr.i";
-%shared_ptr(Created);
-%feature("director") Creator;
+%shared_ptr(C);
+%feature("director") Base;
 
 %inline %{
-struct Created {
-  Created() {};
-  int get_m() { return 1; };
+struct C {
+  C() : m(1) {};
+  C(int n) : m(n) {};
+  int get_m() { return m; };
+  int m;
 };
 
-struct Creator {
-  Creator() {};
-  virtual std::shared_ptr<Created> create() = 0;
-  virtual ~Creator() {}
+struct Base {
+  Base() {};
+  virtual std::shared_ptr<C> ret_c_shared_ptr() = 0;
+  virtual C ret_c_by_value() = 0;
+  virtual int take_c_by_value(C c) = 0;
+  virtual int take_c_shared_ptr_by_value(std::shared_ptr<C> c) = 0;
+  virtual int take_c_shared_ptr_by_ref(std::shared_ptr<C>& c) = 0;
+  virtual ~Base() {}
 };
 
-int crash(Creator* creator) {
-  std::shared_ptr<Created> ptr = creator->create();
+int call_ret_c_shared_ptr(Base* b) {
+  std::shared_ptr<C> ptr = b->ret_c_shared_ptr();
   if (ptr) {
     return ptr->get_m();
   } else {
     return -1;
   }
+}
+
+int call_ret_c_by_value(Base* b) {
+  C c = b->ret_c_by_value();
+  return c.get_m();
+}
+
+int call_take_c_by_value(Base* b) {
+  C c(5);
+  return b->take_c_by_value(c);
+}
+
+int call_take_c_shared_ptr_by_value(Base* b) {
+  std::shared_ptr<C> ptr(new C(6));
+  return b->take_c_shared_ptr_by_value(ptr);
+}
+
+int call_take_c_shared_ptr_by_ref(Base* b) {
+  std::shared_ptr<C> ptr(new C(7));
+  return b->take_c_shared_ptr_by_ref(ptr);
 }
 
 %}

--- a/Examples/test-suite/cpp11_shared_ptr_director.i
+++ b/Examples/test-suite/cpp11_shared_ptr_director.i
@@ -1,0 +1,23 @@
+%module(directors="1") "cpp11_shared_ptr_director"
+
+%{
+#include <memory>
+%}
+
+%include "std_shared_ptr.i";
+%shared_ptr(Created);
+%feature("director") Creator;
+
+%inline %{
+struct Created {};
+
+struct Creator {
+  Creator() {};
+  virtual std::shared_ptr<Created> create() = 0;
+  virtual ~Creator() {}
+};
+
+void crash(Creator* creator) {
+  std::shared_ptr<Created> ptr = creator->create();
+}
+%}

--- a/Examples/test-suite/cpp11_shared_ptr_director.i
+++ b/Examples/test-suite/cpp11_shared_ptr_director.i
@@ -23,6 +23,8 @@ struct Base {
   virtual int take_c_by_value(C c) = 0;
   virtual int take_c_shared_ptr_by_value(std::shared_ptr<C> c) = 0;
   virtual int take_c_shared_ptr_by_ref(std::shared_ptr<C>& c) = 0;
+  virtual int take_c_shared_ptr_by_pointer(std::shared_ptr<C>* c) = 0;
+  virtual int take_c_shared_ptr_by_pointer_ref(std::shared_ptr<C>*const&c) = 0;
   virtual ~Base() {}
 };
 
@@ -50,9 +52,39 @@ int call_take_c_shared_ptr_by_value(Base* b) {
   return b->take_c_shared_ptr_by_value(ptr);
 }
 
+int call_take_c_shared_ptr_by_value_with_null(Base* b) {
+  std::shared_ptr<C> ptr;
+  return b->take_c_shared_ptr_by_value(ptr);
+}
+
 int call_take_c_shared_ptr_by_ref(Base* b) {
   std::shared_ptr<C> ptr(new C(7));
   return b->take_c_shared_ptr_by_ref(ptr);
+}
+
+int call_take_c_shared_ptr_by_ref_with_null(Base* b) {
+  std::shared_ptr<C> ptr;
+  return b->take_c_shared_ptr_by_ref(ptr);
+}
+
+int call_take_c_shared_ptr_by_pointer(Base* b) {
+  std::shared_ptr<C> ptr(new C(8));
+  return b->take_c_shared_ptr_by_pointer(&ptr);
+}
+
+int call_take_c_shared_ptr_by_pointer_with_null(Base* b) {
+  std::shared_ptr<C> ptr;
+  return b->take_c_shared_ptr_by_pointer(&ptr);
+}
+
+int call_take_c_shared_ptr_by_pointer_ref(Base* b) {
+  auto ptr = new std::shared_ptr<C>(new C(9));
+  return b->take_c_shared_ptr_by_pointer_ref(ptr);
+}
+
+int call_take_c_shared_ptr_by_pointer_ref_with_null(Base* b) {
+  auto ptr = new std::shared_ptr<C>();
+  return b->take_c_shared_ptr_by_pointer_ref(ptr);
 }
 
 %}

--- a/Examples/test-suite/cpp11_shared_ptr_director.i
+++ b/Examples/test-suite/cpp11_shared_ptr_director.i
@@ -1,10 +1,10 @@
 %module(directors="1") "cpp11_shared_ptr_director"
 
 %{
-#include <memory>
+#include <boost/shared_ptr.hpp>
 %}
 
-%include "std_shared_ptr.i";
+%include "boost_shared_ptr.i";
 %shared_ptr(C);
 %feature("director") Base;
 
@@ -18,18 +18,18 @@ struct C {
 
 struct Base {
   Base() {};
-  virtual std::shared_ptr<C> ret_c_shared_ptr() = 0;
+  virtual boost::shared_ptr<C> ret_c_shared_ptr() = 0;
   virtual C ret_c_by_value() = 0;
   virtual int take_c_by_value(C c) = 0;
-  virtual int take_c_shared_ptr_by_value(std::shared_ptr<C> c) = 0;
-  virtual int take_c_shared_ptr_by_ref(std::shared_ptr<C>& c) = 0;
-  virtual int take_c_shared_ptr_by_pointer(std::shared_ptr<C>* c) = 0;
-  virtual int take_c_shared_ptr_by_pointer_ref(std::shared_ptr<C>*const&c) = 0;
+  virtual int take_c_shared_ptr_by_value(boost::shared_ptr<C> c) = 0;
+  virtual int take_c_shared_ptr_by_ref(boost::shared_ptr<C>& c) = 0;
+  virtual int take_c_shared_ptr_by_pointer(boost::shared_ptr<C>* c) = 0;
+  virtual int take_c_shared_ptr_by_pointer_ref(boost::shared_ptr<C>*const&c) = 0;
   virtual ~Base() {}
 };
 
 int call_ret_c_shared_ptr(Base* b) {
-  std::shared_ptr<C> ptr = b->ret_c_shared_ptr();
+  boost::shared_ptr<C> ptr = b->ret_c_shared_ptr();
   if (ptr) {
     return ptr->get_m();
   } else {
@@ -48,42 +48,42 @@ int call_take_c_by_value(Base* b) {
 }
 
 int call_take_c_shared_ptr_by_value(Base* b) {
-  std::shared_ptr<C> ptr(new C(6));
+  boost::shared_ptr<C> ptr(new C(6));
   return b->take_c_shared_ptr_by_value(ptr);
 }
 
 int call_take_c_shared_ptr_by_value_with_null(Base* b) {
-  std::shared_ptr<C> ptr;
+  boost::shared_ptr<C> ptr;
   return b->take_c_shared_ptr_by_value(ptr);
 }
 
 int call_take_c_shared_ptr_by_ref(Base* b) {
-  std::shared_ptr<C> ptr(new C(7));
+  boost::shared_ptr<C> ptr(new C(7));
   return b->take_c_shared_ptr_by_ref(ptr);
 }
 
 int call_take_c_shared_ptr_by_ref_with_null(Base* b) {
-  std::shared_ptr<C> ptr;
+  boost::shared_ptr<C> ptr;
   return b->take_c_shared_ptr_by_ref(ptr);
 }
 
 int call_take_c_shared_ptr_by_pointer(Base* b) {
-  std::shared_ptr<C> ptr(new C(8));
+  boost::shared_ptr<C> ptr(new C(8));
   return b->take_c_shared_ptr_by_pointer(&ptr);
 }
 
 int call_take_c_shared_ptr_by_pointer_with_null(Base* b) {
-  std::shared_ptr<C> ptr;
+  boost::shared_ptr<C> ptr;
   return b->take_c_shared_ptr_by_pointer(&ptr);
 }
 
 int call_take_c_shared_ptr_by_pointer_ref(Base* b) {
-  auto ptr = new std::shared_ptr<C>(new C(9));
+  boost::shared_ptr<C> *ptr = new boost::shared_ptr<C>(new C(9));
   return b->take_c_shared_ptr_by_pointer_ref(ptr);
 }
 
 int call_take_c_shared_ptr_by_pointer_ref_with_null(Base* b) {
-  auto ptr = new std::shared_ptr<C>();
+  boost::shared_ptr<C> *ptr = new boost::shared_ptr<C>();
   return b->take_c_shared_ptr_by_pointer_ref(ptr);
 }
 

--- a/Examples/test-suite/cpp11_shared_ptr_director.i
+++ b/Examples/test-suite/cpp11_shared_ptr_director.i
@@ -9,7 +9,10 @@
 %feature("director") Creator;
 
 %inline %{
-struct Created {};
+struct Created {
+  Created() {};
+  int get_m() { return 1; };
+};
 
 struct Creator {
   Creator() {};
@@ -17,7 +20,13 @@ struct Creator {
   virtual ~Creator() {}
 };
 
-void crash(Creator* creator) {
+int crash(Creator* creator) {
   std::shared_ptr<Created> ptr = creator->create();
+  if (ptr) {
+    return ptr->get_m();
+  } else {
+    return -1;
+  }
 }
+
 %}

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -33,7 +33,8 @@ CPP_TEST_CASES = \
 CPP11_TEST_CASES = \
 	cpp11_hash_tables \
 	cpp11_shared_ptr_upcast \
-	cpp11_shared_ptr_const
+	cpp11_shared_ptr_const \
+	cpp11_shared_ptr_director
 
 C_TEST_CASES += \
 	li_cstring \

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
@@ -19,6 +19,6 @@ class Derived < Creator
 
 end
 
-crash(Derived.new(false))
-crash(Derived.new(true))
+p crash(Derived.new(false))
+p crash(Derived.new(true))
 

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
@@ -1,0 +1,24 @@
+require 'cpp11_shared_ptr_director'
+
+include Cpp11_shared_ptr_director
+
+class Derived < Creator
+
+  def initialize(flag)
+    @return_none = flag
+    super()
+  end
+
+  def create
+    if @return_none
+      nil
+    else
+      Created.new
+    end
+  end
+
+end
+
+crash(Derived.new(false))
+crash(Derived.new(true))
+

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
@@ -2,23 +2,47 @@ require 'cpp11_shared_ptr_director'
 
 include Cpp11_shared_ptr_director
 
-class Derived < Creator
+class Derived < Base
 
   def initialize(flag)
     @return_none = flag
     super()
   end
 
-  def create
+  def ret_c_shared_ptr
     if @return_none
       nil
     else
-      Created.new
+      C.new
     end
+  end
+
+  def ret_c_by_value
+    C.new
+  end
+
+  def take_c_by_value(c)
+    c.get_m
+  end
+
+  def take_c_shared_ptr_by_value(c)
+    c.get_m
+  end
+
+  def take_c_shared_ptr_by_ref(c)
+    c.get_m
   end
 
 end
 
-p crash(Derived.new(false))
-p crash(Derived.new(true))
+a = Derived.new(false)
+b = Derived.new(true)
+
+raise unless call_ret_c_shared_ptr(a) ==  1
+raise unless call_ret_c_shared_ptr(b) == -1
+raise unless call_ret_c_by_value(a)   ==  1
+
+raise unless call_take_c_by_value(a)            == 5
+raise unless call_take_c_shared_ptr_by_value(a) == 6
+raise unless call_take_c_shared_ptr_by_ref(a)   == 7
 

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_director_runme.rb
@@ -26,11 +26,35 @@ class Derived < Base
   end
 
   def take_c_shared_ptr_by_value(c)
-    c.get_m
+    if c
+      c.get_m
+    else
+      -2
+    end
   end
 
   def take_c_shared_ptr_by_ref(c)
-    c.get_m
+    if c
+      c.get_m
+    else
+      -3
+    end
+  end
+
+  def take_c_shared_ptr_by_pointer(c)
+    if c
+      c.get_m
+    else
+      -4
+    end
+  end
+
+  def take_c_shared_ptr_by_pointer_ref(c)
+    if c
+      c.get_m
+    else
+      -5
+    end
   end
 
 end
@@ -42,7 +66,14 @@ raise unless call_ret_c_shared_ptr(a) ==  1
 raise unless call_ret_c_shared_ptr(b) == -1
 raise unless call_ret_c_by_value(a)   ==  1
 
-raise unless call_take_c_by_value(a)            == 5
-raise unless call_take_c_shared_ptr_by_value(a) == 6
-raise unless call_take_c_shared_ptr_by_ref(a)   == 7
+raise unless call_take_c_by_value(a)                  == 5
+raise unless call_take_c_shared_ptr_by_value(a)       == 6
+raise unless call_take_c_shared_ptr_by_ref(a)         == 7
+raise unless call_take_c_shared_ptr_by_pointer(a)     == 8
+raise unless call_take_c_shared_ptr_by_pointer_ref(a) == 9
+
+raise unless call_take_c_shared_ptr_by_value_with_null(a)       == -2
+raise unless call_take_c_shared_ptr_by_ref_with_null(a)         == -3
+raise unless call_take_c_shared_ptr_by_pointer_with_null(a)     == -4
+raise unless call_take_c_shared_ptr_by_pointer_ref_with_null(a) == -5
 

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -260,11 +260,19 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > {
+  if ($1) {
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+  } else {
+    $input = Qnil;
+  }
+}
 %typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void * swig_argp, int swig_res = 0) {
   if (NIL_P($input)) {
     $result = $ltype();
   } else {
-    swig_res = SWIG_ConvertPtr($input,&swig_argp,$&descriptor, %convertptr_flags);
+    swig_res = SWIG_ConvertPtr($input, &swig_argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags);
     if (!SWIG_IsOK(swig_res)) {
       %dirout_fail(swig_res,"$type");
     }
@@ -301,6 +309,14 @@
 #error "varout typemap not implemented"
 %}
 
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & {
+  if ($1) {
+    $input = SWIG_NewPointerObj(%as_voidptr(&$1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+  } else {
+    $input = Qnil;
+  }
+}
+
 //
 // shared_ptr by pointer
 //
@@ -330,6 +346,14 @@
 %typemap(varout) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * %{
 #error "varout typemap not implemented"
 %}
+
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
+  if ($1 && *$1) {
+    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+  } else {
+    $input = Qnil;
+  }
+}
 
 //
 // shared_ptr by pointer reference

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -24,9 +24,7 @@
 
 // Typemap customisations...
 
-//
 // plain value
-//
 %typemap(in) CONST TYPE (void *argp, int res = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -82,10 +80,8 @@
   $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
 }
 
-//
 // plain pointer
 // Note: $disown not implemented by default as it will lead to a memory leak of the shared_ptr instance
-//
 %typemap(in) CONST TYPE * (void  *argp = 0, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartarg = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SHARED_PTR_DISOWN | %convertptr_flags, &newmem);
@@ -101,6 +97,7 @@
     $1 = %const_cast((smartarg ? smartarg->get() : 0), $1_ltype);
   }
 }
+
 %typemap(out, fragment="SWIG_null_deleter_python") CONST TYPE * {
   SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_$owner) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), $owner | SWIG_POINTER_OWN));
@@ -136,9 +133,7 @@
 #error "directorout typemap for plain pointer not implemented"
 %}
 
-//
 // plain reference
-//
 %typemap(in) CONST TYPE & (void  *argp = 0, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -190,10 +185,8 @@
 #error "directorout typemap for plain reference not implemented"
 %}
 
-//
 // plain pointer by reference
 // Note: $disown not implemented by default as it will lead to a memory leak of the shared_ptr instance
-//
 %typemap(in) TYPE *CONST& (void  *argp = 0, int res = 0, $*1_ltype temp = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SHARED_PTR_DISOWN | %convertptr_flags, &newmem);
@@ -228,9 +221,7 @@
 #error "directorout typemap for plain pointer by reference not implemented"
 %}
 
-//
 // shared_ptr by value
-//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void *argp, int res = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -280,9 +271,7 @@
   }
 }
 
-//
 // shared_ptr by reference
-//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & (void *argp, int res = 0, $*1_ltype tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -317,9 +306,7 @@
   }
 }
 
-//
 // shared_ptr by pointer
-//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * (void *argp, int res = 0, $*1_ltype tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -355,9 +342,7 @@
   }
 }
 
-//
 // shared_ptr by pointer reference
-//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& (void *argp, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared, $*1_ltype temp = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -24,7 +24,9 @@
 
 // Typemap customisations...
 
+//
 // plain value
+//
 %typemap(in) CONST TYPE (void *argp, int res = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -62,8 +64,28 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorout,noblock=1) CONST TYPE (void *argp, int res = 0) {
+  swig_ruby_owntype newmem = {0, 0};
+  res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
+  if (!SWIG_IsOK(res)) {
+    %dirout_fail(res, "$type");
+  }
+  if (!argp) {
+    %dirout_nullref("$type");
+  } else {
+    $result = *(%reinterpret_cast(argp, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *)->get());
+    if (newmem.own & SWIG_CAST_NEW_MEMORY) delete %reinterpret_cast(argp, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *);
+  }
+}
+%typemap(directorin,noblock=1) CONST TYPE {
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(new $1_ltype(($1_ltype &)$1));
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+}
+
+//
 // plain pointer
 // Note: $disown not implemented by default as it will lead to a memory leak of the shared_ptr instance
+//
 %typemap(in) CONST TYPE * (void  *argp = 0, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartarg = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SHARED_PTR_DISOWN | %convertptr_flags, &newmem);
@@ -79,7 +101,6 @@
     $1 = %const_cast((smartarg ? smartarg->get() : 0), $1_ltype);
   }
 }
-
 %typemap(out, fragment="SWIG_null_deleter_python") CONST TYPE * {
   SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_$owner) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), $owner | SWIG_POINTER_OWN));
@@ -108,7 +129,16 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1) CONST TYPE * %{
+#error "directorin typemap for plain pointer not implemented"
+%}
+%typemap(directorout,noblock=1) CONST TYPE * %{
+#error "directorout typemap for plain pointer not implemented"
+%}
+
+//
 // plain reference
+//
 %typemap(in) CONST TYPE & (void  *argp = 0, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -153,8 +183,17 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1) CONST TYPE & %{
+#error "directorin typemap for plain reference not implemented"
+%}
+%typemap(directorout,noblock=1) CONST TYPE & %{
+#error "directorout typemap for plain reference not implemented"
+%}
+
+//
 // plain pointer by reference
 // Note: $disown not implemented by default as it will lead to a memory leak of the shared_ptr instance
+//
 %typemap(in) TYPE *CONST& (void  *argp = 0, int res = 0, $*1_ltype temp = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SHARED_PTR_DISOWN | %convertptr_flags, &newmem);
@@ -182,7 +221,16 @@
 #error "varout typemap not implemented"
 %}
 
+%typemap(directorin,noblock=1) TYPE *CONST& %{
+#error "directorin typemap for plain pointer by reference not implemented"
+%}
+%typemap(directorout,noblock=1) TYPE *CONST& %{
+#error "directorout typemap for plain pointer by reference not implemented"
+%}
+
+//
 // shared_ptr by value
+//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void *argp, int res = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -195,18 +243,6 @@
 %typemap(out) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > {
   SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
-}
-
-%typemap(directorout) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void * swig_argp, int swig_res = 0) {
-  if (NIL_P($input)) {
-    $result = $ltype();
-  } else {
-    swig_res = SWIG_ConvertPtr($input,&swig_argp,$&descriptor, %convertptr_flags);
-    if (!SWIG_IsOK(swig_res)) {
-      %dirout_fail(swig_res,"$type");
-    }
-    $result = *(%reinterpret_cast(swig_argp, $&ltype));
-  }
 }
 
 %typemap(varin) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > {
@@ -224,7 +260,21 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void * swig_argp, int swig_res = 0) {
+  if (NIL_P($input)) {
+    $result = $ltype();
+  } else {
+    swig_res = SWIG_ConvertPtr($input,&swig_argp,$&descriptor, %convertptr_flags);
+    if (!SWIG_IsOK(swig_res)) {
+      %dirout_fail(swig_res,"$type");
+    }
+    $result = *(%reinterpret_cast(swig_argp, $&ltype));
+  }
+}
+
+//
 // shared_ptr by reference
+//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & (void *argp, int res = 0, $*1_ltype tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -251,7 +301,9 @@
 #error "varout typemap not implemented"
 %}
 
+//
 // shared_ptr by pointer
+//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * (void *argp, int res = 0, $*1_ltype tempshared) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -279,7 +331,9 @@
 #error "varout typemap not implemented"
 %}
 
+//
 // shared_ptr by pointer reference
+//
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& (void *argp, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared, $*1_ltype temp = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -197,6 +197,18 @@
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorout) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void * swig_argp, int swig_res = 0) {
+  if (NIL_P($input)) {
+    $result = $ltype();
+  } else {
+    swig_res = SWIG_ConvertPtr($input,&swig_argp,$&descriptor, %convertptr_flags);
+    if (!SWIG_IsOK(swig_res)) {
+      %dirout_fail(swig_res,"$type");
+    }
+    $result = *(%reinterpret_cast(swig_argp, $&ltype));
+  }
+}
+
 %typemap(varin) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > {
   swig_ruby_owntype newmem = {0, 0};
   void *argp = 0;


### PR DESCRIPTION
Crashing when using shared_ptr and directors is reported in #837 for Python. The same issue exists for Ruby. This PR fix it for Ruby. 

The cause of this issue is that `%typemap(directorout)`  treating null shared_ptr properly  is not defined in `boost_shared_ptr.i`. `%typemap(directorin)` also has to be defined in `boost_shared_ptr.i` for the same reason.

This PR defines appropriate typemaps. `#error` directives are also added in the cases appropriate typemaps can not be defined.