### PR TITLE
[lua] Fix maybe-uninitialized warning in generated code

### DIFF
--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -1796,7 +1796,7 @@ SWIGRUNTIME int  SWIG_Lua_ConvertPtr(lua_State *L,int index,void **ptr,swig_type
 
 SWIGRUNTIME void* SWIG_Lua_MustGetPtr(lua_State *L,int index,swig_type_info *type,int flags,
        int argnum,const char *func_name){
-  void *result;
+  void *result = 0;
   if (!SWIG_IsOK(SWIG_ConvertPtr(L,index,&result,type,flags))){
     luaL_error (L,"Error in %s, expected a %s at argument number %d\n",
 		func_name,(type && type->str)?type->str:"void*",argnum);


### PR DESCRIPTION
When compiling OBS Studio (which use SWIG) with `-Wmaybe-uninitialized` with GCC.

I found out that this warning is emitted:
```
obsluaLUA_wrap.c:2537:10: warning: ‘result’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2537 |   return result;
      |          ^~~~~~
```

And this warning comes from the `SWIG_Lua_MustGetPtr()` which does not initialized `result` if `SWIG_ConvertPtr()` goes wrong. So initializing `result` to 0 should fix the issue.

`make check-lua-test-suite` tests passed succesfully on my system. I did not made further tests.

