### PR TITLE
Python: Fix leak in SWIG_TypeClientData

### DIFF
--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -372,6 +372,8 @@ SWIGRUNTIME void
 SWIG_TypeClientData(swig_type_info *ti, void *clientdata) {
   swig_cast_info *cast = ti->cast;
   /* if (ti->clientdata == clientdata) return; */
+  if (ti->clientdata)
+    free(ti->clientdata);
   ti->clientdata = clientdata;
 
   while (cast) {


### PR DESCRIPTION
This fixes a leak detected using ASAN from SwigPyClientData_New:

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7faf628f5bc8 in malloc (/usr/lib/gcc/x86_64-linux-gnu/9/libasan.so+0x10dbc8)
    #1 0x7faf52f5bda0 in SwigPyClientData_New /home/schueller/projects/openturns/schueller/build2/python/src/CMakeFiles/geom.dir/geom_modulePYTHON_wrap.cxx:1345
    #2 0x7faf52f5dad3 in NearestNeighbourAlgorithmImplementation_swigregister /home/schueller/projects/openturns/schueller/build2/python/src/CMakeFiles/geom.dir/geom_modulePYTHON_wrap.cxx:5528
    #3 0x5c3a3f in cfunction_vectorcall_O ../Objects/methodobject.c:482

I dont have a minimal reproducer, but it may be because I use multiple
swig module.