### PR TITLE
Add and improve Ruby test cases in the context of nesting and namespaces

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -330,7 +330,7 @@ CPP_TEST_CASES += \
 	nested_ignore \
 	nested_inheritance_interface \
 	nested_in_template \
-	nested_scope \
+	nested_scope_flat \
 	nested_template_base \
 	nested_workaround \
 	newobject1 \
@@ -460,6 +460,7 @@ CPP_TEST_CASES += \
 	template_using_directive_and_declaration_forward \
 	template_using_directive_typedef \
 	template_nested \
+	template_nested_flat \
 	template_nested_typemaps \
 	template_ns \
 	template_ns2 \
@@ -858,8 +859,6 @@ setup = \
 	else								  \
 	  echo "$(ACTION)ing $(LANGUAGE) testcase $*" ;		  \
 	fi
-
-
 
 #######################################################################
 # Clean

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -28,6 +28,7 @@ CPP_TEST_CASES = \
 	enum_thorough_typesafe \
 	exception_partial_info \
 	intermediary_classname \
+	nested_scope \
 	li_boost_intrusive_ptr \
 	li_std_list \
 

--- a/Examples/test-suite/csharp/template_nested_flat_runme.cs
+++ b/Examples/test-suite/csharp/template_nested_flat_runme.cs
@@ -1,0 +1,25 @@
+using System;
+using template_nested_flatNamespace;
+#pragma warning disable 219
+
+public class runme {
+  static void Main() {
+    new T_NormalTemplateNormalClass().tmethod(new NormalClass());
+    new OuterClass().T_OuterTMethodNormalClass(new NormalClass());
+
+    TemplateFuncs tf = new TemplateFuncs();
+    if (tf.T_TemplateFuncs1Int(-10) != -10)
+      throw new Exception("it failed");
+    if (tf.T_TemplateFuncs2Double(-12.3) != -12.3)
+      throw new Exception("it failed");
+
+    T_NestedOuterTemplateDouble tn = new T_NestedOuterTemplateDouble();
+    if (tn.hohum(-12.3) != -12.3)
+      throw new Exception("it failed");
+    T_OuterClassInner1Int inner1 = new OuterClass().useInner1(new T_OuterClassInner1Int());
+    T_OuterClassInner2NormalClass inner2 = new T_OuterClassInner2NormalClass();
+    inner2.embeddedVar = 2;
+    T_OuterClassInner2NormalClass inner22 = new OuterClass().useInner2Again(inner2);
+  }
+}
+

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -44,6 +44,7 @@ CPP_TEST_CASES = \
 	java_throws \
 	java_typemaps_proxy \
 	java_typemaps_typewrapper \
+	nested_scope \
 	li_std_list \
 	li_std_map \
 	li_std_set \

