### PR TITLE
[OCaml] Add missing keywords to ocamlkw.swg

### DIFF
--- a/Lib/ocaml/ocamlkw.swg
+++ b/Lib/ocaml/ocamlkw.swg
@@ -12,6 +12,7 @@
 
 OCAMLKW(and);
 OCAMLKW(as);
+OCAMLKW(asr);
 OCAMLKW(assert);
 OCAMLKW(begin);
 OCAMLKW(class);
@@ -33,13 +34,20 @@ OCAMLKW(in);
 OCAMLKW(include);
 OCAMLKW(inherit);
 OCAMLKW(initializer);
+OCAMLKW(land);
 OCAMLKW(lazy);
 OCAMLKW(let);
+OCAMLKW(lor);
+OCAMLKW(lsl);
+OCAMLKW(lsr);
+OCAMLKW(lxor);
 OCAMLKW(match);
 OCAMLKW(method);
+OCAMLKW(mod);
 OCAMLKW(module);
 OCAMLKW(mutable);
 OCAMLKW(new);
+OCAMLKW(nonrec);
 OCAMLKW(object);
 OCAMLKW(of);
 OCAMLKW(open);

--- a/Lib/ocaml/ocamlkw.swg
+++ b/Lib/ocaml/ocamlkw.swg
@@ -6,7 +6,7 @@
 
 /*
   from
-  http://caml.inria.fr/ocaml/htmlman/manual044.html
+  https://caml.inria.fr/pub/docs/manual-ocaml/lex.html
 */
 
 


### PR DESCRIPTION
The asr, land, lor, lsl, lsr, lxor, mod, and nonrec keywords were
missing from ocamlkw.swg.