### PR TITLE
ruby: use correct wstring encoding

### DIFF
--- a/Lib/ruby/std_wstring.i
+++ b/Lib/ruby/std_wstring.i
@@ -1,4 +1,6 @@
 %{
+#include <endian.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,9 +17,17 @@ extern "C" {
 #ifndef SWIG_RUBY_WSTRING_ENCODING
 
 #if WCHAR_MAX == 0x7fff || WCHAR_MAX == 0xffff
+#if BYTE_ORDER == LITTLE_ENDIAN
 #define SWIG_RUBY_WSTRING_ENCODING "UTF-16LE"
+#elif BYTE_ORDER == BIG_ENDIAN
+#define SWIG_RUBY_WSTRING_ENCODING "UTF-16BE"
+#endif
 #elif WCHAR_MAX == 0x7fffffff || WCHAR_MAX == 0xffffffff
+#if BYTE_ORDER == LITTLE_ENDIAN
 #define SWIG_RUBY_WSTRING_ENCODING "UTF-32LE"
+#elif BYTE_ORDER == BIG_ENDIAN
+#define SWIG_RUBY_WSTRING_ENCODING "UTF-32BE"
+#endif
 #else
 #error unsupported wchar_t size. SWIG_RUBY_WSTRING_ENCODING must be given.
 #endif


### PR DESCRIPTION
Fixes ["./li_std_wstring_runme.rb:41:in `<main>'"]: FAILED: Li_std_wstring.test_equal_abc(s) -
