### PR TITLE
Fix performance when calling C# virtual methods.

### DIFF
--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -1537,6 +1537,7 @@ public class Base : global::System.IDisposable {
   internal Base(global::System.IntPtr cPtr, bool cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    SwigDirectorSetup();
   }
 
   internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Base obj) {
@@ -1559,12 +1560,15 @@ public class Base : global::System.IDisposable {
   }
 
   public virtual uint UIntMethod(uint x) {
-    uint ret = examplePINVOKE.Base_UIntMethod(swigCPtr, x);
+    uint ret = (swigMethodOverriden0 ? examplePINVOKE.Base_UIntMethodSwigExplicitBar(swigCPtr, x) : examplePINVOKE.Base_UIntMethod(swigCPtr, x));
     return ret;
   }
 
   public virtual void BaseBoolMethod(Base b, bool flag) {
-    examplePINVOKE.Base_BaseBoolMethod(swigCPtr, Base.getCPtr(b), flag);
+    if (swigMethodOverriden1)
+      examplePINVOKE.Base_BaseBoolMethodSwigExplicitBar(swigCPtr, Base.getCPtr(b), flag);
+    else
+      examplePINVOKE.Base_BaseBoolMethod(swigCPtr, Base.getCPtr(b), flag);
     if (examplePINVOKE.SWIGPendingException.Pending)
       throw examplePINVOKE.SWIGPendingException.Retrieve();
   }
@@ -1573,18 +1577,19 @@ public class Base : global::System.IDisposable {
     SwigDirectorConnect();
   }
 
-  private void SwigDirectorConnect() {
-    if (SwigDerivedClassHasMethod("UIntMethod", swigMethodTypes0))
-      swigDelegate0 = new SwigDelegateBase_0(SwigDirectorUIntMethod);
-    if (SwigDerivedClassHasMethod("BaseBoolMethod", swigMethodTypes1))
-      swigDelegate1 = new SwigDelegateBase_1(SwigDirectorBaseBoolMethod);
-    examplePINVOKE.Base_director_connect(swigCPtr, swigDelegate0, swigDelegate1);
+  private void SwigDirectorSetup() {
+    var classType = typeof(Base);
+    swigMethodOverriden0 = examplePINVOKE.SwigDerivedClassHasMethod(this, "UIntMethod", classType, swigMethodTypes0);
+    swigMethodOverriden1 = examplePINVOKE.SwigDerivedClassHasMethod(this, "BaseBoolMethod", classType, swigMethodTypes1);
   }
 
-  private bool SwigDerivedClassHasMethod(string methodName, global::System.global::System.Type[] methodTypes) {
-    System.Reflection.MethodInfo methodInfo = this.GetType().GetMethod(methodName, methodTypes);
-    bool hasDerivedMethod = methodInfo.DeclaringType.IsSubclassOf(typeof(Base));
-    return hasDerivedMethod;
+  private void SwigDirectorConnect() {
+    SwigDirectorSetup();
+    if (swigMethodOverriden0)
+      swigDelegate0 = new SwigDelegateBase_0(SwigDirectorUIntMethod);
+    if (swigMethodOverriden1)
+      swigDelegate1 = new SwigDelegateBase_1(SwigDirectorBaseBoolMethod);
+    examplePINVOKE.Base_director_connect(swigCPtr, swigDelegate0, swigDelegate1);
   }
 
   private uint SwigDirectorUIntMethod(uint x) {
@@ -1603,6 +1608,9 @@ public class Base : global::System.IDisposable {
 
   private static global::System.Type[] swigMethodTypes0 = new global::System.Type[] { typeof(uint) };
   private static global::System.Type[] swigMethodTypes1 = new global::System.Type[] { typeof(Base), typeof(bool) };
+
+  private bool swigMethodOverriden0;
+  private bool swigMethodOverriden1;
 }
 </pre>
 </div>

--- a/Examples/test-suite/director_basic.i
+++ b/Examples/test-suite/director_basic.i
@@ -121,6 +121,10 @@ public:
   static Bar * call_pmethod(MyClass *myclass, Bar *b) {
     return myclass->pmethod(b);
   }
+
+   // Collisions with generated method names
+   virtual void Connect() { }
+   virtual void Setup() { }
 };
 
 template<class T>

--- a/Lib/csharp/boost_intrusive_ptr.i
+++ b/Lib/csharp/boost_intrusive_ptr.i
@@ -285,13 +285,13 @@
   }
 
 // Base proxy classes
-%typemap(csbody) TYPE %{
+%typemap(csbody, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnBase;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) {
     swigCMemOwnBase = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
@@ -300,13 +300,13 @@
 %}
 
 // Derived proxy classes
-%typemap(csbody_derived) TYPE %{
+%typemap(csbody_derived, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnDerived;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) : base($imclassname.$csclazznameSWIGSmartPtrUpcast(cPtr), true) {
     swigCMemOwnDerived = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
@@ -444,13 +444,13 @@
   }
 
 // Base proxy classes
-%typemap(csbody) TYPE %{
+%typemap(csbody, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnBase;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) {
     swigCMemOwnBase = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
@@ -459,13 +459,13 @@
 %}
 
 // Derived proxy classes
-%typemap(csbody_derived) TYPE %{
+%typemap(csbody_derived, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnDerived;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) : base($imclassname.$csclazznameSWIGSmartPtrUpcast(cPtr), true) {
     swigCMemOwnDerived = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {

--- a/Lib/csharp/boost_shared_ptr.i
+++ b/Lib/csharp/boost_shared_ptr.i
@@ -253,7 +253,7 @@
 
 
 // Proxy classes (base classes, ie, not derived classes)
-%typemap(csbody, directorsetup="\n    SwigDirectorSetup();") TYPE %{
+%typemap(csbody, directorsetup="\n    SetupSwigDirector();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnBase;
 
@@ -268,7 +268,7 @@
 %}
 
 // Derived proxy classes
-%typemap(csbody_derived, directorsetup="\n    SwigDirectorSetup();") TYPE %{
+%typemap(csbody_derived, directorsetup="\n    SetupSwigDirector();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnDerived;
 

--- a/Lib/csharp/boost_shared_ptr.i
+++ b/Lib/csharp/boost_shared_ptr.i
@@ -253,13 +253,13 @@
 
 
 // Proxy classes (base classes, ie, not derived classes)
-%typemap(csbody) TYPE %{
+%typemap(csbody, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnBase;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) {
     swigCMemOwnBase = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
@@ -268,13 +268,13 @@
 %}
 
 // Derived proxy classes
-%typemap(csbody_derived) TYPE %{
+%typemap(csbody_derived, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   private bool swigCMemOwnDerived;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) : base($imclassname.$csclazznameSWIGSmartPtrUpcast(cPtr), true) {
     swigCMemOwnDerived = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {

--- a/Lib/csharp/csharp.swg
+++ b/Lib/csharp/csharp.swg
@@ -891,13 +891,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 
 %define SWIG_CSBODY_PROXY(PTRCTOR_VISIBILITY, CPTR_VISIBILITY, TYPE...)
 // Proxy classes (base classes, ie, not derived classes)
-%typemap(csbody) TYPE %{
+%typemap(csbody, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   protected bool swigCMemOwn;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
@@ -906,11 +906,11 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %}
 
 // Derived proxy classes
-%typemap(csbody_derived) TYPE %{
+%typemap(csbody_derived, directorsetup="\n    SwigDirectorSetup();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) : base($imclassname.$csclazznameSWIGUpcast(cPtr), cMemoryOwn) {
-    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);$directorsetup
   }
 
   CPTR_VISIBILITY static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
@@ -921,7 +921,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 
 %define SWIG_CSBODY_TYPEWRAPPER(PTRCTOR_VISIBILITY, DEFAULTCTOR_VISIBILITY, CPTR_VISIBILITY, TYPE...)
 // Typewrapper classes
-%typemap(csbody) TYPE *, TYPE &, TYPE &&, TYPE [] %{
+%typemap(csbody, directorsetup="") TYPE *, TYPE &, TYPE &&, TYPE [] %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool futureUse) {
@@ -937,7 +937,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
   }
 %}
 
-%typemap(csbody) TYPE (CLASS::*) %{
+%typemap(csbody, directorsetup="") TYPE (CLASS::*) %{
   private string swigCMemberPtr;
 
   PTRCTOR_VISIBILITY $csclassname(string cMemberPtr, bool futureUse) {

--- a/Lib/csharp/csharp.swg
+++ b/Lib/csharp/csharp.swg
@@ -891,7 +891,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 
 %define SWIG_CSBODY_PROXY(PTRCTOR_VISIBILITY, CPTR_VISIBILITY, TYPE...)
 // Proxy classes (base classes, ie, not derived classes)
-%typemap(csbody, directorsetup="\n    SwigDirectorSetup();") TYPE %{
+%typemap(csbody, directorsetup="\n    SetupSwigDirector();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   protected bool swigCMemOwn;
 
@@ -906,7 +906,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %}
 
 // Derived proxy classes
-%typemap(csbody_derived, directorsetup="\n    SwigDirectorSetup();") TYPE %{
+%typemap(csbody_derived, directorsetup="\n    SetupSwigDirector();") TYPE %{
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
   PTRCTOR_VISIBILITY $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) : base($imclassname.$csclazznameSWIGUpcast(cPtr), cMemoryOwn) {
@@ -965,7 +965,7 @@ SWIG_CSBODY_TYPEWRAPPER(internal, protected, internal, SWIGTYPE)
   }
 %}
 
-%typemap(csconstruct, excode=SWIGEXCODE,directorconnect="\n    SwigDirectorConnect();") SWIGTYPE %{: this($imcall, true) {$excode$directorconnect
+%typemap(csconstruct, excode=SWIGEXCODE,directorconnect="\n    ConnectSwigDirector();") SWIGTYPE %{: this($imcall, true) {$excode$directorconnect
   }
 %}
 

--- a/Lib/csharp/csharphead.swg
+++ b/Lib/csharp/csharphead.swg
@@ -332,3 +332,32 @@ SWIGEXPORT void SWIGSTDCALL SWIGRegisterStringCallback_$module(SWIG_CSharpString
 
 #define SWIG_contract_assert(nullreturn, expr, msg) if (!(expr)) {SWIG_CSharpSetPendingExceptionArgument(SWIG_CSharpArgumentOutOfRangeException, msg, ""); return nullreturn; } else
 %}
+
+%pragma(csharp) imclasscode=%{
+    internal static bool SwigDerivedClassHasMethod(object instance, string methodName, global::System.Type classType, global::System.Type[] methodTypes) {
+      global::System.Reflection.MethodInfo methodInfo = instance.GetType().GetMethod(
+          methodName, global::System.Reflection.BindingFlags.Public |
+                      global::System.Reflection.BindingFlags.NonPublic |
+                      global::System.Reflection.BindingFlags.Instance, null, methodTypes, null);
+      bool hasDerivedMethod = methodInfo.IsVirtual && !methodInfo.IsAbstract &&
+                              methodInfo.DeclaringType.IsSubclassOf(classType) &&
+                              methodInfo.DeclaringType != methodInfo.GetBaseDefinition().DeclaringType;
+      /* Could add this code to cover corner case where the GetMethod() returns a method which allows type
+       * promotion, eg it will return foo(double), if looking for foo(int).
+       if (hasDerivedMethod) {
+         hasDerivedMethod = false;
+         if (methodInfo != null) {
+           hasDerivedMethod = true;
+           ParameterInfo[] parameterArray1 = methodInfo.GetParameters();
+           for (int i=0; i<methodTypes.Length; i++) {
+             if (parameterArray1[0].ParameterType != methodTypes[0]) {
+               hasDerivedMethod = false;
+               break;
+             }
+           }
+         }
+       }
+       */
+      return hasDerivedMethod;
+    }
+%}

--- a/Lib/csharp/enums.swg
+++ b/Lib/csharp/enums.swg
@@ -80,7 +80,7 @@
 %typemap(csimports)        enum SWIGTYPE ""
 %typemap(csinterfaces)     enum SWIGTYPE ""
 
-%typemap(csbody) enum SWIGTYPE ""
+%typemap(csbody, directorsetup="") enum SWIGTYPE ""
 
 %csenum(proper);
 

--- a/Lib/csharp/enumsimple.swg
+++ b/Lib/csharp/enumsimple.swg
@@ -82,7 +82,7 @@
 %typemap(csimports)        enum SWIGTYPE ""
 %typemap(csinterfaces)     enum SWIGTYPE ""
 
-%typemap(csbody) enum SWIGTYPE ""
+%typemap(csbody, directorsetup="") enum SWIGTYPE ""
 
 %csenum(simple);
 

--- a/Lib/csharp/enumtypesafe.swg
+++ b/Lib/csharp/enumtypesafe.swg
@@ -88,7 +88,7 @@
  * written to possibly optimise this lookup by taking advantage of characteristics peculiar to the targeted enum.
  * The special variable, $enumvalues, is replaced with a comma separated list of all the enum values.
  */
-%typemap(csbody) enum SWIGTYPE %{
+%typemap(csbody, directorsetup="") enum SWIGTYPE %{
   public readonly int swigValue;
 
   public static $csclassname swigToEnum(int swigValue) {

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1948,12 +1948,12 @@ public:
     if (feature_director) {
       // Generate director connect method
       // put this in classDirectorEnd ???
-      Printf(proxy_class_code, "  private void SwigDirectorSetup() {\n");
+      Printf(proxy_class_code, "  private void SetupSwigDirector() {\n");
       Printf(proxy_class_code, "    var classType = typeof(%s);\n", proxy_class_name);
       Printv(proxy_class_code, director_override_status_init, NIL);
       Printf(proxy_class_code, "  }\n\n");
-      Printf(proxy_class_code, "  private void SwigDirectorConnect() {\n");
-      Printf(proxy_class_code, "    SwigDirectorSetup();\n");
+      Printf(proxy_class_code, "  private void ConnectSwigDirector() {\n");
+      Printf(proxy_class_code, "    SetupSwigDirector();\n");
 
       int i;
       for (i = first_class_dmethod; i < curr_class_dmethod; ++i) {


### PR DESCRIPTION
Previous implementation used reflection check on every call to a virtual method to verify if it was overridden by a subclass. While this works it is also pretty slow and accumulates fast. This check was replaced by checking if delegate associated with the virtual call is not null. This delegate is set only when subclass overrides a virtual method in question. Behaviour of generated code does not change. There still is a case where base class calling overridden virtual method would call C++ method instead of overriding C# method because call happens before SwigDirectorConnect() is called. This happens already and i do not think there is anything we can or should do. C# advices against calling virtuals from constructors anyway.

P.S. Swig codebase is full of mixed tabs and spaces which breaks code alignment if tab width if anything else than 4 spaces. Would you like a PR fixing that?

Edit:
~~Apparently my initial commit broke director_constructor test. This probably was related to condition mentioned above. So i re-added old check back and added delegate null check before it. This gives us a fast exit when virtual method is overridden. It is still slow if method is not overriden because metadata check will still happen. I am not entirely happy with it. Do you think adding `bool directorsInitialized` and do fast nullcheck when set to true while doing show metadata check otherwise is an acceptable solution?~~