### PR TITLE
Lua 5.3 integer support

### DIFF
--- a/Lib/lua/lua.swg
+++ b/Lib/lua/lua.swg
@@ -20,8 +20,14 @@
 // this basically adds to a table of constants
 %typemap(consttab) int, unsigned int, short, unsigned short, long, unsigned long, unsigned char, signed char, bool, enum SWIGTYPE
        {SWIG_LUA_CONSTTAB_INT("$symname", $value)}
+	   
+%typemap(consttab) const int&, const unsigned int&, const short&, const unsigned short &, const long &, const unsigned long &, const unsigned char&, const signed char&, const bool&, const enum SWIGTYPE&
+       {SWIG_LUA_CONSTTAB_INT("$symname", $value)}
 
 %typemap(consttab) float, double
+       {SWIG_LUA_CONSTTAB_FLOAT("$symname", $value)}
+
+%typemap(consttab) const float&, const double&
        {SWIG_LUA_CONSTTAB_FLOAT("$symname", $value)}
 
 %typemap(consttab) long long, unsigned long long, signed long long
@@ -158,15 +164,18 @@ use %include <std_except.i> instead
 %typemap(throws) int,unsigned int,signed int,
 				long,unsigned long,signed long,
 				short,unsigned short,signed short,
-				float,double,
 				long long,unsigned long long,
 				unsigned char, signed char,
                 int&,unsigned int&,signed int&,
 				long&,unsigned long&,signed long&,
 				short&,unsigned short&,signed short&,
-				float&,double&,
 				long long&,unsigned long long&,
 				unsigned char&, signed char&
+%{lua_pushinteger(L,(lua_Integer)$1);SWIG_fail; %}
+
+// number as number+error
+%typemap(throws) float,double,
+				float&,double&,
 %{lua_pushnumber(L,(lua_Number)$1);SWIG_fail; %}
 
 %typemap(throws) bool,bool& 
@@ -174,7 +183,7 @@ use %include <std_except.i> instead
 
 // enum as number+error
 %typemap(throws) enum SWIGTYPE
-%{lua_pushnumber(L,(lua_Number)(int)$1);SWIG_fail; %}
+%{lua_pushinteger(L,(lua_Integer)(int)$1);SWIG_fail; %}
 
 // strings are just sent as errors
 %typemap(throws) char *, const char *

--- a/Lib/lua/lua.swg
+++ b/Lib/lua/lua.swg
@@ -25,10 +25,10 @@
        {SWIG_LUA_CONSTTAB_FLOAT("$symname", $value)}
 
 %typemap(consttab) long long, unsigned long long, signed long long
-       {SWIG_LUA_CONSTTAB_FLOAT("$symname", $value)}
+       {SWIG_LUA_CONSTTAB_INT("$symname", $value)}
 
 %typemap(consttab) const long long&, const unsigned long long&, const signed long long&
-       {SWIG_LUA_CONSTTAB_FLOAT("$symname", *$value)}
+       {SWIG_LUA_CONSTTAB_INT("$symname", *$value)}
 
 %typemap(consttab) char *, const char *, char [], const char []
        {SWIG_LUA_CONSTTAB_STRING("$symname", $value)}
@@ -37,9 +37,6 @@
 // signed char & unsigned char are numbers
 %typemap(consttab) char
        {SWIG_LUA_CONSTTAB_CHAR("$symname", $value)}
-
-%typemap(consttab) long long, unsigned long long
-       {SWIG_LUA_CONSTTAB_STRING("$symname", "$value")}
 
 %typemap(consttab) SWIGTYPE *, SWIGTYPE *const, SWIGTYPE &, SWIGTYPE &&, SWIGTYPE []
        { SWIG_LUA_CONSTTAB_POINTER("$symname",$value, $1_descriptor) }

--- a/Lib/lua/lua_fnptr.i
+++ b/Lib/lua/lua_fnptr.i
@@ -23,8 +23,8 @@ just push the parameters, call the function and return the result.
   int my_func(int a, int b, SWIGLUA_FN fn)
   {
     SWIGLUA_FN_GET(fn);
-    lua_pushnumber(fn.L,a);
-    lua_pushnumber(fn.L,b);
+    lua_pushinteger(fn.L,a);
+    lua_pushinteger(fn.L,b);
     lua_call(fn.L,2,1);    // 2 in, 1 out
     return luaL_checknumber(fn.L,-1);
   }
