### PR TITLE
Fix C# wchar_t* csvarout to be same as csout

### DIFF
--- a/Examples/test-suite/csharp/li_std_wstring_runme.cs
+++ b/Examples/test-suite/csharp/li_std_wstring_runme.cs
@@ -106,6 +106,13 @@ public class runme
                 check_equal(received, expected);
             }
 
+            foreach (string expected in test_strings)
+            {
+                s.wchar_t_ptr_member = expected;
+                string received = s.wchar_t_ptr_member;
+                check_equal(received, expected);
+            }
+
             /* Not working for Japanese and Russian characters on Windows, okay on Linux
              * Is fixed by adding CharSet=CharSet.Unicode to the DllImport, so change to:
              * [global::System.Runtime.InteropServices.DllImport("li_std_wstring", CharSet=global::System.Runtime.InteropServices.CharSet.Unicode, EntryPoint="CSharp_li_std_wstringNamespace_test_wcvalue")]

--- a/Examples/test-suite/csharp/li_std_wstring_runme.cs
+++ b/Examples/test-suite/csharp/li_std_wstring_runme.cs
@@ -75,6 +75,13 @@ public class runme
         check_equal(li_std_wstring.test_ccvalue(x), "abc");
         check_equal(li_std_wstring.test_wchar_overload(x), "abc");
 
+        // Member variables
+        var s = new wchar_test_struct();
+        s.wchar_t_member = h;
+        check_equal(s.wchar_t_member, h);
+        s.wchar_t_ptr_member = x;
+        check_equal(s.wchar_t_ptr_member, "abc");
+
         {
             // Unicode strings
             string[] test_strings = {

--- a/Examples/test-suite/li_std_wstring.i
+++ b/Examples/test-suite/li_std_wstring.i
@@ -70,6 +70,11 @@ size_t size_wstring(const std::wstring& s) {
   return s.size();
 }
 
+struct wchar_test_struct {
+  wchar_t wchar_t_member;
+  wchar_t* wchar_t_ptr_member;
+};
+
 %}
 
 #endif

--- a/Examples/test-suite/python/li_std_wstring_runme.py
+++ b/Examples/test-suite/python/li_std_wstring_runme.py
@@ -54,6 +54,12 @@ check_equal(li_std_wstring.test_value(x), x)
 check_equal(li_std_wstring.test_ccvalue(x), "abc")
 check_equal(li_std_wstring.test_wchar_overload(x), "abc")
 
+ts = li_std_wstring.wchar_test_struct()
+ts.wchar_t_member = h
+check_equal(ts.wchar_t_member, h)
+ts.wchar_t_ptr_member = s
+check_equal(ts.wchar_t_ptr_member, s)
+
 ################### Python specific
 
 # Byte strings only converted in Python 2

--- a/Lib/csharp/wchar.i
+++ b/Lib/csharp/wchar.i
@@ -92,7 +92,7 @@ SWIGEXPORT void SWIGSTDCALL SWIGRegisterWStringCallback_$module(SWIG_CSharpWStri
     } %}
 %typemap(csvarout, excode=SWIGEXCODE2) wchar_t * %{
     get {
-      string ret = $imcall;$excode
+      string ret = global::System.Runtime.InteropServices.Marshal.PtrToStringUni($imcall);$excode
       return ret;
     } %}
 


### PR DESCRIPTION
Bug and fix as reported on user mailing list - Current csvarout tries to return an IntPtr instead of C# string, causing a compilation error.

I can't find any test cases for this, can add if needed.

As an aside I don't see any wchar.i typemaps for directors, and the string helper class doesn't seem to be used anywhere..