### PR TITLE
Add missing defines for PCRE2 (on Windows)

### DIFF
--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -1312,6 +1312,7 @@ void Swig_offset_string(String *s, int number) {
 
 
 #ifdef HAVE_PCRE
+#define PCRE2_STATIC
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
 

--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -1092,6 +1092,7 @@ static DOH *get_lattr(Node *n, List *lattr) {
 }
 
 #ifdef HAVE_PCRE
+#define PCRE2_STATIC
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
 


### PR DESCRIPTION
Following the updates in #2138 I've been testing the CMake install steps on Windows. 

When trying to build (with static linking to the PCRE2 library so not requiring a pcre.dll to be on the system path), I was getting the following errors:

```
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_config_8 referenced in function Swig_pcre_version [C:\
swig\build\swig.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_compile_8 referenced in function Swig_string_regex [C:
\swig\build\swig.vcxproj]
naming.obj : error LNK2001: unresolved external symbol __imp_pcre2_compile_8 [C:\swig\build\swig.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_code_free_8 referenced in function Swig_string_regex [
C:\swig\build\swig.vcxproj]
naming.obj : error LNK2001: unresolved external symbol __imp_pcre2_code_free_8 [C:\swig\build\swig.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_match_data_create_from_pattern_8 referenced in functio
n Swig_string_regex [C:\swig\build\swig.vcxproj]
naming.obj : error LNK2001: unresolved external symbol __imp_pcre2_match_data_create_from_pattern_8 [C:\swig\build\swig
.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_match_8 referenced in function Swig_string_regex [C:\s
wig\build\swig.vcxproj]
naming.obj : error LNK2001: unresolved external symbol __imp_pcre2_match_8 [C:\swig\build\swig.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_match_data_free_8 referenced in function Swig_string_r
egex [C:\swig\build\swig.vcxproj]
naming.obj : error LNK2001: unresolved external symbol __imp_pcre2_match_data_free_8 [C:\swig\build\swig.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_get_ovector_pointer_8 referenced in function Swig_stri
ng_regex [C:\swig\build\swig.vcxproj]
misc.obj : error LNK2019: unresolved external symbol __imp_pcre2_get_error_message_8 referenced in function Swig_string
_regex [C:\swig\build\swig.vcxproj]
naming.obj : error LNK2001: unresolved external symbol __imp_pcre2_get_error_message_8 [C:\swig\build\swig.vcxproj]
C:\swig\build\Release\swig.exe : fatal error LNK1120: 8 unresolved externals [C:\swig\build\swig.vcxproj]
```

This was resolved by adding in the defines in this pull request as noted at https://stackoverflow.com/a/67233379/179520
