### PR TITLE
Avoid possible GC issues in Java example code

### DIFF
--- a/Doc/Manual/Java.html
+++ b/Doc/Manual/Java.html
@@ -8165,13 +8165,10 @@ public class Container {
   // Ensure that the GC doesn't collect any Element set from Java
   // as the underlying C++ class stores a shallow copy
   private Element elementReference;
-  private long getCPtrAndAddReference(Element element) {
-    elementReference = element;
-    return Element.getCPtr(element);
-  }
 
   public void setElement(Element e) {
-    exampleJNI.Container_setElement(swigCPtr, this, getCPtrAndAddReference(e), e);
+    exampleJNI.Container_setElement(swigCPtr, this, Element.getCPtr(e), e);
+    elementReference = e;
   }
 }
 </pre>
@@ -8179,22 +8176,20 @@ public class Container {
 
 <p>
 The following typemaps will generate the desired code.
-The 'javain' typemap matches the input parameter type for the <tt>setElement</tt> method.
+The 'javain' typemap matches the input parameter type for the <tt>setElement</tt> method and allows adding code after the call. 
 The 'javacode' typemap simply adds in the specified code into the Java proxy class.
 </p>
 
 <div class="code">
 <pre>
-%typemap(javain) Element *e "getCPtrAndAddReference($javainput)"
+%typemap(javain, 
+         post="elementReference = $javainput;\n"
+         ) Element *e "Element.getCPtr($javainput)"
 
 %typemap(javacode) Container %{
   // Ensure that the GC doesn't collect any element set from Java
   // as the underlying C++ class stores a shallow copy
   private Element elementReference;
-  private long getCPtrAndAddReference(Element element) {
-    elementReference = element;
-    return Element.getCPtr(element);
-  }
 %}
 </pre>
 </div>


### PR DESCRIPTION
I think the approach suggested [in this section](https://github.com/swig/swig/blob/dd3d04a2f2f2a05d5fc3bedac0a177e7caf6d1bd/Doc/Manual/Java.html#L8087) to avoid a dangling pointer when C++ holds a reference passed from Java could cause trouble given innocent-looking modifications to the C++ code.

The solution suggested in the current docs is to maintain a reference on the Java side to the `element` which the C++ code is holding onto, which prevents the JVM GC from collecting it. This is the suggested code from the link above:

```
  // Ensure that the GC doesn't collect any Element set from Java
  // as the underlying C++ class stores a shallow copy
  private Element elementReference;
  private long getCPtrAndAddReference(Element element) {
    elementReference = element;
    return Element.getCPtr(element);
  }

  public void setElement(Element e) {
    exampleJNI.Container_setElement(swigCPtr, this, getCPtrAndAddReference(e), e);
  }
```

This works fine the first time someone calls `setElement`. When someone calls it a second time, though, the previous value of `elementReference` is overwritten in `getCPtrAndAddReference` before the C++ code has a chance to drop its reference to it. If a GC happens after `elementReference` is overwritten but before the C++ body of `setElement` completes, there would be a dangling pointer in the C++ code to the old element value.

In the example C++ code, this is fine (it just overwrites the old element value) but innocent-looking modifications (e.g. logging the old and new values in C++) could lead to misbehavior. It seems like the Java-side code should be modified to hold on to both old and new references until the call to `setElement` is complete. I think the easiest way is to assign `elementReference` *after* the `setElement` call is complete. 

If this seems like a valuable change, I'd be happy to make this to the C# example code as well, which has the same pattern. I'd also love to hear if folks have better suggestions than doing this with the `post` argument to `javain`, which seems a little weird.