### PR TITLE
Fix typos in attribute2ref() in Lib/typemaps/attribute.swg

### DIFF
--- a/Examples/test-suite/li_attribute.i
+++ b/Examples/test-suite/li_attribute.i
@@ -95,6 +95,7 @@ struct MyFoo; // %attribute2 does not work with templates
 
 // class/struct attribute with get/set methods using return/pass by reference
 %attribute2(MyClass, MyFoo, Foo, GetFoo, SetFoo);
+%attribute2ref(MyClass, MyFoo, Foo2);
 %inline %{
   struct MyFoo { 
     MyFoo() : x(-1) {}
@@ -102,9 +103,11 @@ struct MyFoo; // %attribute2 does not work with templates
   };
   class MyClass {
     MyFoo foo;
+    MyFoo foo2;
   public:
     MyFoo& GetFoo() { return foo; }
     void SetFoo(const MyFoo& other) { foo = other; }
+    MyFoo& Foo2() { return foo2; }
   };
 %} 
 

--- a/Examples/test-suite/python/li_attribute_runme.py
+++ b/Examples/test-suite/python/li_attribute_runme.py
@@ -45,6 +45,9 @@ myClass = li_attribute.MyClass()
 myClass.Foo = myFoo
 if myClass.Foo.x != 8:
     raise RuntimeError
+myClass.Foo2 = myFoo
+if myClass.Foo2.x != 8:
+    raise RuntimeError
 
 # class/struct attribute with get/set methods using return/pass by value
 myClassVal = li_attribute.MyClassVal()

--- a/Lib/typemaps/attribute.swg
+++ b/Lib/typemaps/attribute.swg
@@ -224,7 +224,7 @@
   #if #AccessorMethod != ""
     %attribute_custom(%arg(Class), %arg(AttributeType), AttributeName, AccessorMethod, AccessorMethod, &self_->AccessorMethod(), self_->AccessorMethod() = *val_)
   #else
-    %attribute_custom(%arg(Class), %arg(AttributeType), AccessorName, AccessorName, AccessorName, &self_->AccessorName(), self_->AccessorName() = *val_)
+    %attribute_custom(%arg(Class), %arg(AttributeType), AttributeName, AttributeName, AttributeName, &self_->AttributeName(), self_->AttributeName() = *val_)
   #endif
 %enddef
 


### PR DESCRIPTION
AccessorName was being used instead of AttributeName.

Closes #1872.