--- a/Examples/test-suite/java/template_nested_flat_runme.java
+++ b/Examples/test-suite/java/template_nested_flat_runme.java
@@ -1,0 +1,35 @@
+
+import template_nested_flat.*;
+
+public class template_nested_flat_runme {
+
+  static {
+    try {
+      System.loadLibrary("template_nested_flat");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+    new T_NormalTemplateNormalClass().tmethod(new NormalClass());
+    new OuterClass().T_OuterTMethodNormalClass(new NormalClass());
+
+    TemplateFuncs tf = new TemplateFuncs();
+    if (tf.T_TemplateFuncs1Int(-10) != -10)
+      throw new RuntimeException("it failed");
+    if (tf.T_TemplateFuncs2Double(-12.3) != -12.3)
+      throw new RuntimeException("it failed");
+
+    T_NestedOuterTemplateDouble tn = new T_NestedOuterTemplateDouble();
+    if (tn.hohum(-12.3) != -12.3)
+      throw new RuntimeException("it failed");
+    T_OuterClassInner1Int inner1 = new OuterClass().useInner1(new T_OuterClassInner1Int());
+    T_OuterClassInner2NormalClass inner2 = new T_OuterClassInner2NormalClass();
+    inner2.setEmbeddedVar(2);
+    T_OuterClassInner2NormalClass inner22 = new OuterClass().useInner2Again(inner2);
+    T_OuterClassInner1Double inner3 = new T_OuterClassInner1Double();
+  }
+}
+

--- a/Examples/test-suite/multiple_inheritance_abstract.i
+++ b/Examples/test-suite/multiple_inheritance_abstract.i
@@ -1,9 +1,8 @@
 // This is a copy of the multiple_inheritance_abstract test
-%module  multiple_inheritance_abstract
+%module(ruby_minherit="1") multiple_inheritance_abstract
 
-%warnfilter(SWIGWARN_RUBY_MULTIPLE_INHERITANCE,
-	    SWIGWARN_D_MULTIPLE_INHERITANCE,
-	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance or %interface */
+%warnfilter(SWIGWARN_D_MULTIPLE_INHERITANCE,
+	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance */
 
 #if defined(SWIGJAVA) || defined(SWIGCSHARP)
 %include "swiginterface.i"

--- a/Examples/test-suite/multiple_inheritance_interfaces.i
+++ b/Examples/test-suite/multiple_inheritance_interfaces.i
@@ -1,8 +1,7 @@
-%module  multiple_inheritance_interfaces
+%module(ruby_minherit="1") multiple_inheritance_interfaces
 
-%warnfilter(SWIGWARN_RUBY_MULTIPLE_INHERITANCE,
-	    SWIGWARN_D_MULTIPLE_INHERITANCE,
-	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance or %interface */
+%warnfilter(SWIGWARN_D_MULTIPLE_INHERITANCE,
+	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance */
 
 #if defined(SWIGJAVA) || defined(SWIGCSHARP)
 %include "swiginterface.i"

--- a/Examples/test-suite/multiple_inheritance_nspace.i
+++ b/Examples/test-suite/multiple_inheritance_nspace.i
@@ -1,9 +1,8 @@
 // This is a copy of the multiple_inheritance_abstract test
-%module  multiple_inheritance_nspace
+%module(ruby_minherit="1") multiple_inheritance_nspace
 
-%warnfilter(SWIGWARN_RUBY_MULTIPLE_INHERITANCE,
-	    SWIGWARN_D_MULTIPLE_INHERITANCE,
-	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance or %interface */
+%warnfilter(SWIGWARN_D_MULTIPLE_INHERITANCE,
+	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance */
 
 // nspace feature only supported by these languages
 #if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)

--- a/Examples/test-suite/multiple_inheritance_shared_ptr.i
+++ b/Examples/test-suite/multiple_inheritance_shared_ptr.i
@@ -1,9 +1,8 @@
 // This is a copy of the multiple_inheritance_abstract test and extended for testing %shared_ptr and %interface_impl
-%module  multiple_inheritance_shared_ptr
+%module(ruby_minherit="1") multiple_inheritance_shared_ptr
 
-%warnfilter(SWIGWARN_RUBY_MULTIPLE_INHERITANCE,
-	    SWIGWARN_D_MULTIPLE_INHERITANCE,
-	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance or %interface */
+%warnfilter(SWIGWARN_D_MULTIPLE_INHERITANCE,
+	    SWIGWARN_PHP_MULTIPLE_INHERITANCE); /* languages not supporting multiple inheritance */
 
 // Typemap changes required to mix %shared_ptr and %interface_impl
 // Note we don't have a way to use $javainterfacename/$csinterfacename (yet),

--- a/Examples/test-suite/nested_scope.i
+++ b/Examples/test-suite/nested_scope.i
@@ -1,9 +1,5 @@
 %module nested_scope
 
-#if !defined(SWIGCSHARP) && !defined(SWIGJAVA)
-%feature ("flatnested");
-#endif
-
 %inline %{
 namespace ns {
         // "global" is a case-insensitive keyword in PHP.
@@ -31,9 +27,9 @@ namespace ns {
 		public:
 			struct Nested2;
 #ifdef __clang__
-		struct Nested2 {
-			int data;
-		};
+			struct Nested2 {
+				int data;
+			};
 #endif
 			template <class T> class AbstractClass;
 			class Real;

--- a/Examples/test-suite/nested_scope_flat.i
+++ b/Examples/test-suite/nested_scope_flat.i
@@ -1,0 +1,5 @@
+%module nested_scope_flat
+
+%feature ("flatnested");
+
+%include "nested_scope.i"

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -84,6 +84,8 @@ ruby_naming.cpptest: SWIGOPT += -autorename
 run_testcase = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) ]; then \
 	  env LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(RUNTOOL) $(RUBY) $(RUBYFLAGS) -I$(srcdir):. $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX); \
+	elif [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*.so ] ; then \
+	  env LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(RUNTOOL) $(RUBY) $(RUBYFLAGS) -I$(srcdir):. -r$(SCRIPTDIR)/$(SCRIPTPREFIX)$*.so -e '' ; \
 	fi
 
 # Clean

--- a/Examples/test-suite/ruby/constant_directive_runme.rb
+++ b/Examples/test-suite/ruby/constant_directive_runme.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'constant_directive'
+
+swig_assert("Constant_directive::TYPE1_CONSTANT1.is_a?(Constant_directive::Type1)", binding)
+swig_assert("Constant_directive::getType1Instance().is_a?(Constant_directive::Type1)", binding)
+
+swig_assert_equal('Constant_directive::TYPE1_CONSTANT1.val', '1', binding)
+swig_assert_equal('Constant_directive::TYPE1_CONSTANT2.val', '2', binding)
+swig_assert_equal('Constant_directive::TYPE1_CONSTANT3.val', '3', binding)
+swig_assert_equal('Constant_directive::TYPE1CONST_CONSTANT1.val', '1', binding)
+swig_assert_equal('Constant_directive::TYPE1CPTR_CONSTANT1.val', '1', binding)

--- a/Examples/test-suite/ruby/contract_runme.rb
+++ b/Examples/test-suite/ruby/contract_runme.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'contract'
+
+def swig_assert_runtime_error(msg, type, &block)
+  begin
+    yield(block)
+    raise SwigRubyError.new("#{msg} failed")
+  rescue RuntimeError => e
+    reason = e.to_s
+    if reason =~ /\bcontract violation\b/i && reason =~ /\b#{type}\b/i
+      # OK
+    else
+      raise e
+    end
+  end
+end
+
+Contract::test_preassert(1, 2)
+swig_assert_runtime_error("Preassertions", "require") { Contract::test_preassert(-1, 3) }
+
+Contract::test_postassert(3)
+swig_assert_runtime_error("Postassertions", "ensure") { Contract::test_postassert(-3) }
+
+Contract::test_prepost(2, 3)
+Contract::test_prepost(5, -4)
+swig_assert_runtime_error("Preassertions", "require") { Contract::test_prepost(-3, 4) }
+swig_assert_runtime_error("Postassertions", "ensure") { Contract::test_prepost(4, -10) }
+
+f = Contract::Foo.new
+f.test_preassert(4, 5)
+swig_assert_runtime_error("Method preassertion", "require") { f.test_preassert(-2, 3) }
+
+f.test_postassert(4)
+swig_assert_runtime_error("Method postassertion", "ensure") { f.test_postassert(-4) }
+
+f.test_prepost(3, 4)
+f.test_prepost(4, -3)
+swig_assert_runtime_error("Method preassertion", "require") { f.test_prepost(-4, 2) }
+swig_assert_runtime_error("Method postassertion", "ensure") { f.test_prepost(4, -10) }
+
+Contract::Foo.stest_prepost(4, 0)
+swig_assert_runtime_error("Static method preassertion", "require") { Contract::Foo.stest_prepost(-4, 2) }
+swig_assert_runtime_error("Static method postassertion", "ensure") { Contract::Foo.stest_prepost(4, -10) }
+
+b = Contract::Bar.new
+swig_assert_runtime_error("Inherited preassertion", "require") { b.test_prepost(2, -4) }
+
+d = Contract::D.new
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.foo(-1, 1, 1, 1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.foo(1, -1, 1, 1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.foo(1, 1, -1, 1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.foo(1, 1, 1, -1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.foo(1, 1, 1, 1, -1) }
+
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.bar(-1, 1, 1, 1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.bar(1, -1, 1, 1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.bar(1, 1, -1, 1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.bar(1, 1, 1, -1, 1) }
+swig_assert_runtime_error("Inherited preassertion (D)", "require") { d.bar(1, 1, 1, 1, -1) }
+
+# namespace
+Contract::MyClass.new(1)
+swig_assert_runtime_error("Constructor preassertion", "require") { Contract::MyClass.new(0) }
+

--- a/Examples/test-suite/ruby/cpp11_alias_nested_template_scoping_runme.rb
+++ b/Examples/test-suite/ruby/cpp11_alias_nested_template_scoping_runme.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'cpp11_alias_nested_template_scoping'
+
+ys = Cpp11_alias_nested_template_scoping::Yshort.new
+val = ys.create1
+val = ys.create2
+val = ys.create3
+val = ys.create4
+val = ys.create5
+val = ys.create6
+val = ys.create7
+
+val = ys.create13
+
+val = ys.create15
+val = ys.create16
+val = ys.create17
+

--- a/Examples/test-suite/ruby/cpp17_nested_namespaces_runme.rb
+++ b/Examples/test-suite/ruby/cpp17_nested_namespaces_runme.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'cpp17_nested_namespaces'
+
+Cpp17_nested_namespaces::A1Struct.new.A1Method
+Cpp17_nested_namespaces::B1Struct.new.B1Method
+Cpp17_nested_namespaces::C1Struct.new.C1Method
+
+Cpp17_nested_namespaces.createA1Struct().A1Method
+Cpp17_nested_namespaces.createB1Struct().B1Method
+Cpp17_nested_namespaces.createC1Struct().C1Method
+
+Cpp17_nested_namespaces::B2Struct.new.B2Method
+Cpp17_nested_namespaces::C2Struct.new.C2Method
+Cpp17_nested_namespaces.createB2Struct().B2Method
+Cpp17_nested_namespaces.createC2Struct().C2Method
+
+Cpp17_nested_namespaces::B3Struct.new.B3Method
+Cpp17_nested_namespaces::C3Struct.new.C3Method
+Cpp17_nested_namespaces.createB3Struct().B3Method
+Cpp17_nested_namespaces.createC3Struct().C3Method

--- a/Examples/test-suite/ruby/cpp_enum_runme.rb
+++ b/Examples/test-suite/ruby/cpp_enum_runme.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'cpp_enum'
+
+f = Cpp_enum::Foo.new
+swig_assert_equal('f.hola', 'Cpp_enum::Foo::Hello', binding)
+
+f.hola = Cpp_enum::Foo::Hi
+swig_assert_equal('f.hola', 'Cpp_enum::Foo::Hi', binding)
+
+f.hola = Cpp_enum::Foo::Hello
+swig_assert_equal('f.hola', 'Cpp_enum::Foo::Hello', binding)
+
+Cpp_enum::hi = Cpp_enum::Hello
+swig_assert_equal('Cpp_enum::hi', 'Cpp_enum::Hello', binding)

--- a/Examples/test-suite/ruby/cpp_static_runme.rb
+++ b/Examples/test-suite/ruby/cpp_static_runme.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'cpp_static'
+
+Cpp_static::StaticFunctionTest.static_func()
+Cpp_static::StaticFunctionTest.static_func_2(1)
+Cpp_static::StaticFunctionTest.static_func_3(1, 2)
+
+swig_assert_equal("Cpp_static::StaticMemberTest.static_int", "99", binding)
+Cpp_static::StaticMemberTest.static_int = 10
+swig_assert_equal("Cpp_static::StaticMemberTest.static_int", "10", binding)
+
+swig_assert_equal("Cpp_static::StaticBase.statty", "11", binding)
+swig_assert_equal("Cpp_static::StaticBase.grab_statty_base", "11", binding)
+swig_assert_equal("Cpp_static::StaticDerived.statty", "111", binding)
+swig_assert_equal("Cpp_static::StaticDerived.grab_statty_derived", "111", binding)
+Cpp_static::StaticBase.statty = 22
+Cpp_static::StaticDerived.statty = 222
+swig_assert_equal("Cpp_static::StaticBase.statty", "22", binding)
+swig_assert_equal("Cpp_static::StaticBase.grab_statty_base", "22", binding)
+swig_assert_equal("Cpp_static::StaticDerived.statty", "222", binding)
+swig_assert_equal("Cpp_static::StaticDerived.grab_statty_derived", "222", binding)

--- a/Examples/test-suite/ruby/enums_runme.rb
+++ b/Examples/test-suite/ruby/enums_runme.rb
@@ -25,10 +25,7 @@ Enums::BAR1 == 0
 Enums::BAR2 == 1
 EOF
 
-#
-# @bug: 
-#
-# swig_assert_each_line( <<EOF )
-# Enums::IFoo::Phoo == 50
-# Enums::IFoo::Char == 'a'[0]
-# EOF
+swig_assert_each_line( <<EOF )
+Enums::Phoo == 50
+Enums::Char == 'a'[0]
+EOF

--- a/Examples/test-suite/ruby/import_fragments_runme.rb
+++ b/Examples/test-suite/ruby/import_fragments_runme.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+#
+# Put description here
+#
+# 
+# 
+# 
+#
+
+require 'swig_assert'
+
+exception_file = nil
+
+begin
+  require 'import_fragments'
+rescue LoadError => e
+  # due to missing import_fragments_a
+  exception_file = e.respond_to?(:path) ? e.path : e.to_s.sub(/.* -- /, '')
+end
+
+swig_assert(exception_file == "import_fragments_a",
+            msg: "Loading should have failed due to missing 'import_fragments_a'")
+

--- a/Examples/test-suite/ruby/multiple_inheritance_abstract_runme.rb
+++ b/Examples/test-suite/ruby/multiple_inheritance_abstract_runme.rb
@@ -1,0 +1,243 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'multiple_inheritance_abstract'
+
+# Test base class as a parameter in Ruby
+
+def jcbase1b(cb1)
+  cb1.cbase1y
+end
+
+def jabase1(ab1)
+  ab1.abase1
+end
+
+def jcbase2(cb2)
+  cb2.cbase2
+end
+
+# test Derived1
+d1 = Multiple_inheritance_abstract::Derived1.new
+swig_assert_equal('d1.cbase1y', '3', binding, 'Derived1::cbase1y() failed')
+swig_assert_equal('d1.cbase2', '4', binding, 'Derived1::cbase2() failed')
+
+# test Derived2
+d2 = Multiple_inheritance_abstract::Derived2.new
+swig_assert_equal('d2.cbase1y', '6', binding, 'Derived2::cbase1y() failed')
+swig_assert_equal('d2.abase1', '5', binding, 'Derived2::cbase1y() failed')
+
+# test Derived3
+d3 = Multiple_inheritance_abstract::Derived3.new
+swig_assert_equal('d3.cbase1y', '7', binding, 'Derived3::cbase1y() failed')
+swig_assert_equal('d3.cbase2', '8', binding, 'Derived3::cbase2() failed')
+swig_assert_equal('d3.abase1', '9', binding, 'Derived3::abase1() failed')
+
+# test Bottom1
+b1 = Multiple_inheritance_abstract::Bottom1.new
+swig_assert_equal('b1.cbase1y', '103', binding, 'Bottom1::cbase1y() failed')
+swig_assert_equal('b1.cbase2', '104', binding, 'Bottom1::cbase2() failed')
+
+# test Bottom2
+b2 = Multiple_inheritance_abstract::Bottom2.new
+swig_assert_equal('b2.cbase1y', '206', binding, 'Bottom2::cbase1y() failed')
+swig_assert_equal('b2.abase1', '205', binding, 'Bottom2::abase1() failed')
+
+# test Bottom3
+b3 = Multiple_inheritance_abstract::Bottom3.new
+swig_assert_equal('b3.cbase1y', '307', binding, 'Bottom3::cbase1y() failed')
+swig_assert_equal('b3.cbase2', '308', binding, 'Bottom3::cbase2() failed')
+swig_assert_equal('b3.abase1', '309', binding, 'Bottom3::abase1() failed')
+
+# test interfaces from C++ classes
+cb1 = Multiple_inheritance_abstract::CBase1.new
+cb2 = Multiple_inheritance_abstract::CBase2.new
+swig_assert_equal('cb1.cbase1y', '1', binding, 'CBase1::cbase1y() failed')
+swig_assert_equal('cb2.cbase2', '2', binding, 'CBase2::cbase2() failed')
+
+# test nspace class as return value
+ab1 = d3.cloneit
+swig_assert_equal('ab1.abase1', '9', binding, 'Derived3::abase1() through ABase1 failed')
+
+# test concrete base class as return value
+cb6 = d2.cloneit
+cb7 = d1.cloneit
+swig_assert_equal('cb6.cbase1y', '6', binding, 'Derived2::cbase1y() through CBase1 failed')
+swig_assert_equal('cb7.cbase2', '4', binding, 'Derived1:cbase2() through ABase1 failed')
+
+# test multi inheritance
+cb3 = Multiple_inheritance_abstract::Derived1.new
+cb4 = Multiple_inheritance_abstract::Derived3.new
+cb5 = Multiple_inheritance_abstract::Derived3.new
+ab6 = Multiple_inheritance_abstract::Derived2.new
+swig_assert_equal('cb3.cbase1y', '3', binding, 'Derived1::cbase1y() through CBase1 failed')
+swig_assert_equal('cb4.cbase1y', '7', binding, 'Derived3::cbase1y() through CBase1 failed')
+swig_assert_equal('cb5.cbase2', '8', binding, 'Derived3::cbase2() through CBase2 failed')
+swig_assert_equal('ab6.abase1', '5', binding, 'Derived2::abase1() through ABase1 failed')  
+
+# test base classes as parameter in Ruby
+swig_assert_equal('jcbase1b(d1)', '3', binding, 'jcbase1b() through Derived1 as parameter failed')
+swig_assert_equal('jcbase1b(d2)', '6', binding, 'jcbase1b() through Derived2 as parameter failed')
+swig_assert_equal('jcbase1b(d3)', '7', binding, 'jcbase1b() through Derived3 as parameter failed')
+swig_assert_equal('jcbase2(d1)', '4', binding, 'jcbase2() through Derived1 as parameter failed')
+swig_assert_equal('jcbase2(d3)', '8', binding, 'jcbase2() through Derived3 as parameter failed')
+swig_assert_equal('jabase1(d2)', '5', binding, 'jabase1() through Derived2 as parameter failed')
+swig_assert_equal('jabase1(d3)', '9', binding, 'jabase1() through Derived3 as parameter failed')
+
+# value parameters
+# test CBase1 CBase2 as parameters (note slicing for Derived and Bottom classes)
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(d1)', '1', binding, 'InputValCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(d2)', '1', binding, 'InputValCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(d3)', '1', binding, 'InputValCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase2(d3)', '2', binding, 'InputValCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase2(d1)', '2', binding, 'InputValCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(cb1)', '1', binding, 'InputValCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase2(cb2)', '2', binding, 'InputValCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(b1)', '1', binding, 'InputValCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(b2)', '1', binding, 'InputValCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase1(b3)', '1', binding, 'InputValCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase2(b3)', '2', binding, 'InputValCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValCBase2(b1)', '2', binding, 'InputValCBase2(), Bottom1 as a parameter failed')
+
+# pointer parameters
+# test ABase1 as a parameter
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrABase1(d2)', '5', binding, 'InputPtrABase1() through Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrABase1(d3)', '9', binding, 'InputPtrABase1() through Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrABase1(b2)', '205', binding, 'InputPtrABase1() through Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrABase1(b3)', '309', binding, 'InputPtrABase1() through Bottom3 as a parameter failed')
+
+# test CBase1 CBase2 as parameters
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(d1)', '3', binding, 'InputPtrCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(d2)', '6', binding, 'InputPtrCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(d3)', '7', binding, 'InputPtrCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase2(d3)', '8', binding, 'InputPtrCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase2(d1)', '4', binding, 'InputPtrCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(cb1)', '1', binding, 'InputPtrCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase2(cb2)', '2', binding, 'InputPtrCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(b1)', '103', binding, 'InputPtrCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(b2)', '206', binding, 'InputPtrCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase1(b3)', '307', binding, 'InputPtrCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase2(b3)', '308', binding, 'InputPtrCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrCBase2(b1)', '104', binding, 'InputPtrCBase2(), Bottom1 as a parameter failed')
+
+# reference parameters
+# test ABase1 as a parameter
+swig_assert_equal('Multiple_inheritance_abstract::InputRefABase1(d2)', '5', binding, 'InputRefABase1() through Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefABase1(d3)', '9', binding, 'InputRefABase1() through Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefABase1(b2)', '205', binding, 'InputRefABase1() through Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefABase1(b3)', '309', binding, 'InputRefABase1() through Bottom3 as a parameter failed')
+
+# test CBase1 CBase2 as parameters
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(d1)', '3', binding, 'InputRefCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(d2)', '6', binding, 'InputRefCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(d3)', '7', binding, 'InputRefCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase2(d3)', '8', binding, 'InputRefCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase2(d1)', '4', binding, 'InputRefCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(cb1)', '1', binding, 'InputRefCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase2(cb2)', '2', binding, 'InputRefCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(b1)', '103', binding, 'InputRefCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(b2)', '206', binding, 'InputRefCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase1(b3)', '307', binding, 'InputRefCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase2(b3)', '308', binding, 'InputRefCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefCBase2(b1)', '104', binding, 'InputRefCBase2(), Bottom1 as a parameter failed')
+
+# const reference pointer parameters
+# test ABase1 as a parameter
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefABase1(d2)', '5', binding, 'InputCPtrRefABase1() through Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefABase1(d3)', '9', binding, 'InputCPtrRefABase1() through Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefABase1(b2)', '205', binding, 'InputCPtrRefABase1() through Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefABase1(b3)', '309', binding, 'InputCPtrRefABase1() through Bottom3 as a parameter failed')
+
+# test CBase1 CBase2 as parameters
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(d1)', '3', binding, 'InputCPtrRefCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(d2)', '6', binding, 'InputCPtrRefCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(d3)', '7', binding, 'InputCPtrRefCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase2(d3)', '8', binding, 'InputCPtrRefCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase2(d1)', '4', binding, 'InputCPtrRefCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(cb1)', '1', binding, 'InputCPtrRefCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase2(cb2)', '2', binding, 'InputCPtrRefCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(b1)', '103', binding, 'InputCPtrRefCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(b2)', '206', binding, 'InputCPtrRefCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase1(b3)', '307', binding, 'InputCPtrRefCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase2(b3)', '308', binding, 'InputCPtrRefCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefCBase2(b1)', '104', binding, 'InputCPtrRefCBase2(), Bottom1 as a parameter failed')
+
+# derived classes as parameters
+swig_assert_equal('Multiple_inheritance_abstract::InputValDerived1(d1)', '3+4', binding, 'InputValDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValDerived2(d2)', '6+5', binding, 'InputValDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValDerived3(d3)', '7+8+9', binding, 'InputValDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputRefDerived1(d1)', '3+4', binding, 'InputRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefDerived2(d2)', '6+5', binding, 'InputRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefDerived3(d3)', '7+8+9', binding, 'InputRefDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrDerived1(d1)', '3+4', binding, 'InputPtrDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrDerived2(d2)', '6+5', binding, 'InputPtrDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrDerived3(d3)', '7+8+9', binding, 'InputPtrDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefDerived1(d1)', '3+4', binding, 'InputCPtrRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefDerived2(d2)', '6+5', binding, 'InputCPtrRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefDerived3(d3)', '7+8+9', binding, 'InputCPtrRefDerived3() failed')
+
+# bottom classes as Derived parameters
+swig_assert_equal('Multiple_inheritance_abstract::InputValDerived1(b1)', '3+4', binding, 'InputValDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValDerived2(b2)', '6+5', binding, 'InputValDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValDerived3(b3)', '7+8+9', binding, 'InputValDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputRefDerived1(b1)', '103+104', binding, 'InputRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefDerived2(b2)', '206+205', binding, 'InputRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefDerived3(b3)', '307+308+309', binding, 'InputRefDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrDerived1(b1)', '103+104', binding, 'InputPtrDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrDerived2(b2)', '206+205', binding, 'InputPtrDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrDerived3(b3)', '307+308+309', binding, 'InputPtrDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefDerived1(b1)', '103+104', binding, 'InputCPtrRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefDerived2(b2)', '206+205', binding, 'InputCPtrRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefDerived3(b3)', '307+308+309', binding, 'InputCPtrRefDerived3() failed')
+
+# bottom classes as Bottom parameters
+swig_assert_equal('Multiple_inheritance_abstract::InputValBottom1(b1)', '103+104', binding, 'InputValBottom1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValBottom2(b2)', '206+205', binding, 'InputValBottom2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputValBottom3(b3)', '307+308+309', binding, 'InputValBottom3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputRefBottom1(b1)', '103+104', binding, 'InputRefBottom1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefBottom2(b2)', '206+205', binding, 'InputRefBottom2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputRefBottom3(b3)', '307+308+309', binding, 'InputRefBottom3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrBottom1(b1)', '103+104', binding, 'InputPtrBottom1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrBottom2(b2)', '206+205', binding, 'InputPtrBottom2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputPtrBottom3(b3)', '307+308+309', binding, 'InputPtrBottom3() failed')
+
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefBottom1(b1)', '103+104', binding, 'InputCPtrRefBottom1() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefBottom2(b2)', '206+205', binding, 'InputCPtrRefBottom2() failed')
+swig_assert_equal('Multiple_inheritance_abstract::InputCPtrRefBottom3(b3)', '307+308+309', binding, 'InputCPtrRefBottom3() failed')
+
+# return pointers
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived1_CBase1().cbase1y', '3', binding, 'MakePtrDerived1_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived1_CBase2().cbase2', '4', binding, 'MakePtrDerived1_CBase2 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived2_CBase1().cbase1y', '6', binding, 'MakePtrDerived2_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived2_ABase1().abase1', '5', binding, 'MakePtrDerived2_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived3_ABase1().abase1', '9', binding, 'MakePtrDerived3_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived3_CBase1().cbase1y', '7', binding, 'MakePtrDerived3_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakePtrDerived3_CBase2().cbase2', '8', binding, 'MakePtrDerived3_CBase2 failed')
+
+# return references
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived1_CBase1().cbase1y', '3', binding, 'MakeRefDerived1_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived1_CBase2().cbase2', '4', binding, 'MakeRefDerived1_CBase2 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived2_CBase1().cbase1y', '6', binding, 'MakeRefDerived2_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived2_ABase1().abase1', '5', binding, 'MakeRefDerived2_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived3_ABase1().abase1', '9', binding, 'MakeRefDerived3_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived3_CBase1().cbase1y', '7', binding, 'MakeRefDerived3_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeRefDerived3_CBase2().cbase2', '8', binding, 'MakeRefDerived3_CBase2 failed')
+
+# return by value (sliced objects)
+swig_assert_equal('Multiple_inheritance_abstract::MakeValDerived1_CBase1().cbase1y', '1', binding, 'MakeValDerived1_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeValDerived1_CBase2().cbase2', '2', binding, 'MakeValDerived1_CBase2 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeValDerived2_CBase1().cbase1y', '1', binding, 'MakeValDerived2_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeValDerived3_CBase1().cbase1y', '1', binding, 'MakeValDerived3_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_abstract::MakeValDerived3_CBase2().cbase2', '2', binding, 'MakeValDerived3_CBase2 failed')
+

--- a/Examples/test-suite/ruby/multiple_inheritance_nspace_runme.rb
+++ b/Examples/test-suite/ruby/multiple_inheritance_nspace_runme.rb
@@ -1,0 +1,243 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'multiple_inheritance_nspace'
+
+# Test base class as a parameter in Ruby
+
+def jcbase1b(cb1)
+  cb1.cbase1y
+end
+
+def jabase1(ab1)
+  ab1.abase1
+end
+
+def jcbase2(cb2)
+  cb2.cbase2
+end
+
+# test Derived1
+d1 = Multiple_inheritance_nspace::Derived1.new
+swig_assert_equal('d1.cbase1y', '3', binding, 'Derived1::cbase1y() failed')
+swig_assert_equal('d1.cbase2', '4', binding, 'Derived1::cbase2() failed')
+
+# test Derived2
+d2 = Multiple_inheritance_nspace::Derived2.new
+swig_assert_equal('d2.cbase1y', '6', binding, 'Derived2::cbase1y() failed')
+swig_assert_equal('d2.abase1', '5', binding, 'Derived2::cbase1y() failed')
+
+# test Derived3
+d3 = Multiple_inheritance_nspace::Derived3.new
+swig_assert_equal('d3.cbase1y', '7', binding, 'Derived3::cbase1y() failed')
+swig_assert_equal('d3.cbase2', '8', binding, 'Derived3::cbase2() failed')
+swig_assert_equal('d3.abase1', '9', binding, 'Derived3::abase1() failed')
+
+# test Bottom1
+b1 = Multiple_inheritance_nspace::Bottom1.new
+swig_assert_equal('b1.cbase1y', '103', binding, 'Bottom1::cbase1y() failed')
+swig_assert_equal('b1.cbase2', '104', binding, 'Bottom1::cbase2() failed')
+
+# test Bottom2
+b2 = Multiple_inheritance_nspace::Bottom2.new
+swig_assert_equal('b2.cbase1y', '206', binding, 'Bottom2::cbase1y() failed')
+swig_assert_equal('b2.abase1', '205', binding, 'Bottom2::abase1() failed')
+
+# test Bottom3
+b3 = Multiple_inheritance_nspace::Bottom3.new
+swig_assert_equal('b3.cbase1y', '307', binding, 'Bottom3::cbase1y() failed')
+swig_assert_equal('b3.cbase2', '308', binding, 'Bottom3::cbase2() failed')
+swig_assert_equal('b3.abase1', '309', binding, 'Bottom3::abase1() failed')
+
+# test interfaces from C++ classes
+cb1 = Multiple_inheritance_nspace::CBase1.new
+cb2 = Multiple_inheritance_nspace::CBase2.new
+swig_assert_equal('cb1.cbase1y', '1', binding, 'CBase1::cbase1y() failed')
+swig_assert_equal('cb2.cbase2', '2', binding, 'CBase2::cbase2() failed')
+
+# test nspace class as return value
+ab1 = d3.cloneit
+swig_assert_equal('ab1.abase1', '9', binding, 'Derived3::abase1() through ABase1 failed')
+
+# test concrete base class as return value
+cb6 = d2.cloneit
+cb7 = d1.cloneit
+swig_assert_equal('cb6.cbase1y', '6', binding, 'Derived2::cbase1y() through CBase1 failed')
+swig_assert_equal('cb7.cbase2', '4', binding, 'Derived1:cbase2() through ABase1 failed')
+
+# test multi inheritance
+cb3 = Multiple_inheritance_nspace::Derived1.new
+cb4 = Multiple_inheritance_nspace::Derived3.new
+cb5 = Multiple_inheritance_nspace::Derived3.new
+ab6 = Multiple_inheritance_nspace::Derived2.new
+swig_assert_equal('cb3.cbase1y', '3', binding, 'Derived1::cbase1y() through CBase1 failed')
+swig_assert_equal('cb4.cbase1y', '7', binding, 'Derived3::cbase1y() through CBase1 failed')
+swig_assert_equal('cb5.cbase2', '8', binding, 'Derived3::cbase2() through CBase2 failed')
+swig_assert_equal('ab6.abase1', '5', binding, 'Derived2::abase1() through ABase1 failed')
+
+# test base classes as parameter in Ruby
+swig_assert_equal('jcbase1b(d1)', '3', binding, 'jcbase1b() through Derived1 as parameter failed')
+swig_assert_equal('jcbase1b(d2)', '6', binding, 'jcbase1b() through Derived2 as parameter failed')
+swig_assert_equal('jcbase1b(d3)', '7', binding, 'jcbase1b() through Derived3 as parameter failed')
+swig_assert_equal('jcbase2(d1)', '4', binding, 'jcbase2() through Derived1 as parameter failed')
+swig_assert_equal('jcbase2(d3)', '8', binding, 'jcbase2() through Derived3 as parameter failed')
+swig_assert_equal('jabase1(d2)', '5', binding, 'jabase1() through Derived2 as parameter failed')
+swig_assert_equal('jabase1(d3)', '9', binding, 'jabase1() through Derived3 as parameter failed')
+
+# value parameters
+# test CBase1 CBase2 as parameters (note slicing for Derived and Bottom classes)
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(d1)', '1', binding, 'InputValCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(d2)', '1', binding, 'InputValCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(d3)', '1', binding, 'InputValCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase2(d3)', '2', binding, 'InputValCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase2(d1)', '2', binding, 'InputValCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(cb1)', '1', binding, 'InputValCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase2(cb2)', '2', binding, 'InputValCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(b1)', '1', binding, 'InputValCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(b2)', '1', binding, 'InputValCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase1(b3)', '1', binding, 'InputValCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase2(b3)', '2', binding, 'InputValCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValCBase2(b1)', '2', binding, 'InputValCBase2(), Bottom1 as a parameter failed')
+
+# pointer parameters
+# test ABase1 as a parameter
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrABase1(d2)', '5', binding, 'InputPtrABase1() through Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrABase1(d3)', '9', binding, 'InputPtrABase1() through Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrABase1(b2)', '205', binding, 'InputPtrABase1() through Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrABase1(b3)', '309', binding, 'InputPtrABase1() through Bottom3 as a parameter failed')
+
+# test CBase1 CBase2 as parameters
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(d1)', '3', binding, 'InputPtrCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(d2)', '6', binding, 'InputPtrCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(d3)', '7', binding, 'InputPtrCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase2(d3)', '8', binding, 'InputPtrCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase2(d1)', '4', binding, 'InputPtrCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(cb1)', '1', binding, 'InputPtrCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase2(cb2)', '2', binding, 'InputPtrCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(b1)', '103', binding, 'InputPtrCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(b2)', '206', binding, 'InputPtrCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase1(b3)', '307', binding, 'InputPtrCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase2(b3)', '308', binding, 'InputPtrCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrCBase2(b1)', '104', binding, 'InputPtrCBase2(), Bottom1 as a parameter failed')
+
+# reference parameters
+# test ABase1 as a parameter
+swig_assert_equal('Multiple_inheritance_nspace::InputRefABase1(d2)', '5', binding, 'InputRefABase1() through Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefABase1(d3)', '9', binding, 'InputRefABase1() through Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefABase1(b2)', '205', binding, 'InputRefABase1() through Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefABase1(b3)', '309', binding, 'InputRefABase1() through Bottom3 as a parameter failed')
+
+# test CBase1 CBase2 as parameters
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(d1)', '3', binding, 'InputRefCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(d2)', '6', binding, 'InputRefCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(d3)', '7', binding, 'InputRefCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase2(d3)', '8', binding, 'InputRefCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase2(d1)', '4', binding, 'InputRefCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(cb1)', '1', binding, 'InputRefCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase2(cb2)', '2', binding, 'InputRefCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(b1)', '103', binding, 'InputRefCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(b2)', '206', binding, 'InputRefCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase1(b3)', '307', binding, 'InputRefCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase2(b3)', '308', binding, 'InputRefCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefCBase2(b1)', '104', binding, 'InputRefCBase2(), Bottom1 as a parameter failed')
+
+# const reference pointer parameters
+# test ABase1 as a parameter
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefABase1(d2)', '5', binding, 'InputCPtrRefABase1() through Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefABase1(d3)', '9', binding, 'InputCPtrRefABase1() through Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefABase1(b2)', '205', binding, 'InputCPtrRefABase1() through Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefABase1(b3)', '309', binding, 'InputCPtrRefABase1() through Bottom3 as a parameter failed')
+
+# test CBase1 CBase2 as parameters
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(d1)', '3', binding, 'InputCPtrRefCBase1(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(d2)', '6', binding, 'InputCPtrRefCBase1(), Derived2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(d3)', '7', binding, 'InputCPtrRefCBase1(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase2(d3)', '8', binding, 'InputCPtrRefCBase2(), Derived3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase2(d1)', '4', binding, 'InputCPtrRefCBase2(), Derived1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(cb1)', '1', binding, 'InputCPtrRefCBase1(), CBase1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase2(cb2)', '2', binding, 'InputCPtrRefCBase2(), CBase2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(b1)', '103', binding, 'InputCPtrRefCBase1(), Bottom1 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(b2)', '206', binding, 'InputCPtrRefCBase1(), Bottom2 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase1(b3)', '307', binding, 'InputCPtrRefCBase1(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase2(b3)', '308', binding, 'InputCPtrRefCBase2(), Bottom3 as a parameter failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefCBase2(b1)', '104', binding, 'InputCPtrRefCBase2(), Bottom1 as a parameter failed')
+
+# derived classes as parameters
+swig_assert_equal('Multiple_inheritance_nspace::InputValDerived1(d1)', '3+4', binding, 'InputValDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValDerived2(d2)', '6+5', binding, 'InputValDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValDerived3(d3)', '7+8+9', binding, 'InputValDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputRefDerived1(d1)', '3+4', binding, 'InputRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefDerived2(d2)', '6+5', binding, 'InputRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefDerived3(d3)', '7+8+9', binding, 'InputRefDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrDerived1(d1)', '3+4', binding, 'InputPtrDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrDerived2(d2)', '6+5', binding, 'InputPtrDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrDerived3(d3)', '7+8+9', binding, 'InputPtrDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefDerived1(d1)', '3+4', binding, 'InputCPtrRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefDerived2(d2)', '6+5', binding, 'InputCPtrRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefDerived3(d3)', '7+8+9', binding, 'InputCPtrRefDerived3() failed')
+
+# bottom classes as Derived parameters
+swig_assert_equal('Multiple_inheritance_nspace::InputValDerived1(b1)', '3+4', binding, 'InputValDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValDerived2(b2)', '6+5', binding, 'InputValDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValDerived3(b3)', '7+8+9', binding, 'InputValDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputRefDerived1(b1)', '103+104', binding, 'InputRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefDerived2(b2)', '206+205', binding, 'InputRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefDerived3(b3)', '307+308+309', binding, 'InputRefDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrDerived1(b1)', '103+104', binding, 'InputPtrDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrDerived2(b2)', '206+205', binding, 'InputPtrDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrDerived3(b3)', '307+308+309', binding, 'InputPtrDerived3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefDerived1(b1)', '103+104', binding, 'InputCPtrRefDerived1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefDerived2(b2)', '206+205', binding, 'InputCPtrRefDerived2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefDerived3(b3)', '307+308+309', binding, 'InputCPtrRefDerived3() failed')
+
+# bottom classes as Bottom parameters
+swig_assert_equal('Multiple_inheritance_nspace::InputValBottom1(b1)', '103+104', binding, 'InputValBottom1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValBottom2(b2)', '206+205', binding, 'InputValBottom2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputValBottom3(b3)', '307+308+309', binding, 'InputValBottom3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputRefBottom1(b1)', '103+104', binding, 'InputRefBottom1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefBottom2(b2)', '206+205', binding, 'InputRefBottom2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputRefBottom3(b3)', '307+308+309', binding, 'InputRefBottom3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrBottom1(b1)', '103+104', binding, 'InputPtrBottom1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrBottom2(b2)', '206+205', binding, 'InputPtrBottom2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputPtrBottom3(b3)', '307+308+309', binding, 'InputPtrBottom3() failed')
+
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefBottom1(b1)', '103+104', binding, 'InputCPtrRefBottom1() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefBottom2(b2)', '206+205', binding, 'InputCPtrRefBottom2() failed')
+swig_assert_equal('Multiple_inheritance_nspace::InputCPtrRefBottom3(b3)', '307+308+309', binding, 'InputCPtrRefBottom3() failed')
+
+# return pointers
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived1_CBase1().cbase1y', '3', binding, 'MakePtrDerived1_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived1_CBase2().cbase2', '4', binding, 'MakePtrDerived1_CBase2 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived2_CBase1().cbase1y', '6', binding, 'MakePtrDerived2_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived2_ABase1().abase1', '5', binding, 'MakePtrDerived2_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived3_ABase1().abase1', '9', binding, 'MakePtrDerived3_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived3_CBase1().cbase1y', '7', binding, 'MakePtrDerived3_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakePtrDerived3_CBase2().cbase2', '8', binding, 'MakePtrDerived3_CBase2 failed')
+
+# return references
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived1_CBase1().cbase1y', '3', binding, 'MakeRefDerived1_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived1_CBase2().cbase2', '4', binding, 'MakeRefDerived1_CBase2 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived2_CBase1().cbase1y', '6', binding, 'MakeRefDerived2_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived2_ABase1().abase1', '5', binding, 'MakeRefDerived2_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived3_ABase1().abase1', '9', binding, 'MakeRefDerived3_ABase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived3_CBase1().cbase1y', '7', binding, 'MakeRefDerived3_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeRefDerived3_CBase2().cbase2', '8', binding, 'MakeRefDerived3_CBase2 failed')
+
+# return by value (sliced objects)
+swig_assert_equal('Multiple_inheritance_nspace::MakeValDerived1_CBase1().cbase1y', '1', binding, 'MakeValDerived1_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeValDerived1_CBase2().cbase2', '2', binding, 'MakeValDerived1_CBase2 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeValDerived2_CBase1().cbase1y', '1', binding, 'MakeValDerived2_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeValDerived3_CBase1().cbase1y', '1', binding, 'MakeValDerived3_CBase1 failed')
+swig_assert_equal('Multiple_inheritance_nspace::MakeValDerived3_CBase2().cbase2', '2', binding, 'MakeValDerived3_CBase2 failed')
+

--- a/Examples/test-suite/ruby/namespace_chase_runme.rb
+++ b/Examples/test-suite/ruby/namespace_chase_runme.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'namespace_chase'
+
+s1a = Namespace_chase::Struct1A.new
+s1b = Namespace_chase::Struct1B.new
+s1c = Namespace_chase::Struct1C.new
+
+Namespace_chase.sss3a(s1a, s1b, s1c)
+Namespace_chase.sss3b(s1a, s1b, s1c)

--- a/Examples/test-suite/ruby/namespace_class_runme.rb
+++ b/Examples/test-suite/ruby/namespace_class_runme.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'namespace_class'
+
+begin
+  p = Namespace_class::Private1.new
+  raise SwigRubyError.new("Private1 is private")
+rescue NameError => e
+  # OK
+end
+
+begin
+  p = Namespace_class::Private2.new
+  raise SwigRubyError.new("Private2 is private")
+rescue NameError => e
+  # OK
+end
+
+Namespace_class::EulerT3D.toFrame(1, 1, 1)
+
+b = Namespace_class::BooT_i.new
+b = Namespace_class::BooT_H.new
+
+
+f = Namespace_class::FooT_i.new
+f.quack(1)
+
+f = Namespace_class::FooT_d.new
+f.moo(1)
+
+f = Namespace_class::FooT_H.new
+f.foo(Namespace_class::Hi)
+
+f_type = f.class.to_s
+swig_assert_equal('f_type', '"Namespace_class::FooT_H"', binding)
+

--- a/Examples/test-suite/ruby/namespace_forward_declaration_runme.rb
+++ b/Examples/test-suite/ruby/namespace_forward_declaration_runme.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'namespace_forward_declaration'
+
+xxx = Namespace_forward_declaration::XXX.new
+Namespace_forward_declaration.testXXX1(xxx)
+Namespace_forward_declaration.testXXX2(xxx)
+Namespace_forward_declaration.testXXX3(xxx)
+yyy = Namespace_forward_declaration::YYY.new
+Namespace_forward_declaration.testYYY1(yyy)
+Namespace_forward_declaration.testYYY2(yyy)
+Namespace_forward_declaration.testYYY3(yyy)

--- a/Examples/test-suite/ruby/namespace_virtual_method_runme.rb
+++ b/Examples/test-suite/ruby/namespace_virtual_method_runme.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'namespace_virtual_method'
+
+x = Namespace_virtual_method::Spam.new

--- a/Examples/test-suite/ruby/nested_class_runme.rb
+++ b/Examples/test-suite/ruby/nested_class_runme.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'nested_class'
+
+outer = Nested_class::Outer.new
+is1 = outer.makeInnerStruct1
+ic1 = outer.makeInnerClass1
+iu1 = outer.makeInnerUnion1
+
+is2 = outer.makeInnerStruct2
+ic2 = outer.makeInnerClass2
+iu2 = outer.makeInnerUnion2
+
+ic4 = outer.makeInnerClass4Typedef
+is4 = outer.makeInnerStruct4Typedef
+iu4 = outer.makeInnerUnion4Typedef
+
+ic5 = outer.makeInnerClass5
+is5 = outer.makeInnerStruct5
+iu5 = outer.makeInnerUnion5
+
+ic5 = outer.makeInnerClass5Typedef
+is5 = outer.makeInnerStruct5Typedef
+iu5 = outer.makeInnerUnion5Typedef
+
+im1 = outer.MultipleInstance1
+im2 = outer.MultipleInstance2
+im3 = outer.MultipleInstance3
+im4 = outer.MultipleInstance4
+
+im1 = outer.MultipleDerivedInstance1
+im2 = outer.MultipleDerivedInstance2
+im3 = outer.MultipleDerivedInstance3
+im4 = outer.MultipleDerivedInstance4
+
+im1 = outer.MultipleDerivedInstance1
+im2 = outer.MultipleDerivedInstance2
+im3 = outer.MultipleDerivedInstance3
+im4 = outer.MultipleDerivedInstance4
+
+mat1 = outer.makeInnerMultipleAnonTypedef1
+mat2 = outer.makeInnerMultipleAnonTypedef2
+mat3 = outer.makeInnerMultipleAnonTypedef3
+
+mnt = outer.makeInnerMultipleNamedTypedef
+mnt1 = outer.makeInnerMultipleNamedTypedef1
+mnt2 = outer.makeInnerMultipleNamedTypedef2
+mnt3 = outer.makeInnerMultipleNamedTypedef3
+
+isn = outer.makeInnerSameName

--- a/Examples/test-suite/ruby/nested_directors_runme.rb
+++ b/Examples/test-suite/ruby/nested_directors_runme.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its C# counterpart.
+#
+
+require 'swig_assert'
+require 'nested_directors'
+
+# nested classes not yet supported
+#class CNested < Nested_directors::Base::Nest
+#  def GetValue
+#    true
+#  end
+#end
+
+class CSub < Nested_directors::Sub
+  def GetValue
+    super
+  end
+  def Test
+    GetValue()
+  end
+end
+
+#n = CNested.new
+#swig_assert('n.GetValue()', binding)
+
+s = CSub.new
+swig_assert('s.Test()', binding)

--- a/Examples/test-suite/ruby/nested_in_template_runme.rb
+++ b/Examples/test-suite/ruby/nested_in_template_runme.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'nested_in_template'
+
+
+cd = Nested_in_template::ConcreteDerived.new(88)
+swig_assert_equal('cd.m_value', '88', binding, 'ConcreteDerived not created correctly')

--- a/Examples/test-suite/ruby/nested_scope_flat_runme.rb
+++ b/Examples/test-suite/ruby/nested_scope_flat_runme.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+#
+# Check the availability of expected classes and their member variables.
+#
+
+require 'swig_assert'
+require 'nested_scope_flat'
+
+Nested_scope_flat::Global_.new
+Nested_scope_flat::Outer1.new
+nested2 = Nested_scope_flat::Nested2.new
+nested2.data = 42
+swig_assert_equal("nested2.data", "42", binding)
+Nested_scope_flat::Klass.new
+
+Nested_scope_flat::Abstract_int
+cannot_instantiate = false
+begin
+  Nested_scope_flat::Abstract_int.new
+rescue TypeError
+  cannot_instantiate = true
+end
+swig_assert_simple(cannot_instantiate)
+
+Nested_scope_flat::Real.new.Method()

--- a/Examples/test-suite/ruby/nested_template_base_runme.rb
+++ b/Examples/test-suite/ruby/nested_template_base_runme.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+require 'nested_template_base'
+
+ois = Nested_template_base::InnerS.new(123)
+oic = Nested_template_base::InnerC.new
+
+# Check base method is available
+swig_assert_equal('oic.outer(ois).val', '123', binding, 'Wrong value calling outer')
+
+# Check non-derived class using base class
+swig_assert_equal('oic.innerc().outer(ois).val', '123', binding, 'Wrong value calling innerc')

--- a/Examples/test-suite/ruby/nested_workaround_runme.rb
+++ b/Examples/test-suite/ruby/nested_workaround_runme.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'nested_workaround'
+
+begin
+  inner = Nested_workaround::Inner.new(5)
+  outer = Nested_workaround::Outer.new
+  newInner = outer.doubleInnerValue(inner)
+  swig_assert_equal("newInner.getValue", "10", binding)
+end
+
+begin
+  outer = Nested_workaround::Outer.new
+  inner = outer.createInner(3)
+  newInner = outer.doubleInnerValue(inner)
+  swig_assert_equal("outer.getInnerValue(newInner)", "6", binding)
+end

--- a/Examples/test-suite/ruby/preproc_runme.rb
+++ b/Examples/test-suite/ruby/preproc_runme.rb
@@ -5,23 +5,12 @@
 
 require 'swig_assert'
 
-# helper class for comparing version strings
-class Version
-  attr_reader :array
-  def initialize(s)
-    @array = s.split('.').map { |e| e.to_i }
-  end
-  def <(rhs)
-    a = @array.clone
-    b = rhs.array.clone
-    a << 0 while a.size < b.size
-    b << 0 while b.size < a.size
-    (a <=> b) < 0
-  end
-end
-
+# This extension to the Warning class is intended for suppressing expected
+# Ruby warning messages about invalid or redefined Ruby constants - basically
+# the equivalent of %warnfilter(SWIGWARN_RUBY_WRONG_NAME) but for the moment
+# the wrapper library is loaded by the Ruby interpreter.
+# Note: This only works for Ruby 2.4 and later
 if Object.const_defined?(:Warning) && Warning.respond_to?(:warn)
-  # suppressing warnings like this only works for Ruby 2.4 and later
   module CustomWarningFilter
     def warn(*args)
       msg = args[0]

--- a/Examples/test-suite/ruby/preproc_runme.rb
+++ b/Examples/test-suite/ruby/preproc_runme.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'swig_assert'
+
+# helper class for comparing version strings
+class Version
+  attr_reader :array
+  def initialize(s)
+    @array = s.split('.').map { |e| e.to_i }
+  end
+  def <(rhs)
+    a = @array.clone
+    b = rhs.array.clone
+    a << 0 while a.size < b.size
+    b << 0 while b.size < a.size
+    (a <=> b) < 0
+  end
+end
+
+if Object.const_defined?(:Warning) && Warning.respond_to?(:warn)
+  # suppressing warnings like this only works for Ruby 2.4 and later
+  module CustomWarningFilter
+    def warn(*args)
+      msg = args[0]
+      if msg =~ /[Aa]lready initialized constant Preproc::A[56]/ ||
+         msg =~ /invalid name .?__GMP_HAVE_/
+        # ignore
+      else
+        super
+      end
+    end
+  end
+  Warning.extend CustomWarningFilter
+end
+
+require 'preproc'
+
+swig_assert_equal('Preproc::endif', '1', binding)
+swig_assert_equal('Preproc::define', '1', binding)
+swig_assert_equal('Preproc::ddefined', '1', binding)
+
+swig_assert_equal('2 * Preproc::One', 'Preproc::Two', binding)
+
+swig_assert_equal('Preproc::methodX(99)', '199', binding)
+
+t1 = Preproc::TcxMessageTest
+t2 = Preproc::TcxMessageBug
+

--- a/Examples/test-suite/ruby/template_nested_flat_runme.rb
+++ b/Examples/test-suite/ruby/template_nested_flat_runme.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Java counterpart.
+#
+
+require 'swig_assert'
+require 'template_nested_flat'
+
+Template_nested_flat::T_NormalTemplateNormalClass.new.tmethod(Template_nested_flat::NormalClass.new)
+Template_nested_flat::OuterClass.new.T_OuterTMethodNormalClass(Template_nested_flat::NormalClass.new)
+
+tf = Template_nested_flat::TemplateFuncs.new
+swig_assert_equal("tf.T_TemplateFuncs1Int(-10)", "-10", binding)
+swig_assert_equal("tf.T_TemplateFuncs2Double(-12.3)", "-12.3", binding)
+
+tn = Template_nested_flat::T_NestedOuterTemplateDouble.new
+swig_assert_equal("tn.hohum(-12.3)", "-12.3", binding)
+
+inner1 = Template_nested_flat::OuterClass.new.useInner1(Template_nested_flat::T_OuterClassInner1Int.new)
+inner2 = Template_nested_flat::T_OuterClassInner2NormalClass.new
+inner2.embeddedVar = 2
+inner22 = Template_nested_flat::OuterClass.new.useInner2Again(inner2)
+inner3 = Template_nested_flat::T_OuterClassInner1Double.new

--- a/Examples/test-suite/ruby/template_static_runme.rb
+++ b/Examples/test-suite/ruby/template_static_runme.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+#
+# This test implementation is directly derived from its Python counterpart.
+#
+
+require 'template_static'
+
+Template_static::Foo_i.test
+Template_static::Foo_d.test
+Template_static::Foo::test
+Template_static::Foo::bar_double(1)
+

--- a/Examples/test-suite/template_nested.i
+++ b/Examples/test-suite/template_nested.i
@@ -1,10 +1,10 @@
 %module template_nested
 
-#if !defined(SWIGCSHARP) && !defined(SWIGJAVA)
-%feature ("flatnested");
-#endif
-
 // Test nested templates - that is template classes and template methods within a class.
+
+#if !defined(SWIGCSHARP) && !defined(SWIGJAVA)
+#pragma SWIG nowarn=SWIGWARN_PARSE_NAMED_NESTED_CLASS
+#endif
 
 namespace ns {
 template <class T> struct ForwardTemplate;

--- a/Examples/test-suite/template_nested_flat.i
+++ b/Examples/test-suite/template_nested_flat.i
@@ -1,0 +1,7 @@
+%module template_nested_flat
+
+// Test nested templates ("flatnested" version of template_nested.i)
+
+%feature ("flatnested");
+
+%include "template_nested.i"

--- a/Examples/test-suite/template_static.i
+++ b/Examples/test-suite/template_static.i
@@ -19,6 +19,7 @@ template<class T> int foo<T>::test = 0;
 namespace toto {
   class Foo {
   public:
+      static int test;
       template<class T>
       static double bar(int i) {
 	return 1.0;
@@ -28,6 +29,7 @@ namespace toto {
       int i;
   };
 } 
+int toto::Foo::test = 5;
 %}
 
 %template(bar_double) toto::Foo::bar<double>; 


### PR DESCRIPTION
This is done in preparation for adding namespace support to the Ruby part of SWIG.
Some existing test cases were reorganized or duplicated for flat/nonflat nesting (e.g. nested_scope). For some a Ruby test script was added.
Finally the ruby/Makefile.in was improved so that for test cases without an explicit test script, the generated wrapper library will just be loaded by the Ruby interpreter to ensure loading works fine.