### PR TITLE
Scilab 6.0.2 and 6.1.0 compatible gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,10 @@ jobs:
           VER: '3.0'
           CPPSTD: c++11
         - SWIGLANG: scilab
-          os: ubuntu-18.04 # scilab-6.1 in ubuntu-20.04 not yet working
+          VER: '5.5.2'
+        - SWIGLANG: scilab
+          os: ubuntu-18.04 # scilab 6.0
+        - SWIGLANG: scilab
         - SWIGLANG: tcl
         # c++11 testing
         - SWIGLANG: csharp
@@ -213,7 +216,9 @@ jobs:
           CPPSTD: c++11
         - SWIGLANG: scilab
           CPPSTD: c++11
-          os: ubuntu-18.04 # scilab-6.1 in ubuntu-20.04 not yet working
+          os: ubuntu-18.04 # scilab 6.0
+        - SWIGLANG: scilab
+          CPPSTD: c++11
         - SWIGLANG: tcl
           CPPSTD: c++11
         # c++14 testing
@@ -249,7 +254,9 @@ jobs:
           CPPSTD: c++14
         - SWIGLANG: scilab
           CPPSTD: c++14
-          os: ubuntu-18.04 # scilab-6.1 in ubuntu-20.04 not yet working
+          os: ubuntu-18.04 # scilab 6.0
+        - SWIGLANG: scilab
+          CPPSTD: c++14
         - SWIGLANG: tcl
           CPPSTD: c++14
         # c++17 testing (using gcc11)
@@ -298,7 +305,6 @@ jobs:
         - SWIGLANG: scilab
           CPPSTD: c++17
           GCC: 11
-          os: ubuntu-18.04 # scilab-6.1 in ubuntu-20.04 not yet working
         - SWIGLANG: tcl
           CPPSTD: c++17
           GCC: 11

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,8 +7,18 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.1.0 (in progress)
 ===========================
 
+2022-02-21: davidcl
+	    [Scilab] improve 5.5.2, 6.0.0 and 6.1.0 support. The `targetversion`
+		argument has been removed as the generated code detect the Scilab 
+		version on loader.sce or builder.sce.
+
+		For Scilab 5, long names are reduced to small names preserving the 
+		class prefix and accessor suffix (get or set).
+		For Scilab 6, long names with class prefix and accessor suffix should
+		be used on the user code.
+
 2022-02-20: wsfulton
-            Fix %warnfilter warning suppress for warning 315 SWIGWARN_PARSE_USING_UNDEF.
+        Fix %warnfilter warning suppress for warning 315 SWIGWARN_PARSE_USING_UNDEF.
 
 2022-02-17: olly
 	    [PHP] https://sourceforge.net/p/swig/bugs/1211/

--- a/Doc/Manual/Scilab.html
+++ b/Doc/Manual/Scilab.html
@@ -304,11 +304,6 @@ The following table lists the Scilab specific command line options in addition t
 <td>Generate the gateway XML with the given &lt;gateway_id&gt;</td>
 </tr>
 
-<tr>
-<td><tt>-targetversion</tt></td>
-<td>Generate for Scilab target (major) version</td>
-</tr>
-
 </table>
 
 <p>
