### PR TITLE
[OCaml] Eliminate use of -Wno-write-strings

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,11 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2019-01-28: ZackerySpytz
+            [OCaml] #1429 Remove support for OCaml versions < 3.12.0.
+
+            *** POTENTIAL INCOMPATIBILITY ***
+
 2019-01-22: vadz
             [Ruby, Octave] #1424 Improve autodoc parameter naming.
 

--- a/Doc/Manual/Ocaml.html
+++ b/Doc/Manual/Ocaml.html
@@ -88,7 +88,7 @@ If you're not familiar with the Objective Caml language, you can visit
 
 
 <p>
-SWIG 3.0 works with Ocaml 3.08.3 and above.  Given the choice,
+SWIG is compatible with OCaml 3.12.0 and above.  Given the choice,
 you should use the latest stable release.  The SWIG Ocaml module has
 been tested on Linux (x86, PPC, Sparc) and Cygwin on Windows.  The
 best way to determine whether your system will work is to compile the

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -945,34 +945,34 @@ ocaml_static_cpp: $(SRCDIR_SRCS)
 	$(OCAMLCORE)
 	$(SWIG) -ocaml -c++ $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
 	cp $(ICXXSRCS) $(ICXXSRCS:%.cxx=%.c)
-	$(OCC) -cc '$(CXX) -Wno-write-strings $(CPPFLAGS)' -g -c -ccopt -g -ccopt "-xc++ $(INCLUDES)" $(ICXXSRCS:%.cxx=%.c) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS)
+	$(OCC) -cc '$(CXX) $(CPPFLAGS)' -g -c -ccopt -g -ccopt "-xc++ $(INCLUDES)" $(ICXXSRCS:%.cxx=%.c) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS)
 	$(OCC) -g -c $(INTERFACE:%.i=%.mli)
 	$(OCC) -w -U -g -c $(INTERFACE:%.i=%.ml)
 	test -z "$(PROGFILE)" || $(OCC) -o $(PROGFILE:%.ml=%) $(OCAMLPP) -c $(SRCDIR)$(PROGFILE)
-	$(NOLINK) || $(OCC) -g -ccopt -g -cclib -g -custom -o $(RUNME) swig.cmo $(INTERFACE:%.i=%.cmo) $(PROGFILE:%.ml=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) -cclib "$(LIBS)" -cc '$(CXX) -Wno-write-strings'
+	$(NOLINK) || $(OCC) -g -ccopt -g -cclib -g -custom -o $(RUNME) swig.cmo $(INTERFACE:%.i=%.cmo) $(PROGFILE:%.ml=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) -cclib "$(LIBS)" -cc '$(CXX)'
 
 ocaml_static_cpp_toplevel: $(SRCDIR_SRCS)
 	$(OCAMLCORE)
 	$(SWIG) -ocaml -c++ $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
 	cp $(ICXXSRCS) $(ICXXSRCS:%.cxx=%.c)
-	$(OCC) -cc '$(CXX) -Wno-write-strings $(CPPFLAGS)' -g -c -ccopt -g -ccopt "-xc++ $(INCLUDES)" $(ICXXSRCS:%.cxx=%.c) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS)
+	$(OCC) -cc '$(CXX) $(CPPFLAGS)' -g -c -ccopt -g -ccopt "-xc++ $(INCLUDES)" $(ICXXSRCS:%.cxx=%.c) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS)
 	$(OCC) -g -c $(INTERFACE:%.i=%.mli)
 	$(OCC) -w -U -g -c $(INTERFACE:%.i=%.ml)
 	test -z "$(PROGFILE)" || $(OCC) -o $(PROGFILE:%.ml=%) $(OCAMLPP) -c $(SRCDIR)$(PROGFILE)
