### PR TITLE
Fix class name for nested classes

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -324,6 +324,7 @@ CPP_TEST_CASES += \
 	nested_directors \
 	nested_comment \
 	nested_ignore \
+	nested_inheritance_interface \
 	nested_in_template \
 	nested_scope \
 	nested_template_base \

--- a/Examples/test-suite/csharp/nested_inheritance_interface_runme.cs
+++ b/Examples/test-suite/csharp/nested_inheritance_interface_runme.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using nested_inheritance_interfaceNamespace;
+
+public class nested_inheritance_interface_runme {
+
+  static string SortArrayToString(string[] types) {
+    Array.Sort<string>(types);
+    return string.Join(" ", types);
+  }
+
+  static string SortArrayToString(Type[] types) {
+    List<string> stypes = new List<string>();
+    foreach (Type t in types)
+      stypes.Add(t.Name);
+    return SortArrayToString(stypes.ToArray());
+  }
+
+  public static void Main() {
+    Type[] BNInterfaces = typeof(B.N).GetInterfaces();
+    string expectedInterfacesString = "IASwigInterface IDisposable";
+    string actualInterfacesString = SortArrayToString(BNInterfaces);
+    if (expectedInterfacesString != actualInterfacesString)
+      throw new Exception("Expected interfaces for " + typeof(B.N).Name + ": \n" + expectedInterfacesString + "\n" + "Actual interfaces: \n" + actualInterfacesString);
+
+    if (!typeof(IASwigInterface).IsInterface)
+      throw new Exception(typeof(IASwigInterface).Name + " should be an interface but is not");
+
+    // overloaded methods check
+    B.N d = new B.N();
+  }
+}

--- a/Examples/test-suite/java/nested_inheritance_interface_runme.java
+++ b/Examples/test-suite/java/nested_inheritance_interface_runme.java
@@ -1,0 +1,28 @@
+import nested_inheritance_interface.*;
+import java.util.Arrays;
+
+public class nested_inheritance_interface_runme {
+
+  static {
+    try {
+      System.loadLibrary("nested_inheritance_interface");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+	Class[] BNInterfaces = B.N.class.getInterfaces();
+    String expectedInterfacesString = "[interface nested_inheritance_interface.IASwigInterface]";
+    String actualInterfacesString = Arrays.toString(BNInterfaces);
+    if (!expectedInterfacesString.equals(actualInterfacesString))
+      throw new RuntimeException("Expected interfaces for " + B.N.class.getName() + ": \n" + expectedInterfacesString + "\n" + "Actual interfaces: \n" + actualInterfacesString);
+
+    if (!IASwigInterface.class.isInterface())
+      throw new RuntimeException(IASwigInterface.class.getName() + " should be an interface but is not");
+
+    // overloaded methods check
+    B.N d = new B.N();
+  }
+}

--- a/Examples/test-suite/nested_inheritance_interface.i
+++ b/Examples/test-suite/nested_inheritance_interface.i
@@ -1,0 +1,15 @@
+%module  nested_inheritance_interface
+
+%warnfilter(SWIGWARN_RUBY_MULTIPLE_INHERITANCE,
+	    SWIGWARN_D_MULTIPLE_INHERITANCE,
+	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance or %interface */
+
+#if defined(SWIGJAVA) || defined(SWIGCSHARP)
+%include "swiginterface.i"
+%interface(IA)
+#endif
+
+%inline %{
+struct IA {};
+struct B { struct N : IA {}; };
+%}

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1732,7 +1732,7 @@ public:
       Replaceall(cptr_method_name, ".", "_");
       Replaceall(cptr_method_name, "$interfacename", interface_name);
 
-      String *upcast_method_name = Swig_name_member(getNSpace(), proxy_class_name, cptr_method_name);
+      String *upcast_method_name = Swig_name_member(getNSpace(), getClassPrefix(), cptr_method_name);
       upcastsCode(smart, upcast_method_name, c_classname, c_baseclass);
 
       Delete(upcast_method_name);

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -1876,7 +1876,7 @@ public:
       Replaceall(cptr_method_name, ".", "_");
       Replaceall(cptr_method_name, "$interfacename", interface_name);
 
-      String *upcast_method_name = Swig_name_member(getNSpace(), proxy_class_name, cptr_method_name);
+      String *upcast_method_name = Swig_name_member(getNSpace(), getClassPrefix(), cptr_method_name);
       upcastsCode(smart, upcast_method_name, c_classname, c_baseclass);
       Delete(upcast_method_name);
       Delete(cptr_method_name);


### PR DESCRIPTION
The feature %interface_impl from swiginterface.i differ on generated function
name from JNI wrapper class when using nested classes without flatnested.