### PR TITLE
[ruby] check whether object is of RTypedData.

### DIFF
--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -25,6 +25,7 @@ CPP_TEST_CASES = \
 	ruby_keywords \
 	ruby_minherit_shared_ptr \
 	ruby_naming \
+	ruby_rdata \
 	ruby_track_objects \
 	ruby_track_objects_directors \
 	std_containers \

--- a/Examples/test-suite/ruby/ruby_rdata_runme.rb
+++ b/Examples/test-suite/ruby/ruby_rdata_runme.rb
@@ -1,0 +1,7 @@
+require 'swig_assert'
+require 'ruby_rdata'
+
+include Ruby_rdata
+
+swig_assert_equal_simple(1, take_proc_or_cpp_obj_and_ret_1(Proc.new{}))
+swig_assert_equal_simple(1, take_proc_or_cpp_obj_and_ret_1(C.new))

--- a/Examples/test-suite/ruby_rdata.i
+++ b/Examples/test-suite/ruby_rdata.i
@@ -8,7 +8,7 @@
     return 1;
   }
 
-  int take_proc_or_cpp_obj_and_ret_1(class C) {
+  int take_proc_or_cpp_obj_and_ret_1(C c) {
     return 1;
   }
 

--- a/Examples/test-suite/ruby_rdata.i
+++ b/Examples/test-suite/ruby_rdata.i
@@ -1,0 +1,20 @@
+%module ruby_rdata
+
+%{
+
+  class C {};
+
+  int take_proc_or_cpp_obj_and_ret_1(VALUE obj) {
+    return 1;
+  }
+
+  int take_proc_or_cpp_obj_and_ret_1(class C) {
+    return 1;
+  }
+
+%}
+
+class C {};
+
+int take_proc_or_cpp_obj_and_ret_1(VALUE);
+int take_proc_or_cpp_obj_and_ret_1(C);

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -247,7 +247,7 @@ typedef struct {
 SWIGRUNTIME swig_ruby_owntype
 SWIG_Ruby_AcquirePtr(VALUE obj, swig_ruby_owntype own) {
   swig_ruby_owntype oldown = {0, 0};
-  if (TYPE(obj) == T_DATA) {
+  if (TYPE(obj) == T_DATA && !RTYPEDDATA_P(obj)) {
     oldown.datafree = RDATA(obj)->dfree;
     RDATA(obj)->dfree = own.datafree;
   }
@@ -268,7 +268,7 @@ SWIG_Ruby_ConvertPtrAndOwn(VALUE obj, void **ptr, swig_type_info *ty, int flags,
       *ptr = 0;
     return SWIG_OK;
   } else {
-    if (TYPE(obj) != T_DATA) {
+    if (TYPE(obj) != T_DATA || (TYPE(obj) == T_DATA && RTYPEDDATA_P(obj))) {
       return SWIG_ERROR;
     }
     Data_Get_Struct(obj, void, vptr);


### PR DESCRIPTION
Hi,
`struct RTypedData` has been introduced from ruby-1.9.3, which is not used in the current SWIG, in which `struct RData` is used. 

However `TYPE(obj) == T_DATA` holds for the both `struct RData` objects and `struct RTypedData` objects. So we must check which an object is even if `TYPE(obj) == T_DATA` holds for the object.

Without this PR, overloading in the attached test does not work. This PR fixes that.

Regards.