-	$(NOLINK) || $(OCAMLMKTOP) swig.cmo -I $(OCAMLP4WHERE) dynlink.cma camlp4o.cma swigp4.cmo -g -ccopt -g -cclib -g -custom -o $(RUNME)_top $(INTERFACE:%.i=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) -cclib "$(LIBS)" -cc '$(CXX) -Wno-write-strings'
+	$(NOLINK) || $(OCAMLMKTOP) swig.cmo -I $(OCAMLP4WHERE) dynlink.cma camlp4o.cma swigp4.cmo -g -ccopt -g -cclib -g -custom -o $(RUNME)_top $(INTERFACE:%.i=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) -cclib "$(LIBS)" -cc '$(CXX)'
 
 ocaml_dynamic_cpp: $(SRCDIR_SRCS)
 	$(OCAMLCORE)
 	$(SWIG) -ocaml -c++ $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
 	cp $(ICXXSRCS) $(ICXXSRCS:%.cxx=%.c)
-	$(OCC) -cc '$(CXX) -Wno-write-strings $(CPPFLAGS)' -g -c -ccopt -g -ccopt "-xc++ $(INCLUDES)" $(ICXXSRCS:%.cxx=%.c) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS) -ccopt -fPIC
+	$(OCC) -cc '$(CXX) $(CPPFLAGS)' -g -c -ccopt -g -ccopt "-xc++ $(INCLUDES)" $(ICXXSRCS:%.cxx=%.c) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS) -ccopt -fPIC
 	$(CXXSHARED) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $(INTERFACE:%.i=%@SO@) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) $(CPP_DLLIBS) $(LIBS)
 	$(OCAMLDLGEN) $(INTERFACE:%.i=%.ml) $(INTERFACE:%.i=%@SO@) > $(INTERFACE:%.i=%_dynamic.ml)
 	mv $(INTERFACE:%.i=%_dynamic.ml) $(INTERFACE:%.i=%.ml)
 	rm $(INTERFACE:%.i=%.mli)
 	$(OCAMLFIND) $(OCC) -g -c -package dl $(INTERFACE:%.i=%.ml)
 	test -z "$(PROGFILE)" || $(OCC) -o $(PROGFILE:%.ml=%) $(OCAMLPP) -c $(SRCDIR)$(PROGFILE)
-	$(NOLINK) || $(OCAMLFIND) swig.cmo $(OCC) -cclib -export-dynamic -g -ccopt -g -cclib -g -custom -o $(RUNME) -package dl -linkpkg $(INTERFACE:%.i=%.cmo) $(PROGFILE:%.ml=%.cmo) -cc '$(CXX) -Wno-write-strings'
+	$(NOLINK) || $(OCAMLFIND) swig.cmo $(OCC) -cclib -export-dynamic -g -ccopt -g -cclib -g -custom -o $(RUNME) -package dl -linkpkg $(INTERFACE:%.i=%.cmo) $(PROGFILE:%.ml=%.cmo) -cc '$(CXX)'
 
 # -----------------------------------------------------------------
 # Run ocaml example

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -899,7 +899,7 @@ mzscheme_clean:
 OCC=$(COMPILETOOL) @OCAMLC@
 OCAMLDLGEN=$(COMPILETOOL) @OCAMLDLGEN@
 OCAMLFIND=$(COMPILETOOL) @OCAMLFIND@
-OCAMLMKTOP=$(COMPILETOOL) @OCAMLMKTOP@ $(SWIGWHERE)
+OCAMLMKTOP=$(COMPILETOOL) @OCAMLMKTOP@
 NOLINK ?= false
 OCAMLPP= -pp "camlp4o ./swigp4.cmo"
 OCAMLP4WHERE=`$(COMPILETOOL) @CAMLP4@ -where`
@@ -939,7 +939,7 @@ ocaml_static_toplevel: $(SRCDIR_SRCS)
 	$(OCC) -g -c $(INTERFACE:%.i=%.mli)
 	$(OCC) -w -U -g -c $(INTERFACE:%.i=%.ml)
 	test -z "$(PROGFILE)" || $(OCC) -o $(PROGFILE:%.ml=%) $(OCAMLPP) -c $(SRCDIR)$(PROGFILE)
