### PR TITLE
R member list trial simplify

### DIFF
--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1862,11 +1862,7 @@ int R::functionWrapper(Node *n) {
     /* Add the name of this member to a list for this class_name.
        We will dump all these at the end. */
 
-    int nlen = Len(iname);
-    char *ptr = Char(iname);
-    bool isSet(0);
-    if (nlen > 4) isSet = Strcmp(NewString(&ptr[nlen-4]), "_set") == 0;
-
+    bool isSet(GetFlag(n, "memberset"));
 
     String *tmp = NewString("");
     Printf(tmp, "%s_%s", class_name, isSet ? "set" : "get");

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1864,8 +1864,11 @@ int R::functionWrapper(Node *n) {
 
     bool isSet(GetFlag(n, "memberset"));
 
-    String *tmp = NewString("");
-    Printf(tmp, "%s_%s", class_name, isSet ? "set" : "get");
+    String *tmp = NewString(isSet ? Swig_name_set(NSPACE_TODO, class_name) : Swig_name_get(NSPACE_TODO, class_name));
+
+    if (debugMode) {
+      Printf(stdout, "functionWrapper TMP: %s\n", tmp);
+    }
 
     List *memList = Getattr(ClassMemberTable, tmp);
     if(!memList) {

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -337,10 +337,13 @@ protected:
   int OutputMemberReferenceMethod(String *className, int isSet,  
                                   List *memberList, List *nameList,
                                   List *typeList, File *out);
+#if 0
+  // not used
   int OutputArrayMethod(String *className, List *el, File *out);
   int OutputClassMemberTable(Hash *tb, File *out);
   int OutputClassMethodsTable(File *out);
   int OutputClassAccessInfo(Hash *tb, File *out);
+#endif
 
   int defineArrayAccessors(SwigType *type);
 
@@ -946,12 +949,13 @@ int R::DumpCode(Node *n) {
   We may need to do more.... so this is left as a
   stub for the moment.
 */
+# if 0
+// not called
 int R::OutputClassAccessInfo(Hash *tb, File *out) {
   int n = OutputClassMemberTable(tb, out);
   OutputClassMethodsTable(out);
   return n;
 }
-
 /************************************************************************
   Currently this just writes the information collected about the
   different methods of the C++ classes that have been processed
@@ -1038,7 +1042,8 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
 
   return n;
 }
-
+// end not used
+#endif
 /*******************************************************************
  Write the methods for $ or $<- for accessing a member field in an
  struct or union (or class).
@@ -1180,6 +1185,8 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   return SWIG_OK;
 }
 
+#if 0
+// not used
 /*******************************************************************
  Write the methods for [ or [<- for accessing a member field in an
  struct or union (or class).
@@ -1218,6 +1225,7 @@ int R::OutputArrayMethod(String *className, List *el, File *out) {
   return SWIG_OK;
 }
 
+#endif
 
 /************************************************************
  Called when a enumeration is to be processed.

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -816,6 +816,8 @@ int R::top(Node *n) {
     Swig_register_filebyname("snamespace", s_namespace);
     Printf(s_namespace, "useDynLib(%s)\n", DllName);
   }
+  // Register the naming functions
+  Swig_name_register("wrapper", "R_swig_%f");
 
   /* Associate the different streams with names so that they can be used in %insert directives by the
      typemap code. */
@@ -1866,10 +1868,6 @@ int R::functionWrapper(Node *n) {
 
     String *tmp = NewString(isSet ? Swig_name_set(NSPACE_TODO, class_name) : Swig_name_get(NSPACE_TODO, class_name));
 
-    if (debugMode) {
-      Printf(stdout, "functionWrapper TMP: %s\n", tmp);
-    }
-
     List *memList = Getattr(ClassMemberTable, tmp);
     if(!memList) {
       memList = NewList();
@@ -2897,9 +2895,6 @@ void R::main(int argc, char *argv[]) {
       Swig_file_debug_set();
     }
     /// copyToR copyToC functions.
-
-    // Register the naming functions
-    Swig_name_register("wrapper", "R_swig_%f");
 
   }
 }

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1882,7 +1882,7 @@ int R::functionWrapper(Node *n) {
   int nargs;
 
   String *wname = Swig_name_wrapper(iname);
-  Replace(wname, "_wrap", "R_swig", DOH_REPLACE_FIRST);
+
   if(overname)
     Append(wname, overname);
   Setattr(n,"wrap:name", wname);
@@ -2894,6 +2894,9 @@ void R::main(int argc, char *argv[]) {
       Swig_file_debug_set();
     }
     /// copyToR copyToC functions.
+
+    // Register the naming functions
+    Swig_name_register("wrapper", "R_swig_%f");
 
   }
 }

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -392,6 +392,10 @@ protected:
 
   static int getFunctionPointerNumArgs(Node *n, SwigType *tt);
 
+  // filtering of class member lists by function type. Used in constructing accessors
+  // are we allowed to use stl style functors to customise this?
+  List* filterMemberList(List *class_member_function_types, List *class_member_other, String *R_MEMBER, bool equal);
+
 protected:
   bool copyStruct;
   bool memoryProfile;
@@ -944,6 +948,30 @@ int R::DumpCode(Node *n) {
 }
 
 
+List *R::filterMemberList(List *class_member_types, 
+                          List *class_member_other, 
+                          String *R_MEMBER, bool equal) {
+  // filters class_member_other based on whether corresponding elements of
+  // class_member_function_types are equal or notequal to R_MEMBER
+  List *CM = NewList();
+  Iterator ftype, other;
+
+  for (ftype = First(class_member_types), other = First(class_member_other);
+       ftype.item; 
+       ftype=Next(ftype), other=Next(other)) {
+    // verbose, clean up later if the overall structure works
+    if (equal) {
+      if (ftype.item == R_MEMBER) {
+        Append(CM, other.item);
+      }
+    } else {
+      if (ftype.item != R_MEMBER) {
+        Append(CM, other.item);
+      }
+    }
+  }
+  return(CM);
+}
 
 /*
   We may need to do more.... so this is left as a
@@ -1078,15 +1106,7 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     String *dup = Getitem(nameList, j);
     String *setgetmethod = Getitem(typeList, j);
 
-    // skip this one if it isn't a set method but we're
-    // creating a modification method
-    if (isSet && (setgetmethod != R_MEMBER_SET))
-      continue;
-    // skip the set methods when creating accessor methods
-    if ((!isSet) && (setgetmethod == R_MEMBER_SET))
-      continue;
-
-    if ((!isSet) && (setgetmethod == R_MEMBER_GET))
+    if (setgetmethod == R_MEMBER_GET)
       varaccessor++;
 
     if (Getattr(itemList, item))
@@ -2491,18 +2511,36 @@ int R::classDeclaration(Node *n) {
     OutputMemberReferenceMethod(name, 1, class_member_set_functions, sfile);
 #else
   if (class_member_function_types) {
-    // count the number of set methods
-    unsigned setcount = 0;
-    Iterator ItType;
-    for (ItType = First(class_member_function_types) ; ItType.item; ItType = Next(ItType)) {
-      if (ItType.item == R_MEMBER_SET) ++setcount;
+
+    // collect the "set" methods
+    List *class_set_membernames   = filterMemberList(class_member_function_types, 
+                                                     class_member_function_membernames, R_MEMBER_SET, true);
+    List *class_set_functionnames = filterMemberList(class_member_function_types, 
+                                                     class_member_function_names, R_MEMBER_SET, true);
+    // this one isn't used - collecting to keep code simpler
+    List *class_set_functiontypes = filterMemberList(class_member_function_types, 
+                                                     class_member_function_types, R_MEMBER_SET, true);
+
+    // collect the others
+    List *class_other_membernames   = filterMemberList(class_member_function_types, 
+                                                       class_member_function_membernames, R_MEMBER_SET, false);
+    List *class_other_functionnames = filterMemberList(class_member_function_types, 
+                                                       class_member_function_names, R_MEMBER_SET, false);
+    List *class_other_functiontypes = filterMemberList(class_member_function_types, 
+                                                       class_member_function_types, R_MEMBER_SET, false);
+
+    if (Len(class_other_membernames) > 0) {
+      OutputMemberReferenceMethod(name, 0, class_other_membernames, class_other_functionnames, class_other_functiontypes, sfile);
     }
-    if (Len(class_member_function_types) - setcount > 0) {
-      OutputMemberReferenceMethod(name, 0, class_member_function_membernames, class_member_function_names, class_member_function_types, sfile);
+    if (Len(class_set_membernames) > 0) {
+      OutputMemberReferenceMethod(name, 1, class_set_membernames, class_set_functionnames, class_set_functiontypes, sfile);
     }
-    if (setcount > 0) {
-      OutputMemberReferenceMethod(name, 1, class_member_function_membernames, class_member_function_names, class_member_function_types, sfile);
-    }
+    Delete(class_set_membernames);
+    Delete(class_set_functionnames);
+    Delete(class_set_functiontypes);
+    Delete(class_other_membernames);
+    Delete(class_other_functionnames);
+    Delete(class_other_functiontypes);
  }
 #endif
   


### PR DESCRIPTION
This a first pass at addressing issues with structure/class member access methods in the R module.

This is an alternative version of #1267 - I've been explicit about breaking the lists into types before calling OutputMemberReferenceMethod, rather than doing everything inside. I think it is a bit clearer.