### PR TITLE
Fix parsing of enums with trailing comma with -doxygen

### DIFF
--- a/Examples/test-suite/doxygen_parsing_enums.i
+++ b/Examples/test-suite/doxygen_parsing_enums.i
@@ -32,4 +32,9 @@
 		SOME_ITEM_30  ///< Post comment for the third item
 	};
 
+	enum SomeEnumWithTrailingComma
+	{
+		SOME_ITEM_100, ///< Post comment after comma.
+		SOME_ITEM_200, ///< Post comment after last comma.
+	};
 %}

--- a/Examples/test-suite/java/doxygen_parsing_enums_proper_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_proper_runme.java
@@ -55,6 +55,10 @@ public class doxygen_parsing_enums_proper_runme {
     wantedComments.put("doxygen_parsing_enums_proper.SomeAnotherEnum2.SOME_ITEM_20",
     		"Post comment for the second item \n" +
     		"");
+    wantedComments.put("doxygen_parsing_enums_proper.SomeEnumWithTrailingComma.SOME_ITEM_100",
+    		"Post comment after comma.");
+    wantedComments.put("doxygen_parsing_enums_proper.SomeEnumWithTrailingComma.SOME_ITEM_200",
+    		"Post comment after last comma.");
     
     // and ask the parser to check comments for us
     System.exit(parser.check(wantedComments));

--- a/Examples/test-suite/java/doxygen_parsing_enums_simple_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_simple_runme.java
@@ -47,6 +47,10 @@ public class doxygen_parsing_enums_simple_runme {
     		" The comment for the first item \n" +
     		" \n" +
     		"");
+    wantedComments.put("doxygen_parsing_enums_simple.doxygen_parsing_enums_simpleConstants.SOME_ITEM_100",
+    		"Post comment after comma.");
+    wantedComments.put("doxygen_parsing_enums_simple.doxygen_parsing_enums_simpleConstants.SOME_ITEM_200",
+    		"Post comment after last comma.");
     
     // and ask the parser to check comments for us
     System.exit(parser.check(wantedComments));

--- a/Examples/test-suite/java/doxygen_parsing_enums_typesafe_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_typesafe_runme.java
@@ -55,6 +55,10 @@ public class doxygen_parsing_enums_typesafe_runme {
     wantedComments.put("doxygen_parsing_enums_typesafe.SomeAnotherEnum2.SOME_ITEM_30",
     		"Post comment for the third item \n" +
     		"");
+    wantedComments.put("doxygen_parsing_enums_typesafe.SomeEnumWithTrailingComma.SOME_ITEM_100",
+    		"Post comment after comma.");
+    wantedComments.put("doxygen_parsing_enums_typesafe.SomeEnumWithTrailingComma.SOME_ITEM_200",
+    		"Post comment after last comma.");
 
     
     // and ask the parser to check comments for us

--- a/Examples/test-suite/java/doxygen_parsing_enums_typeunsafe_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_typeunsafe_runme.java
@@ -55,6 +55,10 @@ public class doxygen_parsing_enums_typeunsafe_runme {
     wantedComments.put("doxygen_parsing_enums_typeunsafe.SomeAnotherEnum2.SOME_ITEM_10",
     		"Post comment for the first item \n" +
     		"");
+    wantedComments.put("doxygen_parsing_enums_typeunsafe.SomeEnumWithTrailingComma.SOME_ITEM_100",
+    		"Post comment after comma.");
+    wantedComments.put("doxygen_parsing_enums_typeunsafe.SomeEnumWithTrailingComma.SOME_ITEM_200",
+    		"Post comment after last comma.");
     
     // and ask the parser to check comments for us
     System.exit(parser.check(wantedComments));


### PR DESCRIPTION
To correctly parse Doxygen post-comments after the trailing comma,
switch to right recursion in "enumlist" production rule definition: this
does consume more stack space when parsing, but makes the rules much
easier to write and to understand and hopefully shouldn't result in any
problems with real code (which shouldn't have thousands of enums items
in it).

Closes #1514.