### PR TITLE
configure: use AC_PATH_TOOL for pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,7 +459,7 @@ else
   alllang_default=yes
 fi
 
-AC_CHECK_PROGS([PKG_CONFIG], [pkg-config])
+AC_PATH_TOOL([PKG_CONFIG], [pkg-config])
 
 #--------------------------------------------------------------------
 # Look for Tcl


### PR DESCRIPTION
AC_CHECK_PROGS will find the tool using exactly the name given: it
only searches for "pkg-config".  When doing native builds, this is
generally fine.  However, when cross-compiling, this is not ideal
as `pkg-config` is often configured for the build system, not the
system we want to cross-compile for.

Switch to using the AC_PATH_TOOL tool instead.  This will look for
"pkg-config" with a $host- prefix first before falling back to the
plain "pkg-config".  When doing native builds, things should still
behave the same, but now things work better out of the box when we
cross-compile.

For example, `./configure --host=aarch64-linux-gnu` will first look
for "aarch64-linux-gnu-pkg-config" before falling back to the plain
"pkg-config".