### PR TITLE
Make python shadow sub-modules runnable

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -855,7 +855,7 @@ public:
        */
       Printv(default_import_code, "def swig_import_helper():\n", NULL);
       Printv(default_import_code, tab4, "import importlib\n", NULL);
-      Printv(default_import_code, tab4, "pkg = __name__.rpartition('.')[0]\n", NULL);
+      Printv(default_import_code, tab4, "pkg = __package__ if __package__ else __name__.rpartition('.')[0]\n", NULL);
       Printf(default_import_code, tab4 "mname = '.'.join((pkg, '%s')).lstrip('.')\n", module);
       Printv(default_import_code, tab4, "try:\n", NULL);
       Printv(default_import_code, tab8, "return importlib.import_module(mname)\n", NULL);


### PR DESCRIPTION
Python modules can be run as main from the command line with the -c flag
Currently this does not work as the python wrapper module does not correctly import the extension module. This commit makes the generated code consistent with PEP 366.