### PR TITLE
[Python] #1368: AV in tp_print caused by mismatched Python/extension CRT usage

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,13 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2018-12-04: adr26
+            [Python] #1368 AV in tp_print caused by mismatched Python/extension CRT usage
+
+            Remove all use of tp_print, as this API uses a FILE*, which can be
+            mismatched when modules are built with different C libraries from
+            the main python executable.
+
 2018-12-04: wsfulton
             [Python] #1282 Fix running 'python -m'  when using 'swig -builtin'
 

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -155,7 +155,7 @@ swig_varlink_type(void) {
       sizeof(swig_varlinkobject),         /* tp_basicsize */
       0,                                  /* tp_itemsize */
       (destructor) swig_varlink_dealloc,  /* tp_dealloc */
-      (printfunc) swig_varlink_print,     /* tp_print */
+      0,                                  /* tp_print */
       (getattrfunc) swig_varlink_getattr, /* tp_getattr */
       (setattrfunc) swig_varlink_setattr, /* tp_setattr */
       0,                                  /* tp_compare */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -822,7 +822,7 @@ SwigPyPacked_TypeOnce(void) {
       sizeof(SwigPyPacked),                 /* tp_basicsize */
       0,                                    /* tp_itemsize */
       (destructor)SwigPyPacked_dealloc,     /* tp_dealloc */
-      (printfunc)SwigPyPacked_print,        /* tp_print */
+      0,                                    /* tp_print */
       (getattrfunc)0,                       /* tp_getattr */
       (setattrfunc)0,                       /* tp_setattr */
 #if PY_VERSION_HEX>=0x03000000

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4002,7 +4002,7 @@ public:
     printSlot(f, getSlot(n, "feature:python:tp_basicsize", tp_basicsize), "tp_basicsize");
     printSlot(f, getSlot(n, "feature:python:tp_itemsize"), "tp_itemsize");
     printSlot(f, getSlot(n, "feature:python:tp_dealloc", tp_dealloc_bad), "tp_dealloc", "destructor");
-    Printv(f, "    0,                                    /* tp_print */\n");
+    Printf(f, "    0,                                        /* tp_print */\n");
     printSlot(f, getSlot(n, "feature:python:tp_getattr"), "tp_getattr", "getattrfunc");
     printSlot(f, getSlot(n, "feature:python:tp_setattr"), "tp_setattr", "setattrfunc");
     Printv(f, "#if PY_VERSION_HEX >= 0x03000000\n", NIL);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4002,7 +4002,7 @@ public:
     printSlot(f, getSlot(n, "feature:python:tp_basicsize", tp_basicsize), "tp_basicsize");
     printSlot(f, getSlot(n, "feature:python:tp_itemsize"), "tp_itemsize");
     printSlot(f, getSlot(n, "feature:python:tp_dealloc", tp_dealloc_bad), "tp_dealloc", "destructor");
-    printSlot(f, getSlot(n, "feature:python:tp_print"), "tp_print", "printfunc");
+    Printv(f, "    0,                                    /* tp_print */\n");
     printSlot(f, getSlot(n, "feature:python:tp_getattr"), "tp_getattr", "getattrfunc");
     printSlot(f, getSlot(n, "feature:python:tp_setattr"), "tp_setattr", "setattrfunc");
     Printv(f, "#if PY_VERSION_HEX >= 0x03000000\n", NIL);


### PR DESCRIPTION
Removes use of `tp_print` throughout, for reasons explained in #1368.