### PR TITLE
Define _DEBUG to 1 to do exactly like /LDd, /MDd or /MTd compiler options

### DIFF
--- a/Lib/python/pyruntime.swg
+++ b/Lib/python/pyruntime.swg
@@ -3,7 +3,7 @@
 /* Use debug wrappers with the Python release dll */
 # undef _DEBUG
 # include <Python.h>
-# define _DEBUG
+# define _DEBUG 1
 #else
 # include <Python.h>
 #endif


### PR DESCRIPTION
According to the documentation, Visual Studio defines _DEBUG to 1 in debug build.

> _DEBUG Defined as 1 when the /LDd, /MDd, or /MTd compiler option is set. Otherwise, undefined.

In:
https://msdn.microsoft.com/en-us/library/b0084kay.aspx
or 
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros



I recently faced build errors when using a 3rd party library (Intel TBB) which relied on the fact that _DEBUG must be equal to 1. Intel fixed this issue in Intel TBB 2017 Update 2, however maybe other libraries will have issues. 

This change does the same as Visual Studio so it should be very safe. 