### PR TITLE
add: docs for swig char** python3

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -5498,16 +5498,16 @@ wheel size: 135019664
 What has happened here is the garbage collector has collected the <tt>Bike</tt> instance as it doesn't think it is needed any more.
 The proxy instance, <tt>wheel</tt>, contains a reference to memory that was deleted when the <tt>Bike</tt> instance was collected.
 In order to prevent the garbage collector from collecting the <tt>Bike</tt> instance, a reference to the <tt>Bike</tt> must
-be added to the <tt>wheel</tt> instance. 
+be added to the <tt>wheel</tt> instance.
 </p>
-    
+
 <p>
 You can do this by adding the reference when the <tt>getWheel()</tt> method
 is called using one of three approaches:
 </p>
-    
+
 <p>
-The easier, but less optimized, way is to use the <tt>%pythonappend</tt> directive 
+The easier, but less optimized, way is to use the <tt>%pythonappend</tt> directive
 (see <a href="#Python_nn42">Adding additional Python code</a>):
 </p>
 
@@ -5521,12 +5521,12 @@ The easier, but less optimized, way is to use the <tt>%pythonappend</tt> directi
 </div>
 
 <p>
-The code gets appended to the Python code generated for the 
-<tt>Bike::getWheel</tt> wrapper function, where we store the <tt>Bike</tt> proxy 
-instance onto the <tt>Wheel</tt> proxy instance before it is returned to the 
+The code gets appended to the Python code generated for the
+<tt>Bike::getWheel</tt> wrapper function, where we store the <tt>Bike</tt> proxy
+instance onto the <tt>Wheel</tt> proxy instance before it is returned to the
 caller as follows.
 </p>
-    
+
 <div class="targetlang">
 <pre>
 class Bike(object):
@@ -5543,9 +5543,9 @@ class Bike(object):
 
 
 <p>
-The second option, which performs better and is required if you use the 
+The second option, which performs better and is required if you use the
 <tt>-builtin</tt> option, is to set the reference in the CPython implementation:
-    
+
 <div class="code">
 <pre>
 %extend Wheel {

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -4971,6 +4971,60 @@ int print_args(char **argv) {
 </pre></div>
 
 <p>
+  The following SWIG interface file allows a Python3 list
+  object to be used as a <tt>char **</tt> object.
+</p>
+
+
+<div class="code"><pre>
+  %module argv
+
+  // This tells SWIG to treat char ** as a special case
+  %typemap(in) char ** {
+    /* Check if is a list */
+    if (PyList_Check($input)) {
+      int size = PyList_Size($input);
+      int i = 0;
+      $1 = (char **) malloc((size+1)*sizeof(char *));
+      for (i = 0; i < size; i++) {
+        PyObject *o = PyList_GetItem($input, i);
+        if (PyUnicode_Check(o)) {
+          $1[i] = strdup(PyUnicode_AsUTF8(o));
+        } else {
+          free($1);
+          PyErr_SetString(PyExc_TypeError, "list must contain strings");
+          SWIG_fail;
+        }
+      }
+      $1[i] = 0;
+    } else {
+      PyErr_SetString(PyExc_TypeError, "not a list");
+      SWIG_fail;
+    }
+  }
+
+  // This cleans up the char ** array we malloc'd before the function call
+  %typemap(freearg) char ** {
+    free((char *) $1);
+  }
+
+  // Now a test function
+  %inline %{
+  int print_args(char **argv) {
+    int i = 0;
+    while (argv[i]) {
+      printf("argv[%d] = %s\n", i, argv[i]);
+      i++;
+    }
+    return i;
+  }
+  %}
+
+
+  </pre></div>
+
+<p>
+
 When this module is compiled, the wrapped C function now operates as
 follows :
 </p>
@@ -5112,6 +5166,40 @@ TypeError: Wrong number or type of arguments for overloaded function 'foo'.
     foo()
 </pre>
 </div>
+
+<p>
+  Similarly for Python 3
+</p>
+
+
+<div class="code"><pre>
+%typemap(in) (int argc, char **argv) {
+  /* Check if is a list */
+  if (PyList_Check($input)) {
+    int i;
+    $1 = PyList_Size($input);
+    $2 = (char **) malloc(($1 + 1)*sizeof(char *));
+    for (i = 0; i < $1; i++) {
+      PyObject *o = PyList_GetItem($input, i);
+      if (PyUnicode_Check(o)) {
+        $2[i] = strdup(PyUnicode_AsUTF8(o));
+      } else {
+        free($2);
+        PyErr_SetString(PyExc_TypeError, "list must contain strings");
+        SWIG_fail;
+      }
+    }
+    $2[i] = 0;
+  } else {
+    PyErr_SetString(PyExc_TypeError, "not a list");
+    SWIG_fail;
+  }
+}
+
+%typemap(freearg) (int argc, char **argv) {
+  free((char *) $2);
+}
+</pre></div>
 
 <H3><a name="Python_nn61">33.9.3 Using typemaps to return arguments</a></H3>
 


### PR DESCRIPTION
- Python3 has removed PyString_AsString
- a similar functionality is available using PyUnicode_AsUTF8