### PR TITLE
Fix C# and Java std::set<> typemaps for primitive types

### DIFF
--- a/Examples/test-suite/csharp/li_std_set_runme.cs
+++ b/Examples/test-suite/csharp/li_std_set_runme.cs
@@ -85,5 +85,12 @@ public class runme
         ss = new StringSet{"foo", "bar", "baz"};
         ss.UnionWith(new[] {"baz", "quux"});
         checkThat(ss.SetEquals(new[] {"foo", "bar", "baz", "quux"}), "UnionWith works");
+
+        // Check a set of another type.
+        FooSet fooSet = new FooSet();
+        ISet<Foo> fooISet = fooSet;
+        checkThat(fooISet.Count == 0, "is initially empty");
+        checkThat(fooISet.Add(new Foo(17)), "added successfully");
+        checkThat(fooISet.Count == 1, "is not empty any more");
     }
 }

--- a/Examples/test-suite/csharp/li_std_set_runme.cs
+++ b/Examples/test-suite/csharp/li_std_set_runme.cs
@@ -92,5 +92,14 @@ public class runme
         checkThat(fooISet.Count == 0, "is initially empty");
         checkThat(fooISet.Add(new Foo(17)), "added successfully");
         checkThat(fooISet.Count == 1, "is not empty any more");
+
+        // And a set of primitive type.
+        IntSet intSet = new IntSet();
+        checkThat(intSet.Count == 0, "is initially empty");
+        checkThat(intSet.Add(17), "17 added successfully");
+        checkThat(!intSet.Add(17), "17 not added again");
+        checkThat(intSet.Count == 1, "not empty any more");
+        checkThat(intSet.Add(289), "289 added successfully");
+        checkThat(intSet.Count == 2, "even less empty now");
     }
 }

--- a/Examples/test-suite/java/li_std_set_runme.java
+++ b/Examples/test-suite/java/li_std_set_runme.java
@@ -71,5 +71,11 @@ public class li_std_set_runme {
     checkThat(ss.removeAll(found));
     checkThat(ss.isEmpty());
     checkThat(ss.size() == 0);
+
+    // Check a set of another type.
+    java.util.AbstractSet<Foo> fooSet = new FooSet();
+    checkThat(fooSet.isEmpty());
+    checkThat(fooSet.add(new Foo(17)));
+    checkThat(fooSet.size() == 1);
   }
 }

--- a/Examples/test-suite/java/li_std_set_runme.java
+++ b/Examples/test-suite/java/li_std_set_runme.java
@@ -77,5 +77,14 @@ public class li_std_set_runme {
     checkThat(fooSet.isEmpty());
     checkThat(fooSet.add(new Foo(17)));
     checkThat(fooSet.size() == 1);
+
+    // And a set of primitive type.
+    java.util.AbstractSet<Integer> intSet = new IntSet();
+    checkThat(intSet.isEmpty());
+    checkThat(intSet.add(17));
+    checkThat(!intSet.add(17));
+    checkThat(intSet.size() == 1);
+    checkThat(intSet.add(289));
+    checkThat(intSet.size() == 2);
   }
 }

--- a/Examples/test-suite/li_std_set.i
+++ b/Examples/test-suite/li_std_set.i
@@ -40,10 +40,7 @@
         };
     %}
 
-    // This one doesn't work in Java correctly yet.
-#ifdef SWIGCSHARP
     %template(IntSet) std::set<int>;
-#endif
     %template(StringSet) std::set<std::string>;
     %template(FooSet) std::set<Foo>;
 #endif

--- a/Examples/test-suite/li_std_set.i
+++ b/Examples/test-suite/li_std_set.i
@@ -23,7 +23,25 @@
     %template(v_int) std::vector<int>;
     %template(set_string) std::set<std::string>;
 #elif defined(SWIGJAVA) || defined(SWIGCSHARP)
+    // This operator is only defined because it's needed to store objects of
+    // type Foo in std::set in C++, we don't need to wrap it.
+    %ignore operator<;
+    %inline %{
+        struct Foo
+        {
+            explicit Foo(int n) : n(n) {}
+
+            int n;
+
+            friend bool operator<(Foo foo1, Foo foo2)
+            {
+                return foo1.n < foo2.n;
+            }
+        };
+    %}
+
     %template(StringSet) std::set<std::string>;
+    %template(FooSet) std::set<Foo>;
 #endif
 
 #if defined(SWIGRUBY)

--- a/Examples/test-suite/li_std_set.i
+++ b/Examples/test-suite/li_std_set.i
@@ -40,6 +40,10 @@
         };
     %}
 
+    // This one doesn't work in Java correctly yet.
+#ifdef SWIGCSHARP
+    %template(IntSet) std::set<int>;
+#endif
     %template(StringSet) std::set<std::string>;
     %template(FooSet) std::set<Foo>;
 #endif

--- a/Lib/csharp/std_set.i
+++ b/Lib/csharp/std_set.i
@@ -30,7 +30,7 @@ class set {
 
 %typemap(csinterfaces) std::set<T> "global::System.IDisposable, global::System.Collections.Generic.ISet<$typemap(cstype, T)>\n";
 %proxycode %{
-  void global::System.Collections.Generic.ICollection<$typemap(cstype, T)>.Add(string item) {
+  void global::System.Collections.Generic.ICollection<$typemap(cstype, T)>.Add($typemap(cstype, T) item) {
       ((global::System.Collections.Generic.ISet<$typemap(cstype, T)>)this).Add(item);
   }
 

--- a/Lib/csharp/std_set.i
+++ b/Lib/csharp/std_set.i
@@ -192,7 +192,7 @@ class set {
     private $csclassname collectionRef;
     private global::System.Collections.Generic.IList<$typemap(cstype, T)> ItemsCollection;
     private int currentIndex;
-    private $typemap(cstype, T) currentObject;
+    private object currentObject;
     private int currentSize;
 
     public $csclassnameEnumerator($csclassname collection) {
@@ -212,7 +212,7 @@ class set {
           throw new global::System.InvalidOperationException("Enumeration finished.");
         if (currentObject == null)
           throw new global::System.InvalidOperationException("Collection modified.");
-        return currentObject;
+        return ($typemap(cstype, T))currentObject;
       }
     }
 

--- a/Lib/java/std_set.i
+++ b/Lib/java/std_set.i
@@ -57,6 +57,10 @@ class set {
     return sizeImpl();
   }
 
+  public boolean add($typemap(jboxtype, T) key) {
+    return addImpl(key);
+  }
+
   public boolean addAll(java.util.Collection<? extends $typemap(jboxtype, T)> collection) {
     boolean didAddElement = false;
     for (java.lang.Object object : collection) {
@@ -172,7 +176,7 @@ class set {
       %fragment("SWIG_SetSize");
 
       // Returns whether item was inserted.
-      bool add(const T& key) {
+      bool addImpl(const T& key) {
         return self->insert(key).second;
       }
 


### PR DESCRIPTION
This takes care of the issues discussed in #1568.

The changes here are pretty simple and minimal.