### PR TITLE
Properly handle C99 complex types even in C++ mode

### DIFF
--- a/Examples/test-suite/complextest.i
+++ b/Examples/test-suite/complextest.i
@@ -137,7 +137,7 @@
   {
     return conj(a);
   }
-}
+%}
 
 
 complex Conj4(complex a);

--- a/Examples/test-suite/complextest.i
+++ b/Examples/test-suite/complextest.i
@@ -119,18 +119,6 @@
   {
     return conjf(a);
   }
-
-
-  complex Conj4(complex a)
-  {
-    return conj(a);
-  }
-
-
-  _Complex Conj5(_Complex a)
-  {
-    return conj(a);
-  }
 }
 
 

--- a/Examples/test-suite/complextest.i
+++ b/Examples/test-suite/complextest.i
@@ -119,19 +119,31 @@
   {
     return conjf(a);
   }
+}
 
 
-  complex Conj4(complex a)
+%{
+  /* Clang and GCC support complex or _Complex by themselves
+   * (implying double _Complex) as extensions to the C99 standard,
+   * but issue warnings about it. */
+
+  double complex Conj4(double complex a)
   {
     return conj(a);
   }
 
 
-  _Complex Conj5(_Complex a)
+  double _Complex Conj5(double _Complex a)
   {
     return conj(a);
   }
 }
+
+
+complex Conj4(complex a);
+
+
+_Complex Conj5(_Complex a);
 
 
 #endif

--- a/Examples/test-suite/complextest.i
+++ b/Examples/test-suite/complextest.i
@@ -72,15 +72,15 @@
 
 %inline
 {
-  complex Conj(complex a)
+  double complex Conj(complex a)
   {
     return conj(a);
   }
 
 
-  complex float Conjf(float complex a)
+  float complex Conjf(float complex a)
   {
-    return conj(a);
+    return conjf(a);
   }
 }
 

--- a/Examples/test-suite/complextest.i
+++ b/Examples/test-suite/complextest.i
@@ -119,6 +119,18 @@
   {
     return conjf(a);
   }
+
+
+  complex Conj4(complex a)
+  {
+    return conj(a);
+  }
+
+
+  _Complex Conj5(_Complex a)
+  {
+    return conj(a);
+  }
 }
 
 

--- a/Examples/test-suite/complextest.i
+++ b/Examples/test-suite/complextest.i
@@ -68,19 +68,68 @@
 
 
 %{
+#include <complex.h>
 %}
 
 %inline
 {
-  double complex Conj(complex a)
+  complex double Conj(complex double a)
   {
     return conj(a);
   }
 
 
-  float complex Conjf(float complex a)
+  complex float Conjf(complex float a)
   {
     return conjf(a);
+  }
+
+
+  double complex Conj1(double complex a)
+  {
+    return conj(a);
+  }
+
+
+  float complex Conjf1(float complex a)
+  {
+    return conjf(a);
+  }
+
+
+  _Complex double Conj2(_Complex double a)
+  {
+    return conj(a);
+  }
+
+
+  _Complex float Conjf2(_Complex float a)
+  {
+    return conjf(a);
+  }
+
+
+  double _Complex Conj3(double _Complex a)
+  {
+    return conj(a);
+  }
+
+
+  float _Complex Conjf3(float _Complex a)
+  {
+    return conjf(a);
+  }
+
+
+  complex Conj4(complex a)
+  {
+    return conj(a);
+  }
+
+
+  _Complex Conj5(_Complex a)
+  {
+    return conj(a);
   }
 }
 

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -92,6 +92,7 @@ CPP11_TEST_CASES = \
 	cpp11_std_unordered_set \
 
 C_TEST_CASES += \
+	complextest \
 	file_test \
 	li_cstring \
 	li_cwstring \

--- a/Examples/test-suite/python/complextest_runme.py
+++ b/Examples/test-suite/python/complextest_runme.py
@@ -22,14 +22,6 @@ if 'Conjf3' in dir(complextest):
     if complextest.Conjf3(a) != a.conjugate():
         raise RuntimeError, "bad complex mapping"
 
-if 'Conj4' in dir(complextest):
-    if complextest.Conj4(a) != a.conjugate():
-        raise RuntimeError, "bad complex mapping"
-
-if 'Conj5' in dir(complextest):
-    if complextest.Conj5(a) != a.conjugate():
-        raise RuntimeError, "bad complex mapping"
-
 if 'CopyHalf' in dir(complextest):
 
     v = (complex(1, 2), complex(2, 3), complex(4, 3), 1)

