### PR TITLE
Lib/javascript/v8: use context-aware initialization.

### DIFF
--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -432,7 +432,7 @@ fail:
   $jsmangledname_class_0->SetHiddenPrototype(true);
   v8::Local<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction();
 #else
-  v8::Local<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked();
+  v8::Local<v8::Object> $jsmangledname_obj = $jsmangledname_class_0->GetFunction(context).ToLocalChecked();
 #endif
 %}
 
@@ -447,7 +447,7 @@ fail:
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   $jsparent_obj->Set(SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
 #else
-  SWIGV8_MAYBE_CHECK($jsparent_obj->Set(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj));
+  SWIGV8_MAYBE_CHECK($jsparent_obj->Set(context, SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj));
 #endif
 
 %}
@@ -472,7 +472,7 @@ fail:
 #if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   $jsparent_obj->Set(SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
 #else
-  SWIGV8_MAYBE_CHECK($jsparent_obj->Set(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj));
+  SWIGV8_MAYBE_CHECK($jsparent_obj->Set(context, SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj));
 #endif
 %}
 
@@ -509,7 +509,7 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_register_static_function", "templates")
 %{
-  SWIGV8_AddStaticFunction($jsparent_obj, "$jsname", $jswrapper);
+  SWIGV8_AddStaticFunction($jsparent_obj, "$jsname", $jswrapper, context);
 %}
 
 /* -----------------------------------------------------------------------------
@@ -523,5 +523,5 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_register_static_variable", "templates")
 %{
-  SWIGV8_AddStaticVariable($jsparent_obj, "$jsname", $jsgetter, $jssetter);
+  SWIGV8_AddStaticVariable($jsparent_obj, "$jsname", $jsgetter, $jssetter, context);
 %}

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -61,11 +61,11 @@ SWIGRUNTIME void SWIGV8_AddMemberVariable(SWIGV8_FUNCTION_TEMPLATE class_templ, 
  * Registers a class method with given name for a given object.
  */
 SWIGRUNTIME void SWIGV8_AddStaticFunction(SWIGV8_OBJECT obj, const char* symbol,
-  const SwigV8FunctionCallback& _func) {
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0704)
+  const SwigV8FunctionCallback& _func, v8::Local<v8::Context> context) {
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   obj->Set(SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction());
 #else
-  SWIGV8_MAYBE_CHECK(obj->Set(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()));
+  SWIGV8_MAYBE_CHECK(obj->Set(context, SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction(context).ToLocalChecked()));
 #endif
 }
 
@@ -73,11 +73,12 @@ SWIGRUNTIME void SWIGV8_AddStaticFunction(SWIGV8_OBJECT obj, const char* symbol,
  * Registers a class method with given name for a given object.
  */
 SWIGRUNTIME void SWIGV8_AddStaticVariable(SWIGV8_OBJECT obj, const char* symbol,
-  SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter) {
+  SwigV8AccessorGetterCallback getter, SwigV8AccessorSetterCallback setter,
+  v8::Local<v8::Context> context) {
 #if (V8_MAJOR_VERSION-0) < 5
   obj->SetAccessor(SWIGV8_SYMBOL_NEW(symbol), getter, setter);
 #else
-  SWIGV8_MAYBE_CHECK(obj->SetAccessor(SWIGV8_CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW(symbol), getter, setter));
+  SWIGV8_MAYBE_CHECK(obj->SetAccessor(context, SWIGV8_SYMBOL_NEW(symbol), getter, setter));
 #endif
 }
 

--- a/Lib/javascript/v8/javascriptinit.swg
+++ b/Lib/javascript/v8/javascriptinit.swg
@@ -5,27 +5,27 @@
 %insert(init) %{
 
 SWIGRUNTIME void
-SWIG_V8_SetModule(void *, swig_module_info *swig_module) {
-  v8::Local<v8::Object> global_obj = SWIGV8_CURRENT_CONTEXT()->Global();
+SWIG_V8_SetModule(v8::Local<v8::Context> context, swig_module_info *swig_module) {
+  v8::Local<v8::Object> global_obj = context->Global();
   v8::Local<v8::External> mod = SWIGV8_EXTERNAL_NEW(swig_module);
   assert(!mod.IsEmpty());
 #if (V8_MAJOR_VERSION-0) < 5
   global_obj->SetHiddenValue(SWIGV8_STRING_NEW("swig_module_info_data"), mod);
 #else
   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("swig_module_info_data"));
-  global_obj->SetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey, mod);
+  global_obj->SetPrivate(context, privateKey, mod);
 #endif
 }
 
 SWIGRUNTIME swig_module_info *
-SWIG_V8_GetModule(void *) {
-  v8::Local<v8::Object> global_obj = SWIGV8_CURRENT_CONTEXT()->Global();
+SWIG_V8_GetModule(v8::Local<v8::Context> context) {
+  v8::Local<v8::Object> global_obj = context->Global();
 #if (V8_MAJOR_VERSION-0) < 5
   v8::Local<v8::Value> moduleinfo = global_obj->GetHiddenValue(SWIGV8_STRING_NEW("swig_module_info_data"));
 #else
   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("swig_module_info_data"));
   v8::Local<v8::Value> moduleinfo;
-  if (!global_obj->GetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey).ToLocal(&moduleinfo))
+  if (!global_obj->GetPrivate(context, privateKey).ToLocal(&moduleinfo))
     return 0;
 #endif
 
@@ -52,6 +52,7 @@ SWIG_V8_GetModule(void *) {
 
 #define SWIG_GetModule(clientdata)                SWIG_V8_GetModule(clientdata)
 #define SWIG_SetModule(clientdata, pointer)       SWIG_V8_SetModule(clientdata, pointer)
+#define SWIG_INIT_CLIENT_DATA_TYPE                v8::Local<v8::Context>
 
 %}
 
@@ -64,20 +65,20 @@ SWIG_V8_GetModule(void *) {
 %}
 
 %insert(init) %{
+#if !defined(NODE_MODULE_VERSION) || (NODE_MODULE_VERSION < 12)
 // Note: 'extern "C"'' disables name mangling which makes it easier to load the symbol manually
-// TODO: is it ok to do that?
-extern "C"
-#if (NODE_MODULE_VERSION < 0x000C)
-void SWIGV8_INIT (SWIGV8_OBJECT exports)
+extern "C" void SWIGV8_INIT (SWIGV8_OBJECT exports_obj)
+#elif (NODE_MODULE_VERSION < 64)
+void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, void*)
 #else
-void SWIGV8_INIT (SWIGV8_OBJECT exports, SWIGV8_OBJECT /*module*/)
+void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, v8::Local<v8::Context> context, void*)
 #endif
 {
-  SWIG_InitializeModule(static_cast<void *>(&exports));
+#if !defined(NODE_MODULE_VERSION) || NODE_MODULE_VERSION < 64
+  v8::Local<v8::Context> context = SWIGV8_CURRENT_CONTEXT();
+#endif
 
-  SWIGV8_HANDLESCOPE();
-  
-  SWIGV8_OBJECT exports_obj = exports;
+  SWIG_InitializeModule(context);
 %}
 
 
