### PR TITLE
fix for creating new shadow class in python 3.6

### DIFF
--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1205,12 +1205,16 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
 #if PY_VERSION_HEX >= 0x03000000
     PyObject *empty_args = PyTuple_New(0);
     if (empty_args) {
-      inst = ((PyTypeObject *)data->newargs)->tp_new((PyTypeObject *)data->newargs, empty_args, Py_None);
-      Py_DECREF(empty_args);
-      if (inst) {
-        PyObject_SetAttr(inst, SWIG_This(), swig_this);
-        Py_TYPE(inst)->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
+      PyObject *empty_kwargs = PyDict_New();
+      if (empty_kwargs) {
+        inst = ((PyTypeObject *)data->newargs)->tp_new((PyTypeObject *)data->newargs, empty_args, empty_kwargs);
+        Py_DECREF(empty_kwargs);
+        if (inst) {
+          PyObject_SetAttr(inst, SWIG_This(), swig_this);
+          Py_TYPE(inst)->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
+        }
       }
+      Py_DECREF(empty_args);
     }
 #else
     PyObject *dict = PyDict_New();


### PR DESCRIPTION
I ran into the issue with overriding `__new__` described in #1024 with Swig 3.0.12 and fixed it for python 3.7 by applying 0165180, but this created a new error "SystemError: Objects/tupleobject.c:81: bad argument to internal function" in python 3.6. This patch fixes the issues I had for python 3.5, 3.6 and 3.7.