### PR TITLE
[OCaml] Fix the dynamic_cast test

### DIFF
--- a/Examples/test-suite/ocaml/dynamic_cast_runme.ml
+++ b/Examples/test-suite/ocaml/dynamic_cast_runme.ml
@@ -1,0 +1,9 @@
+open Swig
+open Dynamic_cast
+
+let f = new_Foo '()
+let b = new_Bar '()
+
+let x = f -> blah ()
+let y = b -> blah ()
+assert (_do_test '(y) as string = "Bar::test")

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -307,6 +307,11 @@ SIMPLE_MAP(unsigned long long,caml_val_ulong,caml_long_val);
     $2 = ($2_ltype) caml_string_len($input);
 }
 
+%typemap(out) SWIGTYPE *DYNAMIC, SWIGTYPE &DYNAMIC {
+    swig_type_info *ty = SWIG_TypeDynamicCast($1_descriptor, (void **)&$1);
+    $result = SWIG_Ocaml_ptr_to_val("create_$ntype_from_ptr", (void *)$1, ty);
+}
+
 /* Array reference typemaps */
 %apply SWIGTYPE & { SWIGTYPE ((&)[ANY]) }
 %apply SWIGTYPE && { SWIGTYPE ((&)[ANY]) }


### PR DESCRIPTION
Add out typemaps for SWIGTYPE *DYNAMIC and SWIGTYPE &DYNAMIC.

Add dynamic_cast_runme.ml.