### PR TITLE
Escape spaces in Dependencies (-M, -MM, etc.)

### DIFF
--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -1143,7 +1143,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 	  if (dependencies_target) {
 	    Printf(f_dependencies_file, "%s: ", dependencies_target);
 	  } else {
-	    Printf(f_dependencies_file, "%s: ", outfile);
+	    Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(outfile));
 	  }
 	  List *files = Preprocessor_depend();
 	  List *phony_targets = NewList();

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -1162,7 +1162,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 	  Printf(f_dependencies_file, "\n");
 	  if (depend_phony) {
 	    for (int i = 0; i < Len(phony_targets); i++) {
-	      Printf(f_dependencies_file, "\n%s:\n", Getitem(phony_targets, i));
+	      Printf(f_dependencies_file, "\n%s:\n", Swig_filename_escape_space(Getitem(phony_targets, i)));
 	    }
 	  }
 

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -1141,7 +1141,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 	  } else
 	    f_dependencies_file = stdout;
 	  if (dependencies_target) {
-	    Printf(f_dependencies_file, "%s: ", dependencies_target);
+	    Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(dependencies_target));
 	  } else {
 	    Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(outfile));
 	  }

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -1154,7 +1154,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
                 use_file = 0;
             }
             if (use_file) {
-              Printf(f_dependencies_file, "\\\n  %s ", Getitem(files, i));
+              Printf(f_dependencies_file, "\\\n  %s ", Swig_filename_escape_space(Getitem(files, i)));
               if (depend_phony)
                 Append(phony_targets, Getitem(files, i));
             }

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -250,6 +250,19 @@ String *Swig_filename_escape(String *filename) {
 }
 
 /* -----------------------------------------------------------------------------
+ * Swig_filename_escape()
+ *
+ * Escapes spaces in filename - for Makefiles
+ * ----------------------------------------------------------------------------- */
+
+String *Swig_filename_escape_space(String *filename) {
+  String *adjusted_filename = Copy(filename);
+  Swig_filename_correct(adjusted_filename);
+  Replaceall(adjusted_filename, " ", "\\ ");
+  return adjusted_filename;
+}
+
+/* -----------------------------------------------------------------------------
  * Swig_filename_unescape()
  *
  * Remove double backslash escaping in filename - for Windows

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -315,6 +315,7 @@ extern int        ParmList_is_compactdefargs(ParmList *p);
   extern String *Swig_new_subdirectory(String *basedirectory, String *subdirectory);
   extern void Swig_filename_correct(String *filename);
   extern String *Swig_filename_escape(String *filename);
+  extern String *Swig_filename_escape_space(String *filename);
   extern void Swig_filename_unescape(String *filename);
   extern int Swig_storage_isextern(Node *n);
   extern int Swig_storage_isexternc(Node *n);


### PR DESCRIPTION
This fixes https://github.com/swig/swig/issues/1794
the output of `swig -M -csharp test.i` now is 
```
test_wrap.c: \
  C:\Users\Noah\Downloads\Swig Space\Lib\swig.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\swigwarnings.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\swigwarn.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\swigfragments.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\csharp\csharp.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\csharp\csharphead.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\csharp\csharpkw.swg \
  C:\Users\Noah\Downloads\Swig Space\Lib\csharp\enums.swg \
  test.i \
  C:\Users\Noah\Downloads\Swig Space\Lib\csharp\std_string.i
```