### PR TITLE
using double for long integers in R

### DIFF
--- a/Lib/r/r.swg
+++ b/Lib/r/r.swg
@@ -60,13 +60,7 @@ SWIG_InitializeModule(0);
 	     unsigned int *, unsigned int[ANY],
              short *, short[ANY],
              signed short *, signed short[ANY],
-             unsigned short *, unsigned short[ANY],
-             long *, long[ANY],
-             signed long *, signed long[ANY],
-             unsigned long *, unsigned long[ANY],
-             long long *, long long[ANY],
-             signed long long *, signed long long[ANY],
-             unsigned long long *, unsigned long long[ANY]
+             unsigned short *, unsigned short[ANY]
              
 {
 { int _rswigi;
@@ -79,7 +73,13 @@ SWIG_InitializeModule(0);
 } 
 
 %typemap(in) float *, float[ANY],
-             double *, double[ANY]
+             double *, double[ANY],
+             long *, long[ANY],
+             signed long *, signed long[ANY],
+             unsigned long *, unsigned long[ANY],
+             long long *, long long[ANY],
+             signed long long *, signed long long[ANY],
+             unsigned long long *, unsigned long long[ANY]
              
 {
 {  int _rswigi;
@@ -220,12 +220,12 @@ $1 = %static_cast(CHAR(STRING_ELT($input, 0))[0],$1_ltype);
  }
 
 
-%typemap(in,noblock=1) int, long
+%typemap(in,noblock=1) int
 {
   $1 = %static_cast(INTEGER($input)[0], $1_ltype);
 }
 
-%typemap(out,noblock=1) int, long
+%typemap(out,noblock=1) int
   "$result = Rf_ScalarInteger($1);";
 
 
@@ -238,7 +238,8 @@ $1 = %static_cast(CHAR(STRING_ELT($input, 0))[0],$1_ltype);
 
 %typemap(in,noblock=1) 
              float, 
-             double
+             double,
+             long
 {
   $1 = %static_cast(REAL($input)[0], $1_ltype); 
 }

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -26,6 +26,23 @@
 #define SWIG_GetModule(clientdata)                      SWIG_R_GetModule()
 #define SWIG_SetModule(clientdata, pointer)             SWIG_R_SetModule(pointer)
 
+%fragment(SWIG_From_frag(int),"header") {
+SWIGINTERNINLINE SEXP
+SWIG_From_dec(int)(int value)
+{
+	return Rf_ScalarInteger(value);
+}
+}
+
+%fragment(SWIG_AsVal_frag(int),"header") {
+SWIGINTERNINLINE  int
+SWIG_AsVal_dec(int)(SEXP obj, int *val)
+{
+   if (val) *val = Rf_asInteger(obj);
+   return SWIG_OK;
+}
+}
+
 %fragment(SWIG_From_frag(long),"header") {
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(long)(long value)

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -38,7 +38,11 @@ SWIG_From_dec(long)(long value)
 SWIGINTERNINLINE  int
 SWIG_AsVal_dec(long)(SEXP obj, long *val)
 {
-   if (val) *val = Rf_asInteger(obj);
+   if (val) {
+      double tmp = Rf_asReal(obj);
+      if(tmp > (2L<<(DBL_MANT_DIG-1)) || tmp < -(2L<<(DBL_MANT_DIG-1))) Rf_warning("long integers > 2^DBL_MANT_DIG not properly supported");
+      *val = (long)tmp;
+   }
    return SWIG_OK;
 }
 }
@@ -80,7 +84,11 @@ SWIG_From_dec(unsigned long)(unsigned long value)
 SWIGINTERNINLINE  int
 SWIG_AsVal_dec(unsigned long)(SEXP obj, unsigned long *val)
 {
-   if (val) *val = Rf_asInteger(obj);
+   if (val) {
+      double tmp = Rf_asReal(obj);
+      if(tmp > (2L<<(DBL_MANT_DIG-1))) Rf_warning("long integers > 2^DBL_MANT_DIG not properly supported");
+      *val = (unsigned long)tmp;
+   }
    return SWIG_OK;
 }
 }

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -30,7 +30,7 @@
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(long)(long value)
 {
-	return Rf_ScalarInteger((int)value);
+	return Rf_ScalarReal((double)value);
 }
 }
 
