### PR TITLE
Add support for appending to a typemap definition

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.1 (in progress)
 ===========================
 
+2019-05-23: vadz
+            Add append=1 modifier for typemap definitions.
+
 2019-05-22: ferdynator
 	    [PHP] #1528 Don't add a closing '?>' PHP tag to generated files.
 	    PSR-2 says it MUST be omitted for files containing only PHP.

--- a/Doc/Manual/Typemaps.html
+++ b/Doc/Manual/Typemaps.html
@@ -854,6 +854,31 @@ int isprime(int);                 // typemap2
 </div>
 
 <p>
+For most typemaps, redefining the existing typemap when a new typemap for the same type is encountered is the only possibility which makes sense, however for
+some of them, such as, for example, <tt>cscode</tt> or <tt>javacode</tt> typemaps allowing to inject additional code into the generated classes declarations, it
+may also be useful to add to, rather than replace, the existing typemap definition. The special <tt>append=1</tt> modifier can be used to do it, e.g.:
+</p>
+<div class="code">
+<pre>
+// Implement specific comparison rules for the objects of this type.
+%typemap(csinterfaces_derived) Foo "IEquatable<Foo>"
+%typemap(cscode) Foo {
+    public bool Equals(Foo other) { ... }
+    public override bool Equals(object other) { ... }
+}
+... much later ...
+
+// Add some custom C# code to the generated class declaration: without
+// append=1 here this typemap would have overwritten the one defined
+// above and thus would break IEquatable support.
+%typemap(cscode, append=1) Foo {
+    protected void SomeInternalHelper() { ... }
+}
+%
+</pre>
+</div>
+
+<p>
 One exception to the typemap scoping rules pertains to the <tt>%extend</tt> declaration.  <tt>%extend</tt> is used to attach
 new declarations to a class or structure definition.  Because of this, all of the declarations in an <tt>%extend</tt> block are
 subject to the typemap rules that are in effect at the point where the class itself is defined.  For example:

--- a/Examples/test-suite/operator_overload.i
+++ b/Examples/test-suite/operator_overload.i
@@ -59,6 +59,10 @@ see bottom for a set of possible tests
     newOp.PlusPlusPostfix(0);
     return newOp;
   }
+%}
+
+// Also test appending to the existing typemap while we're at it.
+%typemap(cscode, append=1) Op %{
   public static Op operator--(Op op) {
     // Unlike C++, operator-- must not modify the parameter and both prefix and postfix operations call this method
     Op newOp = new Op(op.i);


### PR DESCRIPTION
If append=1 modifier is used, append to the existing typemap definition
rather than replacing it.

This is especially useful for cscode/javacode typemaps which can be
naturally combined.

Closes #1541.