### PR TITLE
[OCaml] Don't use argout typemaps by default for some reference types

### DIFF
--- a/Examples/ocaml/argout_ref/example.i
+++ b/Examples/ocaml/argout_ref/example.i
@@ -1,6 +1,11 @@
 /* File : example.i */
 %module example
 
+%typemap(argout) (int &x, int &y) {
+  swig_result = caml_list_append(swig_result, caml_val_int(*$1));
+  swig_result = caml_list_append(swig_result, caml_val_int(*$2));
+}
+
 %{
 extern "C" void   factor(int &x, int &y);
 %}

--- a/Examples/test-suite/ocaml/funcptr_cpp_runme.ml
+++ b/Examples/test-suite/ocaml/funcptr_cpp_runme.ml
@@ -1,0 +1,13 @@
+open Swig
+open Funcptr_cpp
+
+let _ =
+  let fp = _ADD_BY_VALUE '() in
+  assert (_call1 '(fp, 10, 11) as int = 21);
+  let fp = _ADD_BY_POINTER '() in
+  assert (_call2 '(fp, 12, 13) as int = 25);
+  let fp = _ADD_BY_REFERENCE '() in
+  assert (_call3 '(fp, 14, 15) as int = 29);
+  let fp = _ADD_BY_VALUE_C '() in
+  assert (_call1 '(fp, 2, 3) as int = 5);
+;;

--- a/Examples/test-suite/ocaml/overload_bool_runme.ml
+++ b/Examples/test-suite/ocaml/overload_bool_runme.ml
@@ -12,4 +12,15 @@ let _ =
   assert (_boolfunction '(false) as string = "false");
   assert (_intfunction '(true) as string = "int");
   assert (_intfunction '(false) as string = "int");
+
+  assert (_overloaded_ref '(true) as string = "bool");
+  assert (_overloaded_ref '(false) as string = "bool");
+  assert (_overloaded_ref '(0) as string = "int");
+  assert (_overloaded_ref '(1) as string = "int");
+  assert (_overloaded_ref '(2) as string = "int");
+  assert (_overloaded_ref '("1234") as string = "string");
+  assert (_boolfunction_ref '(true) as string = "true");
+  assert (_boolfunction_ref '(false) as string = "false");
+  assert (_intfunction_ref '(true) as string = "int");
+  assert (_intfunction_ref '(false) as string = "int");
 ;;

--- a/Examples/test-suite/ocaml/primitive_ref_runme.ml
+++ b/Examples/test-suite/ocaml/primitive_ref_runme.ml
@@ -1,0 +1,20 @@
+open Swig
+open Primitive_ref
+
+let _ =
+  assert (_ref_int '(3) as int = 3);
+  assert (_ref_short '(3) as int = 3);
+  assert (_ref_ushort '(3) as int = 3);
+  assert (_ref_long '(3) as int = 3);
+  assert (_ref_ulong '(3) as int = 3);
+  assert (_ref_schar '(3) as int = 3);
+  assert (_ref_uchar '(3) as int = 3);
+  assert (_ref_float '(3.5) as float = 3.5);
+  assert (_ref_double '(3.5) as float = 3.5);
+  assert (_ref_bool '(true) as bool = true);
+  let arg = C_char 'x' in
+  assert (_ref_char '(arg) as char = 'x');
+  assert (_ref_over '(0) as int = 0);
+  let a = new_A '(12) in
+  assert (_ref_over '(a) as int = 12);
+;;

--- a/Examples/test-suite/ocaml/reference_global_vars_runme.ml
+++ b/Examples/test-suite/ocaml/reference_global_vars_runme.ml
@@ -1,0 +1,57 @@
+open Swig
+open Reference_global_vars
+
+let _ =
+  let tc = _getconstTC '() in
+  assert (tc -> "[num]" () as int = 33);
+
+  let _ = _var_bool (_createref_bool (C_bool false)) in
+  assert (_value_bool (_var_bool '()) as bool = false);
+
+  let _ = _var_bool (_createref_bool (C_bool true)) in
+  assert (_value_bool (_var_bool '()) as bool = true);
+
+  let _ = _var_char (_createref_char (C_char 'w')) in
+  assert (_value_char (_var_char '()) as char = 'w');
+
+  let _ = _var_unsigned_char (_createref_unsigned_char (C_uchar 'w')) in
+  assert (_value_unsigned_char (_var_unsigned_char '()) as char = 'w');
+
+  let _ = _var_signed_char (_createref_signed_char (C_uchar 'w')) in
+  assert (_value_signed_char (_var_signed_char '()) as char = 'w');
+
+  let _ = _var_short (_createref_short (C_short 10)) in
+  assert (_value_short (_var_short '()) as int = 10);
+  
+  let _ = _var_unsigned_short (_createref_unsigned_short (C_ushort 10)) in
+  assert (_value_unsigned_short (_var_unsigned_short '()) as int = 10);
+
+  let _ = _var_int (_createref_int (C_int 10)) in
+  assert (_value_int (_var_int '()) as int = 10);
+
+  let _ = _var_unsigned_int (_createref_unsigned_int (C_int 10)) in
+  assert (_value_unsigned_int (_var_unsigned_int '()) as int = 10);
+
+  let _ = _var_long (_createref_long (C_int64 10L)) in
+  assert (_value_long (_var_long '()) as int = 10);
+
+  let _ = _var_unsigned_long (_createref_unsigned_long (C_int64 10L)) in
+  assert (_value_unsigned_long (_var_unsigned_long '()) as int = 10);
+
+  let _ = _var_long_long (_createref_long_long (C_int64 0x6FFFFFFFFFFFFFF8L)) in
+  assert (_value_long_long (_var_long_long '()) = C_int64 0x6FFFFFFFFFFFFFF8L);
+
+  let _ = _var_unsigned_long_long (_createref_unsigned_long_long (C_int64 0x6FFFFFFFFFFFFFF8L)) in
+  assert (_value_unsigned_long_long (_var_unsigned_long_long '()) = C_int64 0x6FFFFFFFFFFFFFF8L);
+
+  let _ = _var_float (_createref_float (C_float 10.)) in
+  assert (_value_float (_var_float '()) as float = 10.);
+
+  let _ = _var_double (_createref_double (C_double 10.)) in
+  assert (_value_double (_var_double '()) as float = 10.);
+
+  let tc = new_TestClass '(20) in
+  let _ = _var_TestClass (_createref_TestClass (tc)) in
+  let tc = _value_TestClass (_var_TestClass '()) in
+  assert (tc -> "[num]" () as int = 20);
+;;

--- a/Examples/test-suite/ocaml/template_ref_type_runme.ml
+++ b/Examples/test-suite/ocaml/template_ref_type_runme.ml
@@ -1,0 +1,6 @@
+open Swig
+open Template_ref_type
+
+let xr = new_XC '()
+let y = new_Y '()
+let _ = y -> find (xr)

--- a/Lib/ocaml/ocaml.swg
+++ b/Lib/ocaml/ocaml.swg
@@ -459,15 +459,6 @@ extern "C" {
 	}
 	if( !Is_block(v) ) return -1;
 	switch( SWIG_Tag_val(v) ) {
-	case C_int:
-	    if( !caml_long_val( v ) ) {
-		*out = 0;
-		CAMLreturn_type(0);
-	    } else {
-		*out = 0;
-		CAMLreturn_type(1);
-	    }
-	    break;
 	case C_obj:
 	    if (!func_val) {
 	        func_val = caml_named_value("caml_obj_ptr");

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -52,8 +52,12 @@
     $1 = *(($ltype) caml_ptr_val($input,$1_descriptor));
 }
 
-%typemap(out) SWIGTYPE &, SWIGTYPE && {
+%typemap(varout) SWIGTYPE &, SWIGTYPE && {
     $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", (void *)&$1, $1_descriptor);
+}
+
+%typemap(out) SWIGTYPE &, SWIGTYPE && {
+    $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", (void *)$1, $1_descriptor);
 }
 
 #if 0
@@ -84,9 +88,6 @@
     }
 }
 #endif
-
-%typemap(argout) const SWIGTYPE & { }
-%typemap(argout) const SWIGTYPE && { }
 
 %typemap(in) SWIGTYPE {
     $1 = *(($&1_ltype) caml_ptr_val($input,$&1_descriptor)) ;
@@ -123,26 +124,26 @@
 /* The SIMPLE_MAP macro below defines the whole set of typemaps needed
    for simple types. */
 
-%define SIMPLE_MAP(C_NAME, C_TO_MZ, MZ_TO_C)
+%define SIMPLE_MAP(C_NAME, C_TO_OCAML, OCAML_TO_C)
 /* In */
 %typemap(in) C_NAME {
-    $1 = MZ_TO_C($input);
+    $1 = OCAML_TO_C($input);
 }
 %typemap(varin) C_NAME {
-    $1 = MZ_TO_C($input);
+    $1 = OCAML_TO_C($input);
 }
 %typemap(in) C_NAME & ($*1_ltype temp) {
-    temp = ($*1_ltype) MZ_TO_C($input);
+    temp = ($*1_ltype) OCAML_TO_C($input);
     $1 = &temp;
 }
 %typemap(varin) C_NAME & {
-    $1 = MZ_TO_C($input);
+    $1 = OCAML_TO_C($input);
 }
 %typemap(directorout) C_NAME {
-    $1 = MZ_TO_C($input);
+    $1 = OCAML_TO_C($input);
 }
 %typemap(in) C_NAME *INPUT ($*1_ltype temp) {
-    temp = ($*1_ltype) MZ_TO_C($input);
+    temp = ($*1_ltype) OCAML_TO_C($input);
     $1 = &temp;
 }
 %typemap(in,numinputs=0) C_NAME *OUTPUT ($*1_ltype temp) {
@@ -150,25 +151,22 @@
 }
 /* Out */
 %typemap(out) C_NAME {
-    $result = C_TO_MZ($1);
+    $result = C_TO_OCAML($1);
 }
 %typemap(varout) C_NAME {
-    $result = C_TO_MZ($1);
+    $result = C_TO_OCAML($1);
 }
 %typemap(varout) C_NAME & {
-    $result = C_TO_MZ($1);
+    $result = C_TO_OCAML($1);
 }
 %typemap(argout) C_NAME *OUTPUT {
-    swig_result = caml_list_append(swig_result,C_TO_MZ((long)*$1));
+    swig_result = caml_list_append(swig_result, C_TO_OCAML((long)*$1));
 }
 %typemap(out) C_NAME & {
-    $result = C_TO_MZ(*$1);
-}
-%typemap(argout) C_NAME & {
-    swig_result = caml_list_append(swig_result,C_TO_MZ((long)*$1));
+    $result = C_TO_OCAML(*$1);
 }
 %typemap(directorin) C_NAME {
-    args = caml_list_append(args,C_TO_MZ($1));
+    args = caml_list_append(args, C_TO_OCAML($1));
 }
 %enddef
 


### PR DESCRIPTION
The OCaml module's typemaps.i supplied argout typemaps for some
reference types (e.g. int &) by default, which was unintuitive and
inconsistent when compared with other modules. The argout_ref example
depended on this, so add a typemap to argout_ref/example.i.

Add multiple runtime tests that deal with references.