### PR TITLE
Use PyObject_GC_UnTrack for python >= 3.6

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -117,7 +117,7 @@ SwigPyBuiltin_FunpackSetterClosure (PyObject *obj, PyObject *val, void *closure)
 
 SWIGINTERN void
 SwigPyStaticVar_dealloc(PyDescrObject *descr) {
-  _PyObject_GC_UNTRACK(descr);
+  PyObject_GC_UnTrack(descr);
   Py_XDECREF(PyDescr_TYPE(descr));
   Py_XDECREF(PyDescr_NAME(descr));
   PyObject_GC_Del(descr);


### PR DESCRIPTION
The [PyObject_GC_UnTrack]( https://docs.python.org/3/c-api/gcsupport.html#c._PyObject_GC_UNTRACK) macro got deprecated in 3.6 and finally removed in 3.8. Thus for all python versions >= 3.6 instead used `PyObject_GC_UnTrack`.

Closes issue #1586 