-	$(NOLINK) || $(OCAMLMKTOP) swig.cmo -I $(OCAMLP4WHERE) camlp4o.cma swigp4.cmo -g -ccopt -g -cclib -g -custom -o $(RUNME)_top $(INTERFACE:%.i=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) -cclib "$(LIBS)"
+	$(NOLINK) || $(OCAMLMKTOP) swig.cmo -I $(OCAMLP4WHERE) dynlink.cma camlp4o.cma swigp4.cmo -cclib "$(LIBS)" -g -ccopt -g -cclib -g -custom -o $(RUNME)_top $(INTERFACE:%.i=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS)
 
 ocaml_static_cpp: $(SRCDIR_SRCS)
 	$(OCAMLCORE)
@@ -959,7 +959,7 @@ ocaml_static_cpp_toplevel: $(SRCDIR_SRCS)
 	$(OCC) -g -c $(INTERFACE:%.i=%.mli)
 	$(OCC) -w -U -g -c $(INTERFACE:%.i=%.ml)
 	test -z "$(PROGFILE)" || $(OCC) -o $(PROGFILE:%.ml=%) $(OCAMLPP) -c $(SRCDIR)$(PROGFILE)
-	$(NOLINK) || $(OCAMLMKTOP) swig.cmo -I $(OCAMLP4WHERE) dynlink.cma camlp4o.cma swigp4.cmo -g -ccopt -g -cclib -g -custom -o $(RUNME)_top $(INTERFACE:%.i=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS) -cclib "$(LIBS)" -cc '$(CXX)'
+	$(NOLINK) || $(OCAMLMKTOP) -cc '$(CXX) $(CPPFLAGS)' swig.cmo -I $(OCAMLP4WHERE) dynlink.cma camlp4o.cma swigp4.cmo -cclib "$(LIBS)" -g -ccopt -g -cclib -g -custom -o $(RUNME)_top $(INTERFACE:%.i=%.cmo) $(INTERFACE:%.i=%_wrap.@OBJEXT@) $(OBJS)
 
 ocaml_dynamic_cpp: $(SRCDIR_SRCS)
 	$(OCAMLCORE)

--- a/Examples/ocaml/callback/Makefile
+++ b/Examples/ocaml/callback/Makefile
@@ -20,7 +20,7 @@ static:
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
 	ocaml_static_cpp
 
-static_top:
+toplevel:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/class/Makefile
+++ b/Examples/ocaml/class/Makefile
@@ -20,7 +20,7 @@ static:
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
 	ocaml_static_cpp
 
-static_top:
+toplevel:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/shapes/Makefile
+++ b/Examples/ocaml/shapes/Makefile
@@ -11,7 +11,7 @@ OBJS       = example.o
 check: build
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' ocaml_run
 
-build: static
+build: static toplevel
 
 static:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
@@ -20,7 +20,7 @@ static:
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
 	ocaml_static_cpp
 
-static_top:
+toplevel:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/stl/Makefile
+++ b/Examples/ocaml/stl/Makefile
@@ -17,12 +17,6 @@ static:
 	PROGFILE='$(PROGFILE)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
 	ocaml_static_cpp
 
-director:
-	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
-	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
-	PROGFILE='$(PROGFILE)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
-	ocaml_static_cpp_director
-
 dynamic:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \

--- a/Examples/ocaml/string_from_ptr/Makefile
+++ b/Examples/ocaml/string_from_ptr/Makefile
@@ -10,7 +10,7 @@ OBJS       =
 check: build
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' ocaml_run
 
-build: static
+build: static toplevel
 
 static:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
@@ -19,7 +19,7 @@ static:
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
 	ocaml_static
 
-static_top:
+toplevel:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/string_from_ptr/Makefile
+++ b/Examples/ocaml/string_from_ptr/Makefile
@@ -1,7 +1,6 @@
 TOP        = ../..
 SWIGEXE    = $(TOP)/../swig
 SWIG_LIB_DIR = $(TOP)/../$(TOP_BUILDDIR_TO_TOP_SRCDIR)Lib
-SWIGOPT    = -c++
 SRCS       =
 TARGET     = example
 INTERFACE  = example.i
