### PR TITLE
[Python] Add missing keywords 'async' and 'await' to pythonkw.swg.

### DIFF
--- a/Lib/python/pythonkw.swg
+++ b/Lib/python/pythonkw.swg
@@ -14,6 +14,8 @@
 PYTHONKW(and);
 PYTHONKW(as);
 PYTHONKW(assert);
+PYTHONKW(async);
+PYTHONKW(await);
 PYTHONKW(break);
 PYTHONKW(class);
 PYTHONKW(continue);


### PR DESCRIPTION
Fix for #1381.  Adds the new python3.7 keywords 'async' and 'await'.