### PR TITLE
C++11 explicit function template instantiation #2131

### DIFF
--- a/Examples/test-suite/cpp11_template_explicit.i
+++ b/Examples/test-suite/cpp11_template_explicit.i
@@ -4,6 +4,7 @@
 */
 %module cpp11_template_explicit
 
+/* Explicitely silence SWIG warning related to explicit templates */
 #pragma SWIG nowarn=SWIGWARN_PARSE_EXPLICIT_TEMPLATE
 
 %inline %{
@@ -33,6 +34,30 @@ extern template class Temper<B*>;
 
 template class Temper<int>;
 extern template class Temper<short>;
+
+/* Templated function to check support for extern template functions */
+template <typename T>
+T my_templated_function(int a, double b)
+{
+  return T();
+}
+
+/* Explicit extern function template instantiation with simple type */
+extern template int my_templated_function<int>(int, double);
+template int my_templated_function<int>(int, double);
+
+/* Explicit extern function template instantiation with more complex types */
+extern template A my_templated_function<A>(int, double);
+template A my_templated_function<A>(int, double);
+
+extern template Temper<int> my_templated_function<Temper<int>>(int, double);
+template Temper<int> my_templated_function<Temper<int>>(int, double);
+
 %}
 
 %template(TemperInt) Temper<int>;
+
+/* Enable several versions of the templated function */
+%template(my_templated_function_int      ) my_templated_function<int>;
+%template(my_templated_function_A        ) my_templated_function<A>;
+%template(my_templated_function_TemperInt) my_templated_function<Temper<int>>;

--- a/Examples/test-suite/python/cpp11_template_explicit_runme.py
+++ b/Examples/test-suite/python/cpp11_template_explicit_runme.py
@@ -1,0 +1,11 @@
+import cpp11_template_explicit
+
+# Call variants of the same templated function
+t1 = cpp11_template_explicit.my_templated_function_int      (1,1.0)
+t2 = cpp11_template_explicit.my_templated_function_A        (2,2.0)
+t3 = cpp11_template_explicit.my_templated_function_TemperInt(3,3.0)
+
+# Check return types
+assert isinstance(t1,int)
+assert isinstance(t2,cpp11_template_explicit.A)
+assert isinstance(t3,cpp11_template_explicit.TemperInt)

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -4361,12 +4361,23 @@ cpp_template_decl : TEMPLATE LESSTHAN template_parms GREATERTHAN {
                   $$ = 0; 
 		}
 
-		/* Explicit template instantiation without the translation unit */
+		/* Explicit function template instantiation */
+		| TEMPLATE cpp_alternate_rettype idcolon LPAREN parms RPAREN {
+			Swig_warning(WARN_PARSE_EXPLICIT_TEMPLATE, cparse_file, cparse_line, "Explicit function template instantiation ignored.\n");
+                  $$ = 0; 
+				}
+
+		/* Explicit class template instantiation without the translation unit */
 		| EXTERN TEMPLATE cpptype idcolon {
-		  Swig_warning(WARN_PARSE_EXPLICIT_TEMPLATE, cparse_file, cparse_line, "Explicit template instantiation ignored.\n");
+		  Swig_warning(WARN_PARSE_EXPLICIT_TEMPLATE, cparse_file, cparse_line, "Explicit (extern) class template instantiation ignored.\n");
                   $$ = 0; 
                 }
-                ;
+		/* Explicit function template instantiation without the translation unit */
+		| EXTERN TEMPLATE cpp_alternate_rettype idcolon LPAREN parms RPAREN {
+			Swig_warning(WARN_PARSE_EXPLICIT_TEMPLATE, cparse_file, cparse_line, "Explicit (extern) function template instantiation ignored.\n");
+                  $$ = 0; 
+				}
+				;
 
 cpp_template_possible:  c_decl {
 		  $$ = $1;


### PR DESCRIPTION
# Solving issue #2131 

This MR solves issue #2131.

The parser (see `parser.y`) has been adapted to be able to parse explicit (extern) function template instantiation.

A test for Python (see `Examples/test-suite/python/cpp11_template_explicit_runme.py`) has been added.
