### PR TITLE
[OCaml] Fix the wrapping of static const member chars

### DIFF
--- a/Examples/test-suite/ocaml/char_constant_runme.ml
+++ b/Examples/test-suite/ocaml/char_constant_runme.ml
@@ -1,0 +1,16 @@
+open Swig
+open Char_constant
+
+let _ =
+  assert (_CHAR_CONSTANT '() as char = 'x');
+  assert (_STRING_CONSTANT '() as string = "xyzzy");
+  assert (_ESC_CONST '() as char = '\x01');
+  assert (_NULL_CONST '() as char = '\x00');
+  assert (_SPECIALCHARA '() as char = 'A');
+  assert (_SPECIALCHARB '() as char = 'B');
+  assert (_SPECIALCHARC '() as char = 'C');
+  assert (_SPECIALCHARD '() as char = 'D');
+  assert (_SPECIALCHARE '() as char = 'E');
+  assert (_ia '() as char = 'a');
+  assert (_ib '() as char = 'b');
+;;

--- a/Examples/test-suite/ocaml/chartest_runme.ml
+++ b/Examples/test-suite/ocaml/chartest_runme.ml
@@ -1,0 +1,25 @@
+open Swig
+open Chartest
+
+let _ =
+  assert (_GetPrintableChar '() as char = 'a');
+  assert (_GetUnprintableChar '() as char = '\127');
+  assert (_printable_global_char '() as char = 'a');
+  assert (_unprintable_global_char '() as char = '\127');
+  assert (_globchar0 '() as char = '\x00');
+  assert (_globchar1 '() as char = '\x01');
+  assert (_globchar2 '() as char = '\n');
+  assert (_globcharA '() as char = 'A');
+  assert (_globcharB '() as char = 'B');
+  assert (_globcharC '() as char = 'C');
+  assert (_globcharD '() as char = 'D');
+  assert (_globcharE '() as char = 'E');
+  assert (_CharTestClass_memberchar0 '() as char = '\x00');
+  assert (_CharTestClass_memberchar1 '() as char = '\x01');
+  assert (_CharTestClass_memberchar2 '() as char = '\n');
+  assert (_CharTestClass_membercharA '() as char = 'A');
+  assert (_CharTestClass_membercharB '() as char = 'B');
+  assert (_CharTestClass_membercharC '() as char = 'C');
+  assert (_CharTestClass_membercharD '() as char = 'D');
+  assert (_CharTestClass_membercharE '() as char = 'E');
+;;

--- a/Examples/test-suite/ocaml/static_const_member_runme.ml
+++ b/Examples/test-suite/ocaml/static_const_member_runme.ml
@@ -1,0 +1,9 @@
+open Swig
+open Static_const_member
+
+let _ =
+  assert (_X_PN '() as int = 0);
+  assert (_X_CN '() as int = 1);
+  assert (_X_EN '() as int = 2);
+  assert (_X_CHARTEST '() as char = 'A');
+;;

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -905,10 +905,9 @@ public:
   virtual int constantWrapper(Node *n) {
     String *name = Getattr(n, "feature:symname");
     SwigType *type = Getattr(n, "type");
-    String *value = Getattr(n, "value");
+    String *rawval = Getattr(n, "rawval");
+    String *value = rawval ? rawval : Getattr(n, "value");
     SwigType *qname = Getattr(n, "qualified:name");
-    String *rvalue = NewString("");
-    String *temp = 0;
 
     if (qname)
       value = qname;
@@ -920,31 +919,8 @@ public:
     }
     // See if there's a typemap
 
-    Printv(rvalue, value, NIL);
-    if ((SwigType_type(type) == T_CHAR) && (is_a_pointer(type) == 1)) {
-      temp = Copy(rvalue);
-      Clear(rvalue);
-      Printv(rvalue, "\"", temp, "\"", NIL);
-      Delete(temp);
-    }
-    if ((SwigType_type(type) == T_CHAR) && (is_a_pointer(type) == 0)) {
-      temp = Copy(rvalue);
-      Clear(rvalue);
-      Printv(rvalue, "'", temp, "'", NIL);
-      Delete(temp);
-    }
     // Create variable and assign it a value
-
-    Printf(f_header, "static %s = ", SwigType_lstr(type, name));
-    bool is_enum_item = (Cmp(nodeType(n), "enumitem") == 0);
-    if ((SwigType_type(type) == T_STRING)) {
-      Printf(f_header, "\"%s\";\n", value);
-    } else if (SwigType_type(type) == T_CHAR && !is_enum_item) {
-      Printf(f_header, "\'%s\';\n", value);
-    } else {
-      Printf(f_header, "%s;\n", value);
-    }
-
+    Printf(f_header, "static %s = %s;\n", SwigType_lstr(type, name), value);
     SetFlag(n, "feature:immutable");
     variableWrapper(n);
     return SWIG_OK;


### PR DESCRIPTION
OCaml's constantWrapper() was adding unneeded quotes when wrapping
static const member chars.

Add runtime tests for char_constant, chartest, and
static_const_member.