### PR TITLE
Fixed python required version check

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -846,9 +846,13 @@ public:
 	Printv(f_shadow_py, "\n", f_shadow_begin, "\n", NIL);
 
       Printv(f_shadow_py, "\nfrom sys import version_info as _swig_python_version_info\n", NULL);
-      Printv(f_shadow_py, "if _swig_python_version_info < (2, 7, 0):\n", NULL);
-      Printv(f_shadow_py, tab4, "raise RuntimeError(\"Python 2.7 or later required\")\n\n", NULL);
-
+      if (py3) {
+      Printv(f_shadow_py, "if _swig_python_version_info < (3, 0):\n", NULL);
+      Printv(f_shadow_py, tab4, "raise AssertionError(\"Python 3.x required\")\n\n", NULL);
+      } else {
+      Printv(f_shadow_py, "if _swig_python_version_info < (2, 7, 0) or _swig_python_version_info >= (3, 0):\n", NULL);
+      Printv(f_shadow_py, tab4, "raise AssertionError(\"Python 2.7.x required\")\n\n", NULL);
+      }
       if (Len(f_shadow_after_begin) > 0)
 	Printv(f_shadow_py, f_shadow_after_begin, "\n", NIL);
 


### PR DESCRIPTION
If ```-py3``` is enabled, as a consequence should check for python 3 in the python generated module.

Removed *later* from the exception log, indeed some python 2 releases (e.g. 2.7.15, may 2018) are more recent than python 3 (e.g. 3.1, released in february 2011).

This preliminary check is closer to an ```AssertionError``` than a generic ```RuntimeError```

At last, no need to check for any 2.8 or 2.9 releases since there won't be any, ever.
