### PR TITLE
Add directorin typemap for Python shared_ptr

### DIFF
--- a/Examples/test-suite/li_boost_shared_ptr_director.i
+++ b/Examples/test-suite/li_boost_shared_ptr_director.i
@@ -21,6 +21,9 @@ struct Base {
   virtual boost::shared_ptr<C> ret_c_shared_ptr() = 0;
   virtual C ret_c_by_value() = 0;
   virtual int take_c_by_value(C c) = 0;
+  virtual int take_c_by_ref(C& c) = 0;
+  virtual int take_c_by_pointer(C* c) = 0;
+  virtual int take_c_by_pointer_ref(C*& c) = 0;
   virtual int take_c_shared_ptr_by_value(boost::shared_ptr<C> c) = 0;
   virtual int take_c_shared_ptr_by_ref(boost::shared_ptr<C>& c) = 0;
   virtual int take_c_shared_ptr_by_pointer(boost::shared_ptr<C>* c) = 0;
@@ -47,8 +50,34 @@ int call_take_c_by_value(Base* b) {
   return b->take_c_by_value(c);
 }
 
+int call_take_c_by_ref(Base* b) {
+  C c(6);
+  return b->take_c_by_ref(c);
+}
+
+int call_take_c_by_pointer(Base* b) {
+  C c(7);
+  return b->take_c_by_pointer(&c);
+}
+
+int call_take_c_by_pointer_ref(Base* b) {
+  C c(8);
+  C* p(&c);
+  return b->take_c_by_pointer_ref(p);
+}
+
+int call_take_c_by_pointer_with_null(Base* b) {
+  C* p = NULL;
+  return b->take_c_by_pointer(p);
+}
+
+int call_take_c_by_pointer_ref_with_null(Base* b) {
+  C* p = NULL;
+  return b->take_c_by_pointer_ref(p);
+}
+
 int call_take_c_shared_ptr_by_value(Base* b) {
-  boost::shared_ptr<C> ptr(new C(6));
+  boost::shared_ptr<C> ptr(new C(9));
   return b->take_c_shared_ptr_by_value(ptr);
 }
 
@@ -58,7 +87,7 @@ int call_take_c_shared_ptr_by_value_with_null(Base* b) {
 }
 
 int call_take_c_shared_ptr_by_ref(Base* b) {
-  boost::shared_ptr<C> ptr(new C(7));
+  boost::shared_ptr<C> ptr(new C(10));
   return b->take_c_shared_ptr_by_ref(ptr);
 }
 
@@ -68,7 +97,7 @@ int call_take_c_shared_ptr_by_ref_with_null(Base* b) {
 }
 
 int call_take_c_shared_ptr_by_pointer(Base* b) {
-  boost::shared_ptr<C> ptr(new C(8));
+  boost::shared_ptr<C> ptr(new C(11));
   return b->take_c_shared_ptr_by_pointer(&ptr);
 }
 
@@ -78,7 +107,7 @@ int call_take_c_shared_ptr_by_pointer_with_null(Base* b) {
 }
 
 int call_take_c_shared_ptr_by_pointer_ref(Base* b) {
-  boost::shared_ptr<C> *ptr = new boost::shared_ptr<C>(new C(9));
+  boost::shared_ptr<C> *ptr = new boost::shared_ptr<C>(new C(12));
   return b->take_c_shared_ptr_by_pointer_ref(ptr);
 }
 

--- a/Examples/test-suite/python/li_boost_shared_ptr_director_runme.py
+++ b/Examples/test-suite/python/li_boost_shared_ptr_director_runme.py
@@ -1,0 +1,80 @@
+from li_boost_shared_ptr_director import *
+
+class Derived(Base):
+    def __init__(self, flag):
+        self.return_none = flag
+        Base.__init__(self)
+
+    def ret_c_shared_ptr(self):
+        if self.return_none:
+            return None
+        else:
+            return C()
+
+    def ret_c_by_value(self):
+        return C()
+
+    def take_c_by_value(self,c):
+        return c.get_m()
+
+    def take_c_by_ref(self,c):
+        return c.get_m()
+
+    def take_c_by_pointer(self,c):
+        if c:
+            return c.get_m()
+        else:
+            return -2
+
+    def take_c_by_pointer_ref(self,c):
+        if c:
+            return c.get_m()
+        else:
+            return -3
+
+    def take_c_shared_ptr_by_value(self,c):
+        if c:
+            return c.get_m()
+        else:
+            return -4
+
+    def take_c_shared_ptr_by_ref(self,c):
+        if c:
+            return c.get_m()
+        else:
+            return -5
+
+    def take_c_shared_ptr_by_pointer(self,c):
+        if c:
+            return c.get_m()
+        else:
+            return -6
+
+    def take_c_shared_ptr_by_pointer_ref(self,c):
+        if c:
+            return c.get_m()
+        else:
+            return -7
+
+a = Derived(False)
+b = Derived(True)
+
+assert call_ret_c_shared_ptr(a) ==  1
+assert call_ret_c_shared_ptr(b) == -1
+assert call_ret_c_by_value(a)   ==  1
+
+assert call_take_c_by_value(a)                  == 5
+assert call_take_c_by_ref(a)                    == 6
+assert call_take_c_by_pointer(a)                == 7
+assert call_take_c_by_pointer_ref(a)            == 8
+assert call_take_c_shared_ptr_by_value(a)       == 9
+assert call_take_c_shared_ptr_by_ref(a)         == 10
+assert call_take_c_shared_ptr_by_pointer(a)     == 11
+assert call_take_c_shared_ptr_by_pointer_ref(a) == 12
+
+assert call_take_c_by_pointer_with_null(a)                == -2
+assert call_take_c_by_pointer_ref_with_null(a)            == -3
+assert call_take_c_shared_ptr_by_value_with_null(a)       == -4
+assert call_take_c_shared_ptr_by_ref_with_null(a)         == -5
+assert call_take_c_shared_ptr_by_pointer_with_null(a)     == -6
+assert call_take_c_shared_ptr_by_pointer_ref_with_null(a) == -7

--- a/Examples/test-suite/ruby/li_boost_shared_ptr_director_runme.rb
+++ b/Examples/test-suite/ruby/li_boost_shared_ptr_director_runme.rb
@@ -25,7 +25,11 @@ class Derived < Base
     c.get_m
   end
 
-  def take_c_shared_ptr_by_value(c)
+  def take_c_by_ref(c)
+    c.get_m
+  end
+
+  def take_c_by_pointer(c)
     if c
       c.get_m
     else
@@ -33,7 +37,7 @@ class Derived < Base
     end
   end
 
-  def take_c_shared_ptr_by_ref(c)
+  def take_c_by_pointer_ref(c)
     if c
       c.get_m
     else
@@ -41,7 +45,7 @@ class Derived < Base
     end
   end
 
-  def take_c_shared_ptr_by_pointer(c)
+  def take_c_shared_ptr_by_value(c)
     if c
       c.get_m
     else
@@ -49,11 +53,27 @@ class Derived < Base
     end
   end
 
-  def take_c_shared_ptr_by_pointer_ref(c)
+  def take_c_shared_ptr_by_ref(c)
     if c
       c.get_m
     else
       -5
+    end
+  end
+
+  def take_c_shared_ptr_by_pointer(c)
+    if c
+      c.get_m
+    else
+      -6
+    end
+  end
+
+  def take_c_shared_ptr_by_pointer_ref(c)
+    if c
+      c.get_m
+    else
+      -7
     end
   end
 
@@ -67,13 +87,17 @@ raise unless call_ret_c_shared_ptr(b) == -1
 raise unless call_ret_c_by_value(a)   ==  1
 
 raise unless call_take_c_by_value(a)                  == 5
-raise unless call_take_c_shared_ptr_by_value(a)       == 6
-raise unless call_take_c_shared_ptr_by_ref(a)         == 7
-raise unless call_take_c_shared_ptr_by_pointer(a)     == 8
-raise unless call_take_c_shared_ptr_by_pointer_ref(a) == 9
+raise unless call_take_c_by_ref(a)                    == 6
+raise unless call_take_c_by_pointer(a)                == 7
+raise unless call_take_c_by_pointer_ref(a)            == 8
+raise unless call_take_c_shared_ptr_by_value(a)       == 9
+raise unless call_take_c_shared_ptr_by_ref(a)         == 10
+raise unless call_take_c_shared_ptr_by_pointer(a)     == 11
+raise unless call_take_c_shared_ptr_by_pointer_ref(a) == 12
 
-raise unless call_take_c_shared_ptr_by_value_with_null(a)       == -2
-raise unless call_take_c_shared_ptr_by_ref_with_null(a)         == -3
-raise unless call_take_c_shared_ptr_by_pointer_with_null(a)     == -4
-raise unless call_take_c_shared_ptr_by_pointer_ref_with_null(a) == -5
-
+raise unless call_take_c_by_pointer_with_null(a)                == -2
+raise unless call_take_c_by_pointer_ref_with_null(a)            == -3
+raise unless call_take_c_shared_ptr_by_value_with_null(a)       == -4
+raise unless call_take_c_shared_ptr_by_ref_with_null(a)         == -5
+raise unless call_take_c_shared_ptr_by_pointer_with_null(a)     == -6
+raise unless call_take_c_shared_ptr_by_pointer_ref_with_null(a) == -7

--- a/Lib/python/boost_shared_ptr.i
+++ b/Lib/python/boost_shared_ptr.i
@@ -62,6 +62,24 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1) CONST TYPE {
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(new $1_ltype(($1_ltype &)$1));
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+}
+%typemap(directorout,noblock=1) CONST TYPE (void *argp, int res = 0) {
+  int newmem = 0;
+  res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
+  if (!SWIG_IsOK(res)) {
+    %dirout_fail(res, "$type");
+  }
+  if (!argp) {
+    %dirout_nullref("$type");
+  } else {
+    $result = *(%reinterpret_cast(argp, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *)->get());
+    if (newmem & SWIG_CAST_NEW_MEMORY) delete %reinterpret_cast(argp, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *);
+  }
+}
+
 // plain pointer
 // Note: $disown not implemented by default as it will lead to a memory leak of the shared_ptr instance
 %typemap(in) CONST TYPE * (void  *argp = 0, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartarg = 0) {
@@ -108,6 +126,14 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1, fragment="SWIG_null_deleter_python") CONST TYPE * %{
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_0) : 0;
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+%}
+%typemap(directorout,noblock=1) CONST TYPE * %{
+#error "directorout typemap for plain pointer not implemented"
+%}
+
 // plain reference
 %typemap(in) CONST TYPE & (void  *argp = 0, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared) {
   int newmem = 0;
@@ -153,6 +179,14 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1, fragment="SWIG_null_deleter_python") CONST TYPE & %{
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(&$1 SWIG_NO_NULL_DELETER_0);
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+%}
+%typemap(directorout,noblock=1) CONST TYPE & %{
+#error "directorout typemap for plain reference not implemented"
+%}
+
 // plain pointer by reference
 // Note: $disown not implemented by default as it will lead to a memory leak of the shared_ptr instance
 %typemap(in) TYPE *CONST& (void  *argp = 0, int res = 0, $*1_ltype temp = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared) {
@@ -171,7 +205,7 @@
   $1 = &temp;
 }
 %typemap(out, fragment="SWIG_null_deleter_python") TYPE *CONST& {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1 SWIG_NO_NULL_DELETER_$owner);
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = *$1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1 SWIG_NO_NULL_DELETER_$owner) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
@@ -180,6 +214,14 @@
 %}
 %typemap(varout) TYPE *CONST& %{
 #error "varout typemap not implemented"
+%}
+
+%typemap(directorin,noblock=1, fragment="SWIG_null_deleter_python") TYPE *CONST& %{
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_0) : 0;
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+%}
+%typemap(directorout,noblock=1) TYPE *CONST& %{
+#error "directorout typemap for plain pointer by reference not implemented"
 %}
 
 // shared_ptr by value