@@ -341,10 +336,6 @@ In Scilab 5.x, identifier names are composed of 24 characters maximum (this limi
 </p>
 <p>This can cause ambiguities, especially when wrapping structs/classes, for which the wrapped function name is composed of the struct/class name and field names.
 In these cases, the <a href="SWIG.html#SWIG_rename_ignore">%rename directive</a> can be used to choose a different Scilab name.
-</p>
-
-<p>
-Note: truncations can be disabled by specifying the target version 6 of Scilab in the <tt>targetversion</tt> argument (i.e. <tt>-targetversion 6</tt>).
 </p>
 
 <H3><a name="Scilab_wrapping_functions">36.3.3 Functions</a></H3>

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -1357,6 +1357,7 @@ r_clean:
 SCILAB = @SCILAB@
 SCILAB_INC= @SCILABINCLUDE@
 SCILAB_OPT = @SCILABOPT@
+SCILAB_VERSION = @SCILAB_VERSION@
 SCILAB_LIBPREFIX = lib
 
 # ----------------------------------------------------------------
@@ -1389,7 +1390,7 @@ scilab_run:
 # -----------------------------------------------------------------
 
 scilab_version:
-	echo `$(SCILAB) -version | head -1`
+	echo `$(SCILAB) -nwni -version | head -1`
 
 # -----------------------------------------------------------------
 # Cleaning the scilab examples

--- a/Examples/test-suite/scilab/allprotected_runme.sci
+++ b/Examples/test-suite/scilab/allprotected_runme.sci
@@ -21,10 +21,10 @@ checkequal(PubBase_virtualMethod(pubBase), "PublicBase", "PubBase_virtualMethod(
 class = PubBase_instanceMethod(pubBase, klass);
 checkequal(Klass_getName(class), "allprotected_klass", "Klass_getName(PubBase_instanceMethod(pubBase, klass))");
 
-class = PubBase_instanceOverload(pubBase, klass);
+class = PubBase_instanceOverloaded(pubBase, klass);
 checkequal(Klass_getName(class), "allprotected_klass", "Klass_getName(PubBase_instanceOverloaded(pubBase, klass))");
 
-class = PubBase_instanceOverload(pubBase, klass, "allprotected_klass2");
+class = PubBase_instanceOverloaded(pubBase, klass, "allprotected_klass2");
 checkequal(Klass_getName(class), "allprotected_klass2", "Klass_getName(PubBase_instanceOverloaded(pubBase, klass, ""allprotected_klass2""))");
 
 class = PubBase_staticMethod(klass);
@@ -40,12 +40,22 @@ checkequal(Klass_getName(class), "allprotected_klass3", "Klass_getName(PubBase_s
 checkequal(PubBase_EnumVal1_get(), 0, "PubBase_EnumVal1_get()");
 checkequal(PubBase_EnumVal2_get(), 1, "(PubBase_EnumVal2_get()");
 
+v=getversion("scilab");
+if v(1) < 6 then
+    PubBase_instanceMemb_set(pubBase, 12);
+    checkequal(PubBase_instanceMemb_get(pubBase), 12, "PubBase_instanceMemb_get(pubBase)");
+else
+    PubBase_instanceMemberVariable_set(pubBase, 12);
+    checkequal(PubBase_instanceMemberVariable_get(pubBase), 12, "PubBase_instanceMemberVariable_get(pubBase)");
+end
 
-PubBase_instanceMemb_set(pubBase, 12);
-checkequal(PubBase_instanceMemb_get(pubBase), 12, "PubBase_instanceMemb_get(pubBase)");
-
-checkequal(PubBase_staticConstM_get(), 20, "PubBase_staticConstM_get()");
-checkequal(PubBase_staticMember_get(), 10, "PubBase_staticMember_get()")
+if v(1) < 6 then
+    checkequal(PubBase_staticConstM_get(), 20, "PubBase_staticConstMemberVariable_get()");
+    checkequal(PubBase_staticMember_get(), 10, "PubBase_staticMemberVariable_get()")
+else
+    checkequal(PubBase_staticConstMemberVariable_get(), 20, "PubBase_staticConstMemberVariable_get()");
+    checkequal(PubBase_staticMemberVariable_get(), 10, "PubBase_staticMemberVariable_get()")
+end
 
 PubBase_stringMember_set(pubBase, "dummy");
 checkequal(PubBase_stringMember_get(pubBase), "dummy", "PubBase_stringMember_get()");

--- a/Examples/test-suite/scilab/li_std_except_runme.sci
+++ b/Examples/test-suite/scilab/li_std_except_runme.sci
@@ -14,7 +14,7 @@ checkException('Test_throw_domain_error(t)', 20009, 'ValueError: oops');
 
 checkException('Test_throw_exception(t)', 20010, 'SystemError: std::exception');
 
-checkException('Test_throw_invalid_argum(t)', 20009, 'ValueError: oops');
+checkException('Test_throw_invalid_argument(t)', 20009, 'ValueError: oops');
 
 checkException('Test_throw_length_error(t)', 20004, 'IndexError: oops');
 
@@ -22,7 +22,7 @@ checkException('Test_throw_logic_error(t)', 20003, 'RuntimeError: oops');
 
 checkException('Test_throw_out_of_range(t)', 20004, 'IndexError: oops');
 
-checkException('Test_throw_overflow_erro(t)', 20007, 'OverflowError: oops');
+checkException('Test_throw_overflow_error(t)', 20007, 'OverflowError: oops');
 
 checkException('Test_throw_range_error(t)', 20007, 'OverflowError: oops');
 

--- a/Examples/test-suite/scilab/li_std_string_extra_runme.sci
+++ b/Examples/test-suite/scilab/li_std_string_extra_runme.sci
@@ -42,8 +42,12 @@ checkequal(Structure_StaticStr2_get(), "static member string 2", "Structure_Stat
 Structure_StaticStr2_set(s);
 checkequal(Structure_StaticStr2_get(), s, "Structure_StaticStr2_get()");
 
-checkequal(Structure_ConstStati_get(), "const static member string", "Structure_ConstStaticStr_get()");
-
+v = getversion("scilab");
+if v(1) < 6 then
+    checkequal(Structure_ConstStati_get(), "const static member string", "Structure_ConstStati_get()");
+else
+    checkequal(Structure_ConstStaticStr_get(), "const static member string", "Structure_ConstStaticStr_get()");
+end
 
 checkequal(stdstring_empty(), "", "stdstring_empty()");
 checkequal(c_empty(), "", "c_empty()");

--- a/Examples/test-suite/scilab/scilab_identifier_name_runme.sci
+++ b/Examples/test-suite/scilab/scilab_identifier_name_runme.sci
@@ -1,29 +1,46 @@
 exec("swigtest.start", -1);
 
+v = getversion("scilab");
 
-// Test truncating variables, constants, functions identifier names
+// Test truncating variables, constants, functions identifier names in Scilab 5
 // not truncated
 gvar_identifier_name_set(-101);
 checkequal(gvar_identifier_name_get(), -101, "gvar_identifier_name_get()");
 checkequal(CONS_IDENTIFIER_NAME_get(), -11, "CONS_IDENTIFIER_NAME_get()");
 checkequal(function_identifier_name(), -21, "function_identifier_name()");
 
-// truncated
+// truncated in Scilab 5
+if v(1) < 6 then
 too_long_gvar_identi_set(101);
 checkequal(too_long_gvar_identi_get(), 101, "too_long_variable_id_get()");
-checkequal(TOO_LONG_CONST_IDENT_get(), 11, "TOO_LONG_CONST_IDENT_get()");
-checkequal(too_long_function_identi(), 21, "too_long_function_identi()");
+checkequal(TOO_LONG_CONST_IDENT_get(), 11, "TOO_LONG_CONST_IDENTIFIER_NAME_1_get");
+checkequal(too_long_function_identi(), 21, "too_long_function_identifier_name_1()");
+else
+too_long_gvar_identifier_name_1_set(101);
+checkequal(too_long_gvar_identifier_name_1_get(), 101, "too_long_variable_id_get()");
+checkequal(TOO_LONG_CONST_IDENTIFIER_NAME_1_get(), 11, "TOO_LONG_CONST_IDENTIFIER_NAME_1_get");
+checkequal(too_long_function_identifier_name_1(), 21, "too_long_function_identifier_name_1()");
+end
 
 // Test truncating when %scilabconst mode is activated
-checkequal(SC_CONST_IDENTIFIER_NAME, int32(-12), "SC_TOO_LONG_IDENTIF");
-checkequal(SC_TOO_LONG_CONST_IDENTI, int32(14), "SC_TOO_LONG_IDENTIF");
+checkequal(SC_CONST_IDENTIFIER_NAME, int32(-12), "SC_CONST_IDENTIFIER_NAME");
+if v(1) < 6 then
+checkequal(SC_TOO_LONG_CONST_IDENTI, int32(14), "SC_TOO_LONG_CONST_IDENTIFIER_NAME_2");
+else
+checkequal(SC_TOO_LONG_CONST_IDENTIFIER_NAME_2, int32(14), "SC_TOO_LONG_CONST_IDENTIFIER_NAME_2");
+end
 
 // Test truncating in the case of struct
 st = new_st();
 st_m_identifier_name_set(st, 15);
 checkequal(st_m_identifier_name_get(st), 15, "st_m_identifier_name_get(st)");
+if v(1) < 6 then
 st_too_long_member_i_set(st, 25);
-checkequal(st_too_long_member_i_get(st), 25, "st_too_long_member_i_get(st)");
+checkequal(st_too_long_member_i_get(st), 25, "st_too_long_member_identifier_name_get(st)");
+else
+st_too_long_member_identifier_name_set(st, 25);
+checkequal(st_too_long_member_identifier_name_get(st), 25, "st_too_long_member_identifier_name_get(st)");
+end
 delete_st(st);
 
 exec("swigtest.quit", -1);

--- a/Examples/test-suite/scilab/swigtest.start
+++ b/Examples/test-suite/scilab/swigtest.start
@@ -2,6 +2,8 @@ lines(0);
 warning('off');
 ilib_verbose(0);
 
+ver = getversion('scilab');
+
 // Get test name (used in swigtest.quit file)
 [units, typ, names] = file(1);
 swigtestname = strsubst(fileparts(names, "fname"), "_runme", "");
@@ -23,7 +25,12 @@ end
 
 // Module initialization
 try
-    moduleInit = sprintf("%s_Init()", swigtestname);
+    if ver(1) < 6 then
+        entry = stripblanks(part(swigtestname, 1:24-5));
+    else
+        entry = swigtestname;
+    end
+    moduleInit = sprintf("%s_Init()", entry);
     execstr(moduleInit);
 catch
     mfprintf(0, "*** MODULE INIT FAILED ***\n");

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -11,10 +11,11 @@
  * Scilab language module for SWIG.
  * --------------------------------------------------------------------------*/
 
+#include <cstddef>
+#include <cstdlib>
 #include "swigmod.h"
 
 static const int SCILAB_IDENTIFIER_NAME_CHAR_MAX = 24;
-static const int SCILAB_VARIABLE_NAME_CHAR_MAX = SCILAB_IDENTIFIER_NAME_CHAR_MAX - 4;
 
 static const char *usage = (char *) " \
 Scilab options (available with -scilab)\n \
@@ -25,7 +26,6 @@ Scilab options (available with -scilab)\n \
      -buildersources <files>                - Add the (comma separated) files <files> to the builder sources\n \
      -builderverbositylevel <level>         - Set the builder verbosity level to <level> (default 0: off, 2: high)\n \
      -gatewayxml <gateway_id>               - Generate gateway xml with the given <gateway_id>\n \
-     -targetversion <scilab_major_version>  - Generate for Scilab target (major) version (default: 5)\n \
 \n";
 
 
@@ -40,11 +40,11 @@ protected:
 
   String *variablesCode;
 
-  int targetVersion;
-
   bool generateBuilder;
   File *builderFile;
   String *builderCode;
+  String *builderCode5;
+  String *builderCode6;
   int builderFunctionCount;
 
   List *sourceFileList;
@@ -67,6 +67,9 @@ protected:
   bool createLoader;
   File *loaderFile;
   String *loaderScript;
+  String *loaderScript5;
+  String *loaderScript6;
+  int loaderFunctionCount;
 public:
 
   /* ------------------------------------------------------------------------
@@ -74,8 +77,6 @@ public:
    * ----------------------------------------------------------------------*/
 
   virtual void main(int argc, char *argv[]) {
-    targetVersion = 5;
-
     generateBuilder = false;
     sourceFileList = NewList();
     cflags = NewList();
@@ -140,12 +141,6 @@ public:
           createGatewayXML = true;
           gatewayID = NewString(argv[argIndex + 1]);
           Swig_mark_arg(argIndex + 1);
-        } else if (strcmp(argv[argIndex], "-targetversion") == 0) {
-          if (argv[argIndex + 1] != NULL) {
-            Swig_mark_arg(argIndex);
-            targetVersion = atoi(argv[argIndex + 1]);
-            Swig_mark_arg(argIndex + 1);
-          }
         }
       }
     }
@@ -227,11 +222,13 @@ public:
     }
 
     // Module initialization function
+    String *smallFunctionName = createSmallIdentifierName(gatewayName, SCILAB_IDENTIFIER_NAME_CHAR_MAX - 5);
     String *gatewayInitFunctionName = NewStringf("%s_Init", gatewayName);
-    String *wrapperInitFunctionName = NewStringf("SWIG_%s_Init", gatewayName);
+    String *gatewayInitSmallFunctionName = NewStringf("%s_Init", smallFunctionName);
+    String *wrapperFunctionName = NewStringf("SWIG_%s_Init", gatewayName);
 
     /* Add initialization function to builder table */
-    addFunctionToScilab(gatewayInitFunctionName, wrapperInitFunctionName);
+    addFunctionToScilab(gatewayInitFunctionName, gatewayInitSmallFunctionName, wrapperFunctionName);
 
     // Add helper functions to builder table
     addHelperFunctions();
@@ -317,6 +314,8 @@ public:
 
     /* Get some useful attributes of this function */
     String *functionName = Getattr(node, "sym:name");
+    String *smallFunctionName = createSmallIdentifierName(functionName);
+
     SwigType *functionReturnType = Getattr(node, "type");
     ParmList *functionParamsList = Getattr(node, "parms");
 
@@ -361,7 +360,7 @@ public:
     int maxInputArguments = emit_num_arguments(functionParamsList);
     int minInputArguments = emit_num_required(functionParamsList);
     int minOutputArguments = 0;
-    int maxOutputArguments = 0;
+    int maxOutputArguments = 1;
 
     if (!emit_isvarargs(functionParamsList)) {
       Printf(wrapper->code, "SWIG_CheckInputArgument(pvApiCtx, $mininputarguments, $maxinputarguments);\n");
@@ -499,9 +498,11 @@ public:
     Replaceall(wrapper->code, "$symname", functionName);
 
     /* Set CheckInputArgument and CheckOutputArgument input arguments */
-    /* In Scilab there is always one output even if not defined */
-    if (minOutputArguments == 0) {
-      maxOutputArguments = 1;
+    if (maxOutputArguments < 1) {
+        maxOutputArguments = 1;
+    }
+    if (minOutputArguments == 1) {
+      minOutputArguments = 0;
     }
     String *argnumber = NewString("");
     Printf(argnumber, "%d", minInputArguments);
@@ -522,16 +523,14 @@ public:
     /* Dump the function out */
     Wrapper_print(wrapper, wrappersSection);
 
-    String *scilabFunctionName = checkIdentifierName(functionName, SCILAB_IDENTIFIER_NAME_CHAR_MAX);
-
     /* Update builder.sce contents */
     if (isLastOverloaded) {
-      addFunctionToScilab(scilabFunctionName, wrapperName);
+      addFunctionToScilab(functionName, smallFunctionName, wrapperName);
       dispatchFunction(node);
     }
 
     if (!isOverloaded) {
-      addFunctionToScilab(scilabFunctionName, wrapperName);
+      addFunctionToScilab(functionName, smallFunctionName, wrapperName);
     }
 
     /* tidy up */
@@ -592,21 +591,20 @@ public:
     /* Get information about variable */
     String *origVariableName = Getattr(node, "name");	// Ex: Shape::nshapes
     String *variableName = Getattr(node, "sym:name");	// Ex; Shape_nshapes (can be used for function names, ...)
-
-    // Variable names can have SCILAB_VARIABLE_NAME_CHAR_MAX because of suffixes "_get" or "_set" added to function
-    String *scilabVariableName = checkIdentifierName(variableName, SCILAB_VARIABLE_NAME_CHAR_MAX);
+    String *smallVariableName = createSmallIdentifierName(variableName, SCILAB_IDENTIFIER_NAME_CHAR_MAX - 4);
 
     /* Manage GET function */
     Wrapper *getFunctionWrapper = NewWrapper();
     String *getFunctionName = Swig_name_get(NSPACE_TODO, variableName);
-    String *scilabGetFunctionName = Swig_name_get(NSPACE_TODO, scilabVariableName);
+    String *scilabGetFunctionName = Swig_name_get(NSPACE_TODO, variableName);
+    String *scilabGetSmallFunctionName = Swig_name_get(NSPACE_TODO, smallVariableName);
 
     Setattr(node, "wrap:name", getFunctionName);
     Printv(getFunctionWrapper->def, "int ", getFunctionName, "(SWIG_GatewayParameters) {\n", NIL);
 
     /* Check the number of input and output */
     Printf(getFunctionWrapper->def, "SWIG_CheckInputArgument(pvApiCtx, 0, 0);\n");
-    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 1, 1);\n");
+    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 0, 1);\n");
     Printf(getFunctionWrapper->def, "SWIG_Scilab_SetApiContext(pvApiCtx);\n");
 
     String *varoutTypemap = Swig_typemap_lookup("varout", node, origVariableName, 0);
@@ -622,20 +620,21 @@ public:
     Wrapper_print(getFunctionWrapper, wrappersSection);
 
     /* Add function to builder table */
-    addFunctionToScilab(scilabGetFunctionName, getFunctionName);
+    addFunctionToScilab(scilabGetFunctionName, scilabGetSmallFunctionName, getFunctionName);
 
     /* Manage SET function */
     if (is_assignable(node)) {
       Wrapper *setFunctionWrapper = NewWrapper();
       String *setFunctionName = Swig_name_set(NSPACE_TODO, variableName);
-      String *scilabSetFunctionName = Swig_name_set(NSPACE_TODO, scilabVariableName);
+      String *scilabSetFunctionName = Swig_name_set(NSPACE_TODO, variableName);
+      String *scilabSetSmallFunctionName = Swig_name_set(NSPACE_TODO, smallVariableName);
 
       Setattr(node, "wrap:name", setFunctionName);
       Printv(setFunctionWrapper->def, "int ", setFunctionName, "(SWIG_GatewayParameters) {\n", NIL);
 
       /* Check the number of input and output */
       Printf(setFunctionWrapper->def, "SWIG_CheckInputArgument(pvApiCtx, 1, 1);\n");
-      Printf(setFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 1, 1);\n");
+      Printf(setFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 0, 1);\n");
       Printf(setFunctionWrapper->def, "SWIG_Scilab_SetApiContext(pvApiCtx);\n");
 
       String *varinTypemap = Swig_typemap_lookup("varin", node, origVariableName, 0);
@@ -649,7 +648,7 @@ public:
       Wrapper_print(setFunctionWrapper, wrappersSection);
 
       /* Add function to builder table */
-      addFunctionToScilab(scilabSetFunctionName, setFunctionName);
+      addFunctionToScilab(scilabSetFunctionName, scilabSetSmallFunctionName, setFunctionName);
 
       DelWrapper(setFunctionWrapper);
     }
@@ -685,10 +684,9 @@ public:
 
 	constantTypemap = Swig_typemap_lookup("scilabconstcode", node, nodeName, 0);
 	if (constantTypemap != NULL) {
-	  String *scilabConstantName = checkIdentifierName(constantName, SCILAB_IDENTIFIER_NAME_CHAR_MAX);
 
 	  Setattr(node, "wrap:name", constantName);
-	  Replaceall(constantTypemap, "$result", scilabConstantName);
+	  Replaceall(constantTypemap, "$result", constantName);
 	  Replaceall(constantTypemap, "$value", constantValue);
 
 	  emit_action_code(node, variablesCode, constantTypemap);
@@ -706,19 +704,21 @@ public:
       Delete(str);
       constantValue = wname;
     }
+
     // Constant names can have SCILAB_VARIABLE_NAME_CHAR_MAX because of suffixes "_get" added to function
-    String *scilabConstantName = checkIdentifierName(constantName, SCILAB_VARIABLE_NAME_CHAR_MAX);
+    String *smallConstantName = createSmallIdentifierName(constantName, SCILAB_IDENTIFIER_NAME_CHAR_MAX - 4);
 
     /* Create GET function to get the constant value */
     Wrapper *getFunctionWrapper = NewWrapper();
     String *getFunctionName = Swig_name_get(NSPACE_TODO, constantName);
-    String *scilabGetFunctionName = Swig_name_get(NSPACE_TODO, scilabConstantName);
+    String *scilabGetSmallFunctionName = Swig_name_get(NSPACE_TODO, smallConstantName);
+    Setattr(node, "wrap:name", getFunctionName);
     Setattr(node, "wrap:name", getFunctionName);
     Printv(getFunctionWrapper->def, "int ", getFunctionName, "(SWIG_GatewayParameters) {\n", NIL);
 
     /* Check the number of input and output */
     Printf(getFunctionWrapper->def, "SWIG_CheckInputArgument(pvApiCtx, 0, 0);\n");
-    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 1, 1);\n");
+    Printf(getFunctionWrapper->def, "SWIG_CheckOutputArgument(pvApiCtx, 0, 1);\n");
     Printf(getFunctionWrapper->def, "SWIG_Scilab_SetApiContext(pvApiCtx);\n");
 
     constantTypemap = Swig_typemap_lookup("constcode", node, nodeName, 0);