@@ -54,7 +54,7 @@ SWIG_AsVal_dec(long)(SEXP obj, long *val)
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(long long)(long long value)
 {
-	return Rf_ScalarInteger((int)value);
+	return Rf_ScalarReal((double)value);
 }
 %#endif
 }
@@ -65,7 +65,11 @@ SWIG_From_dec(long long)(long long value)
 SWIGINTERNINLINE  int
 SWIG_AsVal_dec(long long)(SEXP obj, long long *val)
 {
-   if (val) *val = Rf_asInteger(obj);
+   if (val) {
+      double tmp = Rf_asReal(obj);
+      if(tmp > (2L<<(DBL_MANT_DIG-1)) || tmp < -(2L<<(DBL_MANT_DIG-1))) Rf_warning("long integers > 2^DBL_MANT_DIG not properly supported");
+      *val = (long)tmp;
+   }
    return SWIG_OK;
 }
 %#endif
@@ -75,7 +79,7 @@ SWIG_AsVal_dec(long long)(SEXP obj, long long *val)
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(unsigned long)(unsigned long value)
 {
-	return Rf_ScalarInteger((int)value);
+	return Rf_ScalarReal((double)value);
 }
 }
 
@@ -100,7 +104,7 @@ SWIG_AsVal_dec(unsigned long)(SEXP obj, unsigned long *val)
 SWIGINTERNINLINE SEXP
 SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
-	return Rf_ScalarInteger((int)value);
+	return Rf_ScalarReal((double)value);
 }
 %#endif
 }
@@ -112,7 +116,11 @@ SWIG_From_dec(unsigned long long)(unsigned long long value)
 SWIGINTERNINLINE  int
 SWIG_AsVal_dec(unsigned long long)(SEXP obj, unsigned long long *val)
 {
-   if (val) *val = Rf_asInteger(obj);
+   if (val) {
+      double tmp = Rf_asReal(obj);
+      if(tmp > (2L<<(DBL_MANT_DIG-1))) Rf_warning("long integers > 2^DBL_MANT_DIG not properly supported");
+      *val = (unsigned long)tmp;
+   }
    return SWIG_OK;
 }
 %#endif

--- a/Lib/r/rrun.swg
+++ b/Lib/r/rrun.swg
@@ -23,6 +23,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <float.h>
 
 #if R_VERSION >= R_Version(2,6,0)
 #define VMAXTYPE void *

--- a/Lib/r/rtype.swg
+++ b/Lib/r/rtype.swg
@@ -4,7 +4,7 @@
  */
 
 %typemap("rtype") int, int *, int &      "integer";
-%typemap("rtype") long, long *, long &   "double";
+%typemap("rtype") long, long *, long &   "numeric";
 %typemap("rtype") float, float*, float & "numeric";
 %typemap("rtype") double, double*, double & "numeric";
 %typemap("rtype") char *, char ** "character";
@@ -25,13 +25,13 @@
 
 %typemap("rtypecheck") int, int &
   %{ (is.integer($arg) || is.numeric($arg)) && length($arg) == 1 %}
-%typemap("rtypecheck") int *, long *
+%typemap("rtypecheck") int *
   %{ is.integer($arg) || is.numeric($arg) %}
 
 
-%typemap("rtypecheck") float, double, long, long &
+%typemap("rtypecheck") float, double, long, float &, double &, long &
   %{ is.numeric($arg) && length($arg) == 1 %}
-%typemap("rtypecheck") float *, double *
+%typemap("rtypecheck") float *, double *, long *
   %{ is.numeric($arg) %}
 
 %typemap("rtypecheck") bool, bool &

--- a/Lib/r/rtype.swg
+++ b/Lib/r/rtype.swg
@@ -4,7 +4,7 @@
  */
 
 %typemap("rtype") int, int *, int &      "integer";
-%typemap("rtype") long, long *, long &      "integer";
+%typemap("rtype") long, long *, long &   "double";
 %typemap("rtype") float, float*, float & "numeric";
 %typemap("rtype") double, double*, double & "numeric";
 %typemap("rtype") char *, char ** "character";
@@ -73,7 +73,7 @@
 %typemap(scoercein) int, int *, int &
   %{  $input = as.integer($input);     %}
 %typemap(scoercein) long, long *, long &
