### PR TITLE
Use "git-describe" as SWIG version in configure

### DIFF
--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -900,8 +900,11 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
   Preprocessor_define((DOH *) "SWIG 1", 0);
   Preprocessor_define((DOH *) "__STDC__", 0);
 
-  // Set the SWIG version value in format 0xAABBCC from package version expected to be in format A.B.C
+  // Set the SWIG version value in format 0xAABBCC from package version expected to be in format A.B.C[-suffix]
   String *package_version = NewString(PACKAGE_VERSION); /* Note that the fakeversion has not been set at this point */
+  if (char* const dash = strchr(Char(package_version), '-')) {
+    *dash = '\0';
+  }
   char *token = strtok(Char(package_version), ".");
   String *vers = NewString("SWIG_VERSION 0x");
   int count = 0;

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 dnl The macros which aren't shipped with the autotools are stored in the
 dnl Tools/config directory in .m4 files.
 
-AC_INIT([swig],[4.0.0],[http://www.swig.org])
+AC_INIT([swig],patsubst(m4_esyscmd_s([git describe --tags --abbrev=7 --dirty]),[^rel-]),[http://www.swig.org])
 AC_PREREQ(2.60)
 
 AC_CONFIG_SRCDIR([Source/Swig/swig.h])


### PR DESCRIPTION
This allows to distinguish between the different pre-release versions of
SWIG 4.0.0 instead of identifying all of them as just "4.0.0".

Update the code producing SWIG_VERSION preprocessor symbol value to
ignore everything after the first dash character in PACKAGE_VERSION.

---

I think this is quite useful to have as otherwise all recent SWIG versions identify itself as "4.0.0", which is not very informative.