### PR TITLE
[ruby] null shared_ptr in std containers.

### DIFF
--- a/Examples/test-suite/cpp11_shared_ptr_nullptr_in_containers.i
+++ b/Examples/test-suite/cpp11_shared_ptr_nullptr_in_containers.i
@@ -3,6 +3,8 @@
 %{
 #include <memory>
 #include <vector>
+
+class C;
 %}
 
 %include <std_shared_ptr.i>
@@ -38,7 +40,7 @@ public:
   }
 
   bool is_last_null(const std::vector<std::shared_ptr<C> >& v) {
-    if( *v.end() ) {
+    if( v.back() ) {
       return false;
     } else {
       return true;

--- a/Examples/test-suite/cpp11_shared_ptr_nullptr_in_containers.i
+++ b/Examples/test-suite/cpp11_shared_ptr_nullptr_in_containers.i
@@ -1,0 +1,48 @@
+%module cpp11_shared_ptr_nullptr_in_containers
+
+%{
+#include <memory>
+#include <vector>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_vector.i>
+
+%shared_ptr(C)
+
+%inline %{
+
+class C {
+public:
+  C() : m(-1) {}
+  C(int i) : m(i) {}
+  int get_m() { return m; }
+  int m;
+};
+
+%}
+
+%template() std::vector<std::shared_ptr<C> >;
+
+%inline %{
+
+  std::vector<std::shared_ptr<C> > ret_vec_c_shared_ptr() {
+    std::vector<std::shared_ptr<C> > ret(3);
+    ret[0] = std::shared_ptr<C>(new C(0));
+    ret[2] = std::shared_ptr<C>(new C(2));
+    return ret;
+  }
+
+  std::vector<std::shared_ptr<C> > ret_arg_vec(const std::vector<std::shared_ptr<C> >& v) {
+    return v;
+  }
+
+  bool is_last_null(const std::vector<std::shared_ptr<C> >& v) {
+    if( *v.end() ) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+%}

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -33,6 +33,7 @@ CPP_TEST_CASES = \
 CPP11_TEST_CASES = \
 	cpp11_hash_tables \
 	cpp11_shared_ptr_upcast \
+	cpp11_shared_ptr_nullptr_in_containers \
 	cpp11_shared_ptr_const
 
 C_TEST_CASES += \

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_nullptr_in_containers_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_nullptr_in_containers_runme.rb
@@ -13,3 +13,4 @@ raise unless a[1]       == nil
 raise unless a[2].get_m == 9
 
 raise unless is_last_null([C.new(7), C.new(8), nil])
+raise if is_last_null([C.new(7), C.new(8)])

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_nullptr_in_containers_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_nullptr_in_containers_runme.rb
@@ -1,0 +1,15 @@
+require "cpp11_shared_ptr_nullptr_in_containers"
+
+include Cpp11_shared_ptr_nullptr_in_containers
+
+a = ret_vec_c_shared_ptr()
+raise unless a[0].get_m == 0
+raise unless a[1]       == nil
+raise unless a[2].get_m == 2
+
+a = ret_arg_vec([C.new(7), nil, C.new(9)])
+raise unless a[0].get_m == 7
+raise unless a[1]       == nil
+raise unless a[2].get_m == 9
+
+raise unless is_last_null([C.new(7), C.new(8), nil])

--- a/Lib/ruby/rubystdcommon_forward.swg
+++ b/Lib/ruby/rubystdcommon_forward.swg
@@ -5,7 +5,8 @@ namespace swig {
   template <class Type> struct traits_asval;
   struct pointer_category;
   template <class Type, class Category> struct traits_as;
-  template<class Type> struct traits_from;
+  template <class Type> struct traits_from;
+  template <class Type> struct traits_from_ptr;
   template <class Type> struct noconst_traits;
   template <class Type> swig_type_info* type_info();
   template <class Type> const char* type_name();

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -113,6 +113,17 @@ namespace swig {
     }
   };
 
+  template <class Type>
+  struct traits_from_ptr<std::shared_ptr<Type> > {
+    static VALUE from(std::shared_ptr<Type> *val, int owner = 0) {
+      if (val && *val) {
+        return SWIG_NewPointerObj(val, type_info<std::shared_ptr<Type> >(), owner);
+      } else {
+        return Qnil;
+      }
+    }
+  };
+
   /*
    The descriptors in the shared_ptr typemaps remove the const qualifier for the SWIG type system.
    Remove const likewise here, otherwise SWIG_TypeQuery("std::shared_ptr<const Type>") will return NULL.


### PR DESCRIPTION
Hi,
in #59, it is reported that null shared_ptr in std containers is not properly treated for Python. The same issue exists for Ruby. This PR fixes it for Ruby.

This PR depends on the PR #930, which I hope will be merged soon.  You can see the [diff](https://github.com/tamuratak/swig/compare/shared_ptr_derived_2...tamuratak:fix_ruby_null_shared_ptr) between #930 and this PR.

The way of fixing this issue is similar to the one in #930. We define `traits_from_ptr<std::shared_ptr<Type>>::from` by using template specialization. `traits_asptr<std::shared_ptr<Type>>::asptr` defined in #930 also needs a patch.

Regards. 