### PR TITLE
Reimplement Doxygen unit tests for Java using Java 9+ API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -449,11 +449,6 @@ matrix:
       env: SWIGLANG=php VER=7.2
       sudo: required
       dist: xenial
-    # jdk 13 has removed tools.jar resulting in: CommentParser.java:2: error: package com.sun.javadoc does not exist
-    - compiler: clang
-      os: osx
-      env: SWIGLANG=java CPP17=1
-      osx_image: xcode10.2
     # Sometimes hits the Travis 50 minute time limit
     - compiler: clang
       os: osx

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -610,11 +610,14 @@ CPP11_TEST_BROKEN = \
 #	cpp11_reference_wrapper \     # No typemaps
 
 # Doxygen support test cases: can only be used with languages supporting
-# Doxygen comment translation, currently only Python and Java.
+# Doxygen comment translation (currently Python and Java) and only if not
+# disabled by configure via SKIP_DOXYGEN_TEST_CASES.
+ifneq ($(SKIP_DOXYGEN_TEST_CASES),1)
 python_HAS_DOXYGEN := 1
 java_HAS_DOXYGEN := 1
 
 $(eval HAS_DOXYGEN := $($(LANGUAGE)_HAS_DOXYGEN))
+endif
 
 ifdef HAS_DOXYGEN
 DOXYGEN_TEST_CASES += \

--- a/Examples/test-suite/java/CommentParser.java
+++ b/Examples/test-suite/java/CommentParser.java
@@ -93,13 +93,13 @@ public class CommentParser {
                 System.out.println("Output is also saved to files '" + expectedFileName +
                                    "' and '" + gotFileName + "'");
                 // here we print original strings, for nicer output
-                System.out.println("\n\n---\nexpected:\n" + wantedComments.get(e.getKey()));
+                System.out.println("\n\n---\nexpected:\n" + wantedStr);
                 System.out.println("\n\n---\ngot:\n" + e.getValue());
 
                 try {
                     // write expected string to file
                     BufferedWriter expectedFile = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(expectedFileName)));
-                    expectedFile.write(wantedComments.get(e.getKey()));
+                    expectedFile.write(wantedStr);
                     expectedFile.close();
 
                     // write translated string to file

--- a/Examples/test-suite/java/CommentParser.java
+++ b/Examples/test-suite/java/CommentParser.java
@@ -1,5 +1,6 @@
 
