### PR TITLE
Fix invalid code generated for "%constant enum EnumType

### DIFF
--- a/Examples/test-suite/constant_directive.i
+++ b/Examples/test-suite/constant_directive.i
@@ -14,6 +14,11 @@ struct Type1 {
   Type1(int val = 0) : val(val) {}
   int val;
 };
+enum EnumType
+{
+  EnumValue
+};
+EnumType enumValue = EnumValue;
 /* Typedefs for const Type and its pointer */
 typedef const Type1 Type1Const;
 typedef const Type1* Type1Cptr;
@@ -46,3 +51,4 @@ Type1 getType1Instance() { return Type1(111); }
 %constant Type1Cfptr TYPE1CFPTR1DEF_CONSTANT1 = getType1Instance;
 /* Regular constant */
 %constant int TYPE_INT = 0;
+%constant enum EnumType newValue = enumValue;

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1533,7 +1533,7 @@ public:
       if (classname_substituted_flag) {
 	if (SwigType_isenum(t)) {
 	  // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
-	  Printf(constants_code, "(%s)%s.%s();\n", return_type, full_imclass_name, Swig_name_get(getNSpace(), symname));
+	  Printf(constants_code, "(%s)%s.%s();\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
 	} else {
 	  // This handles function pointers using the %constant directive
 	  Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -1633,7 +1633,7 @@ public:
       if (classname_substituted_flag) {
 	if (SwigType_isenum(t)) {
 	  // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
-	  Printf(constants_code, "%s.swigToEnum(%s.%s());\n", return_type, full_imclass_name, Swig_name_get(getNSpace(), symname));
+	  Printf(constants_code, "%s.swigToEnum(%s.%s());\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
 	} else {
 	  // This handles function pointers using the %constant directive
 	  Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));


### PR DESCRIPTION
Previously it generated code like:

```cs
public static readonly LightType DefaultLighttype = (LightType).DefaultLighttype_get();
```