### PR TITLE
Add support for LUA lightuserdata to SWIG_Lua_ConvertPtr 

### DIFF
--- a/Examples/test-suite/lua/Makefile.in
+++ b/Examples/test-suite/lua/Makefile.in
@@ -15,6 +15,7 @@ top_builddir = @top_builddir@
 CPP_TEST_CASES += \
 	lua_no_module_global \
 	lua_inherit_getitem  \
+	lua_lightuserdata  \
 
 
 C_TEST_CASES += \

--- a/Examples/test-suite/lua/lua_lightuserdata_runme.lua
+++ b/Examples/test-suite/lua/lua_lightuserdata_runme.lua
@@ -1,0 +1,7 @@
+require("import") -- the import fn
+require("lua_lightuserdata") -- import lib
+
+local t = lua_lightuserdata
+local d = t.get_lightuserdata()
+local r = t.check_lighuserdata(d)
+assert(r)

--- a/Examples/test-suite/lua/lua_lightuserdata_runme.lua
+++ b/Examples/test-suite/lua/lua_lightuserdata_runme.lua
@@ -1,5 +1,5 @@
 require("import") -- the import fn
-require("lua_lightuserdata") -- import lib
+import("lua_lightuserdata") -- import lib
 
 local t = lua_lightuserdata
 local d = t.get_lightuserdata()

--- a/Examples/test-suite/lua_lightuserdata.i
+++ b/Examples/test-suite/lua_lightuserdata.i
@@ -2,15 +2,16 @@
 
 %native(get_lightuserdata) int get_lightuserdata(lua_State* L);
 %{
+static int foo;
 int get_lightuserdata(lua_State* L)
 {
-  lua_pushlightuserdata(L, reinterpret_cast<void*>(0x123456));
+  lua_pushlightuserdata(L, &foo);
   return 1;
 }
 %}
 
 %inline %{
 bool check_lighuserdata(const void* d) {
-  return reinterpret_cast<void*>(0x123456) == d;
+  return d == &foo;
 }
 %}

--- a/Examples/test-suite/lua_lightuserdata.i
+++ b/Examples/test-suite/lua_lightuserdata.i
@@ -1,0 +1,16 @@
+%module lua_lightuserdata
+
+%native(get_lightuserdata) int get_lightuserdata(lua_State* L);
+%{
+int get_lightuserdata(lua_State* L)
+{
+  lua_pushlightuserdata(L, reinterpret_cast<void*>(0x123456));
+  return 1;
+}
+%}
+
+%inline %{
+bool check_lighuserdata(const void* d) {
+  return reinterpret_cast<void*>(0x123456) == d;
+}
+%}

--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -1765,6 +1765,11 @@ SWIGRUNTIME int  SWIG_Lua_ConvertPtr(lua_State *L,int index,void **ptr,swig_type
     *ptr=0;
     return (flags & SWIG_POINTER_NO_NULL) ? SWIG_NullReferenceError : SWIG_OK;
   }
+  if (lua_islightuserdata(L,index))
+  {
+    *ptr=lua_touserdata(L,index);
+    return (flags & SWIG_POINTER_NO_NULL) ? SWIG_NullReferenceError : SWIG_OK;
+  }
   usr=(swig_lua_userdata*)lua_touserdata(L,index);  /* get data */
   if (usr)
   {


### PR DESCRIPTION
SWIG_Lua_ConvertPtr was missing a check if the given object was of lightuserdata type. It would attempt to unwrap it as a regular userdata type, which would result in an invalid pointer address being returned.

This change includes a test case to demonstrate the issue, and an update to SWIG_Lua_ConvertPtr to handle the lightuserdata case.