### PR TITLE
Fix off-by-one error

### DIFF
--- a/Lib/guile/guile_scm_run.swg
+++ b/Lib/guile/guile_scm_run.swg
@@ -24,6 +24,8 @@ scm_module_variable (SCM module, SCM sym)
   return scm_sym2var (sym, scm_module_lookup_closure (module), SCM_BOOL_F);
 }
 
+#define scm_to_utf8_string scm_to_locale_string
+#define scm_from_utf8_string scm_from_locale_string
 #endif
 
 #if SCM_MAJOR_VERSION >= 2
@@ -40,10 +42,6 @@ typedef struct swig_guile_clientdata {
   SCM goops_class;
 } swig_guile_clientdata;
 
-#if SCM_MAJOR_VERSION <= 2
-#define scm_to_utf8_string scm_to_locale_string
-#define scm_from_utf8_string scm_from_locale_string
-#endif
 #define SWIG_scm2str(s) \
   SWIG_Guile_scm2newstr(s, NULL)
 #define SWIG_str02scm(str) \


### PR DESCRIPTION
The condition only applies to guile 1.8 and older so it should really
have been '<2' all along. As we already have such a conditional block
earlier up, merge the two together as well.