### PR TITLE
Fix: incorrect string testing in R AddAccessor

### DIFF
--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1020,12 +1020,15 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   for(j = 0; j < numMems; j+=3) {
     String *item = Getitem(el, j);
     String *dup = Getitem(el, j + 1);
-    char *ptr = Char(dup);
-    ptr = &ptr[Len(dup) - 3];
+    int n = Len(dup);
 
-    if (!strcmp(ptr, "get"))
-      varaccessor++;
-
+    if ((n > 4)) {
+      char *ptr = Char(dup);
+      ptr = &ptr[n - 4];
+      if (!strcmp(ptr, "_get")) {
+        varaccessor++;
+      }
+    }
     if (Getattr(itemList, item))
       continue;
     Setattr(itemList, item, "1");
@@ -1057,12 +1060,15 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     for(j = 0; j < numMems; j+=3) {
       String *item = Getitem(el, j);
       String *dup = Getitem(el, j + 1);
-      char *ptr = Char(dup);
-      ptr = &ptr[Len(dup) - 3];
+      int n = Len(dup);
+      if (n > 4) {
+        char *ptr = Char(dup);
+        ptr = &ptr[Len(dup) - 4];
 
-      if (!strcmp(ptr, "get")) {
-	Printf(f->code, "%s'%s'", first ? "" : ", ", item);
-	first = 0;
+        if (!strcmp(ptr, "_get")) {
+          Printf(f->code, "%s'%s'", first ? "" : ", ", item);
+          first = 0;
+        }
       }
     }
     Printf(f->code, ");\n");
@@ -1337,9 +1343,10 @@ int R::variableWrapper(Node *n) {
 void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
 		    int isSet) {
   if(isSet < 0) {
+    isSet = 0;
     int n = Len(name);
-    char *ptr = Char(name);
     if (n>4) {
+      char *ptr = Char(name);
       isSet = Strcmp(NewString(&ptr[n-4]), "_set") == 0;
     }
   }


### PR DESCRIPTION
A rebased version of #PR1266.

This pull request is for records and testing. I do not intend this PR to be included, 
as other refactoring will supersede it. However it will be a useful basis against
which to test that refactoring.

There is a problem processing methods with short names. The
test looks for a suffix, length 4, testing whether it matches
"_get". If the length of the name is less than 4, the test
isn't applied so "isSet" does not get correctly initialised
and remains set to -1. This leads to methods with short names
not being processed correctly. This fix initialises isSet to 0
prior to attempting the test.

A second problem is addressed, in which a pointer is set relative
to the end of string without checking length.

The following tests now have different R files, with previously
incorrect set-style methods being removed:

abstract_access.R
class_scope_namespace.R
clientdata_prop_a.R
clientdata_prop_b.R
director_basic.R
director_enum.R
director_property.R
inherit_void_arg.R
multiple_inheritance_interfaces.R
template_extend_overload_2.R
template_partial_specialization.R
template_partial_specialization_typedef.R
variable_replacement.R

Tidied up the order of code dependent on string length, and fixed some other occurences

extended tests of suffixes to 4 characters