### PR TITLE
Testsuite improvements

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -418,6 +418,7 @@ CPP_TEST_CASES += \
 	struct_value \
 	swig_exception \
 	symbol_clash \
+	sym \
 	template_arg_replace \
 	template_arg_scope \
 	template_arg_typename \

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -46,7 +46,6 @@ CPP_TEST_CASES = \
 	java_typemaps_typewrapper \
 	nested_scope \
 	li_std_list \
-	li_std_map \
 	li_std_set \
 #	li_boost_intrusive_ptr
 

--- a/Examples/test-suite/perl5/Makefile.in
+++ b/Examples/test-suite/perl5/Makefile.in
@@ -16,11 +16,13 @@ CPP_TEST_CASES += \
 	li_cstring \
 	li_cdata_carrays_cpp \
 	li_reference \
+	memberin1 \
 	director_nestedmodule \
 
 C_TEST_CASES += \
 	li_cstring \
 	li_cdata_carrays \
+	multivalue \
 
 include $(srcdir)/../common.mk
 

--- a/Examples/test-suite/perl5/multivalue_runme.pl
+++ b/Examples/test-suite/perl5/multivalue_runme.pl
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+BEGIN { use_ok('multivalue') }
+require_ok('multivalue');
+
+my ($q, $r);
+
+($q, $r) = multivalue::divide_l(37, 5);
+is($q, 7, "Test divide_l quotient");
+is($r, 2, "Test divide_l remainder");
+
+($q, $r) = multivalue::divide_v(41, 7);
+is($q, 5, "Test divide_v quotient");
+is($r, 6, "Test divide_v remainder");
+
+($q, $r) = multivalue::divide_mv(91, 13);
+is($q, 7, "Test divide_mv quotient");
+is($r, 0, "Test divide_mv remainder");

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -11,12 +11,21 @@ top_builddir = @top_builddir@
 
 CPP_TEST_CASES += \
 	callback \
+	director_nested \
 	director_stl \
+	exception_partial_info \
+	inout \
+	li_cdata_carrays_cpp \
+	li_cstring \
 	li_factory \
 	php_iterator \
 	php_namewarn_rename \
 	php_pragma \
 	prefix \
+
+C_TEST_CASES += \
+	li_cdata_carrays \
+	multivalue \
 
 include $(srcdir)/../common.mk
 

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -11,6 +11,7 @@ top_builddir = @top_builddir@
 
 CPP_TEST_CASES += \
 	callback \
+	director_stl \
 	li_factory \
 	php_iterator \
 	php_namewarn_rename \

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -16,6 +16,7 @@ CPP_TEST_CASES += \
 	php_iterator \
 	php_namewarn_rename \
 	php_pragma \
+	prefix \
 
 include $(srcdir)/../common.mk
 

--- a/Examples/test-suite/php/director_profile_runme.php
+++ b/Examples/test-suite/php/director_profile_runme.php
@@ -3,11 +3,11 @@
 require "tests.php";
 require "director_profile.php";
 
-// No new functions
-check::functions(array('b_fn','b_vfi','b_fi','b_fj','b_fk','b_fl','b_get_self','b_vfs','b_fs'));
-// No new classes
+// New functions
+check::functions(array('b_c_fn','b_vfi','b_fi','b_fj','b_fk','b_fl','b_get_self','b_vfs','b_fs'));
+// New classes
 check::classes(array('A','B'));
-// now new vars
+// No new vars
 check::globals(array());
 
 class MyB extends B {

--- a/Examples/test-suite/php/multivalue_runme.php
+++ b/Examples/test-suite/php/multivalue_runme.php
@@ -1,0 +1,25 @@
+<?php
+
+require "tests.php";
+require "multivalue.php";
+
+// New functions
+check::functions(array('divide_l','divide_v','divide_mv'));
+// New classes
+check::classes(array('multivalue'));
+// No new vars
+check::globals(array());
+
+$r = multivalue::divide_l(37, 5);
+check::equal($r[0], 7, "Test divide_l quotient");
+check::equal($r[1], 2, "Test divide_l remainder");
+
+$r = multivalue::divide_v(41, 7);
+check::equal($r[0], 5, "Test divide_v quotient");
+check::equal($r[1], 6, "Test divide_v remainder");
+
+$r = multivalue::divide_mv(91, 13);
+check::equal($r[0], 7, "Test divide_mv quotient");
+check::equal($r[1], 0, "Test divide_mv remainder");
+
+check::done();

--- a/Examples/test-suite/php/sym_runme.php
+++ b/Examples/test-suite/php/sym_runme.php
@@ -3,11 +3,11 @@
 require "tests.php";
 require "sym.php";
 
-// No new functions
-check::functions(array());
-// No new classes
-check::classes(array('flim','flam'));
-// now new vars
+// New functions
+check::functions(array('flim_hulahoops','flim_jar','flam_jam','flam_jar'));
+// New classes
+check::classes(array('Flim','Flam'));
+// No new vars
 check::globals(array());
 
 $flim=new flim();


### PR DESCRIPTION
This enables some testcases that could be run for PHP but weren't being.

While working on this, I noticed some other oddities, such as a double-listed testcase for java, and a few testcases which aren't actually currently referenced for any language so I've also addressed some of those.  There's more, but I don't think I have the time or energy right now for trying to sort out a lot more.

I've tested these locally, but opening a PR so they get tested with more versions without me breaking git master.

I suspect the previously unused `sym` testcase may be redundant with another testcase, but I failed to find one which clearly covered the same case.  If there is one, we could remove it instead.