### PR TITLE
Python subinterpreter issues

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,10 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.1.0 (in progress)
 ===========================
 
+2022-02-08: benjamin-sch
+            [Python] added an interpreter counter to fix deinitialization
+            issues if multiple subinterpreters are used
+
 2022-02-07: sethrj
             #2196 Add alternative syntax for specifying fragments in typemaps.
 

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1627,19 +1627,19 @@ SWIG_Python_TypeCache(void) {
 
 SWIGRUNTIME swig_module_info *
 SWIG_Python_GetModule(void *SWIGUNUSEDPARM(clientdata)) {
+#ifdef SWIG_LINK_RUNTIME
   static void *type_pointer = (void *)0;
   /* first check if module already created */
   if (!type_pointer) {
-#ifdef SWIG_LINK_RUNTIME
     type_pointer = SWIG_ReturnGlobalTypeList((void *)0);
-#else
-    type_pointer = PyCapsule_Import(SWIGPY_CAPSULE_NAME, 0);
-    if (PyErr_Occurred()) {
-      PyErr_Clear();
-      type_pointer = (void *)0;
-    }
-#endif
   }
+#else
+  void *type_pointer = PyCapsule_Import(SWIGPY_CAPSULE_NAME, 0);
+  if (PyErr_Occurred()) {
+    PyErr_Clear();
+    type_pointer = (void *)0;
+  }
+#endif
   return (swig_module_info *) type_pointer;
 }
 

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1643,12 +1643,17 @@ SWIG_Python_GetModule(void *SWIGUNUSEDPARM(clientdata)) {
   return (swig_module_info *) type_pointer;
 }
 
+
+static int interpreter_counter = 0; // how many (sub-)interpreters are using swig_module's types
+
 SWIGRUNTIME void
 SWIG_Python_DestroyModule(PyObject *obj)
 {
   swig_module_info *swig_module = (swig_module_info *) PyCapsule_GetPointer(obj, SWIGPY_CAPSULE_NAME);
   swig_type_info **types = swig_module->types;
   size_t i;
+  if (--interpreter_counter != 0) // another sub-interpreter may still be using the swig_module's types
+    return;
   for (i =0; i < swig_module->size; ++i) {
     swig_type_info *ty = types[i];
     if (ty->owndata) {
@@ -1676,6 +1681,7 @@ SWIG_Python_SetModule(swig_module_info *swig_module) {
 #endif
   PyObject *pointer = PyCapsule_New((void *) swig_module, SWIGPY_CAPSULE_NAME, SWIG_Python_DestroyModule);
   if (pointer && module) {
+    ++interpreter_counter;
     if (PyModule_AddObject(module, "type_pointer_capsule" SWIG_TYPE_TABLE_NAME, pointer) != 0) {
       Py_DECREF(pointer);
     }


### PR DESCRIPTION
This should avoid the crash reported in #2051 

1) the first commit counts the "capsules" used. It may be greater 1 if subinterpreters are used. As the InitializeModule seems to initialize the types only once in the case of multiple subinterpreters the deletion of the types should be as well only being done once. Otherwise we get the negative refcnt exception.
2) the second commit always gets the type_pointer from the "capsule" as it may be different after a re-initialization if SWIG is used with python embedded in an application and the application deinitializes/initializes python more than once. Furthermore it might be different if subinterpreters are used as each subinterpreter will add its own "capsule" in SWIG_SetModule.
