### PR TITLE
Allow using auto_ptr<> typemaps for other similar types too

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.2 (in progress)
 ===========================
 
+2020-02-11: vadz
+            [C#, Java, Python, Ruby] Allow using auto_ptr<> typemaps for unique_ptr<> too.
+
 2020-02-06: wsfulton
             [Python] #1673 #1674 Fix setting 'this' when extending a proxy class with __slots__.
 

--- a/Doc/Manual/Library.html
+++ b/Doc/Manual/Library.html
@@ -2007,6 +2007,16 @@ directly supported.
 </p>
 
 <p>
+Moreover, the same support can be also used for the (non-deprecated)
+<tt>std::unique_ptr</tt>. To use it, just predefine
+<tt>SWIG_AUTO_PTR_CLASSNAME</tt> as <tt>unique_ptr</tt> <em>before</em>
+including <tt>std_auto_ptr.i</tt> file. For completeness, notice that it's
+also possible to predefine <tt>SWIG_AUTO_PTR_NAMESPACE</tt> to something
+different from its default <tt>std</tt> value, e.g. to use
+<tt>boost::unique_ptr</tt> class.
+</p>
+
+<p>
 A typical example of use would be
 </p>
 <div class="code">

--- a/Lib/auto_ptr.i
+++ b/Lib/auto_ptr.i
@@ -1,0 +1,19 @@
+// This is a helper file for auto_ptr and should not be included directly.
+
+// Predefining these symbols allows to apply typemaps to classes different
+// from std::auto_ptr<> itself, e.g. std::unique_ptr<> or boost::unique_ptr<>.
+// Of course, the class must have similar/same API as std::auto_ptr<> for this
+// to work.
+#if !defined(SWIG_AUTO_PTR_NAMESPACE)
+# define SWIG_AUTO_PTR_NAMESPACE std
+#endif
+
+#if !defined(SWIG_AUTO_PTR_CLASSNAME)
+# define SWIG_AUTO_PTR_CLASSNAME auto_ptr
+#endif
+
+#define SWIG_AUTO_PTR_FULL_NAME SWIG_AUTO_PTR_NAMESPACE::SWIG_AUTO_PTR_CLASSNAME
+
+namespace SWIG_AUTO_PTR_NAMESPACE {
+   template <class T> class SWIG_AUTO_PTR_CLASSNAME {};
+}

--- a/Lib/csharp/std_auto_ptr.i
+++ b/Lib/csharp/std_auto_ptr.i
@@ -5,21 +5,19 @@
     something else (e.g. use shared_ptr<> which SWIG supports fully).
  */
 
+%include <auto_ptr.i>
+
 %define %auto_ptr(TYPE)
-%typemap (ctype) std::auto_ptr<TYPE > "void *"
-%typemap (imtype, out="System.IntPtr") std::auto_ptr<TYPE > "HandleRef"
-%typemap (cstype) std::auto_ptr<TYPE > "$typemap(cstype, TYPE)"
-%typemap (out) std::auto_ptr<TYPE > %{
+%typemap (ctype) SWIG_AUTO_PTR_FULL_NAME<TYPE > "void *"
+%typemap (imtype, out="System.IntPtr") SWIG_AUTO_PTR_FULL_NAME<TYPE > "HandleRef"
+%typemap (cstype) SWIG_AUTO_PTR_FULL_NAME<TYPE > "$typemap(cstype, TYPE)"
+%typemap (out) SWIG_AUTO_PTR_FULL_NAME<TYPE > %{
    $result = (void *)$1.release();
 %}
-%typemap(csout, excode=SWIGEXCODE) std::auto_ptr<TYPE > {
+%typemap(csout, excode=SWIGEXCODE) SWIG_AUTO_PTR_FULL_NAME<TYPE > {
      System.IntPtr cPtr = $imcall;
      $typemap(cstype, TYPE) ret = (cPtr == System.IntPtr.Zero) ? null : new $typemap(cstype, TYPE)(cPtr, true);$excode
      return ret;
    }
-%template() std::auto_ptr<TYPE >;
+%template() SWIG_AUTO_PTR_FULL_NAME<TYPE >;
 %enddef
-
-namespace std {
-   template <class T> class auto_ptr {};
-} 

--- a/Lib/java/std_auto_ptr.i
+++ b/Lib/java/std_auto_ptr.i
@@ -5,23 +5,21 @@
     something else (e.g. use shared_ptr<> which SWIG supports fully).
  */
 
-%define %auto_ptr(TYPE)
-%typemap (jni) std::auto_ptr<TYPE > "jlong"
-%typemap (jtype) std::auto_ptr<TYPE > "long"
-%typemap (jstype) std::auto_ptr<TYPE > "$typemap(jstype, TYPE)"
+%include <auto_ptr.i>
 
-%typemap (out) std::auto_ptr<TYPE > %{
+%define %auto_ptr(TYPE)
+%typemap (jni) SWIG_AUTO_PTR_FULL_NAME<TYPE > "jlong"
+%typemap (jtype) SWIG_AUTO_PTR_FULL_NAME<TYPE > "long"
+%typemap (jstype) SWIG_AUTO_PTR_FULL_NAME<TYPE > "$typemap(jstype, TYPE)"
+
+%typemap (out) SWIG_AUTO_PTR_FULL_NAME<TYPE > %{
    jlong lpp = 0;
    *(TYPE**) &lpp = $1.release();
    $result = lpp;
 %}
-%typemap(javaout) std::auto_ptr<TYPE > {
+%typemap(javaout) SWIG_AUTO_PTR_FULL_NAME<TYPE > {
      long cPtr = $jnicall;
      return (cPtr == 0) ? null : new $typemap(jstype, TYPE)(cPtr, true);
    }
-%template() std::auto_ptr<TYPE >;
+%template() SWIG_AUTO_PTR_FULL_NAME<TYPE >;
 %enddef
-
-namespace std {
-   template <class T> class auto_ptr {};
-} 

--- a/Lib/python/std_auto_ptr.i
+++ b/Lib/python/std_auto_ptr.i
@@ -5,13 +5,11 @@
     something else (e.g. use shared_ptr<> which SWIG supports fully).
  */
 
+%include <auto_ptr.i>
+
 %define %auto_ptr(TYPE)
-%typemap (out) std::auto_ptr<TYPE > %{
+%typemap (out) SWIG_AUTO_PTR_FULL_NAME<TYPE > %{
    %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
 %}
-%template() std::auto_ptr<TYPE >;
+%template() SWIG_AUTO_PTR_FULL_NAME<TYPE >;
 %enddef
-
-namespace std {
-   template <class T> class auto_ptr {};
-} 

--- a/Lib/ruby/std_auto_ptr.i
+++ b/Lib/ruby/std_auto_ptr.i
@@ -5,13 +5,11 @@
     something else (e.g. use shared_ptr<> which SWIG supports fully).
  */
 
+%include <auto_ptr.i>
+
 %define %auto_ptr(TYPE)
-%typemap (out) std::auto_ptr<TYPE > %{
+%typemap (out) SWIG_AUTO_PTR_FULL_NAME<TYPE > %{
    %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
 %}
-%template() std::auto_ptr<TYPE >;
+%template() SWIG_AUTO_PTR_FULL_NAME<TYPE >;
 %enddef
-
-namespace std {
-   template <class T> class auto_ptr {};
-}


### PR DESCRIPTION
Generalize %auto_ptr macro so that it could be used with other types,
e.g. std::unique_ptr<> or even boost::unique_ptr<> using the same
approach as is already used for std::shared_ptr<>, i.e. by allowing to
predefine the class name and/or namespace different from the default one
before including std_auto_ptr.i.
