### PR TITLE
Documentation for argument handling refers to wrong chapter.

### DIFF
--- a/Doc/Manual/Arguments.html
+++ b/Doc/Manual/Arguments.html
@@ -32,7 +32,7 @@
 
 
 <p>
-In Chapter 3, SWIG's treatment of basic datatypes and pointers was
+In Chapter 5, SWIG's treatment of basic datatypes and pointers was
 described.  In particular, primitive types such as <tt>int</tt> and
 <tt>double</tt> are mapped to corresponding types in the target
 language.  For everything else, pointers are used to refer to


### PR DESCRIPTION
Chapter 10 (Argument Handling), first section, refers to Chapter 3 (Getting started on
Windows) but should presumably be Chapter 5 (SWIG Basics)?