### PR TITLE
[C#] typemaps for std::list<T> as LinkedList<T>

### DIFF
--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -25,7 +25,8 @@ CPP_TEST_CASES = \
 	enum_thorough_typesafe \
 	exception_partial_info \
 	intermediary_classname \
-	li_boost_intrusive_ptr
+	li_boost_intrusive_ptr \
+	li_std_list \
 
 CPP11_TEST_CASES = \
 	cpp11_strongly_typed_enumerations_simple \

--- a/Examples/test-suite/csharp/li_std_list_runme.cs
+++ b/Examples/test-suite/csharp/li_std_list_runme.cs
@@ -1,0 +1,404 @@
+using System;
+
+public class li_std_list_runme {
+    private static readonly int collectionSize = 20;
+
+    public static void Main() {
+      // Setup a list of int
+      IntList list = new IntList();
+      IntList.IntListNode node;
+
+      for (int i = 0; i < 20; i++) {
+        int nb = i * 10;
+        list.Add(nb);
+      }
+
+      // Count property test
+      if (list.Count != collectionSize)
+        throw new Exception("Count test failed");
+
+      // IsReadOnly property test
+      if (list.IsReadOnly)
+        throw new Exception("IsReadOnly test failed");
+
+      // Contains method test
+      if (!list.Contains(0))
+        throw new Exception("Contains method test 1 failed");
+      if (!list.Contains(2 * 10))
+        throw new Exception("Contains method test 2 failed");
+      if (!list.Contains(19 * 10))
+        throw new Exception("Contains method test 3 failed");
+      if (list.Contains(20 * 10))
+        throw new Exception("Contains method test 4 failed");
+
+      // Nodes comparison method overload
+      {
+        IntList.IntListNode temp = new IntList.IntListNode(3);
+        if (list.First == temp)
+          throw new Exception("== overload method test (1) failed");
+        temp = new IntList.IntListNode(0);
+        if (list.First == temp)
+          throw new Exception("== overload method test (2) failed");
+        IntList.IntListNode temp2 = new IntList.IntListNode(0);
+        if (temp == temp2)
+          throw new Exception("== overload method test (3) failed");
+        if (!(list.First == list.First))
+          throw new Exception("== overload method test (4) failed");
+        if (list.First != list.First)
+          throw new Exception("!= overload method test (1) failed");
+        if (!(temp != temp2))
+          throw new Exception("!= overload method test (2) failed");
+        if (list.First.Equals(temp))
+          throw new Exception("Equals method test failed");
+        if (list.First.GetHashCode() == temp.GetHashCode())
+          throw new Exception("GetHashCode method test (1) failed");
+        if (list.First.GetHashCode() == list.First.GetHashCode())
+          throw new Exception("GetHashCode method test (2) failed");
+
+      }
+
+      // Getter test
+      {
+        if (list.First == null)
+          throw new Exception("First getter test (1) failed");
+        if (list.Last == null)
+          throw new Exception("Last getter test (1) failed");
+        Console.WriteLine(list.Last.Value);
+        if (list.Last.Next != null)
+          throw new Exception("Next getter test (1) failed");
+        if (list.First.Next == null)
+          throw new Exception("Next getter test (2) failed");
+        if (list.First.Previous != null)
+          throw new Exception("Previous getter test (1) failed");
+         if (list.Last.Previous == null)
+          throw new Exception("Previous getter test (2) failed");
+      }
+
+      // AddFirst method test
+      node = list.AddFirst(34);
+      if (list.First.Value != 34 || node.Value != 34 || node != list.First)
+        throw new Exception("AddFirst method test failed");
+      try {
+        list.AddFirst(null);
+      } catch (ArgumentNullException) {
+        try {
+          list.AddFirst(list.First);
+        } catch (InvalidOperationException) {
+        }
+      }
+
+      // RemoveFirst method test
+      int tmp = list.First.Value;
+      list.RemoveFirst();
+      if (list.First.Value == tmp || list.First.Value != 0 * 10)
+        throw new Exception("RemoveFirst method test failed");
+
+      // AddLast method test
+      node = list.AddLast(8);
+      if (list.Last.Value != 8 || node.Value != 8 || node != list.Last)
+        throw new Exception("AddLast method test failed");
+      try {
+        list.AddLast(null);
+      } catch (ArgumentNullException) {
+        try {
+          list.AddLast(list.First);
+        } catch (InvalidOperationException) {
+        }
+      }
+
+      // RemoveLast method test
+      int tmp2 = list.Last.Value;
+      list.RemoveLast();
+      if (list.Last.Value == tmp2 || list.Last.Value != (list.Count - 1) * 10)
+        throw new Exception("RemoveLast method test failed");
+
+      // AddBefore method test
+      node = list.AddBefore(list.Last, 17);
+      if (list.Last.Previous.Value != 17 || node.Value != 17 || node != list.Last.Previous)
+        throw new Exception("AddBefore method test (1) failed");
+      try {
+        node = null;
+        list.AddBefore(list.Last, node);
+        throw new Exception("AddBefore method test (2) failed");
+      } catch (ArgumentNullException) {
+        try {
+          node = new IntList.IntListNode(1);
+          list.AddBefore(null, node);
+          throw new Exception("AddBefore method test (3) failed");
+        } catch (ArgumentNullException) {
+          try {
+            list.AddBefore(list.Last, list.First);
+          } catch (InvalidOperationException) {
+          }
+        }
+      }
+
+      // AddAfter method test
+      node = list.AddAfter(list.First, 47);
+      if (list.First.Next.Value != 47 || node.Value != 47 || node != list.First.Next)
+        throw new Exception("AddAfter method test (1) failed");
+      try {
+        node = null;
+        list.AddAfter(list.First.Next, node);
+        throw new Exception("AddAfter method test (2) failed");
+      } catch (ArgumentNullException) {
+        try {
+          list.AddAfter(list.First, list.Last);
+        } catch (InvalidOperationException) {
+        }
+      }
+
+      // Find method test
+      node = list.Find(0);
+      if (node == null || node.Value != 0)
+        throw new Exception("Find method test (1) failed");
+      node = list.Find(47);
+      if (node == null || node.Value != 47)
+        throw new Exception("Find method test (2) failed");
+      node = list.Find(190);
+      if (node == null || node.Value != 190)
+        throw new Exception("Find method test (3) failed");
+      node = list.Find(-3);
+      if (node != null)
+        throw new Exception("Find method test (4) failed");
+
+      // Remove method test
+      if (!list.Remove(17) || list.Contains(17) || list.Last.Previous.Value == 17)
+        throw new Exception("Remove method test (1) failed");
+      if (!list.Remove(47) || list.Contains(47) || list.First.Next.Value == 47)
+        throw new Exception("Remove method test (2) failed");
+      if (!list.Remove(0) || list.Contains(0) || list.First.Value == 0)
+        throw new Exception("Remove method test (3) failed");
+      if (!list.Remove(190) || list.Contains(190) || list.Last.Value == 190)
+        throw new Exception("Remove method test (4) failed");
+      try {
+        node = null;
+        list.Remove(node);
+        throw new Exception("Remove method test (5) failed");
+      } catch (ArgumentNullException) {
+        try {
+            node = new IntList.IntListNode(4);
+            list.Remove(node);         
+            throw new Exception("Remove method test (5) failed");
+        } catch (InvalidOperationException) {
+        }
+      }
+
+      // ICollection constructor test
+      {
+        int[] intArray = new int[] { 0, 11, 22, 33, 44, 55, 33 };
+        IntList il = new IntList(intArray);
+        if (intArray.Length != il.Count)
+          throw new Exception("ICollection constructor length check failed: " + intArray.Length + "-" + il.Count);
+        node = il.First;
+        for (int i = 0; i < intArray.Length; i++) {
+          if (intArray[i] != node.Value)
+            throw new Exception("ICollection constructor failed, index:" + i);
+          node = node.Next;
+        }
+        try {
+          new IntList((System.Collections.ICollection)null);
+          throw new Exception("ICollection constructor null test failed");
+        } catch (ArgumentNullException) {
+        }
+      }
+
+      // Enumerator test
+      {
+        node = list.First;
+        System.Collections.IEnumerator myEnumerator = list.GetEnumerator();
+        while (myEnumerator.MoveNext()) {
+          if ((int)myEnumerator.Current != node.Value)
+            throw new Exception("Enumerator (1) test failed");
+          node = node.Next;
+        }
+      }
+      {
+        node = list.First;
+        System.Collections.Generic.IEnumerator<int> myEnumerator = list.GetEnumerator();
+        while (myEnumerator.MoveNext()) {
+          if (myEnumerator.Current != node.Value)
+            throw new Exception("Enumerator (2) test failed");
+          node = node.Next;
+        }
+      }
+      {
+        node = list.First;
+        IntList.IntListEnumerator myEnumerator = list.GetEnumerator();
+        while (myEnumerator.MoveNext()) {
+          if (myEnumerator.Current != node.Value)
+            throw new Exception("Enumerator (3) test failed");
+          node = node.Next;
+        }
+      }
+      {
+        node = list.First;
+        foreach (var elem in list) {
+          if (elem != node.Value)
+            throw new Exception("Enumerator (4) test failed");
+          node = node.Next;
+        }
+      }
+      
+      // CopyTo method test
+      {
+        int[] outputarray = new int[collectionSize - 2];
+        list.CopyTo(outputarray, 0);
+        int index = 0;
+        IntList.IntListNode temp = list.First;
+        foreach (int val in outputarray) {
+          if (temp.Value != val) {
+            throw new Exception("CopyTo method test (1) failed, index:" + index);
+          }
+          index++;
+          temp = temp.Next;
+        }
+      }
+      {
+        DoubleList inputlist = new DoubleList();
+        int arrayLen = 10;
+        for (int i = 0; i < arrayLen; i++) {
+          double num = i * 10.1;
+          inputlist.Add(num);
+        }
+        double[] outputarray = new double[arrayLen];
+        inputlist.CopyTo(outputarray, 0);
+        DoubleList.DoubleListNode temp = inputlist.First;
+        for (int i = 0; i < arrayLen; i++) {
+          if (outputarray[i] != temp.Value)
+            throw new Exception("CopyTo method test (2) failed, index:" + i);
+          temp = temp.Next;
+        }
+      }
+      {
+        StructList inputlist = new StructList();
+        int arrayLen = 10;
+        for (int i = 0; i < arrayLen; i++)
+          inputlist.Add(new Struct(i / 10.0));
+        Struct[] outputarray = new Struct[arrayLen];
+        inputlist.CopyTo(outputarray, 0);
+        StructList.StructListNode temp = inputlist.First;
+        for (int i = 0; i < arrayLen; i++) {
+          if (outputarray[i].num != temp.Value.num)
+            throw new Exception("CopyTo method test (3) failed, index:" + i);
+          temp = temp.Next;
+        }
+        foreach (Struct s in inputlist) {
+          s.num += 20.0;
+        }
+        temp = inputlist.First;
+        for (int i = 0; i < arrayLen; i++) {
+          Console.WriteLine(outputarray[i].num + " - " + temp.Value.num);
+          if (outputarray[i].num != temp.Value.num)
+            throw new Exception("CopyTo method test (4) failed, index:" + i);
+          temp = temp.Next;
+        }
+      }
+      try {
+        list.CopyTo(null, 0);
+        throw new Exception("CopyTo method test (5) failed");
+      } catch (ArgumentNullException) {
+      }
+       
+      // Clear() test
+      list.Clear();
+      if (list.Count != 0)
+        throw new Exception("Clear method failed");
+
+      // Finally test the methods being wrapped
+      {
+        IntList il = new IntList();
+        for (int i = 0; i < 4; i++) {
+          il.Add(i);
+        }
+
+        double x = li_std_list.average(il);
+        x += li_std_list.average(new IntList(new int[] { 1, 2, 3, 4 }));
+
+        DoubleList dlist = new DoubleList();
+        for (int i = 0; i < 10; i++) {
+          dlist.Add(i / 2.0);
+        }
+        li_std_list.halve_in_place(dlist);
+      }
+
+      // Dispose()
+      {
+        using (StructList ls = new StructList(new Struct[] { new Struct(0.0), new Struct(11.1) }))
+        using (DoubleList ld = new DoubleList(new double[] { 0.0, 11.1 })) {  }
+      }
+
+      // More wrapped methods
+      {
+        RealList l0 = li_std_list.listreal(new RealList());
+        float flo = 123.456f;
+        l0.Add(flo);
+        flo = l0.First.Value;
+
+        IntList l1 = li_std_list.listintptr(new IntList());
+        IntPtrList l2 = li_std_list.listintptr(new IntPtrList());
+        IntConstPtrList l3 = li_std_list.listintconstptr(new IntConstPtrList());
+
+        l1.Add(123);
+        l2.Clear();
+        l3.Clear();
+
+        StructList l4 = li_std_list.liststruct(new StructList());
+        StructPtrList l5 = li_std_list.liststructptr(new StructPtrList());
+        StructConstPtrList l6 = li_std_list.liststructconstptr(new StructConstPtrList());
+
+        l4.Add(new Struct(123));
+        l5.Add(new Struct(123));
+        l6.Add(new Struct(123));
+      }
+
+      // Test lists of pointers
+      {
+        StructPtrList inputlist = new StructPtrList();
+        int arrayLen = 10;
+        for (int i = 0; i < arrayLen; i++) {
+          inputlist.Add(new Struct(i / 10.0));
+        }
+        Struct[] outputarray = new Struct[arrayLen];
+        inputlist.CopyTo(outputarray, 0);
+        StructPtrList.StructPtrListNode temp = inputlist.First;
+        for (int i = 0; i < arrayLen; i++) {
+          if (outputarray[i].num != temp.Value.num)
+            throw new Exception("StructPtrList test (1) failed, i:" + i);
+          temp = temp.Next;
+        }
+        foreach (Struct s in inputlist) {
+          s.num += 20.0;
+        }
+        for (int i = 0; i < arrayLen; i++) {
+          if (outputarray[i].num != 20.0 + i / 10.0)
+            throw new Exception("StructPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
+        }
+      }
+
+      // Test lists of const pointers
+      {
+        StructConstPtrList inputlist = new StructConstPtrList();
+        int arrayLen = 10;
+        for (int i = 0; i < arrayLen; i++) {
+          inputlist.Add(new Struct(i / 10.0));
+        }
+        Struct[] outputarray = new Struct[arrayLen];
+        inputlist.CopyTo(outputarray, 0);
+        StructConstPtrList.StructConstPtrListNode temp = inputlist.First;
+        for (int i = 0; i < arrayLen; i++) {
+          if (outputarray[i].num != temp.Value.num)
+            throw new Exception("StructConstPtrList test (1) failed, i:" + i);
+          temp = temp.Next;
+        }
+        foreach (Struct s in inputlist) {
+          s.num += 20.0;
+        }
+        for (int i = 0; i < arrayLen; i++) {
+          if (outputarray[i].num != 20.0 + i / 10.0)
+            throw new Exception("StructConstPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
+        }
+      }
+    }
+  }
+}

--- a/Examples/test-suite/csharp/li_std_list_runme.cs
+++ b/Examples/test-suite/csharp/li_std_list_runme.cs
@@ -1,402 +1,401 @@
 using System;
 
 public class li_std_list_runme {
-    private static readonly int collectionSize = 20;
+  private static readonly int collectionSize = 20;
 
-    public static void Main() {
-      // Setup a list of int
-      IntList list = new IntList();
-      IntList.IntListNode node;
+  public static void Main() {
+    // Setup a list of int
+    IntList list = new IntList();
+    IntList.IntListNode node;
 
-      for (int i = 0; i < 20; i++) {
-        int nb = i * 10;
-        list.Add(nb);
-      }
+    for (int i = 0; i < 20; i++) {
+      int nb = i * 10;
+      list.Add(nb);
+    }
 
-      // Count property test
-      if (list.Count != collectionSize)
-        throw new Exception("Count test failed");
+    // Count property test
+    if (list.Count != collectionSize)
+      throw new Exception("Count test failed");
 
-      // IsReadOnly property test
-      if (list.IsReadOnly)
-        throw new Exception("IsReadOnly test failed");
+    // IsReadOnly property test
+    if (list.IsReadOnly)
+      throw new Exception("IsReadOnly test failed");
 
-      // Contains method test
-      if (!list.Contains(0))
-        throw new Exception("Contains method test 1 failed");
-      if (!list.Contains(2 * 10))
-        throw new Exception("Contains method test 2 failed");
-      if (!list.Contains(19 * 10))
-        throw new Exception("Contains method test 3 failed");
-      if (list.Contains(20 * 10))
-        throw new Exception("Contains method test 4 failed");
+    // Contains method test
+    if (!list.Contains(0))
+      throw new Exception("Contains method test 1 failed");
+    if (!list.Contains(2 * 10))
+      throw new Exception("Contains method test 2 failed");
+    if (!list.Contains(19 * 10))
+      throw new Exception("Contains method test 3 failed");
+    if (list.Contains(20 * 10))
+      throw new Exception("Contains method test 4 failed");
 
-      // Nodes comparison method overload
-      {
-        IntList.IntListNode temp = new IntList.IntListNode(3);
-        if (list.First == temp)
-          throw new Exception("== overload method test (1) failed");
-        temp = new IntList.IntListNode(0);
-        if (list.First == temp)
-          throw new Exception("== overload method test (2) failed");
-        IntList.IntListNode temp2 = new IntList.IntListNode(0);
-        if (temp == temp2)
-          throw new Exception("== overload method test (3) failed");
-        if (!(list.First == list.First))
-          throw new Exception("== overload method test (4) failed");
-        if (list.First != list.First)
-          throw new Exception("!= overload method test (1) failed");
-        if (!(temp != temp2))
-          throw new Exception("!= overload method test (2) failed");
-        if (list.First.Equals(temp))
-          throw new Exception("Equals method test failed");
-        if (list.First.GetHashCode() == temp.GetHashCode())
-          throw new Exception("GetHashCode method test (1) failed");
-        if (list.First.GetHashCode() == list.First.GetHashCode())
-          throw new Exception("GetHashCode method test (2) failed");
+    // Nodes comparison method overload
+    {
+      IntList.IntListNode temp = new IntList.IntListNode(3);
+      if (list.First == temp)
+        throw new Exception("== overload method test (1) failed");
+      temp = new IntList.IntListNode(0);
+      if (list.First == temp)
+        throw new Exception("== overload method test (2) failed");
+      IntList.IntListNode temp2 = new IntList.IntListNode(0);
+      if (temp == temp2)
+        throw new Exception("== overload method test (3) failed");
+      if (!(list.First == list.First))
+        throw new Exception("== overload method test (4) failed");
+      if (list.First != list.First)
+        throw new Exception("!= overload method test (1) failed");
+      if (!(temp != temp2))
+        throw new Exception("!= overload method test (2) failed");
+      if (list.First.Equals(temp))
+        throw new Exception("Equals method test failed");
+      if (list.First.GetHashCode() == temp.GetHashCode())
+        throw new Exception("GetHashCode method test (1) failed");
+      if (list.First.GetHashCode() == list.First.GetHashCode())
+        throw new Exception("GetHashCode method test (2) failed");
 
-      }
+    }
 
-      // Getter test
-      {
-        if (list.First == null)
-          throw new Exception("First getter test (1) failed");
-        if (list.Last == null)
-          throw new Exception("Last getter test (1) failed");
-        if (list.Last.Next != null)
-          throw new Exception("Next getter test (1) failed");
-        if (list.First.Next == null)
-          throw new Exception("Next getter test (2) failed");
-        if (list.First.Previous != null)
-          throw new Exception("Previous getter test (1) failed");
-         if (list.Last.Previous == null)
-          throw new Exception("Previous getter test (2) failed");
-      }
+    // Getter test
+    {
+      if (list.First == null)
+        throw new Exception("First getter test (1) failed");
+      if (list.Last == null)
+        throw new Exception("Last getter test (1) failed");
+      if (list.Last.Next != null)
+        throw new Exception("Next getter test (1) failed");
+      if (list.First.Next == null)
+        throw new Exception("Next getter test (2) failed");
+      if (list.First.Previous != null)
+        throw new Exception("Previous getter test (1) failed");
+       if (list.Last.Previous == null)
+        throw new Exception("Previous getter test (2) failed");
+    }
 
-      // AddFirst method test
-      node = list.AddFirst(34);
-      if (list.First.Value != 34 || node.Value != 34 || node != list.First)
-        throw new Exception("AddFirst method test failed");
+    // AddFirst method test
+    node = list.AddFirst(34);
+    if (list.First.Value != 34 || node.Value != 34 || node != list.First)
+      throw new Exception("AddFirst method test failed");
+    try {
+      list.AddFirst(null);
+    } catch (ArgumentNullException) {
       try {
-        list.AddFirst(null);
+        list.AddFirst(list.First);
+      } catch (InvalidOperationException) {
+      }
+    }
+
+    // RemoveFirst method test
+    int tmp = list.First.Value;
+    list.RemoveFirst();
+    if (list.First.Value == tmp || list.First.Value != 0 * 10)
+      throw new Exception("RemoveFirst method test failed");
+
+    // AddLast method test
+    node = list.AddLast(8);
+    if (list.Last.Value != 8 || node.Value != 8 || node != list.Last)
+      throw new Exception("AddLast method test failed");
+    try {
+      list.AddLast(null);
+    } catch (ArgumentNullException) {
+      try {
+        list.AddLast(list.First);
+      } catch (InvalidOperationException) {
+      }
+    }
+
+    // RemoveLast method test
+    int tmp2 = list.Last.Value;
+    list.RemoveLast();
+    if (list.Last.Value == tmp2 || list.Last.Value != (list.Count - 1) * 10)
+      throw new Exception("RemoveLast method test failed");
+
+    // AddBefore method test
+    node = list.AddBefore(list.Last, 17);
+    if (list.Last.Previous.Value != 17 || node.Value != 17 || node != list.Last.Previous)
+      throw new Exception("AddBefore method test (1) failed");
+    try {
+      node = null;
+      list.AddBefore(list.Last, node);
+      throw new Exception("AddBefore method test (2) failed");
+    } catch (ArgumentNullException) {
+      try {
+        node = new IntList.IntListNode(1);
+        list.AddBefore(null, node);
+        throw new Exception("AddBefore method test (3) failed");
       } catch (ArgumentNullException) {
         try {
-          list.AddFirst(list.First);
+          list.AddBefore(list.Last, list.First);
         } catch (InvalidOperationException) {
-        }
-      }
-
-      // RemoveFirst method test
-      int tmp = list.First.Value;
-      list.RemoveFirst();
-      if (list.First.Value == tmp || list.First.Value != 0 * 10)
-        throw new Exception("RemoveFirst method test failed");
-
-      // AddLast method test
-      node = list.AddLast(8);
-      if (list.Last.Value != 8 || node.Value != 8 || node != list.Last)
-        throw new Exception("AddLast method test failed");
-      try {
-        list.AddLast(null);
-      } catch (ArgumentNullException) {
-        try {
-          list.AddLast(list.First);
-        } catch (InvalidOperationException) {
-        }
-      }
-
-      // RemoveLast method test
-      int tmp2 = list.Last.Value;
-      list.RemoveLast();
-      if (list.Last.Value == tmp2 || list.Last.Value != (list.Count - 1) * 10)
-        throw new Exception("RemoveLast method test failed");
-
-      // AddBefore method test
-      node = list.AddBefore(list.Last, 17);
-      if (list.Last.Previous.Value != 17 || node.Value != 17 || node != list.Last.Previous)
-        throw new Exception("AddBefore method test (1) failed");
-      try {
-        node = null;
-        list.AddBefore(list.Last, node);
-        throw new Exception("AddBefore method test (2) failed");
-      } catch (ArgumentNullException) {
-        try {
-          node = new IntList.IntListNode(1);
-          list.AddBefore(null, node);
-          throw new Exception("AddBefore method test (3) failed");
-        } catch (ArgumentNullException) {
-          try {
-            list.AddBefore(list.Last, list.First);
-          } catch (InvalidOperationException) {
-          }
-        }
-      }
-
-      // AddAfter method test
-      node = list.AddAfter(list.First, 47);
-      if (list.First.Next.Value != 47 || node.Value != 47 || node != list.First.Next)
-        throw new Exception("AddAfter method test (1) failed");
-      try {
-        node = null;
-        list.AddAfter(list.First.Next, node);
-        throw new Exception("AddAfter method test (2) failed");
-      } catch (ArgumentNullException) {
-        try {
-          list.AddAfter(list.First, list.Last);
-        } catch (InvalidOperationException) {
-        }
-      }
-
-      // Find method test
-      node = list.Find(0);
-      if (node == null || node.Value != 0)
-        throw new Exception("Find method test (1) failed");
-      node = list.Find(47);
-      if (node == null || node.Value != 47)
-        throw new Exception("Find method test (2) failed");
-      node = list.Find(190);
-      if (node == null || node.Value != 190)
-        throw new Exception("Find method test (3) failed");
-      node = list.Find(-3);
-      if (node != null)
-        throw new Exception("Find method test (4) failed");
-
-      // Remove method test
-      if (!list.Remove(17) || list.Contains(17) || list.Last.Previous.Value == 17)
-        throw new Exception("Remove method test (1) failed");
-      if (!list.Remove(47) || list.Contains(47) || list.First.Next.Value == 47)
-        throw new Exception("Remove method test (2) failed");
-      if (!list.Remove(0) || list.Contains(0) || list.First.Value == 0)
-        throw new Exception("Remove method test (3) failed");
-      if (!list.Remove(190) || list.Contains(190) || list.Last.Value == 190)
-        throw new Exception("Remove method test (4) failed");
-      try {
-        node = null;
-        list.Remove(node);
-        throw new Exception("Remove method test (5) failed");
-      } catch (ArgumentNullException) {
-        try {
-            node = new IntList.IntListNode(4);
-            list.Remove(node);         
-            throw new Exception("Remove method test (5) failed");
-        } catch (InvalidOperationException) {
-        }
-      }
-
-      // ICollection constructor test
-      {
-        int[] intArray = new int[] { 0, 11, 22, 33, 44, 55, 33 };
-        IntList il = new IntList(intArray);
-        if (intArray.Length != il.Count)
-          throw new Exception("ICollection constructor length check failed: " + intArray.Length + "-" + il.Count);
-        node = il.First;
-        for (int i = 0; i < intArray.Length; i++) {
-          if (intArray[i] != node.Value)
-            throw new Exception("ICollection constructor failed, index:" + i);
-          node = node.Next;
-        }
-        try {
-          new IntList((System.Collections.ICollection)null);
-          throw new Exception("ICollection constructor null test failed");
-        } catch (ArgumentNullException) {
-        }
-      }
-
-      // Enumerator test
-      {
-        node = list.First;
-        System.Collections.IEnumerator myEnumerator = list.GetEnumerator();
-        while (myEnumerator.MoveNext()) {
-          if ((int)myEnumerator.Current != node.Value)
-            throw new Exception("Enumerator (1) test failed");
-          node = node.Next;
-        }
-      }
-      {
-        node = list.First;
-        System.Collections.Generic.IEnumerator<int> myEnumerator = list.GetEnumerator();
-        while (myEnumerator.MoveNext()) {
-          if (myEnumerator.Current != node.Value)
-            throw new Exception("Enumerator (2) test failed");
-          node = node.Next;
-        }
-      }
-      {
-        node = list.First;
-        IntList.IntListEnumerator myEnumerator = list.GetEnumerator();
-        while (myEnumerator.MoveNext()) {
-          if (myEnumerator.Current != node.Value)
-            throw new Exception("Enumerator (3) test failed");
-          node = node.Next;
-        }
-      }
-      {
-        node = list.First;
-        foreach (var elem in list) {
-          if (elem != node.Value)
-            throw new Exception("Enumerator (4) test failed");
-          node = node.Next;
-        }
-      }
-      
-      // CopyTo method test
-      {
-        int[] outputarray = new int[collectionSize - 2];
-        list.CopyTo(outputarray, 0);
-        int index = 0;
-        IntList.IntListNode temp = list.First;
-        foreach (int val in outputarray) {
-          if (temp.Value != val) {
-            throw new Exception("CopyTo method test (1) failed, index:" + index);
-          }
-          index++;
-          temp = temp.Next;
-        }
-      }
-      {
-        DoubleList inputlist = new DoubleList();
-        int arrayLen = 10;
-        for (int i = 0; i < arrayLen; i++) {
-          double num = i * 10.1;
-          inputlist.Add(num);
-        }
-        double[] outputarray = new double[arrayLen];
-        inputlist.CopyTo(outputarray, 0);
-        DoubleList.DoubleListNode temp = inputlist.First;
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i] != temp.Value)
-            throw new Exception("CopyTo method test (2) failed, index:" + i);
-          temp = temp.Next;
-        }
-      }
-      {
-        StructList inputlist = new StructList();
-        int arrayLen = 10;
-        for (int i = 0; i < arrayLen; i++)
-          inputlist.Add(new Struct(i / 10.0));
-        Struct[] outputarray = new Struct[arrayLen];
-        inputlist.CopyTo(outputarray, 0);
-        StructList.StructListNode temp = inputlist.First;
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i].num != temp.Value.num)
-            throw new Exception("CopyTo method test (3) failed, index:" + i);
-          temp = temp.Next;
-        }
-        foreach (Struct s in inputlist) {
-          s.num += 20.0;
-        }
-        temp = inputlist.First;
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i].num != temp.Value.num)
-            throw new Exception("CopyTo method test (4) failed, index:" + i);
-          temp = temp.Next;
-        }
-      }
-      try {
-        list.CopyTo(null, 0);
-        throw new Exception("CopyTo method test (5) failed");
-      } catch (ArgumentNullException) {
-      }
-       
-      // Clear() test
-      list.Clear();
-      if (list.Count != 0)
-        throw new Exception("Clear method failed");
-
-      // Finally test the methods being wrapped
-      {
-        IntList il = new IntList();
-        for (int i = 0; i < 4; i++) {
-          il.Add(i);
-        }
-
-        double x = li_std_list.average(il);
-        x += li_std_list.average(new IntList(new int[] { 1, 2, 3, 4 }));
-
-        DoubleList dlist = new DoubleList();
-        for (int i = 0; i < 10; i++) {
-          dlist.Add(i / 2.0);
-        }
-        li_std_list.halve_in_place(dlist);
-      }
-
-      // Dispose()
-      {
-        using (StructList ls = new StructList(new Struct[] { new Struct(0.0), new Struct(11.1) }))
-        using (DoubleList ld = new DoubleList(new double[] { 0.0, 11.1 })) {  }
-      }
-
-      // More wrapped methods
-      {
-        RealList l0 = li_std_list.listreal(new RealList());
-        float flo = 123.456f;
-        l0.Add(flo);
-        flo = l0.First.Value;
-
-        IntList l1 = li_std_list.listintptr(new IntList());
-        IntPtrList l2 = li_std_list.listintptr(new IntPtrList());
-        IntConstPtrList l3 = li_std_list.listintconstptr(new IntConstPtrList());
-
-        l1.Add(123);
-        l2.Clear();
-        l3.Clear();
-
-        StructList l4 = li_std_list.liststruct(new StructList());
-        StructPtrList l5 = li_std_list.liststructptr(new StructPtrList());
-        StructConstPtrList l6 = li_std_list.liststructconstptr(new StructConstPtrList());
-
-        l4.Add(new Struct(123));
-        l5.Add(new Struct(123));
-        l6.Add(new Struct(123));
-      }
-
-      // Test lists of pointers
-      {
-        StructPtrList inputlist = new StructPtrList();
-        int arrayLen = 10;
-        for (int i = 0; i < arrayLen; i++) {
-          inputlist.Add(new Struct(i / 10.0));
-        }
-        Struct[] outputarray = new Struct[arrayLen];
-        inputlist.CopyTo(outputarray, 0);
-        StructPtrList.StructPtrListNode temp = inputlist.First;
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i].num != temp.Value.num)
-            throw new Exception("StructPtrList test (1) failed, i:" + i);
-          temp = temp.Next;
-        }
-        foreach (Struct s in inputlist) {
-          s.num += 20.0;
-        }
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i].num != 20.0 + i / 10.0)
-            throw new Exception("StructPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
-        }
-      }
-
-      // Test lists of const pointers
-      {
-        StructConstPtrList inputlist = new StructConstPtrList();
-        int arrayLen = 10;
-        for (int i = 0; i < arrayLen; i++) {
-          inputlist.Add(new Struct(i / 10.0));
-        }
-        Struct[] outputarray = new Struct[arrayLen];
-        inputlist.CopyTo(outputarray, 0);
-        StructConstPtrList.StructConstPtrListNode temp = inputlist.First;
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i].num != temp.Value.num)
-            throw new Exception("StructConstPtrList test (1) failed, i:" + i);
-          temp = temp.Next;
-        }
-        foreach (Struct s in inputlist) {
-          s.num += 20.0;
-        }
-        for (int i = 0; i < arrayLen; i++) {
-          if (outputarray[i].num != 20.0 + i / 10.0)
-            throw new Exception("StructConstPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
         }
       }
     }
