### PR TITLE
[ruby] workaround for shared_ptr.i  and shared_ptr of std containers.

### DIFF
--- a/Examples/test-suite/cpp11_shared_ptr_of_std_containers.i
+++ b/Examples/test-suite/cpp11_shared_ptr_of_std_containers.i
@@ -1,0 +1,13 @@
+%module cpp11_shared_ptr_of_std_containers
+
+%{
+#include <memory>
+%}
+
+%include <std_string.i>
+%include <std_vector.i>
+%include <std_shared_ptr.i>
+
+%shared_ptr(std::vector<std::string>);
+
+%template(StringVector) std::vector<std::string>;

--- a/Examples/test-suite/li_boost_shared_ptr.i
+++ b/Examples/test-suite/li_boost_shared_ptr.i
@@ -55,7 +55,7 @@
 %shared_ptr(Space::KlassDerived)
 %shared_ptr(Space::Klass2ndDerived)
 %shared_ptr(Space::Klass3rdDerived)
-%shared_ptr(IgnoredMultipleInheritBase) // IgnoredMultipleInheritBase not actually used in any wrapped functions, so this isn't entirely necessary and warning 520 could instead have been suppressed.
+%shared_ptr(Space::IgnoredMultipleInheritBase) // IgnoredMultipleInheritBase not actually used in any wrapped functions, so this isn't entirely necessary and warning 520 could instead have been suppressed.
 
 #endif
 

--- a/Examples/test-suite/ruby/cpp11_shared_ptr_of_std_containers_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_shared_ptr_of_std_containers_runme.rb
@@ -1,0 +1,9 @@
+require "cpp11_shared_ptr_of_std_containers"
+
+include Cpp11_shared_ptr_of_std_containers
+
+
+a = StringVector.new
+a.push("abc")
+a[0] = "xyz"
+raise unless a[0] == "xyz"

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -382,6 +382,17 @@
   $1 = SWIG_CheckState(res);
 }
 
+%wrapper %{
+
+namespace swig {
+  template<typename Type> int asptr(VALUE obj, Type **vptr);
+  template<>
+  inline int asptr< CONST TYPE >(VALUE obj, CONST TYPE **vptr) {
+    return SWIG_ConvertPtr(obj, 0, SWIG_TypeQuery("std::shared_ptr<" #TYPE  "> *"), 0);
+  }
+}
+
+%}
 
 // various missing typemaps - If ever used (unlikely) ensure compilation error rather than runtime bug
 %typemap(in) CONST TYPE[], CONST TYPE[ANY], CONST TYPE (CLASS::*) %{

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -386,7 +386,6 @@
 %fragment("StdSharedPtrAsptr" #CONST #TYPE,"header",fragment="StdTraitsForwardDeclaration")
 {
 namespace swig {
-  template<typename Type> int asptr(VALUE obj, Type **vptr);
   template<>
   inline int asptr< CONST TYPE >(VALUE obj, CONST TYPE **vptr) {
     assert(!(vptr && *vptr));

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -382,17 +382,20 @@
   $1 = SWIG_CheckState(res);
 }
 
-%wrapper %{
-
+#if defined(SWIG_USE_STD_SHARED_PTR)
+%fragment("StdSharedPtrAsptr" #CONST #TYPE,"header",fragment="StdTraitsForwardDeclaration")
+{
 namespace swig {
   template<typename Type> int asptr(VALUE obj, Type **vptr);
   template<>
   inline int asptr< CONST TYPE >(VALUE obj, CONST TYPE **vptr) {
+    assert(!(vptr && *vptr));
     return SWIG_ConvertPtr(obj, 0, SWIG_TypeQuery("std::shared_ptr<" #TYPE  "> *"), 0);
   }
 }
-
-%}
+}
+%fragment("StdSharedPtrAsptr" #CONST #TYPE);
+#endif
 
 // various missing typemaps - If ever used (unlikely) ensure compilation error rather than runtime bug
 %typemap(in) CONST TYPE[], CONST TYPE[ANY], CONST TYPE (CLASS::*) %{

--- a/Lib/ruby/rubystdcommon_forward.swg
+++ b/Lib/ruby/rubystdcommon_forward.swg
@@ -11,5 +11,6 @@ namespace swig {
   template <class Type> swig_type_info* type_info();
   template <class Type> const char* type_name();
   template <class Type> VALUE from(const Type& val);
+  template <typename Type> int asptr(VALUE obj, Type **vptr);
 }
 }

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -125,17 +125,6 @@ namespace swig {
     }
   };
 
-  template <class Type>
-  struct traits_from_ptr<std::shared_ptr<Type> > {
-    static VALUE from(std::shared_ptr<Type> *val, int owner = 0) {
-      if (val && *val) {
-        return SWIG_NewPointerObj(val, type_info<std::shared_ptr<Type> >(), owner);
-      } else {
-        return Qnil;
-      }
-    }
-  };
-
   /*
    The descriptors in the shared_ptr typemaps remove the const qualifier for the SWIG type system.
    Remove const likewise here, otherwise SWIG_TypeQuery("std::shared_ptr<const Type>") will return NULL.

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -124,6 +124,17 @@ namespace swig {
     }
   };
 
+  template <class Type>
+  struct traits_from_ptr<std::shared_ptr<Type> > {
+    static VALUE from(std::shared_ptr<Type> *val, int owner = 0) {
+      if (val && *val) {
+        return SWIG_NewPointerObj(val, type_info<std::shared_ptr<Type> >(), owner);
+      } else {
+        return Qnil;
+      }
+    }
+  };
+
   /*
    The descriptors in the shared_ptr typemaps remove the const qualifier for the SWIG type system.
    Remove const likewise here, otherwise SWIG_TypeQuery("std::shared_ptr<const Type>") will return NULL.

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -1,4 +1,5 @@
 #define SWIG_SHARED_PTR_NAMESPACE std
+#define SWIG_USE_STD_SHARED_PTR
 %include <boost_shared_ptr.i>
 %include <rubystdcommon_forward.swg>
 


### PR DESCRIPTION
Hi,
in #952, it is reported that std_shared_ptr.i  can not properly treat std shared pointers of std containers for python. This issue also exists for ruby. This PR fixes it for ruby.

The cause of this issue is that typemaps defined in std_shared_ptr.i are overridden by typemaps called in std/std_vector.i, etc through `%typemap_traits_ptr` which are always called after ones in std_shared_ptr.i. 

I have no idea how to correct the order. So this PR is a workaround. Although I doubt  this is ready for merged, I submit this PR to clarify this issue.

Regards.