### PR TITLE
Octave: remove use of ppa:kwwette/octaves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -322,11 +322,6 @@ matrix:
       env: SWIGLANG=java CPP11=1
       sudo: required
       dist: xenial
-    - compiler: gcc
-      os: linux
-      env: SWIGLANG=octave SWIGJOBS=-j2 VER=4.4 CPP11=1
-      sudo: required
-      dist: trusty
     - os: linux
       env: SWIGLANG=python CPP11=1
       sudo: required

--- a/Tools/travis-linux-install.sh
+++ b/Tools/travis-linux-install.sh
@@ -71,21 +71,7 @@ case "$SWIGLANG" in
 		travis_retry sudo apt-get -qq install ocaml camlp4
 		;;
 	"octave")
-		if [[ -z "$VER" ]]; then
-			travis_retry sudo apt-get -qq install liboctave-dev
-		else
-			# Travis adds external PPAs which contain newer versions of packages
-			# than in baseline trusty. These newer packages prevent some of the
-			# Octave packages in ppa:kwwette/octave, which rely on the older
-			# packages in trusty, from installing. To prevent these kind of
-			# interactions arising, clean out all external PPAs added by Travis
-			# before installing Octave
-			sudo rm -rf /etc/apt/sources.list.d/*
-			travis_retry sudo apt-get -qq update
-			travis_retry sudo add-apt-repository -y ppa:kwwette/octaves
-			travis_retry sudo apt-get -qq update
-			travis_retry sudo apt-get -qq install liboctave${VER}-dev
-		fi
+		travis_retry sudo apt-get -qq install liboctave-dev
 		;;
 	"php")
 		travis_retry sudo add-apt-repository -y ppa:ondrej/php


### PR DESCRIPTION
This removes use of my PPA `kwwette/octaves` from the SWIG Travis build, as I'm not sure I'll be keeping that PPA into the future. I've simply deleted the one Octave entry in the build matrix that uses the PPA to build against Octave 4.4. None of the supported (by Travis) Ubuntu platforms have Octave 4.4, but it looks like the remaining 2 Octave entries in the build matrix test against Octave 4.0 (on Ubuntu Xenial), and Octave 5.x (on MacOSX using HomeBrew) which hopefully is sufficient coverage.