### PR TITLE
Namespace quirks

### DIFF
--- a/Examples/test-suite/duplicate_class_name_in_ns.i
+++ b/Examples/test-suite/duplicate_class_name_in_ns.i
@@ -1,0 +1,21 @@
+%module a;
+
+namespace A
+{
+    class Foo {
+    public:
+        Foo(){};
+    };
+}
+
+namespace B
+{
+    template<typename T, typename U>
+        class Foo : public A::Foo {
+    public:
+        Foo(){};
+        int foo();
+    };
+    
+    %template(B) Foo<int, double>;
+}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -4443,11 +4443,12 @@ templateparameterstail : COMMA templateparameter templateparameterstail {
 /* Namespace support */
 
 cpp_using_decl : USING idcolon SEMI {
-                  String *uname = Swig_symbol_type_qualify($2,0);
+          String *uname = Swig_symbol_type_qualify($2,0);
 		  String *name = Swig_scopename_last($2);
-                  $$ = new_node("using");
+          $$ = new_node("using");
 		  Setattr($$,"uname",uname);
 		  Setattr($$,"name", name);
+          Swig_symbol_add_using(name, uname, $$);
 		  Delete(uname);
 		  Delete(name);
 		  add_symbols($$);

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -4443,12 +4443,12 @@ templateparameterstail : COMMA templateparameter templateparameterstail {
 /* Namespace support */
 
 cpp_using_decl : USING idcolon SEMI {
-          String *uname = Swig_symbol_type_qualify($2,0);
+		  String *uname = Swig_symbol_type_qualify($2,0);
 		  String *name = Swig_scopename_last($2);
-          $$ = new_node("using");
+		  $$ = new_node("using");
 		  Setattr($$,"uname",uname);
 		  Setattr($$,"name", name);
-          Swig_symbol_add_using(name, uname, $$);
+		  Swig_symbol_add_using(name, uname, $$);
 		  Delete(uname);
 		  Delete(name);
 		  add_symbols($$);

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -260,7 +260,7 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
   String *tbase;
   String *scopename = 0;
   String *tmp = tscope ? Getattr(tscope, "name") : 0;
-  if( tmp ) {
+  if (tmp) {
     scopename = Swig_scopename_last(Str(tmp));
   }
 

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -50,7 +50,6 @@ void Swig_cparse_debug_templates(int x) {
  * patching typenames and other aspects of the node according to a list of
  * template parameters
  * ----------------------------------------------------------------------------- */
-
 static void cparse_template_expand(Node *templnode, Node *n, String *tname, String *rname, String *templateargs, List *patchlist, List *typelist, List *cpatchlist) {
   static int expanded = 0;
   String *nodeType;
@@ -259,6 +258,12 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
   String *tname;
   String *iname;
   String *tbase;
+  String *scopename = 0;
+  String *tmp = tscope ? Getattr(tscope, "name") : 0;
+  if( tmp ) {
+    scopename = Swig_scopename_last(Str(tmp));
+  }
+
   patchlist = NewList();
   cpatchlist = NewList();
   typelist = NewList();
@@ -373,8 +378,8 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
 	    String *s = Getitem(typelist, i);
 	    /*      Replace(s,name,value, DOH_REPLACE_ID); */
 	    /*      Printf(stdout,"name = '%s', value = '%s', tbase = '%s', iname='%s' s = '%s' --> ", name, dvalue, tbase, iname, s); */
-	    SwigType_typename_replace(s, name, dvalue);
-	    SwigType_typename_replace(s, tbase, iname);
+	    SwigType_typename_replace(s, name, dvalue, scopename);
+	    SwigType_typename_replace(s, tbase, iname, scopename);
 	    /*      Printf(stdout,"'%s'\n", s); */
 	  }
 
@@ -404,7 +409,7 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
       sz = Len(typelist);
       for (i = 0; i < sz; i++) {
 	String *s = Getitem(typelist, i);
-	SwigType_typename_replace(s, tbase, iname);
+	SwigType_typename_replace(s, tbase, iname, scopename);
       }
     }
   }
@@ -428,6 +433,7 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
   Delete(tbase);
   Delete(tname);
   Delete(templateargs);
+  Delete(scopename);
 
   /*  set_nodeType(n,"template"); */
   return 0;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -5527,6 +5527,8 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     Printf(w->code, "const size_t swig_method_index = %d;\n", director_method_index++);
     Printf(w->code, "const char *const swig_method_name = \"%s\";\n", pyname);
 
+    Swig_cresult_name_set("_swig_director_result_");
+
     Append(w->code, "PyObject *method = swig_get_method(swig_method_index, swig_method_name);\n");
     if (Len(parse_args) > 0) {
       if (use_parse) {

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -562,9 +562,13 @@ class TypePass:private Dispatcher {
     String *name = Getattr(n, "name");
     String *ttype = Getattr(n, "templatetype");
     if (Strcmp(ttype, "class") == 0) {
-      String *rname = SwigType_typedef_resolve_all(name);
-      SwigType_typedef_class(rname);
-      Delete(rname);
+      if(Checkattr(n, "specialization", "1")) {
+        String *rname = SwigType_typedef_resolve_all(name);
+        SwigType_typedef_class(rname);
+        Delete(rname);
+      } else {
+        SwigType_typedef_class(name);
+      }
     } else if (Strcmp(ttype, "classforward") == 0) {
       String *rname = SwigType_typedef_resolve_all(name);
       SwigType_typedef_class(rname);

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -562,12 +562,12 @@ class TypePass:private Dispatcher {
     String *name = Getattr(n, "name");
     String *ttype = Getattr(n, "templatetype");
     if (Strcmp(ttype, "class") == 0) {
-      if(Checkattr(n, "specialization", "1")) {
-        String *rname = SwigType_typedef_resolve_all(name);
-        SwigType_typedef_class(rname);
-        Delete(rname);
+      if (Checkattr(n, "specialization", "1")) {
+	String *rname = SwigType_typedef_resolve_all(name);
+	SwigType_typedef_class(rname);
+	Delete(rname);
       } else {
-        SwigType_typedef_class(name);
+	SwigType_typedef_class(name);
       }
     } else if (Strcmp(ttype, "classforward") == 0) {
       String *rname = SwigType_typedef_resolve_all(name);

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -1304,7 +1304,7 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep, String *sc
 	  Append(nt, "<(");
 	  jlen = Len(tparms);
 	  for (j = 0; j < jlen; j++) {
-          SwigType_typename_replace(Getitem(tparms, j), pat, rep, scopename);
+	    SwigType_typename_replace(Getitem(tparms, j), pat, rep, scopename);
 	    Append(nt, Getitem(tparms, j));
 	    if (j < (jlen - 1))
 	      Putc(',', nt);
@@ -1335,8 +1335,8 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep, String *sc
 	Clear(e);
 	if( ! scopename || Strstr(scopename, first) ) {
 	  if (first)
-	    SwigType_typename_replace(first, pat, rep);
-	  SwigType_typename_replace(rest, pat, rep);
+	    SwigType_typename_replace(first, pat, rep, scopename);
+	  SwigType_typename_replace(rest, pat, rep, scopename);
 	  Printv(e, first ? first : "", "::", rest, NIL);
 	}
 	Delete(first);

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -1268,7 +1268,7 @@ String *SwigType_manglestr(const SwigType *s) {
  * Replaces a typename in a type with something else.  Needed for templates.
  * ----------------------------------------------------------------------------- */
 
-void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
+void SwigType_typename_replace(SwigType *t, String *pat, String *rep, String *scopename) {
   String *nt;
   int i, ilen;
   List *elem;
@@ -1304,7 +1304,7 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
 	  Append(nt, "<(");
 	  jlen = Len(tparms);
 	  for (j = 0; j < jlen; j++) {
-	    SwigType_typename_replace(Getitem(tparms, j), pat, rep);
+          SwigType_typename_replace(Getitem(tparms, j), pat, rep, scopename);
 	    Append(nt, Getitem(tparms, j));
 	    if (j < (jlen - 1))
 	      Putc(',', nt);
@@ -1333,10 +1333,12 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
 	}
 
 	Clear(e);
-	if (first)
-	  SwigType_typename_replace(first, pat, rep);
-	SwigType_typename_replace(rest, pat, rep);
-	Printv(e, first ? first : "", "::", rest, NIL);
+	if( ! scopename || Strstr(scopename, first) ) {
+	  if (first)
+	    SwigType_typename_replace(first, pat, rep);
+	  SwigType_typename_replace(rest, pat, rep);
+	  Printv(e, first ? first : "", "::", rest, NIL);
+	}
 	Delete(first);
 	Delete(rest);
       }
@@ -1347,7 +1349,7 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
       Append(e, "f(");
       jlen = Len(fparms);
       for (j = 0; j < jlen; j++) {
-	SwigType_typename_replace(Getitem(fparms, j), pat, rep);
+	SwigType_typename_replace(Getitem(fparms, j), pat, rep, scopename);
 	Append(e, Getitem(fparms, j));
 	if (j < (jlen - 1))
 	  Putc(',', e);

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -221,6 +221,7 @@ extern "C" {
   extern void Swig_symbol_print_tables_summary(void);
   extern void Swig_symbol_print_symbols(void);
   extern void Swig_symbol_print_csymbols(void);
+  extern void Swig_symbol_add_using(String * name, String * uname, Node * n);
   extern void Swig_symbol_init(void);
   extern void Swig_symbol_setscopename(const_String_or_char_ptr name);
   extern String *Swig_symbol_getscopename(void);

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -184,7 +184,7 @@ extern "C" {
   extern SwigType *SwigType_array_type(const SwigType *t);
   extern SwigType *SwigType_default_create(const SwigType *ty);
   extern SwigType *SwigType_default_deduce(const SwigType *t);
-  extern void SwigType_typename_replace(SwigType *t, String *pat, String *rep);
+  extern void SwigType_typename_replace(SwigType *t, String *pat, String *rep, String * scope);
   extern SwigType *SwigType_remove_global_scope_prefix(const SwigType *t);
   extern SwigType *SwigType_alttype(const SwigType *t, int ltmap);
 

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -391,8 +391,12 @@ void Swig_symbol_add_using(String * name, String * uname, Node * n) {
   h = Swig_symbol_clookup(uname,0);
   if (h && checkAttribute(h, "kind", "class")) {
     String *qcurrent = Swig_symbol_qualifiedscopename(0);
-    Append(qcurrent, "::");
-    Append(qcurrent, name);
+    if(qcurrent) {
+        Append(qcurrent, "::");
+        Append(qcurrent, name);
+    } else {
+        qcurrent = NewString(name);
+    }
     Setattr(symtabs, qcurrent, n);
     Delete(qcurrent);
   }

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -391,11 +391,11 @@ void Swig_symbol_add_using(String * name, String * uname, Node * n) {
   h = Swig_symbol_clookup(uname,0);
   if (h && checkAttribute(h, "kind", "class")) {
     String *qcurrent = Swig_symbol_qualifiedscopename(0);
-    if(qcurrent) {
-        Append(qcurrent, "::");
-        Append(qcurrent, name);
+    if (qcurrent) {
+	Append(qcurrent, "::");
+	Append(qcurrent, name);
     } else {
-        qcurrent = NewString(name);
+	qcurrent = NewString(name);
     }
     Setattr(symtabs, qcurrent, n);
     Delete(qcurrent);
@@ -1086,27 +1086,26 @@ static Node *symbol_lookup_qualified(const_String_or_char_ptr name, Symtab *symt
     } else {
       cqname = prefix;
     }
-
     st = Getattr(symtabs, cqname);
     /* Found a scope match */
     if (st) {
       if (!name) {
-        if (qalloc)
-          Delete(qalloc);
-        return st;
+	if (qalloc)
+	  Delete(qalloc);
+	return st;
       }
       if (checkAttribute(st, "nodeType", "using")) {
-        String *uname = Getattr(st, "uname");
-        if (uname) {
-          st = Getattr(symtabs, uname);
-          if (st) {
-            n = symbol_lookup(name, st, checkfunc);
-          } else {
-            fprintf(stderr, "Error: Found corrupt 'using' node\n");
-          }
-        }
+	String *uname = Getattr(st, "uname");
+	if (uname) {
+	  st = Getattr(symtabs, uname);
+	  if (st) {
+	    n = symbol_lookup(name, st, checkfunc);
+	  } else {
+	    fprintf(stderr, "Error: Found corrupt 'using' node\n");
+	  }
+	}
       } else if (Getattr(st, "csymtab")) {
-        n = symbol_lookup(name, st, checkfunc);
+	n = symbol_lookup(name, st, checkfunc);
       }
     }
     if (qalloc)


### PR DESCRIPTION
Classes with the same name in different namespace have not been treated correctly by SWIG.
The changes here resolve most of the issues related to this, including combining it with the use of "using namespace".
Previous attempts to get this into master as separate PRs failed as the different commits are only work together correctly and I don't want to spend time with figuring out what would be a correct order of separate PRs.

Related PRs are #810 and #742.