### PR TITLE
Allow multiple "fragment" keywords in a typemap

### DIFF
--- a/Doc/Manual/Typemaps.html
+++ b/Doc/Manual/Typemaps.html
@@ -3983,14 +3983,16 @@ inclusion of the other fragments.
 
 <li>
 <p>
-A typemap can also use more than one fragment, but since the
-syntax is different, you need to specify the dependent fragments in a comma separated
-list. Consider:
+A typemap can also use more than one fragment. You can provide multiple
+"fragment" keywords to the typemap (the same syntax as the <tt>%fragment</tt>
+directive) or specify the dependent fragments in a comma-separated list.
+Consider:
 </p>
 
 <div class="code">
 <pre>
 %typemap(in, fragment="frag1, frag2, frag3") {...}
+%typemap(out, fragment="frag1", fragment="frag2") {...}
 </pre>
 </div>
 

--- a/Examples/test-suite/fragments.i
+++ b/Examples/test-suite/fragments.i
@@ -61,6 +61,7 @@ typedef int int_infrag1;
 typedef int int_infrag2;
 typedef int int_outfrag1;
 typedef int int_outfrag2;
+typedef int int_outfrag3;
 
 %fragment("infrag2","runtime") %{
 typedef int_infrag1 int_infrag2;
@@ -87,6 +88,13 @@ typedef int int_tcfrag1;
 typedef int_tcfrag1 int_tcfrag2;
 %}
 
+%fragment("outspecial"{bool},"runtime") %{
+typedef int int_outfrag3_temp;
+%}
+%fragment("outfrag3","runtime") %{
+typedef int_outfrag3_temp int_outfrag3;
+%}
+
 %typemap(in, fragment="infrag1", fragment="infrag2") int_infrag2
 %{$typemap(in,int)%}
 
@@ -100,7 +108,12 @@ typedef int_tcfrag1 int_tcfrag2;
 %typemap(out, noblock=1, fragment="outfrag1", fragment="outfrag2") int_outfrag1
 {$typemap(out,int)}
 
+/* Test fragment specialization */
+%typemap(out, noblock=1, fragment="outspecial"{bool}, fragment="outfrag3") int_outfrag3
+{$typemap(out,int)}
+
 %inline %{
 int identity_in(int_infrag2 inp) { return inp; }
 int_outfrag2 identity_out(int inp) { return inp; }
+int_outfrag3 identity_out_2(int inp) { return inp; }
 %}

