### PR TITLE
[OCaml] Runtime tests for abstract_access, abstract_typedef and some others

### DIFF
--- a/Examples/test-suite/ocaml/abstract_access_runme.ml
+++ b/Examples/test-suite/ocaml/abstract_access_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Abstract_access
+
+let d = new_D '()
+let _ = assert ((d -> "do_x" () as int) = 1)

--- a/Examples/test-suite/ocaml/abstract_typedef2_runme.ml
+++ b/Examples/test-suite/ocaml/abstract_typedef2_runme.ml
@@ -1,0 +1,4 @@
+open Swig
+open Abstract_typedef2
+
+let a = new_A_UF '()

--- a/Examples/test-suite/ocaml/abstract_typedef_runme.ml
+++ b/Examples/test-suite/ocaml/abstract_typedef_runme.ml
@@ -1,0 +1,6 @@
+open Swig
+open Abstract_typedef
+
+let e = new_Engine '()
+let a = new_A '()
+let _ =  assert ((a -> "write" (e) as bool) = true)

--- a/Examples/test-suite/ocaml/abstract_virtual_runme.ml
+++ b/Examples/test-suite/ocaml/abstract_virtual_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Abstract_virtual
+
+let d = new_D '()
+let e = new_E '()

--- a/Examples/test-suite/ocaml/aggregate_runme.ml
+++ b/Examples/test-suite/ocaml/aggregate_runme.ml
@@ -1,0 +1,15 @@
+open Swig
+open Aggregate
+
+let _ =
+  assert((_move (_UP '()) as int) = (_UP '() as int));
+  assert((_move (_DOWN '()) as int) = (_DOWN '() as int));
+  assert((_move (_LEFT '()) as int) = (_LEFT '() as int));
+  assert((_move (_RIGHT '()) as int) = (_RIGHT '() as int));
+;;
+
+let _ =
+  try
+    _move(0 to int)
+  with Failure _ -> exit 0
+let _ = raise (Failure "0 test failed")

--- a/Examples/test-suite/ocaml/cast_operator_runme.ml
+++ b/Examples/test-suite/ocaml/cast_operator_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Cast_operator
+
+let a = new_A '()
+let _ = assert ((a -> "tochar" () as string) = "hi")

--- a/Examples/test-suite/ocaml/constover_runme.ml
+++ b/Examples/test-suite/ocaml/constover_runme.ml
@@ -1,0 +1,16 @@
+open Swig
+open Constover
+
+let test_str = "test" to string
+let _ =
+  assert ((_test (test_str) as string) = "test");
+  assert ((_test_pconst (test_str) as string) = "test_pconst");
+;;
+
+let f = new_Foo '()
+let _ =
+  assert ((f -> "test" (test_str) as string) = "test");
+  assert ((f -> "test_pconst" (test_str) as string) = "test_pconst");
+  assert ((f -> "test_constm" (test_str) as string) = "test_constmethod");
+  assert ((f -> "test_pconstm" (test_str) as string) = "test_pconstmethod");
+;;


### PR DESCRIPTION
Add runtime tests for abstract_access, abstract_typedef,
abstract_typedef2, abstract_virtual, aggregate, cast_operator, and
constover. The aggregate and cast_operator tests are based on the
corresponding ruby tests, and the rest are based on python tests.