### PR TITLE
Lib/javascript/v8: resolve race conditions in context-aware init.

### DIFF
--- a/Doc/Manual/Javascript.html
+++ b/Doc/Manual/Javascript.html
@@ -89,19 +89,24 @@ $ swig -javascript -jsc example.i</pre>
 <pre>
 $ swig -c++ -javascript -jsc example.i</pre>
 </div>
-<p>The V8 code that SWIG generates should work with most versions from 3.11.10 up to 3.29.14 and later.</p>
-<p>The API headers for V8 &gt;= 4.3.0 define constants which SWIG can use to
-determine the V8 version it is compiling for.  For versions &lt; 4.3.0, you
+<p>The V8 code that SWIG generates should work with most versions from 3.11.10.
+However, the only early version that receives some testing is 3.14.5, which is
+still shipped with Ubuntu for some reason. Other than that it's probably safer
+to assume that versions earlier than 5.0 are no longer supported. Keep in mind
+that these are V8 versions, not Node.js. To give some perspective, Node.js v6.0
+uses V8 5.0, v12.0 - 7.4, v14.0 - 8.1...</p>
+<p>The API headers for V8 &gt;= 4.3.10 define constants which SWIG can use to
+determine the V8 version it is compiling for.  For versions &lt; 4.3.10, you
 need to specify the V8 version when running SWIG.  This is specified as a hex
 constant, but the constant is read as pairs of decimal digits, so for V8
 3.25.30 use constant 0x032530.  This scheme can't represent components &gt; 99,
-but this constant is only useful for V8 &lt; 4.3.0, and no V8 versions from
+but this constant is only useful for V8 &lt; 4.3.10, and no V8 versions from
 that era had a component &gt; 99.  For example:</p>
 <div class="shell">
 <pre>
 $ swig -c++ -javascript -v8 -DV8_VERSION=0x032530 example.i</pre>
 </div>
-<p>If you're targeting V8 &gt;= 4.3.0, you would just run swig like so:</p>
+<p>If you're targeting V8 &gt;= 4.3.10, you would just run swig like so:</p>
 <div class="shell">
 <pre>
 $ swig -c++ -javascript -v8 example.i</pre>

--- a/Examples/test-suite/grouping.i
+++ b/Examples/test-suite/grouping.i
@@ -14,7 +14,7 @@ int *(test2)(int x) {
     return &y;
 }
 
-int (test3) = 37;
+int test3 = 37;
 
 typedef Integer (UnaryOp)(Integer);
 

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -85,6 +85,8 @@ ifeq (node,$(JSENGINE))
 	run_testcase = \
 		if [ -f $(srcdir)/$*$(SCRIPTSUFFIX) ]; then \
 			env NODE_PATH=$$PWD:$(srcdir) $(RUNTOOL) $(NODEJS) $(srcdir)/$*$(SCRIPTSUFFIX); \
+			[ "$*" != "using2" ] || \
+			env NODE_PATH=$$PWD:$(srcdir) $(RUNTOOL) $(NODEJS) $(srcdir)/node_workers.js $(srcdir)/$*$(SCRIPTSUFFIX); \
 		fi
 
 

--- a/Examples/test-suite/javascript/node_workers.js
+++ b/Examples/test-suite/javascript/node_workers.js
@@ -1,0 +1,22 @@
+//
+// Ascetic wrapper that spawns pair of instances of the same script
+// as Node.js Workers.
+//
+if (process.argv.length < 3) {
+    console.error("usage: node " + process.argv[1] +
+                  " <absolute-or-relative-path-to-a-script>");
+    process.exit(1);
+}
+
+// Even though 'worker_threads' appeared in Node.js v10.5, they weren't
+// available out-of-the-box till v12. For smoother use with 'make test'
+// silently ignore prior versions.
+if (parseInt(process.versions['node']) < 12) process.exit(0);
+
+const { Worker } = require("worker_threads");
+var workers = [];
+
+for (let i = 0; i < 2; i++) {
+    workers[i] = new Worker(process.argv[2]);
+    workers[i].on('exit', (code) => {});
+}