--- a/Examples/test-suite/fragments.i
+++ b/Examples/test-suite/fragments.i
@@ -6,7 +6,7 @@
 int foobar(int a)
 {
   return a;
-}  
+}
 %}
 
 /*
@@ -18,7 +18,7 @@ int foobar(int a)
 int bar(int a)
 {
   return foobar(a);
-}  
+}
 %}
 
 %typemap(in,fragment="Hi") int hola "$1 = 123;";
@@ -28,9 +28,79 @@ int bar(int a)
 
 int bar(int a);
 
-int foo(int hola) 
+int foo(int hola)
 {
   return bar(hola);
 }
 
+%}
+
+/* Instantiate multiple fragments at once using multiple keywords */
+typedef int int_infrag3;
+typedef int explicit_frag3;
+
+%fragment("explicit_frag1","header", noblock=1) {
+typedef int explicit_frag1;
+}
+
+%fragment("explicit_frag2","header", noblock=1, noblock=1) {
+typedef explicit_frag1 explicit_frag2;
+}
+
+%fragment("explicit_frag3","header",
+          fragment="explicit_frag1", fragment="explicit_frag2")
+%{typedef explicit_frag2 explicit_frag3;%}
+
+%fragment("explicit_frag3");
+%inline %{
+explicit_frag3 my_int = 0;
+%}
+
+/* Test typemap's ability to instantiate multiple fragments on demand */
+typedef int int_infrag1;
+typedef int int_infrag2;
+typedef int int_outfrag1;
+typedef int int_outfrag2;
+
+%fragment("infrag2","runtime") %{
+typedef int_infrag1 int_infrag2;
+%}
+
+%fragment("infrag1","runtime") %{
+typedef int int_infrag1;
+%}
+%fragment("infrag2","runtime") %{
+typedef int_infrag1 int_infrag2;
+%}
+
+%fragment("outfrag1","runtime") %{
+typedef int int_outfrag1;
+%}
+%fragment("outfrag2","runtime") %{
+typedef int_outfrag1 int_outfrag2;
+%}
+
+%fragment("tcfrag1","runtime") %{
+typedef int int_tcfrag1;
+%}
+%fragment("tcfrag2","runtime") %{
+typedef int_tcfrag1 int_tcfrag2;
+%}
+
+%typemap(in, fragment="infrag1", fragment="infrag2") int_infrag2
+%{$typemap(in,int)%}
+
+%typemap(check, fragment="tcfrag1", noblock=1, fragment="tcfrag2") int_infrag2
+{(void)sizeof(int_tcfrag2);}
+
+%typemap(out, fragment="outfrag1", fragment="outfrag2", noblock=1) int_outfrag2
+{$typemap(out,int)}
+
+/* Test another permutation of keyword order */
+%typemap(out, noblock=1, fragment="outfrag1", fragment="outfrag2") int_outfrag1
+{$typemap(out,int)}
+
+%inline %{
+int identity_in(int_infrag2 inp) { return inp; }
+int_outfrag2 identity_out(int inp) { return inp; }
 %}

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -1257,6 +1257,51 @@ static String *typemap_warn(const_String_or_char_ptr tmap_method, Parm *p) {
 }
 
 /* -----------------------------------------------------------------------------
+ * typemap_merge_fragment_kwargs()
+ *
+ * If multiple 'fragment' attributes are provided to a typemap, combine them by
+ * concatenating with commas.
+ * ----------------------------------------------------------------------------- */
+
+static void typemap_merge_fragment_kwargs(Parm *kw) {
+  Parm   *reattach_kw = NULL;
+  Parm   *prev_kw     = NULL;
+  Parm   *next_kw     = NULL;
+  String *fragment    = NULL;
+  while (kw) {
+    next_kw = nextSibling(kw);
+    if (Strcmp(Getattr(kw, "name"), "fragment") == 0) {
+      String *thisfragment = Getattr(kw, "value");
+      if (!fragment) {
+        /* First fragment found; it should remain in the list */
+        fragment = thisfragment;
+        prev_kw = kw;
+      } else {
+        /* Concatentate to previously found fragment */
+        Printv(fragment, ",", thisfragment, NULL);
+        reattach_kw = prev_kw;
+      }
+    } else {
+      /* Not a fragment */
+      if (reattach_kw) {
+        /* Update linked list to remove duplicate fragment */
+        DohIncref(kw);
+        set_nextSibling(reattach_kw, kw);
+        set_previousSibling(kw, reattach_kw);
+        Delete(reattach_kw);
+        reattach_kw = NULL;
+      }
+      prev_kw = kw;
+    }
+    kw = next_kw;
+  }
+  if (reattach_kw) {
+    /* Update linked list to remove duplicate fragment */
+    set_nextSibling(reattach_kw, kw);
+  }
+}
+
+/* -----------------------------------------------------------------------------
  * Swig_typemap_lookup()
  *
  * Attach one or more typemaps to a node and optionally generate the typemap contents
@@ -1463,10 +1508,11 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
 
   /* Attach kwargs - ie the typemap attributes */
   kw = Getattr(tm, "kwargs");
+  typemap_merge_fragment_kwargs(kw);
   while (kw) {
     String *value = Copy(Getattr(kw, "value"));
     String *kwtype = Getattr(kw, "type");
-    String *kwname = Getattr(kw, "name");
+    char *ckwname = Char(Getattr(kw, "name"));
     {
       /* Expand special variables in typemap attributes. */
       SwigType *ptype = Getattr(node, "type");
@@ -1487,15 +1533,8 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
       Append(value, mangle);
       Delete(mangle);
     }
-    if (Cmp(kwname, "fragment") != 0) {
-      sprintf(temp, "%s:%s", cmethod, Char(kwname));
+    sprintf(temp, "%s:%s", cmethod, ckwname);
       Setattr(node, typemap_method_name(temp), value);
-    } else {
-      /* Emit this fragment */
-      Setfile(value, Getfile(node));
-      Setline(value, Getline(node));
-      Swig_fragment_emit(value);
-    }
     Delete(value);
     kw = nextSibling(kw);
   }
