### PR TITLE
Remove checks for Python version being >= 2.7.0 in generated code

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -733,12 +733,9 @@ public:
          */
         Printf(default_import_code, "# pull in all the attributes from %s\n", module);
         Printv(default_import_code, "if __name__.rpartition('.')[0] != '':\n", NULL);
-        Printv(default_import_code, tab4, "if _swig_python_version_info >= (2, 7, 0):\n", NULL);
-        Printv(default_import_code, tab8, "try:\n", NULL);
-        Printf(default_import_code, tab8 tab4 "from .%s import *\n", module);
-        Printv(default_import_code, tab8 "except ImportError:\n", NULL);
-        Printf(default_import_code, tab8 tab4 "from %s import *\n", module);
-        Printv(default_import_code, tab4, "else:\n", NULL);
+        Printv(default_import_code, tab4, "try:\n", NULL);
+        Printf(default_import_code, tab8 "from .%s import *\n", module);
+        Printv(default_import_code, tab4 "except ImportError:\n", NULL);
         Printf(default_import_code, tab8 "from %s import *\n", module);
         Printv(default_import_code, "else:\n", NULL);
         Printf(default_import_code, tab4 "from %s import *\n", module);
@@ -1121,12 +1118,9 @@ public:
       Printf(out, "import %s%s%s%s\n", apkg, *Char(apkg) ? "." : "", pfx, mod);
       Delete(apkg);
     } else {
-      Printf(out, "if _swig_python_version_info >= (2, 7, 0):\n");
       if (py3_rlen1)
-	Printf(out, tab4 "from . import %.*s\n", py3_rlen1, rpkg);
-      Printf(out, tab4 "from .%s import %s%s\n", rpkg, pfx, mod);
-      Printf(out, "else:\n");
-      Printf(out, tab4 "import %s%s%s%s\n", rpkg, *Char(rpkg) ? "." : "", pfx, mod);
+	Printf(out, "from . import %.*s\n", py3_rlen1, rpkg);
+      Printf(out, "from .%s import %s%s\n", rpkg, pfx, mod);
       Delete(rpkg);
     }
     return out;


### PR DESCRIPTION
These checks are unnecessary as the generated code throws an exception
if Python version is < 2.7.0 anyhow, so simplify the code by removing
them as we know that the test is always true.

Incidentally, this fixes the problem with generating invalid code when
using relative imports with -builtin in master due to using the
undeclared _swig_python_version_info -- as now this code doesn't use
_swig_python_version_info at all.

---

As the current master doesn't pass Travis CI tests, I wanted to fix this. The problem is due to using `_swig_python_version_info` before it's imported, so initially I did this:
```diff
diff --git a/Source/Modules/python.cxx b/Source/Modules/python.cxx
index 19798b5f8..f2e89c3e9
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -898,15 +898,13 @@ public:

     if (shadow) {
       Swig_banner_target_lang(f_shadow_py, "#");
-      if (Len(f_shadow_begin) > 0)
-       Printv(f_shadow_py, "\n", f_shadow_begin, "\n", NIL);
+      Printv(f_shadow_begin, "\nfrom sys import version_info as _swig_python_version_info\n", NULL);
+      Printv(f_shadow_begin, "if _swig_python_version_info < (2, 7, 0):\n", NULL);
+      Printv(f_shadow_begin, tab4, "raise RuntimeError('Python 2.7 or later required')\n\n", NULL);
+      Printv(f_shadow_py, f_shadow_begin, NIL);
       if (Len(f_shadow_after_begin) > 0)
       Printv(f_shadow_py, f_shadow_after_begin, "\n", NIL);

-      Printv(f_shadow_py, "\nfrom sys import version_info as _swig_python_version_info\n", NULL);
-      Printv(f_shadow_py, "if _swig_python_version_info < (2, 7, 0):\n", NULL);
-      Printv(f_shadow_py, tab4, "raise RuntimeError('Python 2.7 or later required')\n\n", NULL);
-
       if (moduleimport) {
        Replaceall(moduleimport, "$module", module);
        Printv(f_shadow_py, moduleimport, "\n", NIL);
```
which did fix the problem by ensuring that the import always comes first, but then I noticed that these checks of `_swig_python_version_info` seem to be completely unnecessary any more and so we can just remove them, which is what this commit does.