### PR TITLE
[OCaml] Fix and re-enable the string_simple, minherit, and unions tests

### DIFF
--- a/Examples/test-suite/javascript/string_simple_runme.js
+++ b/Examples/test-suite/javascript/string_simple_runme.js
@@ -3,7 +3,7 @@ var string_simple = require("string_simple");
 // Test unicode string
 var str = "olé";
 
-var copy = string_simple.copy_string(str);
+var copy = string_simple.copy_str(str);
 
 if (str !== copy) {
   throw "Error: copy is not equal: original="+str+", copy="+copy;

--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -35,7 +35,6 @@ director_using \
 enum_thorough \
 li_windows \
 member_pointer_const \
-minherit \
 nested_directors \
 preproc_constants \
 smart_pointer_inherit \
@@ -45,8 +44,6 @@ using_protected \
 FAILING_C_TESTS = \
 enums \
 preproc_constants_c \
-string_simple \
-unions \
 
 ml_runme = $(SCRIPTPREFIX)$*$(SCRIPTSUFFIX)
 

--- a/Examples/test-suite/ocaml/string_simple_runme.ml
+++ b/Examples/test-suite/ocaml/string_simple_runme.ml
@@ -1,0 +1,9 @@
+open Swig
+open String_simple
+
+let str = "olé"
+
+let copy = _copy_str (C_string str) as string
+
+let _ = if str <> copy then
+  raise (Failure ("Error: copy is not equal: original="^str^", copy="^copy))

--- a/Examples/test-suite/ocaml/unions_runme.ml
+++ b/Examples/test-suite/ocaml/unions_runme.ml
@@ -8,21 +8,21 @@ let b = new_BigStruct C_void
 let c = new_UnionTest C_void
 let d = new_EmbeddedUnionTest C_void 
 
-let _ = (invoke a) "jill" (C_short 3)
-let _ = (invoke b) "jack" (C_char 'a')  (* Int conversion *)
-let _ = (invoke b) "smallstruct" a      (* Put a in b *)
-let _ = (invoke c) "bs" b
+let _ = (invoke a) "[jill]" (C_short 3)
+let _ = (invoke b) "[jack]" (C_char 'a')  (* Int conversion *)
+let _ = (invoke b) "[smallstruct]" a      (* Put a in b *)
+let _ = (invoke c) "[bs]" b
 
-let _ = if get_int ((invoke a) "jill" C_void) != 3 then
+let _ = if get_int ((invoke a) "[jill]" C_void) != 3 then
 	raise (Failure "jill value is not preserved")
-let _ = if get_int ((invoke b) "jack" C_void) != (int_of_char 'a') then
+let _ = if get_int ((invoke b) "[jack]" C_void) != (int_of_char 'a') then
 	raise (Failure "jack value is not preserved")
-let _ = if get_int ((invoke ((invoke b) "smallstruct" C_void))
-	"jill" C_void) != 3 then
+let _ = if get_int ((invoke ((invoke b) "[smallstruct]" C_void))
+	"[jill]" C_void) != 3 then
 	raise (Failure "jill value is not embedded in bigstruct")
-let _ = if get_int ((invoke ((invoke c) "bs" C_void))
-	"jack" C_void) != (int_of_char 'a') then
+let _ = if get_int ((invoke ((invoke c) "[bs]" C_void))
+	"[jack]" C_void) != (int_of_char 'a') then
 	raise (Failure "union set of bigstruct did not take")
-let _ = if get_int ((invoke ((invoke c) "ss" C_void))
-	"jill" C_void) != (int_of_char 'a') then
+let _ = if get_int ((invoke ((invoke c) "[ss]" C_void))
+	"[jill]" C_void) != (int_of_char 'a') then
 	raise (Failure "corresponding union values are not the same")

--- a/Examples/test-suite/string_simple.i
+++ b/Examples/test-suite/string_simple.i
@@ -1,10 +1,10 @@
 %module string_simple
 
-%newobject copy_string;
+%newobject copy_str;
 
 %inline %{
 #include <string.h>
-const char* copy_string(const char* str) {
+const char* copy_str(const char* str) {
   size_t len = strlen(str);
   char* newstring = (char*) malloc(len + 1);
   strcpy(newstring, str);

--- a/Lib/ocaml/std_string.i
+++ b/Lib/ocaml/std_string.i
@@ -114,7 +114,7 @@ char **c_charptr_array( const std::vector <std::string > &str_v );
 
   let string_array_to_vector sa = 
     let nv = _new_StringVector C_void in
-      array_to_vector nv (fun x -> C_string x) sa ; nv
+      ignore (array_to_vector nv (fun x -> C_string x) sa) ; nv
 	
   let c_string_array ar = 
     _c_charptr_array (string_array_to_vector ar)

--- a/Lib/ocaml/std_vector.i
+++ b/Lib/ocaml/std_vector.i
@@ -71,7 +71,7 @@ namespace std {
   
   let array_to_vector v argcons array = 
     for i = 0 to (Array.length array) - 1 do
-	(invoke v) "set" (C_list [ C_int i ; (argcons array.(i)) ])
+	ignore ((invoke v) "set" (C_list [ C_int i ; (argcons array.(i)) ]))
     done ;
     v
     


### PR DESCRIPTION
copy_string() is a macro in the OCaml C API, so rename the function
in string_simple.i to copy_str(). Add a runtime test.

The minherit runtime test was fixed by b64d685.

Use the proper syntax for accessing member variables in
unions_runme.ml

For string_simple, an `ifdef` for OCaml could be used instead of the renaming.