### PR TITLE
[Java] Add vector constructor with size

### DIFF
--- a/Examples/test-suite/java/li_std_vector_runme.java
+++ b/Examples/test-suite/java/li_std_vector_runme.java
@@ -30,13 +30,6 @@ public class li_std_vector_runme {
     checkThat(v1.size() == 1);
     checkThat(!v1.isEmpty());
 
-    java.util.List<Integer> sizeInit = new IntVector(10);
-    checkThat(sizeInit.size() == 10);
-    sizeInit.set(0, 55);
-    sizeInit.set(9, 66);
-    sizeInit.add(77);
-    checkThat(sizeInit.size() == 11);
-
     int sum = 0;
     for (int n : v1) {
       checkThat(n == 123);

--- a/Examples/test-suite/java/li_std_vector_runme.java
+++ b/Examples/test-suite/java/li_std_vector_runme.java
@@ -11,54 +11,68 @@ public class li_std_vector_runme {
     }
   }
 
+  public static void checkThat(boolean mustBeTrue) throws Throwable {
+    if (!mustBeTrue) {
+      // Index [2], since this function is one hop away from main, and [1] is the current method.
+      throw new RuntimeException("Test failed at line number " + Thread.currentThread().getStackTrace()[2].getLineNumber());
+    }
+  }
+
   public static void main(String argv[]) throws Throwable
   {
     IntVector v1 = li_std_vector.vecintptr(new IntVector());
     IntPtrVector v2 = li_std_vector.vecintptr(new IntPtrVector());
     IntConstPtrVector v3 = li_std_vector.vecintconstptr(new IntConstPtrVector());
 
-    if (!v1.isEmpty()) throw new RuntimeException("v1 test (1) failed");
-    if (v1.size() != 0) throw new RuntimeException("v1 test (2) failed");
-    if (!v1.add(123)) throw new RuntimeException("v1 test (3) failed");
-    if (v1.size() != 1) throw new RuntimeException("v1 test (4) failed");
-    if (v1.isEmpty()) throw new RuntimeException("v1 test (5) failed");
+    checkThat(v1.isEmpty());
+    checkThat(v1.size() == 0);
+    checkThat(v1.add(123));
+    checkThat(v1.size() == 1);
+    checkThat(!v1.isEmpty());
+
+    java.util.List<Integer> sizeInit = new IntVector(10);
+    checkThat(sizeInit.size() == 10);
+    sizeInit.set(0, 55);
+    sizeInit.set(9, 66);
+    sizeInit.add(77);
+    checkThat(sizeInit.size() == 11);
 
     int sum = 0;
     for (int n : v1) {
-      if (n != 123) throw new RuntimeException("v1 loop test failed");
+      checkThat(n == 123);
       sum += n;
     }
-    if (sum != 123) throw new RuntimeException("v1 sum test failed");
-    if (v1.get(0) != 123) throw new RuntimeException("v1 test failed");
+    checkThat(sum == 123);
+    checkThat(v1.get(0) == 123);
     v1.clear();
-    if (!v1.isEmpty()) throw new RuntimeException("v1 test clear failed");
+    checkThat(v1.isEmpty());
     v1.add(123);
 
-    if (v1.set(0, 456) != 123) throw new RuntimeException("v1 test (6) failed");
-    if (v1.size() != 1) throw new RuntimeException("v1 test (7) failed");
-    if (v1.get(0) != 456) throw new RuntimeException("v1 test (8) failed");
+    checkThat(v1.set(0, 456) == 123);
+    checkThat(v1.size() == 1);
+    checkThat(v1.get(0) == 456);
 
     java.util.Iterator<Integer> v1_iterator = v1.iterator();
-    if (!v1_iterator.hasNext()) throw new RuntimeException("v1 test (9) failed");
-    if (v1_iterator.next() != 456) throw new RuntimeException("v1 test (10) failed");
-    if (v1_iterator.hasNext()) throw new RuntimeException("v1 test (11) failed");
+    checkThat(v1_iterator.hasNext());
+    checkThat(v1_iterator.next() == 456);
+    checkThat(!v1_iterator.hasNext());
     try {
       v1_iterator.next();
-      throw new RuntimeException("v1 test (12) failed");
+      checkThat(false);
     } catch (java.util.NoSuchElementException e) {
     }
 
-    if (v1.remove(Integer.valueOf(123))) throw new RuntimeException("v1 test (13) failed");
-    if (!v1.remove(Integer.valueOf(456))) throw new RuntimeException("v1 test (14) failed");
-    if (!v1.isEmpty()) throw new RuntimeException("v1 test (15) failed");
-    if (v1.size() != 0) throw new RuntimeException("v1 test (16) failed");
-    if (v1.remove(Integer.valueOf(456))) throw new RuntimeException("v1 test (17) failed");
+    checkThat(!v1.remove(Integer.valueOf(123)));
+    checkThat(v1.remove(Integer.valueOf(456)));
+    checkThat(v1.isEmpty());
+    checkThat(v1.size() == 0);
+    checkThat(!v1.remove(Integer.valueOf(456)));
 
-    if (new IntVector(3, 0).size() != 3) throw new RuntimeException("constructor initial size test failed");
+    checkThat(new IntVector(3, 0).size() == 3);
     for (int n : new IntVector(10, 999))
-      if (n != 999) throw new RuntimeException("constructor initialization with value failed");
+      checkThat(n == 999);
     for (int n : new IntVector(new IntVector(10, 999)))
-      if (n != 999) throw new RuntimeException("copy constructor initialization with value failed");
+      checkThat(n == 999);
 
     StructVector v4 = li_std_vector.vecstruct(new StructVector());
     StructPtrVector v5 = li_std_vector.vecstructptr(new StructPtrVector());
@@ -68,18 +82,18 @@ public class li_std_vector_runme {
     v5.add(new Struct(34));
     v6.add(new Struct(56));
 
-    if (v4.get(0).getNum() != 12) throw new RuntimeException("v4 test failed");
-    if (v5.get(0).getNum() != 34) throw new RuntimeException("v5 test failed");
-    if (v6.get(0).getNum() != 56) throw new RuntimeException("v6 test failed");
+    checkThat(v4.get(0).getNum() == 12);
+    checkThat(v5.get(0).getNum() == 34);
+    checkThat(v6.get(0).getNum() == 56);
 
     for (Struct s : v4) {
-      if (s.getNum() != 12) throw new RuntimeException("v4 loop test failed");
+      checkThat(s.getNum() == 12);
     }
     for (Struct s : v5) {
-      if (s.getNum() != 34) throw new RuntimeException("v5 loop test failed");
+      checkThat(s.getNum() == 34);
     }
     for (Struct s : v6) {
-      if (s.getNum() != 56) throw new RuntimeException("v6 loop test failed");
+      checkThat(s.getNum() == 56);
     }
 
     StructVector v7 = li_std_vector.vecstruct(new StructVector());
@@ -87,43 +101,43 @@ public class li_std_vector_runme {
     v7.add(new Struct(23));
     v7.add(new Struct(456));
     v7.add(new Struct(7890));
-    if (v7.size() != 4) throw new RuntimeException("v7 test (1) failed");
+    checkThat(v7.size() == 4);
     {
       double[] a7 = {1, 23, 456, 7890};
       int i7 = 0;
       for (Struct s7 : v7) {
-        if (s7.getNum() != a7[i7]) throw new RuntimeException("v7 test (2) failed");
+        checkThat(s7.getNum() == a7[i7]);
         i7++;
       }
-      if (i7 != a7.length) throw new RuntimeException("v7 test (3) failed");
+      checkThat(i7 == a7.length);
     }
-    if (v7.remove(2).getNum() != 456) throw new RuntimeException("v7 test (4) failed");
+    checkThat(v7.remove(2).getNum() == 456);
     {
       double[] a7 = {1, 23, 7890};
       int i7 = 0;
       for (Struct s7 : v7) {
-        if (s7.getNum() != a7[i7]) throw new RuntimeException("v7 test (5) failed");
+        checkThat(s7.getNum() == a7[i7]);
         i7++;
       }
-      if (i7 != a7.length) throw new RuntimeException("v7 test (6) failed");
+      checkThat(i7 == a7.length);
     }
     v7.add(1, new Struct(123));
     {
       double[] a7 = {1, 123, 23, 7890};
       int i7 = 0;
       for (Struct s7 : v7) {
-        if (s7.getNum() != a7[i7]) throw new RuntimeException("v7 test (7) failed");
+        checkThat(s7.getNum() == a7[i7]);
         i7++;
       }
-      if (i7 != a7.length) throw new RuntimeException("v7 test (8) failed");
+      checkThat(i7 == a7.length);
     }
 
     BoolVector v8 = new BoolVector();
-    if (!v8.add(true)) throw new RuntimeException("v8 test (1) failed");;
-    if (v8.get(0) != true) throw new RuntimeException("v8 test (2) failed");;
-    if (v8.set(0, false) != true) throw new RuntimeException("v8 test (3) failed");;
-    if (v8.set(0, false) != false) throw new RuntimeException("v8 test (4) failed");;
-    if (v8.size() != 1) throw new RuntimeException("v8 test (5) failed");;
+    checkThat(v8.add(true));
+    checkThat(v8.get(0) == true);
+    checkThat(v8.set(0, false) == true);
+    checkThat(v8.set(0, false) == false);
+    checkThat(v8.size() == 1);
 
     java.util.ArrayList<Boolean> bl = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(true, false, true, false));
     BoolVector bv = new BoolVector(java.util.Arrays.asList(true, false, true, false));
@@ -136,36 +150,41 @@ public class li_std_vector_runme {
     v9.add(50);
     v9.add(60);
     v9.add(70);
-    if (v9.size() != 7) throw new RuntimeException("v9 test (1) failed");
-    if (!v9.remove(Integer.valueOf(60))) throw new RuntimeException("v9 test (2) failed");
-    if (v9.size() != 6) throw new RuntimeException("v9 test (3) failed");
+    checkThat(v9.size() == 7);
+    checkThat(v9.remove(Integer.valueOf(60)));
+    checkThat(v9.size() == 6);
 
     IntVector v10 = new IntVector(java.util.Arrays.asList(10, 20, 30, 40, 50));
     v10.subList(1, 4).clear(); // Recommended way to call protected method removeRange(1,3)
-    if (v10.size() != 2) throw new RuntimeException("v10 test (1) failed");
-    if (v10.get(0) != 10) throw new RuntimeException("v10 test (2) failed");
-    if (v10.get(1) != 50) throw new RuntimeException("v10 test (3) failed");
+    checkThat(v10.size() == 2);
+    checkThat(v10.get(0) == 10);
+    checkThat(v10.get(1) == 50);
     v10.addAll(1, java.util.Arrays.asList(22, 33));
-    if (v10.size() != 4) throw new RuntimeException("v10 test (4) failed");
-    if (v10.get(1) != 22) throw new RuntimeException("v10 test (5) failed");
-    if (v10.get(2) != 33) throw new RuntimeException("v10 test (6) failed");
+    checkThat(v10.size() == 4);
+    checkThat(v10.get(1) == 22);
+    checkThat(v10.get(2) == 33);
 
     v10.add(v10.size(), 55);
-    if (v10.size() != 5) throw new RuntimeException("v10 test (7) failed");
-    if (v10.get(4) != 55) throw new RuntimeException("v10 test (8) failed");
+    checkThat(v10.size() == 5);
+    checkThat(v10.get(4) == 55);
 
     IntVector v11 = new IntVector(java.util.Arrays.asList(11, 22, 33, 44));
     v11.listIterator(0);
     v11.listIterator(v11.size());
     try {
       v11.listIterator(v11.size() + 1);
-      throw new RuntimeException("v11 test (1) failed");
+      checkThat(false);
     } catch (IndexOutOfBoundsException e) {
     }
     try {
       v11.listIterator(-1);
-      throw new RuntimeException("v11 test (2) failed");
+      checkThat(false);
     } catch (IndexOutOfBoundsException e) {
     }
+
+    IntVector arrayInit = new IntVector(new int[]{1, 2, 3, 4, 5});
+    checkThat(arrayInit.size() == 5);
+    checkThat(arrayInit.get(0) == 1);
+    checkThat(arrayInit.get(4) == 5);
   }
 }

--- a/Lib/java/std_vector.i
+++ b/Lib/java/std_vector.i
@@ -28,9 +28,10 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
 %typemap(javainterfaces) std::vector< CTYPE > "java.util.RandomAccess"
 %proxycode %{
   public $javaclassname($typemap(jstype, CTYPE)[] initialElements) {
-    this();
-    for ($typemap(jstype, CTYPE) element : initialElements) {
-      add(element);
+    this(initialElements.length);
+
+    for (int i = 0; i < initialElements.length; ++i) {
+      set(i, initialElements[i]);
     }
   }
 
@@ -86,6 +87,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
 
     vector();
     vector(const vector &other);
+    vector(size_type count);
 
     size_type capacity() const;
     void reserve(size_type n) throw (std::length_error);

--- a/Lib/java/std_vector.i
+++ b/Lib/java/std_vector.i
@@ -28,10 +28,11 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
 %typemap(javainterfaces) std::vector< CTYPE > "java.util.RandomAccess"
 %proxycode %{
   public $javaclassname($typemap(jstype, CTYPE)[] initialElements) {
-    this(initialElements.length);
+    this();
+    reserve(initialElements.length);
 
-    for (int i = 0; i < initialElements.length; ++i) {
-      set(i, initialElements[i]);
+    for ($typemap(jstype, CTYPE) element : initialElements) {
+      add(element);
     }
   }
 
@@ -87,7 +88,6 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
 
     vector();
     vector(const vector &other);
-    vector(size_type count);
 
     size_type capacity() const;
     void reserve(size_type n) throw (std::length_error);
@@ -183,4 +183,3 @@ namespace std {
 %define specialize_std_vector(T)
 #warning "specialize_std_vector - specialization for type T no longer needed"
 %enddef
-


### PR DESCRIPTION
The vector class for Java has a few constructors:
- No-args
- size plus element to initialize with
- another vector
- an array of the jstype (int not Integer)
- an Iterable of the jboxtype (Integer not int)

But there doesn't exist an option to initialize a vector a certain size without setting all the elements. Only reserve is available after already creating the vector.

This exposes the constructor that just takes a size.

Then, to make the the array constructor more efficient, we can initialize the vector to the right size before the loop, and in the loop just use set (which is just operator[] in c++). This avoids the constant re-allocs of doing `push_back` in a loop.

I also added a helper function to the tests, similar to maps/sets, to make them less verbose.

PTAL @wsfulton 