### PR TITLE
javascript: replace exceptions with SWIG_exit

### DIFF
--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1575,7 +1575,8 @@ void JSCEmitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, Ma
       Printf(arg, "argv[%d]", i);
       break;
     default:
-      throw "Illegal state.";
+      Printf(stdout, "Illegal state.");
+      SWIG_exit(EXIT_FAILURE);
     }
     tm = emitInputTypemap(n, p, wrapper, arg);
     Delete(arg);
@@ -2212,7 +2213,8 @@ void V8Emitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, Mar
       Printf(arg, "args[%d]", i);
       break;
     default:
-      throw "Illegal state.";
+      Printf(stdout, "Illegal state.");
+      SWIG_exit(EXIT_FAILURE);
     }
 
     tm = emitInputTypemap(n, p, wrapper, arg);

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1575,7 +1575,7 @@ void JSCEmitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, Ma
       Printf(arg, "argv[%d]", i);
       break;
     default:
-      Printf(stdout, "Illegal state.");
+      Printf(stderr, "Illegal MarshallingMode.");
       SWIG_exit(EXIT_FAILURE);
     }
     tm = emitInputTypemap(n, p, wrapper, arg);
@@ -2213,7 +2213,7 @@ void V8Emitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, Mar
       Printf(arg, "args[%d]", i);
       break;
     default:
-      Printf(stdout, "Illegal state.");
+      Printf(stderr, "Illegal MarshallingMode.");
       SWIG_exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
When building SWIG for Android, there is no support for C++ exceptions.

In the cases there is "Illegal state", it seems more like an internal
error, so we can replace the throw calls with a debug print and exit
immediately.

Closes #1858