### PR TITLE
Fixes #1225

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4632,8 +4632,8 @@ public:
 		   class_name);
 	  }
 	}
-	Printf(f_shadow_file, "%s_swigregister = %s.%s_swigregister\n", class_name, module, class_name);
-	Printf(f_shadow_file, "%s_swigregister(%s)\n", class_name, class_name);
+	Printf(f_shadow_file, "# Register %s in %s:\n", class_name, module);
+	Printf(f_shadow_file, "%s.%s_swigregister(%s)\n", module, class_name, class_name);
       }
 
       shadow_indent = 0;


### PR DESCRIPTION
Python wrapper does no longer contain PythonClass_swigregister methods that aree not intended for users. The _swigregister call uses the internal lib_wrap.cxx interface.