### PR TITLE
Updated tarball search to match convention

### DIFF
--- a/Tools/pcre-build.sh
+++ b/Tools/pcre-build.sh
@@ -37,7 +37,7 @@ fi
 
 echo "Looking for PCRE tarball..."
 rm -rf pcre
-pcre_tarball=`ls pcre-*.tar*`
+pcre_tarball=`ls pcre2-*.tar*`
 test -n "$pcre_tarball" || bail "Could not find tarball matching pattern: pcre-*.tar*"
 test -f "$pcre_tarball" || bail "Could not find a single PCRE tarball. Found: $pcre_tarball"
 


### PR DESCRIPTION
pcre tarball naming convention has been updated on ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/ causing the script to not find tarballs downloaded straight from the website.