### PR TITLE
[OCaml] Fix the char_binary test for OCaml

### DIFF
--- a/Examples/test-suite/ocaml/char_binary_runme.ml
+++ b/Examples/test-suite/ocaml/char_binary_runme.ml
@@ -1,0 +1,24 @@
+open Swig
+open Char_binary
+
+let _ =
+  let t = new_Test '() in
+  assert (t -> strlen ("hile") as int = 4);
+  assert (t -> ustrlen ("hile") as int = 4);
+  assert (t -> strlen ("hil\x00") as int = 4);
+  assert (t -> ustrlen ("hil\x00") as int = 4);
+
+  let pc = _new_pchar '(5) in
+  assert (_pchar_setitem '(pc, 0, 'h') = C_void);
+  assert (_pchar_setitem '(pc, 1, 'o') = C_void);
+  assert (_pchar_setitem '(pc, 2, 'l') = C_void);
+  assert (_pchar_setitem '(pc, 3, 'a') = C_void);
+  assert (_pchar_setitem '(pc, 4, 0) = C_void);
+  assert (t -> strlen (pc) as int = 4);
+  assert (t -> ustrlen (pc) as int = 4);
+  ignore (_var_pchar '(pc));
+  assert (_var_pchar '() as string = "hola");
+  ignore (_var_namet '(pc));
+  assert (_var_namet '() as string = "hola");
+  _delete_pchar(pc)
+;;

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -353,6 +353,10 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
 %swig_enum_out(varout)
 %swig_enum_out(directorin)
 
+%typemap(in) (char *STRING, int LENGTH), (char *STRING, size_t LENGTH) {
+    $1 = ($1_ltype) caml_string_val($input);
+    $2 = ($2_ltype) caml_string_len($input);
+}
 
 /* Array reference typemaps */
 %apply SWIGTYPE & { SWIGTYPE ((&)[ANY]) }


### PR DESCRIPTION
Add `%typemap(in) (char *STRING, size_t LENGTH)`.

Fix warnings in char_binary.i.

```
./../char_binary.i:7: Warning 453: Can't apply (char *STRING,size_t LENGTH). No typemaps are defined.
./../char_binary.i:8: Warning 453: Can't apply (char *STRING,size_t LENGTH). No typemaps are defined.
```

Add a runtime test (it is based on the Python and Go char_binary
runtime tests).