### PR TITLE
[OCaml] Runtime tests for fvirtual, overload_polymorphic and some others

### DIFF
--- a/Examples/test-suite/ocaml/conversion_runme.ml
+++ b/Examples/test-suite/ocaml/conversion_runme.ml
@@ -1,0 +1,9 @@
+open Swig
+open Conversion
+
+let _ =
+  let bar = new_Bar '() in
+  assert (bar -> ":classof" () as string = "Bar");
+  let foo = bar -> toFoo () in
+  assert (foo -> ":classof" () as string = "Foo");
+;;

--- a/Examples/test-suite/ocaml/extend_constructor_destructor_runme.ml
+++ b/Examples/test-suite/ocaml/extend_constructor_destructor_runme.ml
@@ -1,0 +1,12 @@
+open Swig
+open Extend_constructor_destructor
+
+let check o v =
+  assert ((o -> "[ivar]" () as int) = v);
+  ignore (o -> "~" ());
+  assert ((_globalVar '() as int) = -v)
+
+let ctors = [new_AStruct; new_BStruct; new_CStruct; new_DStruct; new_EStruct;
+             new_FStruct; new_GStruct]
+
+let _  = List.iteri (fun i c -> let j = succ i in check (c (C_int j)) j) ctors

--- a/Examples/test-suite/ocaml/extend_typedef_class_runme.ml
+++ b/Examples/test-suite/ocaml/extend_typedef_class_runme.ml
@@ -1,0 +1,12 @@
+open Swig
+open Extend_typedef_class
+
+let test_obj o v =
+  let cint = C_int v in
+  let _ = o -> "[membervar]" (cint) in
+  assert ((o -> "getvar" () as int) = v)
+
+let ctors = [new_AClass; new_BClass; new_CClass; new_DClass; new_AStruct;
+             new_BStruct; new_CStruct; new_DStruct]
+
+let _  = List.iteri (fun i c -> test_obj (c '()) i) ctors

--- a/Examples/test-suite/ocaml/fvirtual_runme.ml
+++ b/Examples/test-suite/ocaml/fvirtual_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Fvirtual
+
+let _ =
+  let sw = new_NodeSwitch '() and n = new_Node '() in
+  assert (n -> addChild (n) as int = 1);
+  assert (sw -> addChild (n) as int = 2);
+  assert (sw -> addChild (sw) as int = 2);
+  assert (sw -> addChild (n, false) as int = 3)
+;;

--- a/Examples/test-suite/ocaml/overload_polymorphic_runme.ml
+++ b/Examples/test-suite/ocaml/overload_polymorphic_runme.ml
@@ -1,0 +1,9 @@
+open Swig
+open Overload_polymorphic
+
+let _ =
+  let t = new_Derived '() in
+  assert (_test (t) as int = 0);
+  assert (_test '(1) as int = 1);
+  assert (_test2 (t) as int = 1)
+;;

--- a/Examples/test-suite/ocaml/template_rename_runme.ml
+++ b/Examples/test-suite/ocaml/template_rename_runme.ml
@@ -1,0 +1,12 @@
+open Swig
+open Template_rename
+
+let _ =
+  let i = new_iFoo '() and d = new_dFoo '() in
+  assert (i -> blah_test (4) as int = 4);
+  assert (i -> spam_test (5) as int = 5);
+  assert (i -> groki_test (6) as int = 6);
+  assert (d -> blah_test (7) as int = 7);
+  assert (d -> spam (8) as int = 8);
+  assert (d -> grok_test (9) as int = 9)
+;;

--- a/Examples/test-suite/ocaml/using1_runme.ml
+++ b/Examples/test-suite/ocaml/using1_runme.ml
@@ -1,0 +1,4 @@
+open Swig
+open Using1
+
+let _ = assert (_spam '(37) as int = 37)


### PR DESCRIPTION
Add runtime tests for conversion, extend_typedef_class,
extend_constructor_destructor, fvirtual, overload_polymorphic,
template_rename, and using1.