### PR TITLE
Check Py{Bytes,String}_AsStringAndSize() for failure

### DIFF
--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -43,12 +43,11 @@ SWIG_Python_str_AsChar(PyObject *str)
   if (str) {
     char *cstr;
     Py_ssize_t len;
-    if (PyBytes_AsStringAndSize(str, &cstr, &len) == -1)
-      return NULL;
-    newstr = (char *) malloc(len+1);
-    if (!newstr)
-      return NULL;
-    memcpy(newstr, cstr, len+1);
+    if (PyBytes_AsStringAndSize(str, &cstr, &len) != -1) {
+      newstr = (char *) malloc(len+1);
+      if (newstr)
+        memcpy(newstr, cstr, len+1);
+    }
     Py_XDECREF(str);
   }
   return newstr;

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -43,8 +43,11 @@ SWIG_Python_str_AsChar(PyObject *str)
   if (str) {
     char *cstr;
     Py_ssize_t len;
-    PyBytes_AsStringAndSize(str, &cstr, &len);
+    if (PyBytes_AsStringAndSize(str, &cstr, &len) == -1)
+      return NULL;
     newstr = (char *) malloc(len+1);
+    if (!newstr)
+      return NULL;
     memcpy(newstr, cstr, len+1);
     Py_XDECREF(str);
   }

--- a/Lib/python/pystrings.swg
+++ b/Lib/python/pystrings.swg
@@ -32,9 +32,11 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char** cptr, size_t* psize, int *alloc)
     if (alloc)
       *alloc = SWIG_NEWOBJ;
 %#endif
-    PyBytes_AsStringAndSize(obj, &cstr, &len);
+    if (PyBytes_AsStringAndSize(obj, &cstr, &len) == -1)
+      return SWIG_TypeError;
 %#else
-    PyString_AsStringAndSize(obj, &cstr, &len);
+    if (PyString_AsStringAndSize(obj, &cstr, &len) == -1)
+      return SWIG_TypeError;
 %#endif
     if (cptr) {
       if (alloc) {


### PR DESCRIPTION
PyBytes_AsStringAndSize() and PyString_AsStringAndSize() were not
being checked for failure.

Closes #1349.