### PR TITLE
fixing memleak when using stl containers of shared_ptr objects in python

### DIFF
--- a/Lib/python/pystdcommon.swg
+++ b/Lib/python/pystdcommon.swg
@@ -45,13 +45,23 @@ namespace swig {
   template <class Type>
   struct traits_asptr {   
     static int asptr(PyObject *obj, Type **val) {
-      Type *p = 0;
-      swig_type_info *descriptor = type_info<Type>();
-      int res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
-      if (SWIG_IsOK(res)) {
-	if (val) *val = p;
+      if (val) {
+        Type *p = 0;
+        swig_type_info *descriptor = type_info<Type>();
+        int newmem = 0;
+        int res = descriptor ? SWIG_ConvertPtrAndOwn(obj, (void **)&p, descriptor, 0, &newmem) : SWIG_ERROR;
+        if (SWIG_IsOK(res)) {
+          if (newmem & SWIG_CAST_NEW_MEMORY) {
+            res |= SWIG_NEWOBJMASK;
+          }
+          *val = p;
+        }
+        return res;
+      } else {
+        swig_type_info *descriptor = type_info<Type>();
+        int res = descriptor ? SWIG_ConvertPtr(obj, 0, descriptor, 0) : SWIG_ERROR;
+        return res;
       }
-      return res;
     }
   }; 
 


### PR DESCRIPTION
swig/swig#773 fixing memleak of shared_ptr objects in python with creating a [wrapped] vector\<shared_ptr\<Foo\>\> from a list of shared_ptr\<Bar\> where Bar is derived from Foo.