### PR TITLE
fix Scilab linking issue

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2017-05-30: davidcl
+            [Scilab] #994 Undefined symbol error when loading in Scilab 6
+
 2017-05-25: asibross
             [Java] #370 #417 Missing smart pointer handling in Java director extra methods
             swigReleaseOwnership() and swigTakeOwnership().

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -1027,8 +1027,14 @@ public:
     Printf(gatewayHeader, "\n");
 
     gatewayHeaderV6 = NewString("");
+    Printf(gatewayHeaderV6, "#ifdef __cplusplus\n");
+    Printf(gatewayHeaderV6, "extern \"C\" {\n");
+    Printf(gatewayHeaderV6, "#endif\n");
     Printf(gatewayHeaderV6, "#include \"c_gateway_prototype.h\"\n");
     Printf(gatewayHeaderV6, "#include \"addfunction.h\"\n");
+    Printf(gatewayHeaderV6, "#ifdef __cplusplus\n");
+    Printf(gatewayHeaderV6, "}\n");
+    Printf(gatewayHeaderV6, "#endif\n");
     Printf(gatewayHeaderV6, "\n");
     Printf(gatewayHeaderV6, "#define MODULE_NAME L\"%s\"\n", gatewayLibraryName);
     Printf(gatewayHeaderV6, "#ifdef __cplusplus\n");


### PR DESCRIPTION
Add the missing `extern "C"` when wrapping C++ codes