### PR TITLE
[Python] Fix some errors in the documentation for -threads

### DIFF
--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -1391,7 +1391,7 @@
 <li><a href="Ocaml.html#Ocaml_nn25">Director Usage Example</a>
 <li><a href="Ocaml.html#Ocaml_nn26">Creating director objects</a>
 <li><a href="Ocaml.html#Ocaml_nn27">Typemaps for directors, directorin, directorout, directorargout</a>
-<li><a href="Ocaml.html#Ocaml_nn28">typemap</a>
+<li><a href="Ocaml.html#Ocaml_nn28">directorin typemap</a>
 <li><a href="Ocaml.html#Ocaml_nn29">directorout typemap</a>
 <li><a href="Ocaml.html#Ocaml_nn30">directorargout typemap</a>
 </ul>

--- a/Doc/Manual/Ocaml.html
+++ b/Doc/Manual/Ocaml.html
@@ -47,7 +47,7 @@
 <li><a href="#Ocaml_nn25">Director Usage Example</a>
 <li><a href="#Ocaml_nn26">Creating director objects</a>
 <li><a href="#Ocaml_nn27">Typemaps for directors, directorin, directorout, directorargout</a>
-<li><a href="#Ocaml_nn28">typemap</a>
+<li><a href="#Ocaml_nn28">directorin typemap</a>
 <li><a href="#Ocaml_nn29">directorout typemap</a>
 <li><a href="#Ocaml_nn30">directorargout typemap</a>
 </ul>
@@ -944,7 +944,7 @@ well as a function return value in the same way you provide function arguments,
 and to receive arguments the same way you normally receive function returns.
 </p>
 
-<H4><a name="Ocaml_nn28">33.2.5.6 typemap</a></H4>
+<H4><a name="Ocaml_nn28">33.2.5.6 directorin typemap</a></H4>
 
 
 <p>

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -7259,12 +7259,12 @@ will not be able to run any other threads, even if the wrapped C/C++ code is wai
         <p>
         The <tt>threads</tt> module option in the *.i template file:
         </p>
-        <div class="code"><pre>%feature("nothread") method;</pre></div>
+        <div class="code"><pre>%module("threads"=1)</pre></div>
       </li>
     </ul>
   </li>
   <li><p>You can disable thread support for a given method:</p>
-    <div class="code"><pre>%module("threads"=1)</pre></div>
+    <div class="code"><pre>%feature("nothread") method;</pre></div>
       or
       <div class="code"><pre>%nothread method;</pre></div>
   </li>


### PR DESCRIPTION
The documentation for -threads was added in
f0f2fd2daee085021e8b76f823332d52f1982a06

I came across these errors when working on the -threads option for
the OCaml module.

[skip ci]