### PR TITLE
[OCaml] Fix the wrapmacro test

### DIFF
--- a/Doc/Manual/Extending.html
+++ b/Doc/Manual/Extending.html
@@ -3711,7 +3711,7 @@ Below are some practical steps that should help meet these requirements.
   </li>
   <li>
   Copying an existing language module and adapting the source for it is likely to be the most efficient
-  approach to fully developing a new module as a numbe of corner cases are covered in the existing implementations.
+  approach to fully developing a new module as a number of corner cases are covered in the existing implementations.
   The most advanced scripting languages are Python and Ruby.
   The most advanced compiled target languages are Java and C#.
   </li>

--- a/Examples/ocaml/argout_ref/example.i
+++ b/Examples/ocaml/argout_ref/example.i
@@ -1,13 +1,13 @@
 /* File : example.i */
 %module example
 
-%typemap(argout) (int &x, int &y) {
+%typemap(argout) (const int &x, const int &y) {
   swig_result = caml_list_append(swig_result, caml_val_int(*$1));
   swig_result = caml_list_append(swig_result, caml_val_int(*$2));
 }
 
 %{
-extern "C" void   factor(int &x, int &y);
+extern "C" void factor(const int &x, const int &y);
 %}
 
-extern "C" void   factor(int &x, int &y);
+extern "C" void factor(const int &x, const int &y);

--- a/Examples/test-suite/ocaml/global_vars_runme.ml
+++ b/Examples/test-suite/ocaml/global_vars_runme.ml
@@ -1,0 +1,15 @@
+open Swig
+open Global_vars
+
+_init '()
+
+let _ =
+  assert (_b '() as string = "string b");
+  assert (_b '("a string value") as string = "a string value");
+  assert (_b '() as string = "a string value");
+  assert (_x '() as int = 1234);
+  assert (_x '(9876) as int = 9876);
+  assert (_x '() as int = 9876);
+  assert (_Hi '() as int = 0);
+  assert (_Hola '() as int = 1);
+;;

--- a/Examples/test-suite/ocaml/reference_global_vars_runme.ml
+++ b/Examples/test-suite/ocaml/reference_global_vars_runme.ml
@@ -22,7 +22,7 @@ let _ =
 
   let _ = _var_short (_createref_short (C_short 10)) in
   assert (_value_short (_var_short '()) as int = 10);
-  
+
   let _ = _var_unsigned_short (_createref_unsigned_short (C_ushort 10)) in
   assert (_value_unsigned_short (_var_unsigned_short '()) as int = 10);
 

--- a/Examples/test-suite/ocaml/sizet_runme.ml
+++ b/Examples/test-suite/ocaml/sizet_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Sizet
+
+let _ =
+  let s = C_int64 2000L in
+  assert (_test1 '(s) as int = 2000);
+  assert (_test2 '(s) as int = 2000);
+  assert (_test3 '(s) as int = 2000);
+  assert (_test4 '(s) as int = 2000);
+;;

--- a/Examples/test-suite/ocaml/typedef_reference_runme.ml
+++ b/Examples/test-suite/ocaml/typedef_reference_runme.ml
@@ -1,0 +1,11 @@
+open Swig
+open Typedef_reference
+
+let _ =
+  let i = _copy_intp '(2) in
+  assert (_somefunc '(i) as int = 2);
+  assert (_delete_intp '(i) = C_void);
+  let i = _copy_intp '(3) in
+  assert (_otherfunc '(i) as int = 3);
+  assert (_delete_intp '(i) = C_void);
+;;

--- a/Examples/test-suite/ocaml/wrapmacro_runme.ml
+++ b/Examples/test-suite/ocaml/wrapmacro_runme.ml
@@ -1,0 +1,10 @@
+open Swig
+open Wrapmacro
+
+let _ =
+  let args = C_list [ C_int64 2L ; C_int64 1L ] in
+  assert (_maximum '(args) as int = 2);
+  let args =  C_list [ C_double (2. /. 7.) ; C_double 256. ] in 
+  assert (_maximum '(args) as float = 256.);
+  assert (_GUINT16_SWAP_LE_BE_CONSTANT '(0x1234) as int = 0x3412);
+;;

--- a/Lib/ocaml/std_common.i
+++ b/Lib/ocaml/std_common.i
@@ -7,6 +7,7 @@
 %include <std/std_except.i>
 
 %apply size_t { std::size_t };
+%apply const size_t& { const std::size_t& };
 
 %{
 #include <string>

--- a/Lib/ocaml/typecheck.i
+++ b/Lib/ocaml/typecheck.i
@@ -72,7 +72,8 @@
   long, signed long, unsigned long,
   long long, signed long long, unsigned long long,
   const long &, const signed long &, const unsigned long &,
-  const long long &, const signed long long &, const unsigned long long &
+  const long long &, const signed long long &, const unsigned long long &,
+  size_t, const size_t &
 {
   if( !Is_block($input) ) $1 = 0;
   else {

--- a/Lib/ocaml/typemaps.i
+++ b/Lib/ocaml/typemaps.i
@@ -132,11 +132,11 @@
 %typemap(varin) C_NAME {
     $1 = OCAML_TO_C($input);
 }
-%typemap(in) C_NAME & ($*1_ltype temp) {
+%typemap(in) const C_NAME & ($*1_ltype temp) {
     temp = ($*1_ltype) OCAML_TO_C($input);
     $1 = &temp;
 }
-%typemap(varin) C_NAME & {
+%typemap(varin) const C_NAME & {
     $1 = OCAML_TO_C($input);
 }
 %typemap(directorout) C_NAME {
@@ -156,13 +156,13 @@
 %typemap(varout) C_NAME {
     $result = C_TO_OCAML($1);
 }
-%typemap(varout) C_NAME & {
+%typemap(varout) const C_NAME & {
     $result = C_TO_OCAML($1);
 }
 %typemap(argout) C_NAME *OUTPUT {
     swig_result = caml_list_append(swig_result, C_TO_OCAML((long)*$1));
 }
-%typemap(out) C_NAME & {
+%typemap(out) const C_NAME & {
     $result = C_TO_OCAML(*$1);
 }
 %typemap(directorin) C_NAME {


### PR DESCRIPTION
Add a typecheck typemap for size_t and const size_t &.

Add the const qualifier to the typemaps for primitive reference
types.

Add multiple runtime tests.