@@ -212,6 +254,26 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > {
+  if ($1) {
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+  } else {
+    $input = SWIG_Py_Void();
+  }
+}
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > (void * swig_argp, int swig_res = 0) {
+  if ($input==Py_None) {
+    $result = $ltype();
+  } else {
+    swig_res = SWIG_ConvertPtr($input, &swig_argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *), %convertptr_flags);
+    if (!SWIG_IsOK(swig_res)) {
+      %dirout_fail(swig_res,"$type");
+    }
+    $result = *(%reinterpret_cast(swig_argp, $&ltype));
+  }
+}
+
 // shared_ptr by reference
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & (void *argp, int res = 0, $*1_ltype tempshared) {
   int newmem = 0;
@@ -239,6 +301,17 @@
 #error "varout typemap not implemented"
 %}
 
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & {
+  if ($1) {
+    $input = SWIG_NewPointerObj(%as_voidptr(&$1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+  } else {
+    $input = SWIG_Py_Void();
+  }
+}
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & %{
+#error "directorout typemap for shared_ptr ref not implemented"
+%}
+
 // shared_ptr by pointer
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * (void *argp, int res = 0, $*1_ltype tempshared) {
   int newmem = 0;
@@ -255,7 +328,7 @@
   }
 }
 %typemap(out) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 && *$1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1) : 0;
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = ($1 && *$1) ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
   if ($owner) delete $1;
 }
