### PR TITLE
Create v8::Number instead of v8::Integer when uint64_t is bigger than UINT32_MAX

### DIFF
--- a/Examples/test-suite/javascript/integers_runme.js
+++ b/Examples/test-suite/javascript/integers_runme.js
@@ -1,18 +1,24 @@
 var integers = require("integers");
 
-var val = 3902408827
-ret = integers.signed_long_identity(val)
-if (ret != val)
-  throw "Incorrect value: " + ret
+function checkOne(val, signed, typeName) {
+  typeName = (signed ? 'signed_' : 'unsigned_') + typeName
 
-ret = integers.unsigned_long_identity(val)
-if (ret != val)
-  throw "Incorrect value: " + ret
+  var size = integers[typeName + '_size']()
+  if ((!signed && val < 0) || (size < 8))
+    return // out of range, skip test
 
-ret = integers.signed_long_long_identity(val)
-if (ret != val)
-  throw "Incorrect value: " + ret
+  ret = integers[typeName + '_identity'](val)
+  if (ret !== val)
+    throw "Incorrect value: expected " + val + ", got " + ret
+}
 
-ret = integers.unsigned_long_long_identity(val)
-if (ret != val)
-  throw "Incorrect value: " + ret
+function checkAll(val) {
+  checkOne(val, true, 'long')
+  checkOne(val, false, 'long')
+  checkOne(val, true, 'long_long')
+  checkOne(val, false, 'long_long')
+}
+
+checkAll(3902408827)
+checkAll(Number.MAX_SAFE_INTEGER)
+checkAll(Number.MIN_SAFE_INTEGER)

--- a/Lib/javascript/v8/javascriptprimtypes.swg
+++ b/Lib/javascript/v8/javascriptprimtypes.swg
@@ -81,7 +81,7 @@ int SWIG_AsVal_dec(long)(SWIGV8_VALUE obj, long* val)
 SWIGINTERNINLINE
 SWIGV8_VALUE SWIG_From_dec(unsigned long)(unsigned long value)
 {
-  return SWIGV8_INTEGER_NEW_UNS(value);
+  return value <= UINT32_MAX ? (SWIGV8_VALUE)SWIGV8_INTEGER_NEW_UNS(value) : (SWIGV8_VALUE)SWIGV8_NUMBER_NEW(static_cast<double>(value));
 }
 }
 
@@ -149,7 +149,7 @@ int SWIG_AsVal_dec(long long)(SWIGV8_VALUE obj, long long* val)
 SWIGINTERNINLINE
 SWIGV8_VALUE SWIG_From_dec(unsigned long long)(unsigned long long value)
 {
-  return SWIGV8_INTEGER_NEW_UNS(value);
+  return value <= UINT32_MAX ? (SWIGV8_VALUE)SWIGV8_INTEGER_NEW_UNS(value) : (SWIGV8_VALUE)SWIGV8_NUMBER_NEW(static_cast<double>(value));
 }
 %#endif
 }


### PR DESCRIPTION
Currently we are converting uint64_t values to v8:Integer, but the v8::Integer:New takes a uin32_t as input, soo if the value is bigger than UINT32_MAX the value is truncated.

With this PR if the value is bigger than UINT32_MAX it is casted to a double and converted into to a v8::Number instead.