### PR TITLE
Misc. documentation and source comment typo fixes

### DIFF
--- a/Doc/Manual/Extending.html
+++ b/Doc/Manual/Extending.html
@@ -3031,7 +3031,7 @@ virtual int functionWrapper(Node *n) {
   /* Close the function(error) */
   Printv(wrapper-&gt;code, "return ERROR;\n", "}\n", NIL);
 
-  /* final substititions if applicable */
+  /* final substitutions if applicable */
   ...
 
   /* Dump the function out */

--- a/Doc/Manual/Go.html
+++ b/Doc/Manual/Go.html
@@ -607,7 +607,7 @@ be checked dynamically.
 
 <p>
 In order to use C++ templates in Go, you must tell SWIG to create
-wrappers for a particular template instantation.  To do this, use
+wrappers for a particular template instantiation.  To do this, use
 the <tt>%template</tt> directive.
 
 

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -4002,7 +4002,7 @@ class Go(object):
 
 <p>
 The class defines each method in two different ways. The first definition is replaced by the second definition and so the second definition is the one used when the method is called.
-While this possibly provides the best of both worlds, the time to import the module will be slighly slower when the class is defined due to the additional method definitions.
+While this possibly provides the best of both worlds, the time to import the module will be slightly slower when the class is defined due to the additional method definitions.
 </p>
 
 <p>

--- a/Examples/ruby/exceptproxy/example.i
+++ b/Examples/ruby/exceptproxy/example.i
@@ -14,7 +14,7 @@
 %}
 
 
-/* The EmpytError doesn't appear in a throw declaration, and hence
+/* The EmptyError doesn't appear in a throw declaration, and hence
   we need to tell SWIG that the dequeue method throws it.  This can
   now be done via the %catchs feature. */
 %catches(FullError) *::enqueue;

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -1294,7 +1294,7 @@ void DoxygenParser::tokenizeDoxygenComment(const std::string &doxygenComment, co
     string lastLine = lines[lines.size() - 1];
 
     if (trim(lastLine).empty()) {
-      lines.pop_back(); // remove trailing empy line
+      lines.pop_back(); // remove trailing empty line
     }
   }
 

--- a/Source/Modules/allegrocl.cxx
+++ b/Source/Modules/allegrocl.cxx
@@ -471,7 +471,7 @@ void add_defined_foreign_type(Node *n, int overwrite = 0, String *k = 0,
 	  // a synonym type was found (held in variable 'match')
 	  // Printf(stderr, "setting primary synonym of %p to %p\n", new_node, match);
 	  if (new_node == match)
-	    Printf(stderr, "Hey-4 * - '%s' is a synonym of iteself!\n", Getattr(new_node, "name"));
+	    Printf(stderr, "Hey-4 * - '%s' is a synonym of itself!\n", Getattr(new_node, "name"));
 	  Setattr(new_node, "allegrocl:synonym-of", match);
 	  // Printf(stderr,"*** 4\n");
 	  add_linked_type(new_node);

--- a/Source/Modules/chicken.cxx
+++ b/Source/Modules/chicken.cxx
@@ -547,7 +547,7 @@ int CHICKEN::functionWrapper(Node *n) {
   }
   emit_return_variable(n, d, f);
 
-  /* Insert the argumetn output code */
+  /* Insert the argument output code */
   Printv(f->code, argout, NIL);
 
   /* Output cleanup code */
@@ -1456,7 +1456,7 @@ String *CHICKEN::chickenPrimitiveName(String *name) {
   if (value)
     return value;
   else {
-    Swig_error(input_file, line_number, "Internal Error: attempting to reference non-existant primitive name %s\n", name);
+    Swig_error(input_file, line_number, "Internal Error: attempting to reference non-existent primitive name %s\n", name);
     return NewString("#f");
   }
 }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1755,7 +1755,7 @@ public:
 	if (new_value) {
 	  value = new_value;
 	} else {
-	  // Even if the value is not representable in the target language, still use it in the documentaiton, for compatibility with the previous SWIG versions
+	  // Even if the value is not representable in the target language, still use it in the documentation, for compatibility with the previous SWIG versions
 	  // and because it can still be useful to see the C++ expression there.
 	  Node *lookup = Swig_symbol_clookup(value, 0);
 	  if (lookup)

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -496,7 +496,7 @@ public:
     /* Add the failure cleanup code */
     /* TODO */
 
-    /* Final substititions if applicable */
+    /* Final substitutions if applicable */
     Replaceall(wrapper->code, "$symname", functionName);
 
     /* Set CheckInputArgument and CheckOutputArgument input arguments */


### PR DESCRIPTION
Found via `codespell -q 3 -L uint,od,objext,ba,cmo,bae,ans,struc,fo,clos,goin,upto,thru`