### PR TITLE
Add support for std::map<> comparator template argument for Java

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2018-06-09: vadz
+            [Java] Allow exporting std::map using non-default comparison function.
+
 2018-06-08: philippkraft
 	    [Python] Stop exposing <CLASS>_swigregister to Python.  It's not
 	    useful for user Python code to call this, and it just clutters the

--- a/Lib/java/std_map.i
+++ b/Lib/java/std_map.i
@@ -18,21 +18,21 @@
 
 namespace std {
 
-  template<class K, class T> class map {
+  template<class K, class T, class C = std::less<K> > class map {
     public:
       typedef size_t size_type;
       typedef ptrdiff_t difference_type;
       typedef K key_type;
       typedef T mapped_type;
       map();
-      map(const map<K,T> &);
+      map(const map<K,T,C> &);
 
       unsigned int size() const;
       bool empty() const;
       void clear();
       %extend {
         const T& get(const K& key) throw (std::out_of_range) {
-          std::map<K,T >::iterator i = self->find(key);
+          std::map<K,T,C >::iterator i = self->find(key);
           if (i != self->end())
             return i->second;
           else
@@ -42,14 +42,14 @@ namespace std {
           (*self)[key] = x;
         }
         void del(const K& key) throw (std::out_of_range) {
-          std::map<K,T >::iterator i = self->find(key);
+          std::map<K,T,C >::iterator i = self->find(key);
           if (i != self->end())
             self->erase(i);
           else
             throw std::out_of_range("key not found");
         }
         bool has_key(const K& key) {
-          std::map<K,T >::iterator i = self->find(key);
+          std::map<K,T,C >::iterator i = self->find(key);
           return i != self->end();
         }
       }


### PR DESCRIPTION
Allow exporting maps using non-default comparison function, similar to
what was done for C# back in 9efaf954c71118d41ba9bf43ed371bbe83093564