### PR TITLE
Raising IndexError in calls to __getitem__/__setitem__ for std::pair in Python

### DIFF
--- a/Lib/python/std_pair.i
+++ b/Lib/python/std_pair.i
@@ -189,15 +189,19 @@ SwigPython_std_pair_setitem (PyObject *a, Py_ssize_t b, PyObject *c)
 def __repr__(self):
     return str((self.first, self.second))
 def __getitem__(self, index): 
-    if not (index % 2):
+    if index == 0:
         return self.first
-    else:
+    elif index == 1:
         return self.second
-def __setitem__(self, index, val):
-    if not (index % 2):
-        self.first = val
     else:
-        self.second = val%}
+        raise IndexError
+def __setitem__(self, index, val):
+    if index == 0:
+        self.first = val
+    elif index == 1:
+        self.second = val
+    else:
+        raise IndexError%}
 }
 #endif
 %enddef


### PR DESCRIPTION
The current implementation for the python std_pair interface does supply the proper size of the pair via the ```__len__``` method:

```
    def __len__(self):
        return 2
```

However, python 3 (tested with pyton 3.8.2 on Ubuntu 20.04) and python 2 (tested with 2.7.18rc1 on Ubuntu 20.04) does not use the sequence size returned by ```__len__``` but calls ```__getitem__``` until and ```IndexError``` exception is raised. Here we run into the problem with the current implementation as it does newer throw this exception:

```
    def __getitem__(self, index): 
        if not (index % 2):
            return self.first
        else:
            return self.second
```

Therefore, very common python assignments used with lists and tuples in python like:

```
full_list = [23, 24]
l1, l2 = full_list
```

`result1, result2 = swigWrappedMethodReturningStdPair()`

or for loops:

```
for it in full_list:
   print (it)
```

Cannot be done with the SWIG-generated pair. In case of the multiple assignments, the error will be that there are too many values to unpack and the for loop will never terminate and result in an endless loop.

According to the Python documentation, _"```IndexError``` should be raised fora value outside the set of indexes for the sequence (after any special interpretation of negative values)"_ (see https://docs.python.org/3/reference/datamodel.html#object.__getitem__)
The same behaviour is expected from the ```__setitem__``` method, which is also modified by this PR.

This PR increases the conformity of the SWIG-generated pair with other python sequences like list and tuple by throwing an ```IndexError``` exception when the third (non-existent) item is attempted to be accessed.

This will enable the above example usage scenarios also for the auto-generated SWIG pair for Python.