-  }
+
+    // AddAfter method test
+    node = list.AddAfter(list.First, 47);
+    if (list.First.Next.Value != 47 || node.Value != 47 || node != list.First.Next)
+      throw new Exception("AddAfter method test (1) failed");
+    try {
+      node = null;
+      list.AddAfter(list.First.Next, node);
+      throw new Exception("AddAfter method test (2) failed");
+    } catch (ArgumentNullException) {
+      try {
+        list.AddAfter(list.First, list.Last);
+      } catch (InvalidOperationException) {
+      }
+    }
+
+    // Find method test
+    node = list.Find(0);
+    if (node == null || node.Value != 0)
+      throw new Exception("Find method test (1) failed");
+    node = list.Find(47);
+    if (node == null || node.Value != 47)
+      throw new Exception("Find method test (2) failed");
+    node = list.Find(190);
+    if (node == null || node.Value != 190)
+      throw new Exception("Find method test (3) failed");
+    node = list.Find(-3);
+    if (node != null)
+      throw new Exception("Find method test (4) failed");
+
+    // Remove method test
+    if (!list.Remove(17) || list.Contains(17) || list.Last.Previous.Value == 17)
+      throw new Exception("Remove method test (1) failed");
+    if (!list.Remove(47) || list.Contains(47) || list.First.Next.Value == 47)
+      throw new Exception("Remove method test (2) failed");
+    if (!list.Remove(0) || list.Contains(0) || list.First.Value == 0)
+      throw new Exception("Remove method test (3) failed");
+    if (!list.Remove(190) || list.Contains(190) || list.Last.Value == 190)
+      throw new Exception("Remove method test (4) failed");
+    try {
+      node = null;
+      list.Remove(node);
+      throw new Exception("Remove method test (5) failed");
+    } catch (ArgumentNullException) {
+      try {
+          node = new IntList.IntListNode(4);
+          list.Remove(node);         
+          throw new Exception("Remove method test (5) failed");
+      } catch (InvalidOperationException) {
+      }
+    }
+
+    // ICollection constructor test
+    {
+      int[] intArray = new int[] { 0, 11, 22, 33, 44, 55, 33 };
+      IntList il = new IntList(intArray);
+      if (intArray.Length != il.Count)
+        throw new Exception("ICollection constructor length check failed: " + intArray.Length + "-" + il.Count);
+      node = il.First;
+      for (int i = 0; i < intArray.Length; i++) {
+        if (intArray[i] != node.Value)
+          throw new Exception("ICollection constructor failed, index:" + i);
+        node = node.Next;
+      }
+      try {
+        new IntList((System.Collections.ICollection)null);
+        throw new Exception("ICollection constructor null test failed");
+      } catch (ArgumentNullException) {
+      }
+    }
+
+    // Enumerator test
+    {
+      node = list.First;
+      System.Collections.IEnumerator myEnumerator = list.GetEnumerator();
+      while (myEnumerator.MoveNext()) {
+        if ((int)myEnumerator.Current != node.Value)
+          throw new Exception("Enumerator (1) test failed");
+        node = node.Next;
+      }
+    }
+    {
+      node = list.First;
+      System.Collections.Generic.IEnumerator<int> myEnumerator = list.GetEnumerator();
+      while (myEnumerator.MoveNext()) {
+        if (myEnumerator.Current != node.Value)
+          throw new Exception("Enumerator (2) test failed");
+        node = node.Next;
+      }
+    }
+    {
+      node = list.First;
+      IntList.IntListEnumerator myEnumerator = list.GetEnumerator();
+      while (myEnumerator.MoveNext()) {
+        if (myEnumerator.Current != node.Value)
+          throw new Exception("Enumerator (3) test failed");
+        node = node.Next;
+      }
+    }
+    {
+      node = list.First;
+      foreach (var elem in list) {
+        if (elem != node.Value)
+          throw new Exception("Enumerator (4) test failed");
+        node = node.Next;
+      }
+    }
+    
+    // CopyTo method test
+    {
+      int[] outputarray = new int[collectionSize - 2];
+      list.CopyTo(outputarray, 0);
+      int index = 0;
+      IntList.IntListNode temp = list.First;
+      foreach (int val in outputarray) {
+        if (temp.Value != val) {
+          throw new Exception("CopyTo method test (1) failed, index:" + index);
+        }
+        index++;
+        temp = temp.Next;
+      }
+    }
+    {
+      DoubleList inputlist = new DoubleList();
+      int arrayLen = 10;
+      for (int i = 0; i < arrayLen; i++) {
+        double num = i * 10.1;
+        inputlist.Add(num);
+      }
+      double[] outputarray = new double[arrayLen];
+      inputlist.CopyTo(outputarray, 0);
+      DoubleList.DoubleListNode temp = inputlist.First;
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i] != temp.Value)
+          throw new Exception("CopyTo method test (2) failed, index:" + i);
+        temp = temp.Next;
+      }
+    }
+    {
+      StructList inputlist = new StructList();
+      int arrayLen = 10;
+      for (int i = 0; i < arrayLen; i++)
+        inputlist.Add(new Struct(i / 10.0));
+      Struct[] outputarray = new Struct[arrayLen];
+      inputlist.CopyTo(outputarray, 0);
+      StructList.StructListNode temp = inputlist.First;
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i].num != temp.Value.num)
+          throw new Exception("CopyTo method test (3) failed, index:" + i);
+        temp = temp.Next;
+      }
+      foreach (Struct s in inputlist) {
+        s.num += 20.0;
+      }
+      temp = inputlist.First;
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i].num != temp.Value.num)
+          throw new Exception("CopyTo method test (4) failed, index:" + i);
+        temp = temp.Next;
+      }
+    }
+    try {
+      list.CopyTo(null, 0);
+      throw new Exception("CopyTo method test (5) failed");
+    } catch (ArgumentNullException) {
+    }
+     
+    // Clear() test
+    list.Clear();
+    if (list.Count != 0)
+      throw new Exception("Clear method failed");
+
+    // Finally test the methods being wrapped
+    {
+      IntList il = new IntList();
+      for (int i = 0; i < 4; i++) {
+        il.Add(i);
+      }
+
+      double x = li_std_list.average(il);
+      x += li_std_list.average(new IntList(new int[] { 1, 2, 3, 4 }));
+
+      DoubleList dlist = new DoubleList();
+      for (int i = 0; i < 10; i++) {
+        dlist.Add(i / 2.0);
+      }
+      li_std_list.halve_in_place(dlist);
+    }
+
+    // Dispose()
+    {
+      using (StructList ls = new StructList(new Struct[] { new Struct(0.0), new Struct(11.1) }))
+      using (DoubleList ld = new DoubleList(new double[] { 0.0, 11.1 })) {  }
+    }
+
+    // More wrapped methods
+    {
+      RealList l0 = li_std_list.listreal(new RealList());
+      float flo = 123.456f;
+      l0.Add(flo);
+      flo = l0.First.Value;
+
+      IntList l1 = li_std_list.listintptr(new IntList());
+      IntPtrList l2 = li_std_list.listintptr(new IntPtrList());
+      IntConstPtrList l3 = li_std_list.listintconstptr(new IntConstPtrList());
+
+      l1.Add(123);
+      l2.Clear();
+      l3.Clear();
+
+      StructList l4 = li_std_list.liststruct(new StructList());
+      StructPtrList l5 = li_std_list.liststructptr(new StructPtrList());
+      StructConstPtrList l6 = li_std_list.liststructconstptr(new StructConstPtrList());
+
+      l4.Add(new Struct(123));
+      l5.Add(new Struct(123));
+      l6.Add(new Struct(123));
+    }
+
+    // Test lists of pointers
+    {
+      StructPtrList inputlist = new StructPtrList();
+      int arrayLen = 10;
+      for (int i = 0; i < arrayLen; i++) {
+        inputlist.Add(new Struct(i / 10.0));
+      }
+      Struct[] outputarray = new Struct[arrayLen];
+      inputlist.CopyTo(outputarray, 0);
+      StructPtrList.StructPtrListNode temp = inputlist.First;
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i].num != temp.Value.num)
+          throw new Exception("StructPtrList test (1) failed, i:" + i);
+        temp = temp.Next;
+      }
+      foreach (Struct s in inputlist) {
+        s.num += 20.0;
+      }
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i].num != 20.0 + i / 10.0)
+          throw new Exception("StructPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
+      }
+    }
+
+    // Test lists of const pointers
+    {
+      StructConstPtrList inputlist = new StructConstPtrList();
+      int arrayLen = 10;
+      for (int i = 0; i < arrayLen; i++) {
+        inputlist.Add(new Struct(i / 10.0));
+      }
+      Struct[] outputarray = new Struct[arrayLen];
+      inputlist.CopyTo(outputarray, 0);
+      StructConstPtrList.StructConstPtrListNode temp = inputlist.First;
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i].num != temp.Value.num)
+          throw new Exception("StructConstPtrList test (1) failed, i:" + i);
+        temp = temp.Next;
+      }
+      foreach (Struct s in inputlist) {
+        s.num += 20.0;
+      }
+      for (int i = 0; i < arrayLen; i++) {
+        if (outputarray[i].num != 20.0 + i / 10.0)
+          throw new Exception("StructConstPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
+      }
+    }
+  } 
 }

