### PR TITLE
[OCaml] Fix director_pass_by_value

### DIFF
--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -21,7 +21,6 @@ cpp_enum \
 default_constructor \
 director_binary_string \
 director_enum \
-director_pass_by_value \
 director_primitives \
 director_redefined \
 director_string \

--- a/Examples/test-suite/ocaml/director_frob_runme.ml
+++ b/Examples/test-suite/ocaml/director_frob_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Director_frob
+
+let foo = new_Bravo '()
+assert (foo -> abs_method () as string = "Bravo::abs_method()")

--- a/Examples/test-suite/ocaml/director_pass_by_value_runme.ml
+++ b/Examples/test-suite/ocaml/director_pass_by_value_runme.ml
@@ -1,0 +1,24 @@
+open Swig
+open Director_pass_by_value
+
+let passByVal = ref [| |]
+
+let director_pass_by_value_Derived ob meth args =
+  match meth with
+    | "virtualMethod" -> passByVal := Array.append !passByVal [|args|]; C_void
+    | _ -> (invoke ob) meth args
+
+let d =
+  new_derived_object
+    new_DirectorPassByValueAbstractBase
+    (director_pass_by_value_Derived)
+    '()
+
+let _ =
+  let caller = new_Caller '() in
+  assert (caller -> call_virtualMethod (d) = C_void);
+  assert (Array.length !passByVal = 1);
+  let a = List.hd (fnhelper (!passByVal.(0))) in
+  assert (a -> getVal () as int = 0x12345678);
+  assert (a -> "~" () = C_void);
+;;

--- a/Examples/test-suite/ocaml/director_unroll_runme.ml
+++ b/Examples/test-suite/ocaml/director_unroll_runme.ml
@@ -1,0 +1,19 @@
+open Swig
+open Director_unroll
+
+let director_unroll_MyFoo ob meth args =
+  match meth with
+    | "ping" -> C_string "director_unroll_MyFoo::ping()"
+    | _ -> (invoke ob) meth args
+
+let a =
+  new_derived_object
+    new_Foo (director_unroll_MyFoo) '()
+
+let _ =
+  let b = new_Bar '() in
+  let _ = b -> set (a) in
+  let c = b -> get () in
+  assert (director_unroll_MyFoo c "ping" '() as string =
+    "director_unroll_MyFoo::ping()");
+;;

--- a/Lib/ocaml/ocaml.swg
+++ b/Lib/ocaml/ocaml.swg
@@ -578,6 +578,19 @@ extern "C" {
 	}	
     }
 
+    SWIGINTERN CAML_VALUE SWIG_Ocaml_ptr_to_val(const char *name, void *ptr, swig_type_info *descriptor) {
+        CAMLparam0();
+        SWIG_CAMLlocal1(result);
+
+        CAML_VALUE *fromval = caml_named_value(name);
+        if (fromval) {
+            result = caml_callback(*fromval, caml_val_ptr(ptr, descriptor));
+        } else {
+            result = caml_val_ptr(ptr, descriptor);
+        }
+        CAMLreturn(result);
+    }
+
     static swig_module_info *SWIG_Ocaml_GetModule(void *SWIGUNUSEDPARM(clientdata)) {
       CAML_VALUE pointer;
 

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -109,6 +109,17 @@
 
 #endif
 
+%typemap(directorin) SWIGTYPE {
+    $&ltype temp = new $ltype((const $ltype &)$1);
+    swig_result = SWIG_Ocaml_ptr_to_val("create_$ltype_from_ptr", (void *)temp, $&1_descriptor);
+    args = caml_list_append(args, swig_result);
+}
+
+%typemap(directorin) SWIGTYPE *, SWIGTYPE [], SWIGTYPE &, SWIGTYPE && {
+    swig_result = SWIG_Ocaml_ptr_to_val("create_$ltype_from_ptr", (void *)&$1, $&1_descriptor);
+    args = caml_list_append(args, swig_result);
+}
+
 /* The SIMPLE_MAP macro below defines the whole set of typemaps needed
    for simple types. */
 

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -52,22 +52,8 @@
     $1 = *(($ltype) caml_ptr_val($input,$1_descriptor));
 }
 
