### PR TITLE
Stop defaulting to Tcl

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,12 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2019-01-31: olly
+	    SWIG now requires a target language to be specified instead of
+	    defaulting to wrapping for Tcl.  Specifying swig --help without
+	    a target language now just shows the generic help.  The -nolang
+	    option has been removed.
+
 2019-01-22: vadz
             [Ruby, Octave] #1424 Improve autodoc parameter naming.
 

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -890,7 +890,9 @@ int SWIG_main(int argc, char *argv[], Language *l) {
   // Initialize the preprocessor
   Preprocessor_init();
 
-  lang = l;
+  // Set lang to a dummy value if no target language was specified so we
+  // can process options enough to handle -version, etc.
+  lang = l ? l : new Language;
 
   // Set up some default symbols (available in both SWIG interface files
   // and C files)
@@ -923,9 +925,9 @@ int SWIG_main(int argc, char *argv[], Language *l) {
   Wrapper_director_protected_mode_set(1);
 
   // Inform the parser if the nested classes should be ignored unless explicitly told otherwise via feature:flatnested
-  ignore_nested_classes = l->nestedClassesSupport() == Language::NCS_Unknown ? 1 : 0;
+  ignore_nested_classes = lang->nestedClassesSupport() == Language::NCS_Unknown ? 1 : 0;
 
-  kwargs_supported = l->kwargsSupport() ? 1 : 0;
+  kwargs_supported = lang->kwargsSupport() ? 1 : 0;
 
   // Create Library search directories
 
@@ -959,6 +961,11 @@ int SWIG_main(int argc, char *argv[], Language *l) {
   // Define the __cplusplus symbol
   if (CPlusPlus)
     Preprocessor_define((DOH *) "__cplusplus __cplusplus", 0);
+
+  if (!l) {
+    Printf(stderr, "No target language specified\n");
+    return 1;
+  }
 
   // Parse language dependent options
   lang->main(argc, argv);

--- a/Source/Modules/swigmain.cxx
+++ b/Source/Modules/swigmain.cxx
@@ -106,10 +106,6 @@ static swig_module modules[] = {
 #include <SIOUX.h>
 #endif
 
-#ifndef SWIG_LANG
-#define SWIG_LANG "-python"
-#endif
-
 //-----------------------------------------------------------------
 // main()
 //
@@ -262,9 +258,6 @@ int main(int margc, char **margv) {
       if (fac) {
 	dl = (fac) ();
 	Swig_mark_arg(i);
-      } else if (strcmp(argv[i], "-nolang") == 0) {
-	dl = new Language;
-	Swig_mark_arg(i);
       } else if ((strcmp(argv[i], "-help") == 0) || (strcmp(argv[i], "--help") == 0)) {
 	if (strcmp(argv[i], "--help") == 0)
 	  strcpy(argv[i], "-help");
@@ -276,12 +269,6 @@ int main(int margc, char **margv) {
 	}
 	// Swig_mark_arg not called as the general -help options also need to be displayed later on
       }
-    }
-  }
-  if (!dl) {
-    fac = Swig_find_module(SWIG_LANG);
-    if (fac) {
-      dl = (fac) ();
     }
   }
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,9 +16,6 @@ AM_INIT_AUTOMAKE
 
 dnl Some extra defines for the config file
 AH_BOTTOM([
-/* Default language */
-#define SWIG_LANG               "-tcl"
-
 /* Deal with attempt by Microsoft to deprecate C standard runtime functions */
 #if defined(_MSC_VER)
 # define _CRT_SECURE_NO_DEPRECATE


### PR DESCRIPTION
SWIG now requires a target language to be specified instead of
defaulting to wrapping for Tcl.  Specifying swig --help without
a target language now just shows the generic help.  The -nolang
option has been removed.