### PR TITLE
Fix quoting issues with docstrings in the generated Python

### DIFF
--- a/Examples/test-suite/doxygen_misc_constructs.h
+++ b/Examples/test-suite/doxygen_misc_constructs.h
@@ -94,3 +94,9 @@ void cycle(int id, char *fileName)
 /// This doc comment ends with a quote: "and that's ok"
 void doc_ends_with_quote() {}
 
+/**
+    This comment contains embedded triple-quoted string:
+
+        """How quaint"""
+ */
+void doc_with_triple_quotes() {}

--- a/Examples/test-suite/doxygen_misc_constructs.h
+++ b/Examples/test-suite/doxygen_misc_constructs.h
@@ -91,4 +91,6 @@ void backslashC()
 void cycle(int id, char *fileName)
 {}
 
+/// This doc comment ends with a quote: "and that's ok"
+void doc_ends_with_quote() {}
 

--- a/Examples/test-suite/java/doxygen_misc_constructs_runme.java
+++ b/Examples/test-suite/java/doxygen_misc_constructs_runme.java
@@ -185,6 +185,8 @@ public class doxygen_misc_constructs_runme {
                 "\n" +
                 " @param fileName name of the log file\n");
 
+    wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.doc_ends_with_quote()",
+            "This doc comment ends with a quote: \"and that's ok\"");
 
     // and ask the parser to check comments for us
     System.exit(CommentParser.check(wantedComments));

--- a/Examples/test-suite/java/doxygen_misc_constructs_runme.java
+++ b/Examples/test-suite/java/doxygen_misc_constructs_runme.java
@@ -188,6 +188,10 @@ public class doxygen_misc_constructs_runme {
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.doc_ends_with_quote()",
             "This doc comment ends with a quote: \"and that's ok\"");
 
+    wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.doc_with_triple_quotes()",
+            "This comment contains embedded triple-quoted string:\n" +
+            "\"\"\"How quaint\"\"\"");
+
     // and ask the parser to check comments for us
     System.exit(CommentParser.check(wantedComments));
   }

--- a/Examples/test-suite/python/doxygen_misc_constructs_runme.py
+++ b/Examples/test-suite/python/doxygen_misc_constructs_runme.py
@@ -135,3 +135,9 @@ Spaces at the start of line should be taken into account:
 comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.doc_ends_with_quote),
     r'''This doc comment ends with a quote: "and that's ok"'''
 );
+
+comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.doc_with_triple_quotes),
+    r'''This comment contains embedded triple-quoted string:
+
+    """How quaint"""'''
+);

--- a/Examples/test-suite/python/doxygen_misc_constructs_runme.py
+++ b/Examples/test-suite/python/doxygen_misc_constructs_runme.py
@@ -131,3 +131,7 @@ Spaces at the start of line should be taken into account:
 :type fileName: string
 :param fileName: name of the log file"""
 );
+
+comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.doc_ends_with_quote),
+    r'''This doc comment ends with a quote: "and that's ok"'''
+);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1599,6 +1599,16 @@ public:
 
     Append(doc, useSingleQuotes ? "r'''" : "r\"\"\"");
 
+    // We also need to avoid having triple quotes of whichever type we use, as
+    // this would break Python doc string syntax too. Unfortunately there is no
+    // way to have triple quotes inside of raw-triple-quoted string, so we have
+    // to break the string in parts and rely on concatenation of the adjacent
+    // string literals.
+    if (useSingleQuotes)
+      Replaceall(docstr, "'''", "''' \"'''\" '''");
+    else
+      Replaceall(docstr, "\"\"\"", "\"\"\" '\"\"\"' \"\"\"");
+
     Append(doc, docstr);
     Append(doc, useSingleQuotes ? "'''" : "\"\"\"");
     Delete(docstr);


### PR DESCRIPTION
Single-line Doxygen comments ending with a double quote resulted in
syntactically-invalid Python docstrings in the output, so escape the
last quote in this case to avoid it.

See #1747.