### PR TITLE
Force using C11 for Guile builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -428,7 +428,7 @@ matrix:
       env: SWIGLANG=go
     - compiler: clang
       os: osx
-      env: SWIGLANG=guile
+      env: SWIGLANG=guile CSTD=c11
     - compiler: clang
       os: osx
       env: SWIGLANG=java


### PR DESCRIPTION
Compiling code including Guile headers with default compiler options
doesn't work any more since a recent (~2020-05-05) update to Guile 3.0.2
on Homebrew (2.2.7 was used previously) due to

error: redefinition of typedef 'scm_print_state' is a C11 feature

in libguile/print.h and scm.h headers.

Work around this by enabling C11 for this build.

---

This should fix one of the problems which appeared on Travis since the last successful build on master.