### PR TITLE
Doxygen comment whitespace fixes for python

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -620,6 +620,7 @@ DOXYGEN_TEST_CASES += \
 	doxygen_alias \
 	doxygen_basic_notranslate \
 	doxygen_basic_translate \
+	doxygen_basic_translate_style2 \
 	doxygen_ignore \
 	doxygen_misc_constructs \
 	doxygen_nested_class \

--- a/Examples/test-suite/doxygen_basic_translate_style2.i
+++ b/Examples/test-suite/doxygen_basic_translate_style2.i
@@ -1,0 +1,105 @@
+%module doxygen_basic_translate_style2
+
+%include "doxygen_basic_translate.h"
+
+// This test demonstrates a doxygen comment style that starts on the
+// first line and so uses extra spacing in subsequent lines.
+
+%inline %{
+
+/** \brief
+ *  Brief description.
+ * 
+ *  The comment text.
+ *
+ *  \author Some author
+ *
+ *  \return Some number
+ *
+ *  \sa function2
+ */
+int function()
+{
+    return 0;
+}
+
+/** A test of a very very very very very very very very very very very very very very very very
+ *  very very very very very long comment string.
+ */
+void function2()
+{
+}
+
+/** A test for overloaded functions
+ *  This is function \b one
+ */
+void function3(int a)
+{
+}
+
+/** A test for overloaded functions
+ *  This is function \b two
+ */
+void function3(int a, int b)
+{
+}
+
+/** A test of some mixed tag usage
+ *  \if CONDITION
+ *  This \a code fragment shows us something \.
+ *  \par Minuses:
+ *  \arg it's senseless
+ *  \arg it's stupid
+ *  \arg it's null
+ *
+ *  \warning This may not work as expected
+ *  \code
+ *  int main() { while(true); }
+ *  \endcode
+ *  \endif
+ */
+void function4()
+{
+}
+
+
+void function5(int a)
+{
+}
+/**< This is a post comment. */
+
+/** Test for default args
+ *  @param a Some parameter, default is 42
+ */
+void function6(int a=42)
+{
+}
+
+class Shape
+{
+public:
+  typedef Shape* superType;
+};
+
+/** Test for a parameter with difficult type
+ *  (mostly for python)
+ *  @param a Very strange param
+ */
+void function7(Shape::superType *a[10])
+{
+}
+
+/** Multiple parameters test.
+ *
+ *  @param y Vertical coordinate.
+ *  @param x Horizontal coordinate.
+ *  @return Arc tangent of @c y/x.
+ */
+double Atan2(double y, double x)
+{
+    return 0;
+}
+
+/** Comment at the end of file should be ignored.
+ */
+%}

--- a/Examples/test-suite/doxygen_translate_all_tags.i
+++ b/Examples/test-suite/doxygen_translate_all_tags.i
@@ -38,6 +38,10 @@
  * \cite citationword
  * \class someClass headerFile.h headerName
  * \code some test code \endcode
+ *
+ * Code immediately following text.  Pydoc translation must add an
+ * empty line before:
+ * \code more test code \endcode
  */
 void func01(int a)
 {
@@ -120,6 +124,12 @@ void func03(int a)
  * \f{
  *     \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}
  * \f}
+ *
+ * Math immediately following text.  Pydoc translation must add an
+ * empty line before:
+ * \f[
+ *     \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}
+ * \f]
  *
  * \file file.h
  *

