### PR TITLE
Better handling for parameters clashing with keywords for all languages

### DIFF
--- a/Examples/test-suite/autodoc.i
+++ b/Examples/test-suite/autodoc.i
@@ -148,3 +148,11 @@ bool is_python_builtin() { return true; }
 bool is_python_builtin() { return false; }
 #endif
 %}
+
+// Autodoc Python keywords
+%warnfilter(SWIGWARN_PARSE_KEYWORD) process;
+%feature(autodoc,0) process;
+%feature("compactdefaultargs") process;
+%inline %{
+int process(int from) { return from; }
+%}

--- a/Examples/test-suite/errors/swig_typemap_warn.stderr
+++ b/Examples/test-suite/errors/swig_typemap_warn.stderr
@@ -3,5 +3,7 @@ swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int arg3 
 swig_typemap_warn.i:7: Warning 1001: Test warning for 'out' typemap for double mmm (result) - name: mmm symname: mmm &1_ltype: double * descriptor: SWIGTYPE_double
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int abc (arg1) - argnum: 1 &1_ltype: int * descriptor: SWIGTYPE_int
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int arg3 (arg3) - argnum: 3 &1_ltype: int * descriptor: SWIGTYPE_int
+swig_typemap_warn.i:7: Warning 314: 'def' is a python keyword, renaming to '_def'
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int abc (arg1) - argnum: 1 &1_ltype: int * descriptor: SWIGTYPE_int
 swig_typemap_warn.i:7: Warning 1000: Test warning for 'in' typemap for int arg3 (arg3) - argnum: 3 &1_ltype: int * descriptor: SWIGTYPE_int
+swig_typemap_warn.i:7: Warning 314: 'def' is a python keyword, renaming to '_def'

--- a/Examples/test-suite/keyword_rename.i
+++ b/Examples/test-suite/keyword_rename.i
@@ -4,6 +4,8 @@
 
 %module keyword_rename
 
+%feature("kwargs");
+
 #pragma SWIG nowarn=SWIGWARN_PARSE_KEYWORD
 
 %inline %{

--- a/Examples/test-suite/python/autodoc_runme.py
+++ b/Examples/test-suite/python/autodoc_runme.py
@@ -202,3 +202,5 @@ check(inspect.getdoc(banana), "banana(S a, S b, int c, Integer d)")
 check(inspect.getdoc(TInteger), "Proxy of C++ T< int > class.", "::T< int >")
 check(inspect.getdoc(TInteger.__init__), "__init__(TInteger self) -> TInteger", None, skip)
 check(inspect.getdoc(TInteger.inout), "inout(TInteger self, TInteger t) -> TInteger")
+
+check(inspect.getdoc(process), "process(_from) -> int")

--- a/Examples/test-suite/python/keyword_rename_runme.py
+++ b/Examples/test-suite/python/keyword_rename_runme.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
 import keyword_rename
 keyword_rename._in(1)
+keyword_rename._in(_except=1)
 keyword_rename._except(1)
+keyword_rename._except(_in=1)

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1591,21 +1591,6 @@ public:
     return ds;
   }
 
-  virtual String *makeParameterName(Node *n, Parm *p, int arg_num, bool = false) const {
-    // For the keyword arguments, we want to preserve the names as much as possible,
-    // so we only minimally rename them in Swig_name_make(), e.g. replacing "keyword"
-    // with "_keyword" if they have any name at all.
-    if (check_kwargs(n)) {
-      String *name = Getattr(p, "name");
-      if (name)
-	return Swig_name_make(p, 0, name, 0, 0);
-    }
-
-    // For the other cases use the general function which replaces arguments whose
-    // names clash with keywords with (less useful) "argN".
-    return Language::makeParameterName(n, p, arg_num);
-  }
-
   /* -----------------------------------------------------------------------------
    * addMissingParameterNames()
    *


### PR DESCRIPTION
As previously discussed, it seems like it would make sense to generalize Python handling of parameters clashing with the language keywords to all languages, so this PR does just this (and incidentally fixes #1272). I've tested it for the languages I use locally and it seems to work fine -- but I won't be surprised at all if it breaks something for the ones I didn't test...

Note that I couldn't add a part of the [proposed test](https://github.com/swig/swig/issues/1272#issuecomment-452201273):
```python
if process(_from=10) != 10:
```
doesn't work, neither before nor after my changes. I'm not sure how are keyword arguments supposed to be handled, but they just don't work here. This:
```python
if process(10) != 10:
```
works, but doesn't seem like a useful test.