### PR TITLE
Apply patch to configure with 2to3 rename

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -386,7 +386,7 @@ else
   PYSCRIPT = $(RUNME)3.py
 endif
 
-PY2TO3 = 2to3 `2to3 -l | grep -v -E "Available|import$$" | awk '{print "-f "$$0}'`
+PY2TO3 = @PY2TO3PROG@ `@PY2TO3PROG@ -l | grep -v -E "Available|import$$" | awk '{print "-f "$$0}'`
 
 python_run: $(PYSCRIPT)
 ifneq (,$(PEP8))

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -16,7 +16,7 @@ PEP8_FLAGS   = --ignore=E30,E402,E501,E731,W291,W391
 #*_runme.py for Python 2.x, *_runme3.py for Python 3.x
 PY2SCRIPTSUFFIX = _runme.py
 PY3SCRIPTSUFFIX = _runme3.py
-PY2TO3       = 2to3 -x import
+PY2TO3       = @PY2TO3PROG@ -x import
 
 ifeq (,$(PY3))
   SCRIPTSUFFIX = $(PY2SCRIPTSUFFIX)

--- a/configure.ac
+++ b/configure.ac
@@ -902,6 +902,11 @@ if test -n "$PYINCLUDE" || test -n "$PY3INCLUDE" ; then
     AC_MSG_RESULT($pep8_version)
   fi
 fi
+AC_ARG_WITH(2to3, AS_HELP_STRING([--with-2to3], [alternate 2to3 executable])
+AS_HELP_STRING([--with-2to3=path], [Specify 2to3 utility path]),[ PY2TO3="$withval"], [PY2TO3="2to3"])
+if [ ! -z "$PYTHON3" ] ; then
+  AC_CHECK_PROGS(PY2TO3PROG, $PY2TO3)
+fi
 
 #----------------------------------------------------------------
 # Look for Perl5


### PR DESCRIPTION
This is enhancement of configure script to pass the path of 2to3 utility, for Python 3 testing.
Same as the issue #1001 
This adds new option --with-2to3=... to configure script.