### PR TITLE
Octave: error() must be called with an argument

### DIFF
--- a/Examples/test-suite/octave/abstract_access_runme.m
+++ b/Examples/test-suite/octave/abstract_access_runme.m
@@ -2,6 +2,6 @@ abstract_access
 
 d = abstract_access.D();
 if (d.do_x() != 1)
-   error
+   error("failed");
 endif
 

--- a/Examples/test-suite/octave/abstract_typedef_runme.m
+++ b/Examples/test-suite/octave/abstract_typedef_runme.m
@@ -10,7 +10,7 @@ a = A();
   
 
 if (a.write(e) != 1)
-  error
+  error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/callback_runme.m
+++ b/Examples/test-suite/octave/callback_runme.m
@@ -2,39 +2,39 @@ _callback
 callback
 
 if (foo(2) != 2)
-  error
+  error("failed");
 endif
 
 if (A_bar(2) != 4)
-  error
+  error("failed");
 endif
 
 if (foobar(3, _callback.foo) != foo(3))
-  error  
+  error("failed");
 endif
 
 if (foobar(3, foo) != foo(3))
-  error  
+  error("failed");
 endif
 
 if (foobar(3, A_bar) != A_bar(3))
-  error
+  error("failed");
 endif
 
 if (foobar(3, foof) != foof(3))
-  error
+  error("failed");
 endif
 
 if (foobar_i(3, foo_i) != foo_i(3))
-  error
+  error("failed");
 endif
 
 
 if (foobar_d(3.5, foo_d) != foo_d(3.5))
-  error
+  error("failed");
 endif
 
 a = A();
 if (foobarm(3, a, A.foom_cb_ptr) != a.foom(3))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/class_ignore_runme.m
+++ b/Examples/test-suite/octave/class_ignore_runme.m
@@ -8,5 +8,5 @@ class_ignore
 a = class_ignore.Bar();
 
 if (!strcmp(class_ignore.do_blah(a),"Bar::blah"))
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/class_scope_weird_runme.m
+++ b/Examples/test-suite/octave/class_scope_weird_runme.m
@@ -3,5 +3,5 @@ class_scope_weird
 f = class_scope_weird.Foo();
 g = class_scope_weird.Foo(3);
 if (f.bar(3) != 3)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/compactdefaultargs_runme.m
+++ b/Examples/test-suite/octave/compactdefaultargs_runme.m
@@ -4,21 +4,21 @@ defaults1 = Defaults1(1000);
 defaults1 = Defaults1();
 
 if (defaults1.ret(10.0) != 10.0)
-  error
+  error("failed");
 endif
 
 if (defaults1.ret() != -1.0)
-  error
+  error("failed");
 endif
 
 defaults2 = Defaults2(1000);
 defaults2 = Defaults2();
 
 if (defaults2.ret(10.0) != 10.0)
-  error
+  error("failed");
 endif
 
 if (defaults2.ret() != -1.0)
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/constructor_copy_runme.m
+++ b/Examples/test-suite/octave/constructor_copy_runme.m
@@ -10,7 +10,7 @@ f11 = Foo1(f1);
 
 
 if (f1.x != f11.x)
-    error
+    error("failed");
 endif
 
 
@@ -23,7 +23,7 @@ catch
 end_try_catch
 
 if (!good)
-    error
+    error("failed");
 endif
 
 
@@ -31,7 +31,7 @@ bi = Bari(5);
 bc = Bari(bi);
 
 if (bi.x != bc.x)
-    error
+    error("failed");
 endif
     
 
@@ -44,6 +44,6 @@ catch
 end_try_catch
 
 if (!good)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/default_args_runme.m
+++ b/Examples/test-suite/octave/default_args_runme.m
@@ -7,19 +7,19 @@ default_args
 
 
 if (default_args.Statics.staticmethod() != 60)
-  error
+  error("failed");
 endif
 
 if (default_args.cfunc1(1) != 2)
-  error
+  error("failed");
 endif
 
 if (default_args.cfunc2(1) != 3)
-  error
+  error("failed");
 endif
 
 if (default_args.cfunc3(1) != 4)
-  error
+  error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/director_abstract_runme.m
+++ b/Examples/test-suite/octave/director_abstract_runme.m
@@ -28,17 +28,17 @@ MyExample3=@() subclass(director_abstract.Example3_i(),'Color',@(self,r,g,b) b);
 
 me1 = MyExample1();
 if (director_abstract.Example1.get_color(me1, 1,2,3) != 1)
-  error
+  error("failed");
 endif
 
 me2 = MyExample2(1,2);
 if (me2.get_color(me2, 1,2,3) != 2)
-  error
+  error("failed");
 endif
 
 me3 = MyExample3();
 if (me3.get_color(me3, 1,2,3) != 3)
-  error
+  error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/director_basic_runme.m
+++ b/Examples/test-suite/octave/director_basic_runme.m
@@ -33,7 +33,7 @@ endif
 a = director_basic.A1(1);
 
 if (a.rg(2) != 2)
-  error
+  error("failed");
 endif
 
 function self=OctClass()
@@ -62,16 +62,16 @@ bd = dd.cmethod(b);
 
 cc.method(b);
 if (c.cmethod != 7)
-  error
+  error("failed");
 endif
 
 if (bc.x != 34)
-  error
+  error("failed");
 endif
 
 
 if (bd.x != 16)
