### PR TITLE
Fix missing-field-initializers warning with Py3.8

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -256,6 +256,12 @@ SwigPyStaticVar_Type(void) {
 #if PY_VERSION_HEX >= 0x03040000
       0,                                        /* tp_finalize */
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+      0,                                        /* tp_vectorcall */
+#endif
+#if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
+      0,                                        /* tp_print */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                        /* tp_allocs */
       0,                                        /* tp_frees */
@@ -333,6 +339,12 @@ SwigPyObjectType(void) {
       0,                                        /* tp_version_tag */
 #if PY_VERSION_HEX >= 0x03040000
       0,                                        /* tp_finalize */
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+      0,                                        /* tp_vectorcall */
+#endif
+#if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
+      0,                                        /* tp_print */
 #endif
 #ifdef COUNT_ALLOCS
       0,                                        /* tp_allocs */

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -186,6 +186,12 @@ swig_varlink_type(void) {
 #if PY_VERSION_HEX >= 0x03040000
       0,                                  /* tp_finalize */
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+      0,                                  /* tp_vectorcall */
+#endif
+#if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
+      0,                                  /* tp_print */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                  /* tp_allocs */
       0,                                  /* tp_frees */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -696,6 +696,12 @@ SwigPyObject_TypeOnce(void) {
 #if PY_VERSION_HEX >= 0x03040000
       0,                                    /* tp_finalize */
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+      0,                                    /* tp_vectorcall */
+#endif
+#if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
+      0,                                    /* tp_print */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */
       0,                                    /* tp_frees */
@@ -856,6 +862,12 @@ SwigPyPacked_TypeOnce(void) {
       0,                                    /* tp_version_tag */
 #if PY_VERSION_HEX >= 0x03040000
       0,                                    /* tp_finalize */
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+      0,                                    /* tp_vectorcall */
+#endif
+#if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
+      0,                                    /* tp_print */
 #endif
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */


### PR DESCRIPTION
Python 3.8 adds tp_vectorcall, tp_print is added for compat just for 3.8
https://github.com/python/cpython/pull/13185/files#diff-b5db2632fa7acaf3b44abb56f18b9615