### PR TITLE
CCache: take care for program prefix/suffix on configure

### DIFF
--- a/CCache/Makefile.in
+++ b/CCache/Makefile.in
@@ -70,7 +70,7 @@ test: test.sh
 check: test
 
 distclean: clean
-	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h
+	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h config_win32.h
 	/bin/rm -rf autom4te.cache
 
 maintainer-clean: distclean

--- a/CCache/Makefile.in
+++ b/CCache/Makefile.in
@@ -8,6 +8,7 @@ bindir=@bindir@
 mandir=@mandir@
 INSTALLCMD=@INSTALL@
 PACKAGE_NAME=@PACKAGE_NAME@
+MYNAME=@MYNAME@
 # Soft link test can be skipped on systems that don't support soft linking
 NOSOFTLINKSTEST=
 
@@ -25,46 +26,46 @@ OBJS= ccache.o mdfour.o hash.o execute.o util.o args.o stats.o \
 	cleanup.o snprintf.o unify.o
 HEADERS = ccache.h mdfour.h
 
-all: $(PACKAGE_NAME)$(EXEEXT)
+all: $(MYNAME)$(EXEEXT)
 
 # Regenerate Makefile if Makefile.in or config.status have changed.
 Makefile: $(srcdir)/Makefile.in ./config.status
 	$(SHELL) ./config.status
 
 # Note that HTML documentation is actually generated and used from the main SWIG documentation Makefile
-docs: $(srcdir)/$(PACKAGE_NAME).1 $(srcdir)/web/ccache-man.html
+docs: $(srcdir)/$(MYNAME).1 $(srcdir)/web/$(MYNAME)-man.html
 