@@ -736,7 +736,7 @@ public:
     Wrapper_print(getFunctionWrapper, wrappersSection);
 
     /* Add the function to Scilab  */
-    addFunctionToScilab(scilabGetFunctionName, getFunctionName);
+    addFunctionToScilab(getFunctionName, scilabGetSmallFunctionName, getFunctionName);
 
     DelWrapper(getFunctionWrapper);
 
@@ -783,78 +783,13 @@ public:
     return Language::enumvalueDeclaration(node);
   }
 
-  /* ---------------------------------------------------------------------
-   * membervariableHandler()
-   * --------------------------------------------------------------------- */
-  virtual int membervariableHandler(Node *node) {
-    checkMemberIdentifierName(node, SCILAB_VARIABLE_NAME_CHAR_MAX);
-    return Language::membervariableHandler(node);
-  }
-
-  /* -----------------------------------------------------------------------
-   * checkIdentifierName()
-   * If Scilab target version is lower than 6:
-   *   truncates (and displays a warning) too long member identifier names
-   *   (applies on members of structs, classes...)
-   *   (Scilab 5 identifier names are limited to 24 chars max)
-   * ----------------------------------------------------------------------- */
-
-  String *checkIdentifierName(String *name, int char_size_max) {
-    String *scilabIdentifierName;
-    if (targetVersion <= 5) {
-			if (Len(name) > char_size_max) {
-				scilabIdentifierName = DohNewStringWithSize(name, char_size_max);
-				Swig_warning(WARN_SCILAB_TRUNCATED_NAME, input_file, line_number,
-					"Identifier name '%s' exceeds 24 characters and has been truncated to '%s'.\n", name, scilabIdentifierName);
-			} else
-      scilabIdentifierName = name;
-		} else {
-			scilabIdentifierName = DohNewString(name);
-		}
-		return scilabIdentifierName;
-  }
-
-  /* -----------------------------------------------------------------------
-   * checkMemberIdentifierName()
-   * If Scilab target version is lower than 6:
-   *   truncates (and displays a warning) too long member identifier names
-   *   (applies on members of structs, classes...)
-   *   (Scilab 5 identifier names are limited to 24 chars max)
-   * ----------------------------------------------------------------------- */
-
-  void checkMemberIdentifierName(Node *node, int char_size_max) {
-    if (targetVersion <= 5) {
-      String *memberName = Getattr(node, "sym:name");
-      Node *containerNode = parentNode(node);
-      String *containerName = Getattr(containerNode, "sym:name");
-      int lenContainerName = Len(containerName);
-      int lenMemberName = Len(memberName);
-
-      if (lenContainerName + lenMemberName + 1 > char_size_max) {
-        int lenScilabMemberName = char_size_max - lenContainerName - 1;
-
-        if (lenScilabMemberName > 0) {
-	        String *scilabMemberName = DohNewStringWithSize(memberName, lenScilabMemberName);
-	        Setattr(node, "sym:name", scilabMemberName);
-	        Swig_warning(WARN_SCILAB_TRUNCATED_NAME, input_file, line_number,
-		        "Wrapping functions names for member '%s.%s' will exceed 24 characters, "
-		        "so member name has been truncated to '%s'.\n", containerName, memberName, scilabMemberName);
-        } else {
-	        Swig_error(input_file, line_number,
-		        "Wrapping functions names for member '%s.%s' will exceed 24 characters, "
-		        "please rename the container of member '%s'.\n", containerName, memberName, containerName);
-        }
-      }
-    }
-  }
-
   /* -----------------------------------------------------------------------
    * addHelperFunctions()
    * ----------------------------------------------------------------------- */
 
   void addHelperFunctions() {
-    addFunctionToScilab("SWIG_this", "SWIG_this");
-    addFunctionToScilab("SWIG_ptr", "SWIG_ptr");
+    addFunctionToScilab("SWIG_this", "SWIG_this", "SWIG_this");
+    addFunctionToScilab("SWIG_ptr", "SWIG_ptr", "SWIG_ptr");
   }
 
   /* -----------------------------------------------------------------------
@@ -862,20 +797,20 @@ public:
    * Declare a wrapped function in Scilab (builder, gateway, XML, ...)
    * ----------------------------------------------------------------------- */
 
