### PR TITLE
Use suffix for static methods added by %extend

### DIFF
--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -1320,16 +1320,18 @@ int Language::staticmemberfunctionHandler(Node *n) {
     Delete(mrename);
     mrename = mangled;
 
-    if (Getattr(n, "sym:overloaded") && code) {
-      Append(cname, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
-    }
+    if (code) {
+      if (Getattr(n, "sym:overloaded")) {
+	Append(cname, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
+      }
 
-    if (!defaultargs && code) {
-      /* Hmmm. An added static member.  We have to create a little wrapper for this */
-      String *mangled_cname = Swig_name_mangle(cname);
-      Swig_add_extension_code(n, mangled_cname, parms, type, code, CPlusPlus, 0);
-      Setattr(n, "extendname", mangled_cname);
-      Delete(mangled_cname);
+      if (!defaultargs) {
+	/* Hmmm. An added static member.  We have to create a little wrapper for this */
+	String *mangled_cname = Swig_name_mangle(cname);
+	Swig_add_extension_code(n, mangled_cname, parms, type, code, CPlusPlus, 0);
+	Setattr(n, "extendname", mangled_cname);
+	Delete(mangled_cname);
+      }
     }
   }
 

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -1321,8 +1321,11 @@ int Language::staticmemberfunctionHandler(Node *n) {
     mrename = mangled;
 
     if (code) {
+      // See Swig_MethodToFunction() for the explanation of this code.
       if (Getattr(n, "sym:overloaded")) {
 	Append(cname, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
+      } else {
+	Append(cname, "__SWIG");
       }
 
       if (!defaultargs) {

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -1076,9 +1076,18 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
 
     /* Check if the method is overloaded.   If so, and it has code attached, we append an extra suffix
        to avoid a name-clash in the generated wrappers.  This allows overloaded methods to be defined
-       in C. */
-    if (Getattr(n, "sym:overloaded") && code) {
-      Append(mangled, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
+       in C.
+
+       But when not using the suffix used for overloaded functions, we still need to ensure that the
+       wrapper name doesn't conflict with any wrapper functions, so make it sufficiently unique by
+       appending a suffix similar to the one used for overloaded functions to it.
+     */
+    if (code) {
+      if (Getattr(n, "sym:overloaded")) {
+	Append(mangled, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
+      } else {
+	Append(mangled, "__SWIG");
+      }
     }
 
     /* See if there is any code that we need to emit */


### PR DESCRIPTION
This shouldn't result in any visible changes for the existing backends, but applying this allows to fix a conflict between the wrappers for static functions generated by C backend and the functions synthesized by `%extend`, as they use the same naming convention -- and the public wrappers should really keep it, because they need to have the same form as the real functions (i.e. those not added by `%extend`), so the only solution is to change the names used for the functions added by `%extend`.

Luckily, AFAICS, there should be no real problem with doing this and, if anything, this makes non-overloaded functions more consistent with the overloaded ones, which already use a similar `__SWIG_n` prefix.