@@ -76,8 +76,8 @@ if you need that you must add it yourself.
   int my_func(int a, int b, SWIGLUA_FN fn)
   {
     SWIGLUA_FN_GET(fn);
-    lua_pushnumber(fn.L,a);
-    lua_pushnumber(fn.L,b);
+    lua_pushinteger(fn.L,a);
+    lua_pushinteger(fn.L,b);
     lua_call(fn.L,2,1);    // 2 in, 1 out
     return luaL_checknumber(fn.L,-1);
   }

--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -1860,7 +1860,7 @@ SWIG_Lua_InstallConstants(lua_State *L, swig_lua_const_info constants[]) {
     switch(constants[i].type) {
     case SWIG_LUA_INT:
       lua_pushstring(L,constants[i].name);
-      lua_pushinteger(L,(lua_Number)constants[i].lvalue);
+      lua_pushinteger(L,(lua_Integer)constants[i].lvalue);
       lua_rawset(L,-3);
       break;
     case SWIG_LUA_FLOAT:

--- a/Lib/lua/luatypemaps.swg
+++ b/Lib/lua/luatypemaps.swg
@@ -69,7 +69,7 @@ temp=($basetype)lua_tonumber(L,$input); $1=&temp;%}
 %{$1 = ($type)(int)lua_tonumber(L, $input);%}
 
 %typemap(out) enum SWIGTYPE
-%{  lua_pushintger(L, (lua_Integer)(int)($1)); SWIG_arg++;%}
+%{  lua_pushinteger(L, (lua_Integer)(int)($1)); SWIG_arg++;%}
 
 // and const refs
 %typemap(in,checkfn="lua_isnumber") const enum SWIGTYPE &($basetype temp)
@@ -77,9 +77,9 @@ temp=($basetype)lua_tonumber(L,$input); $1=&temp;%}
 %typemap(in,checkfn="lua_isnumber") const enum SWIGTYPE &&($basetype temp)
 %{ temp=($basetype)(int)lua_tonumber(L,$input); $1=&temp;%}
 %typemap(out) const enum SWIGTYPE &
-%{  lua_pushintger(L, (lua_Integer) *$1); SWIG_arg++;%}
+%{  lua_pushinteger(L, (lua_Integer) *$1); SWIG_arg++;%}
 %typemap(out) const enum SWIGTYPE &&
-%{  lua_pushintger(L, (lua_Integer) *$1); SWIG_arg++;%}
+%{  lua_pushinteger(L, (lua_Integer) *$1); SWIG_arg++;%}
 
 
 // boolean (which is a special type in lua)

--- a/Lib/lua/luatypemaps.swg
+++ b/Lib/lua/luatypemaps.swg
@@ -27,11 +27,13 @@
 %{SWIG_contract_assert((lua_tonumber(L,$input)>=0),"number must not be negative")
 $1 = ($type)lua_tonumber(L, $input);%}
 
+%typemap(out) float,double
+%{  lua_pushnumber(L, (lua_Number) $1); SWIG_arg++;%}
+
 %typemap(out) int,short,long,
              unsigned int,unsigned short,unsigned long,
-             signed char,unsigned char,
-             float,double
-%{  lua_pushnumber(L, (lua_Number) $1); SWIG_arg++;%}
+             signed char,unsigned char
+%{  lua_pushinteger(L, (lua_Integer) $1); SWIG_arg++;%}
 
 // we must also provide typemaps for primitives by const reference:
 // given a function:
@@ -47,11 +49,15 @@ $1 = ($type)lua_tonumber(L, $input);%}
 temp=($basetype)lua_tonumber(L,$input); $1=&temp;%}
 
 %typemap(out) const int&, const unsigned int&
+%{  lua_pushinteger(L, (lua_Integer) *$1); SWIG_arg++;%}
+
+%typemap(out) const float&
 %{  lua_pushnumber(L, (lua_Number) *$1); SWIG_arg++;%}
 
 // for the other numbers we can just use an apply statement to cover them
-%apply const int & {const short&,const long&,const signed char&,
-             const float&,const double&};
+%apply const int & {const short&,const long&,const signed char&};
+
+%apply const float & {const double&};
 
 %apply const unsigned int & {const unsigned short&,const unsigned long&,
              const unsigned char&};
@@ -63,7 +69,7 @@ temp=($basetype)lua_tonumber(L,$input); $1=&temp;%}
 %{$1 = ($type)(int)lua_tonumber(L, $input);%}
 
 %typemap(out) enum SWIGTYPE
