### PR TITLE
Document lack of support for `auto` for C++ variables (#1125)

### DIFF
--- a/Doc/Manual/CPlusPlus11.html
+++ b/Doc/Manual/CPlusPlus11.html
@@ -336,6 +336,10 @@ int i; int j;
 decltype(i+j) k;  // syntax error
 </pre></div>
 
+<p>SWIG does not support <tt>auto</tt> as a type specifier for variables, only
+for specifying the return type of <a href="#CPlusPlus11_lambda_functions_and_expressions">lambdas</a>
+and <a href="#CPlusPlus11_alternate_function_syntax">functions</a>.</p>
+
 <H3><a name="CPlusPlus11_range_based_for_loop">7.2.7 Range-based for-loop</a></H3>
 
 


### PR DESCRIPTION
This PR adds a short remark to clarify that SWIG does not support `auto` as a type specifier for variables.

I did my best to capture the remark by @ojwb in #1125 about what _is_ supported, but this could maybe use more contextual information—like why this isn't possible, if it's strictly out of scope—from someone who understands SWIG's innards better than I do.