### PR TITLE
Resolve types of the classes nested inside template classes

### DIFF
--- a/Examples/test-suite/csharp/nested_in_template_runme.cs
+++ b/Examples/test-suite/csharp/nested_in_template_runme.cs
@@ -1,0 +1,10 @@
+using System;
+using nested_in_templateNamespace;
+
+public class runme {
+    static void Main() {
+        var cd = new OuterTemplate1.ConcreteDerived(8.8);
+        if (cd.m_value != 8.8)
+            throw new Exception("ConcreteDerived not created correctly");
+    }
+}

--- a/Examples/test-suite/nested_in_template.i
+++ b/Examples/test-suite/nested_in_template.i
@@ -1,0 +1,34 @@
+%module nested_in_template
+
+#if !defined(SWIGCSHARP) && !defined(SWIGJAVA)
+%feature("flatnested");
+#endif
+
+%inline %{
+template <int>
+struct OuterTemplate;
+
+template <>
+struct OuterTemplate<1>
+{
+  struct AbstractBase
+  {
+    virtual bool IsSameAs(const AbstractBase& other) const = 0;
+    virtual ~AbstractBase() {}
+  };
+
+  struct ConcreteDerived : AbstractBase
+  {
+    ConcreteDerived() : m_value(0.) {}
+    explicit ConcreteDerived(double value) : m_value(value) {}
+
+    virtual bool IsSameAs(const AbstractBase& other) const {
+      return m_value == static_cast<const ConcreteDerived&>(other).m_value;
+    }
+
+    double m_value;
+  };
+};
+%}
+
+%template(OuterTemplate1) OuterTemplate<1>;

--- a/Examples/test-suite/python/nested_in_template_runme.py
+++ b/Examples/test-suite/python/nested_in_template_runme.py
@@ -1,0 +1,5 @@
+from nested_in_template import *
+
+cd = ConcreteDerived(8.8)
+if cd.m_value != 8.8:
+    raise RuntimeError("ConcreteDerived not created correctly")


### PR DESCRIPTION
Do the same thing for the template classes as for the normal classes
during the type resolve pass, i.e. call classDeclaration() from
TypePass::templateDeclaration(), in order to fully qualify the names of
nested types used as method parameters inside template classes too.

Also amend classDeclaration() to prevent it from processing base classes
for the templates as this would result in errors in absence of %template
directives for the base templates.

Add a test checking for the situation described above.

See #1353.

---

I freely admit I don't fully understand what am I doing here, several things in `TypePass::classDeclaration()` remain completely mysterious to me. But at least this fix makes the new test pass, when it failed before.

Unfortunately this doesn't fix #1353 because in my case an enum value of an enum defined inside a namespace is used and this enum value is not fully qualified, i.e. we're still searching for a function taking `q(const).f(r.q(const).NSpace::OuterTemplate<(TemplArg_1)>::AbstractBase)` and so don't find `q(const).f(r.q(const).NSpace::OuterTemplate<(NSpace::TemplArg_1)>::AbstractBase)` overriding it.

I'm still struggling to understand why/how do we end up with the fully qualified enum value in the derived class declaration but not in the base one, and any help with this would still be very welcome. But in the meanwhile I'd like to test this PR to see if it breaks anything else -- if not, it should be applied, as it does fix a real bug, even though it doesn't fix the bug which affects me personally.