### PR TITLE
fixed some missing semicolons. 

### DIFF
--- a/Lib/r/rtype.swg
+++ b/Lib/r/rtype.swg
@@ -94,20 +94,20 @@
   %{  $input = enumToInteger($input, "$R_class"); %}
 
 %typemap(scoercein) SWIGTYPE, SWIGTYPE *, SWIGTYPE *const, SWIGTYPE &, SWIGTYPE &&
- %{ if (inherits($input, "ExternalReference")) $input = slot($input,"ref") %}
+ %{ if (inherits($input, "ExternalReference")) $input = slot($input,"ref"); %}
 
 /*
 %typemap(scoercein) SWIGTYPE *, SWIGTYPE *const
-  %{ $input = coerceIfNotSubclass($input, "$R_class") %}
+  %{ $input = coerceIfNotSubclass($input, "$R_class"); %}
 
 %typemap(scoercein) SWIGTYPE & 
-  %{ $input = coerceIfNotSubclass($input, "$R_class") %}
+  %{ $input = coerceIfNotSubclass($input, "$R_class"); %}
 
 %typemap(scoercein) SWIGTYPE && 
-  %{ $input = coerceIfNotSubclass($input, "$R_class") %}
+  %{ $input = coerceIfNotSubclass($input, "$R_class"); %}
 
 %typemap(scoercein) SWIGTYPE  
-  %{ $input = coerceIfNotSubclass($input, "$&R_class") %}
+  %{ $input = coerceIfNotSubclass($input, "$&R_class"); %}
 */
 
 %typemap(scoercein) SWIGTYPE[ANY]  

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -2120,7 +2120,7 @@ int R::functionWrapper(Node *n) {
 	{
 	  String *finalizer = NewString(iname);
 	  Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
-	  Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s)\n", finalizer);
+	  Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s);\n", finalizer);
 	}
       Printf(sfun->code, "ans\n");
     }


### PR DESCRIPTION
Each one caused a compile error in generated R code. I discovered this while generating wrappers for R for the OpenBabel project. In the case of the r.cxx change, the newline didn't seem to make it into the output, causing two lines of code to appear on one line without a semicolon between them. 