### PR TITLE
Add keys() method to JavaScript wrappers of std::map

### DIFF
--- a/Examples/test-suite/javascript/li_std_map_runme.js
+++ b/Examples/test-suite/javascript/li_std_map_runme.js
@@ -1,0 +1,36 @@
+var li_std_map = require("li_std_map");
+
+var collectionSize = 20;
+var midCollection = collectionSize / 2;
+
+// Set up an string to int map
+var simap = new li_std_map.StringIntMap();
+for (var i = 0; i < collectionSize; i++) {
+    var val = i * 18;
+    simap.set(i.toString(), val);
+}
+
+if (simap.size() != collectionSize)
+    throw "Size test failed";
+
+// Item indexing test
+simap.set("0", 200);
+if (simap.get("0") != 200)
+    throw "Item property test failed";
+simap.set("0", 0 * 18);
+
+// Key presence test
+for (var i = 0; i < collectionSize; i++) {
+    if (!simap.has_key(i.toString()))
+        throw "has_key test " + i + " failed";
+}
+
+// Delete test
+simap.del("7");
+if (simap.has_key("7"))
+    throw "Delete test failed";
+
+// Clear test
+simap.clear();
+if (simap.size() != 0)
+    throw "Clear test failed";

--- a/Examples/test-suite/javascript/li_std_map_runme.js
+++ b/Examples/test-suite/javascript/li_std_map_runme.js
@@ -34,3 +34,14 @@ if (simap.has_key("7"))
 simap.clear();
 if (simap.size() != 0)
     throw "Clear test failed";
+
+// Custom compare function
+var slmap = new li_std_map.StringLengthNumberMap();
+li_std_map.populate(slmap);
+
+var keys = slmap.keys();
+var keys_array = [];
+for (var i = 0; i < keys.size(); i++)
+    keys_array.push(keys.get(i));
+if (keys_array.join(" ") != "a aa zzz xxxx aaaaa")
+    throw "Keys are wrong or in wrong order: " + keys_array;

--- a/Examples/test-suite/li_std_map.i
+++ b/Examples/test-suite/li_std_map.i
@@ -131,6 +131,11 @@ struct LengthCompare {
 %}
 
 // A map sorted by string lengths
+
+// Wrap the vector returned by JavaScript keys() method.
+#ifdef SWIGJAVASCRIPT
+%template(StringVector) std::vector< std::string >;
+#endif
 %template(StringLengthNumberMap) std::map< std::string, int, LengthCompare >;
 
 %inline %{

--- a/Lib/javascript/jsc/std_map.i
+++ b/Lib/javascript/jsc/std_map.i
@@ -67,6 +67,7 @@ namespace std {
             }
             std::vector<K> keys() {
                 std::vector<K> keys;
+                keys.reserve(self->size());
                 for (std::map<  K, T, C >::iterator it = self->begin(); it != self->end(); ++it) {
                     keys.push_back(it->first);
                 }

--- a/Lib/javascript/jsc/std_map.i
+++ b/Lib/javascript/jsc/std_map.i
@@ -6,6 +6,8 @@
 
 %include <std_common.i>
 
+%include <std_vector.i>
+
 // ------------------------------------------------------------------------
 // std::map
 // ------------------------------------------------------------------------
@@ -14,6 +16,7 @@
 #include <map>
 #include <algorithm>
 #include <stdexcept>
+#include <vector>
 %}
 
 // exported class
@@ -61,6 +64,13 @@ namespace std {
             bool has_key(const K& key) {
                 std::map< K, T, C >::iterator i = self->find(key);
                 return i != self->end();
+            }
+            std::vector<K> keys() {
+                std::vector<K> keys;
+                for (std::map<  K, T, C >::iterator it = self->begin(); it != self->end(); ++it) {
+                    keys.push_back(it->first);
+                }
+                return keys;
             }
         }
     };

--- a/Lib/javascript/v8/std_map.i
+++ b/Lib/javascript/v8/std_map.i
@@ -6,6 +6,8 @@
 
 %include <std_common.i>
 
+%include <std_vector.i>
+
 // ------------------------------------------------------------------------
 // std::map
 // ------------------------------------------------------------------------
@@ -14,6 +16,7 @@
 #include <map>
 #include <algorithm>
 #include <stdexcept>
+#include <vector>
 %}
 
 // exported class
@@ -60,6 +63,13 @@ namespace std {
             bool has_key(const K& key) {
                 std::map< K, T, C >::iterator i = self->find(key);
                 return i != self->end();
+            }
+            std::vector<K> keys() {
+                std::vector<K> keys;
+                for (std::map<  K, T, C >::iterator it = self->begin(); it != self->end(); ++it) {
+                    keys.push_back(it->first);
+                }
+                return keys;
             }
         }
     };

--- a/Lib/javascript/v8/std_map.i
+++ b/Lib/javascript/v8/std_map.i
@@ -66,6 +66,7 @@ namespace std {
             }
             std::vector<K> keys() {
                 std::vector<K> keys;
+                keys.reserve(self->size());
                 for (std::map<  K, T, C >::iterator it = self->begin(); it != self->end(); ++it) {
                     keys.push_back(it->first);
                 }


### PR DESCRIPTION
As the commit message explains, this is very far from ideal, but then std containers typemaps for JS are in a rather sorry state. I don't have the possibility to change them all, unfortunately, but at least adding this method makes `map` usable in JS as previously it was simply impossible to find which elements it contained.