### PR TITLE
Python: Unify string quoting

### DIFF
--- a/Examples/python/import_packages/namespace_pkg/normal.py
+++ b/Examples/python/import_packages/namespace_pkg/normal.py
@@ -11,7 +11,7 @@ def run_except_on_windows(commandline, env=None):
 print(" Starting subtest " + os.path.basename(__file__))
 
 # Package brave found under one path
-sys.path.insert(0, 'path1')
+sys.path.insert(0, "path1")
 
 from brave import robin
 print("  Finished from brave import robin")

--- a/Examples/python/import_packages/namespace_pkg/nstest.py
+++ b/Examples/python/import_packages/namespace_pkg/nstest.py
@@ -11,7 +11,7 @@ def run_except_on_windows(commandline, env=None):
         print("  Finished running: " + commandline)
 
 def copyMods():
-    dirs = ['path1', 'path2', 'path3']
+    dirs = ["path1", "path2", "path3"]
 
     # Clean out any old package paths
     for d in dirs:
@@ -20,20 +20,20 @@ def copyMods():
 
     for d in dirs:
         os.mkdir(d)
-        os.mkdir(os.path.join(d, 'brave'))
+        os.mkdir(os.path.join(d, "brave"))
 
-    shutil.copy('robin.py', os.path.join('path1', 'brave'))
-    subprocess.check_call('cp _robin.* ' + os.path.join('path1', 'brave'), shell=True)
+    shutil.copy("robin.py", os.path.join("path1", "brave"))
+    subprocess.check_call("cp _robin.* " + os.path.join("path1", "brave"), shell=True)
 
-    shutil.copy('robin.py', os.path.join('path2', 'brave'))
-    subprocess.check_call('cp _robin.* ' + os.path.join('path3', 'brave'), shell=True)
+    shutil.copy("robin.py", os.path.join("path2", "brave"))
+    subprocess.check_call("cp _robin.* " + os.path.join("path3", "brave"), shell=True)
 
     mkzip()
 
 def mkzip():
     zf = zipfile.ZipFile("path4.zip", "w")
-    zf.writestr("brave/", b'')
-    zf.write('robin.py', 'brave/robin.py')
+    zf.writestr("brave/", b"")
+    zf.write("robin.py", "brave/robin.py")
     zf.close()
 
 

--- a/Examples/python/import_packages/namespace_pkg/split.py
+++ b/Examples/python/import_packages/namespace_pkg/split.py
@@ -12,8 +12,8 @@ print(" Starting subtest " + os.path.basename(__file__))
 
 # Package brave split into two paths.
 # path2/brave/robin.py and path3/brave/_robin.so
-sys.path.insert(0, 'path2')
-sys.path.insert(0, 'path3')
+sys.path.insert(0, "path2")
+sys.path.insert(0, "path3")
 
 from brave import robin
 print("  Finished from brave import robin")

--- a/Examples/python/import_packages/namespace_pkg/zipsplit.py
+++ b/Examples/python/import_packages/namespace_pkg/zipsplit.py
@@ -12,8 +12,8 @@ print(" Starting subtest " + os.path.basename(__file__))
 
 # Package brave split into two paths.
 # brave/robin.py (in path4.zip) and path3/brave/_robin.so
-sys.path.insert(0, 'path4.zip')
-sys.path.insert(0, 'path3')
+sys.path.insert(0, "path4.zip")
+sys.path.insert(0, "path3")
 
 from brave import robin
 print("  Finished from brave import robin")

--- a/Examples/python/performance/constructor/runme.py
+++ b/Examples/python/performance/constructor/runme.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('..')
+sys.path.append("..")
 import harness
 
 

--- a/Examples/python/performance/func/runme.py
+++ b/Examples/python/performance/func/runme.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('..')
+sys.path.append("..")
 import harness
 
 

--- a/Examples/python/performance/harness.py
+++ b/Examples/python/performance/harness.py
@@ -17,16 +17,16 @@ def run(proc):
 
     except IndexError:
         proc = Popen(
-            [sys.executable, 'runme.py', 'Simple_baseline'], stdout=PIPE)
+            [sys.executable, "runme.py", "Simple_baseline"], stdout=PIPE)
         (stdout, stderr) = proc.communicate()
         print stdout
 
         proc = Popen(
-            [sys.executable, 'runme.py', 'Simple_optimized'], stdout=PIPE)
+            [sys.executable, "runme.py", "Simple_optimized"], stdout=PIPE)
         (stdout, stderr) = proc.communicate()
         print stdout
 
         proc = Popen(
-            [sys.executable, 'runme.py', 'Simple_builtin'], stdout=PIPE)
+            [sys.executable, "runme.py", "Simple_builtin"], stdout=PIPE)
         (stdout, stderr) = proc.communicate()
         print stdout

--- a/Examples/python/performance/hierarchy/runme.py
+++ b/Examples/python/performance/hierarchy/runme.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('..')
+sys.path.append("..")
 import harness
 
 

--- a/Examples/python/performance/hierarchy_operator/runme.py
+++ b/Examples/python/performance/hierarchy_operator/runme.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('..')
+sys.path.append("..")
 import harness
 
 

--- a/Examples/python/performance/operator/runme.py
+++ b/Examples/python/performance/operator/runme.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('..')
+sys.path.append("..")
 import harness
 
 

--- a/Examples/test-suite/python/argcargvtest_runme.py
+++ b/Examples/test-suite/python/argcargvtest_runme.py
@@ -1,21 +1,21 @@
 from argcargvtest import *
 
