### PR TITLE
Fix error in generated code for Python in MSVC 2019.

### DIFF
--- a/Lib/python/std_map.i
+++ b/Lib/python/std_map.i
@@ -101,7 +101,7 @@
 %#endif
 	  res = traits_asptr_stdseq<map_type, std::pair<K, T> >::asptr(items, val);
 	} else {
-	  map_type *p;
+	  map_type *p = 0;
 	  swig_type_info *descriptor = swig::type_info<map_type>();
 	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
 	  if (SWIG_IsOK(res) && val)  *val = p;

--- a/Lib/python/std_multimap.i
+++ b/Lib/python/std_multimap.i
@@ -29,7 +29,7 @@
 %#endif
 	  res = traits_asptr_stdseq<std::multimap<K,T>, std::pair<K, T> >::asptr(items, val);
 	} else {
-	  multimap_type *p;
+	  multimap_type *p = 0;
 	  swig_type_info *descriptor = swig::type_info<multimap_type>();
 	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
 	  if (SWIG_IsOK(res) && val)  *val = p;

--- a/Lib/python/std_pair.i
+++ b/Lib/python/std_pair.i
@@ -47,7 +47,7 @@
 	    res = get_pair(first, second, val);
 	  }
 	} else {
-	  value_type *p;
+	  value_type *p = 0;
 	  swig_type_info *descriptor = swig::type_info<value_type>();
 	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
 	  if (SWIG_IsOK(res) && val)  *val = *p;
@@ -104,7 +104,7 @@
 	    res = get_pair(first, second, val);
 	  }
 	} else {
-	  value_type *p;
+	  value_type *p = 0;
 	  swig_type_info *descriptor = swig::type_info<value_type>();
 	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
 	  if (SWIG_IsOK(res) && val)  *val = p;

--- a/Lib/python/std_unordered_map.i
+++ b/Lib/python/std_unordered_map.i
@@ -87,7 +87,7 @@
 %#endif
 	  res = traits_asptr_stdseq<std::unordered_map<K,T,Hash,Compare,Alloc>, std::pair<K, T> >::asptr(items, val);
 	} else {
-	  unordered_map_type *p;
+	  unordered_map_type *p = 0;
 	  swig_type_info *descriptor = swig::type_info<unordered_map_type>();
 	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
 	  if (SWIG_IsOK(res) && val)  *val = p;

--- a/Lib/python/std_unordered_multimap.i
+++ b/Lib/python/std_unordered_multimap.i
@@ -36,7 +36,7 @@
 %#endif
 	  res = traits_asptr_stdseq<std::unordered_multimap<K,T,Hash,Compare,Alloc>, std::pair<K, T> >::asptr(items, val);
 	} else {
-	  unordered_multimap_type *p;
+	  unordered_multimap_type *p = 0;
 	  swig_type_info *descriptor = swig::type_info<unordered_multimap_type>();
 	  res = descriptor ? SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0) : SWIG_ERROR;
 	  if (SWIG_IsOK(res) && val)  *val = p;


### PR DESCRIPTION
Visual Studio 2019 release builds:
error C4703: potentially uninitialized local pointer variable 'p' used