### PR TITLE
fixed deadlock when C# GC runs in multithreaded server

### DIFF
--- a/Lib/csharp/csharp.swg
+++ b/Lib/csharp/csharp.swg
@@ -970,30 +970,40 @@ SWIG_CSBODY_TYPEWRAPPER(internal, protected, internal, SWIGTYPE)
 %}
 
 %typemap(csdestruct, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
+    bool dodelete = false;
     lock(this) {
       if (swigCPtr.Handle != global::System.IntPtr.Zero) {
         if (swigCMemOwn) {
           swigCMemOwn = false;
-          $imcall;
+          dodelete = true;
         }
-        swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
       }
-      global::System.GC.SuppressFinalize(this);
     }
+    if (dodelete)
+    {
+        $imcall;
+    }
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+    global::System.GC.SuppressFinalize(this);
   }
 
 %typemap(csdestruct_derived, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
+    bool dodelete = false;
     lock(this) {
       if (swigCPtr.Handle != global::System.IntPtr.Zero) {
         if (swigCMemOwn) {
           swigCMemOwn = false;
-          $imcall;
+          dodelete = true;
         }
-        swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
       }
-      global::System.GC.SuppressFinalize(this);
       base.Dispose();
     }
+    if (dodelete)
+    {
+        $imcall;
+    }
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+    global::System.GC.SuppressFinalize(this);
   }
 
 %typemap(directordisconnect, methodname="swigDirectorDisconnect") SWIGTYPE %{


### PR DESCRIPTION
This fixes a deadlock on a stressed server (azure). 
The deadlock occurs, when the C# garbage collector is triggered in one server thread, and a lock is held by another server thread that also calls the garbage collector 
To fix this, the code calling the garbage collector (global::System.GC.SuppressFinalize) and all other memory allocating calls (new) must be done from outside any blocking code.    