### PR TITLE
fix bug: raise NameError when compiled with cython

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -850,7 +850,7 @@ public:
       Printf(default_import_code, tab8 "mname = '.'.join((pkg, '%s')).lstrip('.')\n", module);
       Printv(default_import_code, tab8, "try:\n", NULL);
       Printv(default_import_code, tab8, tab4, "return importlib.import_module(mname)\n", NULL);
-      Printv(default_import_code, tab8, "except:\n", NULL);
+      Printv(default_import_code, tab8, "except (ImportError, NameError):\n", NULL);
       Printf(default_import_code, tab8 tab4 "return importlib.import_module('%s')\n", module);
       Printf(default_import_code, tab4 "%s = swig_import_helper()\n", module);
       Printv(default_import_code, tab4, "del swig_import_helper\n", NULL);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -850,7 +850,7 @@ public:
       Printf(default_import_code, tab8 "mname = '.'.join((pkg, '%s')).lstrip('.')\n", module);
       Printv(default_import_code, tab8, "try:\n", NULL);
       Printv(default_import_code, tab8, tab4, "return importlib.import_module(mname)\n", NULL);
-      Printv(default_import_code, tab8, "except ImportError:\n", NULL);
+      Printv(default_import_code, tab8, "except:\n", NULL);
       Printf(default_import_code, tab8 tab4 "return importlib.import_module('%s')\n", module);
       Printf(default_import_code, tab4 "%s = swig_import_helper()\n", module);
       Printv(default_import_code, tab4, "del swig_import_helper\n", NULL);


### PR DESCRIPTION
After compile the python wrapper with Cython, it will throw and exception when running.

    NameError: name '__file__' is not defined

which was raise by this piece of code:
    
    def swig_import_helper():
         from os.path import dirname
         import imp
         fp = None
         try:
             fp, pathname, description = imp.find_module(
                 '_grnn_qt', [dirname(__file__)])
         except ImportError:
             import _grnn_qt
             return _grnn_qt
         if fp is not None:
             try:
                 _mod = imp.load_module('_grnn_qt', fp, pathname, description)
             finally:
                 fp.close()
             return _mod


After doing some [search](https://stackoverflow.com/questions/16771894/python-nameerror-global-name-file-is-not-defined), I found it is because `__file__` does not exist after being complied.

This piece of code will not catch `NameError` when `__file__` is not defined. **I change it to catch every exceptions**. So it will import from the same directory.