### PR TITLE
WIP: Rework the java typemaps to avoid using finalize()

### DIFF
--- a/Examples/test-suite/java/director_pass_by_value_runme.java
+++ b/Examples/test-suite/java/director_pass_by_value_runme.java
@@ -14,7 +14,6 @@ public class director_pass_by_value_runme {
 
   private static void WaitForGC() {
     System.gc();
-    System.runFinalization();
     try {
       java.lang.Thread.sleep(10);
     } catch (java.lang.InterruptedException e) {

--- a/Examples/test-suite/java/java_director_runme.java
+++ b/Examples/test-suite/java/java_director_runme.java
@@ -16,7 +16,6 @@ public class java_director_runme {
   private static void WaitForGC()
   {
     System.gc();
-    System.runFinalization();
     try {
       java.lang.Thread.sleep(10);
     } catch (java.lang.InterruptedException e) {

--- a/Examples/test-suite/java/li_boost_intrusive_ptr_runme.java
+++ b/Examples/test-suite/java/li_boost_intrusive_ptr_runme.java
@@ -16,7 +16,6 @@ public class li_boost_intrusive_ptr_runme {
   private static void WaitForGC()
   {
     System.gc();
-    System.runFinalization();
     try {
       java.lang.Thread.sleep(10);
     } catch (java.lang.InterruptedException e) {
@@ -35,13 +34,6 @@ public class li_boost_intrusive_ptr_runme {
     for (int i=0; i<loopCount; i++) {
       new li_boost_intrusive_ptr_runme().runtest(i);
       System.gc();
-      System.runFinalization();
-      try {
-        if (i%100 == 0) {
-          java.lang.Thread.sleep(1); // give some time to the lower priority finalizer thread
-        }
-      } catch (java.lang.InterruptedException e) {
-      }
     }
 
     if (debug)

--- a/Examples/test-suite/java/li_boost_shared_ptr_runme.java
+++ b/Examples/test-suite/java/li_boost_shared_ptr_runme.java
@@ -16,7 +16,6 @@ public class li_boost_shared_ptr_runme {
   private static void WaitForGC()
   {
     System.gc();
-    System.runFinalization();
     try {
       java.lang.Thread.sleep(10);
     } catch (java.lang.InterruptedException e) {
@@ -35,13 +34,6 @@ public class li_boost_shared_ptr_runme {
     for (int i=0; i<loopCount; i++) {
       new li_boost_shared_ptr_runme().runtest();
       System.gc();
-      System.runFinalization();
-      try {
-        if (i%100 == 0) {
-          java.lang.Thread.sleep(1); // give some time to the lower priority finalizer thread
-        }
-      } catch (java.lang.InterruptedException e) {
-      }
     }
 
     if (debug)

--- a/Examples/test-suite/java/li_std_auto_ptr_runme.java
+++ b/Examples/test-suite/java/li_std_auto_ptr_runme.java
@@ -13,7 +13,6 @@ public class li_std_auto_ptr_runme {
   private static void WaitForGC()
   {
     System.gc();
-    System.runFinalization();
     try {
       java.lang.Thread.sleep(10);
     } catch (java.lang.InterruptedException e) {

--- a/Examples/test-suite/java_director.i
+++ b/Examples/test-suite/java_director.i
@@ -6,15 +6,6 @@
 
 %module(directors="1") java_director
 
-%typemap(javafinalize) SWIGTYPE %{
-  @SuppressWarnings("deprecation")
-  protected void finalize() {
-//    System.out.println("Finalizing " + this);
-    delete();
-  }
-%}
-
-
 %{
 #include <string>
 #include <vector>

--- a/Examples/test-suite/java_director.i
+++ b/Examples/test-suite/java_director.i
@@ -99,7 +99,7 @@ public:
 
 %typemap(directordisconnect, methodname="disconnect_director") hi::Quux1 %{
   public void $methodname() {
-    swigCMemOwn = false;
+    swigSetCMemOwn(false);
     $jnicall;
     // add in a flag to check this method is really called
     disconnectMethodCalled = true;

--- a/Examples/test-suite/java_pgcpp.i
+++ b/Examples/test-suite/java_pgcpp.i
@@ -6,7 +6,7 @@
 
 %typemap(javacode) Space::Classic %{
   public long getCPtrValue() {
-    return this.swigCPtr;
+    return this.getCPtr(this);
   }
 %}
 

--- a/Lib/java/boost_intrusive_ptr.i
+++ b/Lib/java/boost_intrusive_ptr.i
@@ -263,49 +263,76 @@
 
 // Base proxy classes
 %typemap(javabody) TYPE %{
-  private transient long swigCPtr;
-  private transient boolean swigCMemOwnBase;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
-    swigCMemOwnBase = cMemoryOwn;
-    swigCPtr = cPtr;
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
+    return (obj == null) ? 0 : obj.swigWrap.swigCPtr;
   }
 %}
 
 // Derived proxy classes
 %typemap(javabody_derived) TYPE %{
-  private transient long swigCPtr;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
   private transient boolean swigCMemOwnDerived;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
     swigCMemOwnDerived = cMemoryOwn;
-    swigCPtr = cPtr;
-  }
-
-  CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
   }
 %}
 
 %typemap(javadestruct, methodname="delete", methodmodifiers="public synchronized") TYPE {
-    if(swigCPtr != 0 && swigCMemOwnBase) {
-      swigCMemOwnBase = false;
+    if(swigWrap.swigCPtr != 0 && swigWrap.swigCMemOwn) {
+      swigWrap.cMemOwn = false;
       $jnicall;
     }
-    swigCPtr = 0;
+    swigWrap.swigCPtr = 0;
   }
 
 %typemap(javadestruct_derived, methodname="delete", methodmodifiers="public synchronized") TYPE {
-    if(swigCPtr != 0 && swigCMemOwnDerived) {
+    if(swigWrap.swigCPtr != 0 && swigCMemOwnDerived) {
       swigCMemOwnDerived = false;
       $jnicall;
     }
-    swigCPtr = 0;
     super.delete();
   }
 
@@ -413,52 +440,73 @@
 
 // Base proxy classes
 %typemap(javabody) TYPE %{
-  private transient long swigCPtr;
-  private transient boolean swigCMemOwnBase;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
-    swigCMemOwnBase = cMemoryOwn;
-    swigCPtr = cPtr;
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
+    return (obj == null) ? 0 : obj.swigWrap.swigCPtr;
   }
 %}
 
 // Derived proxy classes
 %typemap(javabody_derived) TYPE %{
-  private transient long swigCPtr;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
   private transient boolean swigCMemOwnDerived;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
     swigCMemOwnDerived = cMemoryOwn;
-    swigCPtr = cPtr;
-  }
-
-  CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
   }
 %}
 
 %typemap(javadestruct, methodname="delete", methodmodifiers="public synchronized") TYPE {
-    if (swigCPtr != 0) {
-      if (swigCMemOwnBase) {
-        swigCMemOwnBase = false;
-        $jnicall;
-      }
-      swigCPtr = 0;
-    }
+    swigWrap.run();
   }
 
 %typemap(javadestruct_derived, methodname="delete", methodmodifiers="public synchronized") TYPE {
-    if (swigCPtr != 0) {
+    if (swigWrap.swigCPtr != 0) {
       if (swigCMemOwnDerived) {
         swigCMemOwnDerived = false;
-        $jnicall;
+        swigWrap.run();
       }
-      swigCPtr = 0;
     }
     super.delete();
   }

--- a/Lib/java/boost_intrusive_ptr.i
+++ b/Lib/java/boost_intrusive_ptr.i
@@ -284,6 +284,7 @@
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     swigWrap = new SwigWrap(cPtr, cMemoryOwn);
+    $imclassname.cleaner.register(this, swigWrap);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
@@ -317,6 +318,7 @@
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
     swigWrap = new SwigWrap(cPtr, cMemoryOwn);
     swigCMemOwnDerived = cMemoryOwn;
+    $imclassname.cleaner.register(this, swigWrap);
   }
 %}
 
@@ -461,6 +463,7 @@
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     swigWrap = new SwigWrap(cPtr, cMemoryOwn);
+    $imclassname.cleaner.register(this, swigWrap);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
@@ -494,6 +497,7 @@
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
     swigWrap = new SwigWrap(cPtr, cMemoryOwn);
     swigCMemOwnDerived = cMemoryOwn;
+    $imclassname.cleaner.register(this, swigWrap);
   }
 %}
 

--- a/Lib/java/boost_shared_ptr.i
+++ b/Lib/java/boost_shared_ptr.i
@@ -240,36 +240,68 @@
 
 // Base proxy classes
 %typemap(javabody) TYPE %{
-  private transient long swigCPtr;
-  private transient boolean swigCMemOwn;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
-    swigCMemOwn = cMemoryOwn;
-    swigCPtr = cPtr;
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
+    return (obj == null) ? 0 : obj.swigWrap.swigCPtr;
   }
 
   CPTR_VISIBILITY void swigSetCMemOwn(boolean own) {
-    swigCMemOwn = own;
+    swigWrap.swigCMemOwn = own;
   }
 %}
 
 // Derived proxy classes
 %typemap(javabody_derived) TYPE %{
-  private transient long swigCPtr;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
   private transient boolean swigCMemOwnDerived;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
     swigCMemOwnDerived = cMemoryOwn;
-    swigCPtr = cPtr;
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
+    return (obj == null) ? 0 : obj.swigWrap.swigCPtr;
   }
 
   CPTR_VISIBILITY void swigSetCMemOwn(boolean own) {
@@ -279,22 +311,15 @@
 %}
 
 %typemap(javadestruct, methodname="delete", methodmodifiers="public synchronized") TYPE {
-    if (swigCPtr != 0) {
-      if (swigCMemOwn) {
-        swigCMemOwn = false;
-        $jnicall;
-      }
-      swigCPtr = 0;
-    }
+    swigWrap.run();
   }
 
 %typemap(javadestruct_derived, methodname="delete", methodmodifiers="public synchronized") TYPE {
-    if (swigCPtr != 0) {
+    if (swigWrap.swigCPtr != 0) {
       if (swigCMemOwnDerived) {
         swigCMemOwnDerived = false;
-        $jnicall;
+        swigWrap.run();
       }
-      swigCPtr = 0;
     }
     super.delete();
   }

--- a/Lib/java/boost_shared_ptr.i
+++ b/Lib/java/boost_shared_ptr.i
@@ -261,6 +261,7 @@
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     swigWrap = new SwigWrap(cPtr, cMemoryOwn);
+    $imclassname.cleaner.register(this, swigWrap);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
@@ -298,6 +299,7 @@
     super($imclassname.$javaclazznameSWIGSmartPtrUpcast(cPtr), true);
     swigWrap = new SwigWrap(cPtr, cMemoryOwn);
     swigCMemOwnDerived = cMemoryOwn;
+    $imclassname.cleaner.register(this, swigWrap);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1239,12 +1239,11 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 
 // Derived proxy classes
 %typemap(javabody_derived) TYPE %{
-  static final class SwigWrap implements Runnable {
+  static final class SwigWrap {
     public transient long swigCPtr;
     public SwigWrap(long cPtr) {
       swigCPtr = cPtr;
     }
-    public final void run() { }
   }
   protected final SwigWrap swigWrap;
 
@@ -1343,11 +1342,6 @@ SWIG_PROXY_CONSTRUCTOR(true, true, SWIGTYPE)
 
 %typemap(javadestruct, methodname="delete", methodmodifiers="public synchronized", parameters="") SWIGTYPE {
     swigWrap.run();
-  }
-
-%typemap(javadestruct_derived, methodname="delete", methodmodifiers="public synchronized", parameters="") SWIGTYPE {
-    swigWrap.run();
-    super.delete();
   }
 
 %typemap(directordisconnect, methodname="swigDirectorDisconnect") SWIGTYPE %{

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1344,6 +1344,8 @@ SWIG_PROXY_CONSTRUCTOR(true, true, SWIGTYPE)
     swigWrap.run();
   }
 
+%typemap(javadestruct_derived, methodname="delete") SWIGTYPE "";
+
 %typemap(directordisconnect, methodname="swigDirectorDisconnect") SWIGTYPE %{
   protected void $methodname() {
     swigSetCMemOwn(false);

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1204,30 +1204,57 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 %define SWIG_JAVABODY_PROXY(PTRCTOR_VISIBILITY, CPTR_VISIBILITY, TYPE...)
 // Base proxy classes
 %typemap(javabody) TYPE %{
-  private transient long swigCPtr;
-  protected transient boolean swigCMemOwn;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public transient boolean swigCMemOwn;
+    public SwigWrap(long cPtr, boolean cMemoryOwn) {
+      swigCMemOwn = cMemoryOwn;
+      swigCPtr = cPtr;
+    }
+    public final void run() {
+      if (swigCPtr != 0) {
+        if (swigCMemOwn) {
+          swigCMemOwn = false;
+          $jnicall;
+        }
+        swigCPtr = 0;
+      }
+    }
+  }
+  protected final SwigWrap swigWrap;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
-    swigCMemOwn = cMemoryOwn;
-    swigCPtr = cPtr;
+    swigWrap = new SwigWrap(cPtr, cMemoryOwn);
+    $imclassname.cleaner.register(this, swigWrap);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
+    return (obj == null) ? 0 : obj.swigWrap.swigCPtr;
+  }
+
+  CPTR_VISIBILITY void swigSetCMemOwn(boolean own) {
+    swigWrap.swigCMemOwn = own;
   }
 %}
 
 // Derived proxy classes
 %typemap(javabody_derived) TYPE %{
-  private transient long swigCPtr;
+  static final class SwigWrap implements Runnable {
+    public transient long swigCPtr;
+    public SwigWrap(long cPtr) {
+      swigCPtr = cPtr;
+    }
+    public final void run() { }
+  }
+  protected final SwigWrap swigWrap;
 
   PTRCTOR_VISIBILITY $javaclassname(long cPtr, boolean cMemoryOwn) {
     super($imclassname.$javaclazznameSWIGUpcast(cPtr), cMemoryOwn);
-    swigCPtr = cPtr;
+    swigWrap = new SwigWrap(cPtr);
   }
 
   CPTR_VISIBILITY static long getCPtr($javaclassname obj) {
-    return (obj == null) ? 0 : obj.swigCPtr;
+    return (obj == null) ? 0 : obj.swigWrap.swigCPtr;
   }
 %}
 %enddef
@@ -1272,11 +1299,12 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 SWIG_JAVABODY_PROXY(protected, protected, SWIGTYPE)
 SWIG_JAVABODY_TYPEWRAPPER(protected, protected, protected, SWIGTYPE)
 
-%typemap(javafinalize) SWIGTYPE %{
-  @SuppressWarnings("deprecation")
-  protected void finalize() {
-    delete();
-  }
+%pragma(java) jniclassimportscleaner=%{
+import java.lang.ref.Cleaner;
+%}
+
+%pragma(java) jniclasscodecleaner=%{
+  public static final Cleaner cleaner = java.lang.ref.Cleaner.create();
 %}
 
 /*
@@ -1301,7 +1329,7 @@ SWIG_JAVABODY_TYPEWRAPPER(protected, protected, protected, SWIGTYPE)
  */
 
 %define SWIG_PROXY_CONSTRUCTOR(OWNERSHIP, WEAKREF, TYPENAME...)
-%typemap(javaconstruct,directorconnect="\n    $imclassname.$javaclazznamedirector_connect(this, swigCPtr, OWNERSHIP, WEAKREF);") TYPENAME {
+%typemap(javaconstruct,directorconnect="\n    $imclassname.$javaclazznamedirector_connect(this, swigWrap.swigCPtr, OWNERSHIP, WEAKREF);") TYPENAME {
     this($imcall, OWNERSHIP);$directorconnect
   }
 %enddef
@@ -1314,43 +1342,31 @@ SWIG_PROXY_CONSTRUCTOR(true, false, TYPENAME)
 SWIG_PROXY_CONSTRUCTOR(true, true, SWIGTYPE)
 
 %typemap(javadestruct, methodname="delete", methodmodifiers="public synchronized", parameters="") SWIGTYPE {
-    if (swigCPtr != 0) {
-      if (swigCMemOwn) {
-        swigCMemOwn = false;
-        $jnicall;
-      }
-      swigCPtr = 0;
-    }
+    swigWrap.run();
   }
 
 %typemap(javadestruct_derived, methodname="delete", methodmodifiers="public synchronized", parameters="") SWIGTYPE {
-    if (swigCPtr != 0) {
-      if (swigCMemOwn) {
-        swigCMemOwn = false;
-        $jnicall;
-      }
-      swigCPtr = 0;
-    }
+    swigWrap.run();
     super.delete();
   }
 
 %typemap(directordisconnect, methodname="swigDirectorDisconnect") SWIGTYPE %{
   protected void $methodname() {
-    swigCMemOwn = false;
+    swigSetCMemOwn(false);
     $jnicall;
   }
 %}
 
 %typemap(directorowner_release, methodname="swigReleaseOwnership") SWIGTYPE %{
   public void $methodname() {
-    swigCMemOwn = false;
+    swigSetCMemOwn(false);
     $jnicall;
   }
 %}
 
 %typemap(directorowner_take, methodname="swigTakeOwnership") SWIGTYPE %{
   public void $methodname() {
-    swigCMemOwn = true;
+    swigSetCMemOwn(true);
     $jnicall;
   }
 %}

--- a/Lib/java/swiginterface.i
+++ b/Lib/java/swiginterface.i
@@ -50,7 +50,7 @@
 
 %typemap(javainterfacecode, declaration="  long $interfacename_GetInterfaceCPtr();\n", cptrmethod="$interfacename_GetInterfaceCPtr") CTYPE %{
   public long $interfacename_GetInterfaceCPtr() {
-    return $imclassname.$javaclazzname$interfacename_GetInterfaceCPtr(swigCPtr);
+    return $imclassname.$javaclazzname$interfacename_GetInterfaceCPtr(swigWrap.swigCPtr);
   }
 %}
 %enddef

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -2109,7 +2109,7 @@ public:
       String *destruct_jnicall, *release_jnicall, *take_jnicall;
       String *changeown_method_name = Swig_name_member(getNSpace(), getClassPrefix(), "change_ownership");
 
-      destruct_jnicall = NewStringf("%s()", destruct_methodname);
+      destruct_jnicall = destruct_methodname && *Char(destruct_methodname) ? NewStringf("%s()", destruct_methodname) : NewStringEmpty();
       release_jnicall = NewStringf("%s.%s(this, swigWrap.swigCPtr, false)", full_imclass_name, changeown_method_name);
       take_jnicall = NewStringf("%s.%s(this, swigWrap.swigCPtr, true)", full_imclass_name, changeown_method_name);
 

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -2109,7 +2109,7 @@ public:
       String *destruct_jnicall, *release_jnicall, *take_jnicall;
       String *changeown_method_name = Swig_name_member(getNSpace(), getClassPrefix(), "change_ownership");
 
-      destruct_jnicall = destruct_methodname && *Char(destruct_methodname) ? NewStringf("%s()", destruct_methodname) : NewStringEmpty();
+      destruct_jnicall = NewStringf("%s()", destruct_methodname);
       release_jnicall = NewStringf("%s.%s(this, swigWrap.swigCPtr, false)", full_imclass_name, changeown_method_name);
       take_jnicall = NewStringf("%s.%s(this, swigWrap.swigCPtr, true)", full_imclass_name, changeown_method_name);
 

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -2038,7 +2038,10 @@ public:
       Printv(proxy_class_def, "static ", NIL); // C++ nested classes correspond to static java classes
     String *body = NewString(derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :
 				       typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF)); // main body of class
-    Replaceall(body, "$jnicall", destructor_call);
+    if (destructor_call && *Char(destructor_call))
+      Replaceall(body, "$jnicall", destructor_call);
+    else
+      Replaceall(body, "$jnicall", "throw new UnsupportedOperationException(\"C++ destructor does not have public access\")");
     Printv(proxy_class_def, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
 	   " $javaclassname",	// Class name and bases
 	   (*Char(wanted_base)) ? " extends " : "", wanted_base, *Char(interface_list) ?	// Pure Java interfaces
@@ -3533,7 +3536,10 @@ public:
 
     // Emit the class
     String *body = NewString(typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF)); // main body of class
-    Replaceall(body, "$jnicall", destructor_call);
+    if (destructor_call && *Char(destructor_call))
+      Replaceall(body, "$jnicall", destructor_call);
+    else
+      Replaceall(body, "$jnicall", "throw new UnsupportedOperationException(\"C++ destructor does not have public access\")");
     Printv(swigtype, typemapLookup(n, "javaimports", type, WARN_NONE),	// Import statements
 	   "\n", typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
 	   " $javaclassname",	// Class name and bases


### PR DESCRIPTION
Instead we use java.lang.ref.Cleaner (but will probably switch to
PhantomReference once this is working properly as Cleaner needs
JVM 9 which PhantomReference works with much older JVM versions).

Currently four testcases still fail, and I haven't attempted to
update the documentation at all.

Fixes #1550.