### PR TITLE
Fix guile 2.2 support

### DIFF
--- a/Lib/guile/guile_scm.swg
+++ b/Lib/guile/guile_scm.swg
@@ -26,10 +26,10 @@
     else {									\
       if (!gswig_list_p) {							\
 	      gswig_list_p = 1;							\
-	      gswig_result = scm_listify(gswig_result, object, SCM_UNDEFINED);	\
+	      gswig_result = scm_list_n(gswig_result, object, SCM_UNDEFINED);	\
       }									\
       else									\
-            gswig_result = scm_append(scm_listify(gswig_result, scm_listify(object, SCM_UNDEFINED), SCM_UNDEFINED));		\
+            gswig_result = scm_append(scm_list_n(gswig_result, scm_list_n(object, SCM_UNDEFINED), SCM_UNDEFINED));		\
     }
 
 %}

--- a/Lib/guile/guilemain.i
+++ b/Lib/guile/guilemain.i
@@ -12,11 +12,6 @@
 extern "C" {
 #endif
 
-/* Debugger interface (don't change the order of the following lines) */
-#define GDB_TYPE SCM
-#include <libguile/gdb_interface.h>
-GDB_INTERFACE;
-
 static void
 inner_main(void *closure, int argc, char **argv)
 {

--- a/Lib/guile/typemaps.i
+++ b/Lib/guile/typemaps.i
@@ -69,13 +69,13 @@
 %typemap(throws) SWIGTYPE {
   $&ltype temp = new $ltype($1);
   scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	    scm_listify(SWIG_NewPointerObj(temp, $&descriptor, 1),
+	    scm_list_n(SWIG_NewPointerObj(temp, $&descriptor, 1),
 		    SCM_UNDEFINED));
 }
 
 %typemap(throws) SWIGTYPE & {
   scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	    scm_listify(SWIG_NewPointerObj(&$1, $descriptor, 1),
+	    scm_list_n(SWIG_NewPointerObj(&$1, $descriptor, 1),
 		    SCM_UNDEFINED));
 }
 
@@ -87,13 +87,13 @@
 
 %typemap(throws) SWIGTYPE * {
   scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	    scm_listify(SWIG_NewPointerObj($1, $descriptor, 1),
+	    scm_list_n(SWIG_NewPointerObj($1, $descriptor, 1),
 		    SCM_UNDEFINED));
 }
 
 %typemap(throws) SWIGTYPE [] {
   scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	    scm_listify(SWIG_NewPointerObj($1, $descriptor, 1),
+	    scm_list_n(SWIG_NewPointerObj($1, $descriptor, 1),
 		    SCM_UNDEFINED));
 }
 
@@ -176,7 +176,7 @@
 %typemap(varout) enum SWIGTYPE  { $result = scm_from_long((int)$1); }
 %typemap(throws) enum SWIGTYPE {
   scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-     scm_listify(scm_from_long((int)$1), SCM_UNDEFINED));
+     scm_list_n(scm_from_long((int)$1), SCM_UNDEFINED));
 }
 
 /* The SIMPLE_MAP_WITH_EXPR macro below defines the whole set of
@@ -225,7 +225,7 @@
  %typemap(throws) C_NAME {
    C_NAME swig_c_value = $1;
    scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	     scm_listify(C_TO_SCM_EXPR, SCM_UNDEFINED));
+	     scm_list_n(C_TO_SCM_EXPR, SCM_UNDEFINED));
  }
 %enddef
 
@@ -269,7 +269,7 @@
  /* Throw typemap */
  %typemap(throws) C_NAME {
    scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	     scm_listify(C_TO_SCM($1), SCM_UNDEFINED));
+	     scm_list_n(C_TO_SCM($1), SCM_UNDEFINED));
  }
 %enddef
 
