### PR TITLE
PyTypeObject::ob_base isn't available in PyPy

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -414,11 +414,7 @@ SwigPyBuiltin_ThisClosure (PyObject *self, void *SWIGUNUSEDPARM(closure)) {
 SWIGINTERN void
 SwigPyBuiltin_SetMetaType (PyTypeObject *type, PyTypeObject *metatype)
 {
-#if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
-    type->ob_base.ob_base.ob_type = metatype;
-#else
-    type->ob_type = metatype;
-#endif
+    Py_TYPE(type) = metatype;
 }
 
 

--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -414,7 +414,7 @@ SwigPyBuiltin_ThisClosure (PyObject *self, void *SWIGUNUSEDPARM(closure)) {
 SWIGINTERN void
 SwigPyBuiltin_SetMetaType (PyTypeObject *type, PyTypeObject *metatype)
 {
-#if PY_VERSION_HEX >= 0x03000000
+#if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
     type->ob_base.ob_base.ob_type = metatype;
 #else
     type->ob_type = metatype;


### PR DESCRIPTION
When using SWIG 4.0.2 to build M2Crypto for PyPy 7.3.1 (Python 3.6.9)  in conda-forge the build fails with:

```
  SWIG/_m2crypto_wrap.c: In function 'SwigPyBuiltin_SetMetaType':
  SWIG/_m2crypto_wrap.c:3063:11: error: 'PyTypeObject {aka struct _typeobject}' has no member named 'ob_base'; did you mean 'tp_base'?
       type->ob_base.ob_base.ob_type = metatype;
             ^~~~~~~
             tp_base
```

So far as I can tell the Python 2 branch should be followed in this preprocessor condition:

```cpp
#if PY_VERSION_HEX >= 0x03000000
    type->ob_base.ob_base.ob_type = metatype;
#else
    type->ob_type = metatype;
#endif
```

This PR fixed the issue by checking if `PYPY_VERSION` is defined.