### PR TITLE
[OCaml] Some %typecheck precedence tweaks

### DIFF
--- a/Examples/test-suite/ocaml/overload_numeric_runme.ml
+++ b/Examples/test-suite/ocaml/overload_numeric_runme.ml
@@ -1,0 +1,14 @@
+open Swig
+open Overload_numeric
+
+let _ =
+  let n = new_Nums '() in
+  let arg = C_char 'c' in
+  assert (n -> over (arg) as string = "signed char");
+  let arg = C_short 2 in
+  assert (n -> over (arg) as string = "short");
+  assert (n -> over (2) as string = "int");
+  let arg = C_float 2. in
+  assert (n -> over (arg) as string = "float");
+  assert (n -> over (2.) as string = "double")
+;;

--- a/Lib/ocaml/typecheck.i
+++ b/Lib/ocaml/typecheck.i
@@ -4,7 +4,7 @@
  * Typechecking rules
  * ----------------------------------------------------------------------------- */
 
-%typecheck(SWIG_TYPECHECK_INTEGER) char, signed char, const char &, const signed char & {
+%typecheck(SWIG_TYPECHECK_INT8) char, signed char, const char &, const signed char & {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -14,7 +14,7 @@
   }
 }
 
-%typecheck(SWIG_TYPECHECK_INTEGER) unsigned char, const unsigned char & {
+%typecheck(SWIG_TYPECHECK_UINT8) unsigned char, const unsigned char & {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -24,7 +24,7 @@
   }
 }
 
-%typecheck(SWIG_TYPECHECK_INTEGER) short, signed short, const short &, const signed short &, wchar_t {
+%typecheck(SWIG_TYPECHECK_INT16) short, signed short, const short &, const signed short &, wchar_t {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -34,7 +34,7 @@
   }
 }
 
-%typecheck(SWIG_TYPECHECK_INTEGER) unsigned short, const unsigned short & {
+%typecheck(SWIG_TYPECHECK_UINT16) unsigned short, const unsigned short & {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -47,7 +47,7 @@
 // XXX arty 
 // Will move enum SWIGTYPE later when I figure out what to do with it...
 
-%typecheck(SWIG_TYPECHECK_INTEGER) int, signed int, const int &, const signed int &, enum SWIGTYPE {
+%typecheck(SWIG_TYPECHECK_INT32) int, signed int, const int &, const signed int &, enum SWIGTYPE {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -57,7 +57,7 @@
   }
 }
 
-%typecheck(SWIG_TYPECHECK_INTEGER) unsigned int, const unsigned int & {
+%typecheck(SWIG_TYPECHECK_UINT32) unsigned int, const unsigned int & {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -68,7 +68,12 @@
   }
 }
 
-%typecheck(SWIG_TYPECHECK_INTEGER) long, signed long, unsigned long, long long, signed long long, unsigned long long, const long &, const signed long &, const unsigned long &, const long long &, const signed long long &, const unsigned long long & {
+%typecheck(SWIG_TYPECHECK_INT64)
+  long, signed long, unsigned long,
+  long long, signed long long, unsigned long long,
+  const long &, const signed long &, const unsigned long &,
+  const long long &, const signed long long &, const unsigned long long &
+{
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {
@@ -88,7 +93,7 @@
   }
 }
 
-%typecheck(SWIG_TYPECHECK_DOUBLE) float, const float & {
+%typecheck(SWIG_TYPECHECK_FLOAT) float, const float & {
   if( !Is_block($input) ) $1 = 0;
   else {
       switch( SWIG_Tag_val($input) ) {


### PR DESCRIPTION
Fix warnings in overload_numeric.i.
```
./../overload_numeric.i:36: Warning 509: Overloaded method Nums::over(short) effectively ignored,
./../overload_numeric.i:33: Warning 509: as it is shadowed by Nums::over(signed char).
./../overload_numeric.i:39: Warning 509: Overloaded method Nums::over(int) effectively ignored,
./../overload_numeric.i:33: Warning 509: as it is shadowed by Nums::over(signed char).
```
Add overload_numeric_runme.ml.