### PR TITLE
Add JS Native Directive API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -285,7 +285,7 @@ matrix:
       os: linux
       env: SWIGLANG=scilab
       sudo: required
-      dist: trusty
+      dist: xenial
     - compiler: gcc
       os: linux
       env: SWIGLANG=tcl

--- a/Doc/Manual/Javascript.html
+++ b/Doc/Manual/Javascript.html
@@ -163,7 +163,6 @@ $ make check-javascript-examples V8_VERSION=0x032530 ENGINE=v8</pre>
     <li><p>Multiple output arguments do not work for JSC</p></li>
     <li><p>C89 incompatibility: the JSC generator might still generate C89 violating code</p></li>
     <li><p><code>long long</code> is not supported</p></li>
-    <li><p><code>%native</code> is not supported</p></li>
     <li><p>Javascript callbacks are not supported</p></li>
     <li><p><code>instanceOf</code> does not work under JSC</p></li>
 </ul>

--- a/Examples/javascript/check.list
+++ b/Examples/javascript/check.list
@@ -3,6 +3,7 @@ constant
 enum
 exception
 functor
+native
 nspace
 operator
 overload

--- a/Examples/javascript/native/Makefile
+++ b/Examples/javascript/native/Makefile
@@ -1,0 +1,3 @@
+SRCS =
+
+include $(SRCDIR)../example.mk

--- a/Examples/javascript/native/binding.gyp.in
+++ b/Examples/javascript/native/binding.gyp.in
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "target_name": "example",
+      "sources": [ "example_wrap.cxx" ],
+      "include_dirs": ["$srcdir"]
+    }
+  ]
+}

