### PR TITLE
Add support for the C++11 u and U encoding prefixes for char literals

### DIFF
--- a/Examples/test-suite/cpp11_raw_string_literals.i
+++ b/Examples/test-suite/cpp11_raw_string_literals.i
@@ -47,6 +47,9 @@ wstring         aa =  L"Wide string";
 const char     *bb = u8"UTF-8 string";
 const char16_t *cc =  u"UTF-16 string";
 const char32_t *dd =  U"UTF-32 string";
+// New char literals
+char16_t uchar = u'a';
+char32_t Uchar = U'b';
 %}
 
 /* Raw string literals */

--- a/Examples/test-suite/cpp11_raw_string_literals.i
+++ b/Examples/test-suite/cpp11_raw_string_literals.i
@@ -48,8 +48,8 @@ const char     *bb = u8"UTF-8 string";
 const char16_t *cc =  u"UTF-16 string";
 const char32_t *dd =  U"UTF-32 string";
 // New char literals
-char16_t uchar = u'a';
-char32_t Uchar = U'b';
+char16_t char16_t_char = u'a';
+char32_t char32_t_char = U'b';
 %}
 
 /* Raw string literals */

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -938,6 +938,10 @@ static int look(Scanner *s) {
 	retract(s, 1);
 	state = 1000;
       }
+      else if (c == '\'') { /* Definitely u, U or L char */
+	retract(s, 1);
+	state = 77;
+      }
       else if (c == 'R') { /* Possibly CUSTOM DELIMITER u, U, L string */
 	state = 73;
       }


### PR DESCRIPTION
"u" and "U" are new in C11 and C++11 for char literals.