### PR TITLE
[Perl] Fully qualify aliases in pm file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .gitattributes export-ignore
 .gitignore export-ignore
+CHANGES.current merge=union

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.0 (27 Apr 2019)
 ===========================
 
+2019-04-06: tlby
+            [Perl] Fully qualify aliases in pm file.
+
 2019-04-24: vadz
             #1517 Fix crash if "@return" Doxygen tag was used on a node without any return type.
 

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -373,6 +373,7 @@ CPP_TEST_CASES += \
 	rename_pcre_encoder \
 	rename_pcre_enum \
 	rename_predicates \
+	rename_qualified \
 	rename_wildcard \
 	restrict_cplusplus \
 	return_const_value \

--- a/Examples/test-suite/perl5/rename_qualified_runme.pl
+++ b/Examples/test-suite/perl5/rename_qualified_runme.pl
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+BEGIN { use_ok('rename_qualified') }
+require_ok 'rename_qualified';
+
+sub try (&$$) {
+  my($test, $want, $name) = @_;
+  my $tb = Test::Builder->new();
+  my $got = eval { $test->() };
+  if($@) {
+    my $err = $@;
+    $err =~ s/^/    /mg;
+    $tb->diag($err);
+    return $tb->ok(0, $name);
+  }
+  return $tb->is_eq($got, $want, $name);
+}
+
+TODO: {
+  local $TODO = q(need to diagnose "Can't wrap XXX unless renamed to a valid identifier.");
+  my $s = eval { rename_qualified::New::Struct->new() };
+  try { $s->{InstanceVariable} } 111, 'InstanceVariable';
+  try { $s->InstanceMethod() } 222, 'InstanceMethod';
+  eval { $s->{NewInstanceVariable} = 1111 };
+  try { $s->{NewInstanceVariable} } 1111, 'InstanceVariable write';
+  try { rename_qualified::New::Struct::StaticMethod() } 333, 'StaticMethod';
+  try { $rename_qualified::New::Struct::StaticVariable } 444, 'StaticVariable';
+  eval { $rename_qualified::New::Struct::NewStaticVariable = 4444 };
+  try { $rename_qualified::New::Struct::NewStaticVariable } 4444, 'StaticVariable write';
+  try { rename_qualified::New::Function() } 555, 'Function';
+  try { $rename_qualified::New::GlobalVariable } 666, 'GlobalVariable';
+  eval { $rename_qualified::New::GlobalVariable = 6666 };
+  try { $rename_qualified::New::GlobalVariable } 6666, 'GlobalVariable write';
+}
+try { $rename_qualified::New::Macro } 777, 'Macro';

--- a/Examples/test-suite/perl5/rename_simple_runme.pl
+++ b/Examples/test-suite/perl5/rename_simple_runme.pl
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More tests => 11;
+BEGIN { use_ok('rename_simple') }
+require_ok 'rename_simple';
+
+my $s = rename_simple::NewStruct->new();
+is($s->{NewInstanceVariable}, 111, 'NewInstanceVariable');
+is($s->NewInstanceMethod, 222, 'NewInstanceMethod');
+is(rename_simple::NewStruct::NewStaticMethod(), 333, 'NewStaticMethod');
+is($rename_simple::NewStruct::NewStaticVariable, 444, 'NewStaticVariable');
+is(rename_simple::NewFunction(), 555, 'NewFunction');
+is($rename_simple::NewGlobalVariable, 666, 'NewGlobalVariable');
+
+$s->{NewInstanceVariable} = 1111;
+$rename_simple::NewStruct::NewStaticVariable = 4444;
+$rename_simple::NewGlobalVariable = 6666;
+
+is($s->{NewInstanceVariable}, 1111, 'NewInstanceVariable');
+is($rename_simple::NewStruct::NewStaticVariable, 4444, 'NewStaticVariable');
+is($rename_simple::NewGlobalVariable, 6666, 'NewGlobalVariable');

