### PR TITLE
Misc. typo and whitespace fixes

### DIFF
--- a/Examples/test-suite/doxygen_misc_constructs.i
+++ b/Examples/test-suite/doxygen_misc_constructs.i
@@ -10,16 +10,16 @@
     // Tag '@endink' must be recognized even if it is not
     // followed by whitespace.
 
-    /** Tag endlink must be recognized also when followed by nonspace charater.
+    /** Tag endlink must be recognized also when followed by nonspace character.
      *
      * @link Connection::getId() @endlink<br> */
-     
+
     char g_counter;
 
 
-    /** 
+    /**
       Tag endlink must be recognized also when it is the last token
-      in the commment.
+      in the comment.
 
       @link Connection::getId() @endlink<br>
       @link debugIdeTraceProfilerCoverageSample.py Python example. @endlink
@@ -27,7 +27,7 @@
     int g_zipCode;
 
 
-    // Paramter 'isReportSize' must appear in comment of the overload, which
+    // Parameter 'isReportSize' must appear in comment of the overload, which
     // has it. Empty line before link must be preserved.
     /**
      * Returns address of file line.
@@ -38,20 +38,20 @@
      *
      * @link Connection::getId() @endlink <br>
      */
-    void getAddress(int &fileName, 
-                    int line,     
+    void getAddress(int &fileName,
+                    int line,
                     bool isGetSize = false) {}
 
     // The first comment must be ignored.
-    /** 
+    /**
      * \defgroup icFacade isystem.connect Facade
      *
      * This page shows the core classes, which can be used to control
      * all aspects of winIDEA, for example: debugging, analyzers, IO module, ...
      */
 
-    /** 
-     * This class contains information for connection to winIDEA. Its methods 
+    /**
+     * This class contains information for connection to winIDEA. Its methods
      * return reference to self, so we can use it like this:
      * <pre>
      * CConnectionConfig config = new CConnectionConfig();
@@ -70,7 +70,7 @@
 
     // Text after '\c' must be kept unchanged in Python.
     /**
-     * Determines how long the \c isystem.connect should wait for running 
+     * Determines how long the \c isystem.connect should wait for running
      * instances to respond. Only one of \c lfWaitXXX flags from IConnect::ELaunchFlags
      * may be specified.
      */
@@ -84,11 +84,11 @@
      */
     int getConnection() {return 3;}
 
-    // the follwing must produce no comment in wrapper
+    // the following must produce no comment in wrapper
     /*******************************************************************/
     char getFirstLetter() {return 'a';}
 
-    
+
     /**
      * Class description.
      */
@@ -119,6 +119,6 @@
     void showList() { }
 
     #include "doxygen_misc_constructs.h"
-    
+
 %}
     %include "doxygen_misc_constructs.h"

--- a/Examples/test-suite/java/doxygen_misc_constructs_runme.java
+++ b/Examples/test-suite/java/doxygen_misc_constructs_runme.java
@@ -12,8 +12,8 @@ public class doxygen_misc_constructs_runme {
       System.exit(1);
     }
   }
