### PR TITLE
configure.ac: pick up javascriptcoregtk-4.0,3.0 if available.

### DIFF
--- a/Tools/javascript/jsc_shell.cxx
+++ b/Tools/javascript/jsc_shell.cxx
@@ -18,7 +18,7 @@ typedef int (*JSCIntializer)(JSGlobalContextRef context, JSObjectRef *module);
 
 public:
 
-  JSCShell() {};
+  JSCShell() { context = 0; };
 
   virtual ~JSCShell();
 

--- a/configure.ac
+++ b/configure.ac
@@ -1600,7 +1600,15 @@ else
 
   if test -z "$JSCORELIB" -a -n "$PKG_CONFIG "; then
     AC_MSG_CHECKING(for JavaScriptCore/Webkit library)
-    if $PKG_CONFIG  javascriptcoregtk-1.0; then
+    if $PKG_CONFIG  javascriptcoregtk-4.0; then
+      JSCORELIB=`$PKG_CONFIG  --libs javascriptcoregtk-4.0`
+      JSCOREINC=`$PKG_CONFIG  --cflags-only-I javascriptcoregtk-4.0`
+      JSCOREVERSION=`$PKG_CONFIG  --modversion javascriptcoregtk-4.0`
+    elif $PKG_CONFIG  javascriptcoregtk-3.0; then
+      JSCORELIB=`$PKG_CONFIG  --libs javascriptcoregtk-3.0`
+      JSCOREINC=`$PKG_CONFIG  --cflags-only-I javascriptcoregtk-3.0`
+      JSCOREVERSION=`$PKG_CONFIG  --modversion javascriptcoregtk-3.0`
+    elif $PKG_CONFIG  javascriptcoregtk-1.0; then
       JSCORELIB=`$PKG_CONFIG  --libs javascriptcoregtk-1.0`
       JSCOREVERSION=`$PKG_CONFIG  --modversion javascriptcoregtk-1.0`
     fi


### PR DESCRIPTION
Ubuntu 20 doesn't have libwebkitgtk-dev/libjavascriptcoregtk-1.0-dev,
but it has 4.0. Ubuntu 18 provides 3.0 as option.