### PR TITLE
Fix newline handling for doxygen "///" comments

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -622,6 +622,7 @@ DOXYGEN_TEST_CASES += \
 	doxygen_basic_notranslate \
 	doxygen_basic_translate \
 	doxygen_basic_translate_style2 \
+	doxygen_basic_translate_style3 \
 	doxygen_ignore \
 	doxygen_misc_constructs \
 	doxygen_nested_class \

--- a/Examples/test-suite/doxygen_basic_translate_style3.i
+++ b/Examples/test-suite/doxygen_basic_translate_style3.i
@@ -1,0 +1,95 @@
+%module doxygen_basic_translate_style3
+
+%include "doxygen_basic_translate.h"
+
+%inline %{
+
+/// \brief
+/// Brief description.
+///
+/// The comment text.
+///
+/// \author Some author
+///
+/// \return Some number
+///
+/// \sa function2
+int function()
+{
+    return 0;
+}
+
+/// A test of a very very very very very very very very very very very very very very very very
+/// very very very very very long comment string.
+void function2()
+{
+}
+
+/// A test for overloaded functions
+/// This is function \b one
+void function3(int a)
+{
+}
+
+/// A test for overloaded functions
+/// This is function \b two
+void function3(int a, int b)
+{
+}
+
+/// A test of some mixed tag usage
+/// \if CONDITION
+/// This \a code fragment shows us something \.
+/// \par Minuses:
+/// \arg it's senseless
+/// \arg it's stupid
+/// \arg it's null
+///
+/// \warning This may not work as expected
+/// \code
+/// int main() { while(true); }
+///
+/// // Test blank line in code block
+/// \endcode
+/// \endif
+void function4()
+{
+}
+
+
+void function5(int a)
+{
+}
+///< This is a post comment.
+
+/// Test for default args
+/// @param a Some parameter, default is 42
+void function6(int a=42)
+{
+}
+
+class Shape
+{
+public:
+  typedef Shape* superType;
+};
+
+/// Test for a parameter with difficult type
+/// (mostly for python)
+/// @param a Very strange param
+void function7(Shape::superType *a[10])
+{
+}
+
+/// Multiple parameters test.
+///
+/// @param y Vertical coordinate.
+/// @param x Horizontal coordinate.
+/// @return Arc tangent of @c y/x.
+double Atan2(double y, double x)
+{
+    return 0;
+}
+
+/// Comment at the end of file should be ignored.
+%}

--- a/Examples/test-suite/doxygen_basic_translate_style3.i
+++ b/Examples/test-suite/doxygen_basic_translate_style3.i
@@ -49,11 +49,18 @@ void function3(int a, int b)
 /// \code
 /// int main() { while(true); }
 ///
-/// // Test blank line in code block
+/// int testBlankLine() {}
 /// \endcode
 /// \endif
 void function4()
 {
+  // Note: a comment in the above code block will not get processed
+  // correctly with this doxygen comment style, because
+  // DoxygenParser::tokenizeDoxygenComment strips out the leading
+  // comment characters.  Whereas it works in the other doxygen
+  // comment styles (as shown in the other variations of
+  // doxygen_basic_translate), this test is modified to remove the
+  // comment within the code block.
 }
 
 

