### PR TITLE
Lib/java/javahead.swg: clean up jlong handling.

### DIFF
--- a/Lib/java/arrays_java.i
+++ b/Lib/java/arrays_java.i
@@ -104,7 +104,7 @@ JAVA_ARRAYS_DECL(int, jint, Int, Int)                 /* int[] */
 JAVA_ARRAYS_DECL(unsigned int, jlong, Long, Uint)     /* unsigned int[] */
 JAVA_ARRAYS_DECL(long, jint, Int, Long)               /* long[] */
 JAVA_ARRAYS_DECL(unsigned long, jlong, Long, Ulong)   /* unsigned long[] */
-JAVA_ARRAYS_DECL(jlong, jlong, Long, Longlong)        /* long long[] */
+JAVA_ARRAYS_DECL(long long, jlong, Long, Longlong)    /* long long[] */
 JAVA_ARRAYS_DECL(float, jfloat, Float, Float)         /* float[] */
 JAVA_ARRAYS_DECL(double, jdouble, Double, Double)     /* double[] */
 
@@ -128,7 +128,7 @@ JAVA_ARRAYS_IMPL(int, jint, Int, Int)                 /* int[] */
 JAVA_ARRAYS_IMPL(unsigned int, jlong, Long, Uint)     /* unsigned int[] */
 JAVA_ARRAYS_IMPL(long, jint, Int, Long)               /* long[] */
 JAVA_ARRAYS_IMPL(unsigned long, jlong, Long, Ulong)   /* unsigned long[] */
-JAVA_ARRAYS_IMPL(jlong, jlong, Long, Longlong)        /* long long[] */
+JAVA_ARRAYS_IMPL(long long, jlong, Long, Longlong)    /* long long[] */
 JAVA_ARRAYS_IMPL(float, jfloat, Float, Float)         /* float[] */
 JAVA_ARRAYS_IMPL(double, jdouble, Double, Double)     /* double[] */
 

--- a/Lib/java/javahead.swg
+++ b/Lib/java/javahead.swg
@@ -30,18 +30,6 @@
 #endif
 
 %insert(runtime) %{
-/* Fix for jlong on some versions of gcc on Windows */
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-  typedef long long __int64;
-#endif
-
-/* Fix for jlong on 64-bit x86 Solaris */
-#if defined(__x86_64)
-# ifdef _LP64
-#   undef _LP64
-# endif
-#endif
-
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
+image:
+- Visual Studio 2019
 platform:
-- x86
 - x64
 
 environment:
@@ -7,31 +8,9 @@ environment:
     MAKEJOBS: 2
 
   matrix:
-  - SWIGLANG: csharp
-    VSVER: 12
-  - SWIGLANG: csharp
-    VSVER: 14
   - SWIGLANG: java
-    VSVER: 14
-  - SWIGLANG: python
-    VSVER: 14
-    VER: 27
-# - SWIGLANG: python
-#   VSVER: 14
-#   VER: 36
-#   PY3: 3
-  - SWIGLANG: python
-    OSVARIANT: cygwin
-#  - SWIGLANG: python
-#    OSVARIANT: mingw
-#    VER: 27
-#  - SWIGLANG: python
-#    OSVARIANT: mingw
-#    WITHLANG: python
-#    VER: 37
-#    PY3: 3
-  - BUILDSYSTEM: cmake
-    VSVER: 14
+    OSVARIANT: mingw
+    WITHLANG: java
 
 matrix:
   allow_failures:


### PR DESCRIPTION
As for __int64 definition. __int64 is a non-standard Visual-C-specific
type used in win32/jni_md.h. It is defined by other Win32 compilers in
one way or another, obviously for compatibility. It's more appropriate
to give the compiler a chance to make necessary arrangements instead
of reinventing the wheel. This, giving a chance, can be achieved by
including virtually any standard header. Since jni.h includes stdio.h,
defining __int64 in javahead.swg is redundant. Since doing so actually
triggers compilation errors on MinGW if a system header is included
in the %begin section, it's arguably appropriate to omit it.

As for `#undef _LP64` removal. Undefining a pre-defined macro, which
_LP64 is, is bad style, and if followed by inclusion of systems
headers, it's actually error-prone. Log suggests that it was added
to resolve a warning. I'm inclined to believe that it rather was a
misunderstanding of some kind. Or a bug in warning subsystem of
some particular compiler version, in which case it would have been
more appropriate to advise users to ignore the warning.