### PR TITLE
Try to locate php-config if there is no php-config7.X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2015,7 +2015,12 @@ else
       dnl /usr/bin/php7.0 -> /usr/bin/php-config7.0
       case $PHP in
         *7.*)
-          PHPCONFIG=`echo "$PHP"|sed 's/7\...*$/-config&/'` ;;
+          PHPCONFIG=`echo "$PHP"|sed 's/7\...*$/-config&/'`
+          # try to see if there is php-config in the same directory
+          if test ! -f $PHPCONFIG; then
+            PHPCONFIG=$PHP-config
+          fi
+          ;;
         *)
           PHPCONFIG=$PHP-config ;;
       esac


### PR DESCRIPTION
Gentoo based distros have `php-config` configuration file installed in the same directory as `php` executable.
This patch adds a fallback to `php-config` if no `php-config7.X` configuration file is found for PHP7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/swig/swig/1366)
<!-- Reviewable:end -->
