### PR TITLE
Fix node.js deprecated warnings >= v10.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -377,12 +377,6 @@ matrix:
       env: SWIGLANG=tcl
 
   allow_failures:
-    # Deprecated functions causing build failure since upgrade from Node v10.11.0 to v10.12.0
-    - compiler: gcc
-      os: linux
-      env: SWIGLANG=javascript ENGINE=node VER=10 CPP11=1
-      sudo: required
-      dist: trusty
     # Sometimes hits the Travis 50 minute time limit
     - compiler: gcc
       os: linux

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -93,7 +93,7 @@ SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::Name> property, v8::Local<v8
 #else
     v8::Local<v8::String> sproperty;
     if (property->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocal(&sproperty)) {
-      sproperty->WriteUtf8(buffer, 256);
+      SWIGV8_WRITE_UTF8(sproperty, buffer, 256);
       res = sprintf(msg, "Tried to write read-only variable: %s.", buffer);
     }
     else {

--- a/Lib/javascript/v8/javascriptprimtypes.swg
+++ b/Lib/javascript/v8/javascriptprimtypes.swg
@@ -22,7 +22,7 @@ int SWIG_AsVal_dec(bool)(v8::Handle<v8::Value> obj, bool *val)
     return SWIG_ERROR;
   }
 
-  if (val) *val = obj->BooleanValue();
+  if (val) *val = SWIGV8_BOOLEAN_VALUE(obj);
   return SWIG_OK;
 }
 }
@@ -44,7 +44,7 @@ int SWIG_AsVal_dec(int)(v8::Handle<v8::Value> valRef, int* val)
   if (!valRef->IsNumber()) {
     return SWIG_TypeError;
   }
-  if(val) *val = valRef->IntegerValue();
+  if(val) *val = SWIGV8_INTEGER_VALUE(valRef);
 
   return SWIG_OK;
 }
@@ -68,7 +68,7 @@ int SWIG_AsVal_dec(long)(v8::Handle<v8::Value> obj, long* val)
   if (!obj->IsNumber()) {
     return SWIG_TypeError;
   }
-  if(val) *val = (long) obj->IntegerValue();
+  if(val) *val = (long) SWIGV8_INTEGER_VALUE(obj);
 
   return SWIG_OK;
 }
@@ -95,7 +95,7 @@ int SWIG_AsVal_dec(unsigned long)(v8::Handle<v8::Value> obj, unsigned long *val)
     return SWIG_TypeError;
   }
 
-  long longVal = (long) obj->NumberValue();
+  long longVal = (long) SWIGV8_NUMBER_VALUE(obj);
 
   if(longVal < 0) {
       return SWIG_OverflowError;
@@ -133,7 +133,7 @@ int SWIG_AsVal_dec(long long)(v8::Handle<v8::Value> obj, long long* val)
   if (!obj->IsNumber()) {
     return SWIG_TypeError;
   }
-  if(val) *val = (long long) obj->IntegerValue();
+  if(val) *val = (long long) SWIGV8_INTEGER_VALUE(obj);
 
   return SWIG_OK;
 }
@@ -168,7 +168,7 @@ int SWIG_AsVal_dec(unsigned long long)(v8::Handle<v8::Value> obj, unsigned long 
     return SWIG_TypeError;
   }
 
-  long long longVal = (long long) obj->NumberValue();
+  long long longVal = (long long) SWIGV8_NUMBER_VALUE(obj);
 
   if(longVal < 0) {
       return SWIG_OverflowError;
@@ -198,7 +198,7 @@ int SWIG_AsVal_dec(double)(v8::Handle<v8::Value> obj, double *val)
   if(!obj->IsNumber()) {
     return SWIG_TypeError;
   }
-  if(val) *val = obj->NumberValue();
+  if(val) *val = SWIGV8_NUMBER_VALUE(obj);
 
   return SWIG_OK;
 }

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -91,6 +91,32 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_SET_CLASS_TEMPL(class_templ, class) class_templ.Reset(v8::Isolate::GetCurrent(), class);
 #endif
 
