### PR TITLE
Change C# bool[] typemaps to marshall as 1-byte

### DIFF
--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -37,9 +37,6 @@ CPP11_TEST_CASES = \
 	cpp11_shared_ptr_upcast \
 	cpp11_strongly_typed_enumerations_simple \
 
-# bool[] typemaps don't work correctly when running under mono
-FAILING_CPP_TESTS = csharp_lib_arrays_bool
-
 include $(srcdir)/../common.mk
 
 # Overridden variables here

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -19,6 +19,7 @@ CPP_TEST_CASES = \
 	csharp_exceptions \
 	csharp_features \
 	csharp_lib_arrays \
+	csharp_lib_arrays_bool \
 	csharp_namespace_system_collision \
 	csharp_prepost \
 	csharp_typemaps \
@@ -36,6 +37,9 @@ CPP11_TEST_CASES = \
 	cpp11_shared_ptr_upcast \
 	cpp11_strongly_typed_enumerations_simple \
 
+# bool[] typemaps don't work correctly when running under mono
+FAILING_CPP_TESTS = csharp_lib_arrays_bool
+
 include $(srcdir)/../common.mk
 
 # Overridden variables here
@@ -48,6 +52,7 @@ CSHARPFLAGSSPECIAL =
 intermediary_classname.cpptest: SWIGOPT += -dllimport intermediary_classname
 complextest.cpptest: CSHARPFLAGSSPECIAL = -r:System.Numerics.dll
 csharp_lib_arrays.cpptest: CSHARPFLAGSSPECIAL = -unsafe
+csharp_lib_arrays_bool.cpptest: CSHARPFLAGSSPECIAL = -unsafe
 csharp_swig2_compatibility.cpptest: SWIGOPT += -DSWIG2_CSHARP
 
 # Rules for the different types of tests

--- a/Examples/test-suite/csharp/csharp_lib_arrays_bool_runme.cs
+++ b/Examples/test-suite/csharp/csharp_lib_arrays_bool_runme.cs
@@ -1,0 +1,78 @@
+using System;
+using csharp_lib_arrays_boolNamespace;
+
+public class runme
+{
+  static void Main() 
+  {
+    {
+      bool[] source = { true, false, false, true, false, true, true, false };
+      bool[] target = new bool[ source.Length ];
+
+      csharp_lib_arrays_bool.myArrayCopyUsingFixedArraysBool( source, target, target.Length );
+      CompareArrays(source, target, "bool[] INPUT/OUTPUT Fixed");
+    }
+    
+    {
+      bool[] source = { true, false, false, true, false, true, true, false };
+      bool[] target = { false, true, true, false, true, false, false, true };
+
+      csharp_lib_arrays_bool.myArraySwapUsingFixedArraysBool( source, target, target.Length );
+
+      for (int i=0; i<target.Length; ++i)
+        target[i] = !target[i];
+
+      CompareArrays(source, target, "bool[] INOUT");
+    }
+
+    {
+      bool[] source = { true, false, false, true, false, true, true, false };
+      bool[] target = new bool[ source.Length ];
+
+      if( !csharp_lib_arrays_bool.checkBoolArrayCorrect( source, source.Length ) )
+      {
+        throw new Exception("bool[] INPUT incorrect");
+      }
+
+      csharp_lib_arrays_bool.myArrayCopyBool( source, target, target.Length );
+      CompareArrays(source, target, "bool[] INPUT/OUTPUT");
+    }
+
+    {
+      bool[] source = { true, false, false, true, false, true, true, false };
+      bool[] target = { false, true, true, false, true, false, false, true };
+
+      csharp_lib_arrays_bool.myArraySwapBool( source, target, target.Length );
+
+      for (int i=0; i<target.Length; ++i)
+        target[i] = !target[i];
+
+      CompareArrays(source, target, "bool[] INOUT");
+    }
+  }
+  
+  static void CompareArrays<T>( T[] a, T[] b, string testName ) 
+  {
+    if (a.Length != b.Length)
+      throw new Exception("size mismatch");
+
+    for(int i=0; i<a.Length; ++i) {
+      if (a[i].Equals(b[i]) == false) {
+        Console.Error.WriteLine("C# Array mismatch: " + testName);
+        Console.Error.WriteLine("a:");
+        PrintArray(a);
+        Console.Error.WriteLine("b:");
+        PrintArray(b);
+        throw new Exception("element mismatch");
+      }
+    }
+  }
+
+  static void PrintArray<T>( T[] a )
+  {
+    foreach ( T i in a )
+      Console.Error.Write( "{0} ", i );
+    Console.Error.WriteLine();
+  }
+}
+

--- a/Examples/test-suite/csharp/csharp_lib_arrays_bool_runme.cs
+++ b/Examples/test-suite/csharp/csharp_lib_arrays_bool_runme.cs
@@ -25,6 +25,12 @@ public class runme
       CompareArrays(source, target, "bool[] INOUT");
     }
 
+    if( runtimeIsMono() )
+    {
+      Console.Error.WriteLine("Tests are running on mono, failing bool[] tests skipped");
+      return;
+    }
+
     {
       bool[] source = { true, false, false, true, false, true, true, false };
       bool[] target = new bool[ source.Length ];
@@ -73,6 +79,11 @@ public class runme
     foreach ( T i in a )
       Console.Error.Write( "{0} ", i );
     Console.Error.WriteLine();
+  }
+
+  static bool runtimeIsMono()
+  {
+    return Type.GetType ("Mono.Runtime") != null;
   }
 }
 