-  void addFunctionToScilab(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr wrapperFunctionName) {
+  void addFunctionToScilab(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName, const_String_or_char_ptr wrapperFunctionName) {
     if (!generateBuilder)
-      addFunctionInGatewayHeader(scilabFunctionName, wrapperFunctionName);
+      addFunctionInGatewayHeader(scilabFunctionName, scilabSmallFunctionName, wrapperFunctionName);
 
     if (generateBuilder) {
-      addFunctionInScriptTable(scilabFunctionName, wrapperFunctionName, builderCode);
+      addFunctionInScriptTable(scilabFunctionName, scilabSmallFunctionName, wrapperFunctionName, builderCode5, builderCode6);
     }
 
     if (createLoader) {
-      addFunctionInLoader(scilabFunctionName);
+      addFunctionInLoader(scilabFunctionName, scilabSmallFunctionName);
     }
 
     if (gatewayXMLFile) {
-      Printf(gatewayXML, "<PRIMITIVE gatewayId=\"%s\" primitiveId=\"%d\" primitiveName=\"%s\"/>\n", gatewayID, primitiveID++, scilabFunctionName);
+      Printf(gatewayXML, "<PRIMITIVE gatewayId=\"%s\" primitiveId=\"%d\" primitiveName=\"%s\"/>\n", gatewayID, primitiveID++, scilabSmallFunctionName);
     }
   }
 
@@ -938,13 +873,14 @@ public:
     for (int i = 0; i < Len(sourceFileList); i++) {
       String *sourceFile = Getitem(sourceFileList, i);
       if (i == 0) {
-	Printf(builderCode, "files = \"%s\";\n", sourceFile);
+	      Printf(builderCode, "files = \"%s\";\n", sourceFile);
       } else {
-	Printf(builderCode, "files($ + 1) = \"%s\";\n", sourceFile);
+	      Printf(builderCode, "files($ + 1) = \"%s\";\n", sourceFile);
       }
     }
 
-    Printf(builderCode, "table = [");
+    Printf(builderCode5, "table = [ ..\n");
+    Printf(builderCode6, "table = [ ..\n");
   }
 
   /* -----------------------------------------------------------------------
@@ -952,11 +888,13 @@ public:
    * Add a function wrapper in the function table of generated builder script
    * ----------------------------------------------------------------------- */
 
