### PR TITLE
Safer default for cresult_variable_name

### DIFF
--- a/Examples/python/libffi/example.i
+++ b/Examples/python/libffi/example.i
@@ -56,7 +56,7 @@
   }
   if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, vc+3,
                    &ffi_type_uint, types) == FFI_OK) {
-    ffi_call(&cif, (void (*)()) execlp, &result, values);
+    ffi_call(&cif, (void (*)()) execlp, &_swig_result, values);
   } else {
     free(types);
     free(values);
@@ -155,7 +155,7 @@ int execlp(const char *path, const char *arg1, ...);
   }
   if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, vc+1,
                    &ffi_type_uint, types) == FFI_OK) {
-    ffi_call(&cif, (void (*)()) printf, &result, values);
+    ffi_call(&cif, (void (*)()) printf, &_swig_result, values);
   } else {
     free(types);
     free(values);

--- a/Examples/test-suite/errors/swig_typemap_warn.stderr
+++ b/Examples/test-suite/errors/swig_typemap_warn.stderr
@@ -1,6 +1,6 @@
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int abc (arg1) - argnum: 1 &1_ltype: int * descriptor: SWIGTYPE_int
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int arg3 (arg3) - argnum: 3 &1_ltype: int * descriptor: SWIGTYPE_int
-swig_typemap_warn.i:7: Warning 1001: Test warning for 'out' typemap for double mmm (result) - name: mmm symname: mmm &1_ltype: double * descriptor: SWIGTYPE_double
+swig_typemap_warn.i:7: Warning 1001: Test warning for 'out' typemap for double mmm (_swig_result) - name: mmm symname: mmm &1_ltype: double * descriptor: SWIGTYPE_double
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int abc (arg1) - argnum: 1 &1_ltype: int * descriptor: SWIGTYPE_int
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int arg3 (arg3) - argnum: 3 &1_ltype: int * descriptor: SWIGTYPE_int
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int abc (arg1) - argnum: 1 &1_ltype: int * descriptor: SWIGTYPE_int

--- a/Examples/test-suite/java/special_variables_runme.java
+++ b/Examples/test-suite/java/special_variables_runme.java
@@ -15,13 +15,13 @@ public class special_variables_runme {
   public static void main(String argv[]) 
   {
     verify(special_variables.ExceptionVars(1.0, 2.0),
-           "result = Space::exceptionvars(arg1,arg2);  Space::exceptionvars  ExceptionVars   Java_special_1variables_special_1variablesJNI_ExceptionVars  ");
+           "_swig_result = Space::exceptionvars(arg1,arg2);  Space::exceptionvars  ExceptionVars   Java_special_1variables_special_1variablesJNI_ExceptionVars  ");
 
     verify(special_variables.overloadedmethod(),
-           "result = Space::overloadedmethod();  Space::overloadedmethod  overloadedmethod  __SWIG_1 Java_special_1variables_special_1variablesJNI_overloadedmethod_1_1SWIG_11  ");
+           "_swig_result = Space::overloadedmethod();  Space::overloadedmethod  overloadedmethod  __SWIG_1 Java_special_1variables_special_1variablesJNI_overloadedmethod_1_1SWIG_11  ");
 
     verify(special_variables.overloadedmethod(10.0),
-          "result = Space::overloadedmethod(arg1);  Space::overloadedmethod  overloadedmethod  __SWIG_0 Java_special_1variables_special_1variablesJNI_overloadedmethod_1_1SWIG_10  ");
+          "_swig_result = Space::overloadedmethod(arg1);  Space::overloadedmethod  overloadedmethod  __SWIG_0 Java_special_1variables_special_1variablesJNI_overloadedmethod_1_1SWIG_10  ");
 
     ABC a = new ABC(0, 0.0);
     verify(special_variables.getDeclaration(), "SpaceNamespace::ABC::ABC(int,double) SpaceNamespace::ABC::ABC(int,double)");

