### PR TITLE
[OCaml] Fix member var getters and setters

### DIFF
--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -4,6 +4,7 @@
 
 LANGUAGE     = ocaml
 OCAMLC       = @OCAMLC@
+OCAMLPP      = -pp "camlp4o ./swigp4.cmo"
 VARIANT      = _static
 SCRIPTSUFFIX = _runme.ml
 
@@ -51,7 +52,7 @@ run_testcase = \
 		if [ $(srcdir) != . ]; then \
 			cp $(srcdir)/$(ml_runme) $(ml_runme); \
 		fi ; \
-		$(COMPILETOOL) $(OCAMLC) -c $(ml_runme) && \
+		$(COMPILETOOL) $(OCAMLC) $(OCAMLPP) -c $(ml_runme) && \
 		if [ -f $(top_srcdir)/Examples/test-suite/$*.list ]; then \
 			$(COMPILETOOL) $(OCAMLC) swig.cmo -custom -g -cc '$(CXX)' -o runme `cat $(top_srcdir)/Examples/test-suite/$(*).list | sed -e 's/\(.*\)/\1_wrap.o \1.cmo/g'`&& $(RUNTOOL) ./runme; \
 		else \

--- a/Examples/test-suite/ocaml/li_std_vector_runme.ml
+++ b/Examples/test-suite/ocaml/li_std_vector_runme.ml
@@ -1,0 +1,23 @@
+open Swig
+open Li_std_vector
+
+let _ =
+  let iv = new_IntVector '() in
+  assert (iv -> "empty" () as bool);
+  assert ((iv -> "size" () as int) = 0);
+  ignore (iv -> "push_back" (123));
+  assert ((iv -> "empty" () as bool) = false);
+  assert ((iv -> "size" () as int) = 1);
+  assert ((iv -> "[]" (0) as int) = 123);
+  ignore (iv -> "clear" ());
+  assert (iv -> "empty" () as bool);
+  assert ((iv -> "size" () as int) = 0);
+;;
+
+let _ =
+  let rv = new_RealVector '() in
+  ignore (rv -> "push_back" (100.));
+  ignore (rv -> "push_back" (200.));
+  assert ((rv -> "[]" (0) as float) = 100.);
+  assert ((rv -> "[]" (1) as float) = 200.);
+;;

--- a/Examples/test-suite/ocaml/struct_value_runme.ml
+++ b/Examples/test-suite/ocaml/struct_value_runme.ml
@@ -1,0 +1,11 @@
+open Swig
+open Struct_value
+
+let b = new_Bar (C_void)
+let a = (invoke b) "[a]" (C_void)
+let _ = (invoke a) "[x]" (C_int 3)
+let _ = assert((invoke a) "[x]" (C_void) = C_int 3)
+
+let bb = (invoke b) "[b]" (C_void)
+let _ = (invoke bb) "[x]" (C_int 3)
+let _ = assert((invoke bb) "[x]" (C_void) = C_int 3)

--- a/Lib/ocaml/class.swg
+++ b/Lib/ocaml/class.swg
@@ -56,6 +56,7 @@ begin
 	  (fun mth arg -> invoke_inner raw_ptr mth arg)
 end
 
+let _ = register_class_byname "$realname" create_$classname_from_ptr
 let _ = Callback.register 
           "create_$normalized_from_ptr"
           create_$classname_from_ptr

--- a/Lib/ocaml/swig.ml
+++ b/Lib/ocaml/swig.ml
@@ -155,5 +155,5 @@ let _ = Callback.register "swig_set_type_info" set_type_info
 let class_master_list = Hashtbl.create 20
 let register_class_byname nm co = 
   Hashtbl.replace class_master_list nm (Obj.magic co)
-let create_class nm arg = 
+let create_class nm =
   try (Obj.magic (Hashtbl.find class_master_list nm)) with _ -> raise (NoSuchClass nm)


### PR DESCRIPTION
Add `membervariableHandler()` to the `OCAML` class in ocaml.cxx (it is
partly based on the code in python.cxx and octave.cxx).

In Lib/ocaml/class.swg, wrapped classes/structs were not being added
to `class_master_list`. This is fixed by adding a call to
`register_class_byname`.

Add a unit test in the form of struct_value_runme.ml.