-largs = ['hi', 'hola', 'hello']
+largs = ["hi", "hola", "hello"]
 if mainc(largs) != 3:
     raise RuntimeError("bad main typemap")
 
-targs = ('hi', 'hola')
-if mainv(targs, 1) != 'hola':
+targs = ("hi", "hola")
+if mainv(targs, 1) != "hola":
     print(mainv(targs, 1))
     raise RuntimeError("bad main typemap")
 
-targs = ('hi', 'hola')
-if mainv(targs, 1) != 'hola':
+targs = ("hi", "hola")
+if mainv(targs, 1) != "hola":
     raise RuntimeError("bad main typemap")
 
 try:
     error = 0
-    mainv('hello', 1)
+    mainv("hello", 1)
     error = 1
 except TypeError:
     pass

--- a/Examples/test-suite/python/char_binary_runme.py
+++ b/Examples/test-suite/python/char_binary_runme.py
@@ -1,26 +1,26 @@
 from char_binary import *
 
 t = Test()
-if t.strlen('hile') != 4:
-    print t.strlen('hile')
+if t.strlen("hile") != 4:
+    print t.strlen("hile")
     raise RuntimeError, "bad multi-arg typemap"
-if t.ustrlen('hile') != 4:
-    print t.ustrlen('hile')
+if t.ustrlen("hile") != 4:
+    print t.ustrlen("hile")
     raise RuntimeError, "bad multi-arg typemap"
 
-if t.strlen('hil\0') != 4:
+if t.strlen("hil\0") != 4:
     raise RuntimeError, "bad multi-arg typemap"
-if t.ustrlen('hil\0') != 4:
+if t.ustrlen("hil\0") != 4:
     raise RuntimeError, "bad multi-arg typemap"
 
 #
 # creating a raw char*
 #
 pc = new_pchar(5)
-pchar_setitem(pc, 0, 'h')
-pchar_setitem(pc, 1, 'o')
-pchar_setitem(pc, 2, 'l')
-pchar_setitem(pc, 3, 'a')
+pchar_setitem(pc, 0, "h")
+pchar_setitem(pc, 1, "o")
+pchar_setitem(pc, 2, "l")
+pchar_setitem(pc, 3, "a")
 pchar_setitem(pc, 4, 0)
 
 

--- a/Examples/test-suite/python/comment_verifier.py
+++ b/Examples/test-suite/python/comment_verifier.py
@@ -1,10 +1,10 @@
 def check(got, expected, expected_builtin=None):
   if got is None:  # Absence of comment is equivalent to empty comment.
-      got = ''
+      got = ""
 
   if got != expected:
     import re
-    p = re.compile(r'^[+-]([^+-].*\S)?(\s+)$', re.M)
+    p = re.compile(r"^[+-]([^+-].*\S)?(\s+)$", re.M)
 
     def make_trailing_spaces_visible(str):
         def replace_trailing_spaces(match):

--- a/Examples/test-suite/python/cpp17_u8_char_literals_runme.py
+++ b/Examples/test-suite/python/cpp17_u8_char_literals_runme.py
@@ -1,10 +1,10 @@
 from cpp17_u8_char_literals import *
 
-if cvar.a != 'a':
+if cvar.a != "a":
     raise RuntimeError
 
-if cvar.u != 'u':
+if cvar.u != "u":
     raise RuntimeError
 
-if cvar.u8 != '8':
+if cvar.u8 != "8":
     raise RuntimeError

--- a/Examples/test-suite/python/default_args_runme.py
+++ b/Examples/test-suite/python/default_args_runme.py
@@ -170,23 +170,23 @@ def run(module_name):
     if default_args.CDA().cdefaultargs_test2() != 1:
         raise RuntimeError
 
-    if default_args.chartest1() != 'x':
+    if default_args.chartest1() != "x":
         raise RuntimeError
 
-    if default_args.chartest2() != '\0':
+    if default_args.chartest2() != "\0":
         raise RuntimeError
 
-    if default_args.chartest3() != '\1':
+    if default_args.chartest3() != "\1":
         raise RuntimeError
 
-    if default_args.chartest4() != '\n':
+    if default_args.chartest4() != "\n":
         raise RuntimeError
 
-    if default_args.chartest5() != 'B':
+    if default_args.chartest5() != "B":
         raise RuntimeError
 
-    if default_args.chartest6() != 'C':
+    if default_args.chartest6() != "C":
         raise RuntimeError
 
 if __name__ == "__main__":
-    run('default_args')
+    run("default_args")

--- a/Examples/test-suite/python/director_exception_runme.py
+++ b/Examples/test-suite/python/director_exception_runme.py
@@ -75,7 +75,7 @@ b = launder(a)
 try:
     b.pong()
 except MyException, e:
-    if e.msg == 'foobar':
+    if e.msg == "foobar":
         ok = 1
     else:
         print "Unexpected error message: %s" % str(e)

--- a/Examples/test-suite/python/doxygen_misc_constructs_runme.py
+++ b/Examples/test-suite/python/doxygen_misc_constructs_runme.py
@@ -44,7 +44,7 @@ comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.getConnection),
 
 
 comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.getFirstLetter),
-    r''
+    r""
 )
 
 comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.ClassWithNestedEnum),
@@ -73,7 +73,7 @@ comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.isNoSpaceValidB),
 )
 
 comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.isNoSpaceValidC),
-    r''
+    r""
 )
 
 comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.backslashA),

--- a/Examples/test-suite/python/ignore_parameter_runme.py
+++ b/Examples/test-suite/python/ignore_parameter_runme.py
@@ -2,7 +2,7 @@ from ignore_parameter import *
 
 def check(a, b):
     if a != b:
