### PR TITLE
fix windows(64) bit define issue:

### DIFF
--- a/Lib/stdint.i
+++ b/Lib/stdint.i
@@ -86,8 +86,8 @@ typedef unsigned long long int	uint_fast64_t;
 
 /* Types for `void *' pointers.  */
 #if defined(SWIGWORDSIZE64)
-typedef long int		intptr_t;
-typedef unsigned long int	uintptr_t;
+typedef long long		intptr_t;
+typedef unsigned long long	uintptr_t;
 #else
 typedef int			intptr_t;
 typedef unsigned int		uintptr_t;

--- a/Lib/swigarch.i
+++ b/Lib/swigarch.i
@@ -53,7 +53,7 @@
 #ifndef LONG_MAX
 #include <limits.h>
 #endif
-#if (__WORDSIZE == 32) || (LONG_MAX == INT_MAX)
+#if (__WORDSIZE == 32)
 # error "SWIG wrapped code invalid in 32 bit architecture, regenerate code using -DSWIGWORDSIZE32"
 #endif
 %}


### PR DESCRIPTION
long bit wide is 4 at VC and LLVM-clang-cl env,
but ptr should be 8 at 64bit env,
even then long take 8 bit at linux-64/macos/mingw64,
but long long take 8 bit at all 64bit env,