### PR TITLE
[OCaml] Runtime tests for default_arg_values, inherit_missing and some others

### DIFF
--- a/Examples/test-suite/ocaml/default_arg_values_runme.ml
+++ b/Examples/test-suite/ocaml/default_arg_values_runme.ml
@@ -1,0 +1,17 @@
+open Swig
+open Default_arg_values
+
+let _ =
+  let d = new_Display '() in
+  assert (d -> draw1 () as float = 0.);
+  let arg = C_float 12. in
+  assert (d -> draw1 (arg) as float = 12.);
+  let arg = C_float 123. in
+  let p = _createPtr '(arg) in
+  assert (d -> draw2 () as float = 0.);
+  assert (d -> draw2 (p) as float = 123.);
+  assert (d -> bool0 () as bool = false);
+  assert (d -> bool1 () as bool = true);
+  assert (d -> mybool0 () as bool = false);
+  assert (d -> mybool1 () as bool = true)
+;;

--- a/Examples/test-suite/ocaml/inherit_missing_runme.ml
+++ b/Examples/test-suite/ocaml/inherit_missing_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Inherit_missing
+
+let _ =
+  let a = _new_Foo '() and b = new_Bar '() and c = new_Spam '() in
+  assert (_do_blah '(a) as string =  "Foo::blah");
+  assert (_do_blah '(b) as string =  "Bar::blah");
+  assert (_do_blah '(c) as string =  "Spam::blah");
+  assert (_delete_Foo '(a) =  C_void)
+;;

--- a/Examples/test-suite/ocaml/memberin_extend_runme.ml
+++ b/Examples/test-suite/ocaml/memberin_extend_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Memberin_extend
+
+let _ =
+  let em1 = new_ExtendMe '() and em2 = new_ExtendMe '() in
+  assert (em1 -> "[thing]" ("em1thing") = C_void);
+  assert (em2 -> "[thing]" ("em2thing") = C_void);
+  assert (em1 -> "[thing]" () as string = "em1thing");
+  assert (em2 -> "[thing]" () as string = "em2thing");
+;;

--- a/Examples/test-suite/ocaml/rename_predicates_runme.ml
+++ b/Examples/test-suite/ocaml/rename_predicates_runme.ml
@@ -1,0 +1,40 @@
+open Swig
+open Rename_predicates
+
+let _ =
+  let r = new_RenamePredicates '(123) in
+  assert (r -> MF_member_function () = C_void);
+  assert (_RenamePredicates_MF_static_member_function '() = C_void);
+  assert (r -> MF_member_function () = C_void);
+  assert (r -> MF_extend_function_before () = C_void);
+  assert (r -> MF_extend_function_after () = C_void);
+  assert (_GF_global_function '() = C_void);
+
+  assert (r -> "[MV_member_variable]" () as int = 123);
+  assert (r -> "[MV_member_variable]" (1234) = C_void);
+  assert (r -> "[MV_member_variable]" () as int = 1234);
+
+  assert (_RenamePredicates_MV_static_member_variable '() as int = 456);
+  assert (_RenamePredicates_MV_static_member_variable '(4567) as int = 4567);
+  assert (_RenamePredicates_MV_static_member_variable '() as int = 4567);
+
+  assert (_GV_global_variable '() as int = 789);
+  assert (_GV_global_variable '(7890) as int = 7890);
+  assert (_GV_global_variable '() as int = 7890);
+
+  assert (_UC_UPPERCASE '() = C_void);
+  assert (_LC_lowercase '() = C_void);
+  assert (_TI_Title '() = C_void);
+  assert (_FU_FirstUpperCase '() = C_void);
+  assert (_FL_firstLowerCase '() = C_void);
+  assert (_CA_CamelCase '() = C_void);
+  assert (_LC_lowerCamelCase '() = C_void);
+  assert (_UC_under_case_it '() = C_void);
+
+  let ex = new_ExtendCheck '() in
+  assert (ex -> MF_real_member1 () = C_void);
+  assert (ex -> MF_real_member2 () = C_void);
+  assert (ex -> EX_EXTENDMETHOD1 () = C_void);
+  assert (ex -> EX_EXTENDMETHOD2 () = C_void);
+  assert (ex -> EX_EXTENDMETHOD3 () = C_void)
+;;

--- a/Examples/test-suite/ocaml/template_inherit_runme.ml
+++ b/Examples/test-suite/ocaml/template_inherit_runme.ml
@@ -1,0 +1,22 @@
+open Swig
+open Template_inherit
+
+let _ =
+  let a = new_FooInt '() and b = new_FooDouble '() and c = new_BarInt '()
+  and d = new_BarDouble '() and e = new_FooUInt '() and f = new_BarUInt '() in
+  assert (a -> blah () as string = "Foo");
+  assert (b -> blah () as string = "Foo");
+  assert (e -> blah () as string = "Foo");
+  assert (c -> blah () as string = "Bar");
+  assert (d -> blah () as string = "Bar");
+  assert (f -> blah () as string = "Bar");
+  assert (c -> foomethod () as string = "foomethod");
+  assert (d -> foomethod () as string = "foomethod");
+  assert (f -> foomethod () as string = "foomethod");
+  assert (_invoke_blah_int '(a) as string = "Foo");
+  assert (_invoke_blah_int '(c) as string = "Bar");
+  assert (_invoke_blah_double '(b) as string = "Foo");
+  assert (_invoke_blah_double '(d) as string = "Bar");
+  assert (_invoke_blah_uint '(e) as string = "Foo");
+  assert (_invoke_blah_uint '(f) as string = "Bar")
+;;

--- a/Examples/test-suite/ocaml/template_tbase_template_runme.ml
+++ b/Examples/test-suite/ocaml/template_tbase_template_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Template_tbase_template
+
+let a = _make_Class_dd '()
+assert (a -> test () as string = "test")

--- a/Examples/test-suite/ocaml/typedef_classforward_same_name_runme.ml
+++ b/Examples/test-suite/ocaml/typedef_classforward_same_name_runme.ml
@@ -1,0 +1,11 @@
+open Swig
+open Typedef_classforward_same_name
+
+let _ =
+  let foo = new_Foo '() in
+  ignore (foo -> "[x]" (5));
+  assert (_extractFoo '(foo) as int = 5);
+  let boo = new_Boo '() in
+  ignore (boo -> "[x]" (5));
+  assert (_extractBoo '(boo) as int = 5)
+;;


### PR DESCRIPTION
Add runtime tests for default_arg_values, inherit_missing,
memberin_extend, rename_predicates, template_inherit,
template_tbase_template, and typedef_classforward_same_name.