-  error
+  error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/director_enum_runme.m
+++ b/Examples/test-suite/octave/director_enum_runme.m
@@ -6,5 +6,5 @@ b = director_enum.Foo();
 a = MyFoo();
 
 if (a.say_hi(director_enum.hello) != b.say_hello(director_enum.hi))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/director_nested_runme.m
+++ b/Examples/test-suite/octave/director_nested_runme.m
@@ -31,9 +31,9 @@ c = FooBar_int_get_self(cc);
 c.advance();
 
 if (!strcmp(c.get_name(),"FooBar::get_name hello"))
-  error
+  error("failed");
 endif
 
 if (!strcmp(c.name(),"FooBar::get_name hello"))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/director_unroll_runme.m
+++ b/Examples/test-suite/octave/director_unroll_runme.m
@@ -11,6 +11,6 @@ c = b.get();
 
 if (swig_this(a) != swig_this(c))
   a,c
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/enum_template_runme.m
+++ b/Examples/test-suite/octave/enum_template_runme.m
@@ -6,13 +6,13 @@ endif
 enum_template
 
 if (enum_template.MakeETest() != 1)
-  error
+  error("failed");
 endif
 
 enum_template.TakeETest(0);
 try
   a=enum_template.TakeETest(0);
-  error
+  error("failed");
 catch
 end_try_catch
   

--- a/Examples/test-suite/octave/enums_runme.m
+++ b/Examples/test-suite/octave/enums_runme.m
@@ -6,18 +6,18 @@ enums.bar3(1)
 enums.bar1(1)
 
 if (enums.cvar.enumInstance != 2)
-  error
+  error("failed");
 endif
 
 if (enums.cvar.Slap != 10)
-  error
+  error("failed");
 endif
 
 if (enums.cvar.Mine != 11)
-  error
+  error("failed");
 endif
 
 if (enums.cvar.Thigh != 12)
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/extend_template_ns_runme.m
+++ b/Examples/test-suite/octave/extend_template_ns_runme.m
@@ -7,9 +7,9 @@ extend_template_ns
 
 f = Foo_One();
 if (f.test1(37) != 37)
-    error
+    error("failed");
 endif
 
 if (f.test2(42) != 42)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/extend_template_runme.m
+++ b/Examples/test-suite/octave/extend_template_runme.m
@@ -2,9 +2,9 @@ extend_template
 
 f = extend_template.Foo_0();
 if (f.test1(37) != 37)
-    error
+    error("failed");
 endif
 
 if (f.test2(42) != 42)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/extend_variable_runme.m
+++ b/Examples/test-suite/octave/extend_variable_runme.m
@@ -1,6 +1,6 @@
 extend_variable
 
 if (Foo.Bar != 42)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/friends_runme.m
+++ b/Examples/test-suite/octave/friends_runme.m
@@ -8,25 +8,25 @@ friends
 a = friends.A(2);
 
 if (friends.get_val1(a) != 2)
-  error
+  error("failed");
 endif
 if (friends.get_val2(a) != 4)
-  error
+  error("failed");
 endif
 if (friends.get_val3(a) != 6)
-  error
+  error("failed");
 endif
 
 				# nice overload working fine
 if (friends.get_val1(1,2,3) != 1)
-  error
+  error("failed");
 endif
 
 b = friends.B(3);
 
 				# David's case
 if (friends.mix(a,b) != 5)
-  error
+  error("failed");
 endif
 
 di = friends.D_d(2);
@@ -34,18 +34,18 @@ dd = friends.D_d(3.3);
 
 				# incredible template overloading working just fine
 if (friends.get_val1(di) != 2)
-  error
+  error("failed");
 endif
 if (friends.get_val1(dd) != 3.3)
-  error
+  error("failed");
 endif
 
 friends.set(di, 4);
 friends.set(dd, 1.3);
 
 if (friends.get_val1(di) != 4)
-  error
+  error("failed");
 endif
 if (friends.get_val1(dd) != 1.3)
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/grouping_runme.m
+++ b/Examples/test-suite/octave/grouping_runme.m
@@ -7,14 +7,14 @@ grouping
 
 x = grouping.test1(42);
 if (x != 42)
-    error
+    error("failed");
 endif
 
 grouping.test2(42);
 
 x = (grouping.do_unary(37, grouping.NEGATE));
 if (x != -37)
-    error
+    error("failed");
 endif
 
 grouping.cvar.test3 = 42;

--- a/Examples/test-suite/octave/iadd_runme.m
+++ b/Examples/test-suite/octave/iadd_runme.m
@@ -6,5 +6,5 @@ f.AsA.x = 3;
 f.AsA += f.AsA;
 
 if (f.AsA.x != 6)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/inout_runme.m
+++ b/Examples/test-suite/octave/inout_runme.m
@@ -2,26 +2,26 @@ inout
 
 a = inout.AddOne1(1);
 if (a != 2)
-  error
+  error("failed");
 endif
 
 a = inout.AddOne3(1,1,1);
 if (a != [2,2,2])
-  error
+  error("failed");
 endif
 
 a = inout.AddOne1p((1,1));
 if (a != (2,2))
-  error
+  error("failed");
 endif
 
 a = inout.AddOne2p((1,1),1);
 if (a != [(2,2),2])
-  error
+  error("failed");
 endif
 
 a = inout.AddOne3p(1,(1,1),1);
 if (a != [2,(2,2),2])
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/inplaceadd_runme.m
+++ b/Examples/test-suite/octave/inplaceadd_runme.m
@@ -3,22 +3,22 @@ a = inplaceadd.A(7);
 
 a += 5;
 if (a.val != 12)