@@ -265,6 +338,17 @@
 %}
 %typemap(varout) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * %{
 #error "varout typemap not implemented"
+%}
+
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
+  if ($1 && *$1) {
+    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+  } else {
+    $input = SWIG_Py_Void();
+  }
+}
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& %{
+#error "directorout typemap for pointer to shared_ptr not implemented"
 %}
 
 // shared_ptr by pointer reference
@@ -280,7 +364,7 @@
   $1 = &temp;
 }
 %typemap(out) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = *$1 && **$1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(**$1) : 0;
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = (*$1 && **$1) ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(**$1) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
@@ -289,6 +373,17 @@
 %}
 %typemap(varout) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& %{
 #error "varout typemap not implemented"
+%}
+
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *&, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
+  if ($1 && *$1) {
+    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+  } else {
+    $input = SWIG_Py_Void();
+  }
+}
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *&, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& %{
+#error "directorout typemap for pointer ref to shared_ptr not implemented"
 %}
 
 // Typecheck typemaps

--- a/Lib/python/boost_shared_ptr.i
+++ b/Lib/python/boost_shared_ptr.i
@@ -303,7 +303,8 @@
 
 %typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & {
   if ($1) {
-    $input = SWIG_NewPointerObj(%as_voidptr(&$1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
   } else {
     $input = SWIG_Py_Void();
   }
@@ -342,7 +343,8 @@
 
 %typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
   if ($1 && *$1) {
-    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
   } else {
     $input = SWIG_Py_Void();
   }
@@ -377,7 +379,8 @@
 
 %typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *&, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
   if ($1 && *$1) {
-    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
   } else {
     $input = SWIG_Py_Void();
   }

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -299,7 +299,8 @@
 
 %typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & {
   if ($1) {
-    $input = SWIG_NewPointerObj(%as_voidptr(&$1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
   } else {
     $input = Qnil;
   }
@@ -338,7 +339,8 @@
 
 %typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
   if ($1 && *$1) {
-    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
   } else {
     $input = Qnil;
   }
@@ -373,7 +375,8 @@
 
 %typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *&, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
   if ($1 && *$1) {
-    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+    SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1);
+    $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
   } else {
     $input = Qnil;
   }

--- a/Lib/ruby/boost_shared_ptr.i
+++ b/Lib/ruby/boost_shared_ptr.i
@@ -58,6 +58,10 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
+%typemap(directorin,noblock=1) CONST TYPE {
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(new $1_ltype(($1_ltype &)$1));
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
+}
 %typemap(directorout,noblock=1) CONST TYPE (void *argp, int res = 0) {
   swig_ruby_owntype newmem = {0, 0};
   res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %convertptr_flags, &newmem);
@@ -70,10 +74,6 @@
     $result = *(%reinterpret_cast(argp, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *)->get());
     if (newmem.own & SWIG_CAST_NEW_MEMORY) delete %reinterpret_cast(argp, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *);
   }
-}
-%typemap(directorin,noblock=1) CONST TYPE {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(new $1_ltype(($1_ltype &)$1));
-  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
 }
 
 // plain pointer
@@ -122,8 +122,9 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
-%typemap(directorin,noblock=1) CONST TYPE * %{
-#error "directorin typemap for plain pointer not implemented"
+%typemap(directorin,noblock=1, fragment="SWIG_null_deleter") CONST TYPE * %{
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_0) : 0;
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
 %}
 %typemap(directorout,noblock=1) CONST TYPE * %{
 #error "directorout typemap for plain pointer not implemented"
@@ -174,8 +175,9 @@
   %set_varoutput(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
-%typemap(directorin,noblock=1) CONST TYPE & %{
-#error "directorin typemap for plain reference not implemented"
+%typemap(directorin,noblock=1, fragment="SWIG_null_deleter") CONST TYPE & %{
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(&$1 SWIG_NO_NULL_DELETER_0);
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
 %}
 %typemap(directorout,noblock=1) CONST TYPE & %{
 #error "directorout typemap for plain reference not implemented"
@@ -199,7 +201,7 @@
   $1 = &temp;
 }
 %typemap(out, fragment="SWIG_null_deleter") TYPE *CONST& {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1 SWIG_NO_NULL_DELETER_$owner);
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = *$1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1 SWIG_NO_NULL_DELETER_$owner) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
@@ -210,8 +212,9 @@
 #error "varout typemap not implemented"
 %}
 
-%typemap(directorin,noblock=1) TYPE *CONST& %{
-#error "directorin typemap for plain pointer by reference not implemented"
+%typemap(directorin,noblock=1, fragment="SWIG_null_deleter") TYPE *CONST& %{
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_0) : 0;
+  $input = SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN | %newpointer_flags);
 %}
 %typemap(directorout,noblock=1) TYPE *CONST& %{
 #error "directorout typemap for plain pointer by reference not implemented"
@@ -301,6 +304,9 @@
     $input = Qnil;
   }
 }
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > & %{
+#error "directorout typemap for shared_ptr ref not implemented"
+%}
 
 // shared_ptr by pointer
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * (void *argp, int res = 0, $*1_ltype tempshared) {
@@ -318,7 +324,7 @@
   }
 }
 %typemap(out) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > * {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = $1 && *$1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1) : 0;
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = ($1 && *$1) ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(*$1) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
   if ($owner) delete $1;
 }