@@ -344,7 +344,7 @@ SIMPLE_MAP(unsigned long long, scm_to_ulong_long, scm_from_ulong_long, integer);
 
 %typemap(throws) char * {
   scm_throw(scm_from_locale_symbol((char *) "swig-exception"),
-	    scm_listify(SWIG_str02scm($1), SCM_UNDEFINED));
+	    scm_list_n(SWIG_str02scm($1), SCM_UNDEFINED));
 }
 
 /* Void */

--- a/configure.ac
+++ b/configure.ac
@@ -1704,13 +1704,20 @@ else
   fi
   if test -n "$GUILE_CONFIG" ; then
     if test x"$GUILE" = xyes; then
-      AC_MSG_CHECKING([for guile bindir])
-      guile_bindir="`$GUILE_CONFIG info bindir`"
-      AC_MSG_RESULT([$guile_bindir])
-      GUILE=$guile_bindir/guile
-      if ! test -f "$GUILE" ; then
-	GUILE=
-        AC_PATH_PROG(GUILE, guile)
+      AC_MSG_CHECKING([for guile executable])
+      if $GUILE_CONFIG info guile > /dev/null 2>&1; then
+        GUILE="`$GUILE_CONFIG info guile`"
+        AC_MSG_RESULT([$GUILE])
+      else
+        AC_MSG_RESULT([not in guile-config, constructing path])
+        AC_MSG_CHECKING([for guile bindir])
+        guile_bindir="`$GUILE_CONFIG info bindir`"
+        AC_MSG_RESULT([$guile_bindir])
+        GUILE=$guile_bindir/guile
+        if ! test -f "$GUILE" ; then
+          GUILE=
+          AC_PATH_PROG(GUILE, guile)
+        fi
       fi
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1705,19 +1705,20 @@ else
   if test -n "$GUILE_CONFIG" ; then
     if test x"$GUILE" = xyes; then
       AC_MSG_CHECKING([for guile executable])
-      if $GUILE_CONFIG info guile > /dev/null 2>&1; then
-        GUILE="`$GUILE_CONFIG info guile`"
+      # Try extracting it via guile-config first. If it's defined there it's the most reliable result
+      GUILE="`$GUILE_CONFIG info guile 2>/dev/null`"
+      if test -n "$GUILE";  then
         AC_MSG_RESULT([$GUILE])
       else
         AC_MSG_RESULT([not in guile-config, constructing path])
         AC_MSG_CHECKING([for guile bindir])
         guile_bindir="`$GUILE_CONFIG info bindir`"
         AC_MSG_RESULT([$guile_bindir])
-        GUILE=$guile_bindir/guile
-        if ! test -f "$GUILE" ; then
-          GUILE=
-          AC_PATH_PROG(GUILE, guile)
-        fi
+        GUILE="$guile_bindir/guile"
+      fi
+      if ! test -f "$GUILE" ; then
+        GUILE=
+        AC_PATH_PROG(GUILE, guile)
       fi
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1720,11 +1720,12 @@ else
         GUILE=
         AC_PATH_PROG(GUILE, guile)
       fi
+      if test -z "$GUILE" ; then
+        AC_MSG_WARN([no suitable guile executable found. Disabling Guile])
+      fi
     fi
 
-    if ! test -f "$GUILE" ; then
-      AC_MSG_WARN([no suitable guile executable found. Disabling Guile])
-    else
+    if test -n "$GUILE" ; then
       AC_MSG_CHECKING([for guile version])
       guile_version=`$GUILE -c '(display (effective-version))'`
       AC_MSG_RESULT([$guile_version])
@@ -1737,7 +1738,7 @@ else
       fi
     fi
 
-    if test -f "$GUILE" ; then
+    if test -n "$GUILE" ; then
       # Test if guile-config and guile versions match. They should.
       gc_version="`$GUILE_CONFIG --version 2>&1 | sed '1 s/.* //;q'`"
       g_version="`$GUILE --version | sed '1 s/.* //;q'`"
