### PR TITLE
PHP: Make reserved keywords to reserved function only

### DIFF
--- a/Lib/php/phpkw.swg
+++ b/Lib/php/phpkw.swg
@@ -50,7 +50,6 @@ PHPKW(do);
 PHPKW(echo); // "Language construct"
 PHPKW(else);
 PHPKW(elseif);
-PHPKW(empty); // "Language construct"
 PHPKW(enddeclare);
 PHPKW(endfor);
 PHPKW(endforeach);
@@ -830,6 +829,7 @@ PHPFN(cosh);
 PHPFN(count);
 PHPFN(current);
 PHPFN(each);
+PHPFN(empty);
 PHPFN(end);
 PHPFN(exp);
 PHPFN(extract);

--- a/Lib/php/phpkw.swg
+++ b/Lib/php/phpkw.swg
@@ -30,10 +30,8 @@
  * could lead to confusion."
  */
 /* Check is case insensitive - these *MUST* be listed in lower case here */
-PHPKW(__halt_compiler);
 PHPKW(abstract);
 PHPKW(and);
-PHPKW(array);
 PHPKW(as);
 PHPKW(break);
 PHPKW(callable);
@@ -45,9 +43,7 @@ PHPKW(const);
 PHPKW(continue);
 PHPKW(declare);
 PHPKW(default);
-PHPKW(die); // "Language construct"
 PHPKW(do);
-PHPKW(echo); // "Language construct"
 PHPKW(else);
 PHPKW(elseif);
 PHPKW(enddeclare);
@@ -56,8 +52,6 @@ PHPKW(endforeach);
 PHPKW(endif);
 PHPKW(endswitch);
 PHPKW(endwhile);
-PHPKW(eval); // "Language construct"
-PHPKW(exit); // "Language construct"
 PHPKW(extends);
 PHPKW(final);
 PHPKW(finally);
@@ -68,29 +62,20 @@ PHPKW(global);
 PHPKW(goto);
 PHPKW(if);
 PHPKW(implements);
-PHPKW(include); // "Language construct"
-PHPKW(include_once); // "Language construct"
 PHPKW(instanceof);
 PHPKW(insteadof);
 PHPKW(interface);
-PHPKW(isset); // "Language construct"
-PHPKW(list); // "Language construct"
 PHPKW(namespace);
 PHPKW(new);
 PHPKW(or);
-PHPKW(print); // "Language construct"
 PHPKW(private);
 PHPKW(protected);
 PHPKW(public);
-PHPKW(require); // "Language construct"
-PHPKW(require_once); // "Language construct"
-PHPKW(return); // "Language construct"
 PHPKW(static);
 PHPKW(switch);
 PHPKW(throw);
 PHPKW(trait);
 PHPKW(try);
-PHPKW(unset); // "Language construct"
 PHPKW(use);
 PHPKW(var);
 PHPKW(while);
@@ -766,7 +751,9 @@ PHPCN(datetime);
 /* Built-in PHP functions (incomplete). */
 /* Includes Array Functions - http://php.net/manual/en/ref.array.php */
 /* Check is case insensitive - these *MUST* be listed in lower case here */
+PHPFN(__halt_compiler);
 PHPFN(acos);
+PHPFN(array);
 PHPFN(array_change_key_case);
 PHPFN(array_chunk);
 PHPFN(array_column);
@@ -828,18 +815,26 @@ PHPFN(cos);
 PHPFN(cosh);
 PHPFN(count);
 PHPFN(current);
+PHPFN(die); // "Language construct"
 PHPFN(each);
+PHPFN(echo); // "Language construct"
 PHPFN(empty);
 PHPFN(end);
+PHPFN(eval); // "Language construct"
+PHPFN(exit); // "Language construct"
 PHPFN(exp);
 PHPFN(extract);
 PHPFN(floor);
 PHPFN(fmod);
 PHPFN(in_array);
+PHPFN(include); // "Language construct"
+PHPFN(include_once); // "Language construct"
+PHPFN(isset); // "Language construct"
 PHPFN(key);
 PHPFN(key_exists);
 PHPFN(krsort);
 PHPFN(ksort);
+PHPFN(list); // "Language construct"
 PHPFN(log);
 PHPFN(log10);
 PHPFN(max);
@@ -850,9 +845,13 @@ PHPFN(next);
 PHPFN(pos);
 PHPFN(pow);
 PHPFN(prev);
+PHPFN(print); // "Language construct"
 PHPFN(range);
 PHPFN(reset);
 PHPFN(rsort);
+PHPFN(require); // "Language construct"
+PHPFN(require_once); // "Language construct"
+PHPFN(return); // "Language construct"
 PHPFN(shuffle);
 PHPFN(sin);
 PHPFN(sinh);
@@ -863,6 +862,7 @@ PHPFN(tan);
 PHPFN(tanh);
 PHPFN(uasort);
 PHPFN(uksort);
+PHPFN(unset); // "Language construct"
 PHPFN(usort);
 
 #undef PHPKW


### PR DESCRIPTION
Hi,

SWIG renames variables or properties of objects like empty to c_empty.
I quess, because they are listet as reservced keywords (http://php.net/manual/en/reserved.keywords.php) but f.e. "empty" is listed as "empty()" which allows to use empty as variable or property of objects but not as function or method.

If i use $empty as variable, my IDE does not complaint (which is not a proof i know) and i can run this code:
![grafik](https://user-images.githubusercontent.com/23343388/46818431-80317400-cd81-11e8-8f3c-9ddebaf85ed0.png)

![grafik](https://user-images.githubusercontent.com/23343388/46817413-5aa36b00-cd7f-11e8-8a51-8c34ed5467a8.png)

This can be repeated with all of the keywords which are listet as "keyword()":

![grafik](https://user-images.githubusercontent.com/23343388/46818032-896e1100-cd80-11e8-9eb9-231b8785222c.png)

![grafik](https://user-images.githubusercontent.com/23343388/46818277-23ce5480-cd81-11e8-8d18-8079096b3040.png)


Full source code here: https://github.com/AlexanderGabriel/SWIGCmakePHPExampleWindows/blob/master/test_keywords.php

I patched SWIG (see changes) to allow these keywords f.e. as empty but still not empty() (this will not work/throw an error), made a c-lib and tested it:
![grafik](https://user-images.githubusercontent.com/23343388/46818719-385f1c80-cd82-11e8-9022-9bfb8f8e8645.png) (c-source-file)
![grafik](https://user-images.githubusercontent.com/23343388/46818317-3ba5d880-cd81-11e8-9ca3-3d737dec50c8.png) (Interface-File)

![grafik](https://user-images.githubusercontent.com/23343388/46818888-91c74b80-cd82-11e8-9ff6-4caaa504f7aa.png) (PHP-Testfile test_keywords.php)
![grafik](https://user-images.githubusercontent.com/23343388/46818919-a99ecf80-cd82-11e8-805e-349f99a6abf9.png) (output)


There is a project "mapserver" which has a property "empty" on an object "webObj" in their php-extension since more than 10 years and this worked without any problems: https://mapserver.org/mapscript/php/phpmapscript.html#webobj If that was wrong, this wouldnt have worked the last 10 years.

Would be cool if you accept my PR to make this work with swig-based extensions.

Thank you.

Kind regards,
Alex