### PR TITLE
[OCaml] Runtime tests for constructor_rename, cpp_nodefault and some others

### DIFF
--- a/Examples/test-suite/ocaml/constructor_rename_runme.ml
+++ b/Examples/test-suite/ocaml/constructor_rename_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Constructor_rename
+
+let x = new_RenamedConstructor '()
+let _ = assert ((x -> ":classof" () as string) = "Foo")

--- a/Examples/test-suite/ocaml/cpp_nodefault_runme.ml
+++ b/Examples/test-suite/ocaml/cpp_nodefault_runme.ml
@@ -1,0 +1,18 @@
+open Swig
+open Cpp_nodefault
+
+let foo1 = new_Foo '(1, 2)
+let _ = foo1 -> "[a]" (5)
+let _ = assert ((foo1 -> "[a]" () as int) = 5)
+
+let foo2 = _create '(1, 2)
+let _ = _consume '(foo1,foo2)
+
+let bar1 = new_Bar '()
+let gvar = _gvar '()
+let args = (C_list [ gvar ; foo2 ])
+let _ = bar1 -> "consume" (args)
+let args = '(1, 2)
+let foo3 = bar1 -> "create" (args)
+let _ = foo3 -> "[a]" (6)
+let _ = assert ((foo3 -> "[a]" () as int) = 6)

--- a/Examples/test-suite/ocaml/extend_runme.ml
+++ b/Examples/test-suite/ocaml/extend_runme.ml
@@ -1,0 +1,26 @@
+open Swig
+open Extend
+
+let _ =
+  let base1 = new_Base '() and base2 = new_Base '(10) in
+  assert ((base1 -> "[value]" () as int) = 0);
+  assert ((base2 -> "[value]" () as int) = 10);
+  let cint = C_int 5 in
+  assert ((base1 -> "method" (cint) as int) = 5);
+  assert ((_Base_zeroVal '() as int) = 0);
+  assert ((base2 -> "currentValue" () as int) = 10);
+  let cint = C_int 7 in
+  assert ((base2 -> "extendmethod" (cint) as int) = 14);
+;;
+
+let _ =
+  let der1 = new_Derived '(0) and der2 = new_Derived '(17) in
+  assert ((der1 -> "[value]" () as int) = 0);
+  let cint = C_int 5 in
+  assert ((der1 -> "method" (cint) as int) = 10);
+  assert ((der2 -> "[value]" () as int) = 34);
+  let cfloat = C_float 200. in
+  ignore (der2 -> "[extendval]" (cfloat));
+  assert (abs_float ((der2 -> "[actualval]" () as float) -. 2.) < 0.001);
+  assert (abs_float ((der2 -> "[extendval]" () as float) -. 200.) < 0.001);
+;;

--- a/Examples/test-suite/ocaml/extend_special_variables_runme.ml
+++ b/Examples/test-suite/ocaml/extend_special_variables_runme.ml
@@ -1,0 +1,14 @@
+open Swig
+open Extend_special_variables
+
+let f = new_ForExtensionNewName '()
+let s = f -> "extended_renamed" () as string
+let s2 = f -> "extended_renamed" (10) as string
+
+let _ =
+  assert (s = "name:extended symname:extended_renamed wrapname: overname:__SWIG_0 decl:ForExtension::extended() fulldecl:char const * ForExtension::extended() parentclasssymname:ForExtensionNewName parentclassname:ForExtension")
+  assert (s2 = "name:extended symname:extended_renamed wrapname: overname:__SWIG_1 decl:ForExtension::extended(int) fulldecl:char const * ForExtension::extended(int) parentclasssymname:ForExtensionNewName parentclassname:ForExtension")
+;;
+
+let e = new_ExtendTemplateInt '()
+let _ = e -> "extending" ()

--- a/Examples/test-suite/ocaml/extend_template_runme.ml
+++ b/Examples/test-suite/ocaml/extend_template_runme.ml
@@ -1,0 +1,8 @@
+open Swig
+open Extend_template
+
+let f = new_Foo_0 '()
+let _ =
+  assert((f -> "test1" (37) as int) = 37);
+  assert((f -> "test2" (42) as int) = 42);
+;;

--- a/Examples/test-suite/ocaml/extern_c_runme.ml
+++ b/Examples/test-suite/ocaml/extern_c_runme.ml
@@ -1,0 +1,4 @@
+open Swig
+open Extern_c
+
+let _ = _RealFunction '(2)

--- a/Examples/test-suite/ocaml/global_ns_arg_runme.ml
+++ b/Examples/test-suite/ocaml/global_ns_arg_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Global_ns_arg
+
+let _ = assert ((_foo '(1) as int) = 1)
+let _ = assert ((_bar_fn '(1) as int) = 1)


### PR DESCRIPTION
Add runtime tests for constructor_rename, cpp_nodefault, extend,
extend_special_variables, extend_template, extern_c, and
global_ns_arg.