### PR TITLE
Fixed typo in Perl5 docs.

### DIFF
--- a/Doc/Manual/Perl5.html
+++ b/Doc/Manual/Perl5.html
@@ -1888,7 +1888,7 @@ like this:
 <pre>
 %typemap(out) int {
   $result = sv_newmortal();
-  set_setiv($result, (IV) $1);
+  sv_setiv($result, (IV) $1);
   argvi++;
 }
 </pre>


### PR DESCRIPTION
Fixed typo in section 33.7.2 "Perl5 typemaps". There is no function set_setiv()
in the perl api, the correct name is sv_setiv().