### PR TITLE
[Java] Suppress deprecation warning on finalize method

### DIFF
--- a/Examples/test-suite/java_director.i
+++ b/Examples/test-suite/java_director.i
@@ -7,6 +7,7 @@
 %module(directors="1") java_director
 
 %typemap(javafinalize) SWIGTYPE %{
+  @SuppressWarnings("deprecation")
   protected void finalize() {
 //    System.out.println("Finalizing " + this);
     delete();

--- a/Examples/test-suite/java_throws.i
+++ b/Examples/test-suite/java_throws.i
@@ -192,6 +192,7 @@ try {
 
 // Need to handle the checked exception in NoExceptTest.delete()
 %typemap(javafinalize) SWIGTYPE %{
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     try {
       delete();

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1273,6 +1273,7 @@ SWIG_JAVABODY_PROXY(protected, protected, SWIGTYPE)
 SWIG_JAVABODY_TYPEWRAPPER(protected, protected, protected, SWIGTYPE)
 
 %typemap(javafinalize) SWIGTYPE %{
+  @SuppressWarnings("deprecation")
   protected void finalize() {
     delete();
   }


### PR DESCRIPTION
Java 9 deprecates the finalize method.
For now just suppress the deprecation warning.
Fixes #1237