--- a/Examples/javascript/native/example.i
+++ b/Examples/javascript/native/example.i
@@ -4,100 +4,37 @@
 
 %wrapper
 %{
-#include <cstring>
-#include <string>
-
-
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
-  typedef v8::Handle<v8::Value> V8ReturnValue;
-  typedef v8::Arguments V8Arguments;
-# define V8_RETURN(val) return scope.Close(val)
-#else
-  typedef void V8ReturnValue;
-  typedef v8::FunctionCallbackInfo<v8::Value> V8Arguments;
-# define V8_RETURN(val) args.GetReturnValue().Set(val); return
-#endif
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032318)
-#    define V8_UNDEFINED() v8::Undefined()
-#else
-#    define V8_UNDEFINED() v8::Undefined(v8::Isolate::GetCurrent())
-#endif
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032117)
-#    define V8_HANDLESCOPE() v8::HandleScope scope
-#elif (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032224)
-#    define V8_HANDLESCOPE() v8::HandleScope scope(v8::Isolate::GetCurrent());
-#else
-#    define V8_HANDLESCOPE() v8::HandleScope scope(v8::Isolate::GetCurrent());
-#endif
-
-
-// 'unused' attribute only necessary for GNUC < v3.4
-static /* __attribute__ ((__unused__)) */ V8ErrorHandler V8_ErrorHandler;
-
-
-typedef struct worker_packet {
-    // -- basic --
-	uv_work_t request;
-	v8::Persistent<v8::Function> callback;
-	// -- persistent variables --
-	std::string result;
-	// -- async operation --
-	void (*execute)(std::string&);
-} worker_packet;
-
-
-// async process - parallel with node thread
-static void work_async(uv_work_t* request) {
-    worker_packet* packet = static_cast<worker_packet*>(request->data);
-    packet->execute(packet->result);
-    // add a delay for dramatic effect - not necessary
-}
-
-
-// send async result back to node's thread
-static void work_complete(uv_work_t* request, int status) {
-    V8_HANDLESCOPE();
-    v8::Isolate* iso = v8::Isolate::GetCurrent();
-    worker_packet* packet = static_cast<worker_packet*>(request->data);
-    const int argc = 1;
-    v8::Handle<v8::Value> argv[] = {
-        v8::String::NewFromUtf8(iso, packet->result.c_str())
-    };
-    v8::Local<v8::Function>::New(iso, packet->callback)->Call
-        (iso->GetCurrentContext()->Global(), argc, argv);
-    packet->callback.Reset();
-    delete work;
-}
-
-
-static void entry(const V8Arguments& args) {
-    v8::Isolate* iso = v8::Isolate::GetCurrent();
-    v8::Local<v8::Value> value = args[0];
-    if (!value->IsFunction()) {
-        V8_ErrorHandler.error((-1), "Invalid parameter type.");
-        return;
+#ifdef SWIG_V8_VERSION /* Engine: Node || V8 */
+    
+    static SwigV8ReturnValue JavaScript_do_work(const SwigV8Arguments &args) {
+        SWIGV8_HANDLESCOPE();
+        const int MY_MAGIC_NUMBER = 5;
+        v8::Handle<v8::Value> jsresult =
+        	SWIG_From_int(static_cast< int >(MY_MAGIC_NUMBER));
+        if (args.Length() != 0)
+        	SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
+        SWIGV8_RETURN(jsresult);
+    fail:
+        SWIGV8_RETURN(SWIGV8_UNDEFINED());
     }
-    worker_packet* packet = new worker_packet();
-    packet->request.data = packet;
-    packet->execute = [](std::string& res) { res = "My delayed message."; };
-    v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(value);
-    packet->callback.Reset(iso, callback);
-    uv_queue_work(uv_default_loop(), &packet->request,
-        work_async, work_complete);
-    args.GetReturnValue().Set(Undefined(iso));
-}
 
+#else /* Engine: JavaScriptCore */
 
-V8ReturnValue JavaScript_exampleV8_callback_function(const V8Arguments& args) {
-    V8_HANDLESCOPE();
-	if (args.Length() != 1) {
-        V8_ErrorHandler.error((-1), "Illegal number of arguments.");
-        V8_RETURN(V8_UNDEFINED());
-	}
-    entry(args);
-    v8::Handle<v8::Value> jsresult = V8_UNDEFINED();
-    V8_RETURN(jsresult);
-}
+	static JSValueRef JavaScript_do_work(JSContextRef context,
+		JSObjectRef function, JSObjectRef thisObject, size_t argc,
+		const JSValueRef argv[], JSValueRef* exception) {
+        const int MY_MAGIC_NUMBER = 5;
+        JSValueRef jsresult =
+        	SWIG_From_int SWIG_JSC_FROM_CALL_ARGS(
+        		static_cast< int >(MY_MAGIC_NUMBER));
+        if (argc != 0)
+        	SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
+        return jsresult;
+    fail:
+        return JSValueMakeUndefined(context);
+    }
+
+#endif
 %}
 
 

--- a/Examples/javascript/native/example.i
+++ b/Examples/javascript/native/example.i
@@ -16,9 +16,9 @@ int placeholder() { return 0; }
         SWIGV8_HANDLESCOPE();
         const int MY_MAGIC_NUMBER = 5;
         v8::Handle<v8::Value> jsresult =
-        	SWIG_From_int(static_cast< int >(MY_MAGIC_NUMBER));
+            SWIG_From_int(static_cast< int >(MY_MAGIC_NUMBER));
         if (args.Length() != 0)
-        	SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
+            SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
         SWIGV8_RETURN(jsresult);
     fail:
         SWIGV8_RETURN(SWIGV8_UNDEFINED());
@@ -26,15 +26,15 @@ int placeholder() { return 0; }
 
 #else /* Engine: JavaScriptCore */
 