--- a/Examples/test-suite/csharp_lib_arrays_bool.i
+++ b/Examples/test-suite/csharp_lib_arrays_bool.i
@@ -1,0 +1,78 @@
+%module csharp_lib_arrays_bool
+
+%include "arrays_csharp.i"
+
+%apply bool INPUT[] { bool* sourceArray }
+%apply bool OUTPUT[] { bool* targetArray }
+
+%apply bool INOUT[] { bool* array1 }
+%apply bool INOUT[] { bool* array2 }
+
+%inline %{
+#include <iostream>
+
+/* copy the contents of the first array to the second */
+void myArrayCopyBool( bool* sourceArray, bool* targetArray, int nitems ) {
+  int i;
+  for ( i = 0; i < nitems; i++ ) {
+    targetArray[ i ] = sourceArray[ i ];
+  }
+}
+
+/* swap the contents of the two arrays */
+void myArraySwapBool( bool* array1, bool* array2, int nitems ) {
+  int i;
+  bool temp;
+  for ( i = 0; i < nitems; i++ ) {
+    temp = array1[ i ];
+    array1[ i ] = array2[ i ];
+    array2[ i ] = temp;
+  }
+}
+
+bool checkBoolArrayCorrect( bool* sourceArray, int sourceArraySize ) {
+  if( sourceArraySize != 8 ) {
+    std::cout << "checkBoolArrayCorrect: Expected array with 8 elements" << std::endl;
+    return false;
+  }
+  return sourceArray[0] == true &&
+         sourceArray[1] == false &&
+         sourceArray[2] == false &&
+         sourceArray[3] == true &&
+         sourceArray[4] == false &&
+         sourceArray[5] == true &&
+         sourceArray[6] == true &&
+         sourceArray[7] == false;
+}
+%}
+
+%clear bool* sourceArray;
+%clear bool* targetArray;
+
+%clear bool* array1;
+%clear bool* array2;
+
+// Below replicates the above array handling but this time using the pinned (fixed) array typemaps
+%csmethodmodifiers myArrayCopyUsingFixedArraysBool "public unsafe";
+%csmethodmodifiers myArraySwapUsingFixedArraysBool "public unsafe";
+
+%apply bool FIXED[] { bool* sourceArray }
+%apply bool FIXED[] { bool* targetArray }
+
+%inline %{
+void myArrayCopyUsingFixedArraysBool( bool *sourceArray, bool* targetArray, int nitems ) {
+  myArrayCopyBool(sourceArray, targetArray, nitems);
+}
+%}
+
+%apply bool FIXED[] { bool* array1 }
+%apply bool FIXED[] { bool* array2 }
+
+%inline %{
+void myArraySwapUsingFixedArraysBool( bool* array1, bool* array2, int nitems ) {
+  myArraySwapBool(array1, array2, nitems);
+}
+%}
+
+
+

--- a/Lib/csharp/arrays_csharp.i
+++ b/Lib/csharp/arrays_csharp.i
@@ -103,7 +103,47 @@ CSHARP_ARRAYS(long long, long)
 CSHARP_ARRAYS(unsigned long long, ulong)
 CSHARP_ARRAYS(float, float)
 CSHARP_ARRAYS(double, double)
-CSHARP_ARRAYS(bool, bool)
+
+// By default C# will marshal bools as 4 bytes
+// UnmanagedType.I1 will change this to 1 byte
+// FIXME - When running on mono ArraySubType appears to be ignored and bools will be marshalled as 4-byte
+// https://github.com/mono/mono/issues/15592
+
+// input only arrays
+%typemap(ctype)   bool INPUT[] "bool*"
+%typemap(cstype)  bool INPUT[] "bool[]"
+%typemap(imtype, inattributes="[global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray,ArraySubType=System.Runtime.InteropServices.UnmanagedType.I1)]") bool INPUT[] "bool[]"
+%typemap(csin)    bool INPUT[] "$csinput"
+
+%typemap(in)      bool INPUT[] %{
+$1 = $input;
+%}
+%typemap(freearg) bool INPUT[] ""
+%typemap(argout)  bool INPUT[] ""
+
+// output only arrays
+%typemap(ctype)   bool OUTPUT[] "bool*"
+%typemap(cstype)  bool OUTPUT[] "bool[]"
+%typemap(imtype, inattributes="[global::System.Runtime.InteropServices.Out, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray,ArraySubType=System.Runtime.InteropServices.UnmanagedType.I1)]") bool OUTPUT[] "bool[]"
+%typemap(csin)    bool OUTPUT[] "$csinput"
+
+%typemap(in)      bool OUTPUT[] %{
+$1 = $input;
+%}
+%typemap(freearg) bool OUTPUT[] ""
+%typemap(argout)  bool OUTPUT[] ""
+
+// inout arrays
+%typemap(ctype)   bool INOUT[] "bool*"
+%typemap(cstype)  bool INOUT[] "bool[]"
+%typemap(imtype, inattributes="[global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.Out, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray,ArraySubType=System.Runtime.InteropServices.UnmanagedType.I1)]") bool INOUT[] "bool[]"
+%typemap(csin)    bool INOUT[] "$csinput"
+
+%typemap(in)      bool INOUT[] %{
+$1 = $input;
+%}
+%typemap(freearg) bool INOUT[] ""
+%typemap(argout)  bool INOUT[] ""
 
 
 %define CSHARP_ARRAYS_FIXED( CTYPE, CSTYPE )


### PR DESCRIPTION
Default marshalling for bool[] now uses 1-byte entries in the array, to
ensure array contents is as expected in C++.

When running under mono csharp_lib_arrays_bool testcase will fail
due to an apparent bug in mono. Works correctly under Microsoft's
runtime. See https://github.com/mono/mono/issues/15592