### PR TITLE
stdcommon as() memset() removal for octave, R and scilab

### DIFF
--- a/Lib/octave/octcontainer.swg
+++ b/Lib/octave/octcontainer.swg
@@ -202,8 +202,8 @@ namespace swig
       //      swig::SwigVar_PyObject item = OctSequence_GetItem(_seq, _index);
       octave_value item; // * todo
       try {
-	return swig::as<T>(item, true);
-      } catch (std::exception& e) {
+	return swig::as<T>(item);
+      } catch (const std::exception& e) {
 	char msg[1024];
 	sprintf(msg, "in sequence element %d ", _index);
 	if (!Octave_Error_Occurred()) {

--- a/Lib/octave/octstdcommon.swg
+++ b/Lib/octave/octstdcommon.swg
@@ -103,14 +103,14 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, value_category> {
-    static Type as(const octave_value& obj, bool throw_error) {
+    static Type as(const octave_value& obj) {
       Type v;
       int res = asval(obj, &v);
       if (!obj.is_defined() || !SWIG_IsOK(res)) {
 	if (!Octave_Error_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
-	if (throw_error) throw std::invalid_argument("bad type");
+	throw std::invalid_argument("bad type");
       }
       return v;
     }
@@ -118,7 +118,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, pointer_category> {
-    static Type as(const octave_value& obj, bool throw_error) {
+    static Type as(const octave_value& obj) {
       Type *v = 0;      
       int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res) && v) {
@@ -130,21 +130,17 @@ namespace swig {
 	  return *v;
 	}
       } else {
-	// Uninitialized return value, no Type() constructor required.
-	static Type *v_def = (Type*) malloc(sizeof(Type));
 	if (!Octave_Error_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
-	if (throw_error) throw std::invalid_argument("bad type");
-	memset(v_def,0,sizeof(Type));
-	return *v_def;
+	throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type> 
   struct traits_as<Type*, pointer_category> {
-    static Type* as(const octave_value& obj, bool throw_error) {
+    static Type* as(const octave_value& obj) {
       Type *v = 0;      
       int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res)) {
@@ -153,15 +149,14 @@ namespace swig {
 	if (!Octave_Error_Occurred()) {
 	  %type_error(swig::type_name<Type>());
 	}
-	if (throw_error) throw std::invalid_argument("bad type");
-	return 0;
+	throw std::invalid_argument("bad type");
       }
     }
   };
     
   template <class Type>
-  inline Type as(const octave_value& obj, bool te = false) {
-    return traits_as<Type, typename traits<Type>::category>::as(obj, te);
+  inline Type as(const octave_value& obj) {
+    return traits_as<Type, typename traits<Type>::category>::as(obj);
   }
 
   template <class Type> 

--- a/Lib/r/rstdcommon.swg
+++ b/Lib/r/rstdcommon.swg
@@ -101,12 +101,11 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, value_category> {
-    static Type as(SWIG_Object obj, bool throw_error) {
+    static Type as(SWIG_Object obj) {
       Type v;
       int res = asval(obj, &v);
       if (!obj || !SWIG_IsOK(res)) {
-	if (throw_error)
-          throw std::invalid_argument("bad type");
+        throw std::invalid_argument("bad type");
       }
       return v;
     }
@@ -114,7 +113,7 @@ namespace swig {
 
   template <class Type> 
   struct traits_as<Type, pointer_category> {
-    static Type as(SWIG_Object obj, bool throw_error) {
+    static Type as(SWIG_Object obj) {
       Type *v = 0;      
       int res = (obj ? traits_asptr<Type>::asptr(obj, &v) : SWIG_ERROR);
       if (SWIG_IsOK(res) && v) {
@@ -126,12 +125,7 @@ namespace swig {
 	  return *v;
 	}
       } else {
-	// Uninitialized return value, no Type() constructor required.
-	static Type *v_def = (Type*) malloc(sizeof(Type));
-	if (throw_error)
           throw std::invalid_argument("bad type");
-	memset(v_def,0,sizeof(Type));
-	return *v_def;
       }
     }
   };
@@ -152,8 +146,8 @@ namespace swig {
   };
     
   template <class Type>
-  inline Type as(SWIG_Object obj, bool te = false) {
-    return traits_as<Type, typename traits<Type>::category>::as(obj, te);
+  inline Type as(SWIG_Object obj) {
+    return traits_as<Type, typename traits<Type>::category>::as(obj);
   }
 
   template <class Type> 

--- a/Lib/scilab/scistdcommon.swg
+++ b/Lib/scilab/scistdcommon.swg
@@ -104,23 +104,21 @@ namespace swig {
 
   template <class Type>
   struct traits_as<Type, value_category> {
-    static Type as(const SwigSciObject& obj, bool throw_error) {
+    static Type as(const SwigSciObject& obj) {
       Type v;
       int res = asval(obj, &v);
       if (SWIG_IsOK(res)) {
         return v;
       } else {
-	      %type_error(swig::type_name<Type>());
-	      if (throw_error)
-          throw std::invalid_argument("bad type");
-        return res;
+        %type_error(swig::type_name<Type>());
+        throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type>
   struct traits_as<Type, pointer_category> {
-    static Type as(const SwigSciObject& obj, bool throw_error) {
+    static Type as(const SwigSciObject& obj) {
       Type *v = 0;
       int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res) && v) {
@@ -132,36 +130,29 @@ namespace swig {
 	  return *v;
 	}
       } else {
-	// Uninitialized return value, no Type() constructor required.
-	static Type *v_def = (Type*) malloc(sizeof(Type));
-  %type_error(swig::type_name<Type>());
-	if (throw_error)
-    throw std::invalid_argument("bad type");
-	memset(v_def,0,sizeof(Type));
-	return *v_def;
+        %type_error(swig::type_name<Type>());
+        throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type>
   struct traits_as<Type*, pointer_category> {
-    static Type* as(const SwigSciObject& obj, bool throw_error) {
+    static Type* as(const SwigSciObject& obj) {
       Type *v = 0;
       int res = traits_asptr<Type>::asptr(obj, &v);
       if (SWIG_IsOK(res)) {
 	return v;
       } else {
-  %type_error(swig::type_name<Type>());
-	if (throw_error)
-    throw std::invalid_argument("bad type");
-	return SWIG_OK;
+        %type_error(swig::type_name<Type>());
+        throw std::invalid_argument("bad type");
       }
     }
   };
 
   template <class Type>
-  inline Type as(const SwigSciObject& obj, bool te = false) {
-    return traits_as<Type, typename traits<Type>::category>::as(obj, te);
+  inline Type as(const SwigSciObject& obj) {
+    return traits_as<Type, typename traits<Type>::category>::as(obj);
   }
 
   template <class Type>


### PR DESCRIPTION
  The octave and R test-suite passes on my machine.   The scilab c++11 tests failed before my patches and continue to fail with them.

  In the scilab case, it looks like the failing tests are related to strongly typed enums (and possibly other things).   The container related tests do seem to work.