### PR TITLE
[OCaml] Add missing warning filters for OCaml keywords in the test suite

### DIFF
--- a/Examples/test-suite/constant_directive.i
+++ b/Examples/test-suite/constant_directive.i
@@ -2,6 +2,10 @@
 
 // %constant and struct
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
 #if defined(_MSC_VER)
   #pragma warning(disable : 4190) // warning C4190: 'result' has C-linkage specified, but returns UDT 'Type1' which is incompatible with C

--- a/Examples/test-suite/cpp_namespace.i
+++ b/Examples/test-suite/cpp_namespace.i
@@ -2,6 +2,10 @@
 
 %module cpp_namespace
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %inline %{
   typedef int Bad;
 

--- a/Examples/test-suite/default_arg_expressions.i
+++ b/Examples/test-suite/default_arg_expressions.i
@@ -1,5 +1,9 @@
 %module default_arg_expressions
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %warnfilter(SWIGWARN_TYPEMAP_SWIGTYPELEAK_MSG) ptr;
 %warnfilter(SWIGWARN_TYPEMAP_SWIGTYPELEAK_MSG) UsdGeomTokensPtr;
 %immutable UsdGeomTokens;

--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -2,6 +2,10 @@
 
 %module default_args
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %{
 #if defined(_MSC_VER)
   #pragma warning(disable: 4146) // unary minus operator applied to unsigned type, result still unsigned

--- a/Examples/test-suite/derived_byvalue.i
+++ b/Examples/test-suite/derived_byvalue.i
@@ -1,5 +1,9 @@
 %module derived_byvalue
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %inline %{
 
 struct Foo {

--- a/Examples/test-suite/director_basic.i
+++ b/Examples/test-suite/director_basic.i
@@ -1,5 +1,9 @@
 %module(directors="1") director_basic
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) MyClass::pmethod;
 
  %{

--- a/Examples/test-suite/director_classes.i
+++ b/Examples/test-suite/director_classes.i
@@ -5,6 +5,10 @@
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Base::Ptr;
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Base::ConstPtrRef;
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %module(directors="1") director_classes
 
 %feature("director") Base;

--- a/Examples/test-suite/director_overload.i
+++ b/Examples/test-suite/director_overload.i
@@ -1,5 +1,9 @@
 %module(directors="1") director_overload
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %feature("director");
 
 #ifdef SWIGPYTHON

--- a/Examples/test-suite/director_property.i
+++ b/Examples/test-suite/director_property.i
@@ -2,6 +2,10 @@
 
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) MyClass::pmethod;
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %{
  #include <string>
 

--- a/Examples/test-suite/director_thread.i
+++ b/Examples/test-suite/director_thread.i
@@ -7,6 +7,10 @@
 %module(directors="1") director_thread
 #endif
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %begin %{
 #define SWIG_JAVA_USE_THREAD_NAME
 //#define DEBUG_DIRECTOR_THREAD_NAME

--- a/Examples/test-suite/extend.i
+++ b/Examples/test-suite/extend.i
@@ -1,5 +1,9 @@
 %module extend
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %extend Base {
   ~Base() {
     delete $self; 

--- a/Examples/test-suite/features.i
+++ b/Examples/test-suite/features.i
@@ -2,6 +2,10 @@
 
 %warnfilter(SWIGWARN_LANG_IDENTIFIER,SWIGWARN_IGNORE_OPERATOR_PLUSEQ);
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 // This testcase checks that %feature is working for templates and non user supplied constructors/destructors and is just generally working
 
 // If the default %exception is used it will not compile. It shouldn't get used.

--- a/Examples/test-suite/li_boost_shared_ptr_bits.i
+++ b/Examples/test-suite/li_boost_shared_ptr_bits.i
@@ -4,6 +4,10 @@
 #define SHARED_PTR_WRAPPERS_IMPLEMENTED
 #endif
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 #if defined(SHARED_PTR_WRAPPERS_IMPLEMENTED)
 
 %include <boost_shared_ptr.i>

--- a/Examples/test-suite/li_std_map.i
+++ b/Examples/test-suite/li_std_map.i
@@ -1,6 +1,10 @@
 %module("templatereduce") li_std_map
 %feature("trackobjects");
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
 namespace another {
 struct map {

--- a/Examples/test-suite/li_std_vector_ptr.i
+++ b/Examples/test-suite/li_std_vector_ptr.i
@@ -5,6 +5,10 @@
 
 %template(IntPtrVector) std::vector<int *>;
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
 #include <iostream>
 using namespace std;

--- a/Examples/test-suite/nested_structs.i
+++ b/Examples/test-suite/nested_structs.i
@@ -12,6 +12,10 @@
 
 #endif
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 // bug #491476
 %inline %{
 struct Outer {

--- a/Examples/test-suite/nested_template_base.i
+++ b/Examples/test-suite/nested_template_base.i
@@ -1,5 +1,9 @@
 %module nested_template_base
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
   template <class T> class OuterT {
     public:

--- a/Examples/test-suite/overload_arrays.i
+++ b/Examples/test-suite/overload_arrays.i
@@ -18,6 +18,9 @@
 %rename(Foos) Foo;
 #endif
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) type;
+#endif
 
 %immutable Spam::type;
 

--- a/Examples/test-suite/overload_method.i
+++ b/Examples/test-suite/overload_method.i
@@ -1,6 +1,11 @@
 /* This test confirms the fix to sourceforge bug #3478922 for R */
 
 %module overload_method
+
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %inline %{
 class Base
    {

--- a/Examples/test-suite/overload_simple.i
+++ b/Examples/test-suite/overload_simple.i
@@ -19,6 +19,10 @@
 %rename(Foos) Foo;
 #endif
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) type;
+#endif
+
 %immutable Spam::type;
 
 %inline %{

--- a/Examples/test-suite/preproc.i
+++ b/Examples/test-suite/preproc.i
@@ -21,6 +21,11 @@
 #endif
 %}
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 /* check __cplusplus case */
 %header
 %{

--- a/Examples/test-suite/pure_virtual.i
+++ b/Examples/test-suite/pure_virtual.i
@@ -12,6 +12,10 @@
 	    SWIGWARN_D_MULTIPLE_INHERITANCE,
 	    SWIGWARN_PHP_MULTIPLE_INHERITANCE) E; /* C#, D, Java, PHP multiple inheritance */
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %nodefaultctor C;
 %nodefaultdtor C;
 %nodefaultctor E;

--- a/Examples/test-suite/static_const_member_2.i
+++ b/Examples/test-suite/static_const_member_2.i
@@ -4,6 +4,10 @@
 %warnfilter(SWIGWARN_RUBY_WRONG_NAME) oss::modules::CavityPackFlags::backward_field;
 %warnfilter(SWIGWARN_RUBY_WRONG_NAME) oss::modules::Test::current_profile;
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{ 
  namespace oss 
  {   

--- a/Examples/test-suite/template_default_class_parms.i
+++ b/Examples/test-suite/template_default_class_parms.i
@@ -1,5 +1,9 @@
 %module template_default_class_parms
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %inline %{
 namespace Space {
   struct SomeType {};

--- a/Examples/test-suite/template_default_class_parms_typedef.i
+++ b/Examples/test-suite/template_default_class_parms_typedef.i
@@ -4,6 +4,10 @@
 
 %feature("python:nondynamic");
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %inline %{
 namespace Space {
   struct SomeType {};

--- a/Examples/test-suite/template_typedef_class_template.i
+++ b/Examples/test-suite/template_typedef_class_template.i
@@ -1,5 +1,9 @@
 %module template_typedef_class_template
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
 namespace Standard {
   template <class T, class U > struct Pair {

--- a/Examples/test-suite/template_typemaps.i
+++ b/Examples/test-suite/template_typemaps.i
@@ -25,6 +25,10 @@
 %typemap(out) Integer2 { /* do nothing */ }
 #endif
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %{
   typedef int Integer1;
 %}

--- a/Examples/test-suite/template_typemaps_typedef.i
+++ b/Examples/test-suite/template_typemaps_typedef.i
@@ -2,6 +2,10 @@
 // Similar to template_typedef_class_template
 // Testing typemaps of a typedef of a nested class in a template and where the template uses default parameters
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
 namespace Standard {
   template <class T, class U > struct Pair {

--- a/Examples/test-suite/template_typemaps_typedef2.i
+++ b/Examples/test-suite/template_typemaps_typedef2.i
@@ -4,6 +4,10 @@
 // Similar to template_typedef_class_template
 // Testing typemaps of a typedef of a nested class in a template and where the template uses default parameters
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %inline %{
 namespace Standard {
   template <class T, class U > struct Pair {

--- a/Examples/test-suite/typemap_delete.i
+++ b/Examples/test-suite/typemap_delete.i
@@ -1,5 +1,9 @@
 %module typemap_delete
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) val;
+#endif
+
 %typemap(in) Rect* (Rect temp) {
   $1 = 0;
   will_not_compile

--- a/Examples/test-suite/valuewrapper_opaque.i
+++ b/Examples/test-suite/valuewrapper_opaque.i
@@ -4,6 +4,10 @@
  *  Opaque types
  */
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 %feature("valuewrapper") C;
 class C;
 

--- a/Examples/test-suite/virtual_poly.i
+++ b/Examples/test-suite/virtual_poly.i
@@ -13,6 +13,10 @@
 #endif
 %}
 
+#ifdef SWIGOCAML
+%warnfilter(SWIGWARN_PARSE_KEYWORD) method;
+#endif
+
 //
 // Check this example with directors wherever possible.
 //


### PR DESCRIPTION
"method", "type", and "val" are OCaml keywords.