--- a/Examples/test-suite/python/complextest_runme.py
+++ b/Examples/test-suite/python/complextest_runme.py
@@ -22,6 +22,14 @@ if 'Conjf3' in dir(complextest):
     if complextest.Conjf3(a) != a.conjugate():
         raise RuntimeError, "bad complex mapping"
 
+if 'Conj4' in dir(complextest):
+    if complextest.Conj4(a) != a.conjugate():
+        raise RuntimeError, "bad complex mapping"
+
+if 'Conj5' in dir(complextest):
+    if complextest.Conj5(a) != a.conjugate():
+        raise RuntimeError, "bad complex mapping"
+
 if 'CopyHalf' in dir(complextest):
 
     v = (complex(1, 2), complex(2, 3), complex(4, 3), 1)

--- a/Examples/test-suite/python/complextest_runme.py
+++ b/Examples/test-suite/python/complextest_runme.py
@@ -14,17 +14,34 @@ if complextest.Conj2(a) != a.conjugate():
 if complextest.Conjf2(a) != a.conjugate():
     raise RuntimeError, "bad complex mapping"
 
+if 'Conj3' in dir(complextest):
+    if complextest.Conj3(a) != a.conjugate():
+        raise RuntimeError, "bad complex mapping"
 
-v = (complex(1, 2), complex(2, 3), complex(4, 3), 1)
+if 'Conjf3' in dir(complextest):
+    if complextest.Conjf3(a) != a.conjugate():
+        raise RuntimeError, "bad complex mapping"
 
-if len(complextest.CopyHalf(v)) != 2:
-    raise RuntimeError("CopyHalf failed")
+if 'Conj4' in dir(complextest):
+    if complextest.Conj4(a) != a.conjugate():
+        raise RuntimeError, "bad complex mapping"
 
-if len(complextest.CopyHalfRef(v)) != 2:
-    raise RuntimeError("CopyHalfRef failed")
+if 'Conj5' in dir(complextest):
+    if complextest.Conj5(a) != a.conjugate():
+        raise RuntimeError, "bad complex mapping"
 
-p = complextest.ComplexPair()
-p.z1 = complex(0, 1)
-p.z2 = complex(0, -1)
-if complextest.Conj(p.z2) != p.z1:
-    raise RuntimeError, "bad complex mapping"
+if 'CopyHalf' in dir(complextest):
+
+    v = (complex(1, 2), complex(2, 3), complex(4, 3), 1)
+
+    if len(complextest.CopyHalf(v)) != 2:
+        raise RuntimeError("CopyHalf failed")
+
+    if len(complextest.CopyHalfRef(v)) != 2:
+        raise RuntimeError("CopyHalfRef failed")
+
+    p = complextest.ComplexPair()
+    p.z1 = complex(0, 1)
+    p.z2 = complex(0, -1)
+    if complextest.Conj(p.z2) != p.z1:
+        raise RuntimeError, "bad complex mapping"

--- a/Lib/javascript/jsc/ccomplex.i
+++ b/Lib/javascript/jsc/ccomplex.i
@@ -16,11 +16,11 @@
 /* C complex constructor */
 #define CCplxConst(r, i) ((r) + I*(i))
 
-%swig_cplxflt_convn(float complex, CCplxConst, creal, cimag);
-%swig_cplxdbl_convn(double complex, CCplxConst, creal, cimag);
+%swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
+%swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
-%typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float complex);
-%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, complex);

--- a/Lib/javascript/jsc/ccomplex.i
+++ b/Lib/javascript/jsc/ccomplex.i
@@ -12,6 +12,7 @@
 #include <complex.h>
 %}
 
+#define complex _Complex
 
 /* C complex constructor */
 #define CCplxConst(r, i) ((r) + I*(i))

--- a/Lib/javascript/jsc/ccomplex.i
+++ b/Lib/javascript/jsc/ccomplex.i
@@ -18,7 +18,9 @@
 
 %swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
+%swig_cplxdbl_convn(_Complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
 %typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, _Complex);

--- a/Lib/javascript/jsc/ccomplex.i
+++ b/Lib/javascript/jsc/ccomplex.i
@@ -18,9 +18,7 @@
 
 %swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
