### PR TITLE
Fix name collision with `SwigDirectorConnect()`

### DIFF
--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -1575,9 +1575,9 @@ public class Base : global::System.IDisposable {
 
   private void SwigDirectorConnect() {
     if (SwigDerivedClassHasMethod("UIntMethod", swigMethodTypes0))
-      swigDelegate0 = new SwigDelegateBase_0(SwigDirectorUIntMethod);
+      swigDelegate0 = new SwigDelegateBase_0(SwigDirectorMethodUIntMethod);
     if (SwigDerivedClassHasMethod("BaseBoolMethod", swigMethodTypes1))
-      swigDelegate1 = new SwigDelegateBase_1(SwigDirectorBaseBoolMethod);
+      swigDelegate1 = new SwigDelegateBase_1(SwigDirectorMethodBaseBoolMethod);
     examplePINVOKE.Base_director_connect(swigCPtr, swigDelegate0, swigDelegate1);
   }
 
@@ -1587,11 +1587,11 @@ public class Base : global::System.IDisposable {
     return hasDerivedMethod;
   }
 
-  private uint SwigDirectorUIntMethod(uint x) {
+  private uint SwigDirectorMethodUIntMethod(uint x) {
     return UIntMethod(x);
   }
 
-  private void SwigDirectorBaseBoolMethod(global::System.IntPtr b, bool flag) {
+  private void SwigDirectorMethodBaseBoolMethod(global::System.IntPtr b, bool flag) {
     BaseBoolMethod(new Base(b, false), flag);
   }
 
@@ -1620,9 +1620,9 @@ It uses a support method, <tt>SwigDerivedClassHasMethod()</tt>, which simply use
 BaseBoolMethod, with the list of required parameter types, exists in a subclass.
 If it does not exist, the delegate is not initialised as there is no need for unmanaged code to call back into managed C# code.
 However, if there is an overridden method in any subclass, the delegate is required. 
-It is then initialised to the <tt>SwigDirectorBaseBoolMethod</tt> which in turn will call <tt>BaseBoolMethod</tt> if invoked.
+It is then initialised to the <tt>SwigDirectorMethodBaseBoolMethod</tt> which in turn will call <tt>BaseBoolMethod</tt> if invoked.
 The delegate is not initialised to the <tt>BaseBoolMethod</tt> directly as quite often types will need marshalling from the unmanaged type
-to the managed type in which case an intermediary method (<tt>SwigDirectorBaseBoolMethod</tt>) is required for the marshalling.
+to the managed type in which case an intermediary method (<tt>SwigDirectorMethodBaseBoolMethod</tt>) is required for the marshalling.
 In this case, the C# <tt>Base</tt> class needs to be created from the unmanaged <tt>IntPtr</tt> type.
 </p>
 
@@ -2497,7 +2497,7 @@ The generated proxy class code will then contain the following wrapper for calli
 
 <div class="code"><pre>
 ...
-  private void SwigDirectorsomeCallback(global::System.IntPtr date) {
+  private void SwigDirectorMethodsomeCallback(global::System.IntPtr date) {
     System.DateTime tempdate = new System.DateTime();
     try {
       someCallback(out tempdate);

--- a/Examples/test-suite/director_basic.i
+++ b/Examples/test-suite/director_basic.i
@@ -121,6 +121,9 @@ public:
   static Bar * call_pmethod(MyClass *myclass, Bar *b) {
     return myclass->pmethod(b);
   }
+
+   // Collisions with generated method names
+   virtual void Connect() { }
 };
 
 template<class T>

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1935,7 +1935,7 @@ public:
 	String *methid = Getattr(udata, "class_methodidx");
 	String *overname = Getattr(udata, "overname");
 	Printf(proxy_class_code, "    if (SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s))\n", method, methid);
-	Printf(proxy_class_code, "      swigDelegate%s = new SwigDelegate%s_%s(SwigDirector%s);\n", methid, proxy_class_name, methid, overname);
+	Printf(proxy_class_code, "      swigDelegate%s = new SwigDelegate%s_%s(SwigDirectorMethod%s);\n", methid, proxy_class_name, methid, overname);
       }
       String *director_connect_method_name = Swig_name_member(getNSpace(), getClassPrefix(), "director_connect");
       Printf(proxy_class_code, "    %s.%s(swigCPtr", imclass_name, director_connect_method_name);
@@ -3864,7 +3864,7 @@ public:
 	  Printf(director_delegate_definitions, "  %s\n", im_directoroutattributes);
       }
 
-      Printf(callback_def, "  private %s SwigDirector%s(", tm, overloaded_name);
+      Printf(callback_def, "  private %s SwigDirectorMethod%s(", tm, overloaded_name);
       if (!ignored_method) {
 	const String *csdirectordelegatemodifiers = Getattr(n, "feature:csdirectordelegatemodifiers");
 	String *modifiers = (csdirectordelegatemodifiers ? NewStringf("%s%s", csdirectordelegatemodifiers, Len(csdirectordelegatemodifiers) > 0 ? " " : "") : NewStringf("public "));


### PR DESCRIPTION
Fix class having method `Connect()` creating a name collision with `SwigDirectorConnect()`.

Issue is fixed by prepending director methods with `SwigDirectorMethod` instead of `SwigDirector`.