### PR TITLE
[OCaml] Use int64_t instead of int64 for OCaml versions >= 4.03.0

### DIFF
--- a/Lib/ocaml/ocamldec.swg
+++ b/Lib/ocaml/ocamldec.swg
@@ -23,6 +23,7 @@ SWIGEXT {
 #include <caml/callback.h>
 #include <caml/fail.h>
 #include <caml/misc.h>
+#include <caml/version.h>
 
 #define caml_array_set swig_caml_array_set
 
@@ -101,9 +102,17 @@ SWIGEXT {
 
 
 #ifndef ARCH_ALIGN_INT64
+#if OCAML_VERSION >= 40300
+#define SWIG_Int64_val(v) (*((int64_t *) SWIG_Data_custom_val(v)))
+#else
 #define SWIG_Int64_val(v) (*((int64 *) SWIG_Data_custom_val(v)))
+#endif
+#else
+#if OCAML_VERSION >= 40300
+CAMLextern int64_t Int64_val(caml_value_t v);
 #else
 CAMLextern int64 Int64_val(caml_value_t v);
+#endif
 #define SWIG_Int64_val(v) Int64_val(v)
 #endif
 


### PR DESCRIPTION
OCaml's int64 type was replaced with the C99 int64_t in OCaml 4.03.0.
https://github.com/ocaml/ocaml/commit/b868c05ec91a7ee193010a421de768a3b1a80952

Closes #1194.