@@ -1530,6 +1569,20 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
       Replace(warning, "$symname", symname, DOH_REPLACE_ANY);
     Swig_warning(0, Getfile(node), Getline(node), "%s\n", warning);
     Delete(warning);
+  }
+
+  /* Look for code fragments */
+  {
+    String *fragment;
+    sprintf(temp, "%s:fragment", cmethod);
+    fragment = Getattr(node, typemap_method_name(temp));
+    if (fragment) {
+      String *fname = Copy(fragment);
+      Setfile(fname, Getfile(node));
+      Setline(fname, Getline(node));
+      Swig_fragment_emit(fname);
+      Delete(fname);
+    }
   }
 
   Delete(cname);
@@ -1570,6 +1623,7 @@ String *Swig_typemap_lookup(const_String_or_char_ptr tmap_method, Node *node, co
 static void typemap_attach_kwargs(Hash *tm, const_String_or_char_ptr tmap_method, Parm *firstp, int nmatch) {
   String *temp = NewStringEmpty();
   Parm *kw = Getattr(tm, "kwargs");
+  typemap_merge_fragment_kwargs(kw);
   while (kw) {
     String *value = Copy(Getattr(kw, "value"));
     String *type = Getattr(kw, "type");

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -1466,7 +1466,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
   while (kw) {
     String *value = Copy(Getattr(kw, "value"));
     String *kwtype = Getattr(kw, "type");
-    char *ckwname = Char(Getattr(kw, "name"));
+    String *kwname = Getattr(kw, "name");
     {
       /* Expand special variables in typemap attributes. */
       SwigType *ptype = Getattr(node, "type");
@@ -1487,8 +1487,15 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
       Append(value, mangle);
       Delete(mangle);
     }
-    sprintf(temp, "%s:%s", cmethod, ckwname);
-    Setattr(node, typemap_method_name(temp), value);
+    if (Cmp(kwname, "fragment") != 0) {
+      sprintf(temp, "%s:%s", cmethod, Char(kwname));
+      Setattr(node, typemap_method_name(temp), value);
+    } else {
+      /* Emit this fragment */
+      Setfile(value, Getfile(node));
+      Setline(value, Getline(node));
+      Swig_fragment_emit(value);
+    }
     Delete(value);
     kw = nextSibling(kw);
   }
@@ -1523,20 +1530,6 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
       Replace(warning, "$symname", symname, DOH_REPLACE_ANY);
     Swig_warning(0, Getfile(node), Getline(node), "%s\n", warning);
     Delete(warning);
-  }
-
-  /* Look for code fragments */
-  {
-    String *fragment;
-    sprintf(temp, "%s:fragment", cmethod);
-    fragment = Getattr(node, typemap_method_name(temp));
-    if (fragment) {
-      String *fname = Copy(fragment);
-      Setfile(fname, Getfile(node));
-      Setline(fname, Getline(node));
-      Swig_fragment_emit(fname);
-      Delete(fname);
-    }
   }
 
   Delete(cname);

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -1272,6 +1272,7 @@ static void typemap_merge_fragment_kwargs(Parm *kw) {
     next_kw = nextSibling(kw);
     if (Strcmp(Getattr(kw, "name"), "fragment") == 0) {
       String *thisfragment = Getattr(kw, "value");
+      String *kwtype = Getattr(kw, "type");
       if (!fragment) {
         /* First fragment found; it should remain in the list */
         fragment = thisfragment;
@@ -1280,6 +1281,13 @@ static void typemap_merge_fragment_kwargs(Parm *kw) {
         /* Concatentate to previously found fragment */
         Printv(fragment, ",", thisfragment, NULL);
         reattach_kw = prev_kw;
+      }
+      if (kwtype) {
+        String *mangle = Swig_string_mangle(kwtype);
+        Append(fragment, mangle);
+        Delete(mangle);
+        /* Remove 'type' from kwargs so it's not duplicated later */
+        Setattr(kw, "type", NULL);
       }
     } else {
       /* Not a fragment */


### PR DESCRIPTION
This makes the `%typemap(..., fragment=...)` usage consistent with the use of `%fragment`. Previously only the last `fragment=` keyword in `%typemap` would be added; the others were silently ignored.