### PR TITLE
Add minimal std::auto_ptr<> typemaps to JavaScript too

### DIFF
--- a/Examples/test-suite/javascript/li_std_auto_ptr_runme.js
+++ b/Examples/test-suite/javascript/li_std_auto_ptr_runme.js
@@ -1,0 +1,28 @@
+var li_std_auto_ptr = require("li_std_auto_ptr");
+
+var k1 = li_std_auto_ptr.makeKlassAutoPtr("first");
+if (k1.getLabel() != "first")
+    throw "wrong object label";
+
+var k2 = li_std_auto_ptr.makeKlassAutoPtr("second");
+if (li_std_auto_ptr.Klass.getTotal_count() != 2)
+    throw "number of objects should be 2";
+
+var k3 = li_std_auto_ptr.makeKlassAutoPtr("second");
+if (li_std_auto_ptr.Klass.getTotal_count() != 3)
+    throw "number of objects should be 3";
+
+k3 = null;
+
+// Generally speaking we have no way of triggering garbage collection in JS, so we can't be sure the object is going to be really deleted. Check for it just in
+// one particular case of running node with --expose-gc option.
+if (typeof(global) !== "undefined" && global.gc) {
+    global.gc();
+    if (li_std_auto_ptr.Klass.getTotal_count() != 2)
+        throw "number of objects should be 2 and not " + li_std_auto_ptr.Klass.getTotal_count().toString();
+
+    k2 = k1 = null;
+    global.gc();
+    if (li_std_auto_ptr.Klass.getTotal_count())
+        throw li_std_auto_ptr.Klass.getTotal_count().toString() + " object(s) unexpectedly remain";
+}

--- a/Examples/test-suite/li_std_auto_ptr.i
+++ b/Examples/test-suite/li_std_auto_ptr.i
@@ -12,7 +12,7 @@
 #endif
 %}
 
-#if defined(SWIGCSHARP) || defined(SWIGJAVA) || defined(SWIGPYTHON)
+#if defined(SWIGCSHARP) || defined(SWIGJAVA) || defined(SWIGPYTHON) || defined(SWIGJAVASCRIPT)
 
 %include "std_auto_ptr.i"
 

--- a/Lib/javascript/jsc/std_auto_ptr.i
+++ b/Lib/javascript/jsc/std_auto_ptr.i
@@ -1,0 +1,18 @@
+/*
+    The typemaps here allow to handle functions returning std::auto_ptr<>,
+    which is the most common use of this type. If you have functions taking it
+    as parameter, these typemaps can't be used for them and you need to do
+    something else (e.g. use shared_ptr<> which SWIG supports fully).
+ */
+
+%define %auto_ptr(TYPE)
+
+%typemap (out) std::auto_ptr<TYPE > %{
+   %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
+%}
+%template() std::auto_ptr<TYPE >;
+%enddef
+
+namespace std {
+   template <class T> class auto_ptr {};
+}

--- a/Lib/javascript/v8/std_auto_ptr.i
+++ b/Lib/javascript/v8/std_auto_ptr.i
@@ -1,0 +1,18 @@
+/*
+    The typemaps here allow to handle functions returning std::auto_ptr<>,
+    which is the most common use of this type. If you have functions taking it
+    as parameter, these typemaps can't be used for them and you need to do
+    something else (e.g. use shared_ptr<> which SWIG supports fully).
+ */
+
+%define %auto_ptr(TYPE)
+
+%typemap (out) std::auto_ptr<TYPE > %{
+   %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
+%}
+%template() std::auto_ptr<TYPE >;
+%enddef
+
+namespace std {
+   template <class T> class auto_ptr {};
+}


### PR DESCRIPTION
Allow returning auto_ptr<> from wrapped functions.

Add a unit test checking minimal functionality and, if running under
"nodejs --expose-gc", that the objects are destroyed correctly.