### PR TITLE
swigrun.swg: fix typo

### DIFF
--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -115,7 +115,7 @@
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);


### PR DESCRIPTION
Spotted by lintian QA tool used by Debian packaging