### PR TITLE
Fix some MSVC compiler warnings in the test suite

### DIFF
--- a/Examples/test-suite/nested_in_template.i
+++ b/Examples/test-suite/nested_in_template.i
@@ -19,7 +19,7 @@ struct OuterTemplate<1>
 
   struct ConcreteDerived : AbstractBase
   {
-    ConcreteDerived() : m_value(0.) {}
+    ConcreteDerived() : m_value(0) {}
     explicit ConcreteDerived(int value) : m_value(value) {}
 
     virtual bool IsSameAs(const AbstractBase& other) const {

--- a/Examples/test-suite/python_pybuffer.i
+++ b/Examples/test-suite/python_pybuffer.i
@@ -28,7 +28,7 @@
         ++count;
     return count;
   }
-  int func4(const char *buf4)
+  size_t func4(const char *buf4)
   {
     return strlen(buf4);
   }  

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2224,7 +2224,7 @@ public:
       n = nn;
 
     Parm *parms = Getattr(n, "parms");
-    bool varargs = parms ? emit_isvarargs(parms) : 0;
+    int varargs = parms ? emit_isvarargs(parms) : 0;
 
     /* We prefer to explicitly list all parameters of the C function in the
        generated Python code as this makes the function more convenient to use,


### PR DESCRIPTION
nested_in_template_wrap.cxx(247): warning C4244: 'initializing': conversion from 'double' to 'int', possible loss of data
python_pybuffer_wrap.cxx(2788): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
Modules\python.cxx(2227) : warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning)

These warnings can be seen on Appveyor (e.g. https://ci.appveyor.com/project/swig/swig/builds/22885721/job/3b5gkdjsndjlgl5t)