--- a/Examples/test-suite/csharp/li_std_list_runme.cs
+++ b/Examples/test-suite/csharp/li_std_list_runme.cs
@@ -1,4 +1,5 @@
 using System;
+using li_std_listNamespace;
 
 public class li_std_list_runme {
   private static readonly int collectionSize = 20;
@@ -397,5 +398,5 @@ public class li_std_list_runme {
           throw new Exception("StructConstPtrList test (2) failed (a deep copy was incorrectly made), i:" + i);
       }
     }
-  } 
+  }
 }

--- a/Examples/test-suite/csharp/li_std_list_runme.cs
+++ b/Examples/test-suite/csharp/li_std_list_runme.cs
@@ -63,7 +63,6 @@ public class li_std_list_runme {
           throw new Exception("First getter test (1) failed");
         if (list.Last == null)
           throw new Exception("Last getter test (1) failed");
-        Console.WriteLine(list.Last.Value);
         if (list.Last.Next != null)
           throw new Exception("Next getter test (1) failed");
         if (list.First.Next == null)
@@ -288,7 +287,6 @@ public class li_std_list_runme {
         }
         temp = inputlist.First;
         for (int i = 0; i < arrayLen; i++) {
-          Console.WriteLine(outputarray[i].num + " - " + temp.Value.num);
           if (outputarray[i].num != temp.Value.num)
             throw new Exception("CopyTo method test (4) failed, index:" + i);
           temp = temp.Next;

--- a/Examples/test-suite/li_std_list.i
+++ b/Examples/test-suite/li_std_list.i
@@ -30,6 +30,8 @@ namespace std {
     %template(RealList) list<Real>;
 }
 
+%ignore Struct::operator==;
+
 %inline %{
 
 double average(std::list<int> v) {
@@ -59,8 +61,6 @@ const std::list<Struct> & liststruct(const std::list<Struct> & list) { return li
 const std::list<Struct *> & liststructptr(const std::list<Struct *> & list) { return list; }
 const std::list<const Struct *> & liststructconstptr(const std::list<const Struct *> & list) { return list; }
 %}
-
-%ignore Struct::operator==;
 
 #if !defined(SWIGR)
 %template(IntPtrList) std::list<int *>;

--- a/Examples/test-suite/li_std_list.i
+++ b/Examples/test-suite/li_std_list.i
@@ -12,6 +12,14 @@ namespace std {
     %template(IntList) list<int>;
 }
 
+%template(BoolList) std::list<bool>;
+%template(CharList) std::list<char>;
+%template(ShortList) std::list<short>;
+%template(LongList) std::list<long>;
+%template(UCharList) std::list<unsigned char>;
+%template(UIntList) std::list<unsigned int>;
+%template(UShortList) std::list<unsigned short>;
+%template(ULongList) std::list<unsigned long>;
 %template(DoubleList) std::list<double>;
 
 %inline %{
@@ -38,9 +46,26 @@ struct Struct {
   double num;
   Struct() : num(0.0) {}
   Struct(double d) : num(d) {}
-//  bool operator==(const Struct &other) { return (num == other.num); }
+  bool operator==(const Struct &other) { return (num == other.num); }
 };
+
+const std::list<Real> & listreal(const std::list<Real> & list) { return list; }
+           
+const std::list<int> & listintptr(const std::list<int> & list) { return list; }
+const std::list<int *> & listintptr(const std::list<int *> & list) { return list; }
+const std::list<const int *> & listintconstptr(const std::list<const int *> & list) { return list; }
+           
+const std::list<Struct> & liststruct(const std::list<Struct> & list) { return list; }
+const std::list<Struct *> & liststructptr(const std::list<Struct *> & list) { return list; }
+const std::list<const Struct *> & liststructconstptr(const std::list<const Struct *> & list) { return list; }
 %}
 
+%ignore Struct::operator==;
 
-
+#if !defined(SWIGR)
+%template(IntPtrList) std::list<int *>;
+%template(IntConstPtrList) std::list<const int *>;
+#endif
+%template(StructList) std::list<Struct>;
+%template(StructPtrList) std::list<Struct *>;
+%template(StructConstPtrList) std::list<const Struct *>;

--- a/Lib/csharp/std_list.i
+++ b/Lib/csharp/std_list.i
@@ -8,525 +8,435 @@
  * ----------------------------------------------------------------------------- */
  
 %include <std_common.i>
-
 %define SWIG_STD_LIST_MINIMUM_INTERNAL(CONST_REFERENCE, CTYPE...)
 %typemap(csinterfaces) std::list< CTYPE > "global::System.Collections.Generic.ICollection<$typemap(cstype, CTYPE)>, global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>, global::System.Collections.IEnumerable, global::System.IDisposable"
 %proxycode %{
-	public $csclassname(global::System.Collections.IEnumerable c) : this() 
-	{
-		if (c == null)
-			throw new global::System.ArgumentNullException("c");
-		foreach ($typemap(cstype, CTYPE) element in c) 
-		{
-			this.AddLast(element);
-		}
+  public $csclassname(global::System.Collections.IEnumerable c) : this() {
+    if (c == null)
+      throw new global::System.ArgumentNullException("c");
+    foreach ($typemap(cstype, CTYPE) element in c) {
+      this.AddLast(element);
+    }
+  }
+
+  public bool IsReadOnly {
+    get {
+      return false;
+    }
+  }
+  
+  public int Count {
+    get {
+      return (int)size();
+    }
+  }
+  
+  public $csclassnameNode First {
+    get { 
+	  if (Count == 0)
+	    return null;
+	  return new $csclassnameNode(getFirstIter(), this);
+    }
+  }
+
+  public $csclassnameNode Last {
+    get {
+	  if (Count == 0)
+	    return null;
+      return new $csclassnameNode(getLastIter(), this);
+    }
+  }
+  
+  public  $csclassnameNode AddFirst($typemap(cstype, CTYPE) value) {
+	push_front(value);
+	return new $csclassnameNode(getFirstIter(), this);
+  }
+
+  public void AddFirst($csclassnameNode newNode) {
+    ValidateNewNode(newNode);
+	if (!newNode.inlist) {
+	  push_front(newNode.csharpvalue);
+	  newNode.iter = getFirstIter();
+	  newNode.inlist = true;
+	} else {
+	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+	}
+  }
+
+  public $csclassnameNode AddLast($typemap(cstype, CTYPE) value) {
+    push_back(value);
+	return new $csclassnameNode(getLastIter(), this);
+  }
+
+  public void AddLast($csclassnameNode newNode) {
+    ValidateNewNode(newNode);
+	if (!newNode.inlist) {
+	  push_back(newNode.csharpvalue);
+	  newNode.iter = getLastIter();
+	  newNode.inlist = true;
+	} else {
+	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+	}
+  }
+  
+  public $csclassnameNode AddBefore($csclassnameNode node, $typemap(cstype, CTYPE) value) {
+	return new $csclassnameNode(insertNode(node.iter, value), this);
+  }
+
+  public void AddBefore($csclassnameNode node, $csclassnameNode newNode) {
+    ValidateNode(node);
+	ValidateNewNode(newNode);
+	if (!newNode.inlist) {
+	  newNode.iter = insertNode(node.iter, newNode.csharpvalue);
+	  newNode.inlist = true;
+	} else {
+	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+	}
+  }
+
+  public $csclassnameNode AddAfter($csclassnameNode node, $typemap(cstype, CTYPE) value) {
+	node = node.Next;
+	return new $csclassnameNode(insertNode(node.iter, value), this);
+  }
+
+  public void AddAfter($csclassnameNode node, $csclassnameNode newNode) {
+    ValidateNode(node);
+	ValidateNewNode(newNode);
+	if (!newNode.inlist) {
+	  if (node == this.Last)
+	    AddLast(newNode);
+	  else
+	  {
+	    node = node.Next;
+	    newNode.iter = insertNode(node.iter, newNode.csharpvalue);
+	    newNode.inlist = true;
+	  }
+	} else {
+	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+	}
+  }
+
+  public void Add($typemap(cstype, CTYPE) value) {
+    AddLast(value);
+  }
+
+  public bool Remove($typemap(cstype, CTYPE) value) {
+    var node = Find(value);
+    if (node == null)
+	  return false;
+	Remove(node);
+	return true;
+  }
+
+  public void Remove($csclassnameNode node) {
+    ValidateNode(node);
+    eraseIter(node.iter);  
+  }
+
+  public $csclassnameNode Find($typemap(cstype, CTYPE) value) {
+    System.IntPtr tmp = find(value);
+    if (tmp != System.IntPtr.Zero) {
+	  return new $csclassnameNode(tmp, this);
+	}
+	return null;
+  }
+  
+  public void CopyTo($typemap(cstype, CTYPE)[] array, int index) {
+    if (array == null)
+      throw new global::System.ArgumentNullException("array");
+    if (index < 0 || index > array.Length)
+      throw new global::System.ArgumentOutOfRangeException("index", "Value is less than zero");
+    if (array.Rank > 1)
+      throw new global::System.ArgumentException("Multi dimensional array.", "array");
+    $csclassnameNode node = this.First;
+    if (node != null) {
+      do {
+        array[index++] = node.Value;
+        node = node.Next;
+      } while (node != null);
+    }
+  }
+
+  internal void ValidateNode($csclassnameNode node) {
+    if (node == null) {
+      throw new System.ArgumentNullException("node"); 
+    } 
+    if (!node.inlist || node.list != this) { 
+      throw new System.InvalidOperationException("node");
+    }
+  }
+
+  internal void ValidateNewNode($csclassnameNode node) {
+    if (node == null) {
+      throw new System.ArgumentNullException("node"); 
+    } 
+  }
+
+  global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)> global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>.GetEnumerator() {
+    return new $csclassnameEnumerator(this);
+  }
+
+  global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator() {
+    return new $csclassnameEnumerator(this);
+  }
+
+  public $csclassnameEnumerator GetEnumerator() {
+    return new $csclassnameEnumerator(this);
+  }
+  
+  public sealed class $csclassnameEnumerator : global::System.Collections.IEnumerator,
+    global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)>
+  {
+    private $csclassname collectionRef;
+    private $csclassnameNode currentNode;
+    private int currentIndex;
+    private object currentObject;
+    private int currentSize;
+      
+    public $csclassnameEnumerator($csclassname collection) {
+      collectionRef = collection;
+      currentNode = collection.First;
+      currentIndex = 0;
+      currentObject = null;
+      currentSize = collectionRef.Count;
+    }
+    
+    // Type-safe iterator Current
+    public $typemap(cstype, CTYPE) Current {
+      get {
+        if (currentIndex == -1)
+          throw new global::System.InvalidOperationException("Enumeration not started.");
+        if (currentIndex > currentSize)
+          throw new global::System.InvalidOperationException("Enumeration finished.");
+        if (currentObject == null)
+          throw new global::System.InvalidOperationException("Collection modified.");
+        return ($typemap(cstype, CTYPE))currentObject;
+      }
+    }
+  
+    // Type-unsafe IEnumerator.Current
+    object global::System.Collections.IEnumerator.Current {
+      get {
+        return Current;
+      }
+    }
+    
+    public bool MoveNext() {
+      if (currentNode == null) {
+        currentIndex = collectionRef.Count + 1;
+        return false;
+      }
+      ++currentIndex;
+      currentObject = currentNode.Value;
+      currentNode = currentNode.Next;
+      return true;
+    }
+    
+    public void Reset() {
+      currentIndex = -1;
+      currentObject = null;
+      if (collectionRef.Count != currentSize) {
+        throw new global::System.InvalidOperationException("Collection modified.");
+      }
+    }
+    
+    public void Dispose() {
+      currentIndex = -1;
+      currentObject = null;
+    }
+  }
+  
+  public sealed class $csclassnameNode {
+    internal $csclassname list;
+    internal System.IntPtr iter;
+	internal $typemap(cstype, CTYPE) csharpvalue;
+	internal bool inlist;
+    
+    public $csclassnameNode($typemap(cstype, CTYPE) value) {
+	  csharpvalue = value;
+	  inlist = false;
+    }
+
+    internal $csclassnameNode(System.IntPtr _iter, $csclassname _list) {
+      list = _list;
+      iter = _iter;
+	  inlist = true;
+    }
+    
+    public $csclassname List {
+      get { 
+        return this.list; 
+      }
+    }
+
+    public $csclassnameNode Next {
+      get { 
+	    if (list.getNextIter(iter) == System.IntPtr.Zero)
+		  return null;
+        return new $csclassnameNode(list.getNextIter(iter), list);
+      }
+    }
+  
+    public $csclassnameNode Previous {
+      get {
+	    if (list.getPrevIter(iter) == System.IntPtr.Zero)
+		  return null;
+        return new $csclassnameNode(list.getPrevIter(iter), list);
+      }
+    }
+    
+	public $typemap(cstype, CTYPE) Value {
+      get { 
+        return list.getItem(this.iter); 
+      }
+      set { 
+        list.setItem(this.iter, value); 
+      }
+    }
+
+	public static bool operator== ($csclassnameNode node1, $csclassnameNode node2) {
+	  if (object.ReferenceEquals(node1, null) && object.ReferenceEquals(node2, null))
+	    return true;
+	  if (object.ReferenceEquals(node1, null) || object.ReferenceEquals(node2, null))
+	    return false;
+	  return node1.Equals(node2);
 	}
 
-	public bool IsReadOnly 
-	{
-		get {
-			return false;
-		}
-	}
-	
-	public int Count 
-	{
-		get {
-			return (int)size();
-		}
-	}
-	
-	private	$csclassnameNode _head;
-	internal $csclassnameNode head
-	{
-		get {
-			if (this._head == null && (int)size() > 0)
-			{
-				this._head = new $csclassnameNode(($typemap(cstype, CTYPE))getItem(0), 0, this);
-			}
-			return this._head;
-		}
-		set { this._head = value; }
-	}
-	public $csclassnameNode First
-	{
-		get { return this.head;	}
-	}
-	
-	private	$csclassnameNode _tail;
-	internal $csclassnameNode tail
-	{
-		get {
-			if (this._tail == null && (int)size() > 0) {
-				this._tail = new $csclassnameNode(($typemap(cstype, CTYPE))getItem((int)size() - 1), (int)size() - 1, this);
-			}
-			return this._tail;
-		}
-		set { this._tail = value; }
-	}
-	
-	public $csclassnameNode Last
-	{
-		get { return this.tail;	}
-	}
-	
-	public $csclassnameNode AddFirst($typemap(cstype, CTYPE) value)
-	{
-		$csclassnameNode	newNode = new $csclassnameNode(value, 0, this);
-		AddFirst(newNode);
-		return newNode;
-	}
-	
-	public void AddFirst($csclassnameNode newNode)
-	{
-		if (this.Count == 0)
-		{
-			newNode.next = null;
-			newNode.prev = null;
-			this.head = newNode;
-			this.tail = newNode;
-		}
-		else
-		{
-			$csclassnameNode	tmp = this.First;
-			
-			while (tmp != null)	{
-				tmp.index++;
-				tmp = tmp.Next;
-			}
-			newNode.next = this.head;
-			this.head.prev = newNode;
-			this.head = newNode;
-		}
-		push_front(newNode.Value);
-		if (newNode.index == -1)
-			newNode.index = 0;
-		if (newNode.list == null)
-			newNode.list = this;
+    public static bool operator!= ($csclassnameNode node1, $csclassnameNode node2) {
+	  if (node1 == null && node2 == null)
+	    return false;
+	  if (node1 == null || node2 == null)
+	    return true;
+	  return !node1.Equals(node2);
 	}
 
-	public $csclassnameNode AddLast($typemap(cstype, CTYPE) value)
-	{
-		$csclassnameNode	newNode = new $csclassnameNode(value, (int)size(), this);
-		AddLast(newNode);
-		return newNode;
+	public bool Equals($csclassnameNode node) {
+	  if (node == null)
+	    return false;
+	  if (!node.inlist || !this.inlist)
+	    return object.ReferenceEquals(this, node);
+	  return list.equals(this.iter, node.iter);
 	}
 
-	public void AddLast($csclassnameNode newNode)
-	{
-		if (this.Count == 0)
-		{
-			newNode.next = null;
-			newNode.prev = null;
-			this.head = newNode;
-			this.tail = newNode;
-		}
-		else
-		{
-			newNode.prev = this.Last;
-			this.Last.next = newNode;
-			this.tail = newNode;
-		}
-		push_back(newNode.Value);
-		if (newNode.index == -1)
-			newNode.index = (int)size() - 1;
-		if (newNode.list == null)
-			newNode.list = this;
-	}
-	
-	public $csclassnameNode AddBefore($csclassnameNode node, $typemap(cstype, CTYPE) value)
-	{
-		$csclassnameNode newNode = new $csclassnameNode(value, node.index, this);
-		AddBefore(node, newNode);
-		return newNode;
+	public override bool Equals(object node) {
+	  return Equals(($csclassnameNode)node);
 	}
 
-	public void AddBefore($csclassnameNode node, $csclassnameNode newNode)
-	{
-		ValidateNode(node);
-		ValidateNode(newNode);
-		newNode.next = node;
-		newNode.prev = node.Previous;
-		node.Previous.next = newNode;
-		node.prev = newNode;
-		insertIndex(node.index, newNode.Value);
-
-		if (newNode.index == -1)
-			newNode.index = node.index;
-		if (newNode.list == null)
-			newNode.list = this;
-
-		$csclassnameNode tmp = node;
-		while (tmp != null)
-		{
-			tmp.index++;
-			tmp = tmp.Next;
-		}
+	public override int GetHashCode() {
+	  int hash = 13;
+	  if (inlist) {
+	    hash = (hash * 7) + this.list.GetHashCode();
+	    hash = (hash * 7) + this.Value.GetHashCode();
+	    hash = (hash * 7) + this.list.getNextIter(this.iter).GetHashCode();
+	    hash = (hash * 7) + this.list.getPrevIter(this.iter).GetHashCode();
+	  } else {
+	    hash = (hash * 7) + this.csharpvalue.GetHashCode();	  
+	  }
+	  return hash;
 	}
 
-	public $csclassnameNode AddAfter($csclassnameNode node, $typemap(cstype, CTYPE) value)
-	{
-		$csclassnameNode newNode = new $csclassnameNode(value, node.index + 1, this);
-		AddBefore(node.Next, newNode);
-		return newNode;
+	public void Dispose() {
+	  list.deleteIter(this.iter);
 	}
-
-	public void AddAfter($csclassnameNode node, $csclassnameNode newNode)
-	{
-		AddBefore(node.Next, newNode);
-	}
-
-	public void Add($typemap(cstype, CTYPE) value)
-	{
-		this.AddLast(value);
-	}
-	
-	public void RemoveFirst()
-	{
-		pop_front();
-		this.First.Next.prev = null;
-		this.head = this.First.Next;
-		$csclassnameNode node = this.First;
-		while (node != null) {
-			node.index--;
-			node = node.Next;
-		}
-	}
-
-	public void RemoveLast()
-	{
-		pop_back();
-		this.Last.Previous.next = null;
-		this.tail = this.Last.Previous;
-	}
-
-	public bool Remove($typemap(cstype, CTYPE) value)
-	{
-		$csclassnameNode node = Find(value);
-		return Remove(node);
-	}
-
-	public bool Remove($csclassnameNode node)
-	{
-		ValidateNode(node);
-		if (node != null)
-		{
-			if (node.index == 0)
-				RemoveFirst();
-			else if (node.index == (int)size() - 1)
-				RemoveLast();
-			else
-			{
-				rmvIndex(node.index);
-				$csclassnameNode tmp = node;
-				while (tmp != null) {
-					tmp.index--;
-					tmp = tmp.Next;
-				}
-				node.Next.prev = node.Previous; 
-				node.Previous.next = node.Next;
-				if (this.head == node) {
-					this.head = node.Next;
-				} 
-				else if (this.tail == node) {
-					this.tail = node.Previous;
-				}
-			}
-			return true;
-		}
-		return false;
-	}
-
-	public $csclassnameNode Find($typemap(cstype, CTYPE) value)
-	{
-		int tmpPos = find_item(value);
-		$csclassnameNode tmp = this.First;
-		int i = 0;
-
-		if (tmpPos != -1) {
-			while (i != tmpPos) {
-				tmp = tmp.Next;
-				++i;
-			}
-			return tmp;
-		}
-		return null;
-	}
-	
-	public void CopyTo($typemap(cstype, CTYPE)[] array, int index)
-	{
-		if (array == null)
-			throw new global::System.ArgumentNullException("array");
-		if (index < 0)
-			throw new global::System.ArgumentOutOfRangeException("index", "Value is less than zero");
-		if (array.Rank > 1)
-			throw new global::System.ArgumentException("Multi dimensional array.", "array");
-		$csclassnameNode current = this.First;
-		if (current != null)
-		{
-			do
-			{
-				array[index++] = current.Value;
-				current = current.Next;
-			} while (current != null);
-		}
-	}
-
-	public void Clear()
-	{
-		$csclassnameNode current = this.First;
-		
-		while (current != null)
-		{
-			$csclassnameNode tmp = current;
-			current = current.Next;
-			tmp.list = null;
-			tmp.next = null;
-			tmp.prev = null;
-		}
-		
-		this.head = null;
-		clear();
-	}
-
-	internal void ValidateNode($csclassnameNode node)
-	{
-		if (node == null) {
-			throw new System.ArgumentNullException("node"); 
-		} 
-		
-		if ( node.list != this) { 
-			throw new System.InvalidOperationException("node");
-		}
-	}
-
-	global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)> global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>.GetEnumerator() 
-	{
-		return new $csclassnameEnumerator(this);
-	}
-
-	global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator() 
-	{
-		return new $csclassnameEnumerator(this);
-	}
-
-	public $csclassnameEnumerator GetEnumerator() 
-	{
-		return new $csclassnameEnumerator(this);
-	}
-	
-	public sealed class $csclassnameEnumerator : global::System.Collections.IEnumerator,
-		global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)>
-	{
-		private $csclassname collectionRef;
-		private $csclassnameNode currentNode;
-		private int	currentIndex;
-		private object currentObject;
-		private int	currentSize;
-		
-		public $csclassnameEnumerator($csclassname collection)
-		{
-			collectionRef = collection;
-			currentNode = collection.First;
-			currentIndex = 0;
-			currentObject = null;
-			currentSize = collectionRef.Count;
-		}
-		
-		// Type-safe iterator Current
-		public $typemap(cstype, CTYPE) Current 
-		{
-			get {
-				if (currentIndex == -1)
-					throw new global::System.InvalidOperationException("Enumeration not started.");
-				if (currentIndex > currentSize)
-					throw new global::System.InvalidOperationException("Enumeration finished.");
-				if (currentObject == null)
-					throw new global::System.InvalidOperationException("Collection modified.");
-				return ($typemap(cstype, CTYPE))currentObject;
-			}
-		}
-	
-		// Type-unsafe IEnumerator.Current
-		object global::System.Collections.IEnumerator.Current 
-		{
-			get {
-				return Current;
-			}
-		}
-		
-		public bool MoveNext()
-		{
-			if (currentNode == null) {
-				currentIndex = collectionRef.Count + 1;
-				return false;
-			}
-			++currentIndex;
-			currentObject = currentNode.Value;
-			currentNode = currentNode.Next;
-			return true;
-		}
-		
-		public void Reset()
-		{
-			currentIndex = -1;
-			currentObject = null;
-			if (collectionRef.Count != currentSize) {
-				throw new global::System.InvalidOperationException("Collection modified.");
-			}
-		}
-		
-		public void Dispose()
-		{
-			currentIndex = -1;
-			currentObject = null;
-		}
-	}
-	
-	public sealed class $csclassnameNode
-	{
-		internal $csclassname list;
-		internal $typemap(cstype, CTYPE) item;
-		internal int index;
-		
-		public $csclassnameNode($typemap(cstype, CTYPE) value)
-		{
-			this.item = value;
-		}
-
-		internal $csclassnameNode($typemap(cstype, CTYPE) value, int _index, $csclassname _list)
-		{
-			this.list = _list;
-			this.item = value;
-			this.index = _index;
-		}
-		
-		public $csclassname List
-		{
-			get { return this.list; }
-		}
-
-		private $csclassnameNode _next;
-		internal $csclassnameNode next
-		{
-			get {
-				if (this._next == null && index + 1 < (int)this.list.size()) {
-					this._next = new $csclassnameNode(this.list.getItem(index + 1), index + 1, this.list);
-					this._next.prev = this;
-				}
-				if (index + 1 == (int)this.list.size() - 1)
-					this.list.tail = this._next;
-				return this._next; 
-			}
-			set { this._next = value; }
-		}
-
-		public $csclassnameNode Next
-		{
-			get { return this.next; }
-		}
-	
-		private $csclassnameNode _prev;
-		internal $csclassnameNode	prev
-		{
-			get { 
-				if (this._prev == null && index - 1 >= 0) {
-					this._prev = new $csclassnameNode(this.list.getItem(index - 1), index - 1, this.list);
-					this._prev.next = this;
-				}
-				if (index - 1 == 0)
-					this.list.head = this._prev;
-				return this._prev;
-			}
-			set { this._prev = value; }
-		}
-
-		public $csclassnameNode Previous
-		{
-			get { return this.prev; }
-		}
-		
-		public $typemap(cstype, CTYPE) Value
-		{
-			get { return this.item; }
-			set { this.item = value; }
-		}
-	}
+  }
 %}
 
 public:
-	typedef size_t size_type;
-	typedef CTYPE value_type;
-	typedef CONST_REFERENCE const_reference;
-	void clear();
-	void push_front(CTYPE const& x);
-	void push_back(CTYPE const& x);
-	void pop_front();
-	void pop_back();
-	size_type size() const;
-	%extend {
-		const CTYPE& getItem(int index) {
-			std::list< CTYPE >::iterator it = $self->begin();
-			
-			if (index >= 0 && index < (int)($self->size())) {
-				for (int i = 0; i != index; i++)
-					it++;
-				return *it;
-			} else {
-				throw std::out_of_range("index");
-			}
-		}
-		
-		int find_item(CTYPE const& x) {
-			std::list< CTYPE >::iterator it = $self->begin();
-			int i = 0;
-		
-			while (it != $self->end() && (CTYPE const&)*it != x) {
-				++it;
-				++i;
-			}
-			if (it != $self->end())
-				return i;
-			return -1;
-		}
+  typedef size_t size_type;
+  typedef CTYPE value_type;
+  typedef CONST_REFERENCE const_reference;
+  void push_front(CTYPE const& x);
+  void push_back(CTYPE const& x);
+  %rename(RemoveFirst) pop_front;
+  void pop_front();
+  %rename(RemoveLast) pop_back;
+  void pop_back();
+  size_type size() const;
+  %rename(Clear) clear;
+  void clear();
+  %extend {
+	CONST_REFERENCE getItem(void *iter) {
+      std::list< CTYPE >::iterator it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+	  return *it;
+    }
 
-		void insertIndex(int index, CTYPE const& value) {
-			std::list< CTYPE >::iterator it = $self->begin();
-			int i = 0;
-
-			while (it != $self->end() && i != index) {
-				++it;
-				++i;
-			}
-			$self->insert(it, value);
-		}
-
-		bool rmv(const CTYPE& value) {
-			std::list< CTYPE >::iterator it = std::find($self->begin(), $self->end(), value);
-			
-			if ($self->erase(it) != $self->end())
-				return true;
-			return false;
-		}
-
-		bool rmvIndex(int index) {
-			std::list< CTYPE >::iterator it = $self->begin();
-
-			for (int i = 0; i != index; i++)
-				++it;
-			if (it != $self->end()) {
-				$self->erase(it);
-				return true;
-			}
-			return false;
-		}
-		
-		bool Contains(CTYPE const& value) {
-			return std::find($self->begin(), $self->end(), value) != $self->end();
-		}
+	void setItem(void *iter, CTYPE const& val) {
+	  std::list< CTYPE >::iterator* it = reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+	  *(*it) = val;
 	}
+    
+	void *getFirstIter() {
+	  if ($self->size() == 0)
+	    return NULL;
+	  auto iterator = new std::list< CTYPE >::iterator($self->begin());
+	  return reinterpret_cast<void *>(iterator);
+	}
+
+	void *getLastIter() {
+	  if ($self->size() == 0)
+	    return NULL;
+	  auto iterator = new std::list< CTYPE >::iterator(--$self->end());
+	  return reinterpret_cast<void *>(iterator);
+	}
+
+	void *getNextIter(void *iter) {
+	  auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
+	  if (std::distance(it, --$self->end()) != 0) {
+		auto itnext =  new std::list< CTYPE >::iterator(++it);
+		return itnext;
+	  }
+	  return NULL;
+	}
+
+	void *getPrevIter(void *iter) {
+      auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
+	  if (std::distance($self->begin(), it) != 0) {
+		auto itprev =  new std::list< CTYPE >::iterator(--it);
+		return itprev;
+	  }
+	  return NULL;
+	}
+
+	void *insertNode(void *iter, CTYPE const& value) {
+	  auto it = $self->insert(*(reinterpret_cast<std::list< CTYPE >::iterator *>(iter)), value);
+	  auto newit = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(it));
+	  return newit;
+	}
+
+	void *find(CTYPE const& value) {
+	  if (std::find($self->begin(), $self->end(), value) != $self->end()) {
+	    auto it = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(std::find($self->begin(), $self->end(), value)));
+	    return it;
+	  }
+	  return NULL;
+	}
+
+	void eraseIter(void *iter) {
+	  auto it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+	  $self->erase(it);
+	}
+
+	void deleteIter(void *iter) {
+	  std::list< CTYPE >::iterator* it = reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+	  delete it;
+	}
+	
+	bool equals(void *iter1, void *iter2) {
+	  if (iter1 == NULL && iter2 == NULL)
+	    return true;
+	  std::list< CTYPE >::iterator it1 = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter1);
+	  std::list< CTYPE >::iterator it2 = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter2);
+	  return it1 == it2;
+	}
+   
+    bool Contains(CTYPE const& value) {
+      return std::find($self->begin(), $self->end(), value) != $self->end();
+    }
+  }
 %enddef
  
+%apply void *VOID_INT_PTR { void *iter1, void *iter2, void *iter, void *find, void *insertNode, void *getPrevIter, void *getNextIter, void *getFirstIter, void *getLastIter }
+
 %define SWIG_STD_LIST_ENHANCED(CTYPE...)
 namespace std {
   template<> class list< CTYPE > {
@@ -534,7 +444,9 @@ namespace std {
   };
 }
 %enddef
- 
+
+
+
 %{
 #include <iostream>
 #include <list>
@@ -544,25 +456,28 @@ namespace std {
 
 %csmethodmodifiers std::list::size "private"
 %csmethodmodifiers std::list::getItem "private"
-%csmethodmodifiers std::list::find_item "private"
+%csmethodmodifiers std::list::setItem "private"
 %csmethodmodifiers std::list::push_front "private"
 %csmethodmodifiers std::list::push_back "private"
-%csmethodmodifiers std::list::rmv "private"
-%csmethodmodifiers std::list::rmvIndex "private"
-%csmethodmodifiers std::list::insertIndex "private"
+%csmethodmodifiers std::list::getFirstIter "private"
+%csmethodmodifiers std::list::getNextIter "private"
+%csmethodmodifiers std::list::getPrevIter "private"
+%csmethodmodifiers std::list::getLastIter "private"
+%csmethodmodifiers std::list::find "private"
+%csmethodmodifiers std::list::deleteIter "private"
 
 namespace std {
-	template<class T> 
-	class list {
-		SWIG_STD_LIST_MINIMUM_INTERNAL(T const&, T)
-	};
-	template<class T> 
-	class list<T *> 
-	{
-		SWIG_STD_LIST_MINIMUM_INTERNAL(T *const&, T *)
-	};
-	template<> 
-	class list<bool> {
-		SWIG_STD_LIST_MINIMUM_INTERNAL(bool, bool)
-	};
+  template<class T> 
+  class list {
+    SWIG_STD_LIST_MINIMUM_INTERNAL(T const&, T)
+  };
+  template<class T> 
+  class list<T *> 
+  {
+    SWIG_STD_LIST_MINIMUM_INTERNAL(T *const&, T *)
+  };
+  template<> 
+  class list<bool> {
+    SWIG_STD_LIST_MINIMUM_INTERNAL(bool, bool)
+  };
 }

--- a/Lib/csharp/std_list.i
+++ b/Lib/csharp/std_list.i
@@ -6,7 +6,7 @@
  * The C# wrapper is made to look and feel like a C# System.Collections.Generic.LinkedList<> collection.
  *
  * ----------------------------------------------------------------------------- */
- 
+
 %include <std_common.i>
 %define SWIG_STD_LIST_MINIMUM_INTERNAL(CONST_REFERENCE, CTYPE...)
 %typemap(csinterfaces) std::list< CTYPE > "global::System.Collections.Generic.ICollection<$typemap(cstype, CTYPE)>, global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>, global::System.Collections.IEnumerable, global::System.IDisposable"
@@ -24,96 +24,96 @@
       return false;
     }
   }
-  
+
   public int Count {
     get {
       return (int)size();
     }
   }
-  
+
   public $csclassnameNode First {
-    get { 
-	  if (Count == 0)
-	    return null;
-	  return new $csclassnameNode(getFirstIter(), this);
+    get {
+      if (Count == 0)
+        return null;
+      return new $csclassnameNode(getFirstIter(), this);
     }
   }
 
   public $csclassnameNode Last {
     get {
-	  if (Count == 0)
-	    return null;
+      if (Count == 0)
+        return null;
       return new $csclassnameNode(getLastIter(), this);
     }
   }
-  
-  public  $csclassnameNode AddFirst($typemap(cstype, CTYPE) value) {
-	push_front(value);
-	return new $csclassnameNode(getFirstIter(), this);
+
+  public $csclassnameNode AddFirst($typemap(cstype, CTYPE) value) {
+    push_front(value);
+    return new $csclassnameNode(getFirstIter(), this);
   }
 
   public void AddFirst($csclassnameNode newNode) {
     ValidateNewNode(newNode);
-	if (!newNode.inlist) {
-	  push_front(newNode.csharpvalue);
-	  newNode.iter = getFirstIter();
-	  newNode.inlist = true;
-	} else {
-	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
-	}
+    if (!newNode.inlist) {
+      push_front(newNode.csharpvalue);
+      newNode.iter = getFirstIter();
+      newNode.inlist = true;
+    } else {
+      throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+    }
   }
 
   public $csclassnameNode AddLast($typemap(cstype, CTYPE) value) {
     push_back(value);
-	return new $csclassnameNode(getLastIter(), this);
+    return new $csclassnameNode(getLastIter(), this);
   }
 
   public void AddLast($csclassnameNode newNode) {
     ValidateNewNode(newNode);
-	if (!newNode.inlist) {
-	  push_back(newNode.csharpvalue);
-	  newNode.iter = getLastIter();
-	  newNode.inlist = true;
-	} else {
-	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
-	}
+    if (!newNode.inlist) {
+      push_back(newNode.csharpvalue);
+      newNode.iter = getLastIter();
+      newNode.inlist = true;
+    } else {
+      throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+    }
   }
-  
+
   public $csclassnameNode AddBefore($csclassnameNode node, $typemap(cstype, CTYPE) value) {
-	return new $csclassnameNode(insertNode(node.iter, value), this);
+    return new $csclassnameNode(insertNode(node.iter, value), this);
   }
 
   public void AddBefore($csclassnameNode node, $csclassnameNode newNode) {
     ValidateNode(node);
-	ValidateNewNode(newNode);
-	if (!newNode.inlist) {
-	  newNode.iter = insertNode(node.iter, newNode.csharpvalue);
-	  newNode.inlist = true;
-	} else {
-	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
-	}
+    ValidateNewNode(newNode);
+    if (!newNode.inlist) {
+      newNode.iter = insertNode(node.iter, newNode.csharpvalue);
+      newNode.inlist = true;
+    } else {
+      throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+    }
   }
 
   public $csclassnameNode AddAfter($csclassnameNode node, $typemap(cstype, CTYPE) value) {
-	node = node.Next;
-	return new $csclassnameNode(insertNode(node.iter, value), this);
+    node = node.Next;
+    return new $csclassnameNode(insertNode(node.iter, value), this);
   }
 
   public void AddAfter($csclassnameNode node, $csclassnameNode newNode) {
     ValidateNode(node);
-	ValidateNewNode(newNode);
-	if (!newNode.inlist) {
-	  if (node == this.Last)
-	    AddLast(newNode);
-	  else
-	  {
-	    node = node.Next;
-	    newNode.iter = insertNode(node.iter, newNode.csharpvalue);
-	    newNode.inlist = true;
-	  }
-	} else {
-	  throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
-	}
+    ValidateNewNode(newNode);
+    if (!newNode.inlist) {
+      if (node == this.Last)
+        AddLast(newNode);
+      else
+      {
+        node = node.Next;
+        newNode.iter = insertNode(node.iter, newNode.csharpvalue);
+        newNode.inlist = true;
+      }
+    } else {
+      throw new global::System.InvalidOperationException("The " + newNode.GetType().Name + " node already belongs to a " + this.GetType().Name);
+    }
   }
 
   public void Add($typemap(cstype, CTYPE) value) {
@@ -123,24 +123,24 @@
   public bool Remove($typemap(cstype, CTYPE) value) {
     var node = Find(value);
     if (node == null)
-	  return false;
-	Remove(node);
-	return true;
+      return false;
+    Remove(node);
+    return true;
   }
 
   public void Remove($csclassnameNode node) {
     ValidateNode(node);
-    eraseIter(node.iter);  
+    eraseIter(node.iter);
   }
 
   public $csclassnameNode Find($typemap(cstype, CTYPE) value) {
     System.IntPtr tmp = find(value);
     if (tmp != System.IntPtr.Zero) {
-	  return new $csclassnameNode(tmp, this);
-	}
-	return null;
+      return new $csclassnameNode(tmp, this);
+    }
+    return null;
   }
-  
+
   public void CopyTo($typemap(cstype, CTYPE)[] array, int index) {
     if (array == null)
       throw new global::System.ArgumentNullException("array");
@@ -159,17 +159,17 @@
 
   internal void ValidateNode($csclassnameNode node) {
     if (node == null) {
-      throw new System.ArgumentNullException("node"); 
-    } 
-    if (!node.inlist || node.list != this) { 
+      throw new System.ArgumentNullException("node");
+    }
+    if (!node.inlist || node.list != this) {
       throw new System.InvalidOperationException("node");
     }
   }
 
   internal void ValidateNewNode($csclassnameNode node) {
     if (node == null) {
-      throw new System.ArgumentNullException("node"); 
-    } 
+      throw new System.ArgumentNullException("node");
+    }
   }
 
   global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)> global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>.GetEnumerator() {
@@ -183,7 +183,7 @@
   public $csclassnameEnumerator GetEnumerator() {
     return new $csclassnameEnumerator(this);
   }
-  
+
   public sealed class $csclassnameEnumerator : global::System.Collections.IEnumerator,
     global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)>
   {
@@ -192,7 +192,7 @@
     private int currentIndex;
     private object currentObject;
     private int currentSize;
-      
+
     public $csclassnameEnumerator($csclassname collection) {
       collectionRef = collection;
       currentNode = collection.First;
@@ -200,7 +200,7 @@
       currentObject = null;
       currentSize = collectionRef.Count;
     }
-    
+
     // Type-safe iterator Current
     public $typemap(cstype, CTYPE) Current {
       get {
@@ -213,14 +213,14 @@
         return ($typemap(cstype, CTYPE))currentObject;
       }
     }
-  
+
     // Type-unsafe IEnumerator.Current
     object global::System.Collections.IEnumerator.Current {
       get {
         return Current;
       }
     }
-    
+
     public bool MoveNext() {
       if (currentNode == null) {
         currentIndex = collectionRef.Count + 1;
@@ -231,7 +231,7 @@
       currentNode = currentNode.Next;
       return true;
     }
-    
+
     public void Reset() {
       currentIndex = -1;
       currentObject = null;
@@ -239,105 +239,105 @@
         throw new global::System.InvalidOperationException("Collection modified.");
       }
     }
-    
+
     public void Dispose() {
       currentIndex = -1;
       currentObject = null;
     }
   }
-  
+
   public sealed class $csclassnameNode {
     internal $csclassname list;
     internal System.IntPtr iter;
-	internal $typemap(cstype, CTYPE) csharpvalue;
-	internal bool inlist;
-    
+    internal $typemap(cstype, CTYPE) csharpvalue;
+    internal bool inlist;
+
     public $csclassnameNode($typemap(cstype, CTYPE) value) {
-	  csharpvalue = value;
-	  inlist = false;
+      csharpvalue = value;
+      inlist = false;
     }
 
     internal $csclassnameNode(System.IntPtr _iter, $csclassname _list) {
       list = _list;
       iter = _iter;
-	  inlist = true;
+      inlist = true;
     }
-    
+
     public $csclassname List {
-      get { 
-        return this.list; 
+      get {
+        return this.list;
       }
     }
 
     public $csclassnameNode Next {
-      get { 
-	    if (list.getNextIter(iter) == System.IntPtr.Zero)
-		  return null;
+      get {
+        if (list.getNextIter(iter) == System.IntPtr.Zero)
+          return null;
         return new $csclassnameNode(list.getNextIter(iter), list);
       }
     }
-  
+
     public $csclassnameNode Previous {
       get {
-	    if (list.getPrevIter(iter) == System.IntPtr.Zero)
-		  return null;
+        if (list.getPrevIter(iter) == System.IntPtr.Zero)
+          return null;
         return new $csclassnameNode(list.getPrevIter(iter), list);
       }
     }
-    
-	public $typemap(cstype, CTYPE) Value {
-      get { 
-        return list.getItem(this.iter); 
+
+    public $typemap(cstype, CTYPE) Value {
+      get {
+        return list.getItem(this.iter);
       }
-      set { 
-        list.setItem(this.iter, value); 
+      set {
+        list.setItem(this.iter, value);
       }
     }
 
-	public static bool operator== ($csclassnameNode node1, $csclassnameNode node2) {
-	  if (object.ReferenceEquals(node1, null) && object.ReferenceEquals(node2, null))
-	    return true;
-	  if (object.ReferenceEquals(node1, null) || object.ReferenceEquals(node2, null))
-	    return false;
-	  return node1.Equals(node2);
-	}
+    public static bool operator== ($csclassnameNode node1, $csclassnameNode node2) {
+      if (object.ReferenceEquals(node1, null) && object.ReferenceEquals(node2, null))
+        return true;
+      if (object.ReferenceEquals(node1, null) || object.ReferenceEquals(node2, null))
+        return false;
+      return node1.Equals(node2);
+    }
 
     public static bool operator!= ($csclassnameNode node1, $csclassnameNode node2) {
-	  if (node1 == null && node2 == null)
-	    return false;
-	  if (node1 == null || node2 == null)
-	    return true;
-	  return !node1.Equals(node2);
-	}
+      if (node1 == null && node2 == null)
+        return false;
+      if (node1 == null || node2 == null)
+        return true;
+      return !node1.Equals(node2);
+    }
 
-	public bool Equals($csclassnameNode node) {
-	  if (node == null)
-	    return false;
-	  if (!node.inlist || !this.inlist)
-	    return object.ReferenceEquals(this, node);
-	  return list.equals(this.iter, node.iter);
-	}
+    public bool Equals($csclassnameNode node) {
+      if (node == null)
+        return false;
+      if (!node.inlist || !this.inlist)
+        return object.ReferenceEquals(this, node);
+      return list.equals(this.iter, node.iter);
+    }
 
-	public override bool Equals(object node) {
-	  return Equals(($csclassnameNode)node);
-	}
+    public override bool Equals(object node) {
+      return Equals(($csclassnameNode)node);
+    }
 
-	public override int GetHashCode() {
-	  int hash = 13;
-	  if (inlist) {
-	    hash = (hash * 7) + this.list.GetHashCode();
-	    hash = (hash * 7) + this.Value.GetHashCode();
-	    hash = (hash * 7) + this.list.getNextIter(this.iter).GetHashCode();
-	    hash = (hash * 7) + this.list.getPrevIter(this.iter).GetHashCode();
-	  } else {
-	    hash = (hash * 7) + this.csharpvalue.GetHashCode();	  
-	  }
-	  return hash;
-	}
+    public override int GetHashCode() {
+      int hash = 13;
+      if (inlist) {
+        hash = (hash * 7) + this.list.GetHashCode();
+        hash = (hash * 7) + this.Value.GetHashCode();
+        hash = (hash * 7) + this.list.getNextIter(this.iter).GetHashCode();
+        hash = (hash * 7) + this.list.getPrevIter(this.iter).GetHashCode();
+      } else {
+        hash = (hash * 7) + this.csharpvalue.GetHashCode();
+      }
+      return hash;
+    }
 
-	public void Dispose() {
-	  list.deleteIter(this.iter);
-	}
+    public void Dispose() {
+      list.deleteIter(this.iter);
+    }
   }
 %}
 
@@ -355,86 +355,86 @@ public:
   %rename(Clear) clear;
   void clear();
   %extend {
-	CONST_REFERENCE getItem(void *iter) {
+    CONST_REFERENCE getItem(void *iter) {
       std::list< CTYPE >::iterator it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
-	  return *it;
+      return *it;
     }
 
-	void setItem(void *iter, CTYPE const& val) {
-	  std::list< CTYPE >::iterator* it = reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
-	  *(*it) = val;
-	}
-    
-	void *getFirstIter() {
-	  if ($self->size() == 0)
-	    return NULL;
-	  auto iterator = new std::list< CTYPE >::iterator($self->begin());
-	  return reinterpret_cast<void *>(iterator);
-	}
+    void setItem(void *iter, CTYPE const& val) {
+      std::list< CTYPE >::iterator* it = reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+      *(*it) = val;
+    }
 
-	void *getLastIter() {
-	  if ($self->size() == 0)
-	    return NULL;
-	  auto iterator = new std::list< CTYPE >::iterator(--$self->end());
-	  return reinterpret_cast<void *>(iterator);
-	}
+    void *getFirstIter() {
+      if ($self->size() == 0)
+        return NULL;
+      auto iterator = new std::list< CTYPE >::iterator($self->begin());
+      return reinterpret_cast<void *>(iterator);
+    }
 
-	void *getNextIter(void *iter) {
-	  auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
-	  if (std::distance(it, --$self->end()) != 0) {
-		auto itnext =  new std::list< CTYPE >::iterator(++it);
-		return itnext;
-	  }
-	  return NULL;
-	}
+    void *getLastIter() {
+      if ($self->size() == 0)
+        return NULL;
+      auto iterator = new std::list< CTYPE >::iterator(--$self->end());
+      return reinterpret_cast<void *>(iterator);
+    }
 
-	void *getPrevIter(void *iter) {
+    void *getNextIter(void *iter) {
       auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
-	  if (std::distance($self->begin(), it) != 0) {
-		auto itprev =  new std::list< CTYPE >::iterator(--it);
-		return itprev;
-	  }
-	  return NULL;
-	}
+      if (std::distance(it, --$self->end()) != 0) {
+        auto itnext = new std::list< CTYPE >::iterator(++it);
+        return itnext;
+      }
+      return NULL;
+    }
 
-	void *insertNode(void *iter, CTYPE const& value) {
-	  auto it = $self->insert(*(reinterpret_cast<std::list< CTYPE >::iterator *>(iter)), value);
-	  auto newit = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(it));
-	  return newit;
-	}
+    void *getPrevIter(void *iter) {
+      auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
+      if (std::distance($self->begin(), it) != 0) {
+        auto itprev = new std::list< CTYPE >::iterator(--it);
+        return itprev;
+      }
+      return NULL;
+    }
 
-	void *find(CTYPE const& value) {
-	  if (std::find($self->begin(), $self->end(), value) != $self->end()) {
-	    auto it = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(std::find($self->begin(), $self->end(), value)));
-	    return it;
-	  }
-	  return NULL;
-	}
+    void *insertNode(void *iter, CTYPE const& value) {
+      auto it = $self->insert(*(reinterpret_cast<std::list< CTYPE >::iterator *>(iter)), value);
+      auto newit = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(it));
+      return newit;
+    }
 
-	void eraseIter(void *iter) {
-	  auto it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
-	  $self->erase(it);
-	}
+    void *find(CTYPE const& value) {
+      if (std::find($self->begin(), $self->end(), value) != $self->end()) {
+        auto it = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(std::find($self->begin(), $self->end(), value)));
+        return it;
+      }
+      return NULL;
+    }
 
-	void deleteIter(void *iter) {
-	  std::list< CTYPE >::iterator* it = reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
-	  delete it;
-	}
-	
-	bool equals(void *iter1, void *iter2) {
-	  if (iter1 == NULL && iter2 == NULL)
-	    return true;
-	  std::list< CTYPE >::iterator it1 = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter1);
-	  std::list< CTYPE >::iterator it2 = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter2);
-	  return it1 == it2;
-	}
-   
+    void eraseIter(void *iter) {
+      auto it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+      $self->erase(it);
+    }
+
+    void deleteIter(void *iter) {
+      std::list< CTYPE >::iterator* it = reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+      delete it;
+    }
+
+    bool equals(void *iter1, void *iter2) {
+      if (iter1 == NULL && iter2 == NULL)
+        return true;
+      std::list< CTYPE >::iterator it1 = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter1);
+      std::list< CTYPE >::iterator it2 = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter2);
+      return it1 == it2;
+    }
+
     bool Contains(CTYPE const& value) {
       return std::find($self->begin(), $self->end(), value) != $self->end();
     }
   }
 %enddef
- 
+
 %apply void *VOID_INT_PTR { void *iter1, void *iter2, void *iter, void *find, void *insertNode, void *getPrevIter, void *getNextIter, void *getFirstIter, void *getLastIter }
 
 %define SWIG_STD_LIST_ENHANCED(CTYPE...)
@@ -467,16 +467,16 @@ namespace std {
 %csmethodmodifiers std::list::deleteIter "private"
 
 namespace std {
-  template<class T> 
+  template<class T>
   class list {
     SWIG_STD_LIST_MINIMUM_INTERNAL(T const&, T)
   };
-  template<class T> 
-  class list<T *> 
+  template<class T>
+  class list<T *>
   {
     SWIG_STD_LIST_MINIMUM_INTERNAL(T *const&, T *)
   };
-  template<> 
+  template<>
   class list<bool> {
     SWIG_STD_LIST_MINIMUM_INTERNAL(bool, bool)
   };

--- a/Lib/csharp/std_list.i
+++ b/Lib/csharp/std_list.i
@@ -1,0 +1,568 @@
+/* -----------------------------------------------------------------------------
+ * std_list.i
+ *
+ * SWIG typemaps for std::list<T>
+ * C# implementation
+ * The C# wrapper is made to look and feel like a C# System.Collections.Generic.LinkedList<> collection.
+ *
+ * ----------------------------------------------------------------------------- */
+ 
+%include <std_common.i>
+
+%define SWIG_STD_LIST_MINIMUM_INTERNAL(CONST_REFERENCE, CTYPE...)
+%typemap(csinterfaces) std::list< CTYPE > "global::System.Collections.Generic.ICollection<$typemap(cstype, CTYPE)>, global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>, global::System.Collections.IEnumerable, global::System.IDisposable"
+%proxycode %{
+	public $csclassname(global::System.Collections.IEnumerable c) : this() 
+	{
+		if (c == null)
+			throw new global::System.ArgumentNullException("c");
+		foreach ($typemap(cstype, CTYPE) element in c) 
+		{
+			this.AddLast(element);
+		}
+	}
+
+	public bool IsReadOnly 
+	{
+		get {
+			return false;
+		}
+	}
+	
+	public int Count 
+	{
+		get {
+			return (int)size();
+		}
+	}
+	
+	private	$csclassnameNode _head;
+	internal $csclassnameNode head
+	{
+		get {
+			if (this._head == null && (int)size() > 0)
+			{
+				this._head = new $csclassnameNode(($typemap(cstype, CTYPE))getItem(0), 0, this);
+			}
+			return this._head;
+		}
+		set { this._head = value; }
+	}
+	public $csclassnameNode First
+	{
+		get { return this.head;	}
+	}
+	
+	private	$csclassnameNode _tail;
+	internal $csclassnameNode tail
+	{
+		get {
+			if (this._tail == null && (int)size() > 0) {
+				this._tail = new $csclassnameNode(($typemap(cstype, CTYPE))getItem((int)size() - 1), (int)size() - 1, this);
+			}
+			return this._tail;
+		}
+		set { this._tail = value; }
+	}
+	
+	public $csclassnameNode Last
+	{
+		get { return this.tail;	}
+	}
+	
+	public $csclassnameNode AddFirst($typemap(cstype, CTYPE) value)
+	{
+		$csclassnameNode	newNode = new $csclassnameNode(value, 0, this);
+		AddFirst(newNode);
+		return newNode;
+	}
+	
+	public void AddFirst($csclassnameNode newNode)
+	{
+        if (this.Count == 0)
+        {
+            newNode.next = null;
+            newNode.prev = null;
+            this.head = newNode;
+            this.tail = newNode;
+        }
+        else
+        {
+			$csclassnameNode	tmp = this.First;
+		    
+		    while (tmp != null)	{
+		    	tmp.index++;
+		    	tmp = tmp.Next;
+		    }
+            newNode.next = this.head;
+            this.head.prev = newNode;
+            this.head = newNode;
+        }
+        push_front(newNode.Value);
+		if (newNode.index == -1)
+			newNode.index = 0;
+		if (newNode.list == null)
+			newNode.list = this;
+	}
+
+	public $csclassnameNode AddLast($typemap(cstype, CTYPE) value)
+	{
+		$csclassnameNode	newNode = new $csclassnameNode(value, (int)size(), this);
+		AddLast(newNode);
+		return newNode;
+	}
+
+	public void AddLast($csclassnameNode newNode)
+	{
+        if (this.Count == 0)
+        {
+            newNode.next = null;
+            newNode.prev = null;
+            this.head = newNode;
+            this.tail = newNode;
+        }
+        else
+        {
+            newNode.prev = this.Last;
+            this.Last.next = newNode;
+            this.tail = newNode;
+        }
+        push_back(newNode.Value);
+        if (newNode.index == -1)
+			newNode.index = (int)size() - 1;
+		if (newNode.list == null)
+			newNode.list = this;
+	}
+	
+	public $csclassnameNode AddBefore($csclassnameNode node, $typemap(cstype, CTYPE) value)
+	{
+		$csclassnameNode newNode = new $csclassnameNode(value, node.index, this);
+		AddBefore(node, newNode);
+		return newNode;
+	}
+
+	public void AddBefore($csclassnameNode node, $csclassnameNode newNode)
+	{
+		ValidateNode(node);
+		ValidateNode(newNode);
+		newNode.next = node;
+		newNode.prev = node.Previous;
+		node.Previous.next = newNode;
+		node.prev = newNode;
+		insertIndex(node.index, newNode.Value);
+
+		if (newNode.index == -1)
+			newNode.index = node.index;
+		if (newNode.list == null)
+			newNode.list = this;
+
+		$csclassnameNode tmp = node;
+		while (tmp != null)
+		{
+			tmp.index++;
+			tmp = tmp.Next;
+		}
+	}
+
+	public $csclassnameNode AddAfter($csclassnameNode node, $typemap(cstype, CTYPE) value)
+	{
+		$csclassnameNode newNode = new $csclassnameNode(value, node.index + 1, this);
+		AddBefore(node.Next, newNode);
+		return newNode;
+	}
+
+	public void AddAfter($csclassnameNode node, $csclassnameNode newNode)
+	{
+		AddBefore(node.Next, newNode);
+	}
+
+	public void Add($typemap(cstype, CTYPE) value)
+	{
+		this.AddLast(value);
+	}
+	
+	public void RemoveFirst()
+	{
+		pop_front();
+		this.First.Next.prev = null;
+		this.head = this.First.Next;
+		$csclassnameNode node = this.First;
+		while (node != null) {
+			node.index--;
+			node = node.Next;
+		}
+	}
+
+	public void RemoveLast()
+	{
+		pop_back();
+		this.Last.Previous.next = null;
+		this.tail = this.Last.Previous;
+	}
+
+	public bool Remove($typemap(cstype, CTYPE) value)
+	{
+		$csclassnameNode node = Find(value);
+		return Remove(node);
+	}
+
+	public bool Remove($csclassnameNode node)
+	{
+		ValidateNode(node);
+		if (node != null)
+		{
+			if (node.index == 0)
+				RemoveFirst();
+			else if (node.index == (int)size() - 1)
+				RemoveLast();
+			else
+			{
+				rmvIndex(node.index);
+				$csclassnameNode tmp = node;
+				while (tmp != null) {
+					tmp.index--;
+					tmp = tmp.Next;
+				}
+				node.Next.prev = node.Previous; 
+				node.Previous.next = node.Next;
+				if (this.head == node) {
+				    this.head = node.Next;
+				} 
+				else if (this.tail == node) {
+					this.tail = node.Previous;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	public $csclassnameNode Find($typemap(cstype, CTYPE) value)
+	{
+		int tmpPos = find_item(value);
+		$csclassnameNode tmp = this.First;
+		int i = 0;
+
+		if (tmpPos != -1) {
+			while (i != tmpPos) {
+				tmp = tmp.Next;
+				++i;
+			}
+			return tmp;
+		}
+		return null;
+	}
+	
+	public void CopyTo($typemap(cstype, CTYPE)[] array, int index)
+	{
+		if (array == null)
+			throw new global::System.ArgumentNullException("array");
+		if (index < 0)
+			throw new global::System.ArgumentOutOfRangeException("index", "Value is less than zero");
+		if (array.Rank > 1)
+			throw new global::System.ArgumentException("Multi dimensional array.", "array");
+		$csclassnameNode current = this.First;
+		if (current != null)
+        {
+            do
+            {
+                array[index++] = current.Value;
+                current = current.Next;
+            } while (current != null);
+        }
+	}
+
+	public void Clear()
+	{
+		$csclassnameNode current = this.First;
+		
+		while (current != null)
+		{
+			$csclassnameNode tmp = current;
+			current = current.Next;
+			tmp.list = null;
+			tmp.next = null;
+			tmp.prev = null;
+		}
+		
+		this.head = null;
+		clear();
+	}
+
+	internal void ValidateNode($csclassnameNode node)
+	{
+		if (node == null) {
+		    throw new System.ArgumentNullException("node"); 
+		} 
+		
+		if ( node.list != this) { 
+		    throw new System.InvalidOperationException("node");
+		}
+	}
+
+	global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)> global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>.GetEnumerator() 
+	{
+		return new $csclassnameEnumerator(this);
+	}
+
+	global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator() 
+	{
+		return new $csclassnameEnumerator(this);
+	}
+
+	public $csclassnameEnumerator GetEnumerator() 
+	{
+		return new $csclassnameEnumerator(this);
+	}
+	
+	public sealed class $csclassnameEnumerator : global::System.Collections.IEnumerator,
+		global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)>
+	{
+		private $csclassname collectionRef;
+		private $csclassnameNode currentNode;
+		private int		currentIndex;
+		private object	currentObject;
+		private int		currentSize;
+		
+		public $csclassnameEnumerator($csclassname collection)
+		{
+			collectionRef = collection;
+			currentNode = collection.First;
+			currentIndex = 0;
+			currentObject = null;
+			currentSize = collectionRef.Count;
+		}
+		
+		// Type-safe iterator Current
+		public $typemap(cstype, CTYPE) Current 
+		{
+			get {
+				if (currentIndex == -1)
+					throw new global::System.InvalidOperationException("Enumeration not started.");
+				if (currentIndex > currentSize)
+					throw new global::System.InvalidOperationException("Enumeration finished.");
+				if (currentObject == null)
+					throw new global::System.InvalidOperationException("Collection modified.");
+				return ($typemap(cstype, CTYPE))currentObject;
+			}
+		}
+	
+		// Type-unsafe IEnumerator.Current
+		object global::System.Collections.IEnumerator.Current 
+		{
+			get {
+				return Current;
+			}
+		}
+		
+		public bool MoveNext()
+		{
+            if (currentNode == null) {
+                currentIndex = collectionRef.Count + 1;
+                return false;
+            }
+            ++currentIndex;
+            currentObject = currentNode.Value;
+            currentNode = currentNode.Next;
+            return true;
+		}
+		
+		public void Reset()
+		{
+			currentIndex = -1;
+			currentObject = null;
+			if (collectionRef.Count != currentSize) {
+				throw new global::System.InvalidOperationException("Collection modified.");
+			}
+		}
+		
+		public void Dispose()
+		{
+			currentIndex = -1;
+			currentObject = null;
+		}
+	}
+	
+	public sealed class $csclassnameNode
+	{
+		internal $csclassname		list;
+		internal $typemap(cstype, CTYPE)			item;
+		internal int			index;
+		
+		public $csclassnameNode($typemap(cstype, CTYPE) value)
+		{
+			this.item = value;
+		}
+
+		internal $csclassnameNode($typemap(cstype, CTYPE) value, int _index, $csclassname _list)
+		{
+			this.list = _list;
+			this.item = value;
+			this.index = _index;
+		}
+		
+		public $csclassname List
+		{
+			get { return this.list; }
+		}
+
+		private $csclassnameNode _next;
+		internal $csclassnameNode	next
+		{
+			get {
+				if (this._next == null && index + 1 < (int)this.list.size()) {
+					this._next = new $csclassnameNode(this.list.getItem(index + 1), index + 1, this.list);
+					this._next.prev = this;
+				}
+				if (index + 1 == (int)this.list.size() - 1)
+					this.list.tail = this._next;
+				return this._next; 
+			}
+			set { this._next = value; }
+		}
+
+		public $csclassnameNode Next
+		{
+			get { return this.next; }
+		}
+	
+		private $csclassnameNode _prev;
+		internal $csclassnameNode	prev
+		{
+			get { 
+				if (this._prev == null && index - 1 >= 0) {
+					this._prev = new $csclassnameNode(this.list.getItem(index - 1), index - 1, this.list);
+					this._prev.next = this;
+				}
+				if (index - 1 == 0)
+					this.list.head = this._prev;
+				return this._prev;
+			}
+			set { this._prev = value; }
+		}
+
+		public $csclassnameNode Previous
+		{
+			get { return this.prev; }
+		}
+		
+		public $typemap(cstype, CTYPE) Value
+		{
+			get { return this.item; }
+			set { this.item = value; }
+		}
+	}
+%}
+
+public:
+	typedef size_t size_type;
+	typedef CTYPE value_type;
+	typedef CONST_REFERENCE const_reference;
+	void clear();
+	void push_front(CTYPE const& x);
+	void push_back(CTYPE const& x);
+	void pop_front();
+	void pop_back();
+	size_type size() const;
+	%extend {
+		const CTYPE& getItem(int index) {
+			std::list< CTYPE >::iterator it = $self->begin();
+			
+			if (index >= 0 && index < (int)($self->size())) {
+				for (int i = 0; i != index; i++)
+					it++;
+				return *it;
+			} else {
+				throw std::out_of_range("index");
+			}
+		}
+		
+		int find_item(CTYPE const& x) {
+			std::list< CTYPE >::iterator it = $self->begin();
+			int i = 0;
+		
+			while (it != $self->end() && (CTYPE const&)*it != x) {
+				++it;
+				++i;
+			}
+			if (it != $self->end())
+				return i;
+			return -1;
+		}
+
+		void insertIndex(int index, CTYPE const& value) {
+			std::list< CTYPE >::iterator it = $self->begin();
+			int i = 0;
+
+			while (it != $self->end() && i != index) {
+				++it;
+				++i;
+			}
+			$self->insert(it, value);
+		}
+
+		bool rmv(const CTYPE& value) {
+			std::list< CTYPE >::iterator it = std::find($self->begin(), $self->end(), value);
+			
+			if ($self->erase(it) != $self->end())
+				return true;
+			return false;
+		}
+
+		bool rmvIndex(int index) {
+			std::list< CTYPE >::iterator it = $self->begin();
+
+			for (int i = 0; i != index; i++)
+				++it;
+			if (it != $self->end()) {
+				$self->erase(it);
+				return true;
+			}
+			return false;
+		}
+		
+		bool Contains(CTYPE const& value) {
+			return std::find($self->begin(), $self->end(), value) != $self->end();
+		}
+	}
+%enddef
+ 
+%define SWIG_STD_LIST_ENHANCED(CTYPE...)
+namespace std {
+  template<> class list< CTYPE > {
+    SWIG_STD_LIST_MINIMUM_INTERNAL(%arg(CTYPE const&), %arg(CTYPE));
+  };
+}
+%enddef
+ 
+%{
+#include <iostream>
+#include <list>
+#include <algorithm>
+#include <stdexcept>
+%}
+
+%csmethodmodifiers std::list::size "private"
+%csmethodmodifiers std::list::getItem "private"
+%csmethodmodifiers std::list::find_item "private"
+%csmethodmodifiers std::list::push_front "private"
+%csmethodmodifiers std::list::push_back "private"
+%csmethodmodifiers std::list::rmv "private"
+%csmethodmodifiers std::list::rmvIndex "private"
+%csmethodmodifiers std::list::insertIndex "private"
+
+namespace std {
+	template<class T> 
+	class list {
+		SWIG_STD_LIST_MINIMUM_INTERNAL(T const&, T)
+	};
+	template<class T> 
+	class list<T *> 
+	{
+		SWIG_STD_LIST_MINIMUM_INTERNAL(T *const&, T *)
+	};
+	template<> 
+	class list<bool> {
+		SWIG_STD_LIST_MINIMUM_INTERNAL(bool, bool)
+	};
+}

--- a/Lib/csharp/std_list.i
+++ b/Lib/csharp/std_list.i
@@ -368,51 +368,51 @@ public:
     void *getFirstIter() {
       if ($self->size() == 0)
         return NULL;
-      auto iterator = new std::list< CTYPE >::iterator($self->begin());
-      return reinterpret_cast<void *>(iterator);
+      std::list< CTYPE >::iterator* it = new std::list< CTYPE >::iterator($self->begin());
+      return reinterpret_cast<void *>(it);
     }
 
     void *getLastIter() {
       if ($self->size() == 0)
         return NULL;
-      auto iterator = new std::list< CTYPE >::iterator(--$self->end());
-      return reinterpret_cast<void *>(iterator);
+      std::list< CTYPE >::iterator* it = new std::list< CTYPE >::iterator(--$self->end());
+      return reinterpret_cast<void *>(it);
     }
 
     void *getNextIter(void *iter) {
-      auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
+      std::list< CTYPE >::iterator it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
       if (std::distance(it, --$self->end()) != 0) {
-        auto itnext = new std::list< CTYPE >::iterator(++it);
-        return itnext;
+        std::list< CTYPE >::iterator* itnext = new std::list< CTYPE >::iterator(++it);
+        return reinterpret_cast<void *>(itnext);
       }
       return NULL;
     }
 
     void *getPrevIter(void *iter) {
-      auto it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
+      std::list< CTYPE >::iterator it = *(reinterpret_cast<std::list< CTYPE >::iterator *>(iter));
       if (std::distance($self->begin(), it) != 0) {
-        auto itprev = new std::list< CTYPE >::iterator(--it);
-        return itprev;
+        std::list< CTYPE >::iterator* itprev = new std::list< CTYPE >::iterator(--it);
+        return reinterpret_cast<void *>(itprev);
       }
       return NULL;
     }
 
     void *insertNode(void *iter, CTYPE const& value) {
-      auto it = $self->insert(*(reinterpret_cast<std::list< CTYPE >::iterator *>(iter)), value);
-      auto newit = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(it));
+      std::list< CTYPE >::iterator it = $self->insert(*(reinterpret_cast<std::list< CTYPE >::iterator *>(iter)), value);
+      void* newit = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(it));
       return newit;
     }
 
     void *find(CTYPE const& value) {
       if (std::find($self->begin(), $self->end(), value) != $self->end()) {
-        auto it = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(std::find($self->begin(), $self->end(), value)));
+        void* it = reinterpret_cast<void *>(new std::list< CTYPE >::iterator(std::find($self->begin(), $self->end(), value)));
         return it;
       }
       return NULL;
     }
 
     void eraseIter(void *iter) {
-      auto it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
+      std::list< CTYPE >::iterator it = *reinterpret_cast<std::list< CTYPE >::iterator*>(iter);
       $self->erase(it);
     }
 

--- a/Lib/csharp/std_list.i
+++ b/Lib/csharp/std_list.i
@@ -79,26 +79,26 @@
 	
 	public void AddFirst($csclassnameNode newNode)
 	{
-        if (this.Count == 0)
-        {
-            newNode.next = null;
-            newNode.prev = null;
-            this.head = newNode;
-            this.tail = newNode;
-        }
-        else
-        {
+		if (this.Count == 0)
+		{
+			newNode.next = null;
+			newNode.prev = null;
+			this.head = newNode;
+			this.tail = newNode;
+		}
+		else
+		{
 			$csclassnameNode	tmp = this.First;
-		    
-		    while (tmp != null)	{
-		    	tmp.index++;
-		    	tmp = tmp.Next;
-		    }
-            newNode.next = this.head;
-            this.head.prev = newNode;
-            this.head = newNode;
-        }
-        push_front(newNode.Value);
+			
+			while (tmp != null)	{
+				tmp.index++;
+				tmp = tmp.Next;
+			}
+			newNode.next = this.head;
+			this.head.prev = newNode;
+			this.head = newNode;
+		}
+		push_front(newNode.Value);
 		if (newNode.index == -1)
 			newNode.index = 0;
 		if (newNode.list == null)
@@ -114,21 +114,21 @@
 
 	public void AddLast($csclassnameNode newNode)
 	{
-        if (this.Count == 0)
-        {
-            newNode.next = null;
-            newNode.prev = null;
-            this.head = newNode;
-            this.tail = newNode;
-        }
-        else
-        {
-            newNode.prev = this.Last;
-            this.Last.next = newNode;
-            this.tail = newNode;
-        }
-        push_back(newNode.Value);
-        if (newNode.index == -1)
+		if (this.Count == 0)
+		{
+			newNode.next = null;
+			newNode.prev = null;
+			this.head = newNode;
+			this.tail = newNode;
+		}
+		else
+		{
+			newNode.prev = this.Last;
+			this.Last.next = newNode;
+			this.tail = newNode;
+		}
+		push_back(newNode.Value);
+		if (newNode.index == -1)
 			newNode.index = (int)size() - 1;
 		if (newNode.list == null)
 			newNode.list = this;
@@ -226,7 +226,7 @@
 				node.Next.prev = node.Previous; 
 				node.Previous.next = node.Next;
 				if (this.head == node) {
-				    this.head = node.Next;
+					this.head = node.Next;
 				} 
 				else if (this.tail == node) {
 					this.tail = node.Previous;
@@ -263,13 +263,13 @@
 			throw new global::System.ArgumentException("Multi dimensional array.", "array");
 		$csclassnameNode current = this.First;
 		if (current != null)
-        {
-            do
-            {
-                array[index++] = current.Value;
-                current = current.Next;
-            } while (current != null);
-        }
+		{
+			do
+			{
+				array[index++] = current.Value;
+				current = current.Next;
+			} while (current != null);
+		}
 	}
 
 	public void Clear()
@@ -292,11 +292,11 @@
 	internal void ValidateNode($csclassnameNode node)
 	{
 		if (node == null) {
-		    throw new System.ArgumentNullException("node"); 
+			throw new System.ArgumentNullException("node"); 
 		} 
 		
 		if ( node.list != this) { 
-		    throw new System.InvalidOperationException("node");
+			throw new System.InvalidOperationException("node");
 		}
 	}
 
@@ -320,9 +320,9 @@
 	{
 		private $csclassname collectionRef;
 		private $csclassnameNode currentNode;
-		private int		currentIndex;
-		private object	currentObject;
-		private int		currentSize;
+		private int	currentIndex;
+		private object currentObject;
+		private int	currentSize;
 		
 		public $csclassnameEnumerator($csclassname collection)
 		{
@@ -357,14 +357,14 @@
 		
 		public bool MoveNext()
 		{
-            if (currentNode == null) {
-                currentIndex = collectionRef.Count + 1;
-                return false;
-            }
-            ++currentIndex;
-            currentObject = currentNode.Value;
-            currentNode = currentNode.Next;
-            return true;
+			if (currentNode == null) {
+				currentIndex = collectionRef.Count + 1;
+				return false;
+			}
+			++currentIndex;
+			currentObject = currentNode.Value;
+			currentNode = currentNode.Next;
+			return true;
 		}
 		
 		public void Reset()
@@ -385,9 +385,9 @@
 	
 	public sealed class $csclassnameNode
 	{
-		internal $csclassname		list;
-		internal $typemap(cstype, CTYPE)			item;
-		internal int			index;
+		internal $csclassname list;
+		internal $typemap(cstype, CTYPE) item;
+		internal int index;
 		
 		public $csclassnameNode($typemap(cstype, CTYPE) value)
 		{
@@ -407,7 +407,7 @@
 		}
 
 		private $csclassnameNode _next;
-		internal $csclassnameNode	next
+		internal $csclassnameNode next
 		{
 			get {
 				if (this._next == null && index + 1 < (int)this.list.size()) {


### PR DESCRIPTION
I tried to make a C# wrapper of the C++ STL list, to look like the C# LinkedList. 
I inspired myself a lot of the way the STL vector has been wrapped.

 The main issue here was that a C# LinkedList is a bundle of nodes that contain the data. It is the same for a std::list, except that the only way to manipulate this nodes is to use the iterators. So I needed to create the C# nodes, and copy the data from the std::list in the C# nodes. I'm not very proud of this way of doing, but I didn't get a better solution. So for the moment, I propose this solution, obviously not perfect, and certainly improvable.
I'm open to any other idea or solution one would give.

I also prepared a bunch of tests, but I didn't commit them for the moment, because I don't know if there is a norm or something for them  and I don't know where put them.