-	static JSValueRef JavaScript_do_work(JSContextRef context,
-		JSObjectRef function, JSObjectRef thisObject, size_t argc,
-		const JSValueRef argv[], JSValueRef* exception) {
+    static JSValueRef JavaScript_do_work(JSContextRef context,
+        JSObjectRef function, JSObjectRef thisObject, size_t argc,
+        const JSValueRef argv[], JSValueRef* exception) {
         const int MY_MAGIC_NUMBER = 5;
         JSValueRef jsresult =
-        	SWIG_From_int SWIG_JSC_FROM_CALL_ARGS(
-        		static_cast< int >(MY_MAGIC_NUMBER));
+            SWIG_From_int SWIG_JSC_FROM_CALL_ARGS(
+                static_cast< int >(MY_MAGIC_NUMBER));
         if (argc != 0)
-        	SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
+            SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
         return jsresult;
     fail:
         return JSValueMakeUndefined(context);

--- a/Examples/javascript/native/example.i
+++ b/Examples/javascript/native/example.i
@@ -1,7 +1,13 @@
 /* File : example.i */
 %module example
 
+// placeholder() used to help SWIG generate "SWIG_From_int" call
+%{
+    int placeholder();
+%}
+int placeholder() { return 0; }
 
+// actual demo code
 %wrapper
 %{
 #ifdef SWIG_V8_VERSION /* Engine: Node || V8 */
@@ -38,4 +44,4 @@
 %}
 
 
-%native(num_to_string) void JavaScript_exampleV8_callback_function();
+%native(magicNumber) void JavaScript_do_work();

--- a/Examples/javascript/native/example.i
+++ b/Examples/javascript/native/example.i
@@ -1,0 +1,92 @@
+/* File : example.i */
+%module example
+
+
+%wrapper
+%{
+#include <cstring>
+#include <string>
+
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
+#    define V8_RETURN(val) return scope.Close(val)
+#else
+#    define V8_RETURN(val) args.GetReturnValue().Set(val); return
+#endif
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x032318)
+#    define V8_UNDEFINED() v8::Undefined()
+#else
+#    define V8_UNDEFINED() v8::Undefined(v8::Isolate::GetCurrent())
+#endif
+
+
+// 'unused' attribute only necessary for GNUC < v3.4
+static /* __attribute__ ((__unused__)) */ V8ErrorHandler V8_ErrorHandler;
+
+
+typedef struct worker_packet {
+    // -- basic --
+	uv_work_t request;
+	v8::Persistent<v8::Function> callback;
+	// -- persistent variables --
+	std::string result;
+	// -- async operation --
+	void (*execute)(std::string&);
+} worker_packet;
+
+
+// async process - parallel with node thread
+static void work_async(uv_work_t* request) {
+    worker_packet* packet = static_cast<worker_packet*>(request->data);
+    packet->execute(packet->result);
+    // add a delay for dramatic effect - not necessary
+}
+
+
+// send async result back to node's thread
+static void work_complete(uv_work_t* request, int status) {
+    v8::Isolate* iso = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(iso);
+    worker_packet* packet = static_cast<worker_packet*>(request->data);
+    const int argc = 1;
+    v8::Handle<v8::Value> argv[] = {
+        v8::String::NewFromUtf8(iso, packet->result.c_str())
+    };
+    v8::Local<v8::Function>::New(iso, packet->callback)->Call
+        (iso->GetCurrentContext()->Global(), argc, argv);
+    packet->callback.Reset();
+    delete work;
+}
+
+
+static void entry(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    v8::Isolate* iso = v8::Isolate::GetCurrent();
+    v8::Local<v8::Value> value = args[0];
+    if (!value->IsFunction()) {
+        V8_ErrorHandler.error((-1), "Invalid parameter type.");
+        return;
+    }
+    worker_packet* packet = new worker_packet();
+    packet->request.data = packet;
+    packet->execute = [](std::string& res) { res = "My delayed message."; };
+    v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(value);
+    packet->callback.Reset(iso, callback);
+    uv_queue_work(uv_default_loop(), &packet->request,
+        work_async, work_complete);
+    args.GetReturnValue().Set(Undefined(iso));
+}
+
+
+void JavaScript_exampleV8_callback_function(const v8::Arguments& args) {
+    v8::HandleScope scope
+	if (args.Length() != 1) {
+        V8_ErrorHandler.error((-1), "Illegal number of arguments.");
+        V8_RETURN(V8_UNDEFINED());
+	}
+    entry(args);
+    v8::Handle<v8::Value> jsresult = V8_UNDEFINED();
+    V8_RETURN(jsresult);
+}
+%}
+
+
+%native(num_to_string) void JavaScript_exampleV8_callback_function();

--- a/Examples/javascript/native/example.js
+++ b/Examples/javascript/native/example.js
@@ -1,0 +1,1 @@
+module.exports = require("build/Release/example");

--- a/Examples/javascript/native/index.html
+++ b/Examples/javascript/native/index.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<title>SWIG:Examples:javascript:native</title>
+</head>
+
+<body bgcolor="#ffffff">
+
+
+<tt>SWIG/Examples/javascript/native/</tt>
+<hr>
+
+<H2>Manually wrapped callback function in JavaScript</H2>
+
+<p>
+This example demonstrates how to manually add callback feature support to a SWIG module.
+</p>
+
+<ul>
+<li><a href="example.i">example.i</a>. Interface file containing the API function and async behind-the-scenes functions. 
+<li><a href="runme.java">runme.js</a>. Sample JavaScript program showing the API function being called with a callback function parameter.
+</ul>
+
+<h2>Notes</h2>
+
+The V8 code queues the callback request for processing using the UV interface. An async function callback is invoked when the system is ready to process the next request. When the async function finishes, a completion function callback is invoked to finalize the request. Here the callback function parameter is invoked.
+<br/><br/>
+UV request queueing is only necessary for operations that would take a really long or otherwise unpredictable amount of time (async operations). A callback parameter could also be invoked immediately within the API function.
+
+<hr>
+</body>
+</html>

--- a/Examples/javascript/native/runme.js
+++ b/Examples/javascript/native/runme.js
@@ -1,3 +1,3 @@
 var example = require("example");
 
-console.info("My magic number is: ", example.magicNumber());
+console.log("My magic number is: ", example.magicNumber());

--- a/Examples/javascript/native/runme.js
+++ b/Examples/javascript/native/runme.js
@@ -1,5 +1,3 @@
 var example = require("example");
 
-function callback(msg) { console.log(msg); }
-
-example.num_to_string(callback);
+console.info("My magic number is: ", example.magicNumber());

--- a/Examples/javascript/native/runme.js
+++ b/Examples/javascript/native/runme.js
@@ -1,0 +1,5 @@
+var example = require("example");
+
+function callback(msg) { console.log(msg); }
+
+example.num_to_string(callback);

--- a/Examples/test-suite/javascript/native_directive_runme.js
+++ b/Examples/test-suite/javascript/native_directive_runme.js
@@ -1,0 +1,9 @@
+var native_directive = require("native_directive");
+
+(function main() {
+  var s = "abc.DEF-123";
+  if (native_directive.CountAlphas(s) !== 6)
+    throw "CountAlphas failed";
+  if (native_directive.CountAlphaCharacters(s) !== 6)
+    throw "CountAlphaCharacters failed";
+})();

--- a/Examples/test-suite/native_directive.i
+++ b/Examples/test-suite/native_directive.i
@@ -42,32 +42,58 @@ extern "C" JNIEXPORT jint JNICALL Java_native_1directive_native_1directiveJNI_Co
 #endif
 
 
-#if defined(SWIG_V8_VERSION)
+
+#ifdef SWIGJAVASCRIPT
+%native(CountAlphaCharacters) void JavaScript_alpha_count();
 %{
-static SwigV8ReturnValue wrap_alpha_count(const SwigV8Arguments &args) {
+#ifdef SWIG_V8_VERSION /* engine = node || v8 */
+
+static SwigV8ReturnValue JavaScript_alpha_count(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   v8::Handle<v8::Value> jsresult;
-  char *arg1 = (char *) 0 ;
-  int res1 ;
-  char *buf1 = 0 ;
-  int alloc1 = 0 ;
+  char *arg1 = (char *)0;
+  int res1;
+  char *buf1 = 0;
+  int alloc1 = 0;
   int result;
-  if(args.Length() != 1) SWIG_exception_fail(SWIG_ERROR,
-    "Illegal number of arguments for _wrap_count_characters.");
+  if(args.Length() != 1) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for _wrap_alpha_count.");
   res1 = SWIG_AsCharPtrAndSize(args[0], &buf1, NULL, &alloc1);
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "count_characters"
-      "', argument " "1"" of type '" "char const *""'");
-  }
+  if (!SWIG_IsOK(res1))
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "alpha_count" "', argument " "1"" of type '" "char const *""'");
   arg1 = reinterpret_cast< char * >(buf1);
-  result = (int)count_characters((char const *)arg1);
+  result = (int)alpha_count((char const *)arg1);
   jsresult = SWIG_From_int(static_cast< int >(result));
   if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
   SWIGV8_RETURN(jsresult);
 fail:
   SWIGV8_RETURN(SWIGV8_UNDEFINED());
 }