-%swig_cplxdbl_convn(complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
 %typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
-%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, complex);

--- a/Lib/javascript/v8/ccomplex.i
+++ b/Lib/javascript/v8/ccomplex.i
@@ -16,11 +16,11 @@
 /* C complex constructor */
 #define CCplxConst(r, i) ((r) + I*(i))
 
-%swig_cplxflt_convn(float complex, CCplxConst, creal, cimag);
-%swig_cplxdbl_convn(double complex, CCplxConst, creal, cimag);
+%swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
+%swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
-%typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float complex);
-%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, complex);

--- a/Lib/javascript/v8/ccomplex.i
+++ b/Lib/javascript/v8/ccomplex.i
@@ -12,6 +12,7 @@
 #include <complex.h>
 %}
 
+#define complex _Complex
 
 /* C complex constructor */
 #define CCplxConst(r, i) ((r) + I*(i))

--- a/Lib/javascript/v8/ccomplex.i
+++ b/Lib/javascript/v8/ccomplex.i
@@ -18,7 +18,9 @@
 
 %swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
+%swig_cplxdbl_convn(_Complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
 %typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, _Complex);

--- a/Lib/javascript/v8/ccomplex.i
+++ b/Lib/javascript/v8/ccomplex.i
@@ -18,9 +18,7 @@
 
 %swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
-%swig_cplxdbl_convn(complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
 %typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
-%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, complex);

--- a/Lib/python/ccomplex.i
+++ b/Lib/python/ccomplex.i
@@ -16,11 +16,11 @@
 /* C complex constructor */
 #define CCplxConst(r, i) ((r) + I*(i))
 
-%swig_cplxflt_convn(float complex, CCplxConst, creal, cimag);
-%swig_cplxdbl_convn(double complex, CCplxConst, creal, cimag);
+%swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
+%swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
-%typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float complex);
-%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, complex);

--- a/Lib/python/ccomplex.i
+++ b/Lib/python/ccomplex.i
@@ -12,6 +12,7 @@
 #include <complex.h>
 %}
 
+#define complex _Complex
 
 /* C complex constructor */
 #define CCplxConst(r, i) ((r) + I*(i))

--- a/Lib/python/ccomplex.i
+++ b/Lib/python/ccomplex.i
@@ -18,7 +18,9 @@
 
 %swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
+%swig_cplxdbl_convn(_Complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
 %typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
+%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, _Complex);

--- a/Lib/python/ccomplex.i
+++ b/Lib/python/ccomplex.i
@@ -18,9 +18,7 @@
 
 %swig_cplxflt_convn(float _Complex, CCplxConst, creal, cimag);
 %swig_cplxdbl_convn(double _Complex, CCplxConst, creal, cimag);
-%swig_cplxdbl_convn(complex, CCplxConst, creal, cimag);
 
 /* declaring the typemaps */
 %typemaps_primitive(SWIG_TYPECHECK_CPLXFLT, float _Complex);
 %typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, double _Complex);