-$(PACKAGE_NAME)$(EXEEXT): $(OBJS) $(HEADERS)
+$(MYNAME)$(EXEEXT): $(OBJS) $(HEADERS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
-$(srcdir)/$(PACKAGE_NAME).1: $(srcdir)/ccache.yo
-	-yodl2man -o $(srcdir)/$(PACKAGE_NAME).1 $(srcdir)/ccache.yo
+$(srcdir)/$(MYNAME).1: $(srcdir)/ccache.yo
+	-yodl2man -o $(srcdir)/$(MYNAME).1 $(srcdir)/ccache.yo
 
-$(srcdir)/web/ccache-man.html: $(srcdir)/ccache.yo
-	yodl2html -o $(srcdir)/web/ccache-man.html $(srcdir)/ccache.yo
+$(srcdir)/web/$(MYNAME)-man.html: $(srcdir)/ccache.yo
+	yodl2html -o $(srcdir)/web/$(MYNMAE)-man.html $(srcdir)/ccache.yo
 
-install: $(PACKAGE_NAME)$(EXEEXT)
-	@echo "Installing $(PACKAGE_NAME)"
-	@echo "Installing $(DESTDIR)${bindir}/`echo $(PACKAGE_NAME) | sed '$(transform)'`$(EXEEXT)"
+install: $(MYNAME)$(EXEEXT)
+	@echo "Installing $(MYNAME)"
+	@echo "Installing $(DESTDIR)${bindir}/$(MYNAME)$(EXEEXT)"
 	${INSTALLCMD} -d $(DESTDIR)${bindir}
-	${INSTALLCMD} -m 755 $(PACKAGE_NAME)$(EXEEXT) $(DESTDIR)${bindir}/`echo $(PACKAGE_NAME) | sed '$(transform)'`$(EXEEXT)
+	${INSTALLCMD} -m 755 $(MYNAME)$(EXEEXT) $(DESTDIR)${bindir}/$(MYNAME)$(EXEEXT)
 
-install-docs: $(srcdir)/$(PACKAGE_NAME).1
-	@echo "Installing $(DESTDIR)${mandir}/man1/`echo $(PACKAGE_NAME) | sed '$(transform)'`.1"
+install-docs: $(srcdir)/$(MYNAME).1
+	@echo "Installing $(DESTDIR)${mandir}/man1/$(MYNAME).1"
 	${INSTALLCMD} -d $(DESTDIR)${mandir}/man1
-	${INSTALLCMD} -m 644 $(srcdir)/$(PACKAGE_NAME).1 $(DESTDIR)${mandir}/man1/`echo $(PACKAGE_NAME) | sed '$(transform)'`.1
+	${INSTALLCMD} -m 644 $(srcdir)/$(MYNAME).1 $(DESTDIR)${mandir}/man1/$(MYNAME).1
 
-uninstall: $(PACKAGE_NAME)$(EXEEXT)
-	rm -f $(DESTDIR)${bindir}/`echo $(PACKAGE_NAME) | sed '$(transform)'`$(EXEEXT)
+uninstall: $(MYNAME)$(EXEEXT)
+	rm -f $(DESTDIR)${bindir}/$(MYNAME)$(EXEEXT)
 
-uninstall-docs: $(srcdir)/$(PACKAGE_NAME).1
-	rm -f $(DESTDIR)${mandir}/man1/`echo $(PACKAGE_NAME) | sed '$(transform)'`.1
+uninstall-docs: $(srcdir)/$(MYNAME).1
+	rm -f $(DESTDIR)${mandir}/man1/$(MYNAME).1
 
 clean:
-	/bin/rm -f $(OBJS) *~ $(PACKAGE_NAME)$(EXEEXT)
+	/bin/rm -f $(OBJS) *~ $(MYNAME)$(EXEEXT)
 
 test: test.sh
-	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' $(srcdir)/test.sh
+	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='../$(MYNAME)' $(srcdir)/test.sh
 
 check: test
 
@@ -73,7 +74,7 @@ distclean: clean
 	/bin/rm -rf autom4te.cache
 
 maintainer-clean: distclean
-	/bin/rm -f $(srcdir)/$(PACKAGE_NAME).1 $(srcdir)/web/ccache-man.html
+	/bin/rm -f $(srcdir)/$(MYNAME).1 $(srcdir)/web/$(MYNAME)-man.html
 
 
 # FIXME: To fix this, test.sh needs to be able to take ccache from the

--- a/CCache/Makefile.in
+++ b/CCache/Makefile.in
@@ -8,7 +8,7 @@ bindir=@bindir@
 mandir=@mandir@
 INSTALLCMD=@INSTALL@
 PACKAGE_NAME=@PACKAGE_NAME@
-MYNAME=@MYNAME@
+PROGRAM_NAME=@PROGRAM_NAME@
 # Soft link test can be skipped on systems that don't support soft linking
 NOSOFTLINKSTEST=
 
@@ -26,55 +26,55 @@ OBJS= ccache.o mdfour.o hash.o execute.o util.o args.o stats.o \
 	cleanup.o snprintf.o unify.o
 HEADERS = ccache.h mdfour.h
 
-all: $(MYNAME)$(EXEEXT)
+all: $(PROGRAM_NAME)$(EXEEXT)
 
 # Regenerate Makefile if Makefile.in or config.status have changed.
 Makefile: $(srcdir)/Makefile.in ./config.status
 	$(SHELL) ./config.status
 
 # Note that HTML documentation is actually generated and used from the main SWIG documentation Makefile
-docs: $(srcdir)/$(MYNAME).1 $(srcdir)/web/$(MYNAME)-man.html
+docs: $(srcdir)/$(PROGRAM_NAME).1 $(srcdir)/web/$(PROGRAM_NAME)-man.html
 
-$(MYNAME)$(EXEEXT): $(OBJS) $(HEADERS)
+$(PROGRAM_NAME)$(EXEEXT): $(OBJS) $(HEADERS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
-$(srcdir)/$(MYNAME).1: $(srcdir)/ccache.yo
-	-yodl2man -o $(srcdir)/$(MYNAME).1 $(srcdir)/ccache.yo
+$(srcdir)/$(PROGRAM_NAME).1: $(srcdir)/ccache.yo
+	-yodl2man -o $(srcdir)/$(PROGRAM_NAME).1 $(srcdir)/ccache.yo
 
-$(srcdir)/web/$(MYNAME)-man.html: $(srcdir)/ccache.yo
-	yodl2html -o $(srcdir)/web/$(MYNMAE)-man.html $(srcdir)/ccache.yo
+$(srcdir)/web/$(PROGRAM_NAME)-man.html: $(srcdir)/ccache.yo
+	yodl2html -o $(srcdir)/web/$(PROGRAM_NAME)-man.html $(srcdir)/ccache.yo
 
-install: $(MYNAME)$(EXEEXT)
-	@echo "Installing $(MYNAME)"
-	@echo "Installing $(DESTDIR)${bindir}/$(MYNAME)$(EXEEXT)"
+install: $(PROGRAM_NAME)$(EXEEXT)
+	@echo "Installing $(PROGRAM_NAME)"
+	@echo "Installing $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)"
 	${INSTALLCMD} -d $(DESTDIR)${bindir}
-	${INSTALLCMD} -m 755 $(MYNAME)$(EXEEXT) $(DESTDIR)${bindir}/$(MYNAME)$(EXEEXT)
+	${INSTALLCMD} -m 755 $(PROGRAM_NAME)$(EXEEXT) $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)
 
-install-docs: $(srcdir)/$(MYNAME).1
-	@echo "Installing $(DESTDIR)${mandir}/man1/$(MYNAME).1"
+install-docs: $(srcdir)/$(PROGRAM_NAME).1
+	@echo "Installing $(DESTDIR)${mandir}/man1/$(PROGRAM_NAME).1"
 	${INSTALLCMD} -d $(DESTDIR)${mandir}/man1
-	${INSTALLCMD} -m 644 $(srcdir)/$(MYNAME).1 $(DESTDIR)${mandir}/man1/$(MYNAME).1
+	${INSTALLCMD} -m 644 $(srcdir)/$(PROGRAM_NAME).1 $(DESTDIR)${mandir}/man1/$(PROGRAM_NAME).1
 
-uninstall: $(MYNAME)$(EXEEXT)
-	rm -f $(DESTDIR)${bindir}/$(MYNAME)$(EXEEXT)
+uninstall: $(PROGRAM_NAME)$(EXEEXT)
+	rm -f $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)
 
