### PR TITLE
[OCaml] Fix race conds when running the examples with parallel make

### DIFF
--- a/Examples/ocaml/shapes/Makefile
+++ b/Examples/ocaml/shapes/Makefile
@@ -20,7 +20,7 @@ static:
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
 	ocaml_static_cpp
 
-toplevel:
+toplevel: static
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/string_from_ptr/Makefile
+++ b/Examples/ocaml/string_from_ptr/Makefile
@@ -19,7 +19,7 @@ static:
 	PROGFILE='$(PROGFILE)' OBJS='$(OBJS)' \
 	ocaml_static
 
-toplevel:
+toplevel: static
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \

--- a/Examples/ocaml/strings_test/Makefile
+++ b/Examples/ocaml/strings_test/Makefile
@@ -23,7 +23,7 @@ dynamic:
 	PROGFILE='$(PROGFILE)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \
 	ocaml_static_cpp
 
-toplevel:
+toplevel: static
 	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' SRCS='$(SRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	PROGFILE='$(PROGFILE)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' \


### PR DESCRIPTION
Race conditions could occur when running the examples with parallel make.