-%typemaps_primitive(SWIG_TYPECHECK_CPLXDBL, complex);

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -908,10 +908,6 @@ int yylex(void) {
 	if (strcmp(yytext, "class") == 0) {
 	  Swig_warning(WARN_PARSE_CLASS_KEYWORD, cparse_file, cparse_line, "class keyword used, but not in C++ mode.\n");
 	}
-	if (strcmp(yytext, "complex") == 0) {
-	  yylval.type = NewSwigType(T_COMPLEX);
-	  return (TYPE_COMPLEX);
-	}
 	if (strcmp(yytext, "_Complex") == 0) {
 	  yylval.type = NewSwigType(T_COMPLEX);
 	  return (TYPE_COMPLEX);

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -912,6 +912,10 @@ int yylex(void) {
 	  yylval.type = NewSwigType(T_COMPLEX);
 	  return (TYPE_COMPLEX);
 	}
+	if (strcmp(yytext, "_Complex") == 0) {
+	  yylval.type = NewSwigType(T_COMPLEX);
+	  return (TYPE_COMPLEX);
+	}
 	if (strcmp(yytext, "restrict") == 0)
 	  return (yylex());
       }

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -6294,7 +6294,7 @@ type_specifier : TYPE_INT {
                     $$.type = 0;
                 }
                | TYPE_COMPLEX { 
-                    $$.type = NewString("complex");
+                    $$.type = NewString("_Complex");
                     $$.us = 0;
                 }
                | TYPE_NON_ISO_INT8 { 

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -6232,18 +6232,18 @@ primitive_type_list : type_specifier {
 			} else if (Cmp($1.type,"double") == 0) {
 			  if (Cmp($2.type,"long") == 0) {
 			    $$.type = NewString("long double");
-			  } else if (Cmp($2.type,"complex") == 0 || Cmp($2.type,"_Complex") == 0) {
+			  } else if (Cmp($2.type,"_Complex") == 0) {
 			    $$.type = NewString("double _Complex");
 			  } else {
 			    err = 1;
 			  }
 			} else if (Cmp($1.type,"float") == 0) {
-			  if (Cmp($2.type,"complex") == 0 || Cmp($2.type,"_Complex") == 0) {
+			  if (Cmp($2.type,"_Complex") == 0) {
 			    $$.type = NewString("float _Complex");
 			  } else {
 			    err = 1;
 			  }
-			} else if (Cmp($1.type,"complex") == 0 || Cmp($1.type,"_Complex") == 0) {
+			} else if (Cmp($1.type,"_Complex") == 0) {
 			  $$.type = NewStringf("%s _Complex", $2.type);
 			} else {
 			  err = 1;

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -6232,19 +6232,19 @@ primitive_type_list : type_specifier {
 			} else if (Cmp($1.type,"double") == 0) {
 			  if (Cmp($2.type,"long") == 0) {
 			    $$.type = NewString("long double");
-			  } else if (Cmp($2.type,"complex") == 0) {
-			    $$.type = NewString("double complex");
+			  } else if (Cmp($2.type,"complex") == 0 || Cmp($2.type,"_Complex") == 0) {
+			    $$.type = NewString("double _Complex");
 			  } else {
 			    err = 1;
 			  }
 			} else if (Cmp($1.type,"float") == 0) {
-			  if (Cmp($2.type,"complex") == 0) {
-			    $$.type = NewString("float complex");
+			  if (Cmp($2.type,"complex") == 0 || Cmp($2.type,"_Complex") == 0) {
+			    $$.type = NewString("float _Complex");
 			  } else {
 			    err = 1;
 			  }
-			} else if (Cmp($1.type,"complex") == 0) {
-			  $$.type = NewStringf("%s complex", $2.type);
+			} else if (Cmp($1.type,"complex") == 0 || Cmp($1.type,"_Complex") == 0) {
+			  $$.type = NewStringf("%s _Complex", $2.type);
 			} else {
 			  err = 1;
 			}

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1457,8 +1457,6 @@ int SwigType_type(const SwigType *t) {
     return T_FLTCPLX;
   if (!cparse_cplusplus && (strcmp(c, "double _Complex") == 0))
     return T_DBLCPLX;
-  if (!cparse_cplusplus && (strcmp(c, "complex") == 0))
-    return T_COMPLEX;
   if (strcmp(c, "void") == 0)
     return T_VOID;
   if (strcmp(c, "bool") == 0)

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1453,9 +1453,9 @@ int SwigType_type(const SwigType *t) {
     return T_DOUBLE;
   if (strcmp(c, "long double") == 0)
     return T_LONGDOUBLE;
-  if (!cparse_cplusplus && (strcmp(c, "float complex") == 0))
+  if (!cparse_cplusplus && (strcmp(c, "float _Complex") == 0))
     return T_FLTCPLX;
-  if (!cparse_cplusplus && (strcmp(c, "double complex") == 0))
+  if (!cparse_cplusplus && (strcmp(c, "double _Complex") == 0))
     return T_DBLCPLX;
   if (!cparse_cplusplus && (strcmp(c, "complex") == 0))
     return T_COMPLEX;

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1457,6 +1457,8 @@ int SwigType_type(const SwigType *t) {
     return T_FLTCPLX;
   if (!cparse_cplusplus && (strcmp(c, "double _Complex") == 0))
     return T_DBLCPLX;
+  if (!cparse_cplusplus && (strcmp(c, "_Complex") == 0))
+    return T_COMPLEX;
   if (strcmp(c, "void") == 0)
     return T_VOID;
   if (strcmp(c, "bool") == 0)


### PR DESCRIPTION
Use the `_Complex` keyword rather than the `complex` macro.

Fixes #1487.