-import com.sun.javadoc.*;
+import com.sun.source.doctree.*;
+import com.sun.source.util.DocTrees;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Map;
@@ -9,45 +10,120 @@ import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.*;
+import java.util.spi.ToolProvider;
+import javax.lang.model.*;
+import javax.lang.model.element.*;
+import javax.lang.model.util.*;
+import jdk.javadoc.doclet.*;
 
 
-public class CommentParser {
+public class CommentParser implements Doclet {
     private static Map<String, String> m_parsedComments = new HashMap<String, String>();
 
-    public static boolean start(RootDoc root) {
+    // We need to implement these base class pure virtual methods.
 
+    @Override
+    public void init(Locale locale, Reporter reporter) {
+    }
+
+    @Override
+    public Set<? extends Option> getSupportedOptions() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public String getName() {
+        return "CommentParser";
+    }
+
+    // Element name must be the fully qualified name of the element.
+    //
+    // If there is no comment associated with this element, simply do nothing.
+    private void storeCommentFor(DocTrees docTrees, String fullName, Element e) {
+        DocCommentTree docCommentTree = docTrees.getDocCommentTree(e);
+        if (docCommentTree == null)
+            return;
+
+        StringBuilder name = new StringBuilder(fullName);
+
+        // We must use signature in the key for methods for compatibility with
+        // the existing tests and to allow distinguishing between overloaded
+        // methods.
+        if (e instanceof ExecutableElement) {
+            ExecutableElement ex = (ExecutableElement)e;
+            name.append("(");
+
+            boolean firstParam = true;
+            for (VariableElement p : ex.getParameters()) {
+                if (firstParam) {
+                    firstParam = false;
+                } else {
+                    name.append(", ");
+                }
+
+                name.append(p.asType().toString());
+            }
+
+            name.append(")");
+        }
+
+        // For some reason the comment in the source is split into "body" and
+        // "block tags" parts, so we need to concatenate them back together.
+        StringBuilder comment = new StringBuilder();
+        for (DocTree d : docCommentTree.getFullBody()) {
+            comment.append(d.toString());
+            comment.append("\n");
+        }
+
+        boolean firstBlockTag = true;
+        for (DocTree d : docCommentTree.getBlockTags()) {
+            if (firstBlockTag) {
+                firstBlockTag = false;
+                comment.append("\n");
+            }
+
+            comment.append(d.toString());
+            comment.append("\n");
+        }
+
+        m_parsedComments.put(name.toString(), comment.toString());
+    }
+
+    @Override
+    public boolean run(DocletEnvironment docEnv) {
         /*
          * This method is called by 'javadoc' and gets the whole parsed java
          * file, we get comments and store them
          */
+        DocTrees docTrees = docEnv.getDocTrees();
+        for (TypeElement t : ElementFilter.typesIn(docEnv.getIncludedElements())) {
+            String typeName = t.getQualifiedName().toString();
 
-        for (ClassDoc classDoc : root.classes()) {
+            storeCommentFor(docTrees, typeName, t);
 
-            if (classDoc.getRawCommentText().length() > 0)
-                m_parsedComments.put(classDoc.qualifiedName(), classDoc.getRawCommentText());
+            for (Element e : t.getEnclosedElements()) {
+                // Omit the method name for ctors: this is a bit weird, but
+                // this is what the existing tests expect.
+                String fullName = typeName;
+                if (e.getKind() != ElementKind.CONSTRUCTOR) {
+                    fullName = fullName + "." + e.getSimpleName();
+                }
 
-            for (FieldDoc f : classDoc.enumConstants()) {
-                if (f.getRawCommentText().length() > 0)
-                    m_parsedComments.put(f.qualifiedName(), f.getRawCommentText());
-            }
-            for (FieldDoc f : classDoc.fields()) {
-                if (f.getRawCommentText().length() > 0)
-                    m_parsedComments.put(f.qualifiedName(), f.getRawCommentText());
-            }
-            for (ConstructorDoc c : classDoc.constructors()) {
-                if (c.getRawCommentText().length() > 0)
-                    m_parsedComments.put(c.toString(), c.getRawCommentText());
-            }
-            for (MethodDoc m : classDoc.methods()) {
-                if (m.getRawCommentText().length() > 0)
-                    m_parsedComments.put(m.toString(), m.getRawCommentText());
+                storeCommentFor(docTrees, fullName, e);
             }
         }
+
         return true;
     }
 
     
-    public int check(Map<String, String> wantedComments) {
+    public static int check(Map<String, String> wantedComments) {
         int errorCount=0;
         Iterator<Entry<String, String>> it = m_parsedComments.entrySet().iterator();
 
@@ -131,7 +207,7 @@ public class CommentParser {
     }
 
     
-    private void printKeys(Map<String, String> map) {
+    private static void printKeys(Map<String, String> map) {
         
         Set<String> keys = map.keySet();
         for (String key : keys) {
@@ -155,6 +231,15 @@ public class CommentParser {
         }
     }
 
+    public static void parse(String sourcefile) {
+        ToolProvider javadoc = ToolProvider.findFirst("javadoc").orElseThrow();
+        int result = javadoc.run(System.out, System.err, new String[]{"-quiet", "-doclet", "CommentParser", sourcefile});
+        if (result != 0) {
+          System.err.println("Executing javadoc failed.");
+          System.exit(result);
+        }
+    }
+
     
     public static void main(String argv[]) {
 		
@@ -163,8 +248,7 @@ public class CommentParser {
             System.exit(1);
         }
 		
-        com.sun.tools.javadoc.Main.execute("The comment parser program",
-                                           "CommentParser", new String[]{"-quiet", argv[0]});
+        parse(argv[0]);
 		
         // if we are run as standalone app, print the list of found comments as it would appear in java source
 		

--- a/Examples/test-suite/java/CommentParser.java
+++ b/Examples/test-suite/java/CommentParser.java
@@ -99,7 +99,8 @@ public class CommentParser {
                 try {
                     // write expected string to file
                     BufferedWriter expectedFile = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(expectedFileName)));
-                    expectedFile.write(wantedStr);
+                    if (wantedStr != null)
+                        expectedFile.write(wantedStr);
                     expectedFile.close();
 
                     // write translated string to file

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -108,13 +108,11 @@ setup = \
 	  mkdir $(JAVA_PACKAGE);							  \
 	fi
 
-# Doxygen test cases need to be compiled together with the CommentParser class
-# which depends on com.sun.javadoc package which is located in this JAR.
+# Doxygen test cases need to be compiled together with the CommentParser class.
 CommentParser.class:
 	$(COMPILETOOL) $(JAVAC) -classpath $(JAVA_CLASSPATH) -d . $(srcdir)/CommentParser.java
 
 JAVA_CLASSPATH := .
-$(DOXYGEN_TEST_CASES:=.cpptest): JAVA_CLASSPATH := "$(JAVA_TOOLS_JAR)$(JAVA_CLASSPATH_SEP)."
 $(DOXYGEN_TEST_CASES:=.cpptest): CommentParser.class
 
 # Compiles java files then runs the testcase. A testcase is only run if

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -9,6 +9,7 @@ JAVAFLAGS    = @JAVAFLAGS@
 JAVA_CLASSPATH_SEP = @JAVA_CLASSPATH_SEP@
 JAVA_TOOLS_JAR     = @JAVA_TOOLS_JAR@
 SCRIPTSUFFIX = _runme.java
+SKIP_DOXYGEN_TEST_CASES = @JAVA_SKIP_DOXYGEN_TEST_CASES@
 
 srcdir       = @srcdir@
 top_srcdir   = ../@top_srcdir@

--- a/Examples/test-suite/java/doxygen_alias_runme.java
+++ b/Examples/test-suite/java/doxygen_alias_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_alias.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_alias_runme {
@@ -15,10 +14,7 @@ public class doxygen_alias_runme {
 
   public static void main(String argv[])
   {
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_alias runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_alias"});
+    CommentParser.parse("doxygen_alias");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     wantedComments.put("doxygen_alias.doxygen_alias.make_something()",
@@ -27,6 +23,6 @@ public class doxygen_alias_runme {
       "     @return A new object which may be null.\n" +
       "");
 
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_basic_notranslate_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_notranslate_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_basic_notranslate.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_basic_notranslate_runme {
@@ -15,14 +14,7 @@ public class doxygen_basic_notranslate_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_basic_notranslate runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_basic_notranslate"});
+    CommentParser.parse("doxygen_basic_notranslate");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     wantedComments.put("doxygen_basic_notranslate.doxygen_basic_notranslate.function3(int)",
@@ -97,6 +89,6 @@ public class doxygen_basic_notranslate_runme {
     		"");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_basic_translate_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_basic_translate.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_basic_translate_runme {
@@ -15,14 +14,7 @@ public class doxygen_basic_translate_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_basic_translate runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_basic_translate"});
+    CommentParser.parse("doxygen_basic_translate");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -96,6 +88,6 @@ public class doxygen_basic_translate_runme {
     		"");
 
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_basic_translate_style2_runme.java
+++ b/Examples/test-suite/java/doxygen_basic_translate_style2_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_basic_translate_style2.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_basic_translate_style2_runme {
@@ -15,14 +14,7 @@ public class doxygen_basic_translate_style2_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_basic_translate_style2 runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_basic_translate_style2"});
+    CommentParser.parse("doxygen_basic_translate_style2");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -96,6 +88,6 @@ public class doxygen_basic_translate_style2_runme {
     		"");
 
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_ignore_runme.java
+++ b/Examples/test-suite/java/doxygen_ignore_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_ignore.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_ignore_runme {
@@ -15,10 +14,7 @@ public class doxygen_ignore_runme {
 
   public static void main(String argv[]) 
   {
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_ignore runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_ignore"});
+    CommentParser.parse("doxygen_ignore");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     wantedComments.put("doxygen_ignore.doxygen_ignore.func()",
@@ -39,6 +35,6 @@ public class doxygen_ignore_runme {
       "\n" +
       "");
 
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_misc_constructs_runme.java
+++ b/Examples/test-suite/java/doxygen_misc_constructs_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_misc_constructs.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_misc_constructs_runme {
@@ -15,14 +14,7 @@ public class doxygen_misc_constructs_runme {
 
   public static void main(String argv[])
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_misc_constructs runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_misc_constructs"});
+    CommentParser.parse("doxygen_misc_constructs");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
 
@@ -195,6 +187,6 @@ public class doxygen_misc_constructs_runme {
 
 
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_nested_class_runme.java
+++ b/Examples/test-suite/java/doxygen_nested_class_runme.java
@@ -1,5 +1,4 @@
 import doxygen_nested_class.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_nested_class_runme {
@@ -14,14 +13,7 @@ public class doxygen_nested_class_runme {
 
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_nested_class runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_nested_class"});
+    CommentParser.parse("doxygen_nested_class");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -43,6 +35,6 @@ public class doxygen_nested_class_runme {
     		" doxShort const variable ");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_parsing_enums_proper_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_proper_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_parsing_enums_proper.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_parsing_enums_proper_runme {
@@ -15,14 +14,7 @@ public class doxygen_parsing_enums_proper_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_parsing_enums_proper runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_parsing_enums_proper"});
+    CommentParser.parse("doxygen_parsing_enums_proper");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -61,6 +53,6 @@ public class doxygen_parsing_enums_proper_runme {
     		"Post comment after last comma.");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_parsing_enums_simple_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_simple_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_parsing_enums_simple.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_parsing_enums_simple_runme {
@@ -15,14 +14,7 @@ public class doxygen_parsing_enums_simple_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_parsing_enums_simple runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_parsing_enums_simple"});
+    CommentParser.parse("doxygen_parsing_enums_simple");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -53,6 +45,6 @@ public class doxygen_parsing_enums_simple_runme {
     		"Post comment after last comma.");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_parsing_enums_typesafe_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_typesafe_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_parsing_enums_typesafe.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_parsing_enums_typesafe_runme {
@@ -15,14 +14,7 @@ public class doxygen_parsing_enums_typesafe_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_parsing_enums_typesafe runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_parsing_enums_typesafe"});
+    CommentParser.parse("doxygen_parsing_enums_typesafe");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -62,6 +54,6 @@ public class doxygen_parsing_enums_typesafe_runme {
 
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_parsing_enums_typeunsafe_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_enums_typeunsafe_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_parsing_enums_typeunsafe.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_parsing_enums_typeunsafe_runme {
@@ -15,14 +14,7 @@ public class doxygen_parsing_enums_typeunsafe_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_parsing_enums_typeunsafe runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_parsing_enums_typeunsafe"});
+    CommentParser.parse("doxygen_parsing_enums_typeunsafe");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -61,6 +53,6 @@ public class doxygen_parsing_enums_typeunsafe_runme {
     		"Post comment after last comma.");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_parsing_runme.java
+++ b/Examples/test-suite/java/doxygen_parsing_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_parsing.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_parsing_runme {
@@ -15,14 +14,7 @@ public class doxygen_parsing_runme {
 
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_parsing runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_parsing"});
+    CommentParser.parse("doxygen_parsing");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -136,6 +128,6 @@ public class doxygen_parsing_runme {
     		"");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_translate_all_tags_runme.java
+++ b/Examples/test-suite/java/doxygen_translate_all_tags_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_translate_all_tags.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_translate_all_tags_runme {
@@ -15,14 +14,7 @@ public class doxygen_translate_all_tags_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_translate_all_tags runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_translate_all_tags"});
+    CommentParser.parse("doxygen_translate_all_tags");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -154,6 +146,6 @@ public class doxygen_translate_all_tags_runme {
     		" And here goes simple text \n" +
     		"");
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_translate_links_runme.java
+++ b/Examples/test-suite/java/doxygen_translate_links_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_translate_links.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 
 public class doxygen_translate_links_runme {
@@ -15,14 +14,7 @@ public class doxygen_translate_links_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_translate_links runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_translate_links"});
+    CommentParser.parse("doxygen_translate_links");
 
     HashMap<String, String> wantedComments = new HashMap<String, String>();
     
@@ -64,6 +56,6 @@ public class doxygen_translate_links_runme {
     		"");
     
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/Examples/test-suite/java/doxygen_translate_runme.java
+++ b/Examples/test-suite/java/doxygen_translate_runme.java
@@ -1,6 +1,5 @@
 
 import doxygen_translate.*;
-import com.sun.javadoc.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,14 +15,7 @@ public class doxygen_translate_runme {
   
   public static void main(String argv[]) 
   {
-    /*
-      Here we are using internal javadoc tool, it accepts the name of the class as paramterer,
-      and calls the start() method of that class with parsed information.
-    */
-    CommentParser parser = new CommentParser();
-    com.sun.tools.javadoc.Main.execute("doxygen_translate runtime test",
-                                       "CommentParser",
-                                       new String[]{"-quiet", "doxygen_translate"});
+    CommentParser.parse("doxygen_translate");
 
     Map<String, String> wantedComments = new HashMap<String, String>();
     
@@ -274,6 +266,6 @@ public class doxygen_translate_runme {
                 "");
         
     // and ask the parser to check comments for us
-    System.exit(parser.check(wantedComments));
+    System.exit(CommentParser.check(wantedComments));
   }
 }

--- a/configure.ac
+++ b/configure.ac
@@ -1351,10 +1351,10 @@ fi
 # Check Java version: we require Java 9 or later for Doxygen tests.
 if test -n "$JAVAC"; then
     AC_MSG_CHECKING(if java version is 9 or greater)
-    javac_version=`$JAVAC -version 2>&1`
+    javac_version=`"$JAVAC" -version 2>&1`
     java_version_num=`echo $javac_version | sed -n 's/^javac //p'`
     if test -z "$java_version_num"; then
-        AC_MSG_WARN([unknown format for Java version returned by $JAVAC ($javac_version)])
+        AC_MSG_WARN([unknown format for Java version returned by "$JAVAC" ($javac_version)])
         JAVA_SKIP_DOXYGEN_TEST_CASES=1
         AC_MSG_RESULT(unknown)
     else

--- a/configure.ac
+++ b/configure.ac
@@ -1408,15 +1408,6 @@ if test -z "$JAVA_HOME" && test -n "$JAVA_HOME_MAYBE" ; then
   fi
 fi
 
-# Javadoc support required for the Java test-suite is available by default in jdk9+ and in tools.jar in earlier jdk versions
-AC_MSG_CHECKING(for java tools.jar)
-if test -n "$JAVA_HOME" && test -r "$JAVA_HOME/lib/tools.jar" ; then
-  JAVA_TOOLS_JAR="$JAVA_HOME/lib/tools.jar"
-  AC_MSG_RESULT([$JAVA_TOOLS_JAR])
-else
-  AC_MSG_RESULT(not found)
-fi
-
 case $host in
 *-*-cygwin*)
         # TODO: Only use this flag if the compiler supports it, later versions of gcc no longer have it
@@ -1483,7 +1474,6 @@ AC_SUBST(JAVA)
 AC_SUBST(JAVAC)
 AC_SUBST(JAVAINC)
 AC_SUBST(JAVA_CLASSPATH_SEP)
-AC_SUBST(JAVA_TOOLS_JAR)
 AC_SUBST(JAVADYNAMICLINKING)
 AC_SUBST(JAVALIBRARYPREFIX)
 AC_SUBST(JAVASO)

--- a/configure.ac
+++ b/configure.ac
@@ -1348,6 +1348,33 @@ else
   JAVAC="$JAVACBIN"
 fi
 
+# Check Java version: we require Java 9 or later for Doxygen tests.
+if test -n "$JAVAC"; then
+    AC_MSG_CHECKING(if java version is 9 or greater)
+    javac_version=`$JAVAC -version 2>&1`
+    java_version_num=`echo $javac_version | sed -n 's/^javac //p'`
+    if test -z "$java_version_num"; then
+        AC_MSG_WARN([unknown format for Java version returned by $JAVAC ($javac_version)])
+        JAVA_SKIP_DOXYGEN_TEST_CASES=1
+        AC_MSG_RESULT(unknown)
+    else
+        dnl Until Java 8 version number was in format "1.x", starting from
+        dnl Java 9 it's just "x".
+        case $java_version_num in
+            1.*)
+                JAVA_SKIP_DOXYGEN_TEST_CASES=1
+                AC_MSG_RESULT([no, disabling Doxygen tests])
+                ;;
+
+            *)
+                AC_MSG_RESULT(yes)
+                ;;
+        esac
+    fi
+
+    AC_SUBST(JAVA_SKIP_DOXYGEN_TEST_CASES)
+fi
+
 AC_MSG_CHECKING(for java include file jni.h)
 AC_ARG_WITH(javaincl, [  --with-javaincl=path    Set location of Java include directory], [JAVAINCDIR="$withval"], [JAVAINCDIR=])
 


### PR DESCRIPTION
My Java skills are below average, so the code could almost certainly profit from being reviewed by someone with better language knowledge, but at the very least it works (tested with Java 11 and 14) and allows us to reenable the currently failing test run under macOS, so I'd like to merge this if you don't mind.