### PR TITLE
Always include default parameter values in Python autodoc strings

### DIFF
--- a/Examples/test-suite/autodoc.i
+++ b/Examples/test-suite/autodoc.i
@@ -169,3 +169,13 @@ int process2(int from = 0, int _in = 1, int var = 2) { return from; }
 int process3(int from, int _in, int var) { return from; }
 int process4(int from = 0, int _in = 1, int var = 2) { return from; }
 %}
+
+// Autodoc for methods with default arguments not directly representable in
+// target language.
+%feature(autodoc,0) process_complex_defval;
+%feature("compactdefaultargs") process_complex_defval;
+%inline %{
+const int PROCESS_DEFAULT_VALUE = 17;
+typedef long int some_type;
+int process_complex_defval(int val = PROCESS_DEFAULT_VALUE, int factor = some_type(-1)) { return val*factor; }
+%}

--- a/Examples/test-suite/python/autodoc_runme.py
+++ b/Examples/test-suite/python/autodoc_runme.py
@@ -207,3 +207,5 @@ check(inspect.getdoc(process), "process(int _from, int _in, int var) -> int")
 check(inspect.getdoc(process2), "process2(int _from=0, int _in=1, int var=2) -> int")
 check(inspect.getdoc(process3), "process3(int _from, int _in, int var) -> int")
 check(inspect.getdoc(process4), "process4(int _from=0, int _in=1, int var=2) -> int")
+
+check(inspect.getdoc(process_complex_defval), "process_complex_defval(val=PROCESS_DEFAULT_VALUE, factor=some_type(-1)) -> int")

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1715,9 +1715,19 @@ public:
       // Write default value
       if (value && !calling) {
 	String *new_value = convertValue(value, Getattr(p, "type"));
+	if (new_value) {
+	  value = new_value;
+	} else {
+	  // Even if the value is not representable in the target language, still use it in the documentaiton, for compatibility with the previous SWIG versions
+	  // and because it can still be useful to see the C++ expression there.
+	  Node *lookup = Swig_symbol_clookup(value, 0);
+	  if (lookup)
+	    value = Getattr(lookup, "sym:name");
+	}
+	Printf(doc, "=%s", value);
+
 	if (new_value)
-	  Printf(doc, "=%s", new_value);
-	Delete(new_value);
+	  Delete(new_value);
       }
       Delete(type_str);
       Delete(made_name);


### PR DESCRIPTION
One of side effects of 15b369028fbfcee559d9f4a8e37e2d71428add29 was that
the default values were only included in Python doc strings if we could
be sure that they could be interpreted as valid Python expressions, but
this change was actually undesirable as it may be useful to see C++
expression for the default value in the doc string even when it isn't
valid in Python.

Undo this part of the change and extend autodoc unit test to check that
this stays fixed.

Closes #1271.