### PR TITLE
docker : adding development-ready docker image that can be used in VS…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    # Instructions for building the Docker image
+    "build" : {
+        "dockerfile": "dockerfile",
+        "context": ".."
+    },
+    # VS Code extensions to install
+    "extensions": [
+        # Linter for lex/yacc and flex/bison
+        "daohong-emilio.yash",
+        # Git tools
+        "mhutchie.git-graph",
+        "eamodio.gitlens"
+    ]
+}

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,6 @@
+FROM debian:latest
+
+COPY requirements requirements
+
+RUN    apt update \
+    && apt --yes install $(grep -vE "^\s*#" requirements/requirements_system.dev.txt  | tr "\n" " ")

--- a/requirements/requirements_system.dev.txt
+++ b/requirements/requirements_system.dev.txt
@@ -1,0 +1,18 @@
+# For building SWIG from source
+build-essential
+libpcre2-dev
+libpcre3-dev
+autoconf
+automake
+libtool
+bison
+git
+
+# Required to build Python 2 SWIG test suite
+python-dev
+
+# Required to build Python 3 SWIG test suite
+python3-dev
+
+# For the test suite
+libboost-dev


### PR DESCRIPTION
# Development and docker

As a side quest, I added a `dockerfile` for developers. It only allows to work with Python for now, but other languages can be added by modifying the requirements (see `requirements/requirements_system.dev.txt`) according to the SWIG wiki.

Additionally, I created a `devcontainer` configuation file for those working in Visual Studio Code. Further information can be found here: https://code.visualstudio.com/docs/remote/containers.