### PR TITLE
Add Python 3.11 support: use Py_SET_TYPE()

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -414,7 +414,11 @@ SwigPyBuiltin_ThisClosure (PyObject *self, void *SWIGUNUSEDPARM(closure)) {
 SWIGINTERN void
 SwigPyBuiltin_SetMetaType (PyTypeObject *type, PyTypeObject *metatype)
 {
+#if PY_VERSION_HEX >= 0x030900A4
+    Py_SET_TYPE(type, metatype);
+#else
     Py_TYPE(type) = metatype;
+#endif
 }
 
 


### PR DESCRIPTION
On Python 3.9 and newer, SwigPyBuiltin_SetMetaType() now calls
Py_SET_TYPE(). Py_TYPE() can no longer be usd as an l-value on
Python 3.11:

* https://docs.python.org/dev/c-api/structures.html#c.Py_SET_TYPE
* https://docs.python.org/dev/whatsnew/3.11.html#c-api-changes