--- a/Examples/test-suite/perl5/rename_wildcard_runme.pl
+++ b/Examples/test-suite/perl5/rename_wildcard_runme.pl
@@ -1,0 +1,78 @@
+use strict;
+use warnings;
+use Test::More tests => 9;
+BEGIN { use_ok('rename_wildcard') }
+require_ok 'rename_wildcard';
+
+sub run_ok(&$) {
+  my($test, $name) = @_;
+  my $tb = Test::More->builder();
+  eval { $test->() };
+  return $tb->is_eq($@, '', $name);
+}
+
+run_ok {
+  rename_wildcard::GlobalWildStruct->new()->mm1();
+  rename_wildcard::GlobalWildTemplateStructInt->new()->mm1();
+  rename_wildcard::SpaceWildStruct->new()->mm1();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->mm1();
+} 'Wildcard check';
+run_ok {
+  rename_wildcard::GlobalWildStruct->new()->mm2a();
+  rename_wildcard::GlobalWildTemplateStructInt->new()->mm2b();
+  rename_wildcard::SpaceWildStruct->new()->mm2c();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->mm2d();
+
+  rename_wildcard::GlobalWildTemplateStructInt->new()->tt2b();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->tt2d();
+}'No declaration';
+run_ok {
+  rename_wildcard::GlobalWildStruct->new()->mm3a();
+  rename_wildcard::GlobalWildTemplateStructInt->new()->mm3b();
+  rename_wildcard::SpaceWildStruct->new()->mm3c();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->mm3d();
+
+  rename_wildcard::GlobalWildTemplateStructInt->new()->tt3b();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->tt3d();
+} 'With declaration';
+run_ok {
+  rename_wildcard::GlobalWildStruct->new()->mm4a();
+  rename_wildcard::GlobalWildTemplateStructInt->new()->mm4b();
+  rename_wildcard::SpaceWildStruct->new()->mm4c();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->mm4d();
+
+  rename_wildcard::GlobalWildTemplateStructInt->new()->tt4b();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->tt4d();
+} 'Global override too';
+run_ok {
+  rename_wildcard::GlobalWildStruct->new()->mm5a();
+  rename_wildcard::GlobalWildTemplateStructInt->new()->mm5b();
+  rename_wildcard::SpaceWildStruct->new()->mm5c();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->mm5d();
+
+  rename_wildcard::GlobalWildTemplateStructInt->new()->tt5b();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->tt5d();
+} '%extend renames';
+run_ok {
+  rename_wildcard::GlobalWildStruct->new()->opinta();
+  rename_wildcard::GlobalWildTemplateStructInt->new()->opintb();
+  rename_wildcard::SpaceWildStruct->new()->opintc();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->opintd();
+
+  rename_wildcard::GlobalWildTemplateStructInt->new()->opdoubleb();
+  rename_wildcard::SpaceWildTemplateStructInt->new()->opdoubled();
+} 'operators';
+run_ok {
+  rename_wildcard::NoChangeStruct->new()->mm1();
+  rename_wildcard::NoChangeStruct->new()->mm2();
+  rename_wildcard::NoChangeStruct->new()->mm3();
+  rename_wildcard::NoChangeStruct->new()->mm4();
+  rename_wildcard::NoChangeStruct->new()->mm5();
+  rename_wildcard::NoChangeStruct->new()->opint();
+  rename_wildcard::SpaceNoChangeStruct->new()->mm1();
+  rename_wildcard::SpaceNoChangeStruct->new()->mm2();
+  rename_wildcard::SpaceNoChangeStruct->new()->mm3();
+  rename_wildcard::SpaceNoChangeStruct->new()->mm4();
+  rename_wildcard::SpaceNoChangeStruct->new()->mm5();
+  rename_wildcard::SpaceNoChangeStruct->new()->opint();
+} 'Wildcard renames expected for these';

--- a/Examples/test-suite/rename_qualified.i
+++ b/Examples/test-suite/rename_qualified.i
@@ -1,0 +1,22 @@
+%module rename_qualified
+
+#if defined(SWIGPERL)
+// Java really does not like this, I assume it will choke others too
+%rename("%(regex:/^Old(\\S+)$/New::\\1/)s") "";
+#endif
+
+%inline %{
+struct OldStruct {
+  enum { ONE = 1, TWO, THREE };
+  OldStruct() : InstanceVariable(111) {}
+  int InstanceVariable;
+  int InstanceMethod() { return 222; }
+  static int StaticVariable;
+  static int StaticMethod() { return 333; }
+};
+int OldStruct::StaticVariable = 444;
+
+int OldFunction() { return 555; }
+int OldGlobalVariable = 666;
+#define OldMacro 777
+%}

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -1072,7 +1072,7 @@ public:
 	       "tie %__", iname, "_hash,\"", is_shadow(t), "\", $",
 	       cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(t), ";\n", NIL);
       } else {
-	Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
+	Printv(var_stubs, "*", module, "::", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
     }
     if (export_all)
@@ -1142,10 +1142,10 @@ public:
 	       "tie %__", iname, "_hash,\"", is_shadow(type), "\", $",
 	       cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(type), ";\n", NIL);
       } else if (do_constants) {
-	Printv(const_stubs, "sub ", name, " () { $", cmodule, "::", name, " }\n", NIL);
+	Printv(const_stubs, "sub ", module, "::", name, " () { $", cmodule, "::", name, " }\n", NIL);
 	num_consts++;
       } else {
-	Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
+	Printv(var_stubs, "*", module, "::", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
     }
     if (export_all) {


### PR DESCRIPTION
I found a limitation trying to rename symbols into different Perl packages.
```
%module "Some::Lib"
...
%rename("%(regex:/^SOMELIB_(\\S+)$/Const::\\1/)s", %$isconstant) "";
```
With `-noproxy` the constants matched by this rename end up in `Some::Lib::Const::`, but with `-proxy` they end up in `Const::`.  This patch will make the wrapper fully qualify the aliases emitted in `-proxy` mode to make the behavior consistent.