-%typemap(out) SWIGTYPE & {
-    CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
-    if( fromval ) {
-	$result = caml_callback(*fromval,caml_val_ptr((void *) &$1,$1_descriptor));
-    } else {
-	$result = caml_val_ptr ((void *) &$1,$1_descriptor);
-    }
-}
-
-%typemap(out) SWIGTYPE && {
-    CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
-    if( fromval ) {
-	$result = caml_callback(*fromval,caml_val_ptr((void *) &$1,$1_descriptor));
-    } else {
-	$result = caml_val_ptr ((void *) &$1,$1_descriptor);
-    }
+%typemap(out) SWIGTYPE &, SWIGTYPE && {
+    $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", (void *)&$1, $1_descriptor);
 }
 
 #if 0
@@ -110,25 +96,15 @@
 
 %typemap(out) SWIGTYPE {
     $&1_ltype temp = new $ltype((const $1_ltype &) $1);
-    CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
-    if( fromval ) {
-	$result = caml_callback(*fromval,caml_val_ptr((void *)temp,$&1_descriptor));
-    } else {
-	$result = caml_val_ptr ((void *)temp,$&1_descriptor);
-    }
+    $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", (void *)temp, $&1_descriptor);
 }
 
 #else
 
 %typemap(out) SWIGTYPE {
     void *temp = calloc(1,sizeof($ltype));
-    CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
-    memmove( temp, &$1, sizeof( $1_type ) );
-    if( fromval ) {
-	$result = caml_callback(*fromval,caml_val_ptr((void *)temp,$&1_descriptor));
-    } else {
-	$result = caml_val_ptr ((void *)temp,$&1_descriptor);
-    }
+    memmove(temp, &$1, sizeof($1_type));
+    $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", temp, $&1_descriptor);
 }
 
 #endif
@@ -209,23 +185,8 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
 
 /* Pass through value */
 
-%typemap (in) value,caml::value,CAML_VALUE "$1=$input;";
-%typemap (out) value,caml::value,CAML_VALUE "$result=$1;";
-
-/* Arrays */
-
-%typemap(in) ArrayCarrier * {
-    $1 = ($ltype)caml_ptr_val($input,$1_descriptor);
-}
-
-%typemap(out) ArrayCarrier * {
-    CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
-    if( fromval ) {
-	$result = caml_callback(*fromval,caml_val_ptr((void *)$1,$1_descriptor));
-    } else {
-	$result = caml_val_ptr ((void *)$1,$1_descriptor);
-    }
-}
+%typemap (in) CAML_VALUE "$1=$input;";
+%typemap (out) CAML_VALUE "$result=$1;";
 
 #if 0
 %include <carray.i>
@@ -276,15 +237,11 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
 }
 %enddef
 
-%define %swigtype_ptr_out(how)
 %typemap(out) SWIGTYPE * {
-    CAML_VALUE *fromval = caml_named_value("create_$ntype_from_ptr");
-    if( fromval ) {
-	$result = caml_callback(*fromval,caml_val_ptr((void *)$1,$1_descriptor));
-    } else {
-	$result = caml_val_ptr ((void *)$1,$1_descriptor);
-    }
+    $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", (void *)$1, $1_descriptor);
 }
+
+%define %swigtype_ptr_out(how)
 %typemap(how) SWIGTYPE (CLASS::*) {
     void *v;
     memcpy(&v,& $1, sizeof(void *));


### PR DESCRIPTION
Add a directorin typemap for SWIGTYPE.

Add director_frob_runme.ml, director_pass_by_value_runme.ml, and
director_unroll_runme.ml.

This commit fixes most of the director-related warnings in the OCaml
test suite. Of the director tests that are currently included in the
OCaml test suite, director_basic and director_property are the only
ones which give warnings (due to issues with typecheck typemaps).