-  error
+  error("failed");
 endif
 
 a -= 5;
 if a.val != 7:
-  error
+  error("failed");
 endif
 
 a *= 2;
 
 if (a.val != 14)
-  error
+  error("failed");
 endif
 
 a += a;
 if (a.val != 28)
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/input_runme.m
+++ b/Examples/test-suite/octave/input_runme.m
@@ -7,21 +7,21 @@ input
 
 f = Foo();
 if (f.foo(2) != 4)
-  error
+  error("failed");
 endif
 
 try
   a=f.foo();
-  error
+  error("failed");
 catch
 end_try_catch
 
 if (!strcmp(sfoo("Hello"),"Hello world"))
-  error
+  error("failed");
 endif
 
 try
   a=sfoo();
-  error
+  error("failed");
 catch
 end_try_catch

--- a/Examples/test-suite/octave/li_attribute_runme.m
+++ b/Examples/test-suite/octave/li_attribute_runme.m
@@ -8,7 +8,7 @@ li_attribute
 aa = li_attribute.A(1,2,3);
 
 if (aa.a != 1)
-  error
+  error("failed");
 endif
 aa.a = 3;
 if (aa.a != 3)
@@ -20,31 +20,31 @@ if (aa.b != 2)
 endif
 aa.b = 5;
 if (aa.b != 5)
-  error
+  error("failed");
 endif
 
 if (aa.d != aa.b)
-  error
+  error("failed");
 endif
 
 if (aa.c != 3)
-  error
+  error("failed");
 endif
 
 pi = li_attribute.Param_i(7);
 if (pi.value != 7)
- error
+ error("failed");
 endif
 
 pi.value=3;
 if (pi.value != 3)
- error
+ error("failed");
 endif
 
 b = li_attribute.B(aa);
 
 if (b.a.c != 3)
- error
+ error("failed");
 endif
 
 # class/struct attribute with get/set methods using return/pass by reference
@@ -53,38 +53,38 @@ myFoo.x = 8;
 myClass = li_attribute.MyClass();
 myClass.Foo = myFoo;
 if (myClass.Foo.x != 8)
-  error
+  error("failed");
 endif
 
 # class/struct attribute with get/set methods using return/pass by value
 myClassVal = li_attribute.MyClassVal();
 if (myClassVal.ReadWriteFoo.x != -1)
-  error
+  error("failed");
 endif
 if (myClassVal.ReadOnlyFoo.x != -1)
-  error
+  error("failed");
 endif
 myClassVal.ReadWriteFoo = myFoo;
 if (myClassVal.ReadWriteFoo.x != 8)
-  error
+  error("failed");
 endif
 if (myClassVal.ReadOnlyFoo.x != 8)
-  error
+  error("failed");
 endif
 
 # string attribute with get/set methods using return/pass by value
 myStringyClass = li_attribute.MyStringyClass("initial string");
 if (myStringyClass.ReadWriteString != "initial string")
-  error
+  error("failed");
 endif
 if (myStringyClass.ReadOnlyString != "initial string")
-  error
+  error("failed");
 endif
 myStringyClass.ReadWriteString = "changed string";
 if (myStringyClass.ReadWriteString != "changed string")
-  error
+  error("failed");
 endif
 if (myStringyClass.ReadOnlyString != "changed string")
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/li_carrays_cpp_runme.m
+++ b/Examples/test-suite/octave/li_carrays_cpp_runme.m
@@ -11,5 +11,5 @@ d(0) = 7;
 d(5) = d(0) + 3;
 
 if (d(5) + d(0) != 17)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/li_carrays_runme.m
+++ b/Examples/test-suite/octave/li_carrays_runme.m
@@ -11,5 +11,5 @@ d(0) = 7;
 d(5) = d(0) + 3;
 
 if (d(5) + d(0) != 17)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/li_cmalloc_runme.m
+++ b/Examples/test-suite/octave/li_cmalloc_runme.m
@@ -17,6 +17,6 @@ catch
 end_try_catch
 
 if (ok != 1)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/li_cpointer_cpp_runme.m
+++ b/Examples/test-suite/octave/li_cpointer_cpp_runme.m
@@ -5,7 +5,7 @@ p = new_intp();
 intp_assign(p,3);
 
 if (intp_value(p) != 3)
-    error
+    error("failed");
 endif
 
 delete_intp(p);

--- a/Examples/test-suite/octave/li_cpointer_runme.m
+++ b/Examples/test-suite/octave/li_cpointer_runme.m
@@ -10,7 +10,7 @@ p = new_intp();
 intp_assign(p,3);
 
 if (intp_value(p) != 3)
-    error
+    error("failed");
 endif
 
 delete_intp(p);

--- a/Examples/test-suite/octave/li_cstring_runme.m
+++ b/Examples/test-suite/octave/li_cstring_runme.m
@@ -7,15 +7,15 @@ li_cstring
 
 
 if (count("ab\0ab\0ab\0", 0) != 3)
-    error    
+    error("failed");
 endif
 
 if (!strcmp(test1(),"Hello World"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test2()," !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test3("hello"),"hello-suffix"))
@@ -27,18 +27,18 @@ if (!strcmp(test4("hello"),"hello-suffix"))
 endif
     
 if (!strcmp(test5(4),'xxxx'))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test6(10),'xxxxx'))
