### PR TITLE
Some progress on issue #1044: Wrap move-only classes

### DIFF
--- a/Examples/test-suite/cpp11_move_only.i
+++ b/Examples/test-suite/cpp11_move_only.i
@@ -32,7 +32,6 @@ public:
 };
 
 // create move only object via factory function
-// this still doesn't work:
-// MoveOnly factory(int v) { return MoveOnly(v); }
+MoveOnly factory(int v) { return MoveOnly(v); }
 
 %}

--- a/Examples/test-suite/cpp11_move_only.i
+++ b/Examples/test-suite/cpp11_move_only.i
@@ -1,0 +1,38 @@
+/* Check that C++11 move-only objects can be returned by value. */
+%module cpp11_move_only
+
+%inline %{
+#include <utility>
+%}
+
+
+%inline %{
+using std::swap;
+class MoveOnly
+{
+private:
+  int m_value;
+
+public:
+  MoveOnly &operator=(const MoveOnly &) = delete;
+  MoveOnly(const MoveOnly &) = delete;
+
+  MoveOnly(int v) : m_value(v) {}
+
+  // move constructors which simulate leaving moved-from object in nonsense state.
+  MoveOnly(MoveOnly &&that){*this = std::move(that);}
+  MoveOnly& operator=(MoveOnly &&that){
+    if (this != &that) {
+      std::swap(m_value, that.m_value);
+    }
+    return *this;
+  }
+
+  int value() const {return m_value;}
+};
+
+// create move only object via factory function
+// this still doesn't work:
+// MoveOnly factory(int v) { return MoveOnly(v); }
+
+%}

--- a/Examples/test-suite/cpp11_move_only.i
+++ b/Examples/test-suite/cpp11_move_only.i
@@ -32,6 +32,7 @@ public:
 };
 
 // create move only object via factory function
-MoveOnly factory(int v) { return MoveOnly(v); }
+// this still doesn't work:
+// MoveOnly factory(int v) { return MoveOnly(v); }
 
 %}

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -81,6 +81,7 @@ CPP_TEST_CASES += \
 #	director_profile
 
 CPP11_TEST_CASES = \
+	cpp11_move_only \
 	cpp11_hash_tables \
 	cpp11_shared_ptr_const \
 	cpp11_shared_ptr_nullptr_in_containers \

--- a/Examples/test-suite/python/cpp11_move_only_runme.py
+++ b/Examples/test-suite/python/cpp11_move_only_runme.py
@@ -1,6 +1,7 @@
 import cpp11_move_only
 
-thing = cpp11_move_only.factory(1)
-# Python3 only:
-# assert thing.value == 1, f'{thing.value} != 1'
-assert thing.value == 1, '{} != 1'.format(thing.value)
+thing1 = cpp11_move_only.MoveOnly(1)
+assert thing1.value() == 1, '{} != 1'.format(thing.value)
+
+# thing2 = cpp11_move_only.factory(1)
+# assert thing2.value() == 1, '{} != 1'.format(thing.value)

