### PR TITLE
Updated java std_map to support Obj derivatives by importing original for use in class

### DIFF
--- a/Lib/java/std_list.i
+++ b/Lib/java/std_list.i
@@ -43,7 +43,7 @@ namespace std {
     this();
     java.util.ListIterator<$typemap(jboxtype, T)> it = listIterator(0);
     // Special case the "copy constructor" here to avoid lots of cross-language calls
-    for (Object o : c) {
+    for (java.lang.Object o : c) {
       it.add(($typemap(jboxtype, T))o);
     }
   }

--- a/Lib/java/std_map.i
+++ b/Lib/java/std_map.i
@@ -51,16 +51,13 @@ template<class K, class T, class C = std::less< K> > class map {
 %typemap(javabase) std::map< K, T, C >
     "java.util.AbstractMap<$typemap(jboxtype, K), $typemap(jboxtype, T)>"
 
-%typemap(javaimports) std::map< K, T, C >
-    "import java.lang.Object;"
-
 %proxycode %{
 
   public int size() {
     return sizeImpl();
   }
 
-  public boolean containsKey(Object key) {
+  public boolean containsKey(java.lang.Object key) {
     if (!(key instanceof $typemap(jboxtype, K))) {
       return false;
     }
@@ -68,7 +65,7 @@ template<class K, class T, class C = std::less< K> > class map {
     return containsImpl(($typemap(jboxtype, K))key);
   }
 
-  public $typemap(jboxtype, T) get(Object key) {
+  public $typemap(jboxtype, T) get(java.lang.Object key) {
     if (!(key instanceof $typemap(jboxtype, K))) {
       return null;
     }
@@ -93,7 +90,7 @@ template<class K, class T, class C = std::less< K> > class map {
     }
   }
 
-  public $typemap(jboxtype, T) remove(Object key) {
+  public $typemap(jboxtype, T) remove(java.lang.Object key) {
     if (!(key instanceof $typemap(jboxtype, K))) {
       return null;
     }

--- a/Lib/java/std_map.i
+++ b/Lib/java/std_map.i
@@ -51,6 +51,9 @@ template<class K, class T, class C = std::less< K> > class map {
 %typemap(javabase) std::map< K, T, C >
     "java.util.AbstractMap<$typemap(jboxtype, K), $typemap(jboxtype, T)>"
 
+%typemap(javaimports) std::map< K, T, C >
+    "import java.lang.Object;"
+
 %proxycode %{
 
   public int size() {

--- a/Lib/java/std_set.i
+++ b/Lib/java/std_set.i
@@ -59,7 +59,7 @@ class set {
 
   public boolean addAll(java.util.Collection<? extends $typemap(jboxtype, T)> collection) {
     boolean didAddElement = false;
-    for (Object object : collection) {
+    for (java.lang.Object object : collection) {
       didAddElement |= add(($typemap(jboxtype, T))object);
     }
 
@@ -96,7 +96,7 @@ class set {
   }
 
   public boolean containsAll(java.util.Collection<?> collection) {
-    for (Object object : collection) {
+    for (java.lang.Object object : collection) {
       if (!contains(object)) {
         return false;
       }
@@ -105,7 +105,7 @@ class set {
     return true;
   }
 
-  public boolean contains(Object object) {
+  public boolean contains(java.lang.Object object) {
     if (!(object instanceof $typemap(jboxtype, T))) {
       return false;
     }
@@ -115,14 +115,14 @@ class set {
 
   public boolean removeAll(java.util.Collection<?> collection) {
     boolean didRemoveElement = false;
-    for (Object object : collection) {
+    for (java.lang.Object object : collection) {
       didRemoveElement |= remove(object);
     }
 
     return didRemoveElement;
   }
 
-  public boolean remove(Object object) {
+  public boolean remove(java.lang.Object object) {
     if (!(object instanceof $typemap(jboxtype, T))) {
       return false;
     }

--- a/Lib/java/std_unordered_map.i
+++ b/Lib/java/std_unordered_map.i
@@ -57,7 +57,7 @@ template<class K, class T> class unordered_map {
     return sizeImpl();
   }
 
-  public boolean containsKey(Object key) {
+  public boolean containsKey(java.lang.Object key) {
     if (!(key instanceof $typemap(jboxtype, K))) {
       return false;
     }
@@ -65,7 +65,7 @@ template<class K, class T> class unordered_map {
     return containsImpl(($typemap(jboxtype, K))key);
   }
 
-  public $typemap(jboxtype, T) get(Object key) {
+  public $typemap(jboxtype, T) get(java.lang.Object key) {
     if (!(key instanceof $typemap(jboxtype, K))) {
       return null;
     }
@@ -90,7 +90,7 @@ template<class K, class T> class unordered_map {
     }
   }
 
-  public $typemap(jboxtype, T) remove(Object key) {
+  public $typemap(jboxtype, T) remove(java.lang.Object key) {
     if (!(key instanceof $typemap(jboxtype, K))) {
       return null;
     }

--- a/Lib/java/std_unordered_set.i
+++ b/Lib/java/std_unordered_set.i
@@ -59,7 +59,7 @@ class unordered_set {
 
   public boolean addAll(java.util.Collection<? extends $typemap(jboxtype, T)> collection) {
     boolean didAddElement = false;
-    for (Object object : collection) {
+    for (java.lang.Object object : collection) {
       didAddElement |= add(($typemap(jboxtype, T))object);
     }
 
@@ -96,7 +96,7 @@ class unordered_set {
   }
 
   public boolean containsAll(java.util.Collection<?> collection) {
-    for (Object object : collection) {
+    for (java.lang.Object object : collection) {
       if (!contains(object)) {
         return false;
       }
@@ -105,7 +105,7 @@ class unordered_set {
     return true;
   }
 
-  public boolean contains(Object object) {
+  public boolean contains(java.lang.Object object) {
     if (!(object instanceof $typemap(jboxtype, T))) {
       return false;
     }
@@ -115,14 +115,14 @@ class unordered_set {
 
   public boolean removeAll(java.util.Collection<?> collection) {
     boolean didRemoveElement = false;
-    for (Object object : collection) {
+    for (java.lang.Object object : collection) {
       didRemoveElement |= remove(object);
     }
 
     return didRemoveElement;
   }
 
-  public boolean remove(Object object) {
+  public boolean remove(java.lang.Object object) {
     if (!(object instanceof $typemap(jboxtype, T))) {
       return false;
     }


### PR DESCRIPTION
I am not sure what branch this should go to, so I just made changes from master -> master. Our projects are using a more modified version than this, but I felt this was a necessary change for mainline.

If your native wrappers provide their own 'Object' class, the lack of an import here ends up using the same 'Object' class in the generated package, thus causing compilation errors as it attempts to cast your generated 'Object' to other java.lang.Object derivatives, like String.