-        raise RuntimeError('"%s" != "%s"' % (a, b))
+        raise RuntimeError("'%s' != '%s'" % (a, b))
 
 check(jaguar(200, 0), "hello")
 check(lotus("foo", 1), 101)

--- a/Examples/test-suite/python/li_cstring_runme.py
+++ b/Examples/test-suite/python/li_cstring_runme.py
@@ -18,10 +18,10 @@ if test4("hello") != "hello-suffix":
     print test4("hello")
     raise RuntimeError
 
-if test5(4) != 'xxxx':
+if test5(4) != "xxxx":
     raise RuntimeError
 
-if test6(10) != 'xxxxx':
+if test6(10) != "xxxxx":
     raise RuntimeError
 
 if test7() != "Hello world!":

--- a/Examples/test-suite/python/li_cwstring_runme.py
+++ b/Examples/test-suite/python/li_cwstring_runme.py
@@ -15,10 +15,10 @@ if test3("hello") != u"hello-suffix":
 if test4("hello") != u"hello-suffix":
     raise RuntimeError
 
-if test5(4) != u'xxxx':
+if test5(4) != u"xxxx":
     raise RuntimeError
 
-if test6(10) != u'xxxxx':
+if test6(10) != u"xxxxx":
     raise RuntimeError
 
 if test7() != u"Hello world!":

--- a/Examples/test-suite/python/li_std_set_runme.py
+++ b/Examples/test-suite/python/li_std_set_runme.py
@@ -90,5 +90,5 @@ sum = ()
 for i in s:
     sum = sum + (i,)
 
-if (len(sum) != 3 or (not 1 in sum) or (not 'hello' in sum) or (not (1, 2) in sum)):
+if (len(sum) != 3 or (not 1 in sum) or (not "hello" in sum) or (not (1, 2) in sum)):
     raise RuntimeError

--- a/Examples/test-suite/python/li_std_string_extra_runme.py
+++ b/Examples/test-suite/python/li_std_string_extra_runme.py
@@ -19,7 +19,7 @@ if li_std_string_extra.test_const_reference(x) != x:
 
 s = li_std_string_extra.string("he")
 #s += "ll"
-# s.append('o')
+# s.append("o")
 s = s + "llo"
 
 if s != x:

--- a/Examples/test-suite/python/li_std_vector_extra_runme.py
+++ b/Examples/test-suite/python/li_std_vector_extra_runme.py
@@ -91,7 +91,7 @@ if v.size() != 0:
 
 
 v = vecStr(["hello ", "world"])
-if v[0] != 'hello world':
+if v[0] != "hello world":
     raise RuntimeError, "bad std::string+std::vector"
 
 

--- a/Examples/test-suite/python/primitive_ref_runme.py
+++ b/Examples/test-suite/python/primitive_ref_runme.py
@@ -33,7 +33,7 @@ if ref_double(3.5) != 3.5:
 if ref_bool(True) != True:
     raise RuntimeError
 
-if ref_char('x') != 'x':
+if ref_char("x") != "x":
     raise RuntimeError
 
 if ref_over(0) != 0:

--- a/Examples/test-suite/python/primitive_types_runme.py
+++ b/Examples/test-suite/python/primitive_types_runme.py
@@ -227,7 +227,7 @@ t.var_paramc = sct_paramc
 t.v_check()
 
 # this value contains a '0' char!
-if def_namet != 'hola':
+if def_namet != "hola":
     print "bad namet", def_namet
     raise RuntimeError
 
@@ -236,54 +236,54 @@ if t.var_namet != def_namet:
     print "bad namet", t.var_namet, def_namet
     raise RuntimeError
 
-t.var_namet = 'hola'
+t.var_namet = "hola"
 
-if t.var_namet != 'hola':
+if t.var_namet != "hola":
     print "bad namet", t.var_namet
     raise RuntimeError
 
-t.var_namet = 'hol'
+t.var_namet = "hol"
 
-if t.var_namet != 'hol':
-    # if t.var_namet != 'hol\0\0':
+if t.var_namet != "hol":
+    # if t.var_namet != "hol\0\0":
     print "bad namet", t.var_namet
     raise RuntimeError
 
 
-cvar.var_char = '\0'
-if cvar.var_char != '\0':
+cvar.var_char = "\0"
+if cvar.var_char != "\0":
     raise RuntimeError, "bad char '0' case"
 
 cvar.var_char = 0
-if cvar.var_char != '\0':
+if cvar.var_char != "\0":
     raise RuntimeError, "bad char '0' case"
 
-cvar.var_namet = '\0'
-# if cvar.var_namet != '\0\0\0\0\0':
-if cvar.var_namet != '':
-    print 'hola', '', cvar.var_namet
+cvar.var_namet = "\0"
+# if cvar.var_namet != "\0\0\0\0\0":
+if cvar.var_namet != "":
+    print "hola", "", cvar.var_namet
     raise RuntimeError, "bad char '\0' case"
 
-cvar.var_namet = ''
-# if cvar.var_namet != '\0\0\0\0\0':
-if cvar.var_namet != '':
+cvar.var_namet = ""
+# if cvar.var_namet != "\0\0\0\0\0":
+if cvar.var_namet != "":
     raise RuntimeError, "bad char empty case"
 
 cvar.var_pchar = None
 if cvar.var_pchar != None:
     raise RuntimeError, "bad None case"
 
-cvar.var_pchar = ''
-if cvar.var_pchar != '':
-    print '%c' % (cvar.var_pchar[0],)
+cvar.var_pchar = ""
+if cvar.var_pchar != "":
+    print "%c" % (cvar.var_pchar[0],)
     raise RuntimeError, "bad char empty case"
 
 cvar.var_pcharc = None
 if cvar.var_pcharc != None:
     raise RuntimeError, "bad None case"
 
