### PR TITLE
Fix references to pyopers.swg in the Python docs

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -2568,7 +2568,7 @@ but <b>the line that uses the '+' operator is much faster</b>.
 (<tt>operator==, operator&lt;</tt>, etc.) are also converted to Python
 slot operators.  For a complete list of C++ operators that are
 automatically converted to Python slot operators, refer to the file
-<tt>python/pyopers.swig</tt> in the SWIG library.
+<tt>python/pyopers.swg</tt> in the SWIG library.
 </p>
 
 
@@ -2674,7 +2674,7 @@ the chosen closure function.
 
 <p>
 There is further information on <tt>%feature("python:slot")</tt>
-in the file <tt>python/pyopers.swig</tt> in the SWIG library.
+in the file <tt>python/pyopers.swg</tt> in the SWIG library.
 </p>
 
 


### PR DESCRIPTION
It should be `pyopers.swg`, not `pyopers.swig`!