### PR TITLE
php: Fix char* typecheck typemap to accept Null

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,10 @@ Version 4.1.0 (in progress)
 ===========================
 
 2021-03-18: olly
+	    #1655 [PHP] Fix char* typecheck typemap to accept PHP Null like the
+	    corresponding in typemap does.
+
+2021-03-18: olly
 	    #1900, #1905 [PHP] Fix wrapping of overloaded directed methods with
 	    non-void return.
 

--- a/Examples/test-suite/overload_polymorphic.i
+++ b/Examples/test-suite/overload_polymorphic.i
@@ -23,4 +23,7 @@ class Unknown;
 int test2(Unknown* unknown) { return 0; }
 int test2(Base* base) { return 1; }
 
+int test3(const char*, const Base* = 0, bool = false) { return 0; }
+int test3(Base&, const char* = 0, const Base* = 0, bool = false) { return 1; }
+
 %}

--- a/Examples/test-suite/php/overload_polymorphic_runme.php
+++ b/Examples/test-suite/php/overload_polymorphic_runme.php
@@ -1,0 +1,14 @@
+<?php
+
+require "tests.php";
+require "overload_polymorphic.php";
+
+$t = new Derived();
+
+check::equal(overload_polymorphic::test($t), 0, "test(Derived)");
+check::equal(overload_polymorphic::test(1), 1, "test(1)");
+check::equal(overload_polymorphic::test2($t), 1, "test2(Derived)");
+check::equal(overload_polymorphic::test3($t, null, $t), 1, "test3(Derived, null, Derived)");
+
+check::done();
+?>

--- a/Lib/php/php.swg
+++ b/Lib/php/php.swg
@@ -465,7 +465,10 @@
 %php_typecheck(double,SWIG_TYPECHECK_DOUBLE,IS_DOUBLE)
 %php_typecheck(char,SWIG_TYPECHECK_CHAR,IS_STRING)
 
-%typemap(typecheck,precedence=SWIG_TYPECHECK_STRING) char *, char *&, char []
+%typemap(typecheck,precedence=SWIG_TYPECHECK_STRING) char *, char *&
+ " $1 = (Z_TYPE($input) == IS_STRING || Z_TYPE($input) == IS_NULL); "
+
+%typemap(typecheck,precedence=SWIG_TYPECHECK_STRING) char []
  " $1 = (Z_TYPE($input) == IS_STRING); "
 
 %typecheck(SWIG_TYPECHECK_POINTER) SWIGTYPE


### PR DESCRIPTION
The corresponding in typemap already does.

Fixes #1655, reported by CJSlominski.