### PR TITLE
[OCaml] Fix and re-enable typedef_mptr_runme.ml

### DIFF
--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -30,7 +30,6 @@ li_windows \
 member_pointer_const \
 preproc_constants \
 smart_pointer_inherit \
-typedef_mptr \
 
 FAILING_C_TESTS = \
 enums \

--- a/Examples/test-suite/ocaml/typedef_mptr_runme.ml
+++ b/Examples/test-suite/ocaml/typedef_mptr_runme.ml
@@ -1,16 +1,13 @@
 open Swig
 open Typedef_mptr
 
-let soci x = (string_of_int (get_int x))
-
-let x = new_Foo C_void 
-let add_res = _do_op (C_list [ x ; C_int 2 ; C_int 1 ; _add ])
-and sub_res = _do_op (C_list [ x ; C_int 2 ; C_int 1 ; _sub ])
 let _ =
-  if add_res <> (C_int 3) || sub_res <> (C_int 1) then
-    raise (Failure ("Bad result:" ^
-		    " (add " ^ (soci add_res) ^ ") " ^
-		    " (sub " ^ (soci sub_res) ^ ")"))
-let _ = Printf.printf "2 + 1 = %d, 2 - 1 = %d\n" 
-	  (get_int add_res)
-	  (get_int sub_res)
+  let f = new_Foo '() in
+  let args = C_list [ C_int 2 ; C_int 1 ; _add '() ] in
+  assert (f -> do_op (args) as int = 3);
+  let args = C_list [ C_int 2 ; C_int 1 ; _sub '() ] in
+  assert (f -> do_op (args) as int = 1);
+
+  assert (_do_op (C_list [ f ; C_int 2 ; C_int 1 ; _add '() ]) = C_int 3);
+  assert (_do_op (C_list [ f ; C_int 2 ; C_int 1 ; _sub '() ]) = C_int 1);
+;;


### PR DESCRIPTION
typedef_mptr_runme.ml was attempting to pass OCaml functions to
do_op().

Remove unneeded prints.