--- a/Examples/test-suite/python_varargs_typemap.i
+++ b/Examples/test-suite/python_varargs_typemap.i
@@ -39,7 +39,7 @@
 
 %feature("action") testfunc {
   char **vargs = (char **) arg3;
-  result = testfunc(arg1, arg2, vargs[0], vargs[1], vargs[2], vargs[3], vargs[4],
+  _swig_result = testfunc(arg1, arg2, vargs[0], vargs[1], vargs[2], vargs[3], vargs[4],
                     vargs[5], vargs[6], vargs[7], vargs[8], vargs[9], NULL);
 }
 

--- a/Examples/test-suite/rename.h
+++ b/Examples/test-suite/rename.h
@@ -35,7 +35,7 @@ namespace Space {
 %exception Space::ABC::operator ABC %{
 #if defined(__clang__)
   // Workaround for: warning: conversion function converting 'Space::ABC' to itself will never be used
-  result = *arg1;
+  _swig_result = *arg1;
 #else
   $action
 #endif

--- a/Examples/test-suite/rename4.i
+++ b/Examples/test-suite/rename4.i
@@ -81,7 +81,7 @@ namespace Space {
 %exception Space::ABC::operator ABC %{
 #if defined(__clang__)
   // Workaround for: warning: conversion function converting 'Space::ABC' to itself will never be used
-  result = *arg1;
+  _swig_result = *arg1;
 #else
   $action
 #endif

--- a/Examples/test-suite/special_variables.i
+++ b/Examples/test-suite/special_variables.i
@@ -29,10 +29,10 @@ std::string ExceptionVars(double i, double j) {
 %rename(ExceptionVars) Space::exceptionvars;
 %exception Space::exceptionvars %{
   $action
-  result = $symname(1.0,2.0); // Should expand to ExceptionVars
-  result = $name(3.0,4.0); // Should expand to Space::exceptionvars
+  _swig_result = $symname(1.0,2.0); // Should expand to ExceptionVars
+  _swig_result = $name(3.0,4.0); // Should expand to Space::exceptionvars
   // above will not compile if the variables are not expanded properly
-  result = "$action  $name  $symname  $overname $wrapname $parentclassname $parentclasssymname";
+  _swig_result = "$action  $name  $symname  $overname $wrapname $parentclassname $parentclasssymname";
 %}
 %inline %{
 namespace Space {
@@ -45,11 +45,11 @@ std::string exceptionvars(double i, double j) {
 
 %exception Space::overloadedmethod %{
   $action
-  result = Space::$symname(1.0);
-  result = $name();
-  result = $name(2.0);
+  _swig_result = Space::$symname(1.0);
+  _swig_result = $name();
+  _swig_result = $name(2.0);
   // above will not compile if the variables are not expanded properly
-  result = "$action  $name  $symname  $overname $wrapname $parentclassname $parentclasssymname";
+  _swig_result = "$action  $name  $symname  $overname $wrapname $parentclassname $parentclasssymname";
   // $decl
 %}
 

--- a/Examples/test-suite/typemap_various.i
+++ b/Examples/test-suite/typemap_various.i
@@ -55,7 +55,7 @@ void CheckRetTypemapUsed() {
 
 %newobject FFoo::Bar(bool) const ;
 %typemap(newfree) char* Bar(bool)  {
-   /* hello */ delete[] result;
+   /* hello */ delete[] _swig_result;
 }
 
 %inline {

--- a/Lib/javascript/jsc/javascriptcode.swg
+++ b/Lib/javascript/jsc/javascriptcode.swg
@@ -14,7 +14,7 @@ static JSObjectRef $jswrapper(JSContextRef context, JSObjectRef thisObject, size
     if(argc != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
 
     $jscode
-    return SWIG_JSC_NewPointerObj(context, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
+    return SWIG_JSC_NewPointerObj(context, _swig_result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
     goto fail;
     fail:
     return NULL;
@@ -75,7 +75,7 @@ static JSObjectRef $jswrapper(JSContextRef context, JSObjectRef thisObject, size
 {
     $jslocals
     $jscode
-    return SWIG_JSC_NewPointerObj(context, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
+    return SWIG_JSC_NewPointerObj(context, _swig_result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
 
     goto fail;
     fail:

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -16,7 +16,7 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
   $jscode
 
-  SWIGV8_SetPrivateData(self, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
+  SWIGV8_SetPrivateData(self, _swig_result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
   SWIGV8_RETURN(self);
 
   goto fail;
@@ -83,7 +83,7 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args, V8ErrorHandler 
   if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
   $jscode
 
-  SWIGV8_SetPrivateData(self, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
+  SWIGV8_SetPrivateData(self, _swig_result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
   SWIGV8_RETURN(self);
 
   goto fail;

--- a/Source/Modules/emit.cxx
+++ b/Source/Modules/emit.cxx
@@ -17,7 +17,7 @@
  * emit_return_variable()
  *
  * Emits a variable declaration for a function return value.
- * The variable name is always called result.
+ * The variable name is always defined by Swig_cresult_name().
  * n => Node of the method being wrapped
  * rt => the return type
  * f => the wrapper to generate code into

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -614,7 +614,7 @@ extern "C" Language *swig_javascript(void) {
  * ----------------------------------------------------------------------------- */
 
 JSEmitter::JSEmitter(JSEmitter::JSEngine engine)
-:  engine(engine), templates(NewHash()), namespaces(NULL), current_namespace(NULL), defaultResultName(NewString("result")), f_wrappers(NULL) {
+:  engine(engine), templates(NewHash()), namespaces(NULL), current_namespace(NULL), defaultResultName(NewString(Swig_cresult_name())), f_wrappers(NULL) {
 }
 
 /* -----------------------------------------------------------------------------
@@ -862,7 +862,7 @@ int JSEmitter::emitCtor(Node *n) {
   Delete(wrapper->code);
   wrapper->code = NewString("");
 
-  Printf(wrapper->locals, "%sresult;", SwigType_str(Getattr(n, "type"), 0));
+  Printf(wrapper->locals, "%s%s;", SwigType_str(Getattr(n, "type"), 0), Swig_cresult_name());
 
   marshalInputArgs(n, params, wrapper, Ctor, true, false);
   String *action = emit_action(n);
@@ -1292,7 +1292,7 @@ void JSEmitter::marshalOutput(Node *n, ParmList *params, Wrapper *wrapper, Strin
   // adds a declaration for the result variable
   if (emitReturnVariable)
     emit_return_variable(n, type, wrapper);
-  // if not given, use default result identifier ('result') for output typemap
+  // if not given, use default result identifier for output typemap
   if (cresult == 0)
     cresult = defaultResultName;
 

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -1494,7 +1494,7 @@ public:
 	SwigType_add_pointer(type);
 	String *action = NewString("");
 	Printv(action, "{\n", "  Swig::Director *director = SWIG_DIRECTOR_CAST(arg1);\n",
-	       "  result = sv_newmortal();\n" "  if (director) sv_setsv(result, director->swig_get_self());\n", "}\n", NIL);
+	       "  _swig_result = sv_newmortal();\n" "  if (director) sv_setsv(_swig_result, director->swig_get_self());\n", "}\n", NIL);
 	Setfile(get_attr, Getfile(n));
 	Setline(get_attr, Getline(n));
 	Setattr(get_attr, "wrap:action", action);

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -15,7 +15,7 @@
 #include "swig.h"
 #include "cparse.h"
 
-static const char *cresult_variable_name = "result";
+static const char *cresult_variable_name = "_swig_result";
 
 static Parm *nonvoid_parms(Parm *p) {
   if (p) {


### PR DESCRIPTION
If a wrapped method has a parameter called `result`, compilation of the resulting C++ unit will fail.

A safer default name for `cresult_variable_name` is `"_swig_result"` as it makes a collision with a parameter name much less likely.

A full fix would be a unique and deterministically chosen name. In the meantime, this workaround is simple and I believe it's strictly better than the current value.

It's also spiritually equivalent to the workaround described here: https://github.com/swig/swig/issues/644