### PR TITLE
[OCaml] Add %feature(thread) to release the OCaml master lock

### DIFF
--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -1824,6 +1824,7 @@
 <ul>
 <li><a href="Ocaml.html#Ocaml_nn33">Module docstring</a>
 </ul>
+<li><a href="Ocaml.html#Ocaml_nn34">%feature("thread")</a>
 </ul>
 </div>
 <!-- INDEX -->

--- a/Doc/Manual/Ocaml.html
+++ b/Doc/Manual/Ocaml.html
@@ -57,6 +57,7 @@
 <ul>
 <li><a href="#Ocaml_nn33">Module docstring</a>
 </ul>
+<li><a href="#Ocaml_nn34">%feature("thread")</a>
 </ul>
 </div>
 <!-- INDEX -->
@@ -1115,6 +1116,19 @@ controls on a panel, etc. to be loaded from an XML file."
 %module(docstring=DOCSTRING) xrc
 </pre>
 </div>
+
+<H2><a name="Ocaml_nn34">38.4 %feature("thread")</a></H2>
+
+
+<p>
+When the thread feature is applied to a function, the OCaml master lock is
+released just before the function is called. The master lock is re-acquired immediately
+after the function returns. This feature should only be used by
+multithreaded applications for long-running functions or potentially blocking IO
+operations. See the
+<a href="https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#sec478">OCaml reference manual</a>
+for more details.
+</p>
 
 </body>
 </html>

--- a/Lib/ocaml/ocamldec.swg
+++ b/Lib/ocaml/ocamldec.swg
@@ -24,6 +24,7 @@ SWIGEXT {
 #include <caml/callback.h>
 #include <caml/fail.h>
 #include <caml/misc.h>
+#include <caml/threads.h>
 
 #if defined(CAMLassert)
 /* Both this macro and version.h were introduced in version 4.02.0 */

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -677,6 +677,14 @@ public:
       Append(f->code, "upcall = (director);\n");
     }
 
+    if (!director_method && GetFlagAttr(n, "feature:thread")) {
+      String *preaction = NewString("\ncaml_release_runtime_system();\n");
+      Setattr(n, "wrap:preaction", preaction);
+
+      String *postaction = NewString("\ncaml_acquire_runtime_system();\n");
+      Setattr(n, "wrap:postaction", postaction);
+   }
+
     // Now write code to make the function call
     Swig_director_emit_dynamic_cast(n, f);
     String *actioncode = emit_action(n);


### PR DESCRIPTION
The caml_release_runtime_system() and caml_acquire_runtime_system()
functions are provided by the OCaml C API to release and acquire the
master lock.  This can be helpful for multi-threaded applications.