### PR TITLE
Don't crash if type is not available in Python Doxygen code

### DIFF
--- a/Examples/test-suite/doxygen_misc_constructs.i
+++ b/Examples/test-suite/doxygen_misc_constructs.i
@@ -104,6 +104,9 @@
 
     };
 
+    /// @return This is a bad place for this tag, but it should be ignored.
+    struct StructWithReturnComment {};
+
     /**
         An example of a list in a documentation comment.
 

--- a/Examples/test-suite/java/doxygen_misc_constructs_runme.java
+++ b/Examples/test-suite/java/doxygen_misc_constructs_runme.java
@@ -117,6 +117,9 @@ public class doxygen_misc_constructs_runme {
     wantedComments.put("doxygen_misc_constructs.ClassWithNestedEnum.ENested.THREE",
     		" desc of three\n");
 
+    wantedComments.put("doxygen_misc_constructs.StructWithReturnComment",
+    		" @return This is a bad place for this tag, but it should be ignored.");
+
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.showList()",
 "         An example of a list in a documentation comment.<br>\n" +
 " <br>\n" +

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -336,8 +336,13 @@ static std::string getPyDocType(Node *n, const_String_or_char_ptr lname = "") {
   std::string type;
 
   String *s = Swig_typemap_lookup("doctype", n, lname, 0);
+  if (!s) {
+    if (String *t = Getattr(n, "type"))
+      s = SwigType_str(t, "");
+  }
+
   if (!s)
-    s = SwigType_str(Getattr(n, "type"), "");
+    return type;
 
   if (Language::classLookup(s)) {
     // In Python C++ namespaces are flattened, so remove all but last component


### PR DESCRIPTION
Fix crash if "@return" Doxygen tag was used on a node without any return
type (such as a class, for example). Ignoring it might not be the best
thing to do, but it's definitely better than crashing and it's not
really clear what else could be done anyhow.

Closes #1516.