### PR TITLE
Fix marshalling of std::wstring parameters in directors

### DIFF
--- a/Lib/csharp/std_wstring.i
+++ b/Lib/csharp/std_wstring.i
@@ -25,7 +25,9 @@ class wstring;
 %typemap(ctype, out="void *") wstring "wchar_t *"
 %typemap(imtype,
          inattributes="[global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]",
-         outattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]"
+         outattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]",
+         directorinattributes="[global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]",
+         directoroutattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]"
          ) wstring "string"
 %typemap(cstype) wstring "string"
 %typemap(csdirectorin) wstring "$iminput"
@@ -65,7 +67,9 @@ class wstring;
 %typemap(ctype, out="void *") const wstring & "wchar_t *"
 %typemap(imtype,
          inattributes="[global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]",
-         outattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]"
+         outattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]",
+         directorinattributes="[global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]",
+         directoroutattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPWStr)]"
          ) const wstring & "string"
 %typemap(cstype) const wstring & "string"
 


### PR DESCRIPTION
std::wstring parameters on SWIG directors were being truncated to a single character due to marshalling inconsistencies.
This patch applies the same MarshalAs(UnmanagedType.LPWStr) attribute to director delegate methods and allows std::wstrings to be successfully received in the C# code via director calls.