-  %{  $input = as.integer($input);     %}
+  %{  $input = as.double($input);     %}
 %typemap(scoercein) float, float*, float &,
   double, double *, double &
   %{ %}
@@ -124,11 +124,12 @@
 		    "$input = as.logical($input);";
 %typemap(scoercein) int, 
                     int *, 
-		    int &,
-		    long,
+		    int &
+  "$input = as.integer($input);";
+%typemap(scoercein) long,
 		    long *,
 		    long &
-  "$input = as.integer($input);";
+  "$input = as.double($input);";
 
 %typemap(scoercein) char *, string, std::string,
 string &, std::string &
@@ -211,51 +212,39 @@ string &, std::string &
 		     unsigned char &
  %{    %}
 
-%apply int {size_t,
-std::size_t,
-ptrdiff_t,
-std::ptrdiff_t,
-signed int,
-unsigned int,
-short,
-unsigned short,
-signed char,
-unsigned char}
+%apply int {
+       signed int,
+       unsigned int,
+       short,
+       unsigned short,
+       signed char,
+       unsigned char}
 
-%apply int* {size_t[],
-std::size_t[],
-ptrdiff_t[],
-std::ptrdiff_t[],
-signed int[],
-unsigned int[],
-short[],
-unsigned short[],
-signed char[],
-unsigned char[]}
-
-%apply int* {size_t[ANY],
-std::size_t[ANY],
-ptrdiff_t[ANY],
-std::ptrdiff_t[ANY],
-signed int[ANY],
-unsigned int[ANY],
-short[ANY],
-unsigned short[ANY],
-signed char[ANY],
-unsigned char[ANY]}
-
-%apply int* {size_t*,
-std::size_t*,
-ptrdiff_t*,
-std::ptrdiff_t*,
-signed int*,
-unsigned int*,
-short*,
-unsigned short*,
-signed char*,
-unsigned char*}
+%apply int* {
+       signed int[],
+       unsigned int[],
+       short[],
+       unsigned short[],
+       signed char[],
+       unsigned char[],
+       signed int[ANY],
+       unsigned int[ANY],
+       short[ANY],
+       unsigned short[ANY],
+       signed char[ANY],
+       unsigned char[ANY],
+       signed int*,
+       unsigned int*,
+       short*,
+       unsigned short*,
+       signed char*,
+       unsigned char*}
 
 %apply long {
+       size_t,
+       std::size_t,
+       ptrdiff_t,
+       std::ptrdiff_t,
        long long,
        signed long long,
        unsigned long long,
@@ -263,16 +252,27 @@ unsigned char*}
        unsigned long}
 
 %apply long* {
+       std::size_t*,
+       ptrdiff_t*,
+       std::ptrdiff_t*,
        long long*,
        signed long long*,
        unsigned long long*,
        signed long*,
        unsigned long*,
+       size_t[],
+       std::size_t[],
+       ptrdiff_t[],
+       std::ptrdiff_t[],
        long long[],
        signed long long[],
        unsigned long long[],
        signed long[],
        unsigned long[],
+       size_t[ANY],
+       std::size_t[ANY],
+       ptrdiff_t[ANY],
+       std::ptrdiff_t[ANY],
        long long[ANY],
        signed long long[ANY],
        unsigned long long[ANY],

--- a/Lib/r/rtype.swg
+++ b/Lib/r/rtype.swg
@@ -23,13 +23,13 @@
 %typemap("rtype") SWIGTYPE && "$R_class";
 %typemap("rtype") SWIGTYPE "$&R_class";
 
-%typemap("rtypecheck") int, int &, long, long &
+%typemap("rtypecheck") int, int &
   %{ (is.integer($arg) || is.numeric($arg)) && length($arg) == 1 %}
 %typemap("rtypecheck") int *, long *
   %{ is.integer($arg) || is.numeric($arg) %}
 
 
-%typemap("rtypecheck") float, double
+%typemap("rtypecheck") float, double, long, long &
   %{ is.numeric($arg) && length($arg) == 1 %}
 %typemap("rtypecheck") float *, double *
   %{ is.numeric($arg) %}


### PR DESCRIPTION
R does not support long integers (64bit), so there is no fast way to fully support them.
This uses doubles to represent long integers in R and converts them to/from 64bit integers on the C/C++ side. It issues warning if input long integer cannot be represented precisely (e.g. > 2^DBL_MANT_DIG).

@joequant