### PR TITLE
Python container memory handling fix

### DIFF
--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -49,7 +49,7 @@ namespace swig {
     static PyObject* attr = SWIG_Python_str_FromChar("__owner");
     SwigPyObject* swigThis = SWIG_Python_GetSwigThis(child);
     if (swigThis && (swigThis->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
-      PyObject_GenericSetAttr(child, attr, owner);
+      PyObject_SetAttr(child, attr, owner);
       return true;
     }
     return false;

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -36,8 +36,17 @@
 
 %include <std_except.i>
 
-%fragment("reference_container_owner", "header") {
+%fragment("container_owner_attribute_init", "init") {
+  // thread safe initialization
+  swig::container_owner_attribute();
+}
+%fragment("reference_container_owner", "header", fragment="container_owner_attribute_init") {
 namespace swig {
+  PyObject* container_owner_attribute() {
+    static PyObject* attr = SWIG_Python_str_FromChar("__owner");
+    return attr;
+  }
+
   /**
    * Call to add a back-reference to the owning object when returning a 
    * reference from a container.  Will only set the reference if <code>child</code> 
@@ -46,10 +55,9 @@ namespace swig {
    * @return if the reference was set or not
    */
   bool reference_container_owner(PyObject* child, PyObject* owner) {
-    static PyObject* attr = SWIG_Python_str_FromChar("__owner");
     SwigPyObject* swigThis = SWIG_Python_GetSwigThis(child);
     if (swigThis && (swigThis->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
-      PyObject_SetAttr(child, attr, owner);
+      PyObject_SetAttr(child, container_owner_attribute(), owner);
       return true;
     }
     return false;

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -48,28 +48,32 @@ namespace swig {
     return attr;
   }
 
-  // By default, do not add the back-reference (for value types)
-  // Specialization below will check the reference for pointer types.
-  template <typename Type>
-  bool reference_container_owner(PyObject* child, PyObject* owner)
-  { return false; }
+  template <typename T>
+  struct container_owner {
+    // By default, do not add the back-reference (for value types)
+    // Specialization below will check the reference for pointer types.
+    static bool reference(PyObject* child, PyObject* owner)
+    { return false; }
+  };
 
-  /**
-   * Call to add a back-reference to the owning object when returning a 
-   * reference from a container.  Will only set the reference if <code>child</code> 
-   * is a SWIG wrapper object that does not own the pointer.
-   *
-   * @return if the reference was set or not
-   */
   template <>
-  bool reference_container_owner<swig::pointer_category>(PyObject* child, PyObject* owner) {
-    SwigPyObject* swigThis = SWIG_Python_GetSwigThis(child);
-    if (swigThis && (swigThis->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
-      PyObject_SetAttr(child, container_owner_attribute(), owner);
-      return true;
+  struct container_owner<swig::pointer_category> {  
+    /**
+     * Call to add a back-reference to the owning object when returning a 
+     * reference from a container.  Will only set the reference if <code>child</code> 
+     * is a SWIG wrapper object that does not own the pointer.
+     *
+     * @return if the reference was set or not
+     */
+    static bool reference(PyObject* child, PyObject* owner) {
+      SwigPyObject* swigThis = SWIG_Python_GetSwigThis(child);
+      if (swigThis && (swigThis->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
+        PyObject_SetAttr(child, container_owner_attribute(), owner);
+        return true;
+      }
+      return false;
     }
-    return false;
-  }
+  };
 }
 }
 
@@ -804,8 +808,8 @@ namespace swig
       return self->size();
     }
 
-    %typemap(ret, fragment="reference_container_owner") value_type& {
-      swig::reference_container_owner<swig::traits<$*1_ltype>::category>($result, $self);
+    %typemap(ret, fragment="reference_container_owner", noblock=1) value_type& {
+      (void)swig::container_owner<swig::traits<$*1_ltype>::category>::reference($result, $self);
     }
   }
 %enddef

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -36,6 +36,13 @@
 
 %include <std_except.i>
 
+%fragment("container_owner_attribute", "header") {
+  PyObject* container_owner_attribute() {
+    static PyObject* name = SWIG_Python_str_FromChar("__owner");
+    return name;
+  }
+}
+
 %fragment(SWIG_Traits_frag(swig::SwigPtr_PyObject),"header",fragment="StdTraits") {
 namespace swig {
   template <>  struct traits<SwigPtr_PyObject > {
@@ -765,6 +772,17 @@ namespace swig
 
     size_type __len__() const {
       return self->size();
+    }
+
+    %typemap(ret, fragment="container_owner_attribute") value_type& {
+      PyObject* swigThis = PyObject_GetAttrString($result, "this");
+      PyErr_Clear();
+      if (swigThis && SwigPyObject_Check(swigThis) && 
+          (reinterpret_cast<SwigPyObject*>(swigThis)->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
+        // try to store reference to parent
+        PyObject_GenericSetAttr($result, container_owner_attribute(), $self);
+      }
+      Py_XDECREF(swigThis);
     }
   }
 %enddef

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -36,11 +36,25 @@
 
 %include <std_except.i>
 
-%fragment("container_owner_attribute", "header") {
-  PyObject* container_owner_attribute() {
-    static PyObject* name = SWIG_Python_str_FromChar("__owner");
-    return name;
+%fragment("reference_container_owner", "header") {
+namespace swig {
+  /**
+   * Call to add a back-reference to the owning object when returning a 
+   * reference from a container.  Will only set the reference if <code>child</code> 
+   * is a SWIG wrapper object that does not own the pointer.
+   *
+   * @return if the reference was set or not
+   */
+  bool reference_container_owner(PyObject* child, PyObject* owner) {
+    static PyObject* attr = SWIG_Python_str_FromChar("__owner");
+    SwigPyObject* swigThis = SWIG_Python_GetSwigThis(child);
+    if (swigThis && (swigThis->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
+      PyObject_GenericSetAttr(child, attr, owner);
+      return true;
+    }
+    return false;
   }
+}
 }
 
 %fragment(SWIG_Traits_frag(swig::SwigPtr_PyObject),"header",fragment="StdTraits") {
@@ -774,15 +788,8 @@ namespace swig
       return self->size();
     }
 
-    %typemap(ret, fragment="container_owner_attribute") value_type& {
-      PyObject* swigThis = PyObject_GetAttrString($result, "this");
-      PyErr_Clear();
-      if (swigThis && SwigPyObject_Check(swigThis) && 
-          (reinterpret_cast<SwigPyObject*>(swigThis)->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
-        // try to store reference to parent
-        PyObject_GenericSetAttr($result, container_owner_attribute(), $self);
-      }
-      Py_XDECREF(swigThis);
+    %typemap(ret, fragment="reference_container_owner") value_type& {
+      swig::reference_container_owner($result, $self);
     }
   }
 %enddef

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -40,12 +40,19 @@
   // thread safe initialization
   swig::container_owner_attribute();
 }
+
 %fragment("reference_container_owner", "header", fragment="container_owner_attribute_init") {
 namespace swig {
   PyObject* container_owner_attribute() {
     static PyObject* attr = SWIG_Python_str_FromChar("__owner");
     return attr;
   }
+
+  // By default, do not add the back-reference (for value types)
+  // Specialization below will check the reference for pointer types.
+  template <typename Type>
+  bool reference_container_owner(PyObject* child, PyObject* owner)
+  { return false; }
 
   /**
    * Call to add a back-reference to the owning object when returning a 
@@ -54,7 +61,8 @@ namespace swig {
    *
    * @return if the reference was set or not
    */
-  bool reference_container_owner(PyObject* child, PyObject* owner) {
+  template <>
+  bool reference_container_owner<swig::pointer_category>(PyObject* child, PyObject* owner) {
     SwigPyObject* swigThis = SWIG_Python_GetSwigThis(child);
     if (swigThis && (swigThis->own & SWIG_POINTER_OWN) != SWIG_POINTER_OWN) {
       PyObject_SetAttr(child, container_owner_attribute(), owner);
@@ -797,7 +805,7 @@ namespace swig
     }
 
     %typemap(ret, fragment="reference_container_owner") value_type& {
-      swig::reference_container_owner($result, $self);
+      swig::reference_container_owner<swig::traits<$*1_ltype>::category>($result, $self);
     }
   }
 %enddef


### PR DESCRIPTION
Fixes Issue #945 

For Python container handling (std::vector and friends), prevent a use-after-free due to the index operator returning a reference.  Whenever we are returning a reference from the container (wrapped as an unowned-pointer in the default case), set an attribute pointing to the owning container so it won't be garbage collected while the script user holds the child element reference.  If the reference wrapper is pointer-owning or not a SWIG pointer wrapper then we assume a copy was made and do nothing.