### PR TITLE
Fix for missing space after \endlink in doxygen

### DIFF
--- a/Examples/test-suite/doxygen_misc_constructs.i
+++ b/Examples/test-suite/doxygen_misc_constructs.i
@@ -36,7 +36,7 @@
      * @param line line number
      * @param isGetSize if set, for every object location both address and size are returned
      *
-     * @link Connection::getId() @endlink <br>
+     * @link Connection::getId() @endlink<br>
      */
     void getAddress(int &fileName,
                     int line,
@@ -62,7 +62,7 @@
      * used for unspecified parameters.
      * <p>
      *
-     * @link advancedWinIDEALaunching.py Python example.@endlink <br>
+     * @link advancedWinIDEALaunching.py Python example.@endlink<br>
      */
     class CConnectionConfig
     {

--- a/Examples/test-suite/doxygen_translate_all_tags.i
+++ b/Examples/test-suite/doxygen_translate_all_tags.i
@@ -210,7 +210,7 @@ void func05(int a)
  * 
  * \line example
  *
- * \link someMember Some description follows \endlink
+ * \link someMember Some description follows\endlink with text after
  * 
  * \mainpage Some title
  *

--- a/Examples/test-suite/java/doxygen_translate_all_tags_runme.java
+++ b/Examples/test-suite/java/doxygen_translate_all_tags_runme.java
@@ -93,7 +93,7 @@ public class doxygen_translate_all_tags_runme {
     		" </li><li>With lots of items \n" +
     		" </li><li>lots of lots of items \n" +
     		" </li></ul> \n" +
-    		" {@link someMember Some description follows }\n" +
+    		" {@link someMember Some description follows} with text after\n" +
     		" This will only appear in man\n");
     
     wantedComments.put("doxygen_translate_all_tags.doxygen_translate_all_tags.func07(int, int, int, int)",

--- a/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
+++ b/Examples/test-suite/python/doxygen_translate_all_tags_runme.py
@@ -175,7 +175,7 @@ This will only appear in LATeX
 
 
 
-someMember Some description follows
+someMember Some description follows with text after
 
 
 

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -1196,6 +1196,10 @@ void DoxygenParser::processWordCommands(size_t &pos, const std::string &line) {
     // do it every time.)
     if (getBaseCommand(cmd) == CMD_CODE) skipLeadingSpace = true;
     else skipLeadingSpace = false;
+  } else if (cmd.substr(0,3) == "end") {
+    // If processing an "end" command such as "endlink", don't skip
+    // the space before the next string
+    skipLeadingSpace = false;
   }
 
   if (skipLeadingSpace) {


### PR DESCRIPTION
Fix for Issue #1757.

The "endlink" command is processed in `processWordCommands`, which by
default skips space occurring after the command, which is intended for
removing leading space from a command argument.  For "end" commands,
we don't want to do this.  Note that certain end commands such as
"endcode" aren't processed by `processWordCommands` (believe
`addCommandUnique` ends up handling them).

This fix may also improve behavior with other "end" commands, but nothing that is currently in the test suite.

Update usage of `\link` in `doxygen_translate_all_tags.i` to test handling
of space after `\endlink`.

Tweaking some of the usage in `doxygen_misc_constructs.i` to remove what
seems to be an extra space from the input (otherwise we would need to
add an extra space to the expected output).