### PR TITLE
Perform proper spacing in director method declarations

### DIFF
--- a/Examples/test-suite/director_basic.i
+++ b/Examples/test-suite/director_basic.i
@@ -5,6 +5,7 @@
 #endif
 
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) MyClass::pmethod;
+%warnfilter(SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) ConstPtrClass::getConstPtr;
 
  %{
  #include <string>
@@ -174,7 +175,19 @@ public:
   }
   
 };
-
-%}
+ %}
 
 %template(MyClassT_i) MyClassT<int>;
+
+ %feature("director") ConstPtrClass;
+
+ %inline %{
+
+class ConstPtrClass {
+public:
+  virtual ~ConstPtrClass() {}
+  virtual int *const getConstPtr() = 0;
+};
+
+ %}
+

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -52,6 +52,7 @@ ifeq (node,$(JSENGINE))
   apply_signed_char.cpptest: GYP_CFLAGS = \"-Wno-ignored-qualifiers\"
   constant_pointers.cpptest: GYP_CFLAGS = \"-Wno-ignored-qualifiers\"
   enum_thorough.cpptest: GYP_CFLAGS = \"-Wno-ignored-qualifiers\"
+  director_basic.cpptest: GYP_CFLAGS = \"-Wno-ignored-qualifiers\"
 
 	setup_node = \
 		test -d $* || mkdir $* && \

--- a/Source/Modules/directors.cxx
+++ b/Source/Modules/directors.cxx
@@ -160,7 +160,7 @@ String *Swig_method_decl(SwigType *return_base_type, SwigType *decl, const_Strin
     SwigType *rettype_stripped = SwigType_strip_qualifiers(rettype);
     String *rtype = SwigType_str(rettype, 0);
     Append(result, rtype);
-    if (SwigType_issimple(rettype_stripped) && return_base_type)
+    if ((SwigType_issimple(rettype_stripped) && return_base_type) || SwigType_isqualifier(rettype))
       Append(result, " ");
     Delete(rtype);
     Delete(rettype_stripped);


### PR DESCRIPTION
If a director method returns a const pointer, eg. `int *const`, then in its method declaration a space has to be inserted between 'const' and the method name.
This fixes swig#1810.