--- a/Examples/test-suite/java/doxygen_basic_translate_style2_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_style2_runme.java
@@ -1,0 +1,99 @@
+
+import doxygen_basic_translate_style2.*;
+import com.sun.javadoc.*;
+import java.util.HashMap;
+
+public class doxygen_basic_translate_style2_runme {
+  static {
+    try {
+      System.loadLibrary("doxygen_basic_translate_style2");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+  
+  public static void main(String argv[]) 
+  {
+    /*
+      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
+      and calls the start() method of that class with parsed information.
+    */
+    CommentParser parser = new CommentParser();
+    com.sun.tools.javadoc.Main.execute("doxygen_basic_translate_style2 runtime test",
+                                       "CommentParser",
+                                       new String[]{"-quiet", "doxygen_basic_translate_style2"});
+
+    HashMap<String, String> wantedComments = new HashMap<String, String>();
+    
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function()",
+    		" \n" +
+    		" Brief description.\n" +
+    		" \n" +
+    		" The comment text.\n" +
+    		" @author Some author\n" +
+    		" @return Some number\n" +
+    		" @see function2\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function2()",
+    		" A test of a very very very very very very very very very very very very very very very very \n" +
+    		" very very very very very long comment string. \n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function4()",
+    		" A test of some mixed tag usage \n" +
+    		" If: CONDITION {\n" +
+    		" This <i>code </i>fragment shows us something . \n" +
+    		" <p alt=\"Minuses: \">\n" +
+    		" <li>it's senseless \n" +
+    		" </li><li>it's stupid \n" +
+    		" </li><li>it's null \n" +
+    		" \n" +
+    		" </li></p>Warning: This may not work as expected \n" +
+    		" \n" +
+    		" {@code \n" +
+    		"int main() { while(true); } \n" +
+    		" }\n" +
+    		" }\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function3(int)",
+    		" A test for overloaded functions \n" +
+    		" This is function <b>one </b>\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function5(int)",
+    		" This is a post comment. \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function6(int)",
+    		" Test for default args \n" +
+    		" @param a Some parameter, default is 42" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function6()",
+    		" Test for default args \n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function7(doxygen_basic_translate_style2.SWIGTYPE_p_p_p_Shape)",
+    		" Test for a parameter with difficult type \n" +
+    		" (mostly for python) \n" +
+    		" @param a Very strange param \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.function3(int, int)",
+    		" A test for overloaded functions \n" +
+    		" This is function <b>two </b>\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style2.doxygen_basic_translate_style2.Atan2(double, double)",
+    		" Multiple parameters test.\n" +
+    		" \n" +
+    		" @param y Vertical coordinate.\n" +
+    		" @param x Horizontal coordinate.\n" +
+    		" @return Arc tangent of <code>y/x</code>.\n" +
+    		"");
+
+    // and ask the parser to check comments for us
+    System.exit(parser.check(wantedComments));
+  }
+}

--- a/Examples/test-suite/java/doxygen_translate_all_tags_runme.java
+++ b/Examples/test-suite/java/doxygen_translate_all_tags_runme.java
@@ -40,7 +40,10 @@ public class doxygen_translate_all_tags_runme {
     		" Not everything works right now...\n" +
     		" <code>codeword</code>\n\n\n\n\n\n" +
     		" <i>citationword</i>\n" +
-                " {@code some test code }\n");
+                " {@code some test code }\n\n" +
+    		" Code immediately following text.  Pydoc translation must add an\n" +
+    		" empty line before:\n" +
+    		" {@code more test code }");
     
     wantedComments.put("doxygen_translate_all_tags.doxygen_translate_all_tags.func02(int)",
     		" Conditional comment: SOMECONDITION \n" +
@@ -63,8 +66,11 @@ public class doxygen_translate_all_tags_runme {
                        " @exception SuperError \n" +
                        " \\sqrt{(x_2-x_1)^2+(y_2-y_1)^2} \n" +
                        " \\sqrt{(x_2-x_1)^2+(y_2-y_1)^2} \n" +
-                       " \\sqrt{(x_2-x_1)^2+(y_2-y_1)^2} \n" +
-    		" This will only appear in hmtl \n");
+                       " \\sqrt{(x_2-x_1)^2+(y_2-y_1)^2} \n\n" +
+                       "Math immediately following text.  Pydoc translation must add an\n" +
+                       "empty line before:\n\n" +
+                       " \\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}\n" +
+                       " This will only appear in hmtl \n");
     
     wantedComments.put("doxygen_translate_all_tags.doxygen_translate_all_tags.func05(int)",
                        " If: ANOTHERCONDITION {\n" +

--- a/Examples/test-suite/python/doxygen_basic_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_runme.py
@@ -49,7 +49,6 @@ Warning: This may not work as expected
 
 .. code-block:: c++
 
-
     int main() { while(true); }
 
 }"""

--- a/Examples/test-suite/python/doxygen_basic_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_runme.py
@@ -46,7 +46,6 @@ Title: Minuses:
 * it\'s null
 
 Warning: This may not work as expected
-
 .. code-block:: c++
 
     int main() { while(true); }

--- a/Examples/test-suite/python/doxygen_basic_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_runme.py
@@ -50,7 +50,6 @@ Warning: This may not work as expected
 .. code-block:: c++
 
     int main() { while(true); }
-
 }"""
 )
 comment_verifier.check(inspect.getdoc(doxygen_basic_translate.function5),

--- a/Examples/test-suite/python/doxygen_basic_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_runme.py
@@ -46,6 +46,7 @@ Title: Minuses:
 * it\'s null
 
 Warning: This may not work as expected
+
 .. code-block:: c++
 
     int main() { while(true); }

--- a/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
@@ -44,6 +44,7 @@ Title: Minuses:
 * it\'s null
 
 Warning: This may not work as expected
+
 .. code-block:: c++
 
     int main() { while(true); }

--- a/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
@@ -1,0 +1,82 @@
+import doxygen_basic_translate_spaced
+import inspect
+import string
+import sys
+import comment_verifier
+
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function),
+    """\
+Brief description.
+
+The comment text.
+
+Author: Some author
+
+:rtype: int
+:return: Some number
+
+See also: function2"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function2),
+    """\
+A test of a very very very very very very very very very very very very very very very very
+very very very very very long comment string."""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function3),
+    """*Overload 1:*
+
+A test for overloaded functions
+This is function **one**
+
+|
+
+*Overload 2:*
+
+A test for overloaded functions
+This is function **two**"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function4),
+    """\
+A test of some mixed tag usage
+If: CONDITION {
+This *code* fragment shows us something .
+Title: Minuses:
+* it\'s senseless
+* it\'s stupid
+* it\'s null
+
+Warning: This may not work as expected
+
+.. code-block:: c++
+
+    int main() { while(true); }
+}"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function5),
+    """This is a post comment."""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function6),
+    """\
+Test for default args
+:type a: int
+:param a: Some parameter, default is 42"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function7),
+    """\
+Test for a parameter with difficult type
+(mostly for python)
+:type a: :py:class:`Shape`
+:param a: Very strange param"""
+)
+
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.Atan2),
+    """\
+Multiple parameters test.
+
+:type y: float
+:param y: Vertical coordinate.
+:type x: float
+:param x: Horizontal coordinate.
+:rtype: float
+:return: Arc tangent of ``y/x``."""
+)