--- a/Examples/test-suite/java/doxygen_basic_translate_style3_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_style3_runme.java
@@ -55,7 +55,7 @@ public class doxygen_basic_translate_style3_runme {
     		" {@code \n" +
     		"int main() { while(true); } \n" +
 		"\n" +
-		"// Test blank line in code block \n" +
+		"int testBlankLine() {} \n" +
     		" }\n" +
     		" }\n" +
     		" \n" +

--- a/Examples/test-suite/java/doxygen_basic_translate_style3_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_style3_runme.java
@@ -1,0 +1,101 @@
+
+import doxygen_basic_translate_style3.*;
+import com.sun.javadoc.*;
+import java.util.HashMap;
+
+public class doxygen_basic_translate_style3_runme {
+  static {
+    try {
+      System.loadLibrary("doxygen_basic_translate_style3");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+  
+  public static void main(String argv[]) 
+  {
+    /*
+      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
+      and calls the start() method of that class with parsed information.
+    */
+    CommentParser parser = new CommentParser();
+    com.sun.tools.javadoc.Main.execute("doxygen_basic_translate_style3 runtime test",
+                                       "CommentParser",
+                                       new String[]{"-quiet", "doxygen_basic_translate_style3"});
+
+    HashMap<String, String> wantedComments = new HashMap<String, String>();
+    
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function()",
+    		" \n" +
+    		" Brief description.\n" +
+    		" \n" +
+    		" The comment text.\n" +
+    		" @author Some author\n" +
+    		" @return Some number\n" +
+    		" @see function2\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function2()",
+    		" A test of a very very very very very very very very very very very very very very very very \n" +
+    		" very very very very very long comment string. \n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function4()",
+    		" A test of some mixed tag usage \n" +
+    		" If: CONDITION {\n" +
+    		" This <i>code </i>fragment shows us something . \n" +
+    		" <p alt=\"Minuses: \">\n" +
+    		" <li>it's senseless \n" +
+    		" </li><li>it's stupid \n" +
+    		" </li><li>it's null \n" +
+    		" \n" +
+    		" </li></p>Warning: This may not work as expected \n" +
+    		" \n" +
+    		" {@code \n" +
+    		"int main() { while(true); } \n" +
+		"\n" +
+		"// Test blank line in code block \n" +
+    		" }\n" +
+    		" }\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function3(int)",
+    		" A test for overloaded functions \n" +
+    		" This is function <b>one </b>\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function5(int)",
+    		" This is a post comment. \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function6(int)",
+    		" Test for default args \n" +
+    		" @param a Some parameter, default is 42" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function6()",
+    		" Test for default args \n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function7(doxygen_basic_translate_style3.SWIGTYPE_p_p_p_Shape)",
+    		" Test for a parameter with difficult type \n" +
+    		" (mostly for python) \n" +
+    		" @param a Very strange param \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.function3(int, int)",
+    		" A test for overloaded functions \n" +
+    		" This is function <b>two </b>\n" +
+    		" \n" +
+    		"");
+    wantedComments.put("doxygen_basic_translate_style3.doxygen_basic_translate_style3.Atan2(double, double)",
+    		" Multiple parameters test.\n" +
+    		" \n" +
+    		" @param y Vertical coordinate.\n" +
+    		" @param x Horizontal coordinate.\n" +
+    		" @return Arc tangent of <code>y/x</code>.\n" +
+    		"");
+
+    // and ask the parser to check comments for us
+    System.exit(parser.check(wantedComments));
+  }
+}

--- a/Examples/test-suite/python/doxygen_basic_translate_style3_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style3_runme.py
@@ -49,7 +49,7 @@ Warning: This may not work as expected
 
     int main() { while(true); }
 
-    // Test blank line in code block
+    int testBlankLine() {}
 }"""
 )
 comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function5),

--- a/Examples/test-suite/python/doxygen_basic_translate_style3_runme.py
+++ b/Examples/test-suite/python/doxygen_basic_translate_style3_runme.py
@@ -1,0 +1,82 @@
+import doxygen_basic_translate_style3
+import inspect
+import string
+import sys
+import comment_verifier
+
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function),
+    """\
+Brief description.
+
+The comment text.
+
+Author: Some author
+
+:rtype: int
+:return: Some number
+
+See also: function2"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function2),
+    """\
+A test of a very very very very very very very very very very very very very very very very
+very very very very very long comment string."""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function3),
+    """*Overload 1:*
+A test for overloaded functions
+This is function **one**
+
+|
+
+*Overload 2:*
+A test for overloaded functions
+This is function **two**"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function4),
+    """\
+A test of some mixed tag usage
+If: CONDITION {
+This *code* fragment shows us something .
+Title: Minuses:
+* it\'s senseless
+* it\'s stupid
+* it\'s null
+
+Warning: This may not work as expected
+
+.. code-block:: c++
+
+    int main() { while(true); }
+
+    // Test blank line in code block
+}"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function5),
+    """This is a post comment."""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function6),
+    """\
+Test for default args
+:type a: int
+:param a: Some parameter, default is 42"""
+)
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.function7),
+    """\
+Test for a parameter with difficult type
+(mostly for python)
+:type a: :py:class:`Shape`
+:param a: Very strange param"""
+)
+
+comment_verifier.check(inspect.getdoc(doxygen_basic_translate_style3.Atan2),
+    """\
+Multiple parameters test.
+
+:type y: float
+:param y: Vertical coordinate.
+:type x: float
+:param x: Horizontal coordinate.
+:rtype: float
+:return: Arc tangent of ``y/x``."""
+)

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -433,6 +433,19 @@ static int yylook(void) {
 	    Scanner_locator(scan, cmt);
 	  }
 	  if (scan_doxygen_comments) { /* else just skip this node, to avoid crashes in parser module*/
+
+	    int slashStyle = 0; /* Flag for "///" style doxygen comments */
+	    if (strncmp(loc, "///", 3) == 0) {
+	      slashStyle = 1;
+	      if (Len(cmt) == 3) {
+		/* Modify to make length=4 to ensure that the empty comment does
+		   get processed to preserve the newlines in the original
+		   comments. */
+		cmt = NewStringf("%s ", cmt);
+		loc = Char(cmt);
+	      }
+	    }
+	    
 	    /* Check for all possible Doxygen comment start markers while ignoring
 	       comments starting with a row of asterisks or slashes just as
 	       Doxygen itself does. */
@@ -461,6 +474,13 @@ static int yylook(void) {
 		  Setline(yylval.str, Scanner_start_line(scan));
 		  Setfile(yylval.str, Scanner_file(scan));
 		} else {
+		  if (slashStyle) {
+		    /* Add a newline to the end of each doxygen "///" comment,
+		       since they are processed individually, unlike the
+		       slash-star style, which gets processed as a block with
+		       newlines included. */
+		    Append(yylval.str, "\n");
+		  }
 		  Append(yylval.str, str);
 		}
 


### PR DESCRIPTION
Fix for Issue #1632.  Newlines were not handled correctly when processing doxygen `///` style comments.  Unlike the other styles, the scanner processes each line individually, which results in all of the newlines being stripped out.  The fix adds newlines back in for the comments as they are processed in `cscanner.c`.  A new test case, `doxygen_basic_translate_style3.i` has also been added, mirroring that of the other two supported comment styles.

Previously, the following:
```
/// Test for a parameter with difficult type
/// (mostly for python)
/// @param a Very strange param
void function7(Shape::superType *a[10])
{
}
```
was translated as:
```
Test for a parameter with difficult type (mostly for python) :type a: :py:class:`Shape`
:param a: Very strange param
```
After this fix, it is translated as:
```
Test for a parameter with difficult type
(mostly for python)
:type a: :py:class:`Shape`
:param a: Very strange param
```

It would be good for someone that is familiar with `cscanner.c` to double-check the logic that I have used to modify the `String *cmt`:
```
cmt = NewStringf("%s ", cmt);
```
There may be a better way to append to a string, and as far as I can tell, there is no API for cleaning up the memory created from such a call (and there doesn't seem to be other such cleanup being done in `cscanner.c` anyway).

There is one edge case that still doesn't work correctly with this comment style, which is the use of comments within a code block.  This is because of the way that comment characters are stripped out of the front of the string in `doxyparser.cxx`.  I have modified the case where this was being tested and added a note about the limitation for future reference (it may be less straightforward to address).