-  void addFunctionInScriptTable(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr wrapperFunctionName, String *scriptCode) {
+  void addFunctionInScriptTable(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName, const_String_or_char_ptr wrapperFunctionName, String *scriptCode5, String *scriptCode6) {
     if (++builderFunctionCount % 10 == 0) {
-      Printf(scriptCode, "];\ntable = [table;");
+      Printf(scriptCode5, "];\ntable = [table; ..\n");
+      Printf(scriptCode6, "];\ntable = [table; ..\n");
     }
-    Printf(scriptCode, "\"%s\",\"%s\";", scilabFunctionName, wrapperFunctionName);
+    Printf(scriptCode5, "\"%s\",\"%s\"; ..\n", scilabSmallFunctionName, wrapperFunctionName);
+    Printf(scriptCode6, "\"%s\",\"%s\"; ..\n", scilabFunctionName, wrapperFunctionName);
   }
 
   /* -----------------------------------------------------------------------
@@ -964,7 +902,26 @@ public:
    * ----------------------------------------------------------------------- */
 
   void saveBuilderFile(String *gatewayName) {
-    Printf(builderCode, "];\n");
+    Printf(builderCode5, "];\n");
+    Printf(builderCode6, "];\n");
+
+    if (Equal(builderCode5, builderCode6)) {
+      Append(builderCode, builderCode6);
+    } else {
+      Printf(builderCode, "ver = getversion('scilab');\n");
+      Printf(builderCode, "if ver(1) < 6 then\n");
+      Printf(builderCode, "  // version is less or equal to 5.5.2\n");
+      Printf(builderCode, "  \n");
+      Append(builderCode, builderCode5);
+      Printf(builderCode, "  \n");
+      Printf(builderCode, "else\n");
+      Printf(builderCode, "  // version is 6.0.0 or more\n");
+      Printf(builderCode, "  \n");
+      Append(builderCode, builderCode6);
+      Printf(builderCode, "  \n");
+      Printf(builderCode, "end\n");
+    }
+
     Printf(builderCode, "ierr = 0;\n");
     Printf(builderCode, "if ~isempty(table) then\n");
     Printf(builderCode, "  ierr = execstr(\"ilib_build(''%s'', table, files, libs, [], ldflags, cflags);\", 'errcatch');\n", gatewayName);
@@ -976,7 +933,9 @@ public:
     Printf(builderCode, "if ierr <> 0 then\n");
     Printf(builderCode, "  error(ierr, err_msg);\n");
     Printf(builderCode, "end\n");
-    Printv(builderFile, builderCode, NIL);
+    Write(builderFile, builderCode, Len(builderCode));
+    
+    Delete(builderCode);
     Delete(builderFile);
   }
 
@@ -1048,13 +1007,13 @@ public:
    * Add a function in the gateway header
    * ----------------------------------------------------------------------- */
 
-  void addFunctionInGatewayHeader(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr wrapperFunctionName) {
+  void addFunctionInGatewayHeader(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName, const_String_or_char_ptr wrapperFunctionName) {
     if (gatewayHeaderV5 == NULL) {
       gatewayHeaderV5 = NewString("");
       Printf(gatewayHeaderV5, "static GenericTable Tab[] = {\n");
     } else
       Printf(gatewayHeaderV5, ",\n");
-    Printf(gatewayHeaderV5, " {(Myinterfun)sci_gateway, (GT)%s, (char *)\"%s\"}", wrapperFunctionName, scilabFunctionName);
+    Printf(gatewayHeaderV5, " {(Myinterfun)sci_gateway, (GT)%s, (char *)\"%s\"}", wrapperFunctionName, scilabSmallFunctionName);
 
     Printf(gatewayHeaderV6, "if (wcscmp(pwstFuncName, L\"%s\") == 0) { addCStackFunction((wchar_t *)L\"%s\", &%s, (wchar_t *)MODULE_NAME); }\n", scilabFunctionName, scilabFunctionName, wrapperFunctionName);
   }
@@ -1112,13 +1071,15 @@ public:
 
     emitBanner(loaderFile);
 
-    loaderScript = NewString("");
-    Printf(loaderScript, "%s_path = get_absolute_file_path('loader.sce');\n", gatewayLibraryName);
-    Printf(loaderScript, "[bOK, ilib] = c_link('%s');\n", gatewayLibraryName);
-    Printf(loaderScript, "if bOK then\n");
-    Printf(loaderScript, "  ulink(ilib);\n");
-    Printf(loaderScript, "end\n");
-    Printf(loaderScript, "list_functions = [..\n");
+    loaderFunctionCount = 0;
+    loaderScript = NewString("function loader_function()\n");
+    Printf(loaderScript, "  p = get_absolute_file_path('loader.sce');\n", gatewayLibraryName);
+    Printf(loaderScript, "  [bOK, ilib] = c_link('%s');\n", gatewayLibraryName);
+    Printf(loaderScript, "  if bOK then\n");
+    Printf(loaderScript, "    ulink(ilib);\n");
+    Printf(loaderScript, "  end\n");
+    loaderScript5 = NewString("    list_functions = [ ..\n");
+    loaderScript6 = NewString("    list_functions = [ ..\n");
   }
 
   /* -----------------------------------------------------------------------
@@ -1126,8 +1087,13 @@ public:
    * Add a function in the loader script table
    * ----------------------------------------------------------------------- */
 
-  void addFunctionInLoader(const_String_or_char_ptr scilabFunctionName) {
-    Printf(loaderScript, "  '%s'; ..\n", scilabFunctionName);
+  void addFunctionInLoader(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName) {
+    if (++loaderFunctionCount % 10 == 0) {
+      Printf(loaderScript5, "    ];\n    list_functions = [list_functions; ..\n");
+      Printf(loaderScript6, "    ];\n    list_functions = [list_functions; ..\n");
+    }
+    Printf(loaderScript5, "      '%s'; ..\n", scilabSmallFunctionName);
+    Printf(loaderScript6, "      '%s'; ..\n", scilabFunctionName);
   }
 
   /* -----------------------------------------------------------------------
@@ -1136,16 +1102,64 @@ public:
    * ----------------------------------------------------------------------- */
 
   void saveLoaderFile(String *gatewayLibraryName) {
-    Printf(loaderScript, "];\n");
-    Printf(loaderScript, "addinter(fullfile(%s_path, '%s' + getdynlibext()), '%s', list_functions);\n",
-	   gatewayLibraryName, gatewayLibraryName, gatewayLibraryName);
-    Printf(loaderScript, "clear %s_path;\n", gatewayLibraryName);
-    Printf(loaderScript, "clear bOK;\n");
-    Printf(loaderScript, "clear ilib;\n");
-    Printf(loaderScript, "clear list_functions;\n");
+    Printf(loaderScript5, "    ];\n");
+    Printf(loaderScript6, "    ];\n");
+
+    if (Equal(loaderScript5, loaderScript6)) {
+      Append(loaderScript, loaderScript6);
+    } else {
+      Printf(loaderScript, "  ver = getversion('scilab');\n");
+      Printf(loaderScript, "  if ver(1) < 6 then\n");
+      Printf(loaderScript, "    // version is less or equal to 5.5.2\n");
+      Printf(loaderScript, "    \n");
+      Append(loaderScript, loaderScript5);
+      Delete(loaderScript5);
+      Printf(loaderScript, "    \n");
+      Printf(loaderScript, "  else\n");
+      Printf(loaderScript, "    // version is 6.0.0 or more\n");
+      Printf(loaderScript, "    \n");
+      Append(loaderScript, loaderScript6);
+      Delete(loaderScript6);
+      Printf(loaderScript, "    \n");
+      Printf(loaderScript, "  end\n");
+    }
+
+    Printf(loaderScript, "  addinter(p + '%s' + getdynlibext(), '%s', list_functions);\n", gatewayLibraryName, gatewayLibraryName);
+    Printf(loaderScript, "endfunction\n");
+    Printf(loaderScript, "loader_function();\n");
+    Printf(loaderScript, "clear loader_function;\n");
     Printv(loaderFile, loaderScript, NIL);
 
+    Delete(loaderScript);
     Delete(loaderFile);
+  }
+
+  /* -----------------------------------------------------------------------
+   * createSmallIdentifierName()
+   * Create a Scilab small identifier to be used by Scilab 5
+   * ----------------------------------------------------------------------- */
+
+  String* createSmallIdentifierName(String* name, int outputLen = SCILAB_IDENTIFIER_NAME_CHAR_MAX) {
+    char* s = Char(name);
+    int nameLen = Len(s);
+
+    // truncate and preserve common suffix
+    if (outputLen > 4 && nameLen > outputLen) {
+      String* smallName = NewStringWithSize(name, outputLen);
+      char* smallNameStr = (char*) Data(smallName);
+
+      if (s[nameLen-4] == '_' && s[nameLen - 3] == 'g' && s[nameLen - 2] == 'e' && s[nameLen - 1] == 't') {
+        // get
+        memcpy(&smallNameStr[outputLen - 4], &s[nameLen - 4], 4);
+      } else if (s[nameLen-4] == '_' && s[nameLen - 3] == 's' && s[nameLen - 2] == 'e' && s[nameLen - 1] == 't') {
+        // set
+        memcpy(&smallNameStr[outputLen - 4], &s[nameLen - 4], 4);
+      }
+
+      return smallName;
+    }
+    
+    return name;
   }
 
 };

--- a/Tools/CI-linux-install.sh
+++ b/Tools/CI-linux-install.sh
@@ -137,11 +137,14 @@ case "$SWIGLANG" in
 		fi
 		;;
 	"scilab")
