### PR TITLE
Update CSharp.html

### DIFF
--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -1857,9 +1857,9 @@ and the following usage from C# after running the code through SWIG:
   Wheel wheel = new Bike(10).getWheel();
   Console.WriteLine("wheel size: " + wheel.size);
   // Simulate a garbage collection
-  global::System.GC.Collect();
-  global::System.GC.WaitForPendingFinalizers();
-  global::System.Console.WriteLine("wheel size: " + wheel.size);
+  GC.Collect();
+  GC.WaitForPendingFinalizers();
+  Console.WriteLine("wheel size: " + wheel.size);
 </pre>
 </div>
 
@@ -2006,9 +2006,9 @@ In order to understand why, consider a garbage collection occurring...
   container.setElement(element);
   Console.WriteLine("element.value: " + container.getElement().value);
   // Simulate a garbage collection
-  global::System.GC.Collect();
-  global::System.GC.WaitForPendingFinalizers();
-  global::System.Console.WriteLine("element.value: " + container.getElement().value);
+  GC.Collect();
+  GC.WaitForPendingFinalizers();
+  Console.WriteLine("element.value: " + container.getElement().value);
 </pre>
 </div>
 


### PR DESCRIPTION
global::System seems to be needed inside the typemap examples and also in the examples of generated code. But in these *example* C# programs, that would not be typical usage because the System namespace is almost always imported and then used implicitly. 

Also, it was already not used in the first of the Console... calls in the example. So this is more consistent.