### PR TITLE
Add missing preprocessor defines to the docs list

### DIFF
--- a/Doc/Manual/Preprocessor.html
+++ b/Doc/Manual/Preprocessor.html
@@ -121,7 +121,6 @@ SWIGJAVA                        Defined when using Java
 SWIGJAVASCRIPT                  Defined when using Javascript
 SWIG_JAVASCRIPT_JSC             Defined when using Javascript for JavascriptCore
 SWIG_JAVASCRIPT_V8              Defined when using Javascript for v8 or node.js
-BUILDING_NODE_EXTENSION         Defined when using Javascript for node.js
 SWIGLUA                         Defined when using Lua
 SWIGMZSCHEME                    Defined when using Mzscheme
 SWIGOCAML                       Defined when using OCaml

--- a/Doc/Manual/Preprocessor.html
+++ b/Doc/Manual/Preprocessor.html
@@ -121,6 +121,7 @@ SWIGJAVA                        Defined when using Java
 SWIGJAVASCRIPT                  Defined when using Javascript
 SWIG_JAVASCRIPT_JSC             Defined when using Javascript for JavascriptCore
 SWIG_JAVASCRIPT_V8              Defined when using Javascript for v8 or node.js
+SWIG_JAVASCRIPT_NODE_V8         Defined when using Javascript for node.js
 SWIGLUA                         Defined when using Lua
 SWIGMZSCHEME                    Defined when using Mzscheme
 SWIGOCAML                       Defined when using OCaml

--- a/Doc/Manual/Preprocessor.html
+++ b/Doc/Manual/Preprocessor.html
@@ -110,11 +110,18 @@ SWIG_VERSION                    Hexadecimal (binary-coded decimal) number contai
                                 such as 0x010311 (corresponding to SWIG-1.3.11).
 
 SWIGCSHARP                      Defined when using C#
+SWIGD                           Defined when using D
+SWIG_D_VERSION                  Unsigned integer target version when using D
+SWIGGO                          Defined when using Go
+SWIGGO_CGO                      Defined when using Go for cgo
+SWIGGO_GCCGO                    Defined when using Go for gccgo
+SWIGGO_INTGO_SIZE               Size of the Go type int when using Go (32 or 64)
 SWIGGUILE                       Defined when using Guile
 SWIGJAVA                        Defined when using Java
 SWIGJAVASCRIPT                  Defined when using Javascript
 SWIG_JAVASCRIPT_JSC             Defined when using Javascript for JavascriptCore
-SWIG_JAVASCRIPT_V8              Defined when using Javascript for v8 or node.js 
+SWIG_JAVASCRIPT_V8              Defined when using Javascript for v8 or node.js
+BUILDING_NODE_EXTENSION         Defined when using Javascript for node.js
 SWIGLUA                         Defined when using Lua
 SWIGMZSCHEME                    Defined when using Mzscheme
 SWIGOCAML                       Defined when using OCaml
@@ -123,8 +130,11 @@ SWIGPERL                        Defined when using Perl
 SWIGPHP                         Defined when using PHP (any version)
 SWIGPHP7                        Defined when using PHP7
 SWIGPYTHON                      Defined when using Python
+SWIGPYTHON_PY3                  Defined when using Python with -py3
+SWIGPYTHON_BUILTIN              Defined when using Python with -builtin
 SWIGR                           Defined when using R
 SWIGRUBY                        Defined when using Ruby
+SWIG_RUBY_AUTORENAME            Defined when using Ruby with -autorename
 SWIGSCILAB                      Defined when using Scilab
 SWIGTCL                         Defined when using Tcl
 SWIGXML                         Defined when using XML

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -588,6 +588,7 @@ void JAVASCRIPT::main(int argc, char *argv[]) {
     {
       emitter = swig_javascript_create_V8Emitter();
       Preprocessor_define("SWIG_JAVASCRIPT_V8 1", 0);
+      Preprocessor_define("SWIG_JAVASCRIPT_NODE_V8 1", 0);
       Preprocessor_define("BUILDING_NODE_EXTENSION 1", 0);
       SWIG_library_directory("javascript/v8");
       break;


### PR DESCRIPTION
Searching through the history, these are the defines I found that aren't mentioned in the documentation and didn't find a reference to deprecation:
```
SWIGD
SWIG_D_VERSION
SWIGGO
SWIGGO_CGO
SWIGGO_GCCGO
SWIGGO_INTGO_SIZE
BUILDING_NODE_EXTENSION
SWIGPYTHON_PY3
SWIGPYTHON_BUILTIN
SWIG_RUBY_AUTORENAME
```

These preprocessor defines had a commit saying they were deprecated, but I didn't see them in a commit or changelog saying they were removed:
```
SWIGPERL5
SWIGTCL8
```

These preprocessor defines all have a commit or comment in the change log saying they were removed:
```
SWIGALLEGROCL
SWIGCFFI
SWIGCHICKEN
SWIGCLISP
SWIGSEXP
SWIGPIKE
SWIGMODULA3
SWIGUFFI
```