### PR TITLE
[OCaml] Replace SWIGSTATIC with SWIGINTERN

### DIFF
--- a/Lib/ocaml/ocaml.i
+++ b/Lib/ocaml/ocaml.i
@@ -4,10 +4,6 @@
  * SWIG Configuration File for Ocaml
  * ----------------------------------------------------------------------------- */
 
-%runtime %{
-#define SWIGSTATIC static
-%}
-
 /* Insert common stuff */
 %insert(runtime) "swigrun.swg"
 

--- a/Lib/ocaml/ocaml.swg
+++ b/Lib/ocaml/ocaml.swg
@@ -31,7 +31,7 @@ extern "C" {
 
 /* Cast a pointer if possible; returns 1 if successful */
     
-    SWIGSTATIC int
+    SWIGINTERN int
     SWIG_Cast (void *source, swig_type_info *source_type,
 	       void **ptr, swig_type_info *dest_type)
     {
@@ -79,7 +79,7 @@ extern "C" {
     }
 
 /* Return 0 if successful. */
-    SWIGSTATIC int
+    SWIGINTERN int
     SWIG_GetPtr(void *inptr, void **outptr, 
 		swig_type_info *intype, swig_type_info *outtype) {
 	if (intype) {
@@ -91,9 +91,9 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC void caml_print_list( CAML_VALUE v );
+    SWIGINTERN void caml_print_list( CAML_VALUE v );
 
-    SWIGSTATIC void caml_print_val( CAML_VALUE v ) {
+    SWIGINTERN void caml_print_val( CAML_VALUE v ) {
 	switch( SWIG_Tag_val(v) ) {
 	case C_bool:
 	    if( Bool_val(SWIG_Field(v,0)) ) fprintf( stderr, "true " );
@@ -157,7 +157,7 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC void caml_print_list( CAML_VALUE v ) {
+    SWIGINTERN void caml_print_list( CAML_VALUE v ) {
 	CAMLparam1(v);
 	while( v && Is_block(v) ) {
 	    fprintf( stderr, "[ " );
@@ -168,7 +168,7 @@ extern "C" {
 	CAMLreturn0;
     }
 
-    SWIGSTATIC CAML_VALUE caml_list_nth( CAML_VALUE lst, int n ) {
+    SWIGINTERN CAML_VALUE caml_list_nth( CAML_VALUE lst, int n ) {
 	CAMLparam1(lst);
 	int i = 0;
 	while( i < n && lst && Is_block(lst) ) {
@@ -178,7 +178,7 @@ extern "C" {
 	else CAMLreturn(SWIG_Field(lst,0));
     }
     
-    SWIGSTATIC CAML_VALUE caml_list_append( CAML_VALUE lst, CAML_VALUE elt ) {
+    SWIGINTERN CAML_VALUE caml_list_append( CAML_VALUE lst, CAML_VALUE elt ) {
 	CAMLparam2(lst,elt);
 	SWIG_CAMLlocal3(v,vt,lh);
 	lh = Val_unit;
@@ -212,20 +212,20 @@ extern "C" {
 	CAMLreturn(lh);
     }
 
-    SWIGSTATIC int caml_list_length( CAML_VALUE lst ) {
+    SWIGINTERN int caml_list_length( CAML_VALUE lst ) {
 	CAMLparam1(lst);
 	int i = 0;
 	while( lst && Is_block(lst) ) { i++; lst = SWIG_Field(lst,1); }
 	CAMLreturn(i);
     }
 
-    SWIGSTATIC void caml_array_set( CAML_VALUE arr, int n, CAML_VALUE item ) {
+    SWIGINTERN void caml_array_set( CAML_VALUE arr, int n, CAML_VALUE item ) {
 	CAMLparam2(arr,item);
 	SWIG_Store_field(SWIG_Field(arr,0),n,item);
 	CAMLreturn0;
     }
 
-    SWIGSTATIC value caml_array_nth( CAML_VALUE arr, int n ) {
+    SWIGINTERN value caml_array_nth( CAML_VALUE arr, int n ) {
 	CAMLparam1(arr);
 	if( SWIG_Tag_val(arr) == C_array )
 	    CAMLreturn(SWIG_Field(SWIG_Field(arr,0),n));
@@ -235,7 +235,7 @@ extern "C" {
 	    failwith("Need array or list");
     }
 
-    SWIGSTATIC int caml_array_len( CAML_VALUE arr ) {
+    SWIGINTERN int caml_array_len( CAML_VALUE arr ) {
 	CAMLparam1(arr);
 	if( SWIG_Tag_val(arr) == C_array )
 	    CAMLreturn(Wosize_val(SWIG_Field(arr,0)));
@@ -245,11 +245,11 @@ extern "C" {
 	    failwith("Need array or list");
     }
 
-    SWIGSTATIC CAML_VALUE caml_swig_alloc(int x,int y) {
+    SWIGINTERN CAML_VALUE caml_swig_alloc(int x,int y) {
 	return caml_alloc(x,y);
     }
 
-    SWIGSTATIC value caml_array_new( int n ) {
+    SWIGINTERN value caml_array_new( int n ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(vv);
 	vv = caml_swig_alloc(1,C_array);
@@ -257,7 +257,7 @@ extern "C" {
 	CAMLreturn(vv);
     }
     
-    SWIGSTATIC CAML_VALUE caml_val_bool( int b ) {
+    SWIGINTERN CAML_VALUE caml_val_bool( int b ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(bv);
 	bv = caml_swig_alloc(1,C_bool);
@@ -265,7 +265,7 @@ extern "C" {
 	CAMLreturn(bv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_char( char c ) {
+    SWIGINTERN CAML_VALUE caml_val_char( char c ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(cv);
 	cv = caml_swig_alloc(1,C_char);
@@ -273,7 +273,7 @@ extern "C" {
 	CAMLreturn(cv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_uchar( unsigned char uc ) {
+    SWIGINTERN CAML_VALUE caml_val_uchar( unsigned char uc ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(ucv);
 	ucv = caml_swig_alloc(1,C_uchar);
@@ -281,7 +281,7 @@ extern "C" {
 	CAMLreturn(ucv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_short( short s ) {
+    SWIGINTERN CAML_VALUE caml_val_short( short s ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(sv);
 	sv = caml_swig_alloc(1,C_short);
@@ -289,7 +289,7 @@ extern "C" {
 	CAMLreturn(sv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_ushort( unsigned short us ) {
+    SWIGINTERN CAML_VALUE caml_val_ushort( unsigned short us ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(usv);
 	usv = caml_swig_alloc(1,C_ushort);
@@ -297,7 +297,7 @@ extern "C" {
 	CAMLreturn(usv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_int( int i ) {
+    SWIGINTERN CAML_VALUE caml_val_int( int i ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(iv);
 	iv = caml_swig_alloc(1,C_int);
@@ -305,7 +305,7 @@ extern "C" {
 	CAMLreturn(iv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_uint( unsigned int ui ) {
+    SWIGINTERN CAML_VALUE caml_val_uint( unsigned int ui ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(uiv);
 	uiv = caml_swig_alloc(1,C_int);
@@ -313,7 +313,7 @@ extern "C" {
 	CAMLreturn(uiv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_long( long l ) {
+    SWIGINTERN CAML_VALUE caml_val_long( long l ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(lv);
 	lv = caml_swig_alloc(1,C_int64);
@@ -321,7 +321,7 @@ extern "C" {
 	CAMLreturn(lv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_ulong( unsigned long ul ) {
+    SWIGINTERN CAML_VALUE caml_val_ulong( unsigned long ul ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(ulv);
 	ulv = caml_swig_alloc(1,C_int64);
@@ -329,7 +329,7 @@ extern "C" {
 	CAMLreturn(ulv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_float( float f ) {
+    SWIGINTERN CAML_VALUE caml_val_float( float f ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(fv);
 	fv = caml_swig_alloc(1,C_float);
@@ -337,7 +337,7 @@ extern "C" {
 	CAMLreturn(fv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_double( double d ) {
+    SWIGINTERN CAML_VALUE caml_val_double( double d ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(fv);
 	fv = caml_swig_alloc(1,C_double);
@@ -345,7 +345,7 @@ extern "C" {
 	CAMLreturn(fv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_ptr( void *p, swig_type_info *info ) {
+    SWIGINTERN CAML_VALUE caml_val_ptr( void *p, swig_type_info *info ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(vv);
 	vv = caml_swig_alloc(2,C_ptr);
@@ -354,7 +354,7 @@ extern "C" {
 	CAMLreturn(vv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_string( const char *p ) {
+    SWIGINTERN CAML_VALUE caml_val_string( const char *p ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(vv);
 	if( !p ) CAMLreturn(caml_val_ptr( (void *)p, 0 ));
@@ -363,7 +363,7 @@ extern "C" {
 	CAMLreturn(vv);
     }
 
-    SWIGSTATIC CAML_VALUE caml_val_string_len( const char *p, int len ) {
+    SWIGINTERN CAML_VALUE caml_val_string_len( const char *p, int len ) {
 	CAMLparam0();
 	SWIG_CAMLlocal1(vv);
 	if( !p || len < 0 ) CAMLreturn(caml_val_ptr( (void *)p, 0 ));
@@ -374,14 +374,14 @@ extern "C" {
     }
 
     #define caml_val_obj(v, name) caml_val_obj_helper(v, SWIG_TypeQuery((name)), name)
-    SWIGSTATIC CAML_VALUE caml_val_obj_helper( void *v, swig_type_info *type, char *name) {
+    SWIGINTERN CAML_VALUE caml_val_obj_helper( void *v, swig_type_info *type, char *name) {
 	CAMLparam0();
 	CAMLreturn(callback2(*caml_named_value("caml_create_object_fn"),
 			     caml_val_ptr(v,type),
 			     copy_string(name)));
     }
 
-    SWIGSTATIC long caml_long_val_full( CAML_VALUE v, char *name ) {
+    SWIGINTERN long caml_long_val_full( CAML_VALUE v, char *name ) {
 	CAMLparam1(v);
 	if( !Is_block(v) ) return 0;
 
@@ -417,11 +417,11 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC long caml_long_val( CAML_VALUE v ) {
+    SWIGINTERN long caml_long_val( CAML_VALUE v ) {
 	return caml_long_val_full(v,0);
     }
 
-    SWIGSTATIC double caml_double_val( CAML_VALUE v ) {
+    SWIGINTERN double caml_double_val( CAML_VALUE v ) {
 	CAMLparam1(v);
 	if( !Is_block(v) ) return 0.0;
 	switch( SWIG_Tag_val(v) ) {
@@ -446,7 +446,7 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC int caml_ptr_val_internal( CAML_VALUE v, void **out, 
+    SWIGINTERN int caml_ptr_val_internal( CAML_VALUE v, void **out,
 					  swig_type_info *descriptor ) {
 	CAMLparam1(v);
 	void *outptr = NULL;
@@ -488,7 +488,7 @@ extern "C" {
 	CAMLreturn(SWIG_GetPtr(outptr,out,outdescr,descriptor));
     }
 
-    SWIGSTATIC void *caml_ptr_val( CAML_VALUE v, swig_type_info *descriptor ) {
+    SWIGINTERN void *caml_ptr_val( CAML_VALUE v, swig_type_info *descriptor ) {
         CAMLparam0();
 #ifdef TYPE_CAST_VERBOSE
 	caml_print_val( v );
@@ -500,11 +500,11 @@ extern "C" {
 	    failwith( "No appropriate conversion found." );
     }
 
-    SWIGSTATIC char *caml_string_val( CAML_VALUE v ) {
+    SWIGINTERN char *caml_string_val( CAML_VALUE v ) {
 	return (char *)caml_ptr_val( v, 0 );
     }
 
-    SWIGSTATIC int caml_string_len( CAML_VALUE v ) {
+    SWIGINTERN int caml_string_len( CAML_VALUE v ) {
 	switch( SWIG_Tag_val(v) ) {
 	case C_string:
 	    return string_length(SWIG_Field(v,0));
@@ -513,7 +513,7 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC int caml_bool_check( CAML_VALUE v ) {
+    SWIGINTERN int caml_bool_check( CAML_VALUE v ) {
 	CAMLparam1(v);
 	
 	if( !Is_block(v) ) return 0;
@@ -528,7 +528,7 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC int caml_int_check( CAML_VALUE v ) {
+    SWIGINTERN int caml_int_check( CAML_VALUE v ) {
 	CAMLparam1(v);
 	
 	if( !Is_block(v) ) return 0;
@@ -549,7 +549,7 @@ extern "C" {
 	}
     }
 
-    SWIGSTATIC int caml_float_check( CAML_VALUE v ) {
+    SWIGINTERN int caml_float_check( CAML_VALUE v ) {
 	CAMLparam1(v);
 	if( !Is_block(v) ) return 0;
 
@@ -563,7 +563,7 @@ extern "C" {
 	}	
     }
 
-    SWIGSTATIC int caml_ptr_check( CAML_VALUE v ) {
+    SWIGINTERN int caml_ptr_check( CAML_VALUE v ) {
 	CAMLparam1(v);
 	if( !Is_block(v) ) return 0;
 

--- a/Lib/ocaml/ocamldec.swg
+++ b/Lib/ocaml/ocamldec.swg
@@ -113,54 +113,46 @@ CAMLextern int64 Int64_val(caml_value_t v);
 
 #define SWIG_contract_assert(expr, msg) if(!(expr)) {failwith(msg);} else
 
-    SWIGSTATIC int
+    SWIGINTERN int
     SWIG_GetPtr(void *source, void **result, swig_type_info *type, swig_type_info *result_type);
+
+    SWIGINTERN CAML_VALUE caml_list_nth( CAML_VALUE lst, int n );
+    SWIGINTERN CAML_VALUE caml_list_append( CAML_VALUE lst, CAML_VALUE elt );
+    SWIGINTERN int caml_list_length( CAML_VALUE lst );
+    SWIGINTERN CAML_VALUE caml_array_new( int n );
+    SWIGINTERN void caml_array_set( CAML_VALUE arr, int n, CAML_VALUE item );
+    SWIGINTERN CAML_VALUE caml_array_nth( CAML_VALUE arr, int n );
+    SWIGINTERN int caml_array_len( CAML_VALUE arr );
+
+    SWIGINTERN CAML_VALUE caml_val_char( char c );
+    SWIGINTERN CAML_VALUE caml_val_uchar( unsigned char c );
+
+    SWIGINTERN CAML_VALUE caml_val_short( short s );
+    SWIGINTERN CAML_VALUE caml_val_ushort( unsigned short s );
     
-    SWIGSTATIC void *
-    SWIG_MustGetPtr (CAML_VALUE v,  swig_type_info *type);
-    
-    SWIGSTATIC CAML_VALUE _wrap_delete_void( CAML_VALUE );
-    
-    SWIGSTATIC int enum_to_int( char *name, CAML_VALUE v );
-    SWIGSTATIC CAML_VALUE int_to_enum( char *name, int v );
+    SWIGINTERN CAML_VALUE caml_val_int( int x );
+    SWIGINTERN CAML_VALUE caml_val_uint( unsigned int x );
 
-    SWIGSTATIC CAML_VALUE caml_list_nth( CAML_VALUE lst, int n );
-    SWIGSTATIC CAML_VALUE caml_list_append( CAML_VALUE lst, CAML_VALUE elt );
-    SWIGSTATIC int caml_list_length( CAML_VALUE lst );
-    SWIGSTATIC CAML_VALUE caml_array_new( int n );
-    SWIGSTATIC void caml_array_set( CAML_VALUE arr, int n, CAML_VALUE item );
-    SWIGSTATIC CAML_VALUE caml_array_nth( CAML_VALUE arr, int n );
-    SWIGSTATIC int caml_array_len( CAML_VALUE arr );
+    SWIGINTERN CAML_VALUE caml_val_long( long x );
+    SWIGINTERN CAML_VALUE caml_val_ulong( unsigned long x );
 
-    SWIGSTATIC CAML_VALUE caml_val_char( char c );
-    SWIGSTATIC CAML_VALUE caml_val_uchar( unsigned char c );
+    SWIGINTERN CAML_VALUE caml_val_float( float f );
+    SWIGINTERN CAML_VALUE caml_val_double( double d );
 
-    SWIGSTATIC CAML_VALUE caml_val_short( short s );
-    SWIGSTATIC CAML_VALUE caml_val_ushort( unsigned short s );
-    
-    SWIGSTATIC CAML_VALUE caml_val_int( int x );
-    SWIGSTATIC CAML_VALUE caml_val_uint( unsigned int x );
+    SWIGINTERN CAML_VALUE caml_val_ptr( void *p, swig_type_info *descriptor );
 
-    SWIGSTATIC CAML_VALUE caml_val_long( long x );
-    SWIGSTATIC CAML_VALUE caml_val_ulong( unsigned long x );
+    SWIGINTERN CAML_VALUE caml_val_string( const char *str );
+    SWIGINTERN CAML_VALUE caml_val_string_len( const char *str, int len );
 
-    SWIGSTATIC CAML_VALUE caml_val_float( float f );
-    SWIGSTATIC CAML_VALUE caml_val_double( double d );
+    SWIGINTERN long caml_long_val( CAML_VALUE v );
+    SWIGINTERN double caml_double_val( CAML_VALUE v );
 
-    SWIGSTATIC CAML_VALUE caml_val_ptr( void *p, swig_type_info *descriptor );
-
-    SWIGSTATIC CAML_VALUE caml_val_string( const char *str );
-    SWIGSTATIC CAML_VALUE caml_val_string_len( const char *str, int len );
-
-    SWIGSTATIC long caml_long_val( CAML_VALUE v );
-    SWIGSTATIC double caml_double_val( CAML_VALUE v );
-
-    SWIGSTATIC int caml_ptr_val_internal( CAML_VALUE v, void **out,
+    SWIGINTERN int caml_ptr_val_internal( CAML_VALUE v, void **out,
 				      swig_type_info *descriptor );
-    SWIGSTATIC void *caml_ptr_val( CAML_VALUE v, swig_type_info *descriptor );
+    SWIGINTERN void *caml_ptr_val( CAML_VALUE v, swig_type_info *descriptor );
 
-    SWIGSTATIC char *caml_string_val( CAML_VALUE v );
-    SWIGSTATIC int caml_string_len( CAML_VALUE v );
+    SWIGINTERN char *caml_string_val( CAML_VALUE v );
+    SWIGINTERN int caml_string_len( CAML_VALUE v );
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Use SWIGINTERN to silence unused function warnings.

In addition, remove the declarations for SWIG_MustGetPtr(),
wrap_delete_void(), enum_to_int(), and int_to_enum() -- these
lacked definitions and caused compiler warnings.