### PR TITLE
[OCaml] Runtime tests for inctest, li_cpointer_cpp and some others

### DIFF
--- a/Examples/test-suite/ocaml/inctest_runme.ml
+++ b/Examples/test-suite/ocaml/inctest_runme.ml
@@ -1,0 +1,7 @@
+open Swig
+open Inctest
+
+let _ = new_A '()
+let _ = new_B '()
+let _ = assert (_importtest1 '(5) as int = 15)
+let _ = assert (_importtest2 '("black") as string = "white")

--- a/Examples/test-suite/ocaml/li_cpointer_cpp_runme.ml
+++ b/Examples/test-suite/ocaml/li_cpointer_cpp_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Li_cpointer_cpp
+
+let _ =
+  let p = _new_intp '() in
+  assert (_intp_value '(p) as int = 0);
+  assert (_intp_assign '(p, 3) = C_void);
+  assert (_intp_value '(p) as int = 3);
+  assert (_delete_intp '(p) = C_void)
+;;

--- a/Examples/test-suite/ocaml/newobject2_runme.ml
+++ b/Examples/test-suite/ocaml/newobject2_runme.ml
@@ -1,0 +1,16 @@
+open Swig
+open Newobject2
+
+let _ =
+  assert (_fooCount '() as int = 0);
+  let foo1 = _makeFoo '() in
+  assert (_fooCount '() as int = 1);
+  assert (_do_stuff '(foo1) = C_void);
+  let foo2 = _makeFoo '() in
+  assert (_fooCount '() as int = 2);
+  assert (_do_stuff '(foo2) = C_void);
+  ignore (foo1 -> "~" ());
+  assert (_fooCount '() as int = 1);
+  ignore (foo2 -> "~" ());
+  assert (_fooCount '() as int = 0)
+;;

--- a/Examples/test-suite/ocaml/special_variable_macros_runme.ml
+++ b/Examples/test-suite/ocaml/special_variable_macros_runme.ml
@@ -1,0 +1,14 @@
+open Swig
+open Special_variable_macros
+
+let _ =
+  let name = new_Name '() in
+  assert (_testFred '(name) as string = "none");
+  assert (_testJack '(name) as string = "$specialname");
+  assert (_testJill '(name) as string = "jilly");
+  assert (_testMary '(name) as string = "SWIGTYPE_p_NameWrap");
+  assert (_testJames '(name) as string = "SWIGTYPE_Name");
+  assert (_testJim '(name) as string = "multiname num");
+  let arg = new_PairIntBool '(10, false) in
+  assert (_testJohn '(arg) as int = 123);
+;;

--- a/Examples/test-suite/ocaml/special_variables_runme.ml
+++ b/Examples/test-suite/ocaml/special_variables_runme.ml
@@ -1,0 +1,36 @@
+open Swig
+open Special_variables
+
+let _ =
+  assert (_ExceptionVars '(1.0, 2.0) as string =
+    "result = Space::exceptionvars(arg1,arg2);  Space::exceptionvars  ExceptionVars   _wrap_ExceptionVarsspecial_variables  ");
+  assert (_overloadedmethod '() as string =
+    "result = Space::overloadedmethod();  Space::overloadedmethod  overloadedmethod  __SWIG_1 _wrap_overloadedmethod__SWIG_1special_variables  ");
+  assert (_overloadedmethod '(10.0) as string =
+    "result = Space::overloadedmethod(arg1);  Space::overloadedmethod  overloadedmethod  __SWIG_0 _wrap_overloadedmethod__SWIG_0special_variables  ");
+
+  let _ = new_ABC '(0, 0.0) in
+  assert (_declaration '() as string = "SpaceNamespace::ABC::ABC(int,double) SpaceNamespace::ABC::ABC(int,double)");
+  let a = new_ABC '() in
+  assert (_declaration '() as string = "SpaceNamespace::ABC::ABC() SpaceNamespace::ABC::ABC()");
+  ignore (a -> instancemethod (1));
+  assert (_declaration '() as string = "short * SpaceNamespace::ABC::instancemethod(int) SpaceNamespace::ABC::instancemethod(int)");
+  ignore (a -> instancemethod (1, false));
+  assert (_declaration '() as string = "short * SpaceNamespace::ABC::instancemethod(int,bool) SpaceNamespace::ABC::instancemethod(int,bool)");
+  ignore (a -> constmethod (1));
+  assert (_declaration '() as string = "short * SpaceNamespace::ABC::constmethod(int) const SpaceNamespace::ABC::constmethod(int) const");
+  ignore (_ABC_staticmethod '(0, false));
+  assert (_declaration '() as string = "short * SpaceNamespace::ABC::staticmethod(int,bool) SpaceNamespace::ABC::staticmethod(int,bool)");
+  ignore (a -> "~" ());
+  assert (_declaration '() as string = "SpaceNamespace::ABC::~ABC() SpaceNamespace::ABC::~ABC()");
+  let abc = new_TemplateABC '() in
+  assert (_declaration '() as string = "SpaceNamespace::Template< SpaceNamespace::ABC >::Template() SpaceNamespace::Template< SpaceNamespace::ABC >::Template()");
+  let arg = new_ABC '() in
+  ignore (abc -> tmethod (arg));
+  assert (_declaration '() as string = "std::string SpaceNamespace::Template< SpaceNamespace::ABC >::tmethod(SpaceNamespace::ABC) SpaceNamespace::Template< SpaceNamespace::ABC >::tmethod(SpaceNamespace::ABC)");
+  ignore (abc -> "~" ());
+  assert (_declaration '() as string = "SpaceNamespace::Template< SpaceNamespace::ABC >::~Template() SpaceNamespace::Template< SpaceNamespace::ABC >::~Template()");
+  let arg = new_TemplateABC '() in
+  ignore (_globtemplate (arg));
+  assert (_declaration '() as string = "void SpaceNamespace::globtemplate(SpaceNamespace::Template< SpaceNamespace::ABC >) SpaceNamespace::globtemplate(SpaceNamespace::Template< SpaceNamespace::ABC >)");
+;;

--- a/Examples/test-suite/ocaml/template_extend1_runme.ml
+++ b/Examples/test-suite/ocaml/template_extend1_runme.ml
@@ -1,0 +1,8 @@
+open Swig
+open Template_extend1
+
+let _ =
+  let a = new_lBaz '() and b = new_dBaz '() in
+  assert (a -> foo () as string = "lBaz::foo");
+  assert (b -> foo () as string = "dBaz::foo")
+;;

--- a/Examples/test-suite/ocaml/template_extend2_runme.ml
+++ b/Examples/test-suite/ocaml/template_extend2_runme.ml
@@ -1,0 +1,8 @@
+open Swig
+open Template_extend2
+
+let _ =
+  let a = new_lBaz '() and b = new_dBaz '() in
+  assert (a -> foo () as string = "lBaz::foo");
+  assert (b -> foo () as string = "dBaz::foo")
+;;


### PR DESCRIPTION
Add runtime tests for inctest, li_cpointer_cpp, newobject2,
special_variables, special_variable_macros, template_extend1, and
template_extend2.