### PR TITLE
Make directors implementation for Python work with limited API

### DIFF
--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -14,6 +14,22 @@
 #include <vector>
 #include <map>
 
+#if defined(SWIG_PYTHON_THREADS)
+/*  __THREAD__ is the old macro to activate some thread support */
+# if !defined(__THREAD__)
+#   define __THREAD__ 1
+# endif
+#endif
+
+#ifdef __THREAD__
+# if defined(_WIN32)
+#   define WIN32_LEAN_AND_MEAN /* skip OLE and other unnecessary headers */
+#   define NOMINMAX /* avoid most common clash with windows.h contents */
+#   include <windows.h>
+# else
+#   include <pthread.h>
+# endif
+#endif
 
 /*
   Use -DSWIG_PYTHON_DIRECTOR_NO_VTABLE if you don't want to generate a 'virtual
@@ -244,25 +260,64 @@ namespace Swig {
   };
 
 
-#if defined(SWIG_PYTHON_THREADS)
-/*  __THREAD__ is the old macro to activate some thread support */
-# if !defined(__THREAD__)
-#   define __THREAD__ 1
-# endif
-#endif
-
 #ifdef __THREAD__
-# include "pythread.h"
+# if defined(_WIN32)
+    class Mutex : private CRITICAL_SECTION {
+    public:
+        Mutex() {
+            InitializeCriticalSection(this);
+        }
+
+        ~Mutex() {
+            DeleteCriticalSection(this);
+        }
+
+    private:
+        void Lock() {
+            EnterCriticalSection(this);
+        }
+
+        void Unlock() {
+            LeaveCriticalSection(this);
+        }
+
+        friend class Guard;
+    };
+# else
+    class Mutex {
+    public:
+        Mutex() {
+            pthread_mutex_init(&mutex_, NULL);
+        }
+
+        ~Mutex() {
+            pthread_mutex_destroy(&mutex_);
+        }
+
+    private:
+        void Lock() {
+            pthread_mutex_lock(&mutex_);
+        }
+
+        void Unlock() {
+            pthread_mutex_unlock(&mutex_);
+        }
+
+        friend class Guard;
+
+        pthread_mutex_t mutex_;
+    };
+# endif
   class Guard {
-    PyThread_type_lock &mutex_;
+    Mutex &mutex_;
 
   public:
-    Guard(PyThread_type_lock & mutex) : mutex_(mutex) {
-      PyThread_acquire_lock(mutex_, WAIT_LOCK);
+    Guard(Mutex & mutex) : mutex_(mutex) {
+      mutex_.Lock();
     }
 
     ~Guard() {
-      PyThread_release_lock(mutex_);
+      mutex_.Unlock();
     }
   };
 # define SWIG_GUARD(mutex) Guard _guard(mutex)
@@ -330,7 +385,7 @@ namespace Swig {
     typedef std::map<void *, GCItem_var> swig_ownership_map;
     mutable swig_ownership_map swig_owner;
 #ifdef __THREAD__
-    static PyThread_type_lock swig_mutex_own;
+    static Mutex swig_mutex_own;
 #endif
 
   public:
@@ -382,7 +437,7 @@ namespace Swig {
   };
 
 #ifdef __THREAD__
-  PyThread_type_lock Director::swig_mutex_own = PyThread_allocate_lock();
+  Mutex Director::swig_mutex_own;
 #endif
 }
 


### PR DESCRIPTION
Don't use Python thread functions in directors implementation code, as
they're not exported from Python version-independent library under
Windows, see https://bugs.python.org/issue39123

This morally reverts 4aaf48d65055bd68cc55e81f915af39693e9a7a6, although
this commit uses a somewhat different (and cleaner) implementation of
the mutex abstraction and so it isn't a literal revert.

---

See #1613.