### PR TITLE
Fix OUTPUT Typemap not having return statement bug in PHP wrapper.

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,10 @@ Version 4.0.0 (in progress)
 ===========================
 
 2017-06-27: nihaln
+	    [PHP] Update the OUTPUT Typemap to add return statement to the
+	    PHP Wrapper.
+
+2017-06-27: nihaln
 	    [PHP] Update the enum and value examples to use the OO wrappers
 	    rather than the flat functions produced with -noproxy.  There's
 	    not been a good reason to use -noproxy for since PHP5 OO wrapping

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -1841,7 +1841,7 @@ public:
 	  Delete(wrapobj);
 	}
       } else {
-	if (non_void_return) {
+	if (non_void_return || hasargout) {
 	  Printf(output, "\t\treturn %s;\n", invoke);
 	} else if (Cmp(invoke, "$r") != 0) {
 	  Printf(output, "\t\t%s;\n", invoke);

--- a/Source/Modules/php5.cxx
+++ b/Source/Modules/php5.cxx
@@ -1827,7 +1827,7 @@ public:
 	  Delete(wrapobj);
 	}
       } else {
-	if (non_void_return) {
+	if (non_void_return || hasargout) {
 	  Printf(output, "\t\treturn %s;\n", invoke);
 	} else if (Cmp(invoke, "$r") != 0) {
 	  Printf(output, "\t\t%s;\n", invoke);


### PR DESCRIPTION
The PHP wrapper for OUTPUT Typemap was missing return statement