+#ifdef NODE_VERSION
+#if NODE_VERSION_AT_LEAST(10, 12, 0)
+#define SWIG_NODE_AT_LEAST_1012
+#endif
+#endif
+
+//Necessary to check Node.js version because V8 API changes are backported in Node.js
+#if (defined(NODE_VERSION) && !defined(SWIG_NODE_AT_LEAST_1012)) || \
+    (!defined(NODE_VERSION) && (V8_MAJOR_VERSION-0) < 7)
+#define SWIGV8_TO_OBJECT(handle) (handle)->ToObject()
+#define SWIGV8_TO_STRING(handle) (handle)->ToString()
+#define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue()
+#define SWIGV8_INTEGER_VALUE(handle) (handle)->IntegerValue()
+#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue()
+#define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(buffer, len)
+#define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length()
+#else
+#define SWIGV8_TO_OBJECT(handle) (handle)->ToObject(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
+#define SWIGV8_TO_STRING(handle) (handle)->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
+#define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
+#define SWIGV8_INTEGER_VALUE(handle) (handle)->IntegerValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
+#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
+#define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(v8::Isolate::GetCurrent(), buffer, len)
+#define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length(v8::Isolate::GetCurrent())
+#endif
+
 /* ---------------------------------------------------------------------------
  * Error handling
  *
@@ -258,7 +284,7 @@ SWIGRUNTIME int SWIG_V8_GetInstancePtr(v8::Handle<v8::Value> valRef, void **ptr)
   if(!valRef->IsObject()) {
     return SWIG_TypeError;
   }
-  v8::Handle<v8::Object> objRef = valRef->ToObject();
+  v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
 
   if(objRef->InternalFieldCount() < 1) return SWIG_ERROR;
 
@@ -352,7 +378,7 @@ SWIGRUNTIME int SWIG_V8_ConvertPtr(v8::Handle<v8::Value> valRef, void **ptr, swi
   if(!valRef->IsObject()) {
     return SWIG_TypeError;
   }
-  v8::Handle<v8::Object> objRef = valRef->ToObject();
+  v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
   return SWIG_V8_ConvertInstancePtr(objRef, ptr, info, flags);
 }
 
@@ -479,7 +505,7 @@ SWIGRUNTIMEINLINE
 int SwigV8Packed_Check(v8::Handle<v8::Value> valRef) {
   SWIGV8_HANDLESCOPE();
   
-  v8::Handle<v8::Object> objRef = valRef->ToObject();
+  v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
   if(objRef->InternalFieldCount() < 1) return false;
 #if (V8_MAJOR_VERSION-0) < 5
   v8::Handle<v8::Value> flag = objRef->GetHiddenValue(SWIGV8_STRING_NEW("__swig__packed_data__"));
@@ -489,7 +515,7 @@ int SwigV8Packed_Check(v8::Handle<v8::Value> valRef) {
   if (!objRef->GetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey).ToLocal(&flag))
     return false;
 #endif
-  return (flag->IsBoolean() && flag->BooleanValue());
+  return (flag->IsBoolean() && SWIGV8_BOOLEAN_VALUE(flag));
 }
 
 SWIGRUNTIME
@@ -499,7 +525,7 @@ swig_type_info *SwigV8Packed_UnpackData(v8::Handle<v8::Value> valRef, void *ptr,
     
     SwigV8PackedData *sobj;
 
-    v8::Handle<v8::Object> objRef = valRef->ToObject();
+    v8::Handle<v8::Object> objRef = SWIGV8_TO_OBJECT(valRef);
 
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031511)
     v8::Handle<v8::Value> cdataRef = objRef->GetInternalField(0);

--- a/Lib/javascript/v8/javascriptruntime.swg
+++ b/Lib/javascript/v8/javascriptruntime.swg
@@ -44,6 +44,8 @@
 #ifdef BUILDING_NODE_EXTENSION
 %insert("runtime") %{
 #include <node.h>
+//Older version of node.h does not include this
+#include <node_version.h>
 %}
 #endif
 

--- a/Lib/javascript/v8/javascriptstrings.swg
+++ b/Lib/javascript/v8/javascriptstrings.swg
@@ -7,11 +7,11 @@ SWIGINTERN int
 SWIG_AsCharPtrAndSize(v8::Handle<v8::Value> valRef, char** cptr, size_t* psize, int *alloc)
 {
   if(valRef->IsString()) {
-    v8::Handle<v8::String> js_str = valRef->ToString();
+    v8::Handle<v8::String> js_str = SWIGV8_TO_STRING(valRef);
 
-    size_t len = js_str->Utf8Length() + 1;
+    size_t len = SWIGV8_UTF8_LENGTH(js_str) + 1;
     char* cstr = new char[len];
-    js_str->WriteUtf8(cstr, len);
+    SWIGV8_WRITE_UTF8(js_str, cstr, len);
     
     if(alloc) *alloc = SWIG_NEWOBJ;
     if(psize) *psize = len;
@@ -20,7 +20,7 @@ SWIG_AsCharPtrAndSize(v8::Handle<v8::Value> valRef, char** cptr, size_t* psize, 
     return SWIG_OK;
   } else {
     if(valRef->IsObject()) {
-      v8::Handle<v8::Object> obj = valRef->ToObject();
+      v8::Handle<v8::Object> obj = SWIGV8_TO_OBJECT(valRef);
       // try if the object is a wrapped char[]
       swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
       if (pchar_descriptor) {


### PR DESCRIPTION
Hi,
This PR fixes issue #1337 caused by deprecating V8 API in Node.js(https://github.com/nodejs/node/pull/23159)

This code uses new V8 API if node.js >= v10.12, or if V8 >= v7.0 in case of upstream V8.

V8 API change is here:
https://docs.google.com/document/d/1g8JFi8T_oAE_7uAri7Njtig7fKaPDfotU6huOa1alds/edit