### PR TITLE
Python: Add option to generate flattened static class methods

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -957,6 +957,7 @@ swig -python -help
 <tr><td>-doxygen        </td><td>Convert C++ doxygen comments to pydoc comments in proxy classes</td></tr>
 <tr><td>-extranative    </td><td>Return extra native wrappers for C++ std containers wherever possible</td></tr>
 <tr><td>-fastproxy      </td><td>Use fast proxy mechanism for member methods</td></tr>
+<tr><td>-flatstaticmethod </td><td>Generate Foo_bar for static method Foo::bar</td></tr>
 <tr><td>-globals &lt;name&gt; </td><td>Set &lt;name&gt; used to access C global variable (default: 'cvar')</td></tr>
 <tr><td>-interface &lt;mod&gt;</td><td>Set low-level C/C++ module name to &lt;mod&gt; (default: module name prefixed by '_')</td></tr>
 <tr><td>-keyword        </td><td>Use keyword arguments</td></tr>
@@ -1616,16 +1617,15 @@ In Python, the static member can be accessed in three different ways:
 
 <div class="targetlang">
 <pre>
-&gt;&gt;&gt; example.Spam_foo()    # Spam::foo()
 &gt;&gt;&gt; s = example.Spam()
 &gt;&gt;&gt; s.foo()               # Spam::foo() via an instance
-&gt;&gt;&gt; example.Spam.foo()    # Spam::foo() using Python-2.2 and later
+&gt;&gt;&gt; example.Spam.foo()    # Spam::foo() using class method
+&gt;&gt;&gt; example.Spam_foo()    # Spam::foo() "flattened" name
 </pre>
 </div>
 
 <p>
-The first two methods of access are supported in all versions of Python.  The
-last technique is only available in Python-2.2 and later versions.
+The last technique is only available when using the <tt>-flatstaticmethod</tt> option.
 </p>
 
 <p>

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -100,7 +100,7 @@ LIBS         = -L.
 VALGRIND_OPT += --suppressions=pythonswig.supp
 
 # Custom tests - tests with additional commandline options
-#python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
+python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
 
 # Rules for the different types of tests
 %.cpptest:

--- a/Examples/test-suite/python/autodoc_runme.py
+++ b/Examples/test-suite/python/autodoc_runme.py
@@ -63,12 +63,8 @@ check(inspect.getdoc(A.func3default),
 
 check(inspect.getdoc(A.func0static),
       "func0static(e, arg2, hello, f=2) -> int")
-check(inspect.getdoc(_autodoc.A_func0static),
-      "A_func0static(e, arg2, hello, f=2) -> int")
 check(inspect.getdoc(A.func1static),
       "func1static(A e, short arg2, Tuple hello, double f=2) -> int")
-check(inspect.getdoc(_autodoc.A_func1static),
-      "A_func1static(A e, short arg2, Tuple hello, double f=2) -> int")
 check(inspect.getdoc(A.func2static),
       "func2static(e, arg2, hello, f=2) -> int\n"
       "\n"
@@ -78,26 +74,8 @@ check(inspect.getdoc(A.func2static),
       "arg2: short\n"
       "hello: int tuple[2]\n"
       "f: double")
-check(inspect.getdoc(_autodoc.A_func2static),
-      "A_func2static(e, arg2, hello, f=2) -> int\n"
-      "\n"
-      "Parameters\n"
-      "----------\n"
-      "e: A *\n"
-      "arg2: short\n"
-      "hello: int tuple[2]\n"
-      "f: double")
 check(inspect.getdoc(A.func3static),
       "func3static(A e, short arg2, Tuple hello, double f=2) -> int\n"
-      "\n"
-      "Parameters\n"
-      "----------\n"
-      "e: A *\n"
-      "arg2: short\n"
-      "hello: int tuple[2]\n"
-      "f: double")
-check(inspect.getdoc(_autodoc.A_func3static),
-      "A_func3static(A e, short arg2, Tuple hello, double f=2) -> int\n"
       "\n"
       "Parameters\n"
       "----------\n"
@@ -119,7 +97,7 @@ check(inspect.getdoc(A.variable_d),
       "variable_d : int"
       )
 
-# Check the low-level functions (not present when using -builtin except for the static ones)
+# Check the low-level functions (not present when using -builtin)
 if not is_python_builtin():
     check(inspect.getdoc(_autodoc.A_funk), "just a string.")
     check(inspect.getdoc(_autodoc.A_func0),
@@ -160,6 +138,28 @@ if not is_python_builtin():
           "----------\n"
           "e: A *\n"
           "arg3: short\n"
+          "hello: int tuple[2]\n"
+          "f: double")
+    check(inspect.getdoc(_autodoc.A_func0static),
+          "A_func0static(e, arg2, hello, f=2) -> int")
+    check(inspect.getdoc(_autodoc.A_func1static),
+          "A_func1static(A e, short arg2, Tuple hello, double f=2) -> int")
+    check(inspect.getdoc(_autodoc.A_func2static),
+          "A_func2static(e, arg2, hello, f=2) -> int\n"
+          "\n"
+          "Parameters\n"
+          "----------\n"
+          "e: A *\n"
+          "arg2: short\n"
+          "hello: int tuple[2]\n"
+          "f: double")
+    check(inspect.getdoc(_autodoc.A_func3static),
+          "A_func3static(A e, short arg2, Tuple hello, double f=2) -> int\n"
+          "\n"
+          "Parameters\n"
+          "----------\n"
+          "e: A *\n"
+          "arg2: short\n"
           "hello: int tuple[2]\n"
           "f: double")
     check(inspect.getdoc(_autodoc.A_variable_a_set), "A_variable_a_set(self, variable_a)")

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3312,7 +3312,7 @@ public:
       Wrapper_print(f, f_wrappers);
     }
 
-    bool use_static_method = flat_static_method || !in_class || (Cmp(storage, "friend") == 0);
+    bool use_static_method = flat_static_method || !in_class || constructor || (Cmp(storage, "friend") == 0);
     /* Now register the function with the interpreter.   */
     if (!Getattr(n, "sym:overloaded")) {
       if (!builtin_self && (use_static_method || !builtin))


### PR DESCRIPTION
Like #2093 except that the option is to enable static methods, the default becoming no static methods, for the zen of Python.

cc @jim-easterbrook @wsfulton @casperdcl