### PR TITLE
fix: memory leak, clang memset warning and undefined behavior

### DIFF
--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -434,8 +434,8 @@ namespace swig
     {
       swig::SwigVar_PyObject item = PySequence_GetItem(_seq, _index);
       try {
-	return swig::as<T>(item, true);
-      } catch (std::exception& e) {
+	return swig::as<T>(item);
+      } catch (const std::invalid_argument& e) {
 	char msg[1024];
 	sprintf(msg, "in sequence element %d ", (int)_index);
 	if (!PyErr_Occurred()) {

--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -107,14 +107,14 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, value_category> {
-    static Type as(PyObject *obj, bool throw_error) {
+    static Type as(PyObject *obj) {
       Type v;
       int res = asval(obj, &v);
       if (!obj || !SWIG_IsOK(res)) {
 	if (!PyErr_Occurred()) {
 	  ::%type_error(swig::type_name<Type>());
 	}
-	if (throw_error) throw std::invalid_argument("bad type");
+	throw std::invalid_argument("bad type");
       }
       return v;
     }
@@ -122,7 +122,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, pointer_category> {
-    static Type as(PyObject *obj, bool /* throw_error */) {
+    static Type as(PyObject *obj) {
       Type *v = 0;      
       int res = (obj ? traits_asptr<Type>::asptr(obj, &v) : SWIG_ERROR);
       if (SWIG_IsOK(res) && v) {
@@ -144,7 +144,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type*, pointer_category> {
-    static Type* as(PyObject *obj, bool throw_error) {
+    static Type* as(PyObject *obj) {
       Type *v = 0;      
       int res = (obj ? traits_asptr<Type>::asptr(obj, &v) : SWIG_ERROR);
       if (SWIG_IsOK(res)) {
@@ -153,15 +153,14 @@ namespace swig {
 	if (!PyErr_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
-	if (throw_error) throw std::invalid_argument("bad type");
-	return 0;
+	throw std::invalid_argument("bad type");
       }
     }
   };
     
   template <class Type>
-  inline Type as(PyObject *obj, bool te = false) {
-    return traits_as<Type, typename traits<Type>::category>::as(obj, te);
+  inline Type as(PyObject *obj) {
+    return traits_as<Type, typename traits<Type>::category>::as(obj);
   }
 
   template <class Type> 

--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -134,13 +134,12 @@ namespace swig {
 	  return *v;
 	}
       } else {
-	// Uninitialized return value, no Type() constructor required.
-	static Type *v_def = (Type*) calloc(1, sizeof(Type)); // memory leak?
+	static Type v_def;
 	if (!PyErr_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
 	if (throw_error) throw std::invalid_argument("bad type");
-	return *v_def;
+	return v_def;
       }
     }
   };

--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -122,7 +122,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, pointer_category> {
-    static Type as(PyObject *obj, bool throw_error) {
+    static Type as(PyObject *obj, bool /* throw_error */) {
       Type *v = 0;      
       int res = (obj ? traits_asptr<Type>::asptr(obj, &v) : SWIG_ERROR);
       if (SWIG_IsOK(res) && v) {
@@ -134,12 +134,10 @@ namespace swig {
 	  return *v;
 	}
       } else {
-	static Type v_def;
 	if (!PyErr_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
-	if (throw_error) throw std::invalid_argument("bad type");
-	return v_def;
+	throw std::invalid_argument("bad type");
       }
     }
   };

--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -135,12 +135,11 @@ namespace swig {
 	}
       } else {
 	// Uninitialized return value, no Type() constructor required.
-	static Type *v_def = (Type*) malloc(sizeof(Type));
+	static Type *v_def = (Type*) calloc(1, sizeof(Type)); // memory leak?
 	if (!PyErr_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
 	if (throw_error) throw std::invalid_argument("bad type");
-	memset(v_def,0,sizeof(Type));
 	return *v_def;
       }
     }


### PR DESCRIPTION
  The clang++ compiler warns that the memset() involved with this code points at an object with a vtable pointer that may be overwritten.   One can silence this warning with a cast.   But I think the warning is a sign of deeper problems.

1.  For starters the malloced memory is leaked.   It is not a huge leak as it happens once.   But it is leaked (unless something really strange is going on to free it).
2. The function in question returns Type v_def by **value**.  So, copy/move constructors and operators as well as the destructor for Type may also be called.   Odds are very good that not every possible class that Type can be will do anything reasonable when occupying a block of memory that is all zeros.   For example, the destructor could examine a boolean member and if it is false start doing some action.

   This patch fixes (I think) all of these problems.   The memory leak is fixed by creating a static Type object to return.   Since the objects constructor was called all the other member functions it has are safe.

  The only thing I'm unsure of is why the code in master had a comment about not needing the default constructor.   There may be some reason for this comment.   But you can't really do this memset "trick" unless Type is a POD.

Mike