### PR TITLE
php: Fix directed methods with non-void return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -422,11 +422,6 @@ matrix:
       os: linux
       env: SWIGLANG=d VER=2.086.1
       dist: xenial
-    # seg fault in director_basic testcase
-    - compiler: gcc
-      os: linux
-      env: SWIGLANG=php VER=7.2
-      dist: xenial
     # Experimental languages
     - compiler: gcc
       os: linux

--- a/Examples/test-suite/director_overload.i
+++ b/Examples/test-suite/director_overload.i
@@ -47,5 +47,13 @@ public:
   virtual void notover(int *p) const {}
 };
 
-%}
+class OverloadedGetSet
+{
+  int v;
+public:
+  OverloadedGetSet() : v(42) { }
+  virtual int rw() const { return v; }
+  virtual void rw(int new_v) { v = new_v; }
+};
 
+%}

--- a/Examples/test-suite/director_overload.i
+++ b/Examples/test-suite/director_overload.i
@@ -52,6 +52,7 @@ class OverloadedGetSet
   int v;
 public:
   OverloadedGetSet() : v(42) { }
+  virtual ~OverloadedGetSet() { }
   virtual int rw() const { return v; }
   virtual void rw(int new_v) { v = new_v; }
 };

--- a/Examples/test-suite/php/director_overload_runme.php
+++ b/Examples/test-suite/php/director_overload_runme.php
@@ -1,0 +1,18 @@
+
+<?php
+
+require "tests.php";
+require "director_overload.php";
+
+check::functions(array('new_overloadedClass','new_overloadedPointers','new_overloadedGetSet','overloadedclass_method1','overloadedclass_method3','overloadedclass_method2','overloadedpointers_method','overloadedpointers_notover','overloadedgetset_rw'));
+
+check::classes(array('OverloadedClass','OverloadedPointers','OverloadedGetSet'));
+check::globals(array());
+
+$o = new OverloadedGetSet;
+check::equal($o->rw(), 42, "get_set() initial value not 42");
+check::equal($o->rw(7), null, "get_set() failed to set");
+check::equal($o->rw(), 7, "get_set() didn't return back set value");
+
+check::done();
+?>

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -1566,7 +1566,7 @@ public:
 	      Printf(prepare, "case %d: ", ++last_handled_i);
 	    }
 	    if (non_void_return) {
-	      if ((!directorsEnabled() || !Swig_directorclass(n)) && !constructor) {
+	      if (!constructor) {
 		Append(prepare, "$r=");
 	      } else if (wrapperType == staticmemberfn || wrapperType == staticmembervar) {
 		Append(prepare, "$r=");
@@ -1590,7 +1590,7 @@ public:
 	if (had_a_case)
 	  Printf(prepare, "default: ");
 	if (non_void_return) {
-	  if ((!directorsEnabled() || !Swig_directorclass(n)) && !constructor) {
+	  if (!constructor) {
 	    Append(prepare, "$r=");
 	  } else if (wrapperType == staticmemberfn || wrapperType == staticmembervar) {
 	    Append(prepare, "$r=");


### PR DESCRIPTION
We were treating all such methods like constructors and assigning to the
internal _cPtr, which just seems bizarrely wrong.

Fixes #1900

WIP: Pushing for review and CI at this point - this needs test coverage and a CHANGES entry.  Also should check there's not more strange special casing for directors.