### PR TITLE
Show the original error if calling director method failed

### DIFF
--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -269,6 +269,30 @@ namespace Swig {
     static void raise(const char *msg) {
       throw DirectorMethodException(msg);
     }
+
+    /* this should be called only if a Python error has occurred */
+    static void raise_after_pyerr(const char *msg) {
+      std::string full_msg(msg);
+
+      PyObject *exception, *v, *tb;
+      PyErr_Fetch(&exception, &v, &tb);
+      PyErr_NormalizeException(&exception, &v, &tb);
+
+      if (PyObject *s = PyObject_Str(v)) {
+        if (const char *cstr = SWIG_Python_str_AsChar(s)) {
+          full_msg += ": ";
+          full_msg += cstr;
+          SWIG_Python_str_DelForPy3(cstr);
+        }
+        Py_XDECREF(s);
+      }
+
+      Py_XDECREF(exception);
+      Py_XDECREF(v);
+      Py_XDECREF(tb);
+
+      raise(full_msg.c_str());
+    }
   };
 
   /* attempt to call a pure virtual method via a director method */

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -5643,7 +5643,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
       Printv(w->code, Str(tm), "\n", NIL);
     } else {
       Append(w->code, "  if (error) {\n");
-      Printf(w->code, "    Swig::DirectorMethodException::raise(\"Error detected when calling '%s.%s'\");\n", classname, pyname);
+      Printf(w->code, "    Swig::DirectorMethodException::raise_after_pyerr(\"Error detected when calling '%s.%s'\");\n", classname, pyname);
       Append(w->code, "  }\n");
     }
     Append(w->code, "}\n");


### PR DESCRIPTION
Previously, if calling the director method failed, the precise error
message was lost and just "Error detected" was shown to the user, making
it difficult to understand what the problem actually was.

Change the code to show the contents of the last Python error too to
make finding and fixing errors in Python director methods much simpler.