-    error
+    error("failed");
 endif
     
 if (!strcmp(test7(),"Hello world!"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test8()," !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"))
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/li_cwstring_runme.m
+++ b/Examples/test-suite/octave/li_cwstring_runme.m
@@ -6,38 +6,38 @@ endif
 li_cwstring
 
 if (count("ab\0ab\0ab\0", 0) != 3)
-    error    
+    error("failed");
 endif
 
 if (!strcmp(test1(),"Hello World"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test2()," !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test3("hello"),"hello-suffix"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test4("hello"),"hello-suffix"))
-    error
+    error("failed");
 endif
     
 if (!strcmp(test5(4),'xxxx'))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test6(10),'xxxxx'))
-    error
+    error("failed");
 endif
     
 if (!strcmp(test7(),"Hello world!"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test8()," !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"))
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/li_factory_runme.m
+++ b/Examples/test-suite/octave/li_factory_runme.m
@@ -8,11 +8,11 @@ li_factory
 circle = Geometry_create(Geometry.CIRCLE);
 r = circle.radius();
 if (r != 1.5)
-  error
+  error("failed");
 endif
 
 point = Geometry_create(Geometry.POINT);
 w = point.width();
 if (w != 1.0)
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/li_std_carray_runme.m
+++ b/Examples/test-suite/octave/li_std_carray_runme.m
@@ -9,7 +9,7 @@ endfor
 i = 0;
 for d in v3,
   if (d != i)
-    error
+    error("failed");
   endif
   i = i + 1;
 endfor
@@ -29,7 +29,7 @@ for v3 in m3,
   j = 0;
   for d in v3,
     if (d != i + j)
-      error
+      error("failed");
     endif
     j = j + 1;
   endfor
@@ -39,7 +39,7 @@ endfor
 for i=0:len(m3),
   for j=0:len(m3),
     if (m3(i,j) != i + j)
-      error
+      error("failed");
     endif
   endfor
 endfor

--- a/Examples/test-suite/octave/li_std_set_runme.m
+++ b/Examples/test-suite/octave/li_std_set_runme.m
@@ -11,15 +11,15 @@ for i in s:
     sum = sum + i
 
 if (sum != "abc")
-    error
+    error("failed");
 
 i = s.__iter__()
 if i.next() != "a":
-    error
+    error("failed");
 if i.next() != "b":
-    error
+    error("failed");
 if i.next() != "c":
-    error
+    error("failed");
 
 
 b = s.begin()
@@ -28,7 +28,7 @@ sum = ""
 while (b != e):    
     sum = sum + b.next()
 if sum != "abc":
-    error
+    error("failed");
 
 b = s.rbegin()
 e = s.rend()
@@ -37,7 +37,7 @@ while (b != e):
     sum = sum  + b.next()
 
 if sum != "cba":
-    error
+    error("failed");
 
 
 
@@ -49,11 +49,11 @@ si.append(3)
 i = si.__iter__()
 
 if i.next() != 1:
-    error
+    error("failed");
 if i.next() != 2:
-    error
+    error("failed");
 if i.next() != 3:
-    error
+    error("failed");
 
 
 
@@ -68,17 +68,17 @@ sum = ""
 while (b != e):    
     sum = sum + b.next()
 if sum != "ac":
-    error
+    error("failed");
 
 
 b = s.begin()
 e = s.end()
 if e - b != 2:
-    error
+    error("failed");
     
 m = b + 1
 if m.value() != "c":
-    error
+    error("failed");
 
 
 
@@ -93,4 +93,4 @@ for i in s:
     sum = sum  + (i,)
 
 if sum != (1, 'hello', (1, 2)):
-    error
+    error("failed");

--- a/Examples/test-suite/octave/li_std_stream_runme.m
+++ b/Examples/test-suite/octave/li_std_stream_runme.m
@@ -8,6 +8,6 @@ o << a << " " << 2345 << " " << 1.435;
 
 
 if (o.str() !=  "A class 2345 1.435")
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/li_std_string_extra_runme.m
+++ b/Examples/test-suite/octave/li_std_string_extra_runme.m
@@ -140,23 +140,23 @@ endif
 
 
 if (li_std_string_extra.test_reference_input("hello") != "hello")
-  error
+  error("failed");
 endif
 s = li_std_string_extra.test_reference_inout("hello");
 if (s != "hellohello")
-  error
+  error("failed");
 endif
 
 
 if (li_std_string_extra.stdstring_empty() != "")
-  error
+  error("failed");
 endif
 
 
 if (li_std_string_extra.c_empty() != "")
-  error
+  error("failed");
 endif
 
 #if (li_std_string_extra.c_null() != None)
-#  error
+#  error("failed");
 #endif

--- a/Examples/test-suite/octave/li_std_wstream_runme.m
+++ b/Examples/test-suite/octave/li_std_wstream_runme.m
@@ -9,6 +9,6 @@ o = wostringstream();
 o << a << u" " << 2345 << u" " << 1.435 << wends;
 
 if (o.str() !=  "A class 2345 1.435\0")
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/multi_import_runme.m
+++ b/Examples/test-suite/octave/multi_import_runme.m
@@ -8,22 +8,22 @@ multi_import_b;
 
 x = multi_import_b.XXX();
 if (x.testx() != 0)
-  error
+  error("failed");
 endif
 
 y = multi_import_b.YYY();
 if (y.testx() != 0)
-  error
+  error("failed");
 endif
 if (y.testy() != 1)