-  
-  public static void main(String argv[]) 
+
+  public static void main(String argv[])
   {
     /*
       Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
@@ -25,7 +25,7 @@ public class doxygen_misc_constructs_runme {
                                        new String[]{"-quiet", "doxygen_misc_constructs"});
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
-    
+
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.getConnection()",
     		"\n" +
     		"\n" +
@@ -42,7 +42,7 @@ public class doxygen_misc_constructs_runme {
     		"");
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.getG_zipCode()",
     		" Tag endlink must be recognized also when it is the last token\n" +
-    		" in the commment.\n" +
+    		" in the comment.\n" +
     		" \n" +
     		" {@link Connection::getId()  }<br>\n" +
     		" {@link debugIdeTraceProfilerCoverageSample.py Python example.  }\n" +
@@ -50,14 +50,14 @@ public class doxygen_misc_constructs_runme {
     		"");
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.setG_zipCode(int)",
     		" Tag endlink must be recognized also when it is the last token\n" +
-    		" in the commment.\n" +
+    		" in the comment.\n" +
     		"\n" +
     		" {@link Connection::getId()  }<br>\n" +
     		" {@link debugIdeTraceProfilerCoverageSample.py Python example.  }\n" +
     		"\n" +
     		"");
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.getG_counter()",
-    		" Tag endlink must be recognized also when followed by nonspace charater.\n" +
+    		" Tag endlink must be recognized also when followed by nonspace character.\n" +
     		"\n" +
     		" {@link Connection::getId()  }<br>\n" +
     		"\n" +
@@ -94,7 +94,7 @@ public class doxygen_misc_constructs_runme {
     		"\n" +
     		"");
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.setG_counter(char)",
-    		" Tag endlink must be recognized also when followed by nonspace charater.\n" +
+    		" Tag endlink must be recognized also when followed by nonspace character.\n" +
     		"\n" +
     		" {@link Connection::getId()  }<br>\n" +
     		"\n" +
@@ -133,18 +133,18 @@ public class doxygen_misc_constructs_runme {
     		" This comment without space after '*' is valid in Doxygen.\n" +
     		"\n" +
     		"");
- 
+
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.isNoSpaceValidB()",
     		" .This comment without space after '*' is valid in Doxygen.\n" +
     		"\n" +
     		"");
- 
+
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.backslashA()",
     		" Backslash following<code>word</code> is a valid doxygen command. Output contains\n" +
     		" 'followingword' with 'word' in code font.\n" +
     		"\n" +
     		"");
- 
+
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.backslashB()",
                        " Doxy command without trailing space is ignored - nothing appears\n" +
                        " on output. Standalone \\ and '\\' get to output.\n" +
@@ -189,8 +189,8 @@ public class doxygen_misc_constructs_runme {
                 "     </pre>\n" +
                 "\n" +
                 " @param fileName name of the log file\n");
- 
-    
+
+
     // and ask the parser to check comments for us
     System.exit(parser.check(wantedComments));
   }

--- a/Examples/test-suite/lua/abstract_access_runme.lua
+++ b/Examples/test-suite/lua/abstract_access_runme.lua
@@ -6,7 +6,7 @@ local env = _ENV -- Lua 5.2
 if not env then env = getfenv () end -- Lua 5.1
 setmetatable(env, {__index=function (t,i) error("undefined global variable `"..i.."'",2) end})
 
--- trying to instantiate pure virual classes
+-- trying to instantiate pure virtual classes
 -- should fail
 assert(pcall(abstract_access.A)==false)
 assert(pcall(abstract_access.B)==false)

--- a/Examples/test-suite/ruby/newobject1_runme.rb
+++ b/Examples/test-suite/ruby/newobject1_runme.rb
@@ -8,7 +8,7 @@
 #
 # Ruby's GC is somewhat broken in that it will mark some more stack space
 # leading to the collection of local objects to be delayed.
-# Thus, upon invokation, it sometimes you can wait up to several
+# Thus, upon invocation, it sometimes you can wait up to several
 # instructions to kick in.
 # See: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/7449
 #

--- a/Examples/test-suite/ruby/newobject2_runme.rb
+++ b/Examples/test-suite/ruby/newobject2_runme.rb
@@ -2,7 +2,7 @@
 #
 # Ruby's GC is somewhat broken in that it will mark some more stack space
 # leading to the collection of local objects to be delayed.
-# Thus, upon invokation, it sometimes you can wait up to several
+# Thus, upon invocation, it sometimes you can wait up to several
 # instructions to kick in.
 # See: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/7449
 #

--- a/Examples/test-suite/ruby/swig_assert.rb
+++ b/Examples/test-suite/ruby/swig_assert.rb
@@ -21,7 +21,7 @@ end
 
 def swig_assert_simple(a)
   unless a
-    raise SwigRubyError.new("assertion falied.")
+    raise SwigRubyError.new("assertion failed.")
   end
 end
 

--- a/Examples/test-suite/template_virtual.i
+++ b/Examples/test-suite/template_virtual.i
@@ -1,7 +1,7 @@
 %module template_virtual
 
 // Submitted by Marcelo Matus  
-// assertion emmitted with templates + derivation + pure virtual member
+// assertion emitted with templates + derivation + pure virtual member
 // allocate.cxx:47: int Allocate::is_abstract_inherit(Node*, Node*):
 // Assertion `dn' failed.
  

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -415,7 +415,7 @@ public:
 	  threads = 1;
 	  Swig_mark_arg(i);
 	} else if (strcmp(argv[i], "-nothreads") == 0) {
-	  /* Turn off thread suppor mode */
+	  /* Turn off thread support mode */
 	  nothreads = 1;
 	  Swig_mark_arg(i);
 	} else if (strcmp(argv[i], "-safecstrings") == 0) {
@@ -569,7 +569,7 @@ public:
     if (cppcast) {
       Preprocessor_define((DOH *) "SWIG_CPLUSPLUS_CAST", 0);
     }
-    
+
     if (doxygen)
       doxygenTranslator = new PyDocConverter(doxygen_translator_flags);
 
@@ -587,12 +587,12 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int top(Node *n) {
-    /* check if directors are enabled for this module.  note: this 
+    /* check if directors are enabled for this module.  note: this
      * is a "master" switch, without which no director code will be
      * emitted.  %feature("director") statements are also required
      * to enable directors for individual classes or methods.
      *
-     * use %module(directors="1") modulename at the start of the 
+     * use %module(directors="1") modulename at the start of the
      * interface file to enable director generation.
      */
     String *mod_docstring = NULL;
@@ -864,7 +864,7 @@ public:
          *
          * for attr in _foo.__all__:
          *     globals()[attr] = getattr(_foo, attr)
-         * 
+         *
          */
         Printf(default_import_code, "# pull in all the attributes from %s\n", module);
         Printv(default_import_code, "if __name__.rpartition('.')[0] != '':\n", NULL);
@@ -1807,7 +1807,7 @@ public:
    *
    * For functions that have not had nameless parameters set in the Language class.
    *
-   * Inputs: 
+   * Inputs:
    *   plist - entire parameter list
    *   arg_offset - argument number for first parameter
    * Side effects:
@@ -2304,7 +2304,7 @@ public:
    * is_real_overloaded()
    *
    * Check if the function is overloaded, but not just have some
-   * siblings generated due to the original function have 
+   * siblings generated due to the original function have
    * default arguments.
    * ------------------------------------------------------------ */
   bool is_real_overloaded(Node *n) {
@@ -2317,7 +2317,7 @@ public:
     while (i) {
       Node *nn = Getattr(i, "defaultargs");
       if (nn != h) {
-	/* Check if overloaded function has defaultargs and 
+	/* Check if overloaded function has defaultargs and
 	 * pointed to the first overloaded. */
 	return true;
       }
@@ -2334,7 +2334,7 @@ public:
    * reuse make_autodocParmList() to do so.
    * ------------------------------------------------------------ */
   String *make_pyParmList(Node *n, bool in_class, bool is_calling, int kw) {
-    /* Get the original function for a defaultargs copy, 
+    /* Get the original function for a defaultargs copy,
      * see default_arguments() in parser.y. */
     Node *nn = Getattr(n, "defaultargs");
     if (nn)
@@ -2859,7 +2859,7 @@ public:
     int noargs = funpack && (tuple_required == 0 && tuple_arguments == 0);
     int onearg = funpack && (tuple_required == 1 && tuple_arguments == 1);
 
-    if (builtin && funpack && !overname && !builtin_ctor && 
+    if (builtin && funpack && !overname && !builtin_ctor &&
       !(GetFlag(n, "feature:compactdefaultargs") && (tuple_arguments > tuple_required || varargs))) {
       String *argattr = NewStringf("%d", tuple_arguments);
       Setattr(n, "python:argcount", argattr);
@@ -3092,9 +3092,9 @@ public:
     }
 
     /* if the object is a director, and the method call originated from its
-     * underlying python object, resolve the call by going up the c++ 
-     * inheritance chain.  otherwise try to resolve the method in python.  
-     * without this check an infinite loop is set up between the director and 
+     * underlying python object, resolve the call by going up the c++
+     * inheritance chain.  otherwise try to resolve the method in python.
+     * without this check an infinite loop is set up between the director and
      * shadow class method calls.
      */
 
@@ -3188,7 +3188,7 @@ public:
       //        base class pointers!
 
       /* New addition to unwrap director return values so that the original
-       * python object is returned instead. 
+       * python object is returned instead.
        */
 #if 1
       int unwrap = 0;
@@ -3725,7 +3725,7 @@ public:
   }
 
 
-  /* ------------------------------------------------------------ 
+  /* ------------------------------------------------------------
    * nativeWrapper()
    * ------------------------------------------------------------ */
 
@@ -3760,7 +3760,7 @@ public:
   /* ---------------------------------------------------------------
    * classDirectorMethod()
    *
-   * Emit a virtual director method to pass a method call on to the 
+   * Emit a virtual director method to pass a method call on to the
    * underlying Python object.
    * ** Moved down due to gcc-2.96 internal error **
    * --------------------------------------------------------------- */
@@ -4930,7 +4930,7 @@ public:
     int oldshadow = shadow;
     int use_director = Swig_directorclass(n);
 
-    /* 
+    /*
      * If we're wrapping the constructor of a C++ director class, prepend a new parameter
      * to receive the scripting language object (e.g. 'self')
      *
@@ -5284,7 +5284,7 @@ public:
 
   /* ------------------------------------------------------------
    * insertDirective()
-   * 
+   *
    * Hook for %insert directive.   We're going to look for special %shadow inserts
    * as a special case so we can do indenting correctly
    * ------------------------------------------------------------ */
@@ -5365,7 +5365,7 @@ public:
 /* ---------------------------------------------------------------
  * classDirectorMethod()
  *
- * Emit a virtual director method to pass a method call on to the 
+ * Emit a virtual director method to pass a method call on to the
  * underlying Python object.
  *
  * ** Moved it here due to internal error on gcc-2.96 **
@@ -5466,7 +5466,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
   Append(w->def, " {");
   Append(declaration, ";\n");
 
-  /* declare method return value 
+  /* declare method return value
    * if the return value is a reference or const reference, a specialized typemap must
    * handle it, including declaration of c_result ($result).
    */
@@ -5626,7 +5626,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
 	  } else {
 	    Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
 	    Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
+	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
 	    //       source, nonconst, base);
 	    Printv(arglist, source, NIL);
 	  }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3
+ * This file is part of SWIG, which is licensed as a whole under version 3 
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -569,7 +569,7 @@ public:
     if (cppcast) {
       Preprocessor_define((DOH *) "SWIG_CPLUSPLUS_CAST", 0);
     }
-
+    
     if (doxygen)
       doxygenTranslator = new PyDocConverter(doxygen_translator_flags);
 
@@ -587,12 +587,12 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int top(Node *n) {
-    /* check if directors are enabled for this module.  note: this
+    /* check if directors are enabled for this module.  note: this 
      * is a "master" switch, without which no director code will be
      * emitted.  %feature("director") statements are also required
      * to enable directors for individual classes or methods.
      *
-     * use %module(directors="1") modulename at the start of the
+     * use %module(directors="1") modulename at the start of the 
      * interface file to enable director generation.
      */
     String *mod_docstring = NULL;
@@ -864,7 +864,7 @@ public:
          *
          * for attr in _foo.__all__:
          *     globals()[attr] = getattr(_foo, attr)
-         *
+         * 
          */
         Printf(default_import_code, "# pull in all the attributes from %s\n", module);
         Printv(default_import_code, "if __name__.rpartition('.')[0] != '':\n", NULL);
@@ -1807,7 +1807,7 @@ public:
    *
    * For functions that have not had nameless parameters set in the Language class.
    *
-   * Inputs:
+   * Inputs: 
    *   plist - entire parameter list
    *   arg_offset - argument number for first parameter
    * Side effects:
@@ -2304,7 +2304,7 @@ public:
    * is_real_overloaded()
    *
    * Check if the function is overloaded, but not just have some
-   * siblings generated due to the original function have
+   * siblings generated due to the original function have 
    * default arguments.
    * ------------------------------------------------------------ */
   bool is_real_overloaded(Node *n) {
@@ -2317,7 +2317,7 @@ public:
     while (i) {
       Node *nn = Getattr(i, "defaultargs");
       if (nn != h) {
-	/* Check if overloaded function has defaultargs and
+	/* Check if overloaded function has defaultargs and 
 	 * pointed to the first overloaded. */
 	return true;
       }
@@ -2334,7 +2334,7 @@ public:
    * reuse make_autodocParmList() to do so.
    * ------------------------------------------------------------ */
   String *make_pyParmList(Node *n, bool in_class, bool is_calling, int kw) {
-    /* Get the original function for a defaultargs copy,
+    /* Get the original function for a defaultargs copy, 
      * see default_arguments() in parser.y. */
     Node *nn = Getattr(n, "defaultargs");
     if (nn)
@@ -2859,7 +2859,7 @@ public:
     int noargs = funpack && (tuple_required == 0 && tuple_arguments == 0);
     int onearg = funpack && (tuple_required == 1 && tuple_arguments == 1);
 
-    if (builtin && funpack && !overname && !builtin_ctor &&
+    if (builtin && funpack && !overname && !builtin_ctor && 
       !(GetFlag(n, "feature:compactdefaultargs") && (tuple_arguments > tuple_required || varargs))) {
       String *argattr = NewStringf("%d", tuple_arguments);
       Setattr(n, "python:argcount", argattr);
@@ -3092,9 +3092,9 @@ public:
     }
 
     /* if the object is a director, and the method call originated from its
-     * underlying python object, resolve the call by going up the c++
-     * inheritance chain.  otherwise try to resolve the method in python.
-     * without this check an infinite loop is set up between the director and
+     * underlying python object, resolve the call by going up the c++ 
+     * inheritance chain.  otherwise try to resolve the method in python.  
+     * without this check an infinite loop is set up between the director and 
      * shadow class method calls.
      */
 
@@ -3188,7 +3188,7 @@ public:
       //        base class pointers!
 
       /* New addition to unwrap director return values so that the original
-       * python object is returned instead.
+       * python object is returned instead. 
        */
 #if 1
       int unwrap = 0;
@@ -3725,7 +3725,7 @@ public:
   }
 
 
-  /* ------------------------------------------------------------
+  /* ------------------------------------------------------------ 
    * nativeWrapper()
    * ------------------------------------------------------------ */
 
@@ -3760,7 +3760,7 @@ public:
   /* ---------------------------------------------------------------
    * classDirectorMethod()
    *
-   * Emit a virtual director method to pass a method call on to the
+   * Emit a virtual director method to pass a method call on to the 
    * underlying Python object.
    * ** Moved down due to gcc-2.96 internal error **
    * --------------------------------------------------------------- */
@@ -4930,7 +4930,7 @@ public:
     int oldshadow = shadow;
     int use_director = Swig_directorclass(n);
 
-    /*
+    /* 
      * If we're wrapping the constructor of a C++ director class, prepend a new parameter
      * to receive the scripting language object (e.g. 'self')
      *
@@ -5284,7 +5284,7 @@ public:
 
   /* ------------------------------------------------------------
    * insertDirective()
-   *
+   * 
    * Hook for %insert directive.   We're going to look for special %shadow inserts
    * as a special case so we can do indenting correctly
    * ------------------------------------------------------------ */
@@ -5365,7 +5365,7 @@ public:
 /* ---------------------------------------------------------------
  * classDirectorMethod()
  *
- * Emit a virtual director method to pass a method call on to the
+ * Emit a virtual director method to pass a method call on to the 
  * underlying Python object.
  *
  * ** Moved it here due to internal error on gcc-2.96 **
@@ -5466,7 +5466,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
   Append(w->def, " {");
   Append(declaration, ";\n");
 
-  /* declare method return value
+  /* declare method return value 
    * if the return value is a reference or const reference, a specialized typemap must
    * handle it, including declaration of c_result ($result).
    */
@@ -5626,7 +5626,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
 	  } else {
 	    Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
 	    Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
+	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
 	    //       source, nonconst, base);
 	    Printv(arglist, source, NIL);
 	  }


### PR DESCRIPTION
Found via `codespell -q 3 -L "uint,bae,objext,cmo,goin,struc,ois,upto"`
whitespaces were unintentionally fixed due to my editor's settings. 