### PR TITLE
[perl] Require at least Perl 5.8.0

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.1.0 (in progress)
 ===========================
 
+2022-01-18: olly
+	    [Perl] #1629 Perl 5.8.0 is now the oldest version we aim to support.
+
 2022-01-14: wsfulton
             [Python] Fix %callback and specifying the callback function as a
             static member function using Python staticmethod syntax, such as

--- a/Doc/Manual/Perl5.html
+++ b/Doc/Manual/Perl5.html
@@ -91,10 +91,10 @@
 <p>
 This chapter describes SWIG's support of Perl5. Although the Perl5
 module is one of the earliest SWIG modules, it has continued to evolve
-and has been improved greatly with the help of SWIG users. For the
-best results, it is recommended that SWIG be used with Perl 5.8 or
-later. We're no longer testing regularly with older versions, but
-Perl 5.6 seems to mostly work, while older versions don't.
+and has been improved greatly with the help of SWIG users. As of SWIG
+4.1.0, the minimum version of Perl we aim to support is Perl 5.8.0.
+We can no longer easily test with older versions, and they no longer
+seem to be in active use.
 </p>
 
 <H2><a name="Perl5_nn2">31.1 Overview</a></H2>
@@ -680,7 +680,6 @@ files(s) field".
 installation under "Additional include directories".
 
 <li>Define the symbols WIN32 and MSWIN32 under preprocessor options.
-If using the ActiveWare port, also define the symbol PERL_OBJECT.
 Note that all extensions to the ActiveWare port must be compiled with
 the C++ compiler since Perl has been encapsulated in a C++ class.
 

--- a/Examples/test-suite/perl5/operator_overload_break_runme.pl
+++ b/Examples/test-suite/perl5/operator_overload_break_runme.pl
@@ -4,15 +4,6 @@ use Test::More tests => 9;
 
 use operator_overload_break;
 
-# Workaround for 
-#   ok( not (expression) , "test description" );
-# does not working in older versions of Perl, eg 5.004_04
-sub ok_not ($;$) {
-    my($test, $name) = @_;
-    $test = not $test;
-    ok($test, $name);
-}
-
 pass("loaded");
 
 my $op = operator_overload_break::Op->new(5);
@@ -32,7 +23,7 @@ $op->{k} = 22;
 ok((10 == (32 - $op)),
    "reversed subtraction");
 