@@ -1747,7 +1748,7 @@ else
       fi
     fi
 
-    if test -f "$GUILE" ; then
+    if test -n "$GUILE" ; then
       if test -z "$GUILE_CFLAGS" ; then
         AC_MSG_CHECKING([for guile compile flags])
         GUILE_CFLAGS="`$GUILE_CONFIG compile`" # Note that this can sometimes be empty

--- a/configure.ac
+++ b/configure.ac
@@ -1710,7 +1710,7 @@ else
       if test -n "$GUILE";  then
         AC_MSG_RESULT([$GUILE])
       else
-        AC_MSG_RESULT([not in guile-config, constructing path])
+        AC_MSG_RESULT([not found via guile-config - constructing path])
         AC_MSG_CHECKING([for guile bindir])
         guile_bindir="`$GUILE_CONFIG info bindir`"
         AC_MSG_RESULT([$guile_bindir])
@@ -1722,7 +1722,9 @@ else
       fi
     fi
 
-    if test -f "$GUILE" ; then
+    if ! test -f "$GUILE" ; then
+      AC_MSG_WARN([no suitable guile executable found. Disabling Guile])
+    else
       AC_MSG_CHECKING([for guile version])
       guile_version=`$GUILE -c '(display (effective-version))'`
       AC_MSG_RESULT([$guile_version])
@@ -1730,20 +1732,33 @@ else
       guile_good_version=`$GUILE -c '(if (>= (string->number (effective-version)) 1.8) (display "yes") (display "no"))'`
       AC_MSG_RESULT([$guile_good_version])
       if test x"$guile_good_version" != xyes ; then
+        AC_MSG_WARN([at least guile version 1.8 is required. Disabling Guile])
         GUILE=
       fi
     fi
 
-    if test -z "$GUILE_CFLAGS" ; then
-      AC_MSG_CHECKING([for guile compile flags])
-      GUILE_CFLAGS="`$GUILE_CONFIG compile`" # Note that this can sometimes be empty
-      AC_MSG_RESULT([$GUILE_CFLAGS])
+    if test -f "$GUILE" ; then
+      # Test if guile-config and guile versions match. They should.
+      gc_version="`$GUILE_CONFIG --version 2>&1 | sed '1 s/.* //;q'`"
+      g_version="`$GUILE --version | sed '1 s/.* //;q'`"
+      if test "$gc_version" != "$g_version"; then
+        AC_MSG_WARN([different versions reported by $GUILE_CONFIG ($gc_version) and $GUILE ($g_version). Disabling Guile])
+        GUILE=
+      fi
     fi
 
-    if test -z "$GUILE_LIBS" ; then
-      AC_MSG_CHECKING([for guile link flags])
-      GUILE_LIBS="`$GUILE_CONFIG link`"
-      AC_MSG_RESULT([$GUILE_LIBS])
+    if test -f "$GUILE" ; then
+      if test -z "$GUILE_CFLAGS" ; then
+        AC_MSG_CHECKING([for guile compile flags])
+        GUILE_CFLAGS="`$GUILE_CONFIG compile`" # Note that this can sometimes be empty
+        AC_MSG_RESULT([$GUILE_CFLAGS])
+      fi
+
+      if test -z "$GUILE_LIBS" ; then
+        AC_MSG_CHECKING([for guile link flags])
+        GUILE_LIBS="`$GUILE_CONFIG link`"
+        AC_MSG_RESULT([$GUILE_LIBS])
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
There were a few issues with this. These commits should take care of it. The macOS test with guile (which is using guile 2.2) succeeds now.
Running the tests locally on my Fedora 27 system (also using guile 2.2) works as well.

Note this is probably not a complete removal of all deprecated symbols as discussed in issue #312. It's sufficient to pass the test suite and also to work for gnucash (my main project).

**Edit** I just checked in more detail and I believe this PR does fix all of the known uses of deprecated symbols.