--- a/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
@@ -44,7 +44,6 @@ Title: Minuses:
 * it\'s null
 
 Warning: This may not work as expected
-
 .. code-block:: c++
 
     int main() { while(true); }

--- a/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
@@ -24,14 +24,12 @@ very very very very very long comment string."""
 )
 comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function3),
     """*Overload 1:*
-
 A test for overloaded functions
 This is function **one**
 
 |
 
 *Overload 2:*
-
 A test for overloaded functions
 This is function **two**"""
 )

--- a/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
@@ -1,10 +1,10 @@
-import doxygen_basic_translate_spaced
+import doxygen_basic_translate_style2
 import inspect
 import string
 import sys
 import comment_verifier
 
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function),
     """\
 Brief description.
 
@@ -17,12 +17,12 @@ Author: Some author
 
 See also: function2"""
 )
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function2),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function2),
     """\
 A test of a very very very very very very very very very very very very very very very very
 very very very very very long comment string."""
 )
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function3),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function3),
     """*Overload 1:*
 A test for overloaded functions
 This is function **one**
@@ -33,7 +33,7 @@ This is function **one**
 A test for overloaded functions
 This is function **two**"""
 )
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function4),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function4),
     """\
 A test of some mixed tag usage
 If: CONDITION {
@@ -50,16 +50,16 @@ Warning: This may not work as expected
     int main() { while(true); }
 }"""
 )
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function5),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function5),
     """This is a post comment."""
 )
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function6),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function6),
     """\
 Test for default args
 :type a: int
 :param a: Some parameter, default is 42"""
 )
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.function7),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function7),
     """\
 Test for a parameter with difficult type
 (mostly for python)
@@ -67,7 +67,7 @@ Test for a parameter with difficult type
 :param a: Very strange param"""
 )
 
-comment_verifier.check(inspect.getdoc(doxygen_basic_translate_spaced.Atan2),
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.Atan2),
     """\
 Multiple parameters test.
 

--- a/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
@@ -36,7 +36,14 @@ Not everything works right now...
 
 .. code-block:: c++
 
-    some test code""")
+    some test code
+
+Code immediately following text.  Pydoc translation must add an
+empty line before:
+
+.. code-block:: c++
+
+    more test code""")
 
 comment_verifier.check(inspect.getdoc(doxygen_translate_all_tags.func02),
 r"""Conditional comment: SOMECONDITION
@@ -92,6 +99,13 @@ r""":raises: SuperError
 .. math::
 
     \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}