@@ -337,6 +343,9 @@
     $input = Qnil;
   }
 }
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& %{
+#error "directorout typemap for pointer to shared_ptr not implemented"
+%}
 
 // shared_ptr by pointer reference
 %typemap(in) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& (void *argp, int res = 0, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > tempshared, $*1_ltype temp = 0) {
@@ -351,7 +360,7 @@
   $1 = &temp;
 }
 %typemap(out) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& {
-  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = *$1 && **$1 ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(**$1) : 0;
+  SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartresult = (*$1 && **$1) ? new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >(**$1) : 0;
   %set_output(SWIG_NewPointerObj(%as_voidptr(smartresult), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), SWIG_POINTER_OWN));
 }
 
@@ -360,6 +369,17 @@
 %}
 %typemap(varout) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *& %{
 #error "varout typemap not implemented"
+%}
+
+%typemap(directorin,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *&, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& {
+  if ($1 && *$1) {
+    $input = SWIG_NewPointerObj(%as_voidptr($1), $descriptor(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< TYPE > *), %newpointer_flags);
+  } else {
+    $input = Qnil;
+  }
+}
+%typemap(directorout,noblock=1) SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *&, SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *const& %{
+#error "directorout typemap for pointer ref to shared_ptr not implemented"
 %}
 
 // Typecheck typemaps


### PR DESCRIPTION
Fixed #1029 for me, comments welcome.  Not sure if it's appropriate to put directorin typemaps in this file, nor am I sure how to do the equivalent directorout or if it is necessary, so I would consider it a separate issue.