--- a/Examples/test-suite/python/cpp11_move_only_runme.py
+++ b/Examples/test-suite/python/cpp11_move_only_runme.py
@@ -1,0 +1,6 @@
+import cpp11_move_only
+
+thing = cpp11_move_only.factory(1)
+# Python3 only:
+# assert thing.value == 1, f'{thing.value} != 1'
+assert thing.value == 1, '{} != 1'.format(thing.value)

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -660,6 +660,8 @@ namespace std {
 #ifdef __cplusplus
 %insert("runtime") %{
 #ifdef __cplusplus
+#include <utility>
+
 /* SwigValueWrapper is described in swig.swg */
 template<typename T> class SwigValueWrapper {
   struct SwigMovePointer {
@@ -673,7 +675,14 @@ template<typename T> class SwigValueWrapper {
 public:
   SwigValueWrapper() : pointer(0) { }
   SwigValueWrapper& operator=(const T& t) { SwigMovePointer tmp(new T(t)); pointer = tmp; return *this; }
-  operator T&() const { return *pointer.ptr; }
+  SwigValueWrapper& operator=(T&& t) {
+    if (pointer.ptr != &t) {
+      SwigMovePointer tmp(new T(std::move(t)));
+      pointer = tmp;
+    }
+    return *this;
+  }
+  operator const T&() const { return *pointer.ptr; }
   T *operator&() { return pointer.ptr; }
 };%}
 

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -683,7 +683,6 @@ public:
     return *this;
   }
   operator const T&() const { return *pointer.ptr; }
-  operator T&&() const { return std::move(*pointer.ptr); }
   T *operator&() { return pointer.ptr; }
 };%}
 

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -660,7 +660,9 @@ namespace std {
 #ifdef __cplusplus
 %insert("runtime") %{
 #ifdef __cplusplus
+#if __cplusplus >= 201103L
 #include <utility>
+#endif
 
 /* SwigValueWrapper is described in swig.swg */
 template<typename T> class SwigValueWrapper {
@@ -675,6 +677,7 @@ template<typename T> class SwigValueWrapper {
 public:
   SwigValueWrapper() : pointer(0) { }
   SwigValueWrapper& operator=(const T& t) { SwigMovePointer tmp(new T(t)); pointer = tmp; return *this; }
+#if __cplusplus >= 201103L
   SwigValueWrapper& operator=(T&& t) {
     if (pointer.ptr != &t) {
       SwigMovePointer tmp(new T(std::move(t)));
@@ -682,6 +685,7 @@ public:
     }
     return *this;
   }
+#endif
   operator const T&() const { return *pointer.ptr; }
   T *operator&() { return pointer.ptr; }
 };%}

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -683,6 +683,7 @@ public:
     return *this;
   }
   operator const T&() const { return *pointer.ptr; }
+  operator T&&() const { return std::move(*pointer.ptr); }
   T *operator&() { return pointer.ptr; }
 };%}
 

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -1,12 +1,12 @@
 /* -----------------------------------------------------------------------------
  * swig.swg
  *
- * Common macro definitions for various SWIG directives.  This file is always 
+ * Common macro definitions for various SWIG directives.  This file is always
  * included at the top of each input file.
  * ----------------------------------------------------------------------------- */
 
 /* -----------------------------------------------------------------------------
- * User Directives 
+ * User Directives
  * ----------------------------------------------------------------------------- */
 
 /* Deprecated SWIG-1.1 directives */
@@ -221,7 +221,7 @@
     }
 
 */
