### PR TITLE
 Avoid function-local statics that call Python code to avoid deadlocks

### DIFF
--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -431,6 +431,11 @@ SWIG_init(void) {
     SwigPyBuiltin_AddPublicSymbol(public_interface, swig_const_table[i].name);
 #endif
 
+  SWIG_Py_None_global_Init();
+  SwigPyObject_type_global_Init();
+  SwigPyPacked_type_global_Init();
+  SWIG_Python_TypeCache_global_Init();
+
   SWIG_InstallConstants(d,swig_const_table);
 %}
 

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -259,6 +259,9 @@ _SWIG_Py_None(void)
   return none;
 }
 
+/* This used to be a function-local static variable, but accessing Python
+ * C API from inside a function-local static initializer can lead to deadlocks.
+ * https://github.com/swig/swig/issues/1275 */
 static PyObject *SWIG_Py_None_global = 0;
 
 SWIGRUNTIME void SWIG_Py_None_global_Init(void) {
@@ -506,6 +509,9 @@ SWIGRUNTIME void SwigPyObject_type_global_Init(void) {
   // Do nothing
 }
 #else
+/* This used to be a function-local static variable, but accessing Python
+ * C API from inside a function-local static initializer can lead to deadlocks.
+ * https://github.com/swig/swig/issues/1275 */
 static PyTypeObject *SwigPyObject_type_global = 0;
 
 SWIGRUNTIME void SwigPyObject_type_global_Init(void) {
@@ -859,6 +865,9 @@ SwigPyPacked_compare(SwigPyPacked *v, SwigPyPacked *w)
 
 SWIGRUNTIME PyTypeObject* SwigPyPacked_TypeOnce(void);
 
+/* This used to be a function-local static variable, but accessing Python
+ * C API from inside a function-local static initializer can lead to deadlocks.
+ * https://github.com/swig/swig/issues/1275 */
 static PyTypeObject* SwigPyPacked_type_global = 0;
 
 SWIGRUNTIME void SwigPyPacked_type_global_Init(void) {
@@ -1467,6 +1476,9 @@ SWIG_Python_SetModule(swig_module_info *swig_module) {
   }
 }
 
+/* This used to be a function-local static variable, but accessing Python
+ * C API from inside a function-local static initializer can lead to deadlocks.
+ * https://github.com/swig/swig/issues/1275 */
 static PyObject *SWIG_Python_TypeCache_global = 0;
 
 SWIGRUNTIME void SWIG_Python_TypeCache_global_Init(void) {

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -258,11 +258,24 @@ _SWIG_Py_None(void)
   Py_DECREF(none);
   return none;
 }
-SWIGRUNTIME PyObject * 
+
+static PyObject *SWIG_Py_None_global = 0;
+
+SWIGRUNTIME void SWIG_Py_None_global_Init(void) {
+  SWIG_Py_None_global = _SWIG_Py_None();
+}
+
+SWIGRUNTIME PyObject *
 SWIG_Py_None(void)
 {
-  static PyObject *SWIG_STATIC_POINTER(none) = _SWIG_Py_None();
-  return none;
+  assert(SWIG_Py_None_global);
+  return SWIG_Py_None_global;
+}
+
+#else
+SWIGRUNTIME void SWIG_Py_None_global_Init(void)
+{
+  // Do nothing
 }
 #endif
 
@@ -488,11 +501,21 @@ SwigPyObject_type(void) {
     assert(cd->pytype);
     return cd->pytype;
 }
+
+SWIGRUNTIME void SwigPyObject_type_global_Init(void) {
+  // Do nothing
+}
 #else
+static PyTypeObject *SwigPyObject_type_global = 0;
+
+SWIGRUNTIME void SwigPyObject_type_global_Init(void) {
+  SwigPyObject_type_global = SwigPyObject_TypeOnce();
+}
+
 SWIGRUNTIME PyTypeObject*
 SwigPyObject_type(void) {
-  static PyTypeObject *SWIG_STATIC_POINTER(type) = SwigPyObject_TypeOnce();
-  return type;
+  assert(SwigPyObject_type_global);
+  return SwigPyObject_type_global;
 }
 #endif
 
@@ -836,10 +859,16 @@ SwigPyPacked_compare(SwigPyPacked *v, SwigPyPacked *w)
 
 SWIGRUNTIME PyTypeObject* SwigPyPacked_TypeOnce(void);
 
+static PyTypeObject* SwigPyPacked_type_global = 0;
+
+SWIGRUNTIME void SwigPyPacked_type_global_Init(void) {
+  SwigPyPacked_type_global = SwigPyPacked_TypeOnce();
+}
+
 SWIGRUNTIME PyTypeObject*
 SwigPyPacked_type(void) {
-  static PyTypeObject *SWIG_STATIC_POINTER(type) = SwigPyPacked_TypeOnce();
-  return type;
+  assert(SwigPyPacked_type_global);
+  return SwigPyPacked_type_global;
 }
 
 SWIGRUNTIMEINLINE int
@@ -1438,11 +1467,17 @@ SWIG_Python_SetModule(swig_module_info *swig_module) {
   }
 }
 
+static PyObject *SWIG_Python_TypeCache_global = 0;
+
+SWIGRUNTIME void SWIG_Python_TypeCache_global_Init(void) {
+  SWIG_Python_TypeCache_global = PyDict_New();
+}
+
 /* The python cached type query */
 SWIGRUNTIME PyObject *
 SWIG_Python_TypeCache(void) {
-  static PyObject *SWIG_STATIC_POINTER(cache) = PyDict_New();
-  return cache;
+  assert(SWIG_Python_TypeCache_global);
+  return SWIG_Python_TypeCache_global;
 }
 
 SWIGRUNTIME swig_type_info *


### PR DESCRIPTION
This fixes #1275 , more specifically the following:

https://github.com/swig/swig/blob/master/Lib/python/pyrun.swg#L494 has a function-local static, so first time control passes through it a lock to be held by C++ during the execution of SwigPyObject_TypeOnce() which includes Python C API calls that ultimate allocate memory via the Python allocator and thus can trigger Python GC run. A Python GC run can cause a GIL release while doing destruction of some objects which can in turn switch to a new thread which then calls into a SWIG wrapper hitting the exact same static SwigPyObject_TypeOnce() locked call leading to a deadlock.

Reproducing this deadlock in a small testcase is not simple as we need to make sure garbage collection triggers exactly during the first creation of an object in a certain SWIG module, and that another thread interrupts said garbage collection.