### PR TITLE
AddAccessor - string length bugs leading to uninitialised variables

### DIFF
--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1052,9 +1052,10 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     String *item = Getitem(el, j);
     String *dup = Getitem(el, j + 1);
     char *ptr = Char(dup);
-    ptr = &ptr[Len(dup) - 3];
+    int n = Len(dup);
+    ptr = &ptr[n - 3];
 
-    if (!strcmp(ptr, "get"))
+    if ((n > 3) && !strcmp(ptr, "get"))
       varaccessor++;
 
     if (Getattr(itemList, item))
@@ -1311,6 +1312,7 @@ int R::variableWrapper(Node *n) {
 void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
 		    int isSet) {
   if(isSet < 0) {
+    isSet = 0;
     int n = Len(name);
     char *ptr = Char(name);
     if (n>4) {

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1053,10 +1053,10 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     String *dup = Getitem(el, j + 1);
     int n = Len(dup);
 
-    if ((n > 3)) {
+    if ((n > 4)) {
       char *ptr = Char(dup);
-      ptr = &ptr[n - 3];
-      if (!strcmp(ptr, "get")) {
+      ptr = &ptr[n - 4];
+      if (!strcmp(ptr, "_get")) {
         varaccessor++;
       }
     }
@@ -1092,11 +1092,11 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
       String *item = Getitem(el, j);
       String *dup = Getitem(el, j + 1);
       int n = Len(dup);
-      if (n > 3) {
+      if (n > 4) {
         char *ptr = Char(dup);
-        ptr = &ptr[Len(dup) - 3];
+        ptr = &ptr[Len(dup) - 4];
 
-        if (!strcmp(ptr, "get")) {
+        if (!strcmp(ptr, "_get")) {
           Printf(f->code, "%s'%s'", first ? "" : ", ", item);
           first = 0;
         }

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1051,13 +1051,15 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   for(j = 0; j < numMems; j+=3) {
     String *item = Getitem(el, j);
     String *dup = Getitem(el, j + 1);
-    char *ptr = Char(dup);
     int n = Len(dup);
-    ptr = &ptr[n - 3];
 
-    if ((n > 3) && !strcmp(ptr, "get"))
-      varaccessor++;
-
+    if ((n > 3)) {
+      char *ptr = Char(dup);
+      ptr = &ptr[n - 3];
+      if (!strcmp(ptr, "get")) {
+        varaccessor++;
+      }
+    }
     if (Getattr(itemList, item))
       continue;
     Setattr(itemList, item, "1");
@@ -1089,12 +1091,15 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     for(j = 0; j < numMems; j+=3) {
       String *item = Getitem(el, j);
       String *dup = Getitem(el, j + 1);
-      char *ptr = Char(dup);
-      ptr = &ptr[Len(dup) - 3];
+      int n = Len(dup);
+      if (n > 3) {
+        char *ptr = Char(dup);
+        ptr = &ptr[Len(dup) - 3];
 
-      if (!strcmp(ptr, "get")) {
-	Printf(f->code, "%s'%s'", first ? "" : ", ", item);
-	first = 0;
+        if (!strcmp(ptr, "get")) {
+          Printf(f->code, "%s'%s'", first ? "" : ", ", item);
+          first = 0;
+        }
       }
     }
     Printf(f->code, ");\n");
@@ -1314,8 +1319,8 @@ void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
   if(isSet < 0) {
     isSet = 0;
     int n = Len(name);
-    char *ptr = Char(name);
     if (n>4) {
+      char *ptr = Char(name);
       isSet = Strcmp(NewString(&ptr[n-4]), "_set") == 0;
     }
   }


### PR DESCRIPTION
This pull request is for records and testing. I do not intend this PR to be included, 
as other refactoring will supersede it.

There is a problem processing methods with short names. The
test looks for a suffix, length 4, testing whether it matches
"_get". If the length of the name is less than 4, the test
isn't applied so "isSet" does not get correctly initialised
and remains set to -1. This leads to methods with short names
not being processed correctly. This fix initialises isSet to 0
prior to attempting the test.

A second problem is addressed, in which a pointer is set relative
to the end of string without checking length.

The following tests now have different R files, with previously
incorrect set-style methods being removed:

abstract_access.R
class_scope_namespace.R
clientdata_prop_a.R
clientdata_prop_b.R
director_basic.R
director_enum.R
director_property.R
inherit_void_arg.R
multiple_inheritance_interfaces.R
template_extend_overload_2.R
template_partial_specialization.R
template_partial_specialization_typedef.R
variable_replacement.R