### PR TITLE
Fixes Travis CI Build Errors With Node-v4

### DIFF
--- a/Tools/travis-linux-install.sh
+++ b/Tools/travis-linux-install.sh
@@ -39,7 +39,7 @@ case "$SWIGLANG" in
 				[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 				travis_retry nvm install ${VER}
 				nvm use ${VER}
-				if [ "$VER" == "0.10" ] || [ "$VER" == "0.12" ] ; then
+				if [ "$VER" == "0.10" ] || [ "$VER" == "0.12" ] || [ "$VER" == "4" ] ; then
 #					travis_retry sudo apt-get install -qq nodejs node-gyp
 					travis_retry npm install -g node-gyp@$VER
 				else


### PR DESCRIPTION
Travis-CI is using node-gyp v5.0.1 now to build the tests and examples. This is causing new CI tests to fail. The last successful Travis-CI test used node-gyp v4.0.0. The travis-linux-install script has been updated to lock the node-gyp version for node-v4 to the last successful version (v4.0.0).

The verbose output is as follows using node-gyp v5.0.1:
```
gyp ERR! UNCAUGHT EXCEPTION 
gyp ERR! stack SyntaxError: Unexpected token ...
gyp ERR! stack     at exports.runInThisContext (vm.js:53:16)
gyp ERR! stack     at Module._compile (module.js:373:25)
gyp ERR! stack     at Object.Module._extensions..js (module.js:416:10)
gyp ERR! stack     at Module.load (module.js:343:32)
gyp ERR! stack     at Function.Module._load (module.js:300:12)
gyp ERR! stack     at Module.require (module.js:353:17)
gyp ERR! stack     at require (internal/module.js:12:17)
gyp ERR! stack     at Object.self.commands.(anonymous function) [as configure] (/home/smartbeat/.nvm/versions/node/v4.9.1/lib/node_modules/node-gyp/lib/node-gyp.js:42:14)
gyp ERR! stack     at run (/home/smartbeat/.nvm/versions/node/v4.9.1/lib/node_modules/node-gyp/bin/node-gyp.js:79:30)
gyp ERR! stack     at Object.<anonymous> (/home/smartbeat/.nvm/versions/node/v4.9.1/lib/node_modules/node-gyp/bin/node-gyp.js:140:1)
gyp ERR! System Linux 4.15.0-20-generic
gyp ERR! command "/home/smartbeat/.nvm/versions/node/v4.9.1/bin/node" "/home/smartbeat/.nvm/versions/node/v4.9.1/bin/node-gyp" "--loglevel=verbose" "--directory" "aggregate" "configure" "build"
gyp ERR! cwd /home/smartbeat/Documents/GitHub/swig/Examples/test-suite/javascript/aggregate
gyp ERR! node -v v4.9.1
gyp ERR! node-gyp -v v5.0.1
gyp ERR! This is a bug in `node-gyp`.
gyp ERR! Try to update node-gyp and file an Issue if it does not help:
gyp ERR!     <https://github.com/nodejs/node-gyp/issues>
```