--- a/Lib/javascript/jsc/javascriptinit.swg
+++ b/Lib/javascript/jsc/javascriptinit.swg
@@ -1,18 +1,15 @@
 %insert(init) %{
 SWIGRUNTIME void
-SWIG_JSC_SetModule(void *clientdata, swig_module_info *swig_module) {
-    JSGlobalContextRef context;
+SWIG_JSC_SetModule(JSGlobalContextRef context, swig_module_info *swig_module) {
     JSObjectRef globalObject;
     JSStringRef moduleName;
     JSClassDefinition classDef;
     JSClassRef classRef;
     JSObjectRef object;
 
-    if(clientdata == 0){
+    if(context == 0){
         return;
     }
-
-    context = (JSGlobalContextRef)clientdata;
 
     globalObject = JSContextGetGlobalObject(context);
     moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
@@ -29,18 +26,15 @@ SWIG_JSC_SetModule(void *clientdata, swig_module_info *swig_module) {
     JSStringRelease(moduleName);
 }
 SWIGRUNTIME swig_module_info *
-SWIG_JSC_GetModule(void *clientdata) {
-    JSGlobalContextRef context;
+SWIG_JSC_GetModule(JSGlobalContextRef context) {
     JSObjectRef globalObject;
     JSStringRef moduleName;
     JSValueRef value;
     JSObjectRef object;
 
-    if(clientdata == 0){
+    if(context == 0){
         return 0;
     }
-
-    context = (JSGlobalContextRef)clientdata;
 
     globalObject = JSContextGetGlobalObject(context);
     moduleName = JSStringCreateWithUTF8CString("swig_module_info_data");
@@ -59,6 +53,7 @@ SWIG_JSC_GetModule(void *clientdata) {
 
 #define SWIG_GetModule(clientdata)                SWIG_JSC_GetModule(clientdata)
 #define SWIG_SetModule(clientdata, pointer)       SWIG_JSC_SetModule(clientdata, pointer)
+#define SWIG_INIT_CLIENT_DATA_TYPE                JSGlobalContextRef
 %}
 
 %insert(init) "swiginit.swg"
@@ -76,7 +71,7 @@ extern "C" {
 #endif
 
 bool SWIGJSC_INIT (JSGlobalContextRef context, JSObjectRef *exports) {
-    SWIG_InitializeModule((void*)context);
+    SWIG_InitializeModule(context);
 %}
 
 /* -----------------------------------------------------------------------------

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -444,7 +444,7 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_register_class", "templates")
 %{
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
+#if (V8_MAJOR_VERSION-0) < 5
   $jsparent_obj->Set(SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
 #else
   SWIGV8_MAYBE_CHECK($jsparent_obj->Set(context, SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj));
@@ -469,7 +469,7 @@ fail:
  * ----------------------------------------------------------------------------- */
 %fragment("jsv8_register_namespace", "templates")
 %{
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
+#if (V8_MAJOR_VERSION-0) < 5
   $jsparent_obj->Set(SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj);
 #else
   SWIGV8_MAYBE_CHECK($jsparent_obj->Set(context, SWIGV8_SYMBOL_NEW("$jsname"), $jsmangledname_obj));

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -377,8 +377,10 @@ fail:
 %{
   /* Name: $jsmangledname, Type: $jsmangledtype, Dtor: $jsdtor */
   SWIGV8_FUNCTION_TEMPLATE $jsmangledname_class = SWIGV8_CreateClassTemplate("$jsmangledname");
-  SWIGV8_SET_CLASS_TEMPL($jsmangledname_clientData.class_templ, $jsmangledname_class);
-  $jsmangledname_clientData.dtor = $jsdtor;
+  if ($jsmangledname_clientData.class_templ.IsEmpty()) {
+    SWIGV8_SET_CLASS_TEMPL($jsmangledname_clientData.class_templ, $jsmangledname_class);
+    $jsmangledname_clientData.dtor = $jsdtor;
+  }
   if (SWIGTYPE_$jsmangledtype->clientdata == 0) {
     SWIGTYPE_$jsmangledtype->clientdata = &$jsmangledname_clientData;
   }

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -62,7 +62,7 @@ SWIGRUNTIME void SWIGV8_AddMemberVariable(SWIGV8_FUNCTION_TEMPLATE class_templ, 
  */
 SWIGRUNTIME void SWIGV8_AddStaticFunction(SWIGV8_OBJECT obj, const char* symbol,
   const SwigV8FunctionCallback& _func, v8::Local<v8::Context> context) {
-#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
+#if (V8_MAJOR_VERSION-0) < 5
   obj->Set(SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction());
 #else
   SWIGV8_MAYBE_CHECK(obj->Set(context, SWIGV8_SYMBOL_NEW(symbol), SWIGV8_FUNCTEMPLATE_NEW(_func)->GetFunction(context).ToLocalChecked()));

--- a/Lib/javascript/v8/javascriptinit.swg
+++ b/Lib/javascript/v8/javascriptinit.swg
@@ -65,17 +65,25 @@ SWIG_V8_GetModule(v8::Local<v8::Context> context) {
 %}
 
 %insert(init) %{
+// This is when we opt for context-aware initialization, in node v10 and
+// later. It's possible to lower it, 64 is just a conservative value...
+#define SWIG_NODE_CONTEXT_AWARE 64
+
 #if !defined(NODE_MODULE_VERSION) || (NODE_MODULE_VERSION < 12)
 // Note: 'extern "C"'' disables name mangling which makes it easier to load the symbol manually
 extern "C" void SWIGV8_INIT (SWIGV8_OBJECT exports_obj)
-#elif (NODE_MODULE_VERSION < 64)
+#elif (NODE_MODULE_VERSION < SWIG_NODE_CONTEXT_AWARE)
 void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, void*)
 #else
 void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, v8::Local<v8::Context> context, void*)
 #endif
 {
-#if !defined(NODE_MODULE_VERSION) || NODE_MODULE_VERSION < 64
+#if !defined(NODE_MODULE_VERSION) || NODE_MODULE_VERSION<SWIG_NODE_CONTEXT_AWARE
   v8::Local<v8::Context> context = SWIGV8_CURRENT_CONTEXT();
+#else
+  v8::Isolate *isolate = context->GetIsolate();
+  v8::Locker locker(isolate);
+  isolate->Enter();
 #endif
 
   SWIG_InitializeModule(context);
@@ -97,7 +105,9 @@ void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, v8::Local<
 %fragment("js_initializer", "templates")
 %{
   // a class template for creating proxies of undefined types
-  SWIGV8_SET_CLASS_TEMPL(SWIGV8_SWIGTYPE_Proxy_class_templ, SWIGV8_CreateClassTemplate("SwigProxy"));
+  if (SWIGV8_SWIGTYPE_Proxy_class_templ.IsEmpty()) {
+    SWIGV8_SET_CLASS_TEMPL(SWIGV8_SWIGTYPE_Proxy_class_templ, SWIGV8_CreateClassTemplate("SwigProxy"));
+  }
 
   /* create objects for namespaces */
   $jsv8nspaces
@@ -122,10 +132,14 @@ void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, v8::Local<
 
   /* create and register namespace objects */
   $jsv8registernspaces
+
+#if defined(NODE_MODULE_VERSION) && NODE_MODULE_VERSION>=SWIG_NODE_CONTEXT_AWARE
+  isolate->Exit();
+#endif
 }
 
 #if defined(BUILDING_NODE_EXTENSION)
-#if (NODE_MODULE_VERSION < 64)
+#if (NODE_MODULE_VERSION < SWIG_NODE_CONTEXT_AWARE)
 NODE_MODULE($jsname, $jsname_initialize)
 #else
 NODE_MODULE_CONTEXT_AWARE($jsname, $jsname_initialize)

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -310,7 +310,7 @@ SWIGRUNTIME int SWIG_V8_GetInstancePtr(SWIGV8_VALUE valRef, void **ptr) {
   if(!valRef->IsObject()) {
     return SWIG_TypeError;
   }
-  SWIGV8_OBJECT objRef = SWIGV8_TO_OBJECT(valRef);
+  SWIGV8_OBJECT objRef = SWIGV8_OBJECT::Cast(valRef);
 
   if(objRef->InternalFieldCount() < 1) return SWIG_ERROR;
 
@@ -405,7 +405,7 @@ SWIGRUNTIME int SWIG_V8_ConvertPtr(SWIGV8_VALUE valRef, void **ptr, swig_type_in
   if(!valRef->IsObject()) {
     return SWIG_TypeError;
   }
-  SWIGV8_OBJECT objRef = SWIGV8_TO_OBJECT(valRef);
+  SWIGV8_OBJECT objRef = SWIGV8_OBJECT::Cast(valRef);
   return SWIG_V8_ConvertInstancePtr(objRef, ptr, info, flags);
 }
 

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -50,21 +50,22 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_THROW_EXCEPTION(err) v8::ThrowException(err)
 #define SWIGV8_STRING_NEW(str) v8::String::New(str)
 #define SWIGV8_SYMBOL_NEW(sym) v8::String::NewSymbol(sym)
-#elif (SWIG_V8_VERSION < 0x0704)
-#define SWIGV8_ADJUST_MEMORY(size) v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(size)
-#define SWIGV8_CURRENT_CONTEXT() v8::Isolate::GetCurrent()->GetCurrentContext()
-#define SWIGV8_THROW_EXCEPTION(err) v8::Isolate::GetCurrent()->ThrowException(err)
-#define SWIGV8_STRING_NEW(str) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str, v8::String::kNormalString)
-#define SWIGV8_SYMBOL_NEW(sym) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), sym, v8::String::kNormalString)
 #else
 #define SWIGV8_ADJUST_MEMORY(size) v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(size)
 #define SWIGV8_CURRENT_CONTEXT() v8::Isolate::GetCurrent()->GetCurrentContext()
 #define SWIGV8_THROW_EXCEPTION(err) v8::Isolate::GetCurrent()->ThrowException(err)
+#if (SWIG_V8_VERSION < 0x0704)
+#define SWIGV8_STRING_NEW(str) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str, v8::String::kNormalString)
+#define SWIGV8_SYMBOL_NEW(sym) v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), sym, v8::String::kNormalString)
+#else
 #define SWIGV8_STRING_NEW(str) (v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str, v8::NewStringType::kNormal)).ToLocalChecked()
 #define SWIGV8_SYMBOL_NEW(sym) (v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), sym, v8::NewStringType::kNormal)).ToLocalChecked()
 #endif
+#endif
 
-#if (SWIG_V8_VERSION < 0x0704)
+#if (V8_MAJOR_VERSION-0) < 5
+#define SWIGV8_MAYBE_CHECK(maybe) maybe
+#elif (SWIG_V8_VERSION < 0x0704)
 #define SWIGV8_MAYBE_CHECK(maybe) maybe.FromJust()
 #else
 #define SWIGV8_MAYBE_CHECK(maybe) maybe.Check()
@@ -120,15 +121,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_SET_CLASS_TEMPL(class_templ, class) class_templ.Reset(v8::Isolate::GetCurrent(), class);
 #endif
 
-#ifdef NODE_VERSION
-#if NODE_VERSION_AT_LEAST(10, 12, 0)
-#define SWIG_NODE_AT_LEAST_1012
-#endif
-#endif
-
-//Necessary to check Node.js version because V8 API changes are backported in Node.js
-#if (defined(NODE_VERSION) && !defined(SWIG_NODE_AT_LEAST_1012)) || \
-    (!defined(NODE_VERSION) && (V8_MAJOR_VERSION-0) < 7)
+#if (V8_MAJOR_VERSION-0) < 6 || (SWIG_V8_VERSION < 0x0608)
 #define SWIGV8_TO_OBJECT(handle) (handle)->ToObject()
 #define SWIGV8_TO_STRING(handle) (handle)->ToString()
 #define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue()
@@ -136,22 +129,18 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue()
 #define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(buffer, len)
 #define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length()
-#elif (SWIG_V8_VERSION < 0x0704)
-#define SWIGV8_TO_OBJECT(handle) (handle)->ToObject(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
-#define SWIGV8_TO_STRING(handle) (handle)->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
-#define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
-#define SWIGV8_INTEGER_VALUE(handle) (handle)->IntegerValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
-#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
-#define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(v8::Isolate::GetCurrent(), buffer, len)
-#define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length(v8::Isolate::GetCurrent())
 #else
 #define SWIGV8_TO_OBJECT(handle) (handle)->ToObject(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
 #define SWIGV8_TO_STRING(handle) (handle)->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
 #define SWIGV8_NUMBER_VALUE(handle) (handle)->NumberValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
 #define SWIGV8_INTEGER_VALUE(handle) (handle)->IntegerValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
-#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(v8::Isolate::GetCurrent())
 #define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(v8::Isolate::GetCurrent(), buffer, len)
 #define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length(v8::Isolate::GetCurrent())
+#if (SWIG_V8_VERSION < 0x0704)
+#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
+#else
+#define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(v8::Isolate::GetCurrent())
+#endif
 #endif
 
 /* ---------------------------------------------------------------------------

--- a/Lib/javascript/v8/javascriptstrings.swg
+++ b/Lib/javascript/v8/javascriptstrings.swg
@@ -8,9 +8,9 @@ SWIG_AsCharPtrAndSize(SWIGV8_VALUE valRef, char** cptr, size_t* psize, int *allo
 {
   if(valRef->IsString()) {
 %#if (V8_MAJOR_VERSION-0) < 4 && (SWIG_V8_VERSION < 0x031903)
-    v8::Handle<v8::String> js_str = SWIGV8_TO_STRING(valRef);
+    v8::Handle<v8::String> js_str = v8::Handle<v8::String>::Cast(valRef);
 %#else
-    v8::Local<v8::String> js_str = SWIGV8_TO_STRING(valRef);
+    v8::Local<v8::String> js_str = v8::Local<v8::String>::Cast(valRef);
 %#endif
 
     size_t len = SWIGV8_UTF8_LENGTH(js_str) + 1;
@@ -24,7 +24,7 @@ SWIG_AsCharPtrAndSize(SWIGV8_VALUE valRef, char** cptr, size_t* psize, int *allo
     return SWIG_OK;
   } else {
     if(valRef->IsObject()) {
-      SWIGV8_OBJECT obj = SWIGV8_TO_OBJECT(valRef);
+      SWIGV8_OBJECT obj = SWIGV8_OBJECT::Cast(valRef);
       // try if the object is a wrapped char[]
       swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
       if (pchar_descriptor) {


### PR DESCRIPTION
Rare crashes in initialization procedure were observed with worker_threads. Solution is to serialize it. This is [the] one prior to the last commit.

Then there is a trivial test for worker_threads in the last commit. I'm not sure if ~with~this would be an acceptable way to solve it. If not, elaborate on expectations.

Two remaining commits are unrelated to the main problem, the race condition, but I figured I'll throw them in at once...