### PR TITLE
Fix Go callback example (swig/swig#600 and swig/swig#955)

### DIFF
--- a/Examples/go/callback/gocallback.go
+++ b/Examples/go/callback/gocallback.go
@@ -36,6 +36,6 @@ func DeleteGoCallback(p GoCallback) {
 	p.deleteCallback()
 }
 
-func (p *goCallback) Run() {
+func (p *overwrittenMethodsOnCallback) Run() {
 	fmt.Println("GoCallback.Run")
 }


### PR DESCRIPTION
Fix Go callback example.
See swig/swig#600 and swig/swig#955.