+
+.. math::
+
+    \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}
+
+Math immediately following text.  Pydoc translation must add an
+empty line before:
 
 .. math::
 

--- a/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
@@ -90,17 +90,13 @@ r""":raises: SuperError
 
 :math:`\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}`
 
-
 .. math::
 
     \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}
 
-
-
 .. math::
 
     \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}
-
 
 
 

--- a/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
@@ -283,10 +283,8 @@ r"""TODO: Some very important task
 
 
 
-
 very long
 text with tags <sometag>
-
 
 
 

--- a/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
@@ -37,7 +37,7 @@ Not everything works right now...
 
 .. code-block:: c++
 
-     some test code""")
+    some test code""")
 
 comment_verifier.check(inspect.getdoc(doxygen_translate_all_tags.func02),
 r"""Conditional comment: SOMECONDITION

--- a/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
@@ -34,7 +34,6 @@ Not everything works right now...
 
 'citationword'
 
-
 .. code-block:: c++
 
     some test code""")

--- a/Examples/test-suite/python/doxygen_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_runme.py
@@ -120,10 +120,8 @@ TODO: Some very important task
 :type b: float
 :param b: B is mentioned again...
 
-
 very long
 text with tags <sometag>
-
 
 Version: 0.0.0.2
 

--- a/Examples/test-suite/python/doxygen_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_runme.py
@@ -23,7 +23,7 @@ Author: Zubr
 
 .. code-block:: c++
 
-     some test code
+    some test code
 
 
 Conditional comment: SOMECONDITION

--- a/Examples/test-suite/python/doxygen_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_runme.py
@@ -25,7 +25,6 @@ Author: Zubr
 
     some test code
 
-
 Conditional comment: SOMECONDITION
 Some conditional comment
 End of conditional comment.

--- a/Examples/test-suite/python/doxygen_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_runme.py
@@ -20,7 +20,6 @@ Author: Zubr
 
 'citationword'
 
