### PR TITLE
Extend std::auto_ptr<> support to Ruby

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.1 (21 Aug 2019)
 ===========================
 
+2019-09-09: vadz
+            [Ruby] Add std::auto_ptr<> typemaps.
+
 2019-08-20: TekuConcept
             [Javascript] #1535 Add %native support to Javascript.
 

--- a/Examples/test-suite/li_std_auto_ptr.i
+++ b/Examples/test-suite/li_std_auto_ptr.i
@@ -12,7 +12,7 @@
 #endif
 %}
 
-#if defined(SWIGCSHARP) || defined(SWIGJAVA) || defined(SWIGPYTHON)
+#if defined(SWIGCSHARP) || defined(SWIGJAVA) || defined(SWIGPYTHON) || defined(SWIGRUBY)
 
 %include "std_auto_ptr.i"
 

--- a/Examples/test-suite/ruby/li_std_auto_ptr_runme.rb
+++ b/Examples/test-suite/ruby/li_std_auto_ptr_runme.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require 'swig_assert'
+
+require 'li_std_auto_ptr'
+
+k1 = Li_std_auto_ptr::makeKlassAutoPtr("first")
+k2 = Li_std_auto_ptr::makeKlassAutoPtr("second")
+swig_assert_equal_simple(Li_std_auto_ptr::Klass::getTotal_count(), 2)
+
+k1 = nil
+GC.start
+
+# GC can need a few runs to actually collect the object.
+100.times do ||
+  next if Li_std_auto_ptr::Klass::getTotal_count() == 2
+
+  swig_assert_equal_simple(Li_std_auto_ptr::Klass::getTotal_count(), 1)
+  break
+end
+
+swig_assert_equal_simple(k2.getLabel(), "second")
+
+if Li_std_auto_ptr::Klass::getTotal_count() != 1
+  STDERR.puts "GC failed to collect the first object, count still #{Li_std_auto_ptr::Klass::getTotal_count()}"
+
+  # Skip the rest of the test as it's not going to work correctly anyhow.
+  exit
+end
+
+k2 = nil
+GC.start
+
+100.times do ||
+  next if Li_std_auto_ptr::Klass::getTotal_count() == 1
+
+  swig_assert_equal_simple(Li_std_auto_ptr::Klass::getTotal_count(), 0)
+  break
+end
+
+if Li_std_auto_ptr::Klass::getTotal_count() != 0
+  STDERR.puts "GC failed to collect the second object, count still #{Li_std_auto_ptr::Klass::getTotal_count()}"
+end

--- a/Lib/ruby/std_auto_ptr.i
+++ b/Lib/ruby/std_auto_ptr.i
@@ -1,0 +1,17 @@
+/*
+    The typemaps here allow to handle functions returning std::auto_ptr<>,
+    which is the most common use of this type. If you have functions taking it
+    as parameter, these typemaps can't be used for them and you need to do
+    something else (e.g. use shared_ptr<> which SWIG supports fully).
+ */
+
+%define %auto_ptr(TYPE)
+%typemap (out) std::auto_ptr<TYPE > %{
+   %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
+%}
+%template() std::auto_ptr<TYPE >;
+%enddef
+
+namespace std {
+   template <class T> class auto_ptr {};
+}


### PR DESCRIPTION
This is trivial as exactly the same typemap as for Python can be used
for Ruby too, all the differenced are abstracted by the unified typemap
library.

---

I don't know if it's better to copy the file or add a common file included from both Python and Ruby files. I'd prefer the latter, but `shared_ptr` typemaps are present in both languages directories, in spite of being 99% identical, so I did the same thing for this one too.