-uninstall-docs: $(srcdir)/$(MYNAME).1
-	rm -f $(DESTDIR)${mandir}/man1/$(MYNAME).1
+uninstall-docs: $(srcdir)/$(PROGRAM_NAME).1
+	rm -f $(DESTDIR)${mandir}/man1/$(PROGRAM_NAME).1
 
 clean:
-	/bin/rm -f $(OBJS) *~ $(MYNAME)$(EXEEXT)
+	/bin/rm -f $(OBJS) *~ $(PROGRAM_NAME)$(EXEEXT)
 
 test: test.sh
-	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='../$(MYNAME)' $(srcdir)/test.sh
+	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='../$(PROGRAM_NAME)' $(srcdir)/test.sh
 
 check: test
 
 distclean: clean
-	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h config_w32.h
+	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h config_win32.h
 	/bin/rm -rf autom4te.cache
 
 maintainer-clean: distclean
-	/bin/rm -f $(srcdir)/$(MYNAME).1 $(srcdir)/web/$(MYNAME)-man.html
+	/bin/rm -f $(srcdir)/$(PROGRAM_NAME).1 $(srcdir)/web/$(PROGRAM_NAME)-man.html
 
 
 # FIXME: To fix this, test.sh needs to be able to take ccache from the

--- a/CCache/Makefile.in
+++ b/CCache/Makefile.in
@@ -70,7 +70,7 @@ test: test.sh
 check: test
 
 distclean: clean
-	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h config_win32.h
+	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h config_w32.h
 	/bin/rm -rf autom4te.cache
 
 maintainer-clean: distclean

--- a/CCache/ccache.h
+++ b/CCache/ccache.h
@@ -51,8 +51,6 @@
 #define STATUS_FATAL 4
 #define STATUS_NOCACHE 5
 
-#define MYNAME PACKAGE_NAME
-
 #define LIMIT_MULTIPLE 0.8
 
 /* default maximum cache size */

--- a/CCache/ccache.h
+++ b/CCache/ccache.h
@@ -6,7 +6,7 @@
 #include "config.h"
 #else
 #include <sys/locking.h>
-#define PACKAGE_NAME "ccache-swig.exe"
+#include "config_w32.h"
 #endif
 
 #include <stdio.h>

--- a/CCache/ccache.h
+++ b/CCache/ccache.h
@@ -6,7 +6,7 @@
 #include "config.h"
 #else
 #include <sys/locking.h>
-#include "config_w32.h"
+#include "config_win32.h"
 #endif
 
 #include <stdio.h>
@@ -50,6 +50,8 @@
 #define STATUS_NOTFOUND 3
 #define STATUS_FATAL 4
 #define STATUS_NOCACHE 5
+
+#define MYNAME PROGRAM_NAME
 
 #define LIMIT_MULTIPLE 0.8
 

--- a/CCache/config_w32.h.in
+++ b/CCache/config_w32.h.in
@@ -1,3 +1,3 @@
 #if !defined(MYNAME)