-cvar.var_pcharc = ''
-if cvar.var_pcharc != '':
+cvar.var_pcharc = ""
+if cvar.var_pcharc != "":
     raise RuntimeError, "bad char empty case"
 
 
@@ -291,10 +291,10 @@ if cvar.var_pcharc != '':
 # creating a raw char*
 #
 pc = new_pchar(5)
-pchar_setitem(pc, 0, 'h')
-pchar_setitem(pc, 1, 'o')
-pchar_setitem(pc, 2, 'l')
-pchar_setitem(pc, 3, 'a')
+pchar_setitem(pc, 0, "h")
+pchar_setitem(pc, 1, "o")
+pchar_setitem(pc, 2, "l")
+pchar_setitem(pc, 3, "a")
 pchar_setitem(pc, 4, 0)
 
 
@@ -331,7 +331,7 @@ if error:
 try:
     error = 0
     a = t.var_char
-    t.var_char = '23'
+    t.var_char = "23"
     error = 1
 except TypeError:
     if a != t.var_char:
@@ -393,7 +393,7 @@ if error:
 try:
     error = 0
     a = t.var_namet
-    t.var_namet = '123456'
+    t.var_namet = "123456"
     error = 1
 except TypeError:
     if a != t.var_namet:
@@ -410,11 +410,11 @@ if t.var_namet != t2.var_namet:
     raise RuntimeError, "bad SWIGTYPE* typemap"
 
 
-if cvar.fixsize != 'ho\0la\0\0\0':
+if cvar.fixsize != "ho\0la\0\0\0":
     raise RuntimeError, "bad FIXSIZE typemap"
 
-cvar.fixsize = 'ho'
-if cvar.fixsize != 'ho\0\0\0\0\0\0':
+cvar.fixsize = "ho"
+if cvar.fixsize != "ho\0\0\0\0\0\0":
     raise RuntimeError, "bad FIXSIZE typemap"
 
 
@@ -487,26 +487,26 @@ def checkType(t, e, val, delta):
     """t = Test object, e = type name (e.g. ulong), val = max or min allowed value, delta = +1 for max, -1 for min"""
     error = 0
     # Set the extreme valid value for var_*
-    setattr(t, 'var_' + e, val)
+    setattr(t, "var_" + e, val)
     # Make sure it was set properly and works properly in the val_* and ref_* methods
-    if getattr(t, 'var_' + e) != val or getattr(t, 'val_' + e)(val) != val or getattr(t, 'ref_' + e)(val) != val:
+    if getattr(t, "var_" + e) != val or getattr(t, "val_" + e)(val) != val or getattr(t, "ref_" + e)(val) != val:
         error = 1
     # Make sure setting a more extreme value fails without changing the value
     try:
-        a = getattr(t, 'var_' + e)
-        setattr(t, 'var_' + e, val + delta)
+        a = getattr(t, "var_" + e)
+        setattr(t, "var_" + e, val + delta)
         error = 1
     except OverflowError:
-        if a != getattr(t, 'var_' + e):
+        if a != getattr(t, "var_" + e):
             error = 1
     # Make sure the val_* and ref_* methods fail with a more extreme value
     try:
-        getattr(t, 'val_' + e)(val + delta)
+        getattr(t, "val_" + e)(val + delta)
         error = 1
     except OverflowError:
         pass
     try:
-        getattr(t, 'ref_' + e)(val + delta)
+        getattr(t, "ref_" + e)(val + delta)
         error = 1
     except OverflowError:
         pass
@@ -518,16 +518,16 @@ def checkFull(t, e, maxval, minval):
     checkType(t, e, maxval,  1)
     checkType(t, e, minval, -1)
 
