### PR TITLE
Ruby: Fix missing checks for lower bounds of unsigned long (long) parameters

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -336,6 +336,7 @@ CPP_TEST_CASES += \
 	newobject1 \
 	newobject3 \
 	null_pointer \
+	numeric_bounds_checking \
 	operator_overload \
 	operator_overload_break \
 	operator_pointer_ref \

--- a/Examples/test-suite/numeric_bounds_checking.i
+++ b/Examples/test-suite/numeric_bounds_checking.i
@@ -1,0 +1,47 @@
+%module numeric_bounds_checking
+
+// Tests the bounds checking for integral parameters passed to wrapped functions.
+// Note that it needs an accompanying _runme file to perform the actual test.
+
+%inline %{
+#include <limits.h>
+struct Limits {
+  signed char schar_min() { return SCHAR_MIN; }
+  signed char schar_max() { return SCHAR_MAX; }
+  unsigned char uchar_min() { return 0U; }
+  unsigned char uchar_max() { return UCHAR_MAX; }
+  short shrt_min() { return SHRT_MIN; }
+  short shrt_max() { return SHRT_MAX; }
+  unsigned short ushrt_min() { return 0U; }
+  unsigned short ushrt_max() { return USHRT_MAX; }
+  int int_min() { return INT_MIN; }
+  int int_max() { return INT_MAX; }
+  unsigned int uint_min() { return 0U; }
+  unsigned int uint_max() { return UINT_MAX; }
+  long long_min() { return LONG_MIN; }
+  long long_max() { return LONG_MAX; }
+  unsigned long ulong_min() { return 0UL; }
+  unsigned long ulong_max() { return ULONG_MAX; }
+#ifdef LLONG_MIN
+  long long llong_min() { return LLONG_MIN; }
+  long long llong_max() { return LLONG_MAX; }
+  unsigned long long ullong_min() { return 0ULL; }
+  unsigned long long ullong_max() { return ULLONG_MAX; }
+#endif
+};
+
+struct Checker {
+  signed char pass_schar(signed char v) { return v; }
+  unsigned char pass_uchar(unsigned char v) { return v; }
+  short pass_shrt(short v) { return v; }
+  unsigned short pass_ushrt(unsigned short v) { return v; }
+  int pass_int(int v) { return v; }
+  unsigned int pass_uint(unsigned int v) { return v; }
+  long pass_long(long v) { return v; }
+  unsigned long pass_ulong(unsigned long v) { return v; }
+#ifdef LLONG_MIN
+  long long pass_long(long long v) { return v; }
+  unsigned long long pass_ulong(unsigned long long v) { return v; }
+#endif
+};
+%}

--- a/Examples/test-suite/ruby/numeric_bounds_checking_runme.rb
+++ b/Examples/test-suite/ruby/numeric_bounds_checking_runme.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+#
+# Tests the bounds checking for integral parameters passed to wrapped functions.
+#
+
+require 'swig_assert'
+require 'numeric_bounds_checking'
+
+limits = Numeric_bounds_checking::Limits.new
+checker = Numeric_bounds_checking::Checker.new
+
+all_ok = true
+
+types = %w(schar uchar
+           shrt  ushrt
+           int   uint
+           long  ulong)
+types += %w(llong ullong) if limits.respond_to?(:llong_min)
+
+types.each do |t|
+  min = limits.send("#{t}_min")
+  max = limits.send("#{t}_max")
+
+  meth = "pass_#{t}"
+
+  # check within bounds
+  swig_assert_equal("checker.#{meth}(#{min})", "#{min}", binding)
+  swig_assert_equal("checker.#{meth}(#{max})", "#{max}", binding)
+
+  # check outside bounds
+  [ min - 1, max + 1].each do |val|
+    ok = false
+    begin
+      ret = checker.send("#{meth}", val)
+    rescue RangeError, TypeError
+      ok = true
+    end
+    $stderr.puts "\n#{meth}(#{val}): Expected exception but got #{ret} for #{val} (type '#{t}')  " unless ok
+    all_ok = all_ok && ok
+  end
+  raise SwigRubyError.new("\nAt least one bounds check failed  ") unless all_ok
+end

--- a/Examples/test-suite/ruby/numeric_bounds_checking_runme.rb
+++ b/Examples/test-suite/ruby/numeric_bounds_checking_runme.rb
@@ -28,7 +28,7 @@ types.each do |t|
   swig_assert_equal("checker.#{meth}(#{max})", "#{max}", binding)
 
   # check outside bounds
-  [ min - 1, max + 1].each do |val|
+  [ min - 1, max + 1 ].each do |val|
     ok = false
     begin
       ret = checker.send("#{meth}", val)

--- a/Lib/ruby/rubyprimtypes.swg
+++ b/Lib/ruby/rubyprimtypes.swg
@@ -113,6 +113,8 @@ SWIG_AsVal_dec(unsigned long)(VALUE obj, unsigned long *val)
     a[0] = obj;
     a[1] = (VALUE)(&v);
     if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2ULONG), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (rb_funcall(obj, swig_lowerthan_id, 1, INT2FIX(0)) != Qfalse)
+        return SWIG_OverflowError;
       if (val) *val = v;
       return SWIG_OK;
     }
@@ -189,6 +191,8 @@ SWIG_AsVal_dec(unsigned long long)(VALUE obj, unsigned long long *val)
     a[0] = obj;
     a[1] = (VALUE)(&v);
     if (rb_rescue(VALUEFUNC(SWIG_AUX_NUM2ULL), (VALUE)a, VALUEFUNC(SWIG_ruby_failed), 0) != Qnil) {
+      if (rb_funcall(obj, swig_lowerthan_id, 1, INT2FIX(0)) != Qfalse)
+        return SWIG_OverflowError;
       if (val) *val = v;
       return SWIG_OK;
     }

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -80,6 +80,7 @@ static VALUE swig_runtime_data_type_pointer = Qnil;
 /* Global IDs used to keep some internal SWIG stuff */
 static ID swig_arity_id = 0;
 static ID swig_call_id  = 0;
+static ID swig_lowerthan_id = 0;
 
 /*
   If your swig extension is to be run within an embedded ruby and has
@@ -144,6 +145,7 @@ SWIG_Ruby_InitRuntime(void)
     _mSWIG = rb_define_module("SWIG");
     swig_call_id  = rb_intern("call");
     swig_arity_id = rb_intern("arity");
+    swig_lowerthan_id = rb_intern("<");
   }
 }
 


### PR DESCRIPTION
The Ruby C API functions which are used for converting a function's parameter from a Ruby value to an `unsigned long` or `unsigned long long` integer parameter, does not check for the lower bound (which of course is 0). Consequently if a value of e.g. `-1` is provided for such a parameter, the C/C++ code will be provided with some positive value (I think it is just the binary equivalent to the signed version).
More discussions on this topic can be found at https://bugs.ruby-lang.org/issues/9089 .

In this PR I want to provide the associated test cases first (still without the fix) in order to show which builds in the CI pipeline are affected, and then add the fix to this PR.

Note: The test is currently limited to Ruby but of course could be extended to other languages if the need arises.