-ok_not((3 == $op),
+ok(not(3 == $op),
        'not equal');
 
 $op->{k} = 3;

--- a/Examples/test-suite/perl5/operator_overload_runme.pl
+++ b/Examples/test-suite/perl5/operator_overload_runme.pl
@@ -4,15 +4,6 @@ use Test::More tests => 39;
 
 use operator_overload;
 
-# Workaround for 
-#   ok( not (expression) , "test description" );
-# does not working in older versions of Perl, eg 5.004_04
-sub ok_not ($;$) {
-    my($test, $name) = @_;
-    $test = not $test;
-    ok($test, $name);
-}
-
 pass("loaded");
 
 # first check all the operators are implemented correctly from pure C++ code
@@ -30,7 +21,7 @@ isa_ok($op2, "operator_overload::Op");
 $op->{i} = 5;
 $op2->{i} = 3;
 
-ok_not(($op == $op2), "operator equal: not equal");
+ok(not($op == $op2), "operator equal: not equal");
 
 $op->{i} = 3;
 ok(($op == $op2), "operator equal: equal");
@@ -42,7 +33,7 @@ $op2->{i} = 3;
 ok(($op != $op2), "operator not equal: not equal");
 
 $op->{i} = 3;
-ok_not(($op != $op2), "operator not equal: equal");
+ok(not($op != $op2), "operator not equal: equal");
 
 # stringify operator
 $op->{i} = 3;
@@ -99,16 +90,16 @@ is($op3->{i}, 2, "operator modulus");
 $op->{i} = 8;
 $op2->{i} = 3;
 ok($op > $op2, "operator greater than");
-ok_not(($op2 > $op), "operator greater than");
+ok(not($op2 > $op), "operator greater than");
 $op->{i} = 3;
-ok_not(($op2 > $op), "operator greater than");
-ok_not(($op > $op2), "operator greater than");
+ok(not($op2 > $op), "operator greater than");
+ok(not($op > $op2), "operator greater than");
 
 # greater than or equal operator
 $op->{i} = 8;
 $op2->{i} = 3;
 ok($op >= $op2, "operator greater than or equal");
-ok_not(($op2 >= $op), "operator greater than or equal");
+ok(not($op2 >= $op), "operator greater than or equal");
 $op->{i} = 3;
 ok(($op2 >= $op), "operator greater than or equal");
 ok(($op >= $op2), "operator greater than or equal");
@@ -117,16 +108,16 @@ ok(($op >= $op2), "operator greater than or equal");
 $op2->{i} = 8;
 $op->{i} = 3;
 ok($op < $op2, "operator lesser than");
-ok_not(($op2 < $op), "operator lesser than");
+ok(not($op2 < $op), "operator lesser than");
 $op2->{i} = 3;
-ok_not(($op2 < $op), "operator lesser than");
-ok_not(($op < $op2), "operator lesser than");
+ok(not($op2 < $op), "operator lesser than");
+ok(not($op < $op2), "operator lesser than");
 
 # less than or equal operator
 $op2->{i} = 8;
 $op->{i} = 3;
 ok($op <= $op2, "operator lesser than or equal");
-ok_not(($op2 <= $op), "operator lesser than or equal");
+ok(not($op2 <= $op), "operator lesser than or equal");
 $op2->{i} = 3;
 ok(($op2 <= $op), "operator less than or equal");
 ok(($op <= $op2), "operator less than or equal");

--- a/Examples/test-suite/perl5/packageoption_runme.pl
+++ b/Examples/test-suite/perl5/packageoption_runme.pl
@@ -5,15 +5,6 @@ use Test::More tests => 4;
 BEGIN { use_ok('packageoption_a'); }
 BEGIN { use_ok('packageoption_b'); }
 
-# Workaround for 
-#   ok( not (expression) , "test description" );
-# does not working in older versions of Perl, eg 5.004_04
-sub ok_not ($;$) {
-    my($test, $name) = @_;
-    $test = not $test;
-    ok($test, $name);
-}
-
 my $a = CommonPackage::A->new();
 
 isa_ok($a, 'CommonPackage::A');

--- a/Lib/perl5/perlhead.swg
+++ b/Lib/perl5/perlhead.swg
@@ -8,22 +8,9 @@ extern "C" {
 #include "perl.h"
 #include "XSUB.h"
 
-/* Add in functionality missing in older versions of Perl. Much of this is based on Devel-PPPort on cpan. */
-
-/* Add PERL_REVISION, PERL_VERSION, PERL_SUBVERSION if missing */
-#ifndef PERL_REVISION
-#  if !defined(__PATCHLEVEL_H_INCLUDED__) && !(defined(PATCHLEVEL) && defined(SUBVERSION))
-#    define PERL_PATCHLEVEL_H_IMPLICIT
-#    include <patchlevel.h>
-#  endif
-#  if !(defined(PERL_VERSION) || (defined(SUBVERSION) && defined(PATCHLEVEL)))
-#    include <could_not_find_Perl_patchlevel.h>
-#  endif
-#  ifndef PERL_REVISION
-#    define PERL_REVISION       (5)
-#    define PERL_VERSION        PATCHLEVEL
-#    define PERL_SUBVERSION     SUBVERSION
-#  endif
+/* PERL_REVISION was added in Perl 5.6. */
+#if !defined PERL_REVISION || (PERL_REVISION-0 == 5 && PERL_VERSION-0 < 8)
+# error SWIG requires Perl >= 5.8.0
 #endif
 
 #if defined(WIN32) && defined(PERL_OBJECT) && !defined(PerlIO_exportFILE)
@@ -36,15 +23,6 @@ extern "C" {
 
 #ifndef SvUOK
 # define SvUOK(sv)           SvIOK_UV(sv)
-#endif
-
-#if ((PERL_VERSION < 4) || ((PERL_VERSION == 4) && (PERL_SUBVERSION <= 5)))
-#  define PL_sv_undef               sv_undef
-#  define PL_na	                    na
-#  define PL_errgv                  errgv
-#  define PL_sv_no                  sv_no
-#  define PL_sv_yes                 sv_yes
-#  define PL_markstack_ptr          markstack_ptr
 #endif
 
 #ifndef IVSIZE

--- a/Lib/perl5/perlinit.swg
+++ b/Lib/perl5/perlinit.swg
@@ -4,14 +4,10 @@
 #ifdef __cplusplus
 extern "C"
 #endif
-#ifndef PERL_OBJECT
 #ifndef MULTIPLICITY
 SWIGEXPORT void SWIG_init (CV* cv);
 #else
 SWIGEXPORT void SWIG_init (pTHXo_ CV* cv);
-#endif
-#else
-SWIGEXPORT void SWIG_init (CV *cv, CPerlObj *);
 #endif
 %}
 

--- a/Lib/perl5/perlrun.swg
+++ b/Lib/perl5/perlrun.swg
@@ -6,13 +6,8 @@
  * type checking.
  * ----------------------------------------------------------------------------- */
 
-#ifdef PERL_OBJECT
-#define SWIG_PERL_OBJECT_DECL CPerlObj *SWIGUNUSEDPARM(pPerl),
-#define SWIG_PERL_OBJECT_CALL pPerl,
-#else
 #define SWIG_PERL_OBJECT_DECL
 #define SWIG_PERL_OBJECT_CALL
-#endif
 
 /* Common SWIG API */
 
@@ -88,31 +83,11 @@ extern "C" {
 #endif
 
 /* Macro to call an XS function */
-#ifdef PERL_OBJECT 
-#  define SWIG_CALLXS(_name) _name(cv,pPerl) 
-#else 
-#  ifndef MULTIPLICITY 
-#    define SWIG_CALLXS(_name) _name(cv) 
-#  else 
-#    define SWIG_CALLXS(_name) _name(PERL_GET_THX, cv) 
-#  endif 
-#endif 
-
-#ifdef PERL_OBJECT
-#define MAGIC_PPERL  CPerlObj *pPerl = (CPerlObj *) this;
-
-#ifdef __cplusplus
-extern "C" {
+#ifndef MULTIPLICITY
+#  define SWIG_CALLXS(_name) _name(cv)
+#else
+#  define SWIG_CALLXS(_name) _name(PERL_GET_THX, cv)
 #endif
-typedef int (CPerlObj::*SwigMagicFunc)(SV *, MAGIC *);
-#ifdef __cplusplus
-}
-#endif
-
-#define SWIG_MAGIC(a,b) (SV *a, MAGIC *b)
-#define SWIGCLASS_STATIC
-
-#else /* PERL_OBJECT */
 
 #define MAGIC_PPERL
 #define SWIGCLASS_STATIC static SWIGUNUSED
@@ -141,24 +116,14 @@ typedef int (*SwigMagicFunc)(struct interpreter *, SV *, MAGIC *);
 #endif
 
 #endif /* MULTIPLICITY */
-#endif /* PERL_OBJECT */
 
-#  ifdef PERL_OBJECT
-#    define SWIG_croak_null() SWIG_Perl_croak_null(pPerl)
-static void SWIGUNUSED SWIG_Perl_croak_null(CPerlObj *pPerl)
-#  else
 static void SWIGUNUSED SWIG_croak_null()
-#  endif
 {
   SV *err = get_sv("@", GV_ADD);
-#  if (PERL_VERSION < 6)
-  croak("%_", err);
-#  else
   if (sv_isobject(err))
     croak(0);
   else
     croak("%s", SvPV_nolen(err));
-#  endif
 }
 
 
@@ -462,20 +427,15 @@ typedef struct {
 } swig_variable_info;
 
 /* Magic variable code */
-#ifndef PERL_OBJECT
-# ifdef __cplusplus
+#ifdef __cplusplus
 #  define swig_create_magic(s,a,b,c) _swig_create_magic(s,const_cast<char*>(a),b,c)
-# else
-#  define swig_create_magic(s,a,b,c) _swig_create_magic(s,(char*)(a),b,c)
-# endif
-# ifndef MULTIPLICITY
-SWIGRUNTIME void _swig_create_magic(SV *sv, char *name, int (*set)(SV *, MAGIC *), int (*get)(SV *,MAGIC *)) 
-# else
-SWIGRUNTIME void _swig_create_magic(SV *sv, char *name, int (*set)(struct interpreter*, SV *, MAGIC *), int (*get)(struct interpreter*, SV *,MAGIC *)) 
-# endif
 #else
-#  define swig_create_magic(s,a,b,c) _swig_create_magic(pPerl,s,a,b,c)
-SWIGRUNTIME void _swig_create_magic(CPerlObj *pPerl, SV *sv, const char *name, int (CPerlObj::*set)(SV *, MAGIC *), int (CPerlObj::*get)(SV *, MAGIC *)) 
+#  define swig_create_magic(s,a,b,c) _swig_create_magic(s,(char*)(a),b,c)
+#endif
+#ifndef MULTIPLICITY
+SWIGRUNTIME void _swig_create_magic(SV *sv, char *name, int (*set)(SV *, MAGIC *), int (*get)(SV *,MAGIC *))
+#else
+SWIGRUNTIME void _swig_create_magic(SV *sv, char *name, int (*set)(struct interpreter*, SV *, MAGIC *), int (*get)(struct interpreter*, SV *,MAGIC *))
 #endif
 {
   MAGIC *mg;

--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -10,6 +10,7 @@ published on the SWIG web site at http://swig.org/release.html.
 SWIG-4.1.0 summary:
 - Add PHP 8 support.
 - PHP wrapping is now done entirely via PHP's C API - no more .php wrapper.
+- Perl 5.8.0 is now the oldest version SWIG supports.
 - GitHub Actions is now used instead of Travis CI for continuous integration.
 
 SWIG-4.0.2 summary:

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -445,13 +445,7 @@ public:
 
     Printv(magic,
            "#ifdef __cplusplus\nextern \"C\" {\n#endif\n\n",
-	   "#ifdef PERL_OBJECT\n",
-	   "#define MAGIC_CLASS _wrap_", underscore_module, "_var::\n",
-	   "class _wrap_", underscore_module, "_var : public CPerlObj {\n",
-	   "public:\n",
-	   "#else\n",
 	   "#define MAGIC_CLASS\n",
-	   "#endif\n",
 	   "SWIGCLASS_STATIC int swig_magic_readonly(pTHX_ SV *SWIGUNUSEDPARM(sv), MAGIC *SWIGUNUSEDPARM(mg)) {\n",
 	   tab4, "MAGIC_PPERL\n", tab4, "croak(\"Value is read-only.\");\n", tab4, "return 0;\n", "}\n", NIL);
 
@@ -470,7 +464,6 @@ public:
 
     /* Dump out variable wrappers */
 
-    Printv(magic, "\n\n#ifdef PERL_OBJECT\n", "};\n", "#endif\n", NIL);
     Printv(magic, "\n#ifdef __cplusplus\n}\n#endif\n", NIL);
 
     Printf(f_header, "%s\n", magic);

--- a/configure.ac
+++ b/configure.ac
@@ -983,7 +983,7 @@ else
 # First figure out what the name of Perl5 is
 
 if test "x$PERLBIN" = xyes; then
-AC_CHECK_PROGS(PERL, perl perl5.6.1 perl5.6.0 perl5.004 perl5.003 perl5.002 perl5.001 perl5 perl)
+AC_CHECK_PROGS(PERL, perl perl5)
 else
 PERL="$PERLBIN"
 fi


### PR DESCRIPTION
As discussed and agreed in #1629, it's become hard to test with Perl
5.6 or earlier, such old versions are no longer in active use, and
4.1.0 is an appropriate time to make such a change.

I've dropped the compatibility code that was obvious to me, but there's
probably more that can be cleaned up now.