### PR TITLE
Use java variadic function to construct std::vector

### DIFF
--- a/Lib/java/std_vector.i
+++ b/Lib/java/std_vector.i
@@ -27,7 +27,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
 %typemap(javabase) std::vector< CTYPE > "java.util.AbstractList<$typemap(jboxtype, CTYPE)>"
 %typemap(javainterfaces) std::vector< CTYPE > "java.util.RandomAccess"
 %proxycode %{
-  public $javaclassname($typemap(jstype, CTYPE)[] initialElements) {
+  public $javaclassname($typemap(jstype, CTYPE)... initialElements) {
     this();
     reserve(initialElements.length);
 


### PR DESCRIPTION
This makes actions below possible:

        StdVectorDouble doubles= new StdVectorDouble(2.5,3.6);
        StdVectorDouble doublesArray= new StdVectorDouble(new double[]{2.5,3.6});

For types that this constructor may be overlapped by `std::vector(count, value)`, such as int, there is still possible alternative:

        StdVectorInt integers= new StdVectorInt(2,3);// count=2, value=3
        StdVectorInt integers= new StdVectorInt(new int[]{2,3});// initialElements= int[]{2,3}

PS: part of the .i file

	%template(StdVectorLong) std::vector<int64_t>;
	%template(StdVectorInt) std::vector<int>;
	%template(StdVectorString) std::vector<std::string>;
	%template(StdVectorDouble) std::vector<double>;
