### PR TITLE
Fix garbage collection for guile >= 2.0.12

### DIFF
--- a/Examples/test-suite/schemerunme/reference_global_vars.scm
+++ b/Examples/test-suite/schemerunme/reference_global_vars.scm
@@ -56,4 +56,12 @@
 (if (!= (TestClass-num-get (value-TestClass (var-TestClass))) 20)
   (begin (display "Runtime test 13 failed.\n") (exit 1)))
 
+; Test garbage collection on guile >= 2.0.12
+(if (or (and (string=? (major-version) "2")
+             (string=? (minor-version) "0")
+             (string>=? (micro-version) "12"))
+        (and (string>=? (major-version) "2")
+             (string>=? (minor-version) "1")))
+    (gc))
+
 (exit 0)

--- a/Lib/guile/guile_scm_run.swg
+++ b/Lib/guile/guile_scm_run.swg
@@ -99,6 +99,7 @@ SWIG_Guile_scm2newstr(SCM str, size_t *len) {
 static int swig_initialized = 0;
 static scm_t_bits swig_tag = 0;
 static scm_t_bits swig_collectable_tag = 0;
+static scm_t_bits swig_finalized_tag = 0;
 static scm_t_bits swig_destroyed_tag = 0;
 static scm_t_bits swig_member_function_tag = 0;
 static SCM swig_make_func = SCM_EOL;
@@ -163,7 +164,19 @@ SWIG_Guile_PointerType(SCM object)
   }
   else scm_wrong_type_arg("SWIG-Guile-PointerType", 1, object);
 }
-  
+
+SWIGINTERN int
+SWIG_Guile_IsValidSmob(SCM smob)
+{
+  /* We do not accept smobs representing destroyed pointers, but we have to
+     allow finalized smobs because Guile >= 2.0.12 sets all smob instances
+     to the 'finalized' type before calling their 'free' function. This change
+     was introduced to Guile in commit 8dff3af087c6eaa83ae0d72aa8b22aef5c65d65d */
+  return SCM_SMOB_PREDICATE(swig_tag, smob)
+    || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)
+    || SCM_SMOB_PREDICATE(swig_finalized_tag, smob);
+}
+
 SWIGINTERN int
 SWIG_Guile_ConvertPtr(SCM s, void **result, swig_type_info *type, int flags)
 {
@@ -179,8 +192,7 @@ SWIG_Guile_ConvertPtr(SCM s, void **result, swig_type_info *type, int flags)
     *result = SCM_POINTER_VALUE(s);
     return SWIG_OK;
 #endif /* if SCM_MAJOR_VERSION >= 2 */
-  } else if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {
-    /* we do not accept smobs representing destroyed pointers */
+  } else if (SWIG_Guile_IsValidSmob(smob)) {
     from = (swig_type_info *) SCM_CELL_WORD_2(smob);
     if (!from) return SWIG_ERROR;
     if (type) {
@@ -239,7 +251,7 @@ SWIG_Guile_MarkPointerNoncollectable(SCM s)
 {
   SCM smob = SWIG_Guile_GetSmob(s);
   if (!SCM_NULLP(smob)) {
-    if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {
+    if (SWIG_Guile_IsValidSmob(smob)) {
       SCM_SET_CELL_TYPE(smob, swig_tag);
     }
     else scm_wrong_type_arg(NULL, 0, s);
@@ -252,7 +264,7 @@ SWIG_Guile_MarkPointerDestroyed(SCM s)
 {
   SCM smob = SWIG_Guile_GetSmob(s);
   if (!SCM_NULLP(smob)) {
-    if (SCM_SMOB_PREDICATE(swig_tag, smob) || SCM_SMOB_PREDICATE(swig_collectable_tag, smob)) {
+    if (SWIG_Guile_IsValidSmob(smob)) {
       SCM_SET_CELL_TYPE(smob, swig_destroyed_tag);
     }
     else scm_wrong_type_arg(NULL, 0, s);
@@ -419,6 +431,8 @@ SWIG_Guile_Init ()
     scm_set_smob_print(swig_collectable_tag, print_collectable_swig);
     scm_set_smob_equalp(swig_collectable_tag, equalp_swig);
     scm_set_smob_free(swig_collectable_tag, free_swig);
+    /* For Guile >= 2.0.12. See libguile/smob.c:clear_smobnum */
+    swig_finalized_tag = swig_collectable_tag & ~0xff00;
   }
   if (ensure_smob_tag(swig_module, &swig_destroyed_tag,
 		      "destroyed-swig-pointer", "destroyed-swig-pointer-tag")) {


### PR DESCRIPTION
## The Problem
This [thread](https://lists.gnu.org/archive/html/guile-devel/2016-10/msg00012.html) discusses a change introduced to Guile 2.0.12 that changes the type of every smob to "finalized" just before calling its `free` function.

The `_wrap_delete_*` methods that SWIG generates call `SWIG_Guile_MustGetPtr` and `SWIG_Guile_MarkPointerDestroyed`, both of which end up calling `SWIG_Guile_ConvertPtr`. The issue is that `SWIG_Guile_ConvertPtr` expects an object of type `swig_tag` or `swig_collectable_tag`, but it gets a "finalized" smob instead.

## The Solution
This PR adds `SWIG_Guile_IsValidSmob`, which considers a "finalized" smob valid for the purposes of getting and marking pointers.  `swig_finalized_tag` is created the same way it's done in Guile, in `libguile/smob.c:clear_smobnum`. 

## Reproducer
Using Guile >= 2.0.12, add a call to the garbage collector at the end of `Examples/test-suite/schemerunme/reference_global_vars.scm` before the script exits:
```scheme
;class reference
(var-TestClass (createref-TestClass (new-TestClass 20)))
(if (!= (TestClass-num-get (value-TestClass (var-TestClass))) 20)
  (begin (display "Runtime test 13 failed.\n") (exit 1)))

(gc)

(exit 0)
```
and run
```bash
cd Examples/test-suite/guile && make reference_global_vars.cpptest
```
The test will report:
```
Backtrace:
           1 (primitive-load "/root/swig/Examples/test-suite/guile/.?")
           0 (gc)

ERROR: In procedure gc:
ERROR: In procedure delete-TestClass: Wrong type argument in position 1: #<finalized smob 20ee680>
make: *** [reference_global_vars.cpptest] Error 1
```
With the changes in this PR, the test completes without error.