### PR TITLE
[OCaml] Runtime tests for overload_method, typedef_class and some others

### DIFF
--- a/Examples/test-suite/ocaml/overload_method_runme.ml
+++ b/Examples/test-suite/ocaml/overload_method_runme.ml
@@ -1,0 +1,11 @@
+open Swig
+open Overload_method
+
+let _ =
+  let b = new_Base '() in
+  assert (b -> "method" () as int = 42);
+  assert (b -> "overloaded_method" () as int = 42);
+  assert (b -> "overloaded_method" (5) = C_void);
+  assert (b -> "overloaded_method" () as int = 5);
+  assert (b -> "method" () as int = 5);
+;;

--- a/Examples/test-suite/ocaml/typedef_class_runme.ml
+++ b/Examples/test-suite/ocaml/typedef_class_runme.ml
@@ -1,0 +1,13 @@
+open Swig
+open Typedef_class
+
+let a = new_RealA '()
+let _ = a -> "[a]" (3)
+
+let b = new_B '()
+let _ = assert (b -> testA (a) as int = 3)
+
+let bb = new_BB '()
+let bb2 = new_BB '(2)
+let _ = assert (bb -> aa_method (1.) as int = 0)
+let bbb = new_BBB '()

--- a/Examples/test-suite/ocaml/typedef_inherit_runme.ml
+++ b/Examples/test-suite/ocaml/typedef_inherit_runme.ml
@@ -1,0 +1,11 @@
+open Swig
+open Typedef_inherit
+
+let _ =
+  let a = new_Foo '() and b = new_Bar '() in
+  assert (_do_blah (a) as string = "Foo::blah");
+  assert (_do_blah (b) as string = "Bar::blah");
+  let c = new_Spam '() and d = new_Grok '() in
+  assert (_do_blah2 (c) as string = "Spam::blah");
+  assert (_do_blah2 (d) as string = "Grok::blah")
+;;

--- a/Examples/test-suite/ocaml/typemap_arrays_runme.ml
+++ b/Examples/test-suite/ocaml/typemap_arrays_runme.ml
@@ -1,0 +1,4 @@
+open Swig
+open Typemap_arrays
+
+let _ = assert (_sumA '() as int = 60)

--- a/Examples/test-suite/ocaml/typemap_delete_runme.ml
+++ b/Examples/test-suite/ocaml/typemap_delete_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Typemap_delete
+
+let r = new_Rect '(123)
+let _ = assert (r -> "[val]" () as int = 123)

--- a/Examples/test-suite/ocaml/types_directive_runme.ml
+++ b/Examples/test-suite/ocaml/types_directive_runme.ml
@@ -1,0 +1,14 @@
+open Swig
+open Types_directive
+
+let _ =
+  (* Check that a Time1 instance is accepted where a Date instance is expected. *)
+  let d1 = new_Time1 '(2001, 2, 3, 60) in
+  let newDate = _add '(d1, 7) in
+  assert (newDate -> "[day]" () as int = 10);
+
+  (* Check that a Time2 instance is accepted where a Date instance is expected. *)
+  let d2 = new_Time2 '(1999, 8, 7, 60) in
+  let newDate = _add '(d2, 7) in
+  assert (newDate -> "[day]" () as int = 14)
+;;

--- a/Examples/test-suite/ocaml/valuewrapper_runme.ml
+++ b/Examples/test-suite/ocaml/valuewrapper_runme.ml
@@ -1,0 +1,8 @@
+open Swig
+open Valuewrapper
+
+let _ =
+  let x1 = new_Xi '(5) and y1 = new_YXi '() in
+  assert (y1 -> spam (x1) as int = 0);
+  assert (y1 -> spam () as int = 0)
+;;


### PR DESCRIPTION
Add runtime tests for overload_method, typedef_class,
typedef_inherit, typemap_arrays, typemap_delete, types_directive, and
valuewrapper.