### PR TITLE
[OCaml] Runtime tests for template_opaque, using_extend and some others

### DIFF
--- a/Examples/test-suite/ocaml/namespace_virtual_method_runme.ml
+++ b/Examples/test-suite/ocaml/namespace_virtual_method_runme.ml
@@ -1,0 +1,4 @@
+open Swig
+open Namespace_virtual_method
+
+let x = new_Spam '()

--- a/Examples/test-suite/ocaml/template_opaque_runme.ml
+++ b/Examples/test-suite/ocaml/template_opaque_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Template_opaque
+
+let v = new_OpaqueVectorType (C_uint 10l)
+let _ = _FillVector '(v)

--- a/Examples/test-suite/ocaml/using_extend_runme.ml
+++ b/Examples/test-suite/ocaml/using_extend_runme.ml
@@ -1,0 +1,12 @@
+open Swig
+open Using_extend
+
+let _ =
+  let f = new_FooBar '() in
+  assert (f -> blah (3) as int = 3);
+  assert (f -> blah (3.5) as float = 3.5);
+  assert (f -> blah ("hello") as string = "hello");
+  assert (f -> blah (3, 4) as int = 7);
+  assert (f -> blah (3.5, 7.5) as float = 11.);
+  assert (f -> duh (3) as int = 3)
+;;

--- a/Examples/test-suite/ocaml/using_inherit_runme.ml
+++ b/Examples/test-suite/ocaml/using_inherit_runme.ml
@@ -1,0 +1,24 @@
+open Swig
+open Using_inherit
+
+let _ =
+  let b = new_Bar '() in
+  assert (b -> test (3) as int = 3);
+  assert (b -> test (3.5) as float = 3.5);
+  let b = new_Bar2 '() in
+  assert (b -> test (3) as int = 6);
+  assert (b -> test (3.5) as float = 7.0);
+  let b = new_Bar3 '() in
+  assert (b -> test (3) as int = 6);
+  assert (b -> test (3.5) as float = 7.0);
+  let b = new_Bar4 '() in
+  assert (b -> test (3) as int = 6);
+  assert (b -> test (3.5) as float = 7.0);
+
+  let f = new_Fred1 '() in
+  assert (f -> test (3) as int = 3);
+  assert (f -> test (3.5) as float = 7.0);
+  let f = new_Fred2 '() in
+  assert (f -> test (3) as int = 3);
+  assert (f -> test (3.5) as float = 7.0)
+;;

--- a/Examples/test-suite/ocaml/using_pointers_runme.ml
+++ b/Examples/test-suite/ocaml/using_pointers_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Using_pointers
+
+let f = new_FooBar '()
+try
+  ignore (f -> exception_spec (1)); assert false
+with Failure _ -> ()
+try
+  ignore (f -> exception_spec (2)); assert false
+with Failure _ -> ()

--- a/Examples/test-suite/ocaml/using_private_runme.ml
+++ b/Examples/test-suite/ocaml/using_private_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Using_private
+
+let _ =
+  let f = new_FooBar '() in
+  let _ = f -> "[x]" (3) in
+  assert (f -> blah (4) as int = 4);
+  assert (f -> defaulted () as int = -1);
+  assert (f -> defaulted (222) as int = 222)
+;;

--- a/Examples/test-suite/ocaml/varargs_overload_runme.ml
+++ b/Examples/test-suite/ocaml/varargs_overload_runme.ml
@@ -1,0 +1,15 @@
+open Swig
+open Varargs_overload
+
+let _ =
+  assert (_vararg_over1 '("Hello") as string = "Hello");
+  assert (_vararg_over1 '(2) as string = "2");
+  assert (_vararg_over2 '("Hello") as string = "Hello");
+  assert (_vararg_over2 '(2, 2.2) as string = "2 2.2");
+
+  assert (_vararg_over3 '("Hello") as string = "Hello");
+  assert (_vararg_over3 '(2, 2.2, "hey") as string = "2 2.2 hey");
+  assert (_vararg_over4 '("Hello") as string = "Hello");
+  assert (_vararg_over4 '(123) as string = "123");
+  assert (_vararg_over4 '("Hello", 123) as string = "Hello")
+;;


### PR DESCRIPTION
Add runtime tests for namespace_virtual_method, template_opaque,
using_extend, using_inherit, using_pointers, using_private, and
varargs_overload.