### PR TITLE
Missing escaping in maintainer scripts

### DIFF
--- a/Tools/mkdist.py
+++ b/Tools/mkdist.py
@@ -3,28 +3,11 @@
 import sys
 import os
 import subprocess
+from utils import *
 
 def failed():
     print("mkdist.py failed to complete")
     sys.exit(2)
-
-def check_file_exists(path):
-    """
-    Checks if a file exists or not.
-    """
-    return os.path.isfile(path)
-
-def check_dir_exists(path):
-    """
-    Checks if a folder exists or not.
-    """
-    return os.path.isdir(path)
-
-def run_command(*args, **kwargs):
-    """
-    Runs an os command using subprocess module.
-    """
-    return subprocess.call(args, **kwargs)
 
 import argparse
 parser = argparse.ArgumentParser(description="Build a SWIG distribution tarball swig-x.y.z.tar.gz")
@@ -44,8 +27,10 @@ skip_checks = args.skip_checks
 toolsdir = os.path.dirname(os.path.abspath(__file__))
 # Root directory path (swig) $ENV/swig
 rootdir = os.path.abspath(os.path.join(toolsdir, os.pardir))
+# current directory
+current_dir = os.getcwd()
 # version directory path $ENV/swig/<x.x.x>
-dirpath = os.path.join(rootdir, dirname)
+dirpath = os.path.join(current_dir, dirname)
 
 if sys.version_info[0:2] < (2, 7):
      print("Error: Python 2.7 or higher is required")
@@ -125,6 +110,7 @@ output = tar_ps.communicate()
 # Go build the system
 
 print("Building system")
+run_command("mkdir", "-p", dirpath)
 run_command("./autogen.sh", cwd=dirpath) == 0 or failed()
 
 cmdpath = os.path.join(dirpath, "Source", "CParse")

--- a/Tools/mkrelease.py
+++ b/Tools/mkrelease.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+from utils import *
 
 def failed(message):
   if message == "":
@@ -27,15 +28,17 @@ skip_checks = args.skip_checks
 username = args.username
 
 print("Looking for rsync")
-os.system("which rsync") and failed("rsync not installed/found. Please install.")
+run_command("which", "rsync") and failed("rsync not installed/found. Please install.")
 
 print("Making source tarball")
 force = "--force-tag" if force_tag else ""
 skip = "--skip-checks" if skip_checks else ""
-os.system("python ./mkdist.py {} {} --branch {} {}".format(force, skip, branch, version)) and failed("")
+toolsdir = os.path.dirname(os.path.abspath(__file__))
+cmd = "python {}/mkdist.py {} {} --branch {} {}".format(toolsdir, force, skip, branch, version).split()
+run_command(*cmd) and failed("")
 
 print("Build Windows package")
-os.system("./mkwindows.sh " + version) and failed("")
+run_command("{}/mkwindows.sh".format(toolsdir), version) and failed("")
 
 if username:
     print("Uploading to SourceForge")
@@ -45,11 +48,11 @@ if username:
 
     # If a file with 'readme' in the name exists in the same folder as the zip/tarball, it gets automatically displayed as the release notes by SF
     full_readme_file = "readme-" + version + ".txt"
-    os.system("rm -f " + full_readme_file)
-    os.system("cat swig-" + version + "/README " + "swig-" + version + "/CHANGES.current " + "swig-" + version + "/RELEASENOTES " + "> " + full_readme_file)
+    run_command("rm", "-f", full_readme_file)
+    run_command("cat", "swig-" + version + "/README", "swig-" + version + "/CHANGES.current", "swig-" + version + "/RELEASENOTES", ">", full_readme_file)
 
-    os.system("rsync --archive --verbose -P --times -e ssh " + "swig-" + version + ".tar.gz " + full_readme_file + " " + swig_dir_sf) and failed("")
-    os.system("rsync --archive --verbose -P --times -e ssh " + "swigwin-" + version + ".zip " + full_readme_file + " " + swigwin_dir_sf) and failed("")
+    run_command("rsync", "--archive", "--verbose", "-P", "--times", "-e", "ssh", "swig-" + version + ".tar.gz", full_readme_file, swig_dir_sf) and failed("")
+    run_command("rsync", "--archive", "--verbose", "-P", "--times", "-e", "ssh", "swigwin-" + version + ".zip", full_readme_file, swigwin_dir_sf) and failed("")
 
     print("Finished")
 

--- a/Tools/utils.py
+++ b/Tools/utils.py
@@ -1,0 +1,26 @@
+import os, subprocess
+
+
+def check_file_exists(path):
+    """
+    Checks if a file exists or not.
+    """
+    return os.path.isfile(path)
+
+
+def check_dir_exists(path):
+    """
+    Checks if a folder exists or not.
+    """
+    return os.path.isdir(path)
+
+
+def run_command(*args, **kwargs):
+    """
+    Runs an os command using subprocess module.
+    """
+    redirect_out = list(map(str.strip, " ".join(args).split(" > ")))
+    if len(redirect_out) > 1:
+        args, filepath = redirect_out[0].split(), redirect_out[-1]
+        kwargs.update(stdout=open(filepath, "w"))
+    return subprocess.call(args, **kwargs)


### PR DESCRIPTION
https://huntr.dev/users/d3v53c has fixed the Remote Code Execution vulnerability 🔨. d3v53c has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/swig/pull/3
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/pip/swig/1/README.md

### User Comments:

### 📊 Metadata *

SWIG is a compiler that integrates C and C++ with languages including Perl, Python, Tcl, Ruby, PHP, Java, C#, D, Go, Lua, Octave, R, Scheme (Guile, MzScheme/Racket), Scilab, Ocaml. SWIG can also export its parse tree into XML. One of the python tools of swig include a mkdist.py script. This script takes in arguments and execute it without sanitation leading to Arbitrary code execution

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-swig/

### ⚙️ Description *

Mitigating the arbitrary code execution by total reworking rather than using more library code for sanitising. subprocess module provides a level of safety from code execution vulnerabilities. Also, changed the output directory of the build, maybe need some pointers on that.

### 💻 Technical Description *

Every call to "os.system" api is replaced by "subprocess.call/Popen" apis. subprocess module provides much more reliability for system command executions.

### 🐛 Proof of Concept (PoC) *

Run command, "python3 Tools/mkdist.py 'a; touch arbitrary-code-exec.pwn #"

Before fix
![image](https://user-images.githubusercontent.com/64132745/93142598-318e6200-f69b-11ea-84bf-822205b5e588.png)

### 🔥 Proof of Fix (PoF) *

After fix
![image](https://user-images.githubusercontent.com/64132745/93142784-8b8f2780-f69b-11ea-96f2-66dcc767ac75.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/93143020-f80a2680-f69b-11ea-93d7-56105f102a8e.png)

