### PR TITLE
Fix %apply for anonymous template instantiations

### DIFF
--- a/Examples/test-suite/typemap_template.i
+++ b/Examples/test-suite/typemap_template.i
@@ -27,7 +27,7 @@ template<typename T> struct TemplateTest1 {
 %template(TTint) TemplateTest1< int >;
 
 %inline %{
-  void extratest(const TemplateTest1< YY > &t, 
+  void extratest(const TemplateTest1< YY > &t,
                  const TemplateTest1< ZZ > &tt,
                  const TemplateTest1< int > &ttt)
   {}
@@ -38,3 +38,27 @@ template<typename T> struct TemplateTest1 {
 %inline %{
   void wasbug(TemplateTest1< int >::Double wbug) {}
 %}
+
+/* Test bug where the %apply directive was ignored inside anonymous template
+ * instantiations */
+
+template<class T>
+struct Foo {
+  %typemap(in) Foo<T> ""
+  %apply Foo<T> { const Foo<T> & }
+};
+
+%{
+template<class T> struct Foo {};
+%}
+
+%template(Foo_int) Foo<int>;
+%template() Foo<double>;
+
+%inline %{
+  void this_works(Foo<int> f) {}
+  void this_also_works(const Foo<int>& f) {}
+  void this_also_also_works(Foo<double> f) {}
+  void this_fails(const Foo<double>& f) {}
+%}
+

--- a/Examples/test-suite/typemap_template.i
+++ b/Examples/test-suite/typemap_template.i
@@ -59,6 +59,6 @@ template<class T> struct Foo {};
   void this_works(Foo<int> f) {}
   void this_also_works(const Foo<int>& f) {}
   void this_also_also_works(Foo<double> f) {}
-  void this_fails(const Foo<double>& f) {}
+  void this_used_to_fail(const Foo<double>& f) {}
 %}
 

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -2962,7 +2962,7 @@ template_directive: SWIGTEMPLATE LPAREN idstringopt RPAREN idcolonnt LESSTHAN va
                             Swig_cparse_template_expand(templnode,nname,temparms,tscope);
                             Setattr(templnode,"sym:name",nname);
 			    Delete(nname);
-                            Setattr(templnode,"feature:onlychildren", "typemap,typemapitem,typemapcopy,typedef,types,fragment");
+                            Setattr(templnode,"feature:onlychildren", "typemap,typemapitem,typemapcopy,typedef,types,fragment,apply");
 			    if ($3) {
 			      Swig_warning(WARN_PARSE_NESTED_TEMPLATE, cparse_file, cparse_line, "Named nested template instantiations not supported. Processing as if no name was given to %%template().\n");
 			    }


### PR DESCRIPTION
Any `%apply` directives inside a templated class were being ignored for classes instantiated anonymously with `%template() CLASS<T>`. This was inconsistent with how `%typemap` was treated.

(This fix is *independent* from the Fortran PR https://github.com/swig/swig/pull/1195; nothing there currently needs this fix.)