### PR TITLE
Fix compiler warnings when SWIGRUNTIME_DEBUG is defined

### DIFF
--- a/Lib/swiginit.swg
+++ b/Lib/swiginit.swg
@@ -98,7 +98,7 @@ SWIG_InitializeModule(void *clientdata) {
 
   /* Now work on filling in swig_module.types */
 #ifdef SWIGRUNTIME_DEBUG
-  printf("SWIG_InitializeModule: size %d\n", swig_module.size);
+  printf("SWIG_InitializeModule: size %lu\n", (unsigned long)swig_module.size);
 #endif
   for (i = 0; i < swig_module.size; ++i) {
     swig_type_info *type = 0;
@@ -106,7 +106,7 @@ SWIG_InitializeModule(void *clientdata) {
     swig_cast_info *cast;
 
 #ifdef SWIGRUNTIME_DEBUG
-    printf("SWIG_InitializeModule: type %d %s\n", i, swig_module.type_initial[i]->name);
+    printf("SWIG_InitializeModule: type %lu %s\n", (unsigned long)i, swig_module.type_initial[i]->name);
 #endif
 
     /* if there is another module already loaded */
@@ -182,7 +182,7 @@ SWIG_InitializeModule(void *clientdata) {
   for (i = 0; i < swig_module.size; ++i) {
     int j = 0;
     swig_cast_info *cast = swig_module.cast_initial[i];
-    printf("SWIG_InitializeModule: type %d %s\n", i, swig_module.type_initial[i]->name);
+    printf("SWIG_InitializeModule: type %lu %s\n", (unsigned long)i, swig_module.type_initial[i]->name);
     while (cast->type) {
       printf("SWIG_InitializeModule: cast type %s\n", cast->type->name);
       cast++;


### PR DESCRIPTION
When SWIGRUNTIME_DEBUG is defined, I get the following (with GCC 8.2.0):

```
casts_wrap.cxx: In function ‘void SWIG_InitializeModule(void*)’:
casts_wrap.cxx:3051:10: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
   printf("SWIG_InitializeModule: size %d\n", swig_module.size);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~
casts_wrap.cxx:3059:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
     printf("SWIG_InitializeModule: type %d %s\n", i, swig_module.type_initial[i]->name);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~
casts_wrap.cxx:3134:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
     printf("SWIG_InitializeModule: type %d %s\n", i, swig_module.type_initial[i]->name);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~
```

It would be best to use `%zu`, but `%zu` is C99.