### PR TITLE
[OCaml] Define CAML_NAME_SPACE before including caml/ headers

### DIFF
--- a/Lib/ocaml/cstring.i
+++ b/Lib/ocaml/cstring.i
@@ -108,7 +108,7 @@
 %define %cstring_mutable(TYPEMAP,...)
 %typemap(in) TYPEMAP {
    char *t = String_val($input);
-   int   n = string_length($input);
+   int   n = caml_string_length($input);
    $1 = ($1_ltype) t;
 #if #__VA_ARGS__ == ""
 #ifdef __cplusplus

--- a/Lib/ocaml/director.swg
+++ b/Lib/ocaml/director.swg
@@ -74,12 +74,12 @@ namespace Swig {
     public:
       /* wrap a ocaml object. */
       Director(CAML_VALUE self) : swig_self(self), swig_disown_flag(false) {
-        register_global_root(&swig_self);
+        caml_register_global_root(&swig_self);
       }
 
       /* discard our reference at destruction */
       virtual ~Director() {
-        remove_global_root(&swig_self);
+        caml_remove_global_root(&swig_self);
         swig_disown();
         // Disown is safe here because we're just divorcing a reference that points to us.
       }

--- a/Lib/ocaml/ocaml.swg
+++ b/Lib/ocaml/ocaml.swg
@@ -507,7 +507,7 @@ extern "C" {
     SWIGINTERN int caml_string_len( CAML_VALUE v ) {
 	switch( SWIG_Tag_val(v) ) {
 	case C_string:
-	    return string_length(SWIG_Field(v,0));
+	    return caml_string_length(SWIG_Field(v,0));
 	default:
 	    return strlen((char *)caml_ptr_val(v,0));
 	}

--- a/Lib/ocaml/ocamldec.swg
+++ b/Lib/ocaml/ocamldec.swg
@@ -16,6 +16,7 @@ SWIGEXT {
 #endif
 #define value caml_value_t
 #define CAML_VALUE caml_value_t
+#define CAML_NAME_SPACE
 #include <caml/alloc.h>
 #include <caml/custom.h>
 #include <caml/mlvalues.h>


### PR DESCRIPTION
When this macro is not defined, the caml/ headers will define
macros without the caml_ prefix as aliases for some functions in the
OCaml C API.

For example, caml/compatibility.h defines `invalid_argument` as an
alias for `caml_invalid_argument` when CAML_NAME_SPACE is not defined,
which breaks code that uses std::invalid_argument.

Rename some functions that were missed in
05589508a6aca2866210dfda27e79d12abd8f5f6.