### PR TITLE
Fix C++ director wrapper return values not being initialized in C# module

### DIFF
--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -3884,7 +3884,9 @@ public:
 
 	vt = cplus_value_type(returntype);
 	if (!vt) {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
+	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+	  Delete(construct_result);
 	} else {
 	  Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
 	  Delete(vt);


### PR DESCRIPTION
Sometimes when returning by value, the C++ wrapper around C# directors didn't initialize return values, causing a compiler warning if they are enabled (and in our case, a compiler error). This change simply adds a SwigValueInit there.