+
+#else /* engine = jsc */
+
+static JSValueRef JavaScript_alpha_count(JSContextRef context, JSObjectRef function,
+  JSObjectRef thisObject, size_t argc, const JSValueRef argv[], JSValueRef* exception)
+{
+  char *arg1 = (char *)0;
+  int res1;
+  char *buf1 = 0;
+  int alloc1 = 0;
+  int result;
+  JSValueRef jsresult;
+  if (argc != 1) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments.");
+  res1 = SWIG_JSC_AsCharPtrAndSize(context, argv[0], &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1))
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "alpha_count" "', argument " "1"" of type '" "char const *""'");
+  arg1 = reinterpret_cast< char * >(buf1);
+  result = (int)alpha_count((char const *)arg1);
+  jsresult = SWIG_From_int  SWIG_JSC_FROM_CALL_ARGS(static_cast< int >(result));
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return jsresult;
+fail:
+  return JSValueMakeUndefined(context);
+}
+
+#endif /* engine */
 %}
-%native(CountAlphaCharacters) void wrap_alpha_count();
-#endif
+#endif /* SWIGJAVASCRIPT */
 

--- a/Examples/test-suite/native_directive.i
+++ b/Examples/test-suite/native_directive.i
@@ -42,6 +42,9 @@ extern "C" JNIEXPORT jint JNICALL Java_native_1directive_native_1directiveJNI_Co
 #endif
 
 