-%{  lua_pushnumber(L, (lua_Number)(int)($1)); SWIG_arg++;%}
+%{  lua_pushintger(L, (lua_Integer)(int)($1)); SWIG_arg++;%}
 
 // and const refs
 %typemap(in,checkfn="lua_isnumber") const enum SWIGTYPE &($basetype temp)
@@ -71,9 +77,9 @@ temp=($basetype)lua_tonumber(L,$input); $1=&temp;%}
 %typemap(in,checkfn="lua_isnumber") const enum SWIGTYPE &&($basetype temp)
 %{ temp=($basetype)(int)lua_tonumber(L,$input); $1=&temp;%}
 %typemap(out) const enum SWIGTYPE &
-%{  lua_pushnumber(L, (lua_Number) *$1); SWIG_arg++;%}
+%{  lua_pushintger(L, (lua_Integer) *$1); SWIG_arg++;%}
 %typemap(out) const enum SWIGTYPE &&
-%{  lua_pushnumber(L, (lua_Number) *$1); SWIG_arg++;%}
+%{  lua_pushintger(L, (lua_Integer) *$1); SWIG_arg++;%}
 
 
 // boolean (which is a special type in lua)

--- a/Lib/lua/typemaps.i
+++ b/Lib/lua/typemaps.i
@@ -378,6 +378,52 @@ for array handling
 */
 %define SWIG_TYPEMAP_NUM_ARR(NAME,TYPE)
 %{SWIG_DECLARE_TYPEMAP_ARR_FN(NAME,TYPE)%}
