### PR TITLE
R member list trial

### DIFF
--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -337,10 +337,13 @@ protected:
   int OutputMemberReferenceMethod(String *className, int isSet,  
                                   List *memberList, List *nameList,
                                   List *typeList, File *out);
+#if 0
+  // not used
   int OutputArrayMethod(String *className, List *el, File *out);
   int OutputClassMemberTable(Hash *tb, File *out);
   int OutputClassMethodsTable(File *out);
   int OutputClassAccessInfo(Hash *tb, File *out);
+#endif
 
   int defineArrayAccessors(SwigType *type);
 
@@ -946,12 +949,13 @@ int R::DumpCode(Node *n) {
   We may need to do more.... so this is left as a
   stub for the moment.
 */
+# if 0
+// not called
 int R::OutputClassAccessInfo(Hash *tb, File *out) {
   int n = OutputClassMemberTable(tb, out);
   OutputClassMethodsTable(out);
   return n;
 }
-
 /************************************************************************
   Currently this just writes the information collected about the
   different methods of the C++ classes that have been processed
@@ -1038,7 +1042,8 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
 
   return n;
 }
-
+// end not used
+#endif
 /*******************************************************************
  Write the methods for $ or $<- for accessing a member field in an
  struct or union (or class).
@@ -1180,6 +1185,8 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   return SWIG_OK;
 }
 
+#if 0
+// not used
 /*******************************************************************
  Write the methods for [ or [<- for accessing a member field in an
  struct or union (or class).
@@ -1218,6 +1225,7 @@ int R::OutputArrayMethod(String *className, List *el, File *out) {
   return SWIG_OK;
 }
 
+#endif
 
 /************************************************************
  Called when a enumeration is to be processed.


### PR DESCRIPTION
This a first pass at addressing issues with structure/class member access methods in the R module.

I'll summarise what I think is going on, and would appreciate extra eyes on the code. It ends up being moderately complicated. Complication could be isolated by splitting the various `class\_member\_function` lists into parts, rather than doing the work in `OutputMemberReferenceMethod`.

Some issues were pointed out in #1266, however that approach does not solve everything.

Here is a summary.

Structure and class variables need to be wrapped in functions to enable access from R. These automatically generate accessors have _set/_get suffixes. The current methods for generating class access code depends on this naming scheme to identify the automatically generate functions. This approach breaks when other methods exist that end in _set/_get, or when there is a method called set/get. The latter case occurs in several existing tests (see below). The set/get methods end up being misclassified because the wrapper name is constructed as classname_set, meaning the method gets identified as being an automatically generated wrapper.

Other modules utilise memberset/memberget flags attached to the parse tree. This is the best way of addressing the problem, I think, and what I've attempted in this patch.

It is best to compare the new R code produced by this patch to that produced by #1266, however some differences remain. They are due to errors in the current implementation, details below (alphabetical order). Typical problem is inclusion of the set method on the varaccessor list. This list is meant to be a list of autogenerated class variable accessors that require `$<-` and `[[<-` operators, and those corresponding operators. These bits of code shouldn't exist.

1. `abstract_typedef2.R`, ` default_args.R`, `director_classes.R`, `director_primitives.R` - method called _set_

1. `director_string.R` - method called _get_

1. `director_unroll.R`, `features.R` - methods called _set_ and _get_

1. `r_overload_comma.R` - methods ending with _\_get_

1. `template_basic.R` - methods called _set_ and _get_

1. `template_default_arg_overloaded.R - methods named _set_

1. `template_enum_typedef.R` - method named _get_

1. `template_explicit.R` - methods called _set_ and _get_

1. `template_inherit_abstract.R`, `virtual_poly.R`, `virtual_vs_nonvirtual_base.R` - method named _get_

