### PR TITLE
[OCaml] Fix dead code generation in overloaded function wrappers

### DIFF
--- a/Examples/test-suite/ocaml/overload_extend_runme.ml
+++ b/Examples/test-suite/ocaml/overload_extend_runme.ml
@@ -1,0 +1,11 @@
+open Swig
+open Overload_extend
+
+let _ =
+  let f = new_Foo '() in
+  assert (f -> test () as int = 0);
+  assert (f -> test (3) as int = 1);
+  assert (f -> test ("hello") as int = 2);
+  assert (f -> test (3., 2.) as float = 5.);
+  assert (f -> test (3.) as float = 1003.)
+;;

--- a/Examples/test-suite/ocaml/overload_rename_runme.ml
+++ b/Examples/test-suite/ocaml/overload_rename_runme.ml
@@ -1,0 +1,7 @@
+open Swig
+open Overload_rename
+
+let _ = new_Foo (C_float 1.)
+let _ = new_Foo (C_list [ C_float 1. ; C_float 1. ])
+let _ = new_Foo_int (C_list [ C_float 1. ; C_int 1 ])
+let _ = new_Foo_int (C_list [ C_float 1. ; C_int 1 ; C_float 1. ])

--- a/Examples/test-suite/ocaml/overload_subtype_runme.ml
+++ b/Examples/test-suite/ocaml/overload_subtype_runme.ml
@@ -1,0 +1,8 @@
+open Swig
+open Overload_subtype
+
+let _ =
+  let f = new_Foo '() and b = new_Bar '() in
+  assert (_spam (f) as int = 1);
+  assert (_spam (b) as int = 2)
+;;

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -524,15 +524,6 @@ public:
     // adds local variables
     Wrapper_add_local(f, "args", "CAMLparam1(args)");
     Wrapper_add_local(f, "ret", "SWIG_CAMLlocal2(swig_result,rv)");
-    if (isOverloaded) {
-      Wrapper_add_local(f, "i", "int i");
-      Wrapper_add_local(f, "argc", "int argc = caml_list_length(args)");
-      Wrapper_add_local(f, "argv", "CAML_VALUE *argv");
-
-      Printv(f->code,
-	     "argv = (CAML_VALUE *)malloc( argc * sizeof( CAML_VALUE ) );\n"
-	     "for( i = 0; i < argc; i++ ) {\n" "  argv[i] = caml_list_nth(args,i);\n" "}\n", NIL);
-    }
     d = SwigType_typedef_qualified(d);
     emit_parameter_variables(l, f);
 
@@ -701,8 +692,6 @@ public:
     // Wrap things up (in a manner of speaking)
 
     Printv(f->code, tab4, "swig_result = caml_list_append(swig_result,rv);\n", NIL);
-    if (isOverloaded)
-      Printv(f->code, "free(argv);\n", NIL);
     Printv(f->code, tab4, "CAMLreturn(swig_result);\n", NIL);
     Printv(f->code, "}\n", NIL);
 


### PR DESCRIPTION
The OCaml module was generating dead code in the wrappers for
overloaded functions. Only the generated dispatch function needs to
allocate an array for the passed arguments.

In addition, add overload_extend, overload_rename and overload_subtype
runtime tests.