-  error
+  error("failed");
 endif
 
 z = multi_import_a.ZZZ();
 if (z.testx() != 0)
-  error
+  error("failed");
 endif
 if (z.testz() != 2)
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/namespace_typemap_runme.m
+++ b/Examples/test-suite/octave/namespace_typemap_runme.m
@@ -1,106 +1,106 @@
 namespace_typemap
 
 if (!strcmp(stest1("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest2("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest3("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest4("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest5("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest6("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest7("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest8("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest9("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest10("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest11("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(stest12("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 c = complex(2,3);
 r = real(c);
 
 if (ctest1(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest2(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest3(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest4(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest5(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest6(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest7(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest8(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest9(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest10(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest11(c) != r)
-    error
+    error("failed");
 endif
 
 if (ctest12(c) != r)
-    error
+    error("failed");
 endif
 
 try
     ttest1(-14)
-    error
+    error("failed");
 catch
 end_try_catch

--- a/Examples/test-suite/octave/naturalvar_runme.m
+++ b/Examples/test-suite/octave/naturalvar_runme.m
@@ -14,6 +14,6 @@ cvar.s = "hello";
 b.s = "hello";
 
 if (b.s != cvar.s)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/overload_extend2_runme.m
+++ b/Examples/test-suite/octave/overload_extend2_runme.m
@@ -2,29 +2,29 @@ overload_extend2
 
 f = overload_extend2.Foo();
 if (f.test(3) != 1)
-    error
+    error("failed");
 endif
 if (f.test("hello") != 2)
-    error
+    error("failed");
 endif
 if (f.test(3.5,2.5) != 3)
-    error
+    error("failed");
 endif
 if (f.test("hello",20) != 1020)
-    error
+    error("failed");
 endif
 if (f.test("hello",20,100) != 120)
-    error
+    error("failed");
 endif
 
 # C default args
 if (f.test(f) != 30)
-    error
+    error("failed");
 endif
 if (f.test(f,100) != 120)
-    error
+    error("failed");
 endif
 if (f.test(f,100,200) != 300)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/overload_extend_c_runme.m
+++ b/Examples/test-suite/octave/overload_extend_c_runme.m
@@ -7,18 +7,18 @@ overload_extend_c
 
 f = overload_extend_c.Foo();
 if (f.test() != 0)
-    error
+    error("failed");
 endif
 if (f.test(3) != 1)
-    error
+    error("failed");
 endif
 if (f.test("hello") != 2)
-    error
+    error("failed");
 endif
 if (f.test(3,2) != 5)
-    error
+    error("failed");
 endif
 if (f.test(3.1)-.1 != 1003) # :)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/overload_extend_runme.m
+++ b/Examples/test-suite/octave/overload_extend_runme.m
@@ -7,18 +7,18 @@ overload_extend
 
 f = overload_extend.Foo();
 if (f.test() != 0)
-    error
+    error("failed");
 endif
 if (f.test(3) != 1)
-    error
+    error("failed");
 endif
 if (f.test("hello") != 2)
-    error
+    error("failed");
 endif
 if (f.test(3,2) != 5)
-    error
+    error("failed");
 endif
 if (f.test(3.1)-.1 != 1003) # :)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/preproc_runme.m
+++ b/Examples/test-suite/octave/preproc_runme.m
@@ -6,18 +6,18 @@ endif
 preproc
 
 if (preproc.cvar.endif != 1)
-  error
+  error("failed");
 endif
 
 if (preproc.cvar.define != 1)
-  error
+  error("failed");
 endif
 
 if (preproc.cvar.defined != 1)
-  error
+  error("failed");
 endif
 
 if (2*preproc.one != preproc.two)
-  error
+  error("failed");
 endif
 

--- a/Examples/test-suite/octave/primitive_ref_runme.m
+++ b/Examples/test-suite/octave/primitive_ref_runme.m
@@ -1,53 +1,53 @@
 primitive_ref
 
 if (ref_int(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_uint(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_short(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_ushort(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_long(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_ulong(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_schar(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_uchar(3) != 3)
-    error
+    error("failed");
 endif
 
 if (ref_float(3.5) != 3.5)
-    error
+    error("failed");
 endif
 
 if (ref_double(3.5) != 3.5)
-    error
+    error("failed");
 endif
 
 if (ref_bool(true) != true)
-    error
+    error("failed");
 endif
 
 if (!strcmp(ref_char('x'),'x'))
-    error
+    error("failed");
 endif
 
 if (ref_over(0) != 0)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/reference_global_vars_runme.m
+++ b/Examples/test-suite/octave/reference_global_vars_runme.m
@@ -2,90 +2,90 @@ reference_global_vars
 
 # const class reference variable
 if (getconstTC().num != 33)
-    error
+    error("failed");
 endif
 
 # primitive reference variables
 cvar.var_bool = createref_bool(false);
 if (value_bool(cvar.var_bool) != 0)
-    error
+    error("failed");
 endif
 
 cvar.var_bool = createref_bool(true);
 if (value_bool(cvar.var_bool) != 1)
-    error
+    error("failed");
 endif
 
 cvar.var_char = createref_char('w');
 if (!strcmp(value_char(cvar.var_char),'w'))
-    error
+    error("failed");
 endif
 
 cvar.var_unsigned_char = createref_unsigned_char(10);
 if (value_unsigned_char(cvar.var_unsigned_char) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_signed_char = createref_signed_char(10);
 if (value_signed_char(cvar.var_signed_char) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_short = createref_short(10);
 if (value_short(cvar.var_short) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_unsigned_short = createref_unsigned_short(10);
 if (value_unsigned_short(cvar.var_unsigned_short) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_int = createref_int(10);
 if (value_int(cvar.var_int) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_unsigned_int = createref_unsigned_int(10);
 if (value_unsigned_int(cvar.var_unsigned_int) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_long = createref_long(10);
 if (value_long(cvar.var_long) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_unsigned_long = createref_unsigned_long(10);
 if (value_unsigned_long(cvar.var_unsigned_long) != 10)
-    error
+    error("failed");
 endif
 
 cvar.var_long_long = createref_long_long(int64(0x6FFFFFFFFFFFFFF8));
 if (value_long_long(cvar.var_long_long) != int64(0x6FFFFFFFFFFFFFF8))
-    error
+    error("failed");
 endif
 
 #ull = abs(0xFFFFFFF2FFFFFFF0)
 ull = uint64(55834574864);
 cvar.var_unsigned_long_long = createref_unsigned_long_long(ull);
 if (value_unsigned_long_long(cvar.var_unsigned_long_long) != ull)
-    error
+    error("failed");
 endif
 
 cvar.var_float = createref_float(10.5);
 if (value_float(cvar.var_float) != 10.5)
-    error
+    error("failed");
 endif
 
 cvar.var_double = createref_double(10.5);
 if (value_double(cvar.var_double) != 10.5)
-    error
+    error("failed");
 endif
 
 # class reference variable
 cvar.var_TestClass = createref_TestClass(TestClass(20));
 if (value_TestClass(cvar.var_TestClass).num != 20)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/rename_scope_runme.m
+++ b/Examples/test-suite/octave/rename_scope_runme.m
@@ -4,11 +4,11 @@ a = Natural_UP();
 b = Natural_BP();
 
 if (a.rtest() != 1)
-    error
+    error("failed");
 endif
 
 if (b.rtest() != 1)
-    error
+    error("failed");
 endif
 
 f = @equals;

--- a/Examples/test-suite/octave/ret_by_value_runme.m
+++ b/Examples/test-suite/octave/ret_by_value_runme.m
@@ -7,9 +7,9 @@ ret_by_value
 
 a = ret_by_value.get_test();
 if (a.myInt != 100)
-    error
+    error("failed");
 endif
 
 if (a.myShort != 200)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/smart_pointer_extend_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_extend_runme.m
@@ -9,7 +9,7 @@ f = Foo();
 b = Bar(f);
 
 if (b.extension() != f.extension())
-  error
+  error("failed");
 endif
 
 
@@ -18,15 +18,15 @@ d = CDerived();
 p = CPtr();
 
 if (b.bar() != p.bar())
-  error
+  error("failed");
 endif
 
 if (d.foo() != p.foo())
-  error
+  error("failed");
 endif
 
 if (b.hello() != p.hello())
-  error
+  error("failed");
 endif
 
 
@@ -36,11 +36,11 @@ d = DFoo();
 dp = DPtrFoo(d);
 
 if (d.SExt(1) != dp.SExt(1))
-  error
+  error("failed");
 endif
 
 if (d.Ext(1) != dp.Ext(1))
-  error
+  error("failed");
 endif
 
   

--- a/Examples/test-suite/octave/smart_pointer_member_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_member_runme.m
@@ -4,7 +4,7 @@ f = Foo();
 f.y = 1;
 
 if (f.y != 1)
-  error
+  error("failed");
 endif
 
 b = Bar(f);
@@ -15,18 +15,18 @@ if (f.y != 2)
 endif
 
 if (swig_this(b.x) != swig_this(f.x))
-  error
+  error("failed");
 endif
 
 if (b.z != f.z)
-  error
+  error("failed");
 endif
 
 try
   if (Foo.z == Bar.z)
-    error
+    error("failed");
   endif
-    error
+    error("failed");
 catch
 end_try_catch
 

--- a/Examples/test-suite/octave/smart_pointer_multi_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_multi_runme.m
@@ -7,11 +7,11 @@ g = Grok(b);
 
 s.x = 3;
 if (s.getx() != 3)
-    error
+    error("failed");
 endif
 
 g.x = 4;
 if (g.getx() != 4)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/smart_pointer_multi_typedef_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_multi_typedef_runme.m
@@ -7,12 +7,12 @@ g = Grok(b);
 
 s.x = 3;
 if (s.getx() != 3)
-    error
+    error("failed");
 endif
 
 g.x = 4;
 if (g.getx() != 4)
-    error
+    error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/smart_pointer_overload_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_overload_runme.m
@@ -10,23 +10,23 @@ b = Bar(f);
 
 
 if (f.test(3) != 1)
-    error
+    error("failed");
 endif
 if (f.test(3.5) != 2)
-    error
+    error("failed");
 endif
 if (f.test("hello") != 3)
-    error
+    error("failed");
 endif
 
 if (b.test(3) != 1)
-    error
+    error("failed");
 endif
 if (b.test(3.5) != 2)
-    error
+    error("failed");
 endif
 if (b.test("hello") != 3)
-    error
+    error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/smart_pointer_rename_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_rename_runme.m
@@ -9,14 +9,14 @@ f = Foo();
 b = Bar(f);
 
 if (b.test() != 3)
-    error
+    error("failed");
 endif
 
 if (b.ftest1(1) != 1)
-    error
+    error("failed");
 endif
 
 if (b.ftest2(2,3) != 2)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/smart_pointer_simple_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_simple_runme.m
@@ -10,11 +10,11 @@ b = Bar(f);
 
 b.x = 3;
 if (b.getx() != 3)
-    error
+    error("failed");
 endif
 
 fp = b.__deref__();
 fp.x = 4;
 if (fp.getx() != 4)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/smart_pointer_templatevariables_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_templatevariables_runme.m
@@ -3,17 +3,17 @@ smart_pointer_templatevariables
 d = DiffImContainerPtr_D(create(1234, 5678));
 
 if (d.id != 1234)
-  error
+  error("failed");
 endif
 #if (d.xyz != 5678):
-#  error
+#  error("failed");
 
 d.id = 4321;
 #d.xyz = 8765
 
 if (d.id != 4321)
-  error
+  error("failed");
 endif
 #if (d.xyz != 8765):
-#  error
+#  error("failed");
 

--- a/Examples/test-suite/octave/smart_pointer_typedef_runme.m
+++ b/Examples/test-suite/octave/smart_pointer_typedef_runme.m
@@ -10,11 +10,11 @@ b = Bar(f);
 
 b.x = 3;
 if (b.getx() != 3)
-    error
+    error("failed");
 endif
 
 fp = b.__deref__();
 fp.x = 4;
 if (fp.getx() != 4)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/static_const_member_2_runme.m
+++ b/Examples/test-suite/octave/static_const_member_2_runme.m
@@ -18,6 +18,6 @@ end_try_catch
 
 
 if (Foo.BAZ.val != 2*Foo.BAR.val)
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/std_containers_runme.m
+++ b/Examples/test-suite/octave/std_containers_runme.m
@@ -132,7 +132,7 @@ s.append(3);
 j=1;
 for i in s,
   if (i != j)
-    error
+    error("failed");
   endif
   j = j + 1;
 endfor

--- a/Examples/test-suite/octave/struct_value_runme.m
+++ b/Examples/test-suite/octave/struct_value_runme.m
@@ -9,10 +9,10 @@ b = struct_value.Bar();
 
 b.a.x = 3;
 if (b.a.x != 3)
-  error
+  error("failed");
 endif
 
 b.b.x = 3;
 if (b.b.x != 3)
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/swigobject_runme.m
+++ b/Examples/test-suite/octave/swigobject_runme.m
@@ -11,7 +11,7 @@ a1 = a_ptr(a);
 a2 = a_ptr(a);
 
 if (swig_this(a1) != swig_this(a2))
-  error
+  error("failed");
 endif
   
 
@@ -20,7 +20,7 @@ xstr1 = printf("0x%x",lthis);
 xstr2 = pointer_str(a);
 
 if (xstr1 != xstr2)
-  error
+  error("failed");
 endif
 
 s = str(a.this);
@@ -29,5 +29,5 @@ r = repr(a.this);
 v1 = v_ptr(a);
 v2 = v_ptr(a);
 if (uint64(v1) != uint64(v2))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/template_extend1_runme.m
+++ b/Examples/test-suite/octave/template_extend1_runme.m
@@ -9,9 +9,9 @@ a = template_extend1.lBaz();
 b = template_extend1.dBaz();
 
 if (!strcmp(a.foo(),"lBaz::foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(b.foo(),"dBaz::foo"))
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/template_extend2_runme.m
+++ b/Examples/test-suite/octave/template_extend2_runme.m
@@ -9,9 +9,9 @@ a = template_extend2.lBaz();
 b = template_extend2.dBaz();
 
 if (!strcmp(a.foo(),"lBaz::foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(b.foo(),"dBaz::foo"))
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/template_inherit_runme.m
+++ b/Examples/test-suite/octave/template_inherit_runme.m
@@ -12,62 +12,62 @@ e = FooUInt();
 f = BarUInt();
 
 if (!strcmp(a.blah(),"Foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(b.blah(),"Foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(e.blah(),"Foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(c.blah(),"Bar"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(d.blah(),"Bar"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(f.blah(),"Bar"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(c.foomethod(),"foomethod"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(d.foomethod(),"foomethod"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(f.foomethod(),"foomethod"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(invoke_blah_int(a),"Foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(invoke_blah_int(c),"Bar"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(invoke_blah_double(b),"Foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(invoke_blah_double(d),"Bar"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(invoke_blah_uint(e),"Foo"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(invoke_blah_uint(f),"Bar"))
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/template_ns4_runme.m
+++ b/Examples/test-suite/octave/template_ns4_runme.m
@@ -7,5 +7,5 @@ template_ns4
 
 d = make_Class_DD();
 if (!strcmp(d.test(),"test"))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/template_ns_runme.m
+++ b/Examples/test-suite/octave/template_ns_runme.m
@@ -3,19 +3,19 @@ p1 = pairii(2,3);
 p2 = pairii(p1);
 
 if (p2.first != 2)
-    error
+    error("failed");
 endif
 if (p2.second != 3)
-    error
+    error("failed");
 endif
 
 p3 = pairdd(3.5,2.5);
 p4 = pairdd(p3);
 
 if (p4.first != 3.5)
-    error
+    error("failed");
 endif
 
 if (p4.second != 2.5)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/template_tbase_template_runme.m
+++ b/Examples/test-suite/octave/template_tbase_template_runme.m
@@ -2,5 +2,5 @@ template_tbase_template
 
 a = make_Class_dd();
 if (!strcmp(a.test(),"test"))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/template_typedef_cplx2_runme.m
+++ b/Examples/test-suite/octave/template_typedef_cplx2_runme.m
@@ -15,7 +15,7 @@ end_try_catch
 if (strfind('ArithUnaryFunction',swig_type(d)) != 1)
   d
   error("is not an ArithUnaryFunction")
-  error
+  error("failed");
 endif
 
 try
@@ -77,7 +77,7 @@ end_try_catch
 if (strfind('ArithUnaryFunction',swig_type(g)) != 1)
   g
   error("is not an ArithUnaryFunction")
-  error
+  error("failed");
 endif
 
 
@@ -98,6 +98,6 @@ try
   a = g.get_value();
 catch
   error(g, "has not get_value() method")
-  error
+  error("failed");
 end_try_catch
 

--- a/Examples/test-suite/octave/template_typedef_runme.m
+++ b/Examples/test-suite/octave/template_typedef_runme.m
@@ -8,7 +8,7 @@ try
   a = swig_this(d);
   a = swig_this(c);
 catch
-  error
+  error("failed");
 end_try_catch
 
 try
@@ -37,15 +37,15 @@ end_try_catch
 
 # the old large format
 if (strcmp("<unknown>",swig_typequery("vfncs::ArithUnaryFunction<vfncs::arith_traits<float,double>::argument_type,vfncs::arith_traits<float,double >::result_type > *")))
-  error
+  error("failed");
 endif
 
 # the reduced format
 if (strcmp("<unknown>",swig_typequery("vfncs::ArithUnaryFunction<double,double> *")))
-  error
+  error("failed");
 endif
 
 # this is a bad name
 if (!strcmp("<unknown>",swig_typequery("vfncs::ArithUnaryFunction<double,doublex> *")))
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/typemap_namespace_runme.m
+++ b/Examples/test-suite/octave/typemap_namespace_runme.m
@@ -1,10 +1,10 @@
 typemap_namespace
 
 if (!strcmp(test1("hello"),"hello"))
-    error
+    error("failed");
 endif
 
 if (!strcmp(test2("hello"),"hello"))
-    error
+    error("failed");
 endif
 

--- a/Examples/test-suite/octave/typemap_ns_using_runme.m
+++ b/Examples/test-suite/octave/typemap_ns_using_runme.m
@@ -1,5 +1,5 @@
 typemap_ns_using
 
 if (typemap_ns_using.spam(37) != 37)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/types_directive_runme.m
+++ b/Examples/test-suite/octave/types_directive_runme.m
@@ -3,13 +3,13 @@ types_directive
 d1 = Time1(2001, 2, 3, 60);
 newDate = add(d1, 7); # check that a Time1 instance is accepted where Date is expected
 if (newDate.day != 10)
-  error
+  error("failed");
 endif
 
 d2 = Time2(1999, 8, 7, 60);
 newDate = add(d2, 7); # check that a Time2 instance is accepted where Date is expected
 if (newDate.day != 14)
-  error
+  error("failed");
 endif
 
 

--- a/Examples/test-suite/octave/using1_runme.m
+++ b/Examples/test-suite/octave/using1_runme.m
@@ -6,5 +6,5 @@ endif
 using1
 
 if (using1.spam(37) != 37)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/using2_runme.m
+++ b/Examples/test-suite/octave/using2_runme.m
@@ -6,5 +6,5 @@ endif
 using2
 
 if (using2.spam(37) != 37)
-    error
+    error("failed");
 endif

--- a/Examples/test-suite/octave/virtual_poly_runme.m
+++ b/Examples/test-suite/octave/virtual_poly_runme.m
@@ -10,23 +10,23 @@ dc = d.copy();
 ic = i.copy();
 
 if (d.get() != dc.get())
-  error
+  error("failed");
 endif
 
 if (i.get() != ic.get())
-  error
+  error("failed");
 endif
 
 virtual_poly.incr(ic);
 
 if ((i.get() + 1) != ic.get())
-  error
+  error("failed");
 endif
 
 
 dr = d.ref_this();
 if (d.get() != dr.get())
-  error
+  error("failed");
 endif
 
 
@@ -35,10 +35,10 @@ endif
 #
 ddc = virtual_poly.NDouble_narrow(d.nnumber());
 if (d.get() != ddc.get())
-  error
+  error("failed");
 endif
 
 dic = virtual_poly.NInt_narrow(i.nnumber());
 if (i.get() != dic.get())
-  error
+  error("failed");
 endif

--- a/Examples/test-suite/octave/voidtest_runme.m
+++ b/Examples/test-suite/octave/voidtest_runme.m
@@ -27,16 +27,16 @@ end_try_catch
 v1 = voidtest.vfunc1(f);
 v2 = voidtest.vfunc2(f);
 if (swig_this(v1) != swig_this(v2))
-    error
+    error("failed");
 endif
 
 v3 = voidtest.vfunc3(v1);
 if (swig_this(v3) != swig_this(f))
-    error
+    error("failed");
 endif
 v4 = voidtest.vfunc1(f);
 if (swig_this(v4) != swig_this(v1))
-    error
+    error("failed");
 endif
 
 


### PR DESCRIPTION
This fixes a spurious error message in the Octave tests. For modern Octave versions, the `error()` function must be called with an argument (the error message), whereas the test scripts were calling `error` without any argument. One of these calls inside a `try`/`catch` block was raising a syntax error, even though the test itself did not fail. The fix is to just add an argument for `error()`.

cc @wsfulton 