### PR TITLE
Don't use invalid iterators in Doxygen command parsing code

### DIFF
--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -1081,6 +1081,13 @@ bool DoxygenParser::addDoxyCommand(DoxygenParser::TokenList &tokList, const std:
     tokList.push_back(Token(COMMAND, cmd));
     return true;
   } else {
+    if (cmd.empty()) {
+      // This actually indicates a bug in the code in this file, as this
+      // function shouldn't be called at all in this case.
+      printListError(WARN_DOXYGEN_UNKNOWN_COMMAND, "Unexpected empty Doxygen command.");
+      return false;
+    }
+
     // This function is called for the special Doxygen commands, but also for
     // HTML commands (or anything that looks like them, actually) and entities.
     // We don't recognize all of those, so just ignore them and pass them
@@ -1181,6 +1188,11 @@ void DoxygenParser::processWordCommands(size_t &pos, const std::string &line) {
   size_t endOfWordPos = getEndOfWordCommand(line, pos);
 
   string cmd = line.substr(pos, endOfWordPos - pos);
+  if (cmd.empty()) {
+    // This was a bare backslash, just ignore it.
+    return;
+  }
+
   addDoxyCommand(m_tokenList, cmd);
 
   // A flag for whether we want to skip leading spaces after the command


### PR DESCRIPTION
Check that the string is non-empty before dereferencing its begin()
iterator and avoid calling addDoxyCommand() with an empty string in the
first place.

---

This is an alternative fix for #1949.