### PR TITLE
Fix for Issue #1643

### DIFF
--- a/Examples/test-suite/doxygen_basic_translate.i
+++ b/Examples/test-suite/doxygen_basic_translate.i
@@ -108,6 +108,20 @@ double Atan2(double y, double x)
 }
 
 /**
+ * @brief Test variadic function
+ * @param ... extra args
+ */
+void function8(...) {
+}
+
+/**
+ * @brief Test unnamed argument
+ * @param baz Description of baz
+ */
+void function9(int) {
+} 
+
+/**
  * Comment at the end of file should be ignored.
  */
 %}

--- a/Examples/test-suite/java/doxygen_basic_translate_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_runme.java
@@ -94,6 +94,13 @@ public class doxygen_basic_translate_runme {
     		" @param x Horizontal coordinate.\n" +
     		" @return Arc tangent of <code>y/x</code>.\n" +
     		"");
+    wantedComments.put("doxygen_basic_translate.doxygen_basic_translate.function8()",
+		" Test variadic function\n" +
+		"");
+
+    wantedComments.put("doxygen_basic_translate.doxygen_basic_translate.function9(int)",
+		" Test unnamed argument\n" +
+		"");    
 
     // and ask the parser to check comments for us
     System.exit(parser.check(wantedComments));

--- a/Examples/test-suite/python/doxygen_basic_translate_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_runme.py
@@ -70,6 +70,16 @@ Test for a parameter with difficult type
 :type a: :py:class:`Shape`
 :param a: Very strange param"""
 )
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate.function8),
+    """\
+Test variadic function
+:param ...: extra args"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate.function9),
+    """\
+Test unnamed argument
+:param baz: Description of baz"""
+)
 
 comment_verifier.check(inspect.getdoc(doxygen_basic_translate.Atan2),
     """\

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -418,11 +418,10 @@ std::string PyDocConverter::getParamType(std::string param) {
   ParmList *plist = CopyParmList(Getattr(currentNode, "parms"));
   for (Parm *p = plist; p; p = nextSibling(p)) {
     String *pname = Getattr(p, "name");
-    if (Char(pname) != param)
-      continue;
-
-    type = getPyDocType(p, pname);
-    break;
+    if (pname && Char(pname) == param) {
+      type = getPyDocType(p, pname);
+      break;
+    }
   }
   Delete(plist);
   return type;


### PR DESCRIPTION
Fixes Issue #1643, in which swig -doxygen would segfault when processing a doxygen comment for a parameter whose name does not appear in the actual argument list.  Test cases have been added to doxygen_basic_translate.i, and expected output updated for Python and Java.