@@ -16,23 +15,23 @@ build: static
 static:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
-	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
+	TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
-	ocaml_static_cpp
+	ocaml_static
 
 static_top:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
-	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
+	TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
-	ocaml_static_cpp_toplevel
+	ocaml_static_toplevel
 
 dynamic:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
-	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)'
+	TARGET='$(TARGET)' INTERFACE='$(INTERFACE)'
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
-	ocaml_dynamic_cpp
+	ocaml_dynamic
 
 clean:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' ocaml_clean

--- a/Examples/ocaml/strings_test/Makefile
+++ b/Examples/ocaml/strings_test/Makefile
@@ -9,7 +9,7 @@ PROGFILE   = runme.ml
 check: build
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' ocaml_run
 
-build: static
+build: static toplevel
 
 static:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
@@ -23,7 +23,7 @@ dynamic:
 	PROGFILE='$(PROGFILE)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
 	ocaml_static_cpp
 
-top:
+toplevel:
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	PROGFILE='$(PROGFILE)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/strings_test/example.h
+++ b/Examples/ocaml/strings_test/example.h
@@ -19,7 +19,7 @@ void takes_char_ptr( char *p ) {
     cout << "takes_char_ptr( \"" << p << "\" );" << endl;
 }
 
-char *gives_char_ptr() {
+const char *gives_const_char_ptr() {
     return "foo";
 }
 
@@ -28,8 +28,8 @@ void takes_and_gives_std_string( std::string &inout ) {
     inout.insert( inout.end(), ']' );
 }
 
-void takes_and_gives_char_ptr( char *&inout ) {
-    char *pout = strchr( inout, '.' );
+void takes_and_gives_const_char_ptr( const char *&inout ) {
+    const char *pout = strchr( inout, '.' );
     if( pout ) inout = pout + 1;
     else inout = "foo";
 }

--- a/Examples/ocaml/strings_test/runme.ml
+++ b/Examples/ocaml/strings_test/runme.ml
@@ -8,10 +8,10 @@ let _ = print_endline
   ("_gives_std_string <<" ^ (get_string (_gives_std_string C_void)) ^ " >>")
 let _ = _takes_char_ptr (C_string "bar")
 let _ = print_endline 
-  ("_gives_char_ptr << " ^ (get_string (_gives_char_ptr C_void)) ^ " >>")
+  ("_gives_const_char_ptr << " ^ (get_string (_gives_const_char_ptr C_void)) ^ " >>")
 let _ = print_endline
   ("_takes_and_gives_std_string << " ^ 
    (get_string (_takes_and_gives_std_string (C_string "foo"))) ^ " >>")
 let _ = print_endline
-  ("_takes_and_gives_char_ptr << " ^
-   (get_string (_takes_and_gives_char_ptr (C_string "bar.bar"))) ^ " >>")
+  ("_takes_and_gives_const_char_ptr << " ^
+   (get_string (_takes_and_gives_const_char_ptr (C_string "bar.bar"))) ^ " >>")

--- a/Lib/ocaml/ocaml.swg
+++ b/Lib/ocaml/ocaml.swg
@@ -381,7 +381,7 @@ extern "C" {
 			     caml_copy_string(name)));
     }
 
-    SWIGINTERN long caml_long_val_full( CAML_VALUE v, char *name ) {
+    SWIGINTERN long caml_long_val_full( CAML_VALUE v, const char *name ) {
 	CAMLparam1(v);
 	if( !Is_block(v) ) return 0;
 

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -920,7 +920,7 @@ public:
     // See if there's a typemap
 
     // Create variable and assign it a value
-    Printf(f_header, "static %s = %s;\n", SwigType_lstr(type, name), value);
+    Printf(f_header, "static %s = %s;\n", SwigType_str(type, name), value);
     SetFlag(n, "feature:immutable");
     variableWrapper(n);
     return SWIG_OK;


### PR DESCRIPTION
Don't convert string literals to char * in the strings_test example.

In constantWrapper(), use SwigType_str() instead of SwigType_lstr()
in order to keep const qualifiers.