-		# Travis has the wrong version of Java pre-installed resulting in error using scilab:
-		# /usr/bin/scilab-bin: error while loading shared libraries: libjava.so: cannot open shared object file: No such file or directory
-		echo "JAVA_HOME was set to $JAVA_HOME"
-		unset JAVA_HOME
-		$RETRY sudo apt-get -qq install scilab
+		if [[ -z "$VER" ]]; then
+			$RETRY sudo apt-get -qq install scilab scilab-include
+		else
+			$RETRY wget --progress=dot:giga "https://www.scilab.org/download/$VER/scilab-$VER.bin.linux-x86_64.tar.gz"
+			# $HOME/.local/bin is in PATH and writeable
+			mkdir -p "$HOME/.local"
+			tar -xzf "scilab-$VER.bin.linux-x86_64.tar.gz" --strip-components=1 -C "$HOME/.local"
+		fi	
 		;;
 	"tcl")
 		$RETRY sudo apt-get -qq install tcl-dev

--- a/configure.ac
+++ b/configure.ac
@@ -1218,7 +1218,7 @@ if test x"${SCILABBIN}" = xno; then
 else
   # Check for Scilab executable
   if test "x$SCILABBIN" = xyes; then
-    AC_CHECK_PROGS(SCILAB, scilab)
+    AC_PATH_PROG(SCILAB, scilab)
   else
     AC_MSG_CHECKING(for scilab)
     if test -f "$SCILABBIN"; then
