### PR TITLE
naming: Add unreachable return to !HAVE_PCRE path

### DIFF
--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -1132,6 +1132,7 @@ static int name_regexmatch_value(Node *n, String *pattern, String *s) {
   Swig_error("SWIG", Getline(n),
              "PCRE regex matching is not available in this SWIG build.\n");
   SWIG_exit(EXIT_FAILURE);
+  return 0;
 }
 
 #endif /* HAVE_PCRE/!HAVE_PCRE */


### PR DESCRIPTION
Android builds all host tools with -Werror=no-return, which generates a
false positive in name_regexmatch_value() if HAVE_PCRE is not present.

Fix this by adding a return code to the !HAVE_PCRE path. This return
will not be reached but will suppress the compiler warning.

If/when SWIG can require C++11 compilers, a better fix would be to make
SWIG_exit() [[noreturn]].

Closes #1860