### PR TITLE
Correct %init documentation for C#/Java

### DIFF
--- a/Doc/Manual/SWIG.html
+++ b/Doc/Manual/SWIG.html
@@ -3438,6 +3438,18 @@ initialization on module loading, you could write this:
 %}
 </pre></div>
 
+<p>
+Please note that some language backends (e.g. C# or Java) don't have any
+initialization function, hence you should define a global object performing
+the necessary initialization for them instead:
+</p>
+
+<div class="code"><pre>
+%init %{
+  static struct MyInit { MyInit() { init_variables(); } } myInit;
+%}
+</pre></div>
+
 <H2><a name="SWIG_nn45">5.7 An Interface Building Strategy</a></H2>
 
 


### PR DESCRIPTION
For these languages, %init doesn't inject the code into the
initialization function (because there is none), but just puts it into
the global scope instead.

[skip ci]

---

I initially thought to fix this by generating the wrapper struct automatically, but realized that it would break any existing code. I don't see any backwards compatible way to fix this, so I decided to at least document it.