### PR TITLE
Add missing includes to library and test cases

### DIFF
--- a/Examples/test-suite/char_strings.i
+++ b/Examples/test-suite/char_strings.i
@@ -11,6 +11,7 @@ below.
 
 %{
 #include <stdio.h>
+#include <string.h>
 
 #define OTHERLAND_MSG "Little message from the safe world."
 #define CPLUSPLUS_MSG "A message from the deep dark world of C++, where anything is possible."
@@ -150,11 +151,11 @@ const char global_const_char_array2[sizeof(CPLUSPLUS_MSG)+1] = CPLUSPLUS_MSG;
 %inline {
   struct Formatpos;
   struct OBFormat;
-  
+
   static int GetNextFormat(Formatpos& itr, const  char*& str,OBFormat*& pFormat) {
     return 0;
   }
-  
+
 
 
 }

--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -18,6 +18,7 @@
 %{
 #define TESTCASE_THROW1(T1)
 #define TESTCASE_THROW2(T1, T2)
+#include <string.h>
 %}
 
 %include <std_string.i>
@@ -71,7 +72,7 @@
   class EnumClass {
     public:
       enum speed { FAST, SLOW };
-      // Note: default values should be EnumClass::FAST and SWEET 
+      // Note: default values should be EnumClass::FAST and SWEET
       bool blah(speed s = FAST, flavor f = SWEET) { return (s == FAST && f == SWEET); };
   };
 
@@ -83,16 +84,16 @@
 
   // casts
   const char * casts1(const char *m = (const char *) NULL) {
-    char *ret = NULL; 
-    if (m) { 
+    char *ret = NULL;
+    if (m) {
       ret = new char[strlen(m)+1];
       strcpy(ret, m);
     }
     return ret;
   }
   const char * casts2(const char *m = (const char *) "Hello") {
-    char *ret = NULL; 
-    if (m) { 
+    char *ret = NULL;
+    if (m) {
       ret = new char[strlen(m)+1];
       strcpy(ret, m);
     }
@@ -108,16 +109,16 @@
   char chartest6(char c = '\x43') { return c; } // 'C'
 
   // namespaces
-  namespace AType { 
-    enum AType { NoType }; 
-  } 
+  namespace AType {
+    enum AType { NoType };
+  }
   void dummy(AType::AType aType = AType::NoType) {}
-  namespace A { 
-    namespace B { 
-      int CONST_NUM = 10; 
-    } 
+  namespace A {
+    namespace B {
+      int CONST_NUM = 10;
+    }
     int afunction(int i = B::CONST_NUM) { return i; }
-  } 
+  }
 
   // references
   int reftest1(const int &x = 42) { return x; }
@@ -131,7 +132,7 @@
       void test(int x = Oak + Fir + Cedar) {}
   };
   enum Tree::types chops(enum Tree::types type) { return type; }
- 
+
 %}
 
 // Rename a class member
@@ -155,11 +156,11 @@
       static int spam;
 
       Foo(){}
-     
+
       Foo(int x, int y = 0, int z = 0){}
 
       void meth(int x, int y = 0, int z = 0){}
-    
+
       // Use a renamed member as a default argument.  SWIG has to resolve
       // bar to Foo::bar and not Foo::spam.  SWIG-1.3.11 got this wrong.
       // (Different default parameter wrapping in SWIG-1.3.23 ensures SWIG doesn't have to resolve these symbols).
@@ -189,20 +190,20 @@
 // tests valuewrapper
 %feature("compactdefaultargs") MyClass2::set;
 %inline %{
-  enum MyType { Val1, Val2 }; 
+  enum MyType { Val1, Val2 };
 
-  class MyClass1 
-  { 
-    public: 
+  class MyClass1
+  {
+    public:
       MyClass1(MyType myType) {}
-  }; 
+  };
 
-  class MyClass2 
-  { 
-    public : 
+  class MyClass2
+  {
+    public :
       void set(MyClass1 cl1 = Val1) {}
-      // This could have been written : set(MyClass1 cl1 = MyClass1(Val1)) 
-      // But it works in C++ since there is a "conversion" constructor in  MyClass1. 
+      // This could have been written : set(MyClass1 cl1 = MyClass1(Val1))
+      // But it works in C++ since there is a "conversion" constructor in  MyClass1.
       void set2(MyClass1 cl1 = Val1) {}
   };
 %}
@@ -281,7 +282,7 @@ struct ConstMethods {
 };
 %}
 
-// const methods 
+// const methods
 // runtime test needed to check that the const method is called
 struct ConstMethods {
   int coo(double d = 0.0) const;
@@ -305,8 +306,8 @@ struct ConstMethods {
       return(x+p);
     }
 
-    typedef struct Pointf { 
-      double		x,y; 
+    typedef struct Pointf {
+      double		x,y;
     } Pointf;
   }
 %}

--- a/Examples/test-suite/director_thread.i
+++ b/Examples/test-suite/director_thread.i
@@ -20,7 +20,6 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <process.h>
-#include <stdio.h>
 #else
 #include <pthread.h>
 #include <errno.h>
@@ -30,6 +29,7 @@
 #endif
 
 #include <assert.h>
+#include <stdio.h>
 #include "swig_examples_lock.h"
 
 class Foo;  

--- a/Examples/test-suite/li_cdata.i
+++ b/Examples/test-suite/li_cdata.i
@@ -5,4 +5,8 @@
 %cdata(int);
 %cdata(double);
 
+%{
+#include <stdlib.h>
+%}
+
 void *malloc(size_t size);

--- a/Examples/test-suite/li_cdata_cpp.i
+++ b/Examples/test-suite/li_cdata_cpp.i
@@ -5,4 +5,8 @@
 %cdata(int);
 %cdata(double);
 
+%{
+#include <stdlib.h>
+%}
+
 void *malloc(size_t size);

--- a/Examples/test-suite/li_std_except.i
+++ b/Examples/test-suite/li_std_except.i
@@ -9,6 +9,8 @@
 %}
 
 %inline %{
+  #include <stdexcept>
+  #include <typeinfo>
   struct E1 : public std::exception
   {
   };

--- a/Examples/test-suite/memberin_extend.i
+++ b/Examples/test-suite/memberin_extend.i
@@ -11,6 +11,7 @@ struct ExtendMe {
 
 %{
 #include <map>
+#include <string.h>
 std::map<ExtendMe*, char *> ExtendMeStringMap;
 void ExtendMe_thing_set(ExtendMe *self, const char *val) {
   char *old_val = ExtendMeStringMap[self];

--- a/Examples/test-suite/mod.h
+++ b/Examples/test-suite/mod.h
@@ -1,4 +1,4 @@
-
+#include <cstddef>
 
 class C;
 

--- a/Examples/test-suite/namespace_typemap.i
+++ b/Examples/test-suite/namespace_typemap.i
@@ -2,6 +2,7 @@
 %module namespace_typemap
 
 %{
+#include <string.h>
 namespace test {
    /* A minimalistic string class */
    class string_class {

--- a/Examples/test-suite/nested_extend_c.i
+++ b/Examples/test-suite/nested_extend_c.i
@@ -12,6 +12,10 @@
 
 #endif
 
+%{
+#include "stdlib.h"
+%}
+
 #if !defined(SWIGOCTAVE) && !defined(SWIG_JAVASCRIPT_V8)
 %extend hiA {
   hiA() {

--- a/Examples/test-suite/operator_overload_break.i
+++ b/Examples/test-suite/operator_overload_break.i
@@ -18,6 +18,7 @@
 
 %{
 #include <iostream>
+#include <stdlib.h>
 using namespace std;
 %}
 

--- a/Examples/test-suite/operator_pointer_ref.i
+++ b/Examples/test-suite/operator_pointer_ref.i
@@ -4,6 +4,8 @@
 #if defined(_MSC_VER)
   #pragma warning(disable: 4996) // 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _strdup. See online help for details.
 #endif
+#include <string.h>
+#include <stdlib.h>
 %}
 
 %rename(AsCharStarRef) operator char*&;

--- a/Examples/test-suite/smart_pointer_const_overload.i
+++ b/Examples/test-suite/smart_pointer_const_overload.i
@@ -3,6 +3,10 @@
 %warnfilter(SWIGWARN_LANG_OVERLOAD_IGNORED) Bar::operator->;      // Overloaded method Bar::operator ->() ignored
 %warnfilter(SWIGWARN_LANG_OVERLOAD_IGNORED) Bar2::operator->;     // Overloaded method Bar2::operator ->() ignored
 
+%{
+#include <stdlib.h>
+%}
+
 %inline %{
 int CONST_ACCESS = 1;
 int MUTABLE_ACCESS = 2;

--- a/Examples/test-suite/special_variable_macros.i
+++ b/Examples/test-suite/special_variable_macros.i
@@ -9,6 +9,8 @@
 #if defined(_MSC_VER)
   #pragma warning(disable: 4996) // 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _strdup. See online help for details.
 #endif
+#include <stdlib.h>
+#include <string.h>
 %}
 
 %ignore Name::operator=;

--- a/Examples/test-suite/string_simple.i
+++ b/Examples/test-suite/string_simple.i
@@ -3,6 +3,7 @@
 %newobject copy_string;
 
 %inline %{
+#include <stdlib.h>
 #include <string.h>
 const char* copy_string(const char* str) {
   size_t len = strlen(str);

--- a/Examples/test-suite/testdir/inctest/subdir2/hello.i
+++ b/Examples/test-suite/testdir/inctest/subdir2/hello.i
@@ -3,6 +3,7 @@
 
 %{
 typedef char * TypedefString;
+#include <string.h>
 %}
 
 

--- a/Examples/test-suite/threads.i
+++ b/Examples/test-suite/threads.i
@@ -9,6 +9,7 @@
 
 %inline %{
   #include <string>
+  #include <string.h>
   struct Kerfuffle {
     std::string StdString(std::string str) {
       return str;

--- a/Examples/test-suite/threads_exception.i
+++ b/Examples/test-suite/threads_exception.i
@@ -13,6 +13,7 @@
 %}
 
 %{
+#include <string.h>
 struct A {};
 %}
 

--- a/Examples/test-suite/typedef_struct.i
+++ b/Examples/test-suite/typedef_struct.i
@@ -31,6 +31,7 @@
 
 #define MS_NOOVERRIDE -1111
 
+#include <stdlib.h>
 %}
 
 

--- a/Examples/test-suite/varargs.i
+++ b/Examples/test-suite/varargs.i
@@ -7,6 +7,10 @@
 %varargs(int mode = 0) Foo::statictest(const char*fmt, ...);
 %varargs(2, int mode = 0) test_plenty(const char*fmt, ...);
 
+%{
+#include <string.h>
+%}
+
 %inline %{
 char *test(const char *fmt, ...) {
   return (char *) fmt;

--- a/Lib/carrays.i
+++ b/Lib/carrays.i
@@ -5,6 +5,12 @@
  * pointers as arrays.
  * ----------------------------------------------------------------------------- */
 
+#ifndef __cplusplus
+// C uses free/calloc/malloc
+%include "swigfragments.swg"
+%fragment("<stdlib.h>");
+#endif
+
 /* -----------------------------------------------------------------------------
  * %array_functions(TYPE,NAME)
  *

--- a/Lib/cdata.i
+++ b/Lib/cdata.i
@@ -4,6 +4,8 @@
  * SWIG library file containing macros for manipulating raw C data as strings.
  * ----------------------------------------------------------------------------- */
 
+%include <swigfragments.swg>
+
 %{
 typedef struct SWIGCDATA {
     char *data;

--- a/Lib/cdata.i
+++ b/Lib/cdata.i
@@ -68,7 +68,7 @@ static jbyteArray SWIG_JavaArrayOutCDATA(JNIEnv *jenv, char *result, jsize sz) {
 
 
 /* -----------------------------------------------------------------------------
- * %cdata(TYPE [, NAME]) 
+ * %cdata(TYPE [, NAME])
  *
  * Convert raw C data to a binary string.
  * ----------------------------------------------------------------------------- */
@@ -106,6 +106,8 @@ SWIGCDATA cdata_##NAME(TYPE *ptr, int nelements);
 %rename(cdata) ::cdata_void(void *ptr, int nelements);
 
 %cdata(void);
+
+%fragment("<string.h>");
 
 /* Memory move function. Due to multi-argument typemaps this appears to be wrapped as
 void memmove(void *data, const char *s); */

--- a/Lib/cpointer.i
+++ b/Lib/cpointer.i
@@ -5,6 +5,12 @@
  * pointer objects.
  * ----------------------------------------------------------------------------- */
 
+#ifndef __cplusplus
+// C uses free/calloc/malloc
+%include "swigfragments.swg"
+%fragment("<stdlib.h>");
+#endif
+
 /* -----------------------------------------------------------------------------
  * %pointer_class(type,name)
  *

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -442,6 +442,10 @@ namespace std {
  * Default char * and C array typemaps
  * ----------------------------------------------------------------------------- */
 
+%fragment("<string.h>", "runtime") %{
+#include <string.h>
+%}
+
 /* Set up the typemap for handling new return strings */
 
 #ifdef __cplusplus
@@ -453,7 +457,7 @@ namespace std {
 /* Default typemap for handling char * members */
 
 #ifdef __cplusplus
-%typemap(memberin) char * {
+%typemap(memberin,fragment="<string.h>") char * {
   delete [] $1;
   if ($input) {
      $1 = ($1_type) (new char[strlen((const char *)$input)+1]);
@@ -462,7 +466,7 @@ namespace std {
      $1 = 0;
   }
 }
-%typemap(memberin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG) const char * {
+%typemap(memberin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG,fragment="<string.h>") const char * {
   if ($input) {
      $1 = ($1_type) (new char[strlen((const char *)$input)+1]);
      strcpy((char *)$1, (const char *)$input);
@@ -470,7 +474,7 @@ namespace std {
      $1 = 0;
   }
 }
-%typemap(globalin) char * {
+%typemap(globalin,fragment="<string.h>") char * {
   delete [] $1;
   if ($input) {
      $1 = ($1_type) (new char[strlen((const char *)$input)+1]);
@@ -479,7 +483,7 @@ namespace std {
      $1 = 0;
   }
 }
-%typemap(globalin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG) const char * {
+%typemap(globalin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG,fragment="<string.h>") const char * {
   if ($input) {
      $1 = ($1_type) (new char[strlen((const char *)$input)+1]);
      strcpy((char *)$1, (const char *)$input);
@@ -488,7 +492,7 @@ namespace std {
   }
 }
 #else
-%typemap(memberin) char * {
+%typemap(memberin,fragment="<string.h>") char * {
   free($1);
   if ($input) {
      $1 = ($1_type) malloc(strlen((const char *)$input)+1);
@@ -497,7 +501,7 @@ namespace std {
      $1 = 0;
   }
 }
-%typemap(memberin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG) const char * {
+%typemap(memberin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG,fragment="<string.h>") const char * {
   if ($input) {
      $1 = ($1_type) malloc(strlen((const char *)$input)+1);
      strcpy((char *)$1, (const char *)$input);
@@ -505,7 +509,7 @@ namespace std {
      $1 = 0;
   }
 }
-%typemap(globalin) char * {
+%typemap(globalin,fragment="<string.h>") char * {
   free($1);
   if ($input) {
      $1 = ($1_type) malloc(strlen((const char *)$input)+1);
@@ -514,7 +518,7 @@ namespace std {
      $1 = 0;
   }
 }
-%typemap(globalin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG) const char * {
+%typemap(globalin,warning=SWIGWARN_TYPEMAP_CHARLEAK_MSG,fragment="<string.h>") const char * {
   if ($input) {
      $1 = ($1_type) malloc(strlen((const char *)$input)+1);
      strcpy((char *)$1, (const char *)$input);
@@ -527,7 +531,7 @@ namespace std {
 
 /* Character array handling */
 
-%typemap(memberin) char [ANY] {
+%typemap(memberin,fragment="<string.h>") char [ANY] {
   if($input) {
     strncpy((char*)$1, (const char *)$input, $1_dim0-1);
     $1[$1_dim0-1] = 0;
@@ -536,7 +540,7 @@ namespace std {
   }
 }
 
-%typemap(globalin) char [ANY] {
+%typemap(globalin,fragment="<string.h>") char [ANY] {
   if($input) {
     strncpy((char*)$1, (const char *)$input, $1_dim0-1);
     $1[$1_dim0-1] = 0;
@@ -545,25 +549,25 @@ namespace std {
   }
 }
 
-%typemap(memberin) char [] {
+%typemap(memberin,fragment="<string.h>") char [] {
   if ($input) strcpy((char *)$1, (const char *)$input);
   else $1[0] = 0;
 }
 
-%typemap(globalin) char [] {
+%typemap(globalin,fragment="<string.h>") char [] {
   if ($input) strcpy((char *)$1, (const char *)$input);
   else $1[0] = 0;
 }
 
 /* memberin/globalin typemap for arrays. */
 
-%typemap(memberin) SWIGTYPE [ANY] {
+%typemap(memberin,fragment="<string.h>") SWIGTYPE [ANY] {
   size_t ii;
   $1_basetype *b = ($1_basetype *) $1;
   for (ii = 0; ii < (size_t)$1_size; ii++) b[ii] = *(($1_basetype *) $input + ii);
 }
 
-%typemap(globalin) SWIGTYPE [ANY] {
+%typemap(globalin,fragment="<string.h>") SWIGTYPE [ANY] {
   size_t ii;
   $1_basetype *b = ($1_basetype *) $1;
   for (ii = 0; ii < (size_t)$1_size; ii++) b[ii] = *(($1_basetype *) $input + ii);
@@ -571,7 +575,7 @@ namespace std {
 
 /* memberin/globalin typemap for double arrays. */
 
-%typemap(memberin) SWIGTYPE [ANY][ANY] {
+%typemap(memberin,fragment="<string.h>") SWIGTYPE [ANY][ANY] {
   $basetype (*inp)[$1_dim1] = ($basetype (*)[$1_dim1])($input);
   $basetype (*dest)[$1_dim1] = ($basetype (*)[$1_dim1])($1);
   size_t ii = 0;
@@ -583,7 +587,7 @@ namespace std {
   }
 }
 
-%typemap(globalin) SWIGTYPE [ANY][ANY] {
+%typemap(globalin,fragment="<string.h>") SWIGTYPE [ANY][ANY] {
   $basetype (*inp)[$1_dim1] = ($basetype (*)[$1_dim1])($input);
   $basetype (*dest)[$1_dim1] = ($basetype (*)[$1_dim1])($1);
   size_t ii = 0;

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -442,10 +442,6 @@ namespace std {
  * Default char * and C array typemaps
  * ----------------------------------------------------------------------------- */
 
-%fragment("<string.h>", "runtime") %{
-#include <string.h>
-%}
-
 /* Set up the typemap for handling new return strings */
 
 #ifdef __cplusplus

--- a/Lib/swigfragments.swg
+++ b/Lib/swigfragments.swg
@@ -29,6 +29,10 @@
 #include <math.h>
 %}
 
+%fragment("<string.h>", "header") %{
+#include <string.h>
+%}
+
 %fragment("<stddef.h>", "header") %{
 #include <stddef.h>
 %}


### PR DESCRIPTION
Many of these tests implicitly required the target language library files to include the headers upstream. This change allows tests in future language modules to pass without requiring those modules' base library to unconditionally include these headers.