### PR TITLE
Harmonize parameters in autodoc in Ruby and Octave with Python

### DIFF
--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -418,13 +418,14 @@ public:
    *   The "lname" attribute in each parameter in plist will be contain a parameter name
    * ----------------------------------------------------------------------------- */
 
-  void addMissingParameterNames(ParmList *plist, int arg_offset) {
+  void addMissingParameterNames(Node* n, ParmList *plist, int arg_offset) {
     Parm *p = plist;
     int i = arg_offset;
     while (p) {
       if (!Getattr(p, "lname")) {
-        String *pname = Swig_cparm_name(p, i);
-        Delete(pname);
+	String *name = makeParameterName(n, p, i);
+	Setattr(p, "lname", name);
+	Delete(name);
       }
       i++;
       p = nextSibling(p);
@@ -436,14 +437,14 @@ public:
     ParmList *plist = CopyParmList(Getattr(n, "parms"));
     Parm *p;
     Parm *pnext;
-    int start_arg_num = is_wrapping_class() ? 1 : 0;
+    int arg_num = is_wrapping_class() ? 1 : 0;
 
-    addMissingParameterNames(plist, start_arg_num); // for $1_name substitutions done in Swig_typemap_attach_parms
+    addMissingParameterNames(n, plist, arg_num); // for $1_name substitutions done in Swig_typemap_attach_parms
 
     Swig_typemap_attach_parms("in", plist, 0);
     Swig_typemap_attach_parms("doc", plist, 0);
 
-    for (p = plist; p; p = pnext) {
+    for (p = plist; p; p = pnext, arg_num++) {
 
       String *tm = Getattr(p, "tmap:in");
       if (tm) {
@@ -465,9 +466,10 @@ public:
         value = Getattr(p, "tmap:doc:value");
       }
 
-      name = name ? name : Getattr(p, "name");
-      name = name ? name : Getattr(p, "lname");
-      name = Swig_name_make(p, 0, name, 0, 0); // rename parameter if a keyword
+      String *made_name = 0;
+      if (!name) {
+	name = made_name = makeParameterName(n, p, arg_num);
+      }
 
       type = type ? type : Getattr(p, "type");
       value = value ? value : Getattr(p, "value");
@@ -503,7 +505,7 @@ public:
 
       Delete(type_str);
       Delete(tex_name);
-      Delete(name);
+      Delete(made_name);
     }
     if (pdocs)
       Setattr(n, "feature:pdocs", pdocs);


### PR DESCRIPTION
Backport changes to Python version of `make_autodocParmList()` to Ruby and
Octave modules, which use similar code.

In particular, this improves handling of parameters clashing with the
language keywords/reserved words for these languages as well.

---

As requested in [this comment](https://github.com/swig/swig/pull/1414#issuecomment-455863927) I've tried to harmonize Ruby/Octave versions of this function with Python. Sorry in advance if I did anything horrible, I don't know much about Ruby and even less about Octave...