### PR TITLE
Drop deprecated PyEval_CallObject method

### DIFF
--- a/Lib/python/defarg.swg
+++ b/Lib/python/defarg.swg
@@ -33,5 +33,5 @@ SWIGINTERN PyObject *swig_call_defargs(PyObject *self, PyObject *args) {
     SWIG_PYTHON_THREAD_END_BLOCK;
     return NULL;
   }
-  return PyEval_CallObject(func,parms);
+  return PyObject_Call(func, parms, NULL);
 }


### PR DESCRIPTION
see https://docs.python.org/3.9/whatsnew/3.9.html