### PR TITLE
Scilab - make generated gateways compatible with 6.1.0

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.0.2 (in progress)
 ===========================
 
+2020-02-27: davidcl
+            [Scilab] #1737 makes generated gateway compatible with Scilab 6.1.0.
+
 2020-02-18: ryannevell
             [Lua] #1728 Add support for LUA lightuserdata to SWIG_Lua_ConvertPtr.
 

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -500,9 +500,10 @@ public:
     Replaceall(wrapper->code, "$symname", functionName);
 
     /* Set CheckInputArgument and CheckOutputArgument input arguments */
-    /* In Scilab there is always one output even if not defined */
-    if (minOutputArguments == 0) {
-      maxOutputArguments = 1;
+    /* In Scilab, there was always one output even if not defined before 6.1 */
+    /* after 6.1.0, the gateways could enforce the presence of an output argument by using minOutputArguments==1, relax this constraint by default */
+    if (maxOutputArguments == 1) {
+      minOutputArguments = 0;
     }
     String *argnumber = NewString("");
     Printf(argnumber, "%d", minInputArguments);
@@ -607,7 +608,7 @@ public:
 
     /* Check the number of input and output */
     Printf(getFunctionWrapper->def, "SWIG_CheckInputArgument(pvApiCtx, 0, 0);\n");
-    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 1, 1);\n");
+    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 0, 1);\n");
     Printf(getFunctionWrapper->def, "SWIG_Scilab_SetApiContext(pvApiCtx);\n");
 
     String *varoutTypemap = Swig_typemap_lookup("varout", node, origVariableName, 0);
@@ -636,7 +637,7 @@ public:
 
       /* Check the number of input and output */
       Printf(setFunctionWrapper->def, "SWIG_CheckInputArgument(pvApiCtx, 1, 1);\n");
-      Printf(setFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 1, 1);\n");
+      Printf(setFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 0, 1);\n");
       Printf(setFunctionWrapper->def, "SWIG_Scilab_SetApiContext(pvApiCtx);\n");
 
       String *varinTypemap = Swig_typemap_lookup("varin", node, origVariableName, 0);
@@ -719,7 +720,7 @@ public:
 
     /* Check the number of input and output */
     Printf(getFunctionWrapper->def, "SWIG_CheckInputArgument(pvApiCtx, 0, 0);\n");
-    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 1, 1);\n");
+    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 0, 1);\n");
     Printf(getFunctionWrapper->def, "SWIG_Scilab_SetApiContext(pvApiCtx);\n");
 
     constantTypemap = Swig_typemap_lookup("constcode", node, nodeName, 0);


### PR DESCRIPTION
This fix #1737 but using the correct 0 or 1 output argument syntax. For any function mapped `foo`, this will handle both:
```scilab
foo();
a = foo();
```