-
 .. code-block:: c++
 
     some test code

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -519,7 +519,7 @@ void PyDocConverter::handlePlainString(DoxygenEntity &tag, std::string &translat
 }
 
 void PyDocConverter::handleTagVerbatim(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg) {
-  translatedComment += arg + " ";
+  translatedComment += arg;
   for (DoxygenEntityListCIt it = tag.entityList.begin(); it != tag.entityList.end(); it++) {
     translatedComment += it->data;
   }

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -493,6 +493,11 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
   std::string code;
   handleTagVerbatim(tag, code, arg);
 
+  // Try and remove leading newline, which is present for block \code
+  // command:
+  if (code[0] == '\n')
+    code.erase(code.begin());
+
   translatedComment += codeIndent;
   for (size_t n = 0; n < code.length(); n++) {
     if (code[n] == '\n') {

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -496,7 +496,6 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
   IndentGuard indent(translatedComment, m_indent);
 
   trimWhitespace(translatedComment);
-  translatedComment += '\n';
 
   // Use the current indent for the code-block line itself.
   translatedComment += indent.getFirstLineIndent();

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -498,7 +498,7 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
   translatedComment += ".. code-block:: c++\n\n";
 
   // For now on, use extra indent level for all the subsequent lines.
-  codeIndent += m_indent;
+  codeIndent = m_indent;
 
   std::string code;
   handleTagVerbatim(tag, code, arg);

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -495,7 +495,7 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
 
   // Try and remove leading newline, which is present for block \code
   // command:
-  if (code[0] == '\n')
+  if ((! code.empty()) && code[0] == '\n')
     code.erase(code.begin());
 
   translatedComment += codeIndent;
@@ -515,8 +515,12 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
   }
 
   trimWhitespace(translatedComment);
-  if (*translatedComment.rbegin() != '\n')
-    translatedComment += '\n';
+
+  // For block commands, the translator adds the newline after
+  // \endcode, so try and compensate by removing the last newline from
+  // the code text:
+  if ((! translatedComment.empty()) && translatedComment[translatedComment.size()-1] == '\n')
+    translatedComment = translatedComment.substr(0, translatedComment.size()-1); // use translatedComment.pop_back() in C++ 11
 }
 
 void PyDocConverter::handlePlainString(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -446,7 +446,6 @@ void PyDocConverter::handleMath(DoxygenEntity &tag, std::string &translatedComme
     indent.Init(translatedComment, m_indent);
 
     trimWhitespace(translatedComment);
-    translatedComment += '\n';
 
     const string formulaIndent = indent.getFirstLineIndent();
     translatedComment += formulaIndent;
@@ -480,8 +479,6 @@ void PyDocConverter::handleMath(DoxygenEntity &tag, std::string &translatedComme
 
   if (inlineFormula) {
     translatedComment += "`";
-  } else {
-    translatedComment += '\n';
   }
 }
 

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -499,16 +499,18 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
   translatedComment += '\n';
 
   // Use the current indent for the code-block line itself.
-  string codeIndent = indent.getFirstLineIndent();
-  translatedComment += codeIndent;
+  translatedComment += indent.getFirstLineIndent();
 
   // Go out on a limb and assume that examples in the C or C++ sources use C++.
   // In the worst case, we'll highlight C code using C++ syntax which is not a
   // big deal (TODO: handle Doxygen code command language argument).
   translatedComment += ".. code-block:: c++\n\n";
 
-  // For now on, use extra indent level for all the subsequent lines.
-  codeIndent = m_indent;
+  // Specify the level of extra indentation that will be used for
+  // subsequent lines within the code block.  Note that the correct
+  // "starting indentation" is already present in the input, so we
+  // only need to add the desired code block indentation.
+  string codeIndent = m_indent;
 
   std::string code;
   handleTagVerbatim(tag, code, arg);

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -219,7 +219,7 @@ void PyDocConverter::fillStaticTables() {
   tagHandlers["short"] = make_handler(&PyDocConverter::handleParagraph);
   tagHandlers["todo"] = make_handler(&PyDocConverter::handleParagraph);
   tagHandlers["version"] = make_handler(&PyDocConverter::handleParagraph);
-  tagHandlers["verbatim"] = make_handler(&PyDocConverter::handleParagraph);
+  tagHandlers["verbatim"] = make_handler(&PyDocConverter::handleVerbatimBlock);
   tagHandlers["warning"] = make_handler(&PyDocConverter::handleParagraph);
   tagHandlers["xmlonly"] = make_handler(&PyDocConverter::handleParagraph);
   // these commands have special handlers
@@ -417,6 +417,19 @@ void PyDocConverter::translateEntity(DoxygenEntity &doxyEntity, std::string &tra
 
 void PyDocConverter::handleParagraph(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
   translatedComment += translateSubtree(tag);
+}
+
+void PyDocConverter::handleVerbatimBlock(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
+  string verb = translateSubtree(tag);
+
+  if ((! verb.empty()) && verb[0] == '\n')
+    verb.erase(verb.begin());
+  
+  // Remove the last newline to prevent doubling the newline already present after \endverbatim
+  trimWhitespace(verb); // Needed to catch trailing newline below
+  if ((! verb.empty()) && verb[verb.size()-1] == '\n')
+    verb = verb.substr(0, verb.size()-1);
+  translatedComment += verb;
 }
 
 void PyDocConverter::handleMath(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg) {

--- a/Source/Doxygen/pydoc.h
+++ b/Source/Doxygen/pydoc.h
@@ -80,6 +80,11 @@ protected:
   void handleParagraph(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg = std::string());
 
   /*
+   * Handle Doxygen verbatim tag
+   */
+  void handleVerbatimBlock(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg = std::string());
+
+  /*
    * Handle one of the Doxygen formula-related tags.
    */
   void handleMath(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);


### PR DESCRIPTION
Fixes and cleanup of the whitespace in the translated comments generated for python with the doxygen flag:

- Fix inconsistent indentation of content for `\code` command between inline and block usage
- Fix incorrect indentation for `\code` when using an alternative doxygen comment style that includes extra spaces
- Remove extraneous newlines in the generated comments surrounding `\code`, `\verbatim`, and `\f` math commands
  - Also ensure that generated pydoc output does contain an empty line in front of code and math blocks, which is required for sphinx
  - The end result is that the structure of the pydoc output should resemble that of the original doxygen comments, except that newlines are added before code and math blocks if necessary
- Remove extra newline added at the start of generated docstrings
- Update doxygen python `_runme.py` files for new expected output
- Add new test case `doxygen_basic_translate_style2.i` to test handling of the alternative doxygen comment style, which was not previously represented in the test cases