### PR TITLE
D: Replace deprecated imports (package std.c). Fixes #1593

### DIFF
--- a/Lib/d/wrapperloader.swg
+++ b/Lib/d/wrapperloader.swg
@@ -40,9 +40,10 @@ private {
   } else {
     version(D_Version2) {
       static import std.conv;
+    } else {
+      static import std.c.string;
     }
     static import std.string;
-    static import std.c.string;
   }
 
   version(D_Version2) {
@@ -112,7 +113,7 @@ private {
     version(Tango) {
       import tango.sys.Common;
     } else version(linux) {
-      import std.c.linux.linux;
+      import core.sys.posix.dlfcn;
     } else {
       extern(C) {
         const RTLD_NOW = 2;


### PR DESCRIPTION
This PR replaces #1594.

I tried to fix the remaining errors but I have no experience with D. However, I was able to locate the file (and statement) that causes one of the errors. `Source/Modules/d.cxx`: 

```cpp
// Helper function to determine if a method has been overridden in a
// subclass of the wrapped class. If not, we just pass null to the
// director_connect_function since the method from the C++ class should
// be called as usual (see above).
// Only emit it if the proxy class has at least one method.
if (first_class_dmethod < curr_class_dmethod) {
    Printf(proxy_class_body_code, "\n");
    Printf(proxy_class_body_code, "private bool swigIsMethodOverridden(DelegateType, FunctionType, alias fn)() %s{\n", (d_version > 1) ? "const " : "");
    Printf(proxy_class_body_code, "  DelegateType dg = &fn;\n");
    Printf(proxy_class_body_code, "  return dg.funcptr != SwigNonVirtualAddressOf!(FunctionType, fn);\n");
    Printf(proxy_class_body_code, "}\n");
    Printf(proxy_class_body_code, "\n");
    Printf(proxy_class_body_code, "private static Function SwigNonVirtualAddressOf(Function, alias fn)() {\n");
    Printf(proxy_class_body_code, "  return cast(Function) &fn;\n");
    Printf(proxy_class_body_code, "}\n");
}
```

The parameter `alias fn` cannot be called because the method `swigIsMethodOverridden` is `const`. Maybe an experienced D programmer knows how to fix this.