### PR TITLE
Fix segfault in doxygen code block with empty line

### DIFF
--- a/Examples/test-suite/doxygen_basic_translate.i
+++ b/Examples/test-suite/doxygen_basic_translate.i
@@ -57,6 +57,8 @@ void function3(int a, int b)
  * \warning This may not work as expected
  * \code
  * int main() { while(true); }
+ *
+ * // Test blank line in code block
  * \endcode
  * \endif
  */

--- a/Examples/test-suite/doxygen_basic_translate_style2.i
+++ b/Examples/test-suite/doxygen_basic_translate_style2.i
@@ -55,6 +55,8 @@ void function3(int a, int b)
  *  \warning This may not work as expected
  *  \code
  *  int main() { while(true); }
+ *
+ *  // Test blank line in code block
  *  \endcode
  *  \endif
  */

--- a/Examples/test-suite/java/doxygen_basic_translate_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_runme.java
@@ -54,6 +54,8 @@ public class doxygen_basic_translate_runme {
     		" \n" +
     		" {@code \n" +
     		"int main() { while(true); } \n" +
+		"\n" +
+		"// Test blank line in code block \n" +
     		" }\n" +
     		" }\n" +
     		" \n" +

--- a/Examples/test-suite/java/doxygen_basic_translate_style2_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_style2_runme.java
@@ -54,6 +54,8 @@ public class doxygen_basic_translate_style2_runme {
     		" \n" +
     		" {@code \n" +
     		"int main() { while(true); } \n" +
+		"\n" +
+		"// Test blank line in code block \n" +
     		" }\n" +
     		" }\n" +
     		" \n" +

--- a/Examples/test-suite/python/doxygen_basic_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_runme.py
@@ -50,6 +50,8 @@ Warning: This may not work as expected
 .. code-block:: c++
 
     int main() { while(true); }
+
+    // Test blank line in code block
 }"""
 )
 comment_verifier.check(inspect.getdoc(doxygen_basic_translate.function5),

--- a/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style2_runme.py
@@ -48,6 +48,8 @@ Warning: This may not work as expected
 .. code-block:: c++
 
     int main() { while(true); }
+
+    // Test blank line in code block
 }"""
 )
 comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style2.function5),

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -289,6 +289,18 @@ DoxygenParser::TokenListCIt DoxygenParser::getEndOfParagraph(const TokenList &to
   TokenListCIt endOfParagraph = m_tokenListIt;
 
   while (endOfParagraph != tokList.end()) {
+    // If \code or \verbatim is encountered within a paragraph, then
+    // go all the way to the end of that command, since the content
+    // could contain empty lines that would appear to be paragraph
+    // ends:
+    if (endOfParagraph->m_tokenType == COMMAND &&
+	(endOfParagraph->m_tokenString == "code" ||
+	 endOfParagraph->m_tokenString == "verbatim")) {
+      const string theCommand = endOfParagraph->m_tokenString;
+      endOfParagraph = getEndCommand("end" + theCommand, tokList);
+      endOfParagraph++; // Move after the end command
+      return endOfParagraph;
+    }
     if (endOfParagraph->m_tokenType == END_LINE) {
       endOfParagraph++;
       if (endOfParagraph != tokList.end()

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -971,7 +971,9 @@ DoxygenEntityList DoxygenParser::parse(TokenListCIt endParsingIndex, const Token
   std::string currPlainstringCommandType = root ? "partofdescription" : "plainstd::string";
   DoxygenEntityList aNewList;
 
-  while (m_tokenListIt != endParsingIndex) {
+  // Less than check (instead of not equal) is a safeguard in case the
+  // iterator is incremented past the end
+  while (m_tokenListIt < endParsingIndex) {
 
     Token currToken = *m_tokenListIt;
 
@@ -987,6 +989,10 @@ DoxygenEntityList DoxygenParser::parse(TokenListCIt endParsingIndex, const Token
     } else if (currToken.m_tokenType == PLAINSTRING) {
       addCommand(currPlainstringCommandType, tokList, aNewList);
     }
+
+    // If addCommand above misbehaves, it can move the iterator past endParsingIndex
+    if (m_tokenListIt > endParsingIndex)
+      printListError(WARN_DOXYGEN_UNEXPECTED_ITERATOR_VALUE, "Unexpected iterator value in DoxygenParser::parse");
 
     if (endParsingIndex != tokList.end() && m_tokenListIt == tokList.end()) {
       // this could happen if we can't reach the original endParsingIndex

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -221,6 +221,7 @@
 #define WARN_DOXYGEN_HTML_ERROR               563
 #define WARN_DOXYGEN_COMMAND_ERROR            564
 #define WARN_DOXYGEN_UNKNOWN_CHARACTER        565
+#define WARN_DOXYGEN_UNEXPECTED_ITERATOR_VALUE  566
 
 /* -- Reserved (600-799) -- */
 


### PR DESCRIPTION
Fix for Issue #1548.  Parsing a doxygen `\code` block that contained an empty line was not handled correctly and could lead to dereferencing an invalid iterator (segfault) in certain contexts.  The fix addresses this by changing the way the end of a paragraph is identified (go all the way to `\endcode` or `\endverbatim`).  I have also added some additional safety to how the iterator value is checked against the end, producing a warning if a similar unexpected scenario occurs in the future.

The `doxygen_basic_translate.i` and `doxygen_basic_translate_style2.i` test cases have been updated to include a regression check by adding a newline within the `\code` block for `function4`.  This usage produced a segfault previously.

Part of the reason that the invalid iterator dereference was able to occur is because the `DoxygenParser` class stores an iterator `m_tokenListIt` that is incremented within different pieces of code separately from the surrounding loop structure (the code path is not obvious and does involve recursion).  I'm not a C++ guru, but it does make me nervous because it assumes that any code that increments the iterator isn't moving it too far (which is exactly what was happening).