### PR TITLE
[javascript][v8] SWIG_V8_VERSION generation method corrected.

### DIFF
--- a/Lib/javascript/v8/javascriptruntime.swg
+++ b/Lib/javascript/v8/javascriptruntime.swg
@@ -58,7 +58,10 @@
 
 #if defined(V8_MAJOR_VERSION) && defined(V8_MINOR_VERSION)
 #undef SWIG_V8_VERSION
-#define SWIG_V8_VERSION (V8_MAJOR_VERSION * 256 + V8_MINOR_VERSION)
+#define SWIG_V8_VERSION ((V8_MAJOR_VERSION / 10) * 4096 + \
+                         (V8_MAJOR_VERSION % 10) * 256 + \
+                         (V8_MINOR_VERSION / 10) * 16 + \
+                         (V8_MINOR_VERSION % 10))
 #endif
 
 #include <errno.h>


### PR DESCRIPTION
When "V8_MAJOR_VERSION" is 4 or higher, this fix is required if the definition of "SWIG_V8_VERSION" is as follows.

|node.js|V8|SWIG_V8_VERSION|
|:---:|:---:|:---:|
|16.0.0|9.0.257.17|0x0900|
|14.16.1|8.4.371.19|0x0804|
|12.22.1|7.8.279.23|0x0708|
|10.24.1|6.8.275.32|0x0608|
|8.17.0|6.2.414.78|0x0602|
|6.17.1|5.1.281.111|0x0501|
|4.9.1|4.5.103.53|0x0405|

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>