### PR TITLE
Forward declaration within typedef when names are identical.

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,11 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2017-12-30: davedissian
+            Fixed a symbol lookup issue when encountering a typedef of a symbol from the tag
+            namespace to the global namespace when the names are identical, such as 'typedef
+            struct Foo Foo;'.
+
 2017-12-13: wsfulton
             [Perl] add missing support for directorfree typemaps.
 

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -490,6 +490,7 @@ CPP_TEST_CASES += \
 	throw_exception \
 	typedef_array_member \
 	typedef_class \
+	typedef_classforward_same_name \
 	typedef_funcptr \
 	typedef_inherit \
 	typedef_mptr \
@@ -676,6 +677,7 @@ C_TEST_CASES += \
 	string_simple \
 	struct_rename \
 	struct_initialization \
+	typedef_classforward_same_name \
 	typedef_struct \
 	typemap_subst \
 	union_parameter \

--- a/Examples/test-suite/java/typedef_classforward_same_name_runme.java
+++ b/Examples/test-suite/java/typedef_classforward_same_name_runme.java
@@ -1,0 +1,22 @@
+
+import typedef_classforward_same_name.*;
+
+public class typedef_classforward_same_name_runme {
+
+  static {
+    try {
+	    System.loadLibrary("typedef_classforward_same_name");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+    Foo foo = new Foo();
+    foo.setX(5);
+    if (typedef_classforward_same_name.extract(foo) == 5) {
+      // All good!
+    }
+  }
+}

--- a/Examples/test-suite/typedef_classforward_same_name.i
+++ b/Examples/test-suite/typedef_classforward_same_name.i
@@ -1,0 +1,9 @@
+%module typedef_classforward_same_name
+
+%inline %{
+typedef struct Foo Foo;
+struct Foo {
+   int x;
+};
+int extract(Foo* foo) { return foo->x; }
+%}

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -3296,6 +3296,14 @@ Node *Language::classLookup(const SwigType *s) const {
 	break;
       if (Strcmp(nodeType(n), "class") == 0)
 	break;
+      Node *sibling = n;
+      while (sibling) {
+       sibling = Getattr(sibling, "csym:nextSibling");
+       if (sibling && Strcmp(nodeType(sibling), "class") == 0)
+         break;
+      }
+      if (sibling)
+       break;
       n = parentNode(n);
       if (!n)
 	break;


### PR DESCRIPTION
This pull request fixes #838 (sorry it took so long to re-do this PR).

I determined that `Language::classLookup` seems to fail when there exists a `cdecl` in the symbol table where the name is identical to another struct/class in the symbol table. This situation is similar to the case:

```
typedef struct Foo {
   ....
} Foo;
```

This is handled as a special case, as documented in symbol.c:

```
 * Due to the unified namespace for structures, special handling is performed for
 * the following:
 *
 *        typedef struct Foo {
 *
 *        } Foo;
 * 
 * In this case, the symbol table contains an entry for the structure itself.  The
 * typedef is left out of the symbol table.
```

This PR adds a similar workaround for the case:

```
typedef struct Foo Foo;
```

By replacing the broken `cdecl` node in the symbol table with the correct `classforward` node during parsing, we fix this issue nicely without having to add a more brittle hack to `Language::classLookup` and other places to work around this particular edge case.