### PR TITLE
Incorporate template argument namespace

### DIFF
--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -463,6 +463,16 @@ class TypePass:private Dispatcher {
 	  SwigType_typedef_class(fname);
 	  scopename = Copy(fname);
 	}
+        // Incorportate the template argument namespace, so the wrapper class package declaration and location is correct
+        SwigType* tan = SwigType_templateargs(name);
+        Replace(tan, "<(", "", DOH_REPLACE_ANY);
+        Replace(tan, ")>", "", DOH_REPLACE_ANY);
+        SwigType* ansname = Swig_scopename_prefix(tan);
+        Replace(ansname, "::", ".", DOH_REPLACE_ANY);
+        Setattr(n, "sym:nspace", ansname);
+        Delete(tan);
+        Delete(ansname);
+
 	Delete(deftype_name);
 	Delete(resolved_name);
       } else {


### PR DESCRIPTION
When declaring a templated type, the namespace of the template argument is ignored and the wrapper class is generated without the correct package declaration and placed in the root directory instead of the corresponding package directory. 

Currently (see example below), the following structure would be generated:

* foo
  * bar
    * TestyMcTestface.java
* baz
  * ter
    * TestyMcTestface.java
* FooTestyList.java
* BazTestyList.java

with the patch the correct structure is generated
* foo
  * bar
    * TestyMcTestface.java
    * FooTestyList.java
* baz
  * ter
    * TestyMcTestface.java
    * BazTestyList.java

Furhtermore, without the patch FooTestyList and BazTestyList only have the package declaration 'package testy;' whereas it should be 'package testy.foo.bar;' and 'package testy.baz.ter;'. 


Example: 
--- test.i --- 
%module test

%include <std_list.i>

%nspace foo::bar::TestyMcTestface;
%template(FooTestyList) std::list&lt;foo::bar::TestyMcTestface&gt;;

%nspace baz::ter::TestyMcTestface;
%template(BazTestyList) std::list&lt;baz::ter::TestyMcTestface&gt;;

%include "../test.hpp"
--- test.hpp ---

namespace foo { namespace bar {

class TestyMcTestface { };

} }

namespace baz { namespace ter {

class TestyMcTestface { };

} }
--- command --- 
swig -outcurrentdir -c++ -java -package testy test.i
--- END --- 