### PR TITLE
Fix missing value for first item of enums with trailing comma

### DIFF
--- a/Examples/test-suite/java/java_enums_runme.java
+++ b/Examples/test-suite/java/java_enums_runme.java
@@ -13,6 +13,12 @@ public class java_enums_runme implements stuff {
 
   public static void main(String argv[]) 
   {
+      if (WithTrailingComma.Second != 1)
+          throw new RuntimeException("Incorrect value for Second");
+
+      if (WithTrailingCommaAndIgnoredFirstItem.SecondNonIgnoredOne != 2)
+          throw new RuntimeException("Incorrect value for SecondNonIgnoredOne");
+
       int number = 200;
 
       // Switch statement will only compile if these enums are initialised 

--- a/Examples/test-suite/java_enums.i
+++ b/Examples/test-suite/java_enums.i
@@ -18,6 +18,21 @@ import java.io.*; // For Serializable
 // Set default Java const code generation
 %javaconst(1);
 
+// Test enums with trailing comma after the last item.
+enum WithTrailingComma
+{
+    First,
+    Second,
+};
+
+%ignore ReallyFirstOneIsIgnored;
+enum WithTrailingCommaAndIgnoredFirstItem
+{
+    ReallyFirstOneIsIgnored,
+    FirstNonIgnoredOne,
+    SecondNonIgnoredOne,
+};
+
 // Change the default generation so that these enums are generated into an interface instead of a class
 %typemap(javaclassmodifiers) enum stuff "public interface"
 

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -6375,6 +6375,12 @@ optional_ignored_defines
 		;
 
 /* Enum lists - any #define macros (constant directives) within the enum list are ignored. Trailing commas accepted. */
+
+/*
+   Note that "_last" attribute is not supposed to be set on the last enum element, as might be expected from its name, but on the _first_ one, and _only_ on it,
+   so we propagate it back to the first item while parsing and reset it on all the subsequent ones.
+ */
+
 enumlist	: enumlist_item {
 		  Setattr($1,"_last",$1);
 		  $$ = $1;
@@ -6389,6 +6395,8 @@ enumlist	: enumlist_item {
 		    set_nextSibling($1, $3);
 		    Setattr($1,"_last",Getattr($3,"_last"));
 		    Setattr($3,"_last",NULL);
+		  } else {
+		    Setattr($1,"_last",$1);
 		  }
 		  $$ = $1;
 		}
@@ -6397,6 +6405,8 @@ enumlist	: enumlist_item {
 		    set_nextSibling($1, $4);
 		    Setattr($1,"_last",Getattr($4,"_last"));
 		    Setattr($4,"_last",NULL);
+		  } else {
+		    Setattr($1,"_last",$1);
 		  }
 		  set_comment($1, $3);
 		  $$ = $1;


### PR DESCRIPTION
The value of the first item of an enum with a trailing comma after its
last item was not correctly initialized to 0 any more after the changes
of 74adaa5738368ce473870451422f4a7175b6a736 (see #1515) because "_last"
attribute was not set correctly in this case.

Do set it for the last item when it's followed by a comma too and add
more unit tests checking for this.

Closes #1566.