### PR TITLE
Don't add a closing php-tag

### DIFF
--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -676,7 +676,7 @@ public:
       Delete(s_fakeoowrappers);
       s_fakeoowrappers = NULL;
     }
-    Printf(f_phpcode, "%s\n?>\n", s_phpclasses);
+    Printf(f_phpcode, "%s\n", s_phpclasses);
     Delete(f_phpcode);
 
     return SWIG_OK;


### PR DESCRIPTION
This PR removes the closing `?>` PHP tag from generated files. [PSR-2](https://www.php-fig.org/psr/psr-2/) states:

> The closing `?>` tag MUST be omitted from files containing only PHP.

A problem might occur if files with any character after the closing tag are used with `include` or `require`. It might trigger an output and disallow HTTP header manipulation. See the popular [_headers already sent_](https://stackoverflow.com/a/8028987/1847340) debate on SO.