@@ -124,6 +125,10 @@ void SWIGV8_INIT (SWIGV8_OBJECT exports, SWIGV8_OBJECT /*module*/)
 }
 
 #if defined(BUILDING_NODE_EXTENSION)
+#if (NODE_MODULE_VERSION < 64)
 NODE_MODULE($jsname, $jsname_initialize)
+#else
+NODE_MODULE_CONTEXT_AWARE($jsname, $jsname_initialize)
+#endif
 #endif
 %}

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -450,7 +450,7 @@ SWIGRUNTIME SWIGV8_VALUE SWIG_V8_NewPointerObj(void *ptr, swig_type_info *info, 
   }
 #endif
 
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903) || (SWIG_V8_VERSION < 0x0704)
+#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
   v8::Local<v8::Object> result = class_templ->InstanceTemplate()->NewInstance();
 #else
   v8::Local<v8::Object> result = class_templ->InstanceTemplate()->NewInstance(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked();

--- a/Lib/swiginit.swg
+++ b/Lib/swiginit.swg
@@ -50,9 +50,12 @@ extern "C" {
 #define SWIGRUNTIME_DEBUG
 #endif
 
+#ifndef SWIG_INIT_CLIENT_DATA_TYPE
+#define SWIG_INIT_CLIENT_DATA_TYPE void *
+#endif
 
 SWIGRUNTIME void
-SWIG_InitializeModule(void *clientdata) {
+SWIG_InitializeModule(SWIG_INIT_CLIENT_DATA_TYPE clientdata) {
   size_t i;
   swig_module_info *module_head, *iter;
   int init;

--- a/configure.ac
+++ b/configure.ac
@@ -1546,7 +1546,7 @@ else
   # Look for Node.js which is the default Javascript engine
   #----------------------------------------------------------------
 
-  AC_CHECK_PROGS(NODEJS, [nodejs node])
+  AC_CHECK_PROGS(NODEJS, [node nodejs])
 
   if test -n "$NODEJS"; then
     # node-gyp is needed to run the test-suite/examples


### PR DESCRIPTION
Context-aware initialization allows to instantiate add-ons multiple times, most importantly in multiple workers' contexts. Workers made first appearance in v10.5. Condition for performing context-aware initialization, NODE_MODULE_VERSION >= 0x0040, a.k.a. v10+, is just a conservative choice. It was an option for longer than that and formally one can go all the way to supported minimum, v6.x, which is denoted by NODE_MODULE_VERSION 0x0030...

2nd and 3rd commits are not directly related, just minor cleanups.