@@ -1231,18 +1231,18 @@ else
 
   if test -n "$SCILAB"; then
     # Check for Scilab version (needs api_scilab so needs version 5.3.3 or higher)
-    SCILAB_FULL_VERSION=`$SCILAB -version | head -1 | sed -e 's|Scilab version \"\(.*\)\"|\1|g'`
+    SCILAB_VERSION=`$SCILAB -nwni -version | head -1 | sed -e 's|Scilab version \"\(.*\)\"|\1|g'`
 
     AC_MSG_CHECKING(Scilab version is 5.3.3 or higher)
-    SCILAB_MAJOR_VERSION=`echo $SCILAB_FULL_VERSION | cut -d. -f1`
-    SCILAB_MINOR_VERSION=`echo $SCILAB_FULL_VERSION | cut -d. -f2`
-    SCILAB_MAINTENANCE_VERSION=`echo $SCILAB_FULL_VERSION | cut -d. -f3`
-    SCILAB_VERSION="$SCILAB_MAJOR_VERSION$SCILAB_MINOR_VERSION$SCILAB_MAINTENANCE_VERSION"
+    SCILAB_MAJOR_VERSION=`echo $SCILAB_VERSION | cut -d. -f1`
+    SCILAB_MINOR_VERSION=`echo $SCILAB_VERSION | cut -d. -f2`
+    SCILAB_MAINTENANCE_VERSION=`echo $SCILAB_VERSION | cut -d. -f3`
+    SCILAB_VERSION_NO_DOTS="$SCILAB_MAJOR_VERSION$SCILAB_MINOR_VERSION$SCILAB_MAINTENANCE_VERSION"
 
