### PR TITLE
[OCaml] class_scope_weird, cpp_static, and ignore_parameter runtime tests

### DIFF
--- a/Examples/test-suite/ocaml/class_scope_weird_runme.ml
+++ b/Examples/test-suite/ocaml/class_scope_weird_runme.ml
@@ -1,0 +1,6 @@
+open Swig
+open Class_scope_weird
+
+let f = new_Foo (C_void)
+let g = new_Foo (C_int 3)
+let _ = assert (get_int ((invoke f) "bar" (C_int 3)) = 3)

--- a/Examples/test-suite/ocaml/cpp_static_runme.ml
+++ b/Examples/test-suite/ocaml/cpp_static_runme.ml
@@ -1,0 +1,17 @@
+open Swig
+open Cpp_static
+
+let _ = _StaticFunctionTest_static_func (C_void)
+let _ = _StaticFunctionTest_static_func_2 (C_int 1)
+let _ = _StaticFunctionTest_static_func_3 (C_list [C_int 1; C_int 2])
+
+let _ = assert (get_int (_StaticMemberTest_static_int (C_void)) = 99)
+let _ = _StaticMemberTest_static_int (C_int 10)
+let _ = assert (get_int (_StaticMemberTest_static_int (C_void)) = 10)
+
+let _ = assert (get_int (_StaticBase_statty (C_void)) = 11)
+let _ = assert (get_int (_StaticDerived_statty (C_void)) = 111)
+let _ = _StaticBase_statty (C_int 22)
+let _ = _StaticDerived_statty (C_int 222)
+let _ = assert (get_int (_StaticBase_statty (C_void)) = 22)
+let _ = assert (get_int (_StaticDerived_statty (C_void)) = 222)

--- a/Examples/test-suite/ocaml/ignore_parameter_runme.ml
+++ b/Examples/test-suite/ocaml/ignore_parameter_runme.ml
@@ -1,0 +1,20 @@
+open Swig
+open Ignore_parameter
+
+let _ =
+  assert (get_string (_jaguar (C_list [ C_int 200 ; C_float 0. ])) = "hello");
+  assert (get_int (_lotus (C_list [ C_string "fast" ; C_float 0. ])) = 101);
+  assert (get_float (_tvr (C_list [ C_string "fast" ; C_int 200 ])) = 8.8);
+  assert (get_int (_ferrari (C_void)) = 101);
+;;
+let sc = new_SportsCars (C_void)
+let _ =
+  assert (get_string ((invoke sc) "daimler" (C_list [ C_int 200 ; C_float 0. ])) = "hello");
+  assert (get_int ((invoke sc) "astonmartin" (C_list [ C_string "fast" ; C_float 0. ])) = 101);
+  assert (get_float ((invoke sc) "bugatti" (C_list [ C_string "fast" ; C_int 200 ])) = 8.8);
+  assert (get_int ((invoke sc) "lamborghini" (C_void)) = 101);
+;;
+let mc = new_MiniCooper (C_list [ C_int 200 ; C_float 0. ])
+let mm = new_MorrisMinor (C_list [ C_string "slow" ; C_float 0. ])
+let fa = new_FordAnglia (C_list [ C_string "slow" ; C_int 200 ])
+let aa = new_AustinAllegro (C_void)


### PR DESCRIPTION
They are based on the corresponding python runtime tests.