### PR TITLE
[Python] Fix overload_simple_cast test with 3.10

### DIFF
--- a/Examples/test-suite/python/python_overload_simple_cast_runme.py
+++ b/Examples/test-suite/python/python_overload_simple_cast_runme.py
@@ -9,6 +9,8 @@ class Ai:
     def __int__(self):
         return self.x
 
+    def __index__(self):
+        return self.x
 
 class Ad:
 


### PR DESCRIPTION
Closes #2044

see bpo-37999