### PR TITLE
[OCaml] Add the caml_ prefix to some OCaml functions

### DIFF
--- a/Lib/exception.i
+++ b/Lib/exception.i
@@ -131,7 +131,7 @@ SWIGINTERN void SWIG_JavaException(JNIEnv *jenv, int code, const char *msg) {
 SWIGINTERN void SWIG_exception_(int code, const char *msg) {
   char msg_buf[OCAML_MSG_BUF_LEN];
   sprintf( msg_buf, "Exception(%d): %s\n", code, msg );
-  failwith( msg_buf );
+  caml_failwith( msg_buf );
 }
 #define SWIG_exception(a,b) SWIG_exception_((a),(b))
 %}

--- a/Lib/ocaml/carray.i
+++ b/Lib/ocaml/carray.i
@@ -89,7 +89,7 @@ type _value = c_obj
 	    caml_array_set 
 		($result,
 		 i,
-		 callback(*fromval,caml_val_ptr((void *)&$1[i],$*1_descriptor)));
+		 caml_callback(*fromval,caml_val_ptr((void *)&$1[i],$*1_descriptor)));
 	} else {
 	    caml_array_set
 		($result,
@@ -119,7 +119,7 @@ type _value = c_obj
 	    caml_array_set 
 		($result,
 		 i,
-		 callback2(*caml_named_value(SWIG_MODULE "_int_to_enum"),
+		 caml_callback2(*caml_named_value(SWIG_MODULE "_int_to_enum"),
 			   *caml_named_value("$type_marker"),
 			   Val_int($1[i])));
     }

--- a/Lib/ocaml/director.swg
+++ b/Lib/ocaml/director.swg
@@ -93,7 +93,7 @@ namespace Swig {
       void swig_disown() const {
         if (!swig_disown_flag) {
           swig_disown_flag=true;
-          callback(*caml_named_value("caml_obj_disown"),swig_self);
+          caml_callback(*caml_named_value("caml_obj_disown"),swig_self);
         }
       }
   };

--- a/Lib/ocaml/ocaml.swg
+++ b/Lib/ocaml/ocaml.swg
@@ -189,22 +189,22 @@ extern "C" {
 
 	while( lst && Is_block(lst) ) {
 	    if( v && v != Val_unit ) {
-		vt = alloc_tuple(2);
+		vt = caml_alloc_tuple(2);
 		SWIG_Store_field(v,1,vt);
 		v = vt;
 	    } else {
-		v = lh = alloc_tuple(2);
+		v = lh = caml_alloc_tuple(2);
 	    }
 	    SWIG_Store_field(v,0,SWIG_Field(lst,0));
 	    lst = SWIG_Field(lst,1);
 	}
 
 	if( v && Is_block(v) ) {
-	    vt = alloc_tuple(2);
+	    vt = caml_alloc_tuple(2);
 	    SWIG_Store_field(v,1,vt);
 	    v = vt;
 	} else {
-	    v = lh = alloc_tuple(2);
+	    v = lh = caml_alloc_tuple(2);
 	}
 	SWIG_Store_field(v,0,elt);
 	SWIG_Store_field(v,1,Val_unit);
@@ -232,7 +232,7 @@ extern "C" {
 	else if( SWIG_Tag_val(arr) == C_list )
 	    CAMLreturn(caml_list_nth(arr,0));
 	else
-	    failwith("Need array or list");
+	    caml_failwith("Need array or list");
     }
 
     SWIGINTERN int caml_array_len( CAML_VALUE arr ) {
@@ -242,7 +242,7 @@ extern "C" {
 	else if( SWIG_Tag_val(arr) == C_list )
 	    CAMLreturn(caml_list_length(arr));
 	else
-	    failwith("Need array or list");
+	    caml_failwith("Need array or list");
     }
 
     SWIGINTERN CAML_VALUE caml_swig_alloc(int x,int y) {
@@ -253,7 +253,7 @@ extern "C" {
 	CAMLparam0();
 	SWIG_CAMLlocal1(vv);
 	vv = caml_swig_alloc(1,C_array);
-	SWIG_Store_field(vv,0,alloc_tuple(n));
+	SWIG_Store_field(vv,0,caml_alloc_tuple(n));
 	CAMLreturn(vv);
     }
     
@@ -317,7 +317,7 @@ extern "C" {
 	CAMLparam0();
 	SWIG_CAMLlocal1(lv);
 	lv = caml_swig_alloc(1,C_int64);
-	SWIG_Store_field(lv,0,copy_int64(l));
+	SWIG_Store_field(lv,0,caml_copy_int64(l));
 	CAMLreturn(lv);
     }
 
@@ -325,7 +325,7 @@ extern "C" {
 	CAMLparam0();
 	SWIG_CAMLlocal1(ulv);
 	ulv = caml_swig_alloc(1,C_int64);
-	SWIG_Store_field(ulv,0,copy_int64(ul));
+	SWIG_Store_field(ulv,0,caml_copy_int64(ul));
 	CAMLreturn(ulv);
     }
 
@@ -333,7 +333,7 @@ extern "C" {
 	CAMLparam0();
 	SWIG_CAMLlocal1(fv);
 	fv = caml_swig_alloc(1,C_float);
-	SWIG_Store_field(fv,0,copy_double((double)f));
+	SWIG_Store_field(fv,0,caml_copy_double((double)f));
 	CAMLreturn(fv);
     }
 
@@ -341,7 +341,7 @@ extern "C" {
 	CAMLparam0();
 	SWIG_CAMLlocal1(fv);
 	fv = caml_swig_alloc(1,C_double);
-	SWIG_Store_field(fv,0,copy_double(d));
+	SWIG_Store_field(fv,0,caml_copy_double(d));
 	CAMLreturn(fv);
     }
 
@@ -349,8 +349,8 @@ extern "C" {
 	CAMLparam0();
 	SWIG_CAMLlocal1(vv);
 	vv = caml_swig_alloc(2,C_ptr);
-	SWIG_Store_field(vv,0,copy_int64((long)p));
-	SWIG_Store_field(vv,1,copy_int64((long)info));
+	SWIG_Store_field(vv,0,caml_copy_int64((long)p));
+	SWIG_Store_field(vv,1,caml_copy_int64((long)info));
 	CAMLreturn(vv);
     }
 
@@ -359,7 +359,7 @@ extern "C" {
 	SWIG_CAMLlocal1(vv);
 	if( !p ) CAMLreturn(caml_val_ptr( (void *)p, 0 ));
 	vv = caml_swig_alloc(1,C_string);
-	SWIG_Store_field(vv,0,copy_string(p));
+	SWIG_Store_field(vv,0,caml_copy_string(p));
 	CAMLreturn(vv);
     }
 
@@ -368,7 +368,7 @@ extern "C" {
 	SWIG_CAMLlocal1(vv);
 	if( !p || len < 0 ) CAMLreturn(caml_val_ptr( (void *)p, 0 ));
 	vv = caml_swig_alloc(1,C_string);
-	SWIG_Store_field(vv,0,alloc_string(len));
+	SWIG_Store_field(vv,0,caml_alloc_string(len));
 	memcpy(String_val(SWIG_Field(vv,0)),p,len);
 	CAMLreturn(vv);
     }
@@ -376,9 +376,9 @@ extern "C" {
     #define caml_val_obj(v, name) caml_val_obj_helper(v, SWIG_TypeQuery((name)), name)
     SWIGINTERN CAML_VALUE caml_val_obj_helper( void *v, swig_type_info *type, char *name) {
 	CAMLparam0();
-	CAMLreturn(callback2(*caml_named_value("caml_create_object_fn"),
+	CAMLreturn(caml_callback2(*caml_named_value("caml_create_object_fn"),
 			     caml_val_ptr(v,type),
-			     copy_string(name)));
+			     caml_copy_string(name)));
     }
 
     SWIGINTERN long caml_long_val_full( CAML_VALUE v, char *name ) {
@@ -408,12 +408,12 @@ extern "C" {
 	case C_enum: {
 	    SWIG_CAMLlocal1(ret);
 	    CAML_VALUE *enum_to_int = caml_named_value(SWIG_MODULE "_enum_to_int");
-	    if( !name ) failwith( "Not an enum conversion" );
-	    ret = callback2(*enum_to_int,*caml_named_value(name),v);
+	    if( !name ) caml_failwith( "Not an enum conversion" );
+	    ret = caml_callback2(*enum_to_int,*caml_named_value(name),v);
 	    CAMLreturn(caml_long_val(ret));
 	}
 	default:
-	    failwith("No conversion to int");
+	    caml_failwith("No conversion to int");
 	}
     }
 
@@ -442,7 +442,7 @@ extern "C" {
 	    CAMLreturn_type(Double_val(SWIG_Field(v,0)));
 	default:
 	    fprintf( stderr, "Unknown block tag %d\n", SWIG_Tag_val(v) );
-	    failwith("No conversion to double");
+	    caml_failwith("No conversion to double");
 	}
     }
 
@@ -470,7 +470,7 @@ extern "C" {
 	case C_obj:
 	    CAMLreturn
 		(caml_ptr_val_internal
-		 (callback(*caml_named_value("caml_obj_ptr"),v),
+		 (caml_callback(*caml_named_value("caml_obj_ptr"),v),
 		  out,descriptor));
 	case C_string:
 	    outptr = (void *)String_val(SWIG_Field(v,0));
@@ -497,7 +497,7 @@ extern "C" {
 	if( !caml_ptr_val_internal( v, &out, descriptor ) )
 	    CAMLreturn_type(out);
 	else
-	    failwith( "No appropriate conversion found." );
+	    caml_failwith( "No appropriate conversion found." );
     }
 
     SWIGINTERN char *caml_string_val( CAML_VALUE v ) {
@@ -581,7 +581,7 @@ extern "C" {
     static swig_module_info *SWIG_Ocaml_GetModule(void *SWIGUNUSEDPARM(clientdata)) {
       CAML_VALUE pointer;
 
-      pointer = callback(*caml_named_value("swig_find_type_info"), caml_val_int(0));
+      pointer = caml_callback(*caml_named_value("swig_find_type_info"), caml_val_int(0));
       if (Is_block(pointer) && SWIG_Tag_val(pointer) == C_ptr) {
         return (swig_module_info *)(void *)(long)SWIG_Int64_val(SWIG_Field(pointer,0));
       }
@@ -592,7 +592,7 @@ extern "C" {
       CAML_VALUE mod_pointer;
 
       mod_pointer = caml_val_ptr(pointer, NULL);
-      callback(*caml_named_value("swig_set_type_info"), mod_pointer);
+      caml_callback(*caml_named_value("swig_set_type_info"), mod_pointer);
     }
 
 #ifdef __cplusplus

--- a/Lib/ocaml/ocamldec.swg
+++ b/Lib/ocaml/ocamldec.swg
@@ -63,7 +63,7 @@ SWIGEXT {
 #define SWIG_Store_field(block, offset, val) do{ \
   mlsize_t caml__temp_offset = (offset); \
   caml_value_t caml__temp_val = (val); \
-  modify (&SWIG_Field ((block), caml__temp_offset), caml__temp_val); \
+  caml_modify (&SWIG_Field ((block), caml__temp_offset), caml__temp_val); \
 }while(0)
 
 #define SWIG_Data_custom_val(v) ((void *) &SWIG_Field((v), 1))
@@ -126,7 +126,7 @@ CAMLextern int64 Int64_val(caml_value_t v);
 #define SWIG_GetModule(clientdata) SWIG_Ocaml_GetModule(clientdata)
 #define SWIG_SetModule(clientdata, pointer) SWIG_Ocaml_SetModule(pointer)
 
-#define SWIG_contract_assert(expr, msg) if(!(expr)) {failwith(msg);} else
+#define SWIG_contract_assert(expr, msg) if(!(expr)) {caml_failwith(msg);} else
 
     SWIGINTERN int
     SWIG_GetPtr(void *source, void **result, swig_type_info *type, swig_type_info *result_type);

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -62,7 +62,7 @@
     /* %typemap(out) SWIGTYPE & */
     CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
     if( fromval ) {
-	$result = callback(*fromval,caml_val_ptr((void *) &$1,$1_descriptor));
+	$result = caml_callback(*fromval,caml_val_ptr((void *) &$1,$1_descriptor));
     } else {
 	$result = caml_val_ptr ((void *) &$1,$1_descriptor);
     }
@@ -72,7 +72,7 @@
     /* %typemap(out) SWIGTYPE && */
     CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
     if( fromval ) {
-	$result = callback(*fromval,caml_val_ptr((void *) &$1,$1_descriptor));
+	$result = caml_callback(*fromval,caml_val_ptr((void *) &$1,$1_descriptor));
     } else {
 	$result = caml_val_ptr ((void *) &$1,$1_descriptor);
     }
@@ -84,7 +84,7 @@
     if( fromval ) {
 	swig_result =
 	    caml_list_append(swig_result,
-			     callback(*fromval,caml_val_ptr((void *) $1,
+			     caml_callback(*fromval,caml_val_ptr((void *) $1,
 							    $1_descriptor)));
     } else {
 	swig_result =
@@ -97,7 +97,7 @@
     if( fromval ) {
 	swig_result =
 	    caml_list_append(swig_result,
-			     callback(*fromval,caml_val_ptr((void *) $1,
+			     caml_callback(*fromval,caml_val_ptr((void *) $1,
 							    $1_descriptor)));
     } else {
 	swig_result =
@@ -121,7 +121,7 @@
     $&1_ltype temp = new $ltype((const $1_ltype &) $1);
     CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
     if( fromval ) {
-	$result = callback(*fromval,caml_val_ptr((void *)temp,$&1_descriptor));
+	$result = caml_callback(*fromval,caml_val_ptr((void *)temp,$&1_descriptor));
     } else {
 	$result = caml_val_ptr ((void *)temp,$&1_descriptor);
     }
@@ -135,7 +135,7 @@
     CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
     memmove( temp, &$1, sizeof( $1_type ) );
     if( fromval ) {
-	$result = callback(*fromval,caml_val_ptr((void *)temp,$&1_descriptor));
+	$result = caml_callback(*fromval,caml_val_ptr((void *)temp,$&1_descriptor));
     } else {
 	$result = caml_val_ptr ((void *)temp,$&1_descriptor);
     }
@@ -234,7 +234,7 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
 %typemap(out) ArrayCarrier * {
     CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
     if( fromval ) {
-	$result = callback(*fromval,caml_val_ptr((void *)$1,$1_descriptor));
+	$result = caml_callback(*fromval,caml_val_ptr((void *)$1,$1_descriptor));
     } else {
 	$result = caml_val_ptr ((void *)$1,$1_descriptor);
     }
@@ -299,7 +299,7 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
     /* %typemap(how) SWIGTYPE *, SWIGTYPE (CLASS::*) */
     CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
     if( fromval ) {
-	$result = callback(*fromval,caml_val_ptr((void *)$1,$1_descriptor));
+	$result = caml_callback(*fromval,caml_val_ptr((void *)$1,$1_descriptor));
     } else {
 	$result = caml_val_ptr ((void *)$1,$1_descriptor);
     }
@@ -321,7 +321,7 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
 
 %define %swigtype_array_fail(how,msg)
 %typemap(how) SWIGTYPE [] {
-    failwith(msg);
+    caml_failwith(msg);
 }
 %enddef
 
@@ -343,7 +343,7 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
 
 %define %swig_enum_out(how)
 %typemap(how) enum SWIGTYPE {
-    $result = callback2(*caml_named_value(SWIG_MODULE "_int_to_enum"),*caml_named_value("$type_marker"),Val_int((int)$1));
+    $result = caml_callback2(*caml_named_value(SWIG_MODULE "_int_to_enum"),*caml_named_value("$type_marker"),Val_int((int)$1));
 }
 %enddef
 

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -68,7 +68,7 @@ public:
     director_prot_ctor_code = NewString("");
     Printv(director_prot_ctor_code,
 	   "if ( $comparison ) { /* subclassed */\n",
-	   "  $director_new \n", "} else {\n", "  failwith(\"accessing abstract class or protected constructor\"); \n", "}\n", NIL);
+	   "  $director_new \n", "} else {\n", "  caml_failwith(\"accessing abstract class or protected constructor\"); \n", "}\n", NIL);
     director_multiple_inheritance = 1;
     director_language = 1;
   }
@@ -733,7 +733,7 @@ public:
 	       "argv = (CAML_VALUE *)malloc( argc * sizeof( CAML_VALUE ) );\n"
 	       "for( i = 0; i < argc; i++ ) {\n" "  argv[i] = caml_list_nth(args,i);\n" "}\n", NIL);
 	Printv(df->code, dispatch, "\n", NIL);
-	Printf(df->code, "failwith(\"No matching function for overloaded '%s'\");\n", iname);
+	Printf(df->code, "caml_failwith(\"No matching function for overloaded '%s'\");\n", iname);
 	Printv(df->code, "}\n", NIL);
 	Wrapper_print(df, f_wrappers);
 
@@ -1583,7 +1583,7 @@ public:
       /* pass the method call on to the Python object */
       Printv(w->code,
 	     "swig_result = caml_swig_alloc(1,C_list);\n" "SWIG_Store_field(swig_result,0,args);\n" "args = swig_result;\n" "swig_result = Val_unit;\n", 0);
-      Printf(w->code, "swig_result = " "callback3(*caml_named_value(\"swig_runmethod\")," "swig_get_self(),copy_string(\"%s\"),args);\n", Getattr(n, "name"));
+      Printf(w->code, "swig_result = " "caml_callback3(*caml_named_value(\"swig_runmethod\")," "swig_get_self(),caml_copy_string(\"%s\"),args);\n", Getattr(n, "name"));
       /* exception handling */
       tm = Swig_typemap_lookup("director:except", n, Swig_cresult_name(), 0);
       if (!tm) {


### PR DESCRIPTION
In OCaml 3.08.0, many functions in the OCaml C API were renamed to
include a caml_ prefix. Their previous names were retained as macros
in caml/compatibility.h and were (apparently) deprecated.

Rename occurrences of alloc_string, alloc_tuple, callback, callback2,
callback3, copy_double, copy_int64, copy_string, failwith, and modify
in the OCaml module.

The OCaml module requires OCaml >= 3.08.3, so this change is safe
for all supported OCaml versions.