-checkFull(t, 'llong',  maxllong,  minllong)
-checkFull(t, 'long',   maxlong,   minlong)
-checkFull(t, 'int',    maxint,    minint)
-checkFull(t, 'short',  maxshort,  minshort)
-checkFull(t, 'schar',  maxchar,   minchar)
-checkFull(t, 'ullong', maxullong, 0)
-checkFull(t, 'ulong',  maxulong,  0)
-checkFull(t, 'uint',   maxuint,   0)
-checkFull(t, 'ushort', maxushort, 0)
-checkFull(t, 'uchar',  maxuchar,  0)
+checkFull(t, "llong",  maxllong,  minllong)
+checkFull(t, "long",   maxlong,   minlong)
+checkFull(t, "int",    maxint,    minint)
+checkFull(t, "short",  maxshort,  minshort)
+checkFull(t, "schar",  maxchar,   minchar)
+checkFull(t, "ullong", maxullong, 0)
+checkFull(t, "ulong",  maxulong,  0)
+checkFull(t, "uint",   maxuint,   0)
+checkFull(t, "ushort", maxushort, 0)
+checkFull(t, "uchar",  maxuchar,  0)
 
 def checkOverload(t, name, val, delta, prevval, limit):
     """
@@ -556,16 +556,16 @@ def checkOverload(t, name, val, delta, prevval, limit):
                 raise RuntimeError, "bad " + name + " typemap"
 
 # Check that overloading works: uchar > schar > ushort > short > uint > int > ulong > long > ullong > llong
-checkOverload(t, 'uchar',  maxuchar,  +1, 0,         maxullong)
-checkOverload(t, 'ushort', maxushort, +1, maxuchar,  maxullong)
-checkOverload(t, 'uint',   maxuint,   +1, maxushort, maxullong)
-checkOverload(t, 'ulong',  maxulong,  +1, maxuint,   maxullong)
-checkOverload(t, 'ullong', maxullong, +1, maxulong,  maxullong)
-checkOverload(t, 'schar',  minchar,   -1, 0,         minllong)
-checkOverload(t, 'short',  minshort,  -1, minchar,   minllong)
-checkOverload(t, 'int',    minint,    -1, minshort,  minllong)
-checkOverload(t, 'long',   minlong,   -1, minint,    minllong)
-checkOverload(t, 'llong',  minllong,  -1, minlong,   minllong)
+checkOverload(t, "uchar",  maxuchar,  +1, 0,         maxullong)
+checkOverload(t, "ushort", maxushort, +1, maxuchar,  maxullong)
+checkOverload(t, "uint",   maxuint,   +1, maxushort, maxullong)
+checkOverload(t, "ulong",  maxulong,  +1, maxuint,   maxullong)
+checkOverload(t, "ullong", maxullong, +1, maxulong,  maxullong)
+checkOverload(t, "schar",  minchar,   -1, 0,         minllong)
+checkOverload(t, "short",  minshort,  -1, minchar,   minllong)
+checkOverload(t, "int",    minint,    -1, minshort,  minllong)
+checkOverload(t, "long",   minlong,   -1, minint,    minllong)
+checkOverload(t, "llong",  minllong,  -1, minlong,   minllong)
 
 # Make sure that large ints can be converted to doubles properly
 if val_double(sys.maxint + 1) != float(sys.maxint + 1):

--- a/Examples/test-suite/python/python_pybuffer_runme.py
+++ b/Examples/test-suite/python/python_pybuffer_runme.py
@@ -14,13 +14,13 @@ if len(sys.argv) >= 2 and sys.argv[1] == "benchmark":
     k = 1000000  # number of times to execute the functions
 
     t = time.time()
-    a = bytearray(b'hello world')
+    a = bytearray(b"hello world")
     for i in range(k):
         python_pybuffer.title1(a)
     print "Time used by bytearray:", time.time() - t
 
     t = time.time()
-    b = 'hello world'
+    b = "hello world"
     for i in range(k):
         python_pybuffer.title2(b)
     print "Time used by string:", time.time() - t
@@ -30,7 +30,7 @@ else:
     buf2 = bytearray(50)
 
     python_pybuffer.func1(buf1)
-    check(buf1 == b'a' * 10)
+    check(buf1 == b"a" * 10)
 
     python_pybuffer.func2(buf2)
     check(buf2.startswith(b"Hello world!\x00"))
@@ -43,4 +43,4 @@ else:
 
     buf3 = bytearray(b"hello")
     python_pybuffer.title1(buf3)
-    check(buf3 == b'Hello')
+    check(buf3 == b"Hello")

--- a/Examples/test-suite/python/python_strict_unicode_runme.py
+++ b/Examples/test-suite/python/python_strict_unicode_runme.py
@@ -1,8 +1,8 @@
 import python_strict_unicode
 
-test_bytes   = b'hello \x01world\x99'
-BYTES        = b'BYTES'
-test_unicode = u'h\udce9llo w\u00f6rld'
+test_bytes   = b"hello \x01world\x99"
+BYTES        = b"BYTES"
+test_unicode = u"h\udce9llo w\u00f6rld"
 
 # Test that byte string inputs and outputs work as expected
 bdbl = python_strict_unicode.double_str(test_bytes)
@@ -20,12 +20,12 @@ if type(bout) != type(BYTES):
 udbl = python_strict_unicode.double_wstr(test_unicode)
 if udbl != test_unicode + test_unicode:
     raise RuntimeError("Failed to double wide string")
-if type(udbl) != type(u''):
+if type(udbl) != type(u""):
     raise RuntimeError("Wrong type output for wide string")
 uout = python_strict_unicode.same_wstr(test_unicode)
 if uout != test_unicode:
     raise RuntimeError("Failed to copy wchar_t*")
-if type(uout) != type(u''):
+if type(uout) != type(u""):
     raise RuntimeError("Wrong type output for wchar_t*")
 
 # Test that overloading is handled properly
@@ -35,9 +35,9 @@ if bovr != BYTES:
 if type(bovr) != type(BYTES):
     raise RuntimeError("Wrong type output from overload")
 uovr = python_strict_unicode.overload(test_unicode)
-if uovr != u'UNICODE':
+if uovr != u"UNICODE":
     raise RuntimeError("Failed to return unicode from overload")
-if type(uovr) != type(u''):
+if type(uovr) != type(u""):
     raise RuntimeERror("Wrong type output from overload")
 
 # Test that bytes aren't accepted as wide strings and unicode isn't accepted as narrow strings

--- a/Examples/test-suite/python/reference_global_vars_runme.py
+++ b/Examples/test-suite/python/reference_global_vars_runme.py
@@ -13,8 +13,8 @@ cvar.var_bool = createref_bool(True)
 if value_bool(cvar.var_bool) != True:
     raise RuntimeError
 
-cvar.var_char = createref_char('w')
-if value_char(cvar.var_char) != 'w':
+cvar.var_char = createref_char("w")
+if value_char(cvar.var_char) != "w":
     raise RuntimeError
 
 cvar.var_unsigned_char = createref_unsigned_char(10)

--- a/Examples/test-suite/python/std_containers_runme.py
+++ b/Examples/test-suite/python/std_containers_runme.py
@@ -60,9 +60,9 @@ if mi[0][1] != mc[0][1]:
 
 
 map = {}
-map['hello'] = 1
-map['hi'] = 2
-map['3'] = 2
+map["hello"] = 1
+map["hi"] = 2
+map["3"] = 2
 
 imap = std_containers.mapident(map)
 for k in map:
@@ -70,13 +70,13 @@ for k in map:
         raise RuntimeError, "bad map"
 
 # Test __contains__ (required for 'x in y' to work)
-if not imap.__contains__('hello'):
+if not imap.__contains__("hello"):
     raise RuntimeError("hello imap.__contains__")
-if 'hello' not in imap:
+if "hello" not in imap:
     raise RuntimeError("hello not in imap")
-if imap.__contains__('oops'):
+if imap.__contains__("oops"):
     raise RuntimeError("oops imap.__contains__")
-if 'oops' in imap:
+if "oops" in imap:
     raise RuntimeError("oops in imap")
 
 mapc = {}

--- a/Examples/test-suite/python/swigobject_runme.py
+++ b/Examples/test-suite/python/swigobject_runme.py
@@ -15,11 +15,11 @@ lthis = long(a.this)
 # match pointer value, but deal with leading zeros on 8/16 bit systems and
 # different C++ compilers interpretation of %p
 xstr1 = "%016X" % (lthis,)
-xstr1 = str.lstrip(xstr1, '0')
+xstr1 = str.lstrip(xstr1, "0")
 xstr2 = pointer_str(a)
 xstr2 = str.replace(xstr2, "0x", "")
 xstr2 = str.replace(xstr2, "0X", "")
-xstr2 = str.lstrip(xstr2, '0')
+xstr2 = str.lstrip(xstr2, "0")
 xstr2 = str.upper(xstr2)
 
 if xstr1 != xstr2:

--- a/Examples/test-suite/python/template_typedef_cplx2_runme.py
+++ b/Examples/test-suite/python/template_typedef_cplx2_runme.py
@@ -11,8 +11,8 @@ except:
     print d, "is not an instance"
     raise RuntimeError
 
-s = '%s' % d
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % d
+if str.find(s, "ArithUnaryFunction") == -1:
     print d, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -23,8 +23,8 @@ except:
     print e, "is not an instance"
     raise RuntimeError
 
-s = '%s' % e
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % e
+if str.find(s, "ArithUnaryFunction") == -1:
     print e, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -40,8 +40,8 @@ except:
     print c, "is not an instance"
     raise RuntimeError
 
-s = '%s' % c
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % c
+if str.find(s, "ArithUnaryFunction") == -1:
     print c, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -52,8 +52,8 @@ except:
     print f, "is not an instance"
     raise RuntimeError
 
-s = '%s' % f
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % f
+if str.find(s, "ArithUnaryFunction") == -1:
     print f, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -68,8 +68,8 @@ except:
     print g, "is not an instance"
     raise RuntimeError
 
-s = '%s' % g
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % g
+if str.find(s, "ArithUnaryFunction") == -1:
     print g, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -81,8 +81,8 @@ except:
     print h, "is not an instance"
     raise RuntimeError
 
-s = '%s' % h
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % h
+if str.find(s, "ArithUnaryFunction") == -1:
     print h, "is not an ArithUnaryFunction"
     raise RuntimeError
 

--- a/Examples/test-suite/python/template_typedef_cplx_runme.py
+++ b/Examples/test-suite/python/template_typedef_cplx_runme.py
@@ -11,8 +11,8 @@ except:
     print d, "is not an instance"
     raise RuntimeError
 
-s = '%s' % d
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % d
+if str.find(s, "ArithUnaryFunction") == -1:
     print d, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -23,8 +23,8 @@ except:
     print e, "is not an instance"
     raise RuntimeError
 
-s = '%s' % e
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % e
+if str.find(s, "ArithUnaryFunction") == -1:
     print e, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -40,8 +40,8 @@ except:
     print c, "is not an instance"
     raise RuntimeError
 
-s = '%s' % c
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % c
+if str.find(s, "ArithUnaryFunction") == -1:
     print c, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -52,8 +52,8 @@ except:
     print f, "is not an instance"
     raise RuntimeError
 
-s = '%s' % f
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % f
+if str.find(s, "ArithUnaryFunction") == -1:
     print f, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -68,8 +68,8 @@ except:
     print g, "is not an instance"
     raise RuntimeError
 
-s = '%s' % g
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % g
+if str.find(s, "ArithUnaryFunction") == -1:
     print g, "is not an ArithUnaryFunction"
     raise RuntimeError
 
@@ -81,7 +81,7 @@ except:
     print h, "is not an instance"
     raise RuntimeError
 
-s = '%s' % h
-if str.find(s, 'ArithUnaryFunction') == -1:
+s = "%s" % h
+if str.find(s, "ArithUnaryFunction") == -1:
     print h, "is not an ArithUnaryFunction"
     raise RuntimeError

--- a/Examples/test-suite/python/unicode_strings_runme.py
+++ b/Examples/test-suite/python/unicode_strings_runme.py
@@ -5,13 +5,13 @@ import unicode_strings
 # The 'u' string prefix isn't valid in Python 3.0 - 3.2 and is redundant
 # in 3.3+. Since this file is run through 2to3 before testing, though,
 # mark this as a unicode string in 2.x so it'll become a str in 3.x.
-test_string = u'h\udce9llo w\u00f6rld'
+test_string = u"h\udce9llo w\u00f6rld"
 
 if sys.version_info[0:2] >= (3, 1):
     if unicode_strings.non_utf8_c_str() != test_string:
-        raise ValueError('Test comparison mismatch')
+        raise ValueError("Test comparison mismatch")
     if unicode_strings.non_utf8_std_string() != test_string:
-        raise ValueError('Test comparison mismatch')
+        raise ValueError("Test comparison mismatch")
 
 def check(s1, s2):
     if s1 != s2:

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -462,12 +462,12 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int top(Node *n) {
-    /* check if directors are enabled for this module.  note: this 
+    /* check if directors are enabled for this module.  note: this
      * is a "master" switch, without which no director code will be
      * emitted.  %feature("director") statements are also required
      * to enable directors for individual classes or methods.
      *
-     * use %module(directors="1") modulename at the start of the 
+     * use %module(directors="1") modulename at the start of the
      * interface file to enable director generation.
      */
     String *mod_docstring = NULL;
@@ -1606,7 +1606,7 @@ public:
    *
    * For functions that have not had nameless parameters set in the Language class.
    *
-   * Inputs: 
+   * Inputs:
    *   plist - entire parameter list
    *   arg_num - the number to start from when naming arguments
    * Side effects:
@@ -2173,7 +2173,7 @@ public:
     while (i) {
       Node *nn = Getattr(i, "defaultargs");
       if (nn != h) {
-	/* Check if overloaded function has defaultargs and 
+	/* Check if overloaded function has defaultargs and
 	 * pointed to the first overloaded. */
 	return true;
       }
@@ -2190,7 +2190,7 @@ public:
    * reuse make_autodocParmList() to do so.
    * ------------------------------------------------------------ */
   String *make_pyParmList(Node *n, bool in_class, bool is_calling, int kw, bool has_self_for_count = false) {
-    /* Get the original function for a defaultargs copy, 
+    /* Get the original function for a defaultargs copy,
      * see default_arguments() in parser.y. */
     Node *nn = Getattr(n, "defaultargs");
     if (nn)
@@ -2972,9 +2972,9 @@ public:
     }
 
     /* if the object is a director, and the method call originated from its
-     * underlying python object, resolve the call by going up the c++ 
-     * inheritance chain.  otherwise try to resolve the method in python.  
-     * without this check an infinite loop is set up between the director and 
+     * underlying python object, resolve the call by going up the c++
+     * inheritance chain.  otherwise try to resolve the method in python.
+     * without this check an infinite loop is set up between the director and
      * shadow class method calls.
      */
 
@@ -3068,7 +3068,7 @@ public:
       //        base class pointers!
 
       /* New addition to unwrap director return values so that the original
-       * python object is returned instead. 
+       * python object is returned instead.
        */
 #if 1
       int unwrap = 0;
@@ -3613,7 +3613,7 @@ public:
   }
 
 
-  /* ------------------------------------------------------------ 
+  /* ------------------------------------------------------------
    * nativeWrapper()
    * ------------------------------------------------------------ */
 
@@ -3648,7 +3648,7 @@ public:
   /* ---------------------------------------------------------------
    * classDirectorMethod()
    *
-   * Emit a virtual director method to pass a method call on to the 
+   * Emit a virtual director method to pass a method call on to the
    * underlying Python object.
    * ** Moved down due to gcc-2.96 internal error **
    * --------------------------------------------------------------- */
@@ -4759,7 +4759,7 @@ public:
     int oldshadow = shadow;
     int use_director = Swig_directorclass(n);
 
-    /* 
+    /*
      * If we're wrapping the constructor of a C++ director class, prepend a new parameter
      * to receive the scripting language object (e.g. 'self')
      *
@@ -5088,7 +5088,7 @@ public:
 
   /* ------------------------------------------------------------
    * insertDirective()
-   * 
+   *
    * Hook for %insert directive.   We're going to look for special %shadow inserts
    * as a special case so we can do indenting correctly
    * ------------------------------------------------------------ */
@@ -5171,7 +5171,7 @@ public:
 /* ---------------------------------------------------------------
  * classDirectorMethod()
  *
- * Emit a virtual director method to pass a method call on to the 
+ * Emit a virtual director method to pass a method call on to the
  * underlying Python object.
  *
  * ** Moved it here due to internal error on gcc-2.96 **
@@ -5272,7 +5272,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
   Append(w->def, " {");
   Append(declaration, ";\n");
 
-  /* declare method return value 
+  /* declare method return value
    * if the return value is a reference or const reference, a specialized typemap must
    * handle it, including declaration of c_result ($result).
    */
@@ -5432,7 +5432,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
 	  } else {
 	    Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
 	    Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
+	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
 	    //       source, nonconst, base);
 	    Printv(arglist, source, NIL);
 	  }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -685,13 +685,13 @@ public:
 	 * same package, otherwise load it as a global module.
 	 */
         Printv(default_import_code, "# Import the low-level C/C++ module\n", NULL);
-        Printv(default_import_code, "if __package__ or '.' in __name__:\n", NULL);
+        Printv(default_import_code, "if __package__ or \".\" in __name__:\n", NULL);
         Printv(default_import_code, tab4, "from . import ", module, "\n", NULL);
         Printv(default_import_code, "else:\n", NULL);
         Printv(default_import_code, tab4, "import ", module, "\n", NULL);
       } else {
         Printv(default_import_code, "# Pull in all the attributes from the low-level C/C++ module\n", NULL);
-        Printv(default_import_code, "if __package__ or '.' in __name__:\n", NULL);
+        Printv(default_import_code, "if __package__ or \".\" in __name__:\n", NULL);
         Printv(default_import_code, tab4, "from .", module, " import *\n", NULL);
         Printv(default_import_code, "else:\n", NULL);
         Printv(default_import_code, tab4, "from ", module, " import *\n", NULL);
@@ -848,7 +848,7 @@ public:
 
       Printv(f_shadow_py, "\nfrom sys import version_info as _swig_python_version_info\n", NULL);
       Printv(f_shadow_py, "if _swig_python_version_info < (2, 7, 0):\n", NULL);
-      Printv(f_shadow_py, tab4, "raise RuntimeError('Python 2.7 or later required')\n\n", NULL);
+      Printv(f_shadow_py, tab4, "raise RuntimeError(\"Python 2.7 or later required\")\n\n", NULL);
 
       if (Len(f_shadow_after_begin) > 0)
 	Printv(f_shadow_py, f_shadow_after_begin, "\n", NIL);
@@ -1720,7 +1720,7 @@ public:
       }
       // Write the function annotation
       if (func_annotation)
-	Printf(doc, ": '%s'", type_str);
+	Printf(doc, ": \"%s\"", type_str);
 
       // Write default value
       if (value && !calling) {
@@ -2011,10 +2011,10 @@ public:
       // This must have been an octal number. This is the only case we
       // cannot use in Python directly, since Python 2 and 3 use non-
       // compatible representations.
-      result = NewString(*s == '-' ? "int('-" : "int('");
+      result = NewString(*s == '-' ? "int(\"-" : "int(\"");
       String *octal_string = NewStringWithSize(p, (int) (end - p));
       Append(result, octal_string);
-      Append(result, "', 8)");
+      Append(result, "\", 8)");
       Delete(octal_string);
       return result;
     }
@@ -4425,7 +4425,7 @@ public:
 	    Printv(f_shadow, tab4, str, "\n\n", NIL);
 	}
 
-	Printv(f_shadow, tab4, "thisown = property(lambda x: x.this.own(), ", "lambda x, v: x.this.own(v), doc='The membership flag')\n", NIL);
+	Printv(f_shadow, tab4, "thisown = property(lambda x: x.this.own(), ", "lambda x, v: x.this.own(v), doc=\"The membership flag\")\n", NIL);
 	/* Add static attribute */
 	if (GetFlag(n, "feature:python:nondynamic")) {
 	  Printv(f_shadow_file, tab4, "__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n", NIL);

--- a/Tools/obs-buildlogs.py
+++ b/Tools/obs-buildlogs.py
@@ -11,9 +11,9 @@ def remove_old_files():
     os.remove(file)
 
 def download():
-  repos = subprocess.Popen(['osc', 'repositories'], stdout=subprocess.PIPE)
+  repos = subprocess.Popen(["osc", "repositories"], stdout=subprocess.PIPE)
   for line in repos.stdout:
-    command = ['osc', 'buildlog', '--last'] + line.split()
+    command = ["osc", "buildlog", "--last"] + line.split()
     filename = "-".join(line.split()) + ".log"
     print("Downloading logs using: {}".format(" ".join(command)))
     buildlog = subprocess.Popen(command, stdout=subprocess.PIPE)

--- a/Tools/testflags.py
+++ b/Tools/testflags.py
@@ -23,7 +23,7 @@ def get_cflags(language, std, compiler):
         "scilab":"-Werror " + c_common,
            "tcl":"-Werror " + c_common,
     }
-    if compiler == 'clang':
+    if compiler == "clang":
         cflags["guile"] += " -Wno-attributes" # -Wno-attributes is for clang LLVM 3.5 and bdw-gc < 7.5 used by guile
 
     if language not in cflags:
@@ -54,7 +54,7 @@ def get_cxxflags(language, std, compiler):
         "scilab":"-Werror " + cxx_common,
            "tcl":"-Werror " + cxx_common,
     }
-    if compiler == 'clang':
+    if compiler == "clang":
         cxxflags["guile"] += " -Wno-attributes" # -Wno-attributes is for clang LLVM 3.5 and bdw-gc < 7.5 used by guile
 
     if language not in cxxflags:
@@ -64,12 +64,12 @@ def get_cxxflags(language, std, compiler):
 
 import argparse
 parser = argparse.ArgumentParser(description="Display CFLAGS or CXXFLAGS to use for testing the SWIG examples and test-suite.")
-parser.add_argument('-l', '--language', required=True, help='set language to show flags for')
+parser.add_argument("-l", "--language", required=True, help="set language to show flags for")
 flags = parser.add_mutually_exclusive_group(required=True)
-flags.add_argument('-c', '--cflags', action='store_true', default=False, help='show CFLAGS')
-flags.add_argument('-x', '--cxxflags', action='store_true', default=False, help='show CXXFLAGS')
-parser.add_argument('-s', '--std', required=False, help='language standard flags for the -std= option')
-parser.add_argument('-C', '--compiler', required=False, help='compiler used (clang or gcc)')
+flags.add_argument("-c", "--cflags", action="store_true", default=False, help="show CFLAGS")
+flags.add_argument("-x", "--cxxflags", action="store_true", default=False, help="show CXXFLAGS")
+parser.add_argument("-s", "--std", required=False, help="language standard flags for the -std= option")
+parser.add_argument("-C", "--compiler", required=False, help="compiler used (clang or gcc)")
 args = parser.parse_args()
 
 if args.cflags:


### PR DESCRIPTION
**Before:**

![BEFORE](https://user-images.githubusercontent.com/2927132/60679548-56018280-9ecb-11e9-91ea-574c78375d4a.png)

**After:**

![AFTER](https://user-images.githubusercontent.com/2927132/60679559-5e59bd80-9ecb-11e9-840f-412106a1dd8c.png)

This is a pretty common notation in Python 3: https://stackoverflow.com/a/56190

Actually it could be nice to use this notation everywhere in Python generator, so if the SWIG maintainers agree, I would expand my PR with it, or make an additional one.