### PR TITLE
Ruby: Fix warnings in generated code about missing parameter in variadic macro

### DIFF
--- a/Lib/ruby/rubyclasses.swg
+++ b/Lib/ruby/rubyclasses.swg
@@ -207,8 +207,8 @@ namespace swig {
                        (VALUEFUNC(swig_rescue_swallow)), Qnil);
       }
       if (ret == Qnil) {
-        VALUE a = rb_funcall(         _obj, hash_id, 0 );
-        VALUE b = rb_funcall( VALUE(other), hash_id, 0 );
+        VALUE a = rb_funcall2(         _obj, hash_id, 0, 0 );
+        VALUE b = rb_funcall2( VALUE(other), hash_id, 0, 0 );
         res = op_func(a, b);
       } else {
         res = RTEST(ret);

--- a/Lib/ruby/rubycomplex.swg
+++ b/Lib/ruby/rubycomplex.swg
@@ -36,12 +36,12 @@ SWIGINTERN int SWIG_Is_Complex( VALUE obj ) {
 
 SWIGINTERN VALUE SWIG_Complex_Real(VALUE obj) {
   static ID real_id = rb_intern("real");
-  return rb_funcall(obj, real_id, 0);
+  return rb_funcall2(obj, real_id, 0, 0);
 }
 
 SWIGINTERN VALUE SWIG_Complex_Imaginary(VALUE obj) {
   static ID imag_id = rb_intern("imag");
-  return rb_funcall(obj, imag_id, 0);
+  return rb_funcall2(obj, imag_id, 0, 0);
 }
 }
 

--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -803,9 +803,9 @@ namespace swig
       static ID id_start = rb_intern("begin");
       static ID id_noend = rb_intern("exclude_end?");
 
-      VALUE start = rb_funcall( i, id_start, 0 );
-      VALUE end   = rb_funcall( i, id_end, 0 );
-      bool  noend = ( rb_funcall( i, id_noend, 0 ) == Qtrue );
+      VALUE start = rb_funcall2( i, id_start, 0, 0 );
+      VALUE end   = rb_funcall2( i, id_end, 0, 0 );
+      bool  noend = ( rb_funcall2( i, id_noend, 0, 0 ) == Qtrue );
 
       int len = $self->size();
 

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -443,7 +443,7 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 {
   if ( rb_respond_to( proc, swig_arity_id ) )
     {
-      VALUE num = rb_funcall( proc, swig_arity_id, 0 );
+      VALUE num = rb_funcall2( proc, swig_arity_id, 0, 0 );
       int arity = NUM2INT(num);
       if ( arity < 0 && (arity+1) < -minimal ) return 1;
       if ( arity == minimal ) return 1;

--- a/Lib/ruby/std_map.i
+++ b/Lib/ruby/std_map.i
@@ -96,7 +96,7 @@
 	int res = SWIG_ERROR;
 	if ( TYPE(obj) == T_HASH ) {
 	  static ID id_to_a = rb_intern("to_a");
-	  VALUE items = rb_funcall(obj, id_to_a, 0);
+	  VALUE items = rb_funcall2(obj, id_to_a, 0, 0);
 	  res = traits_asptr_stdseq<std::map<K,T>, std::pair<K, T> >::asptr(items, val);
 	} else {
 	  map_type *p;

--- a/Lib/ruby/std_multimap.i
+++ b/Lib/ruby/std_multimap.i
@@ -23,7 +23,7 @@
 	int res = SWIG_ERROR;
 	if ( TYPE(obj) == T_HASH ) {
 	  static ID id_to_a = rb_intern("to_a");
-	  VALUE items = rb_funcall(obj, id_to_a, 0);
+	  VALUE items = rb_funcall2(obj, id_to_a, 0, 0);
 	  return traits_asptr_stdseq<std::multimap<K,T>, std::pair<K, T> >::asptr(items, val);
 	} else {
 	  multimap_type *p;

--- a/Lib/ruby/std_unordered_map.i
+++ b/Lib/ruby/std_unordered_map.i
@@ -23,7 +23,7 @@
 	int res = SWIG_ERROR;
 	if (TYPE(obj) == T_HASH) {
 	  static ID id_to_a = rb_intern("to_a");
-	  VALUE items = rb_funcall(obj, id_to_a, 0);
+	  VALUE items = rb_funcall2(obj, id_to_a, 0, 0);
 	  res = traits_asptr_stdseq<std::unordered_map<K,T,Hash,Compare,Alloc>, std::pair<K, T> >::asptr(items, val);
 	} else {
 	  map_type *p;

--- a/Lib/ruby/std_unordered_multimap.i
+++ b/Lib/ruby/std_unordered_multimap.i
@@ -23,7 +23,7 @@
 	int res = SWIG_ERROR;
 	if ( TYPE(obj) == T_HASH ) {
 	  static ID id_to_a = rb_intern("to_a");
-	  VALUE items = rb_funcall(obj, id_to_a, 0);
+	  VALUE items = rb_funcall2(obj, id_to_a, 0, 0);
 	  return traits_asptr_stdseq<std::unordered_multimap<K,T,Hash,Compare,Alloc>, std::pair<K, T> >::asptr(items, val);
 	} else {
 	  multimap_type *p;

--- a/Lib/ruby/timeval.i
+++ b/Lib/ruby/timeval.i
@@ -55,7 +55,7 @@ struct timeval rb_time_timeval(VALUE);
     if (NIL_P($input))
 	$1 = (time_t)-1;
     else
-	$1 = NUM2LONG(rb_funcall($input, rb_intern("tv_sec"), 0));
+	$1 = NUM2LONG(rb_funcall2($input, rb_intern("tv_sec"), 0, 0));
 }
 
 %typemap(typecheck) time_t


### PR DESCRIPTION
The Ruby C API function `rb_funcall` is used in various places in generated code for invoking a Ruby method without parameters. The C function uses a variadic parameter list for the arguments passed to Ruby, therefore in these cases the list of variadic parameters is empty.
As an optimization Ruby may implement the `rb_funcall` function as a macro (e.g. in Ruby 2.6.6) for which however a C/C++ compiler in '-pedantic' mode will issue a warning due to the empty list of arguments for `...` as of C99 and C++11.
In order to prevent such compiler warnings, this PR replaces all such occurrences with a call to `rb_funcallv` (which incidentally is invoked by the `rb_funcall` macro anyway, at least for Ruby 2.6.6).