+// TODO: C#
+// TODO: Python
+
 
 #ifdef SWIGJAVASCRIPT
 %native(CountAlphaCharacters) void JavaScript_alpha_count();

--- a/Examples/test-suite/native_directive.i
+++ b/Examples/test-suite/native_directive.i
@@ -41,3 +41,33 @@ extern "C" JNIEXPORT jint JNICALL Java_native_1directive_native_1directiveJNI_Co
 %}
 #endif
 
+
+#if defined(SWIG_V8_VERSION)
+%{
+static SwigV8ReturnValue wrap_alpha_count(const SwigV8Arguments &args) {
+  SWIGV8_HANDLESCOPE();
+  v8::Handle<v8::Value> jsresult;
+  char *arg1 = (char *) 0 ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  int result;
+  if(args.Length() != 1) SWIG_exception_fail(SWIG_ERROR,
+    "Illegal number of arguments for _wrap_count_characters.");
+  res1 = SWIG_AsCharPtrAndSize(args[0], &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "count_characters"
+      "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  result = (int)count_characters((char const *)arg1);
+  jsresult = SWIG_From_int(static_cast< int >(result));
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  SWIGV8_RETURN(jsresult);
+fail:
+  SWIGV8_RETURN(SWIGV8_UNDEFINED());
+}
+%}
+%native(CountAlphaCharacters) void wrap_alpha_count();
+#endif
+

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -198,6 +198,11 @@ public:
   virtual int emitWrapperFunction(Node *n);
 
   /**
+   * Invoked by nativeWrapper callback
+   */
+  virtual int emitNativeFunction(Node *n);
+
+  /**
    * Invoked from constantWrapper after call to Language::constantWrapper.
    **/
   virtual int emitConstant(Node *n);
@@ -311,6 +316,7 @@ public:
   virtual int classHandler(Node *n);
   virtual int functionWrapper(Node *n);
   virtual int constantWrapper(Node *n);
+  virtual int nativeWrapper(Node *n);
   virtual void main(int argc, char *argv[]);
   virtual int top(Node *n);
 
@@ -437,6 +443,18 @@ int JAVASCRIPT::constantWrapper(Node *n) {
   // however, there is a remaining bug with function pointer constants
   // which could be fixed with a cleaner approach
   emitter->emitConstant(n);
+
+  return SWIG_OK;
+}
+
+/* ---------------------------------------------------------------------
+ * nativeWrapper()
+ *
+ * Function wrapper for generating placeholders for native functions
+ * --------------------------------------------------------------------- */
+
+int JAVASCRIPT::nativeWrapper(Node *n) {
+  emitter->emitNativeFunction(n);
 
   return SWIG_OK;
 }
@@ -766,6 +784,17 @@ int JSEmitter::emitWrapperFunction(Node *n) {
   }
 
   return ret;
+}
+
+int JSEmitter::emitNativeFunction(Node *n) {
+  String *wrap_name = Getattr(n, "wrap:name");
+
+  Setattr(n, "feature:extend", "last");
+  enterFunction(n);
+  state.function(WRAPPER_NAME, wrap_name);
+  exitFunction(n);
+
+  return SWIG_OK;
 }
 
 int JSEmitter::enterClass(Node *n) {

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -788,14 +788,6 @@ int JSEmitter::emitWrapperFunction(Node *n) {
 
 int JSEmitter::emitNativeFunction(Node *n) {
   String *wrapname = Getattr(n, "wrap:name");
-  // ismember never seems to be the case;
-  // it is technically possible to add native member functions,
-  // just not at the moment? leaving this as an option for later;
-  // the code will automatically defaulting to static space
-  if (GetFlag(n, "ismember") != 0)
-    Setattr(n, "feature:extend", "1"); // member space
-  else
-    Setattr(n, "feature:extend", "0"); // static space
   enterFunction(n);
   state.function(WRAPPER_NAME, wrapname);
   exitFunction(n);

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -787,13 +787,18 @@ int JSEmitter::emitWrapperFunction(Node *n) {
 }
 
 int JSEmitter::emitNativeFunction(Node *n) {
-  String *wrap_name = Getattr(n, "wrap:name");
-
-  Setattr(n, "feature:extend", "last");
+  String *wrapname = Getattr(n, "wrap:name");
+  // ismember never seems to be the case;
+  // it is technically possible to add native member functions,
+  // just not at the moment? leaving this as an option for later;
+  // the code will automatically defaulting to static space
+  if (GetFlag(n, "ismember") != 0)
+    Setattr(n, "feature:extend", "1"); // member space
+  else
+    Setattr(n, "feature:extend", "0"); // static space
   enterFunction(n);
-  state.function(WRAPPER_NAME, wrap_name);
+  state.function(WRAPPER_NAME, wrapname);
   exitFunction(n);
-
   return SWIG_OK;
 }
 

--- a/Tools/travis-linux-install.sh
+++ b/Tools/travis-linux-install.sh
@@ -114,6 +114,10 @@ case "$SWIGLANG" in
 		fi
 		;;
 	"scilab")
+		# Travis has the wrong version of Java pre-installed resulting in error using scilab:
+		# /usr/bin/scilab-bin: error while loading shared libraries: libjava.so: cannot open shared object file: No such file or directory
+		echo "JAVA_HOME was set to $JAVA_HOME"
+		unset JAVA_HOME
 		travis_retry sudo apt-get -qq install scilab
 		;;
 	"tcl")


### PR DESCRIPTION
Adds `%native(function)` api support for JavaScript. Custom node functions can now be written and included in the same swig module such as functions with function callbacks as parameters.
Deprecates #763 

**Additions Include:**
- native directive support for javascript
- updated JS documentation
- native directive example project
- native directive testcase