+
+// fixed size array's
+%typemap(in) TYPE INPUT[ANY]
+%{	$1 = SWIG_get_##NAME##_num_array_fixed(L,$input,$1_dim0);
+	if (!$1) SWIG_fail;%}
+
+%typemap(freearg) TYPE INPUT[ANY]
+%{	SWIG_FREE_ARRAY($1);%}
+
+// variable size array's
+%typemap(in) (TYPE *INPUT,int)
+%{	$1 = SWIG_get_##NAME##_num_array_var(L,$input,&$2);
+	if (!$1) SWIG_fail;%}
+
+%typemap(freearg) (TYPE *INPUT,int)
+%{	SWIG_FREE_ARRAY($1);%}
+
+// out fixed arrays
+%typemap(in,numinputs=0) TYPE OUTPUT[ANY]
+%{  $1 = SWIG_ALLOC_ARRAY(TYPE,$1_dim0); %}
+
+%typemap(argout) TYPE OUTPUT[ANY]
+%{	SWIG_write_##NAME##_num_array(L,$1,$1_dim0); SWIG_arg++; %}
+
+%typemap(freearg) TYPE OUTPUT[ANY]
+%{	SWIG_FREE_ARRAY($1); %}
+
+// inout fixed arrays
+%typemap(in) TYPE INOUT[ANY]=TYPE INPUT[ANY];
+%typemap(argout) TYPE INOUT[ANY]=TYPE OUTPUT[ANY];
+%typemap(freearg) TYPE INOUT[ANY]=TYPE INPUT[ANY];
+// inout variable arrays
+%typemap(in) (TYPE *INOUT,int)=(TYPE *INPUT,int);
+%typemap(argout) (TYPE *INOUT,int)
+%{	SWIG_write_##NAME##_num_array(L,$1,$2); SWIG_arg++; %}
+%typemap(freearg) (TYPE *INOUT,int)=(TYPE *INPUT,int);
+
+// TODO out variable arrays (is there a standard form for such things?)
+
+// referencing so that (int *INPUT,int) and (int INPUT[],int) are the same
+%typemap(in) (TYPE INPUT[],int)=(TYPE *INPUT,int);
+%typemap(freearg) (TYPE INPUT[],int)=(TYPE *INPUT,int);
+
+%enddef
+
+
 %define SWIG_TYPEMAP_NUM_ARR_INTEGER(NAME,TYPE)
 %{SWIG_DECLARE_TYPEMAP_ARR_FN_INTEGER(NAME,TYPE)%}
 

--- a/Lib/lua/typemaps.i
+++ b/Lib/lua/typemaps.i
@@ -45,6 +45,30 @@ or provide a %apply statement
 */
 
 
+%define SWIG_INTEGER_TYPEMAP(TYPE)
+%typemap(in,checkfn="lua_isnumber")	TYPE *INPUT($*ltype temp), TYPE &INPUT($*ltype temp)
+%{ temp = ($*ltype)lua_tonumber(L,$input);
+   $1 = &temp; %}
+%typemap(in, numinputs=0) TYPE *OUTPUT ($*ltype temp)
+%{ $1 = &temp; %}
+%typemap(argout) TYPE *OUTPUT
+%{  
+ lua_pushinteger(L, (lua_Integer) *$1);
+ SWIG_arg++;
+%}
+
+%typemap(in) TYPE *INOUT = TYPE *INPUT;
+%typemap(argout) TYPE *INOUT = TYPE *OUTPUT;
+%typemap(in) TYPE &OUTPUT = TYPE *OUTPUT;
+%typemap(argout) TYPE &OUTPUT = TYPE *OUTPUT;
+%typemap(in) TYPE &INOUT = TYPE *INPUT;
+%typemap(argout) TYPE &INOUT = TYPE *OUTPUT;
+// const version (the $*ltype is the basic number without ptr or const's)
+%typemap(in,checkfn="lua_isnumber")	const TYPE *INPUT($*ltype temp)
+%{ temp = ($*ltype)lua_tonumber(L,$input);
+   $1 = &temp; %}
+%enddef
+
 %define SWIG_NUMBER_TYPEMAP(TYPE)
 %typemap(in,checkfn="lua_isnumber")	TYPE *INPUT($*ltype temp), TYPE &INPUT($*ltype temp)
 %{ temp = ($*ltype)lua_tonumber(L,$input);
@@ -66,16 +90,16 @@ or provide a %apply statement
 %enddef
 
 // now the code
-SWIG_NUMBER_TYPEMAP(unsigned char); SWIG_NUMBER_TYPEMAP(signed char);
+SWIG_INTEGER_TYPEMAP(unsigned char); SWIG_INTEGER_TYPEMAP(signed char);
 
-SWIG_NUMBER_TYPEMAP(short); SWIG_NUMBER_TYPEMAP(unsigned short); SWIG_NUMBER_TYPEMAP(signed short);
-SWIG_NUMBER_TYPEMAP(int); SWIG_NUMBER_TYPEMAP(unsigned int); SWIG_NUMBER_TYPEMAP(signed int);
-SWIG_NUMBER_TYPEMAP(long); SWIG_NUMBER_TYPEMAP(unsigned long); SWIG_NUMBER_TYPEMAP(signed long);
+SWIG_INTEGER_TYPEMAP(short); SWIG_INTEGER_TYPEMAP(unsigned short); SWIG_INTEGER_TYPEMAP(signed short);
+SWIG_INTEGER_TYPEMAP(int); SWIG_INTEGER_TYPEMAP(unsigned int); SWIG_INTEGER_TYPEMAP(signed int);
+SWIG_INTEGER_TYPEMAP(long); SWIG_INTEGER_TYPEMAP(unsigned long); SWIG_INTEGER_TYPEMAP(signed long);
 SWIG_NUMBER_TYPEMAP(float);
 SWIG_NUMBER_TYPEMAP(double);
-SWIG_NUMBER_TYPEMAP(enum SWIGTYPE);
+SWIG_INTEGER_TYPEMAP(enum SWIGTYPE);
 // also for long longs's
-SWIG_NUMBER_TYPEMAP(long long); SWIG_NUMBER_TYPEMAP(unsigned long long); SWIG_NUMBER_TYPEMAP(signed long long);
+SWIG_INTEGER_TYPEMAP(long long); SWIG_INTEGER_TYPEMAP(unsigned long long); SWIG_INTEGER_TYPEMAP(signed long long);
 
 // note we dont do char, as a char* is probably a string not a ptr to a single char
 
@@ -289,6 +313,63 @@ SWIGINTERN int SWIG_table_size(lua_State* L, int index)
 			lua_rawseti(L,-2,i+1);/* -1 is the number, -2 is the table*/ \
 		}\
 	}
+#define SWIG_DECLARE_TYPEMAP_ARR_FN_INTEGER(NAME,TYPE)\
+	SWIGINTERN int SWIG_read_##NAME##_num_array(lua_State* L,int index,TYPE *array,int size){\
+		int i;\
+		for (i = 0; i < size; i++) {\
+			lua_rawgeti(L,index,i+1);\
+			if (lua_isnumber(L,-1)){\
+				array[i] = (TYPE)lua_tonumber(L,-1);\
+			} else {\
+				lua_pop(L,1);\
+				return 0;\
+			}\
+			lua_pop(L,1);\
+		}\
+		return 1;\
+	}\
+	SWIGINTERN TYPE* SWIG_get_##NAME##_num_array_fixed(lua_State* L, int index, int size){\
+		TYPE *array;\
+		if (!lua_istable(L,index) || SWIG_itable_size(L,index) != size) {\
+			SWIG_Lua_pushferrstring(L,"expected a table of size %d",size);\
+			return 0;\
+		}\
+		array=SWIG_ALLOC_ARRAY(TYPE,size);\
+		if (!SWIG_read_##NAME##_num_array(L,index,array,size)){\
+			SWIG_Lua_pusherrstring(L,"table must contain numbers");\
+			SWIG_FREE_ARRAY(array);\
+			return 0;\
+		}\
+		return array;\
+	}\
+	SWIGINTERN TYPE* SWIG_get_##NAME##_num_array_var(lua_State* L, int index, int* size)\
+	{\
+		TYPE *array;\
+		if (!lua_istable(L,index)) {\
+			SWIG_Lua_pusherrstring(L,"expected a table");\
+			return 0;\
+		}\
+		*size=SWIG_itable_size(L,index);\
+		if (*size<1){\
+			SWIG_Lua_pusherrstring(L,"table appears to be empty");\
+			return 0;\
+		}\
+		array=SWIG_ALLOC_ARRAY(TYPE,*size);\
+		if (!SWIG_read_##NAME##_num_array(L,index,array,*size)){\
+			SWIG_Lua_pusherrstring(L,"table must contain numbers");\
+			SWIG_FREE_ARRAY(array);\
+			return 0;\
+		}\
+		return array;\
+	}\
+	SWIGINTERN void SWIG_write_##NAME##_num_array(lua_State* L,TYPE *array,int size){\
+		int i;\
+		lua_newtable(L);\
+		for (i = 0; i < size; i++){\
+			lua_pushinteger(L,(lua_Integer)array[i]);\
+			lua_rawseti(L,-2,i+1);/* -1 is the number, -2 is the table*/ \
+		}\
+	}
 %}
 
 /*
@@ -297,6 +378,8 @@ for array handling
 */
 %define SWIG_TYPEMAP_NUM_ARR(NAME,TYPE)
 %{SWIG_DECLARE_TYPEMAP_ARR_FN(NAME,TYPE)%}