-   
+
 %define %aggregate_check(TYPE, NAME, FIRST, ...)
 %wrapper %{
 static int NAME(TYPE x) {
@@ -229,7 +229,7 @@ static int NAME(TYPE x) {
     static  int size = sizeof(values);
     int     i,j;
     for (i = 0, j = 0; i < size; i+=sizeof(TYPE),j++) {
-        if (x == values[j]) return 1; 
+        if (x == values[j]) return 1;
     }
     return 0;
 }
@@ -240,7 +240,7 @@ static int NAME(TYPE x) {
 /* -----------------------------------------------------------------------------
  * %rename predicates
  * ----------------------------------------------------------------------------- */
-/* 
+/*
    Predicates to be used with %rename, for example:
 
    - to rename all the functions:
@@ -268,7 +268,7 @@ static int NAME(TYPE x) {
 
 */
 
-%define %$not            "not" %enddef 
+%define %$not            "not" %enddef
 %define %$isenum         "match"="enum"  %enddef
 %define %$isenumitem     "match"="enumitem"  %enddef
 %define %$isaccess       "match"="access"   %enddef
@@ -401,7 +401,7 @@ static int NAME(TYPE x) {
 
 
 /* -----------------------------------------------------------------------------
- * Default handling of certain overloaded operators 
+ * Default handling of certain overloaded operators
  * ----------------------------------------------------------------------------- */
 
 #ifdef __cplusplus
@@ -601,8 +601,8 @@ namespace std {
 
 /*  The SwigValueWrapper class  */
 
-/*  
- * This template wrapper is used to handle C++ objects that are passed or 
+/*
+ * This template wrapper is used to handle C++ objects that are passed or
  * returned by value.   This is necessary to handle objects that define
  * no default-constructor (making it difficult for SWIG to properly declare
  * local variables).
@@ -611,7 +611,7 @@ namespace std {
  *
  *      Vector cross_product(Vector a, Vector b)
  *
- * Now, if Vector is defined as a C++ class with no default constructor, 
+ * Now, if Vector is defined as a C++ class with no default constructor,
  * code is generated as follows:
  *
  *     Vector *wrap_cross_product(Vector *inarg1, Vector *inarg2) {
@@ -621,16 +621,16 @@ namespace std {
  *
  *          arg1 = *inarg1;
  *          arg2 = *inarg2;
- *          ...            
+ *          ...
  *          result = cross_product(arg1,arg2);
  *          ...
  *          return new Vector(result);
  *    }
- *         
+ *
  * In the wrappers, the template SwigValueWrapper simply provides a thin
  * layer around a Vector *.  However, it does this in a way that allows
  * the object to be bound after the variable declaration (which is not possible
- * with the bare object when it lacks a default constructor).  
+ * with the bare object when it lacks a default constructor).
  *
  * An observant reader will notice that the code after the variable declarations
  * is *identical* to the code used for classes that do define default constructors.
@@ -647,10 +647,10 @@ namespace std {
  * might be assigned.  For example:
  *
  *       arg1 = *inarg1;       // Assignment from a pointer
- *       arg1 = Vector(1,2,3); // Assignment from a value  
+ *       arg1 = Vector(1,2,3); // Assignment from a value
  *
  * The class offers a strong guarantee of exception safety.
- * With regards to the implementation, the private SwigMovePointer nested class is 
+ * With regards to the implementation, the private SwigMovePointer nested class is
  * a simple smart pointer with move semantics, much like std::auto_ptr.
  *
  * This wrapping technique was suggested by William Fulton and is henceforth
@@ -692,11 +692,11 @@ public:
 
 /*
  * SwigValueInit() is a generic initialisation solution as the following approach:
- * 
+ *
  *       T c_result = T();
- * 
+ *
  * doesn't compile for all types for example:
- * 
+ *
  *       unsigned int c_result = unsigned int();
  */
 %insert("runtime") %{

--- a/Lib/typemaps/swigmacros.swg
+++ b/Lib/typemaps/swigmacros.swg
@@ -142,18 +142,8 @@ nocppval
 %insert("header") {
 %define_as(SWIG_as_voidptr(a),    %const_cast(%static_cast(a,const void *), void *))
 %define_as(SWIG_as_voidptrptr(a), ((void)%as_voidptr(*a),%reinterpret_cast(a, void**)))
-
-template <class O, class N>
-N* new_copy(O& old) {
-  return new N(%static_cast(old, N&&));
 }
 
-template <class O, class N>
-N* new_copy(const O& old) {
-  return new N(%static_cast(old, const N&));
-}
-
-}
 
 /* -----------------------------------------------------------------------------
  * Allocating/freeing elements
@@ -161,7 +151,7 @@ N* new_copy(const O& old) {
 
 #if defined(__cplusplus)
 # define %new_instance(Type...)             (new Type())
-# define %new_copy(val,Type...)             (new_copy<decltype(val), Type>(val))
+# define %new_copy(val,Type...)             (new Type(%static_cast(val, const Type&)))
 # define %new_array(size,Type...)           (new Type[size]())
 # define %new_copy_array(ptr,size,Type...)  %reinterpret_cast(memcpy(new Type[size], ptr, sizeof(Type)*(size)), Type*)
 # define %delete(cptr)                      delete cptr

--- a/Lib/typemaps/swigmacros.swg
+++ b/Lib/typemaps/swigmacros.swg
@@ -142,8 +142,18 @@ nocppval
 %insert("header") {
 %define_as(SWIG_as_voidptr(a),    %const_cast(%static_cast(a,const void *), void *))
 %define_as(SWIG_as_voidptrptr(a), ((void)%as_voidptr(*a),%reinterpret_cast(a, void**)))
+
+template <class O, class N>
+N* new_copy(O& old) {
+  return new N(%static_cast(old, N&&));
 }
 
+template <class O, class N>
+N* new_copy(const O& old) {
+  return new N(%static_cast(old, const N&));
+}
+
+}
 
 /* -----------------------------------------------------------------------------
  * Allocating/freeing elements
@@ -151,7 +161,7 @@ nocppval
 
 #if defined(__cplusplus)
 # define %new_instance(Type...)             (new Type())
-# define %new_copy(val,Type...)             (new Type(%static_cast(val, const Type&)))
+# define %new_copy(val,Type...)             (new_copy<decltype(val), Type>(val))
 # define %new_array(size,Type...)           (new Type[size]())
 # define %new_copy_array(ptr,size,Type...)  %reinterpret_cast(memcpy(new Type[size], ptr, sizeof(Type)*(size)), Type*)
 # define %delete(cptr)                      delete cptr


### PR DESCRIPTION
This includes two commits. The first commit I'm feel pretty confident of: it creates a test case demonstrating the issue, and addresses the first compiler error that pops up. The line in `Examples/test-suite/cpp11_move_only.i` that triggers the error is commented out right now, so I _could_ push just the first commit if you want.

The second commit allows my test case to _work_, but I don't know what ramifications it will have in other places. I'm including it primarily to highlight where the problem occurs.


