### PR TITLE
Support abstract conversion operators

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -184,6 +184,7 @@ CPP_TEST_CASES += \
 	director_classes \
 	director_classic \
 	director_constructor \
+	director_conversion_operators \
 	director_default \
 	director_detect \
 	director_enum \

--- a/Examples/test-suite/director_conversion_operators.i
+++ b/Examples/test-suite/director_conversion_operators.i
@@ -1,0 +1,35 @@
+%module(directors="1") director_conversion_operators
+
+%feature("director");
+
+%warnfilter(SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Bar;
+
+%rename(toFoo) Bar::operator Foo();
+%rename(toFooPtr) Bar::operator Foo *();
+%rename(toFooRef) Bar::operator Foo &();
+%rename(toFooPtrRef) Bar::operator Foo *&();
+
+%rename(toOtherFoo) Bar::operator OtherFoo();
+%rename(toOtherFooPtr) Bar::operator OtherFoo *();
+%rename(toOtherFooRef) Bar::operator OtherFoo &();
+%rename(toOtherFooPtrRef) Bar::operator OtherFoo *&();
+
+%inline %{
+   struct Foo {
+   };
+   struct OtherFoo {
+   };
+   struct Bar {
+      Foo myFoo;
+      Foo *myFooPtr;
+      virtual ~Bar() { }
+      virtual operator Foo () { return Foo(); }
+      virtual operator Foo *() { return &myFoo; }
+      virtual operator Foo &() { return myFoo; }
+      virtual operator Foo *&() { return myFooPtr; }
+      virtual operator OtherFoo () = 0;
+      virtual operator OtherFoo *() = 0;
+      virtual operator OtherFoo &() = 0;
+      virtual operator OtherFoo *&() = 0;
+   };
+%}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -4800,6 +4800,9 @@ cpp_conversion_operator : storage_class CONVERSIONOPERATOR type pointer LPAREN p
 		 if ($8.qualifier) {
 		   SwigType_push($4,$8.qualifier);
 		 }
+		 if ($8.val) {
+		   Setattr($$,"value",$8.val);
+		 }
 		 Setattr($$,"refqualifier",$8.refqualifier);
 		 Setattr($$,"decl",$4);
 		 Setattr($$,"parms",$6);
@@ -4818,6 +4821,9 @@ cpp_conversion_operator : storage_class CONVERSIONOPERATOR type pointer LPAREN p
 		 if ($8.qualifier) {
 		   SwigType_push(decl,$8.qualifier);
 		 }
+		 if ($8.val) {
+		   Setattr($$,"value",$8.val);
+		 }
 		 Setattr($$,"refqualifier",$8.refqualifier);
 		 Setattr($$,"decl",decl);
 		 Setattr($$,"parms",$6);
@@ -4835,6 +4841,9 @@ cpp_conversion_operator : storage_class CONVERSIONOPERATOR type pointer LPAREN p
 		 SwigType_add_function(decl,$6);
 		 if ($8.qualifier) {
 		   SwigType_push(decl,$8.qualifier);
+		 }
+		 if ($8.val) {
+		   Setattr($$,"value",$8.val);
 		 }
 		 Setattr($$,"refqualifier",$8.refqualifier);
 		 Setattr($$,"decl",decl);
@@ -4856,6 +4865,9 @@ cpp_conversion_operator : storage_class CONVERSIONOPERATOR type pointer LPAREN p
 		 if ($9.qualifier) {
 		   SwigType_push(decl,$9.qualifier);
 		 }
+		 if ($9.val) {
+		   Setattr($$,"value",$9.val);
+		 }
 		 Setattr($$,"refqualifier",$9.refqualifier);
 		 Setattr($$,"decl",decl);
 		 Setattr($$,"parms",$7);
@@ -4873,7 +4885,10 @@ cpp_conversion_operator : storage_class CONVERSIONOPERATOR type pointer LPAREN p
 		if ($7.qualifier) {
 		  SwigType_push(t,$7.qualifier);
 		}
-		 Setattr($$,"refqualifier",$7.refqualifier);
+		if ($7.val) {
+		  Setattr($$,"value",$7.val);
+		}
+		Setattr($$,"refqualifier",$7.refqualifier);
 		Setattr($$,"decl",t);
 		Setattr($$,"parms",$5);
 		Setattr($$,"conversion_operator","1");


### PR DESCRIPTION
Swig's C++ parser for user-defined conversion operators did not honor the trailing "= 0" and therefore treated such abstract operators as non-abstract, with the effects described in issue #1723.

This PR fixes the parser, specifically the special treatment of conversion operators, for all supported variants of such operators. The associated test cases demonstrate that compilable code is generated for classes using such operators.