### PR TITLE
Add support for parsing curly braces in typemap kwargs

### DIFF
--- a/Doc/Manual/Typemaps.html
+++ b/Doc/Manual/Typemaps.html
@@ -734,7 +734,7 @@ these methods is described later.
 </p>
 
 <p>
-<em>modifiers</em> is an optional comma separated list of <tt>name="value"</tt> values. 
+<em>modifiers</em> is an optional comma separated list of <tt>name="value"</tt> or <tt>name={value}</tt> values. 
 These are sometimes to attach extra information to a typemap and is often target-language dependent.
 They are also known as typemap attributes.
 </p>
@@ -803,6 +803,7 @@ Here are some examples of valid typemap specifications:
 
 /* Typemap with modifiers */
 %typemap(in, doc="integer") int "$1 = scm_to_int($input);";
+%typemap(in, doc={embedded MACRO will be expanded}) int "$1 = scm_to_int($input);";
 
 /* Typemap applied to patterns of multiple arguments */
 %typemap(in) (char *str, int len),

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -507,6 +507,7 @@ CPP_TEST_CASES += \
 	typedef_sizet \
 	typedef_struct_cpp \
 	typedef_typedef \
+	typemap_args \
 	typemap_arrays \
 	typemap_array_qualifiers \
 	typemap_delete \

--- a/Examples/test-suite/typemap_args.i
+++ b/Examples/test-suite/typemap_args.i
@@ -1,0 +1,32 @@
+%module typemap_args
+
+%define MYTYPECHECK_int_YAY    SWIG_TYPECHECK_INTEGER %enddef
+%define MYTYPECHECK_double_YAY SWIG_TYPECHECK_DOUBLE  %enddef
+
+%fragment("includeme"{int}, "header") %{
+#define INCLUDED_INT_TYPECHECK
+%}
+%fragment("includeme"{double}, "header") %{
+#define INCLUDED_DOUBLE_TYPECHECK
+%}
+
+%define %add_typecheck(TYPE)
+%typemap(typecheck, precedence={MYTYPECHECK_ ## TYPE ## _YAY}, fragment="includeme"{TYPE}) TYPE {
+  $1 = (TYPE)$1;
+}
+%enddef
+
+%add_typecheck(int)
+%add_typecheck(double)
+
+%inline %{
+int foo(int a) { return a; }
+double foo(double a) { return a * 2; }
+%}
+
+%{
+/* If these two lines don't compile out, it's because the
+ * necessary fragment wasn't included */
+INCLUDED_INT_TYPECHECK;
+INCLUDED_DOUBLE_TYPECHECK;
+%}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -1688,7 +1688,7 @@ static String *add_qualifier_to_declarator(SwigType *type, SwigType *qualifier) 
 %type <decl>     abstract_declarator direct_abstract_declarator ctor_end;
 %type <tmap>     typemap_type;
 %type <str>      idcolon idcolontail idcolonnt idcolontailnt idtemplate idtemplatetemplate stringbrace stringbracesemi;
-%type <str>      string stringnum wstring;
+%type <str>      string stringnum stringnumbrace wstring;
 %type <tparms>   template_parms;
 %type <dtype>    cpp_end cpp_vend;
 %type <intvalue> rename_namewarn;
@@ -7224,12 +7224,12 @@ options        : LPAREN kwargs RPAREN {
 
  
 /* Keyword arguments */
-kwargs         : idstring EQUAL stringnum {
+kwargs         : idstring EQUAL stringnumbrace {
 		 $$ = NewHash();
 		 Setattr($$,"name",$1);
 		 Setattr($$,"value",$3);
                }
-               | idstring EQUAL stringnum COMMA kwargs {
+               | idstring EQUAL stringnumbrace COMMA kwargs {
 		 $$ = NewHash();
 		 Setattr($$,"name",$1);
 		 Setattr($$,"value",$3);
@@ -7257,6 +7257,26 @@ kwargs         : idstring EQUAL stringnum {
 
 stringnum      : string {
 		 $$ = $1;
+               }
+               | exprnum {
+                 $$ = Char($1.val);
+               }
+               ;
+
+stringnumbrace : string {
+		 $$ = $1;
+               }
+               | LBRACE {
+                  /* Assign exact typemap contents */
+		   String *code;
+                   skip_balanced('{','}');
+		   Delitem(scanner_ccode,0);
+		   Delitem(scanner_ccode,DOH_END);
+		   code = Copy(scanner_ccode);
+                  $$ = code;
+               }
+               | HBLOCK {
+	          $$ = $1;
                }
                | exprnum {
                  $$ = Char($1.val);


### PR DESCRIPTION
This enables more advanced typemap construction (using macro concatenation) inside of typemap keyword arguments, which (for Java, C#, and Fortran) can require extra complexity.