+%define SWIG_TYPEMAP_NUM_ARR_INTEGER(NAME,TYPE)
+%{SWIG_DECLARE_TYPEMAP_ARR_FN_INTEGER(NAME,TYPE)%}
 
 // fixed size array's
 %typemap(in) TYPE INPUT[ANY]
@@ -347,14 +430,14 @@ for array handling
 // as well as defining typemaps for
 // fixed len arrays in & out, & variable length arrays in
 
-SWIG_TYPEMAP_NUM_ARR(schar,signed char);
-SWIG_TYPEMAP_NUM_ARR(uchar,unsigned char);
-SWIG_TYPEMAP_NUM_ARR(int,int);
-SWIG_TYPEMAP_NUM_ARR(uint,unsigned int);
-SWIG_TYPEMAP_NUM_ARR(short,short);
-SWIG_TYPEMAP_NUM_ARR(ushort,unsigned short);
-SWIG_TYPEMAP_NUM_ARR(long,long);
-SWIG_TYPEMAP_NUM_ARR(ulong,unsigned long);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(schar,signed char);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(uchar,unsigned char);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(int,int);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(uint,unsigned int);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(short,short);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(ushort,unsigned short);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(long,long);
+SWIG_TYPEMAP_NUM_ARR_INTEGER(ulong,unsigned long);
 SWIG_TYPEMAP_NUM_ARR(float,float);
 SWIG_TYPEMAP_NUM_ARR(double,double);
 


### PR DESCRIPTION
Lua 5.3 added an integer type.
The original number type is now treated as real type.

e.g.:
```c
// push the number to Lua, in variable x
lua_pushnumber(L, (lua_Number)24);
```

```lua
-- x always is type of number, in Lua 5.3 it is real type
-- 24 is type of integer in Lua 5.3, in Lua 5.2 it is type of number
if x == 24 then
    print("Yes!")
else
    print("No!")
end
```

outputs "No!". Because x is now 24.0, not 24.
In Lua 5.2 and earlier this program should output "Yes." because both x and 24 is type of number.

This change breaks a lot of programs including swig-lua interface.
We can't use Lua 5.3 or later before this pr got merged to swig.