### PR TITLE
[OCaml] Fix possible memory leaks in generated dispatch functions

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -19,6 +19,7 @@ Active SWIG Developers:
  Oliver Buchtala (oliver.buchtala@gmail.com)              (Javascript)
  Neha Narang (narangneha03@gmail.com)                     (Javascript)
  Simon Marchetto (simon.marchetto@scilab-enterprises.com) (Scilab)
+ Zackery Spytz (zspytz@gmail.com)                         (OCaml, SWIG core)
 
 Past SWIG developers and major contributors include:
  Dave Beazley (dave-swig@dabeaz.com)                      (SWIG core, Python, Tcl, Perl)
@@ -28,7 +29,7 @@ Past SWIG developers and major contributors include:
  Mikel Bancroft (mikel@franz.com)                         (Allegro CL)
  Surendra Singhi (efuzzyone@netscape.net)                 (CLISP, CFFI)
  Marcelo Matus (mmatus@acms.arizona.edu)                  (SWIG core, Python, UTL[python,perl,tcl,ruby])
- Art Yerkes (ayerkes@speakeasy.net)                       (Ocaml)
+ Art Yerkes (ayerkes@speakeasy.net)                       (OCaml)
  Lyle Johnson (lyle@users.sourceforge.net)                (Ruby)
  Charlie Savage (cfis@interserv.com)                      (Ruby)
  Thien-Thi Nguyen (ttn@glug.org)                          (build/test/misc)

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -752,7 +752,7 @@ public:
 	Printv(df->code,
 	       "argv = (CAML_VALUE *)malloc( argc * sizeof( CAML_VALUE ) );\n"
 	       "for( i = 0; i < argc; i++ ) {\n" "  argv[i] = caml_list_nth(args,i);\n" "}\n", NIL);
-	Printv(df->code, dispatch, "\n", NIL);
+	Printv(df->code, dispatch, "\nfree(argv);\n", NIL);
 	Node *sibl = n;
 	while (Getattr(sibl, "sym:previousSibling"))
 	  sibl = Getattr(sibl, "sym:previousSibling");


### PR DESCRIPTION
All paths now free argv.