-#define MYNAME "@MYNAME@@EXEEXT@"
+#define MYNAME "@MYNAME@.exe"
 #endif

--- a/CCache/config_w32.h.in
+++ b/CCache/config_w32.h.in
@@ -1,3 +1,0 @@
-#if !defined(MYNAME)
-#define MYNAME "@MYNAME@.exe"
-#endif

--- a/CCache/config_w32.h.in
+++ b/CCache/config_w32.h.in
@@ -1,0 +1,3 @@
+#if !defined(MYNAME)
+#define MYNAME "@MYNAME@@EXEEXT@"
+#endif

--- a/CCache/config_win32.h.in
+++ b/CCache/config_win32.h.in
@@ -1,0 +1,3 @@
+#if !defined(PROGRAM_NAME)
+#define PROGRAM_NAME "@PROGRAM_NAME@.exe"
+#endif

--- a/CCache/configure.ac
+++ b/CCache/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_SRCDIR([ccache.h])
 AC_MSG_NOTICE([Configuring ccache])
 
 AC_CONFIG_HEADER(config.h)
+AC_CONFIG_FILES([config_w32.h])
 
 dnl Checks for programs.
 AC_PROG_CC

--- a/CCache/configure.ac
+++ b/CCache/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_SRCDIR([ccache.h])
 AC_MSG_NOTICE([Configuring ccache])
 
 AC_CONFIG_HEADER(config.h)
-AC_CONFIG_FILES([config_w32.h])
+AC_CONFIG_FILES([config_win32.h])
 
 dnl Checks for programs.
 AC_PROG_CC
@@ -15,19 +15,19 @@ AC_PROG_CPP
 AC_PROG_INSTALL
 AC_ARG_PROGRAM # for program_transform_name
 
-AC_SUBST(MYNAME)
+AC_SUBST(PROGRAM_NAME)
 if test "x$program_prefix" != "xNONE" -a "x$program_prefix" != "x" 
 then
-	MYNAME="$program_prefix$PACKAGE_NAME"
+	PROGRAM_NAME="$program_prefix$PACKAGE_NAME"
 else
-	MYNAME="$PACKAGE_NAME"
+	PROGRAM_NAME="$PACKAGE_NAME"
 fi
 if test "x$program_suffix" != "xNONE" -a "x$program_suffix" != "x" 
 then
-	MYNAME="$MYNAME$program_suffix"
+	PROGRAM_NAME="$PROGRAM_NAME$program_suffix"
 fi
 
-AC_DEFINE_UNQUOTED(MYNAME, "$MYNAME", [Define my program name])
+AC_DEFINE_UNQUOTED(PROGRAM_NAME, "$PROGRAM_NAME", [Define my program name])
    
 AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])

--- a/CCache/configure.ac
+++ b/CCache/configure.ac
@@ -14,6 +14,20 @@ AC_PROG_CPP
 AC_PROG_INSTALL
 AC_ARG_PROGRAM # for program_transform_name
 
+AC_SUBST(MYNAME)
+if test "x$program_prefix" != "xNONE" -a "x$program_prefix" != "x" 
+then
+	MYNAME="$program_prefix$PACKAGE_NAME"
+else
+	MYNAME="$PACKAGE_NAME"
+fi
+if test "x$program_suffix" != "xNONE" -a "x$program_suffix" != "x" 
+then
+	MYNAME="$MYNAME$program_suffix"
+fi
+
+AC_DEFINE_UNQUOTED(MYNAME, "$MYNAME", [Define my program name])
+   
 AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])
 

--- a/CCache/test.sh
+++ b/CCache/test.sh
@@ -20,7 +20,12 @@ fi
 PATH="`echo $PATH | \
  sed -e 's!:/usr\(/local\)*/lib\([0-9]\)*/ccache\(/\)*!!g'`"
 
-CCACHE=../ccache-swig
+if test -n "$CCACHE"; then
+ CCACHE="$CCACHE"
+else
+ CCACHE=../ccache-swig
+fi
+
 TESTDIR=test.$$
 
 test_failed() {


### PR DESCRIPTION
While swig configure passes program prefix/suffix to CCache configure, it have been ignored.
This is a fix to CCache/configure to take a look --program-prefix/--program-suffix options.
As the program name of "ccache" program is embeded in it by using MYNAME symbol as C string in the souce code, make utility define it and passes to compiler.