### PR TITLE
Allow customizing type mangling in SWIG preprocessor

### DIFF
--- a/Source/Preprocessor/cpp.c
+++ b/Source/Preprocessor/cpp.c
@@ -929,14 +929,14 @@ static String *expand_macro(String *name, List *args, String *line_file) {
       /* Non-standard mangle expansions.  
          The #@Name is replaced by mangle_arg(Name). */
       if (strstr(Char(ns), "\004")) {
-	String *marg = Swig_string_mangle(arg);
+	String *marg = Swig_name_type(arg);
 	Clear(temp);
 	Printf(temp, "\004%s", aname);
 	Replace(ns, temp, marg, DOH_REPLACE_ID_END);
 	Delete(marg);
       }
       if (strstr(Char(ns), "\005")) {
-	String *marg = Swig_string_mangle(arg);
+	String *marg = Swig_name_type(arg);
 	Clear(temp);
 	Clear(tempa);
 	Printf(temp, "\005%s", aname);

--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -173,6 +173,33 @@ String *Swig_name_mangle(const_String_or_char_ptr s) {
 }
 
 /* -----------------------------------------------------------------------------
+ * Swig_name_type()
+ *
+ * Returns the name of a type.
+ * ----------------------------------------------------------------------------- */
+
+String *Swig_name_type(const_String_or_char_ptr tname) {
+  String *r, *s;
+  String* f = naming_hash ? Getattr(naming_hash, "type") : NULL;
+
+  /* Don't bother doing anything else if there is no special naming format. */
+  if (f) {
+    s = Copy(f);
+    Replace(s, "%c", tname, DOH_REPLACE_ANY);
+  } else {
+    s = (String*)tname;
+  }
+
+  r = Swig_name_mangle(s);
+
+  if (s != tname)
+    Delete(s);
+
+  return r;
+}
+
+
+/* -----------------------------------------------------------------------------
  * Swig_name_wrapper()
  *
  * Returns the name of a wrapper function.

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -273,6 +273,7 @@ extern int        ParmList_is_compactdefargs(ParmList *p);
   extern void Swig_name_register(const_String_or_char_ptr method, const_String_or_char_ptr format);
   extern void Swig_name_unregister(const_String_or_char_ptr method);
   extern String *Swig_name_mangle(const_String_or_char_ptr s);
+  extern String *Swig_name_type(const_String_or_char_ptr tname);
   extern String *Swig_name_wrapper(const_String_or_char_ptr fname);
   extern String *Swig_name_member(const_String_or_char_ptr nspace, const_String_or_char_ptr classname, const_String_or_char_ptr membername);
   extern String *Swig_name_get(const_String_or_char_ptr nspace, const_String_or_char_ptr vname);


### PR DESCRIPTION
Use the "type" naming format for the types mangled by "#@" and "##@"
preprocessor operators, in order to allow customizing them for a
particular backend.

This isn't used by any backend yet, so this doesn't change anything so
far.

---

This is needed by C backend to ensure that mangling used in the extension methods and the actual macros created by `%attribute` and friends is consistent and I don't see any better way to make these macros include the global prefix used for everything else in the C backend.

As the commit message says, this should have no noticeable effect (including performance-wise) on the existing backends.