### PR TITLE
#1360: Leak of SWIG var link object

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,11 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2018-11-23: adr26
+            [Python] #1360 Leak of SWIG var link object
+
+            Fix reference counting on _SWIG_globals to allow var link to be freed on module unload.
+
 2018-11-22: rupertnash
             [Python] #1282 Make generated module runnable via python -m (PEP 366 conforming)
 

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -227,11 +227,7 @@ SWIG_Python_addvarlink(PyObject *p, const char *name, PyObject *(*get_attr)(void
 SWIGINTERN PyObject *
 SWIG_globals(void) {
   static PyObject *_SWIG_globals = 0; 
-  if (!_SWIG_globals) {
-    _SWIG_globals = SWIG_newvarlink();
-  } else {
-    Py_INCREF(_SWIG_globals);
-  }
+  if (!_SWIG_globals) _SWIG_globals = SWIG_newvarlink();  
   return _SWIG_globals;
 }
 

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -331,6 +331,9 @@ SWIGEXPORT
 #endif
 SWIG_init(void) {
   PyObject *m, *d, *md, *globals;
+
+  (void)globals;
+
 #if PY_VERSION_HEX >= 0x03000000
   static struct PyModuleDef SWIG_module = {
     PyModuleDef_HEAD_INIT,

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -332,8 +332,6 @@ SWIGEXPORT
 SWIG_init(void) {
   PyObject *m, *d, *md, *globals;
 
-  (void)globals;
-
 #if PY_VERSION_HEX >= 0x03000000
   static struct PyModuleDef SWIG_module = {
     PyModuleDef_HEAD_INIT,
@@ -385,6 +383,8 @@ SWIG_init(void) {
   metatype = SwigPyObjectType();
   assert(metatype);
 #endif
+
+  (void)globals;
 
   /* Create singletons now to avoid potential deadlocks with multi-threaded usage after module initialization */
   SWIG_This();

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -227,7 +227,11 @@ SWIG_Python_addvarlink(PyObject *p, const char *name, PyObject *(*get_attr)(void
 SWIGINTERN PyObject *
 SWIG_globals(void) {
   static PyObject *_SWIG_globals = 0; 
-  if (!_SWIG_globals) _SWIG_globals = SWIG_newvarlink();  
+  if (!_SWIG_globals) {
+    _SWIG_globals = SWIG_newvarlink();
+  } else {
+    Py_INCREF(_SWIG_globals);
+  }
   return _SWIG_globals;
 }
 
@@ -326,7 +330,7 @@ SWIGEXPORT
   void
 #endif
 SWIG_init(void) {
-  PyObject *m, *d, *md;
+  PyObject *m, *d, *md, *globals;
 #if PY_VERSION_HEX >= 0x03000000
   static struct PyModuleDef SWIG_module = {
     PyModuleDef_HEAD_INIT,

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3316,21 +3316,21 @@ public:
     getf = NewWrapper();
     setf = NewWrapper();
 
-    Printf(f_init, "\t globals = SWIG_globals();\n");
-    Printf(f_init, "\t if (!globals) {\n");
-    Printf(f_init, "     PyErr_SetString(PyExc_TypeError, \"Failure to create SWIG globals.\");\n");
-    Printf(f_init, "#if PY_VERSION_HEX >= 0x03000000\n");
-    Printf(f_init, "\t   return NULL;\n");
-    Printf(f_init, "#else\n");
-    Printf(f_init, "\t   return;\n");
-    Printf(f_init, "#endif\n");
-    Printf(f_init, "\t }\n");
-
     /* If this is our first call, add the globals variable to the
        Python dictionary. */
 
     if (!have_globals) {
+      Printf(f_init, "\t globals = SWIG_globals();\n");
+      Printf(f_init, "\t if (!globals) {\n");
+      Printf(f_init, "     PyErr_SetString(PyExc_TypeError, \"Failure to create SWIG globals.\");\n");
+      Printf(f_init, "#if PY_VERSION_HEX >= 0x03000000\n");
+      Printf(f_init, "\t   return NULL;\n");
+      Printf(f_init, "#else\n");
+      Printf(f_init, "\t   return;\n");
+      Printf(f_init, "#endif\n");
+      Printf(f_init, "\t }\n");
       Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", globals);\n", global_name);
+      Printf(f_init, "\t Py_DECREF(globals);\n");
       if (builtin)
 	Printf(f_init, "\t SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", global_name);
       have_globals = 1;
@@ -3418,12 +3418,11 @@ public:
     Wrapper_print(getf, f_wrappers);
 
     /* Now add this to the variable linking mechanism */
-    Printf(f_init, "\t SWIG_addvarlink(globals,\"%s\",%s, %s);\n", iname, vargetname, varsetname);
+    Printf(f_init, "\t SWIG_addvarlink(globals, \"%s\", %s, %s);\n", iname, vargetname, varsetname);
     if (builtin && shadow && !assignable && !in_class) {
-      Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", PyObject_GetAttrString(SWIG_globals(), \"%s\"));\n", iname, iname);
+      Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", PyObject_GetAttrString(globals, \"%s\"));\n", iname, iname);
       Printf(f_init, "\t SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", iname);
     }
-    Printf(f_init, "\t Py_DECREF(globals);\n");
     Delete(vargetname);
     Delete(varsetname);
     Delete(getname);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3320,11 +3320,21 @@ public:
     getf = NewWrapper();
     setf = NewWrapper();
 
+    Printf(f_init, "\t globals = SWIG_globals();\n");
+    Printf(f_init, "\t if (!globals) {\n");
+    Printf(f_init, "     PyErr_SetString(PyExc_TypeError, \"Failure to create SWIG globals.\");\n");
+    Printf(f_init, "#if PY_VERSION_HEX >= 0x03000000\n");
+    Printf(f_init, "\t   return NULL;\n");
+    Printf(f_init, "#else\n");
+    Printf(f_init, "\t   return;\n");
+    Printf(f_init, "#endif\n");
+    Printf(f_init, "\t }\n");
+
     /* If this is our first call, add the globals variable to the
        Python dictionary. */
 
     if (!have_globals) {
-      Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", SWIG_globals());\n", global_name);
+      Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", globals);\n", global_name);
       if (builtin)
 	Printf(f_init, "\t SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", global_name);
       have_globals = 1;
@@ -3412,11 +3422,12 @@ public:
     Wrapper_print(getf, f_wrappers);
 
     /* Now add this to the variable linking mechanism */
-    Printf(f_init, "\t SWIG_addvarlink(SWIG_globals(), \"%s\", %s, %s);\n", iname, vargetname, varsetname);
+    Printf(f_init, "\t SWIG_addvarlink(globals,\"%s\",%s, %s);\n", iname, vargetname, varsetname);
     if (builtin && shadow && !assignable && !in_class) {
       Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", PyObject_GetAttrString(SWIG_globals(), \"%s\"));\n", iname, iname);
       Printf(f_init, "\t SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", iname);
     }
+    Printf(f_init, "\t Py_DECREF(globals);\n");
     Delete(vargetname);
     Delete(varsetname);
     Delete(getname);


### PR DESCRIPTION
Fix reference counting on `_SWIG_globals` to allow var link to be freed on module unload.