### PR TITLE
appveyor.yml: test mingw build with master.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
+image:
+- Visual Studio 2019
 platform:
-- x86
 - x64
 
 environment:
@@ -7,31 +8,9 @@ environment:
     MAKEJOBS: 2
 
   matrix:
-  - SWIGLANG: csharp
-    VSVER: 12
-  - SWIGLANG: csharp
-    VSVER: 14
   - SWIGLANG: java
-    VSVER: 14
-  - SWIGLANG: python
-    VSVER: 14
-    VER: 27
-# - SWIGLANG: python
-#   VSVER: 14
-#   VER: 36
-#   PY3: 3
-  - SWIGLANG: python
-    OSVARIANT: cygwin
-#  - SWIGLANG: python
-#    OSVARIANT: mingw
-#    VER: 27
-#  - SWIGLANG: python
-#    OSVARIANT: mingw
-#    WITHLANG: python
-#    VER: 37
-#    PY3: 3
-  - BUILDSYSTEM: cmake
-    VSVER: 14
+    OSVARIANT: mingw
+    WITHLANG: java
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This is just to test pre-#1934 java build with mingw on appveyor. To be closed straight away.