### PR TITLE
Catch exceptions by reference rather than by value.

### DIFF
--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -628,7 +628,7 @@ namespace swig
       try {
 	r = swig::from< const Sequence* >( swig::getslice(self, i, j) );
       }
-      catch( std::out_of_range ) {
+      catch( std::out_of_range& ) {
       }
       return r;
     }
@@ -687,7 +687,7 @@ namespace swig
 	r = swig::from< Sequence::value_type >( *(at) );
 	$self->erase(at); 
       }
-      catch (std::out_of_range)
+      catch (std::out_of_range&)
 	{
 	}
       return r;
@@ -757,7 +757,7 @@ namespace swig
       try {
 	r = swig::from< Sequence::value_type >( *(swig::cgetpos(self, i)) );
       }
-      catch( std::out_of_range ) {
+      catch( std::out_of_range& ) {
       }
       return r;
     }
@@ -780,7 +780,7 @@ namespace swig
       try {
 	r = swig::from< const Sequence* >( swig::getslice(self, i, j) );
       }
-      catch( std::out_of_range ) {
+      catch( std::out_of_range& ) {
       }
       return r;
     }
@@ -790,7 +790,7 @@ namespace swig
       try {
 	r = swig::from< Sequence::value_type >( *(swig::cgetpos(self, i)) );
       }
-      catch( std::out_of_range ) {
+      catch( std::out_of_range& ) {
       }
       return r;
     }


### PR DESCRIPTION
Fixes -Wcatch-value gcc warnings.