### PR TITLE
Fix some rejections of valid floating-point literals

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (in progress)
 ===========================
 
+2019-02-21: ZackerySpytz
+            #1480 Fix some rejections of valid floating-point literals.
+
 2019-02-19: wsfulton
             #1475 Fix regression parsing gcc preprocessor linemarkers in the form:
 

--- a/Examples/test-suite/primitive_types.i
+++ b/Examples/test-suite/primitive_types.i
@@ -630,6 +630,10 @@ macro(size_t,             pfx, sizet)
     float val_float(float x) {
       return x;
     } 
+
+    float val_float_3(float f = 0e1f, float f2 = 020e0f, float f3 = 0.3e4f) {
+      return f + f2 + f3;
+    }
 %}
 
 

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -1160,6 +1160,8 @@ static int look(Scanner *s) {
 	return SWIG_TOKEN_INT;
       if (isdigit(c))
 	state = 84;
+      else if ((c == 'e') || (c == 'E'))
+	state = 82;
       else if ((c == 'x') || (c == 'X'))
 	state = 85;
       else if ((c == 'b') || (c == 'B'))
@@ -1181,6 +1183,10 @@ static int look(Scanner *s) {
 	return SWIG_TOKEN_INT;
       if (isdigit(c))
 	state = 84;
+      else if (c == '.')
+	state = 81;
+      else if ((c == 'e') || (c == 'E'))
+	state = 82;
       else if ((c == 'l') || (c == 'L')) {
 	state = 87;
       } else if ((c == 'u') || (c == 'U')) {


### PR DESCRIPTION
Some valid floating-point literals were giving
"Error: Syntax error in input(1)".