### PR TITLE
as() memset() fix for ruby

### DIFF
--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -183,8 +183,8 @@ namespace swig
     {
       VALUE item = rb_ary_entry(_seq, _index );
       try {
-	return swig::as<T>(item, true);
-      } catch (std::exception& e) {
+	return swig::as<T>(item);
+      } catch (const std::invalid_argument& e) {
 	char msg[1024];
 	sprintf(msg, "in sequence element %d ", _index);
 	VALUE lastErr = rb_gv_get("$!");
@@ -926,7 +926,7 @@ namespace swig
       VALUE elem = argv[0];
       int idx = 0;
       try {
-	Sequence::value_type val = swig::as<Sequence::value_type>( elem, true );
+	Sequence::value_type val = swig::as<Sequence::value_type>( elem );
 	if ( i >= len ) {
 	  $self->resize(i-1, val);
 	  return $self;
@@ -943,7 +943,7 @@ namespace swig
 	  }
 
       } 
-      catch( std::invalid_argument )
+      catch( const std::invalid_argument & )
 	{
 	  rb_raise( rb_eArgError, "%s",
 		    Ruby_Format_TypeError( "", 
@@ -967,10 +967,10 @@ namespace swig
 	  Sequence::iterator start = $self->begin();
 	  VALUE elem = argv[idx];
 	  try {
-	    Sequence::value_type val = swig::as<Sequence::value_type>( elem, true );
+	    Sequence::value_type val = swig::as<Sequence::value_type>( elem );
 	    $self->insert( start, val );
 	  }
-	  catch( std::invalid_argument )
+	  catch( const std::invalid_argument & )
 	    {
 	      rb_raise( rb_eArgError, "%s",
 			Ruby_Format_TypeError( "", 

--- a/Lib/ruby/rubystdcommon.swg
+++ b/Lib/ruby/rubystdcommon.swg
@@ -115,15 +115,15 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, value_category> {
-    static Type as(VALUE obj, bool throw_error) {
+    static Type as(VALUE obj) {
       Type v;
       int res = asval(obj, &v);
       if (!SWIG_IsOK(res)) {
-	if (throw_error) throw std::invalid_argument("bad type");
 	VALUE lastErr = rb_gv_get("$!");
 	if (lastErr == Qnil) {
 	  %type_error(swig::type_name<Type>());
 	}
+        throw std::invalid_argument("bad type");
       }
       return v;
     }
@@ -131,7 +131,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, pointer_category> {
-    static Type as(VALUE obj, bool throw_error) {
+    static Type as(VALUE obj) {
       Type *v = 0;      
       int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res) && v) {
@@ -143,40 +143,35 @@ namespace swig {
 	  return *v;
 	}
       } else {
-	// Uninitialized return value, no Type() constructor required.
-	if (throw_error) throw std::invalid_argument("bad type");
 	VALUE lastErr = rb_gv_get("$!");
 	if (lastErr == Qnil) {
 	  %type_error(swig::type_name<Type>());
 	}
-	static Type *v_def = (Type*) malloc(sizeof(Type));
-	memset(v_def,0,sizeof(Type));
-	return *v_def;
+        throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type> 
   struct traits_as<Type*, pointer_category> {
-    static Type* as(VALUE obj, bool throw_error) {
+    static Type* as(VALUE obj) {
       Type *v = 0;      
       int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res)) {
 	return v;
       } else {
-	if (throw_error) throw std::invalid_argument("bad type");
 	VALUE lastErr = rb_gv_get("$!");
 	if (lastErr == Qnil) {
 	  %type_error(swig::type_name<Type>());
 	}
-	return 0;
+        throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type>
-  inline Type as(VALUE obj, bool te = false) {
-    return traits_as< Type, typename traits< Type >::category >::as(obj, te);
+  inline Type as(VALUE obj) {
+    return traits_as< Type, typename traits< Type >::category >::as(obj);
   }
 
   template <class Type> 

--- a/Lib/ruby/std_shared_ptr.i
+++ b/Lib/ruby/std_shared_ptr.i
@@ -80,35 +80,35 @@ namespace swig {
 
   template <class Type>
   struct traits_as<std::shared_ptr<Type>, pointer_category> {
-    static std::shared_ptr<Type> as(VALUE obj, bool throw_error) {
+    static std::shared_ptr<Type> as(VALUE obj) {
       std::shared_ptr<Type> ret;
       std::shared_ptr<Type> *v = &ret;
       int res = traits_asptr<std::shared_ptr<Type> >::asptr(obj, &v);
       if (SWIG_IsOK(res)) {
 	return ret;
       } else {
-	if (throw_error) throw std::invalid_argument("bad type");
+	
 	VALUE lastErr = rb_gv_get("$!");
 	if (lastErr == Qnil)
 	  SWIG_Error(SWIG_TypeError,  swig::type_name<std::shared_ptr<Type> >());
-	return std::shared_ptr<Type>();
+        throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type>
   struct traits_as<std::shared_ptr<Type> *, pointer_category> {
-    static std::shared_ptr<Type> * as(VALUE obj, bool throw_error) {
+    static std::shared_ptr<Type> * as(VALUE obj) {
       std::shared_ptr<Type> *p = 0;
       int res = traits_asptr<std::shared_ptr<Type> >::asptr(obj, &p);
       if (SWIG_IsOK(res)) {
 	return p;
       } else {
-	if (throw_error) throw std::invalid_argument("bad type");
+	
 	VALUE lastErr = rb_gv_get("$!");
 	if (lastErr == Qnil)
 	  SWIG_Error(SWIG_TypeError,  swig::type_name<std::shared_ptr<Type> *>());
-	return 0;
+        throw std::invalid_argument("bad type");
       }
     }
   };


### PR DESCRIPTION
Since the templates are fresh in my brain, here is a similar fix for ruby as the one for python. 