-    if test $SCILAB_VERSION -ge 533; then
-      AC_MSG_RESULT(yes)
+    if test -n "$SCILAB_VERSION_NO_DOTS" && test "$SCILAB_VERSION_NO_DOTS" -ge 533; then
+      AC_MSG_RESULT(yes - $SCILAB_VERSION)
     else
-      AC_MSG_RESULT(no)
+      AC_MSG_RESULT(no - $SCILAB_VERSION)
       SCILAB=
     fi
 
@@ -1250,22 +1250,27 @@ else
       # Set Scilab startup options depending on version
       AC_MSG_CHECKING(for Scilab startup options)
       SCILABOPT="-nwni -nb"
-      if test $SCILAB_VERSION -ge 540; then
+      if test $SCILAB_VERSION_NO_DOTS -ge 540; then
         SCILABOPT+=" -noatomsautoload"
       fi
-      if test $SCILAB_VERSION -ge 600; then
+      if test $SCILAB_VERSION_NO_DOTS -ge 600; then
         SCILABOPT+=" -quit"
       fi
       AC_MSG_RESULT($SCILABOPT)
 
       # Check for Scilab header files
       AC_MSG_CHECKING(for Scilab header files)
+      headers="`AS_DIRNAME(["$SCILAB"])`/../include"
       if test "$SCILABINCDIR" != ""; then
         dirs="$SCILABINCDIR"
+      elif test -d "$SCI"; then
+        dirs="$SCI/include $SCI/../../include"
+      elif test -d "$headers"; then
+        dirs="$headers"
       elif test -n "$PKG_CONFIG "; then
         dirs=`$PKG_CONFIG  scilab --cflags-only-I | sed -e 's/-I//g'`
       else
-        dirs=""
+        dirs="/usr/include"
       fi
       for i in $dirs; do
         if test -r $i/api_scilab.h; then
@@ -1290,6 +1295,7 @@ fi
 AC_SUBST(SCILAB)
 AC_SUBST(SCILABINCLUDE)
 AC_SUBST(SCILABOPT)
+AC_SUBST(SCILAB_VERSION)
 
 
 #----------------------------------------------------------------


### PR DESCRIPTION
This fix #1737 by upgrading the Scilab code generator to have Scilab 6.0 and 6.1 compatible semantics. The test suite has been upgraded to detect the scilab version when needed.

The Travis CI support #1742 should probably be merged before this pull request. 