### PR TITLE
Updated and tested Windows CMake build docs

### DIFF
--- a/Doc/Manual/Windows.html
+++ b/Doc/Manual/Windows.html
@@ -230,72 +230,69 @@ SWIG can also be compiled and run using <a href="https://www.msys2.org/">MSYS2</
 <p>
 SWIG can be built using <a href="https://cmake.org/">CMake</a> and Visual Studio rather than autotools. As with the other approaches to 
 building SWIG the dependencies need to be installed. The steps below are one of a number of ways of installing the dependencies without requiring Cygwin or MinGW.
-For fully working build steps always check the Continuous Integration setups currently detailed in the <a href="https://github.com/swig/swig/blob/master/appveyor.yml">Appveyor YAML file</a>.
+For fully working build steps always check the Continuous Integration (CI) setups currently detailed in the <a href="https://github.com/swig/swig/blob/master/appveyor.yml">Appveyor YAML file</a>.
 </p>
 
 <ol>
     <li>
-        Install Nuget from <a href="https://www.nuget.org/downloads">https://www.nuget.org/downloads</a> (v5.8.1 is used in this example, and installed to C:\Tools). Nuget is the package manager
+        Install Nuget from <a href="https://www.nuget.org/downloads">https://www.nuget.org/downloads</a> (v6.0.0 is used in this example, and installed to <tt>C:\Tools</tt>). Nuget is the package manager
         for .NET, but allows us to easily install <a href="https://cmake.org/">CMake</a> and other dependencies required by SWIG.
     </li>
     <li>
-        Install CMake using the following command: <pre>C:\Tools\nuget install CMake-win64 -Version 3.15.5 -OutputDirectory C:\Tools\CMake</pre>
+        Install <a href="https://www.nuget.org/packages/CMake-win64/">CMake-win64 Nuget package</a> using the following command: <pre>C:\Tools\nuget install CMake-win64 -Version 3.15.5 -OutputDirectory C:\Tools\CMake</pre>
         Alternatively you can download CMake from <a href="https://cmake.org/download/">https://cmake.org/download/</a>.
     </li>
     <li>
-        Install Bison using the following command: <pre>C:\Tools\nuget install bison-win32 -Version 2.4.1.1 -OutputDirectory C:\Tools\bison</pre>
+        Install the <a href="https://www.nuget.org/packages/bison-win32/">Bison Nuget package</a> using the following command: <pre>C:\Tools\nuget install bison-win32 -Version 2.4.1.1 -OutputDirectory C:\Tools\bison</pre>
         Alternatively download Bison from <a href="https://sourceforge.net/projects/gnuwin32/files/bison/">https://sourceforge.net/projects/gnuwin32/files/bison/</a> (2.4.1 is used in this example)
-        and save to a folder e.g. C:\Tools\Bison
+        and save to a folder e.g. <tt>C:\Tools\Bison</tt>
     </li>
     <li>
-        Install PCRE2 using the following commands:
-<div class="shell"><pre>
-git clone https://github.com/PhilipHazel/pcre2.git
-cd pcre2
-cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=C:/pcre .
-cmake --build . --config Release --target install
-</pre></div>
-Alternatively, use <tt>WITH_PCRE</tt> option to disable PCRE2 support if you are sure not to need it.
+        Unfortunately, PCRE2 is not yet available on Nuget. Instead we will use CMake to build and install <a href="https://www.pcre.org/">PCRE2</a> to <tt>C:\Tools\pcre2</tt> using the following commands:
+        <div class="shell"><pre>
+        cd C:\
+        SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;%PATH%
+        git clone https://github.com/PhilipHazel/pcre2.git
+        cd pcre2
+        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=C:/Tools/pcre2 -S . -B build
+        cmake --build build --config Release --target install</pre></div>
+        Alternatively, set <tt>WITH_PCRE=OFF</tt> to disable PCRE2 support if you are sure you do not require it.
     </li>
     <li>
         We will also need the SWIG source code. Either download a zipped archive from GitHub, or if git is installed clone the latest codebase
         using <pre>git clone https://github.com/swig/swig.git</pre>
-        In this example we are assuming the source code is available at C:\swig
+        In this example we are assuming the source code is available at <tt>C:\swig</tt>
+    </li>
+    <li>
+    <p>
+        Now we have all the required dependencies we can build SWIG using the commands below. We are assuming Visual Studio 2019 is installed. For other versions of Visual Studio change <tt>"Visual Studio 16 2019 -A x64"</tt> to the relevant
+        <a href="https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators">Visual Studio Generator</a> and
+        architecture. We add the required build tools to the system PATH, and then
+        build a Release version of SWIG. If all runs successfully a new swig.exe should be generated in the <tt>C:/swig/install2/bin</tt> folder.
+    </p>
+    <div class="shell">
+        <pre>
+    cd C:\swig
+    SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\bison-win32.2.4.1.1\tools\native\bin;%PATH%
+    SET PCRE_ROOT=C:/Tools/pcre2
+    SET PCRE_PLATFORM=x64
+    cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
+    -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
+    cmake --build build --config Release --target install
+    
+    REM to test the exe
+    cd install2/bin
+    swig.exe -help</pre></div>
     </li>
 </ol>
-
-<p>
-    We are assuming Visual Studio 2017 is installed. For other versions of Visual Studio change <i>"Visual Studio 15 2017 Win64"</i> to the relevant
-    <a href="https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators">Visual Studio Generator</a>.
-    Now we have all the required dependencies we can build SWIG using the commands below. We add the required build tools to the system PATH, and then
-    build a Release version of SWIG. If all runs successfully a new swig.exe should be generated in a /Release folder.
-</p>
-
-<div class="shell">
-    <pre>
-cd C:\swig
-SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\bison-win32.2.4.1.1\tools\native\bin;%PATH%
-SET PCRE_ROOT=C:/pcre
-SET PCRE_PLATFORM=x64
-cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
-  -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8.lib .
-cmake --build . --config Release
-
-REM to test the exe
-cd /Release
-swig.exe -help
-</pre>
-</div>
-
 <p>
     In addition to Release builds you can create a Debug build using:
 </p>
 <div class="shell">
-    <pre>cmake --build . --config Debug</pre>
+    <pre>cmake --build build --config Debug</pre>
 </div>
 <p>
-    A Visual Studio solution file should be generated named swig.sln. This can be opened and debugged by running the swig project and setting the
-    Debugging Command Arguments. For example to debug one of the test-suite .i files included with the SWIG source use the following:
+    A Visual Studio solution file should be generated named swig.sln. This can be opened and debugged by running the swig project and setting <tt>Properties > Debugging > Command Arguments</tt>. For example to debug one of the test-suite .i files included with the SWIG source use the following:
 </p>
 <div class="shell">
     <pre>-python -c++ -o C:\Temp\doxygen_parsing.cpp C:\swig\Examples\test-suite\doxygen_parsing.i</pre>

--- a/Doc/Manual/Windows.html
+++ b/Doc/Manual/Windows.html
@@ -277,7 +277,7 @@ For fully working build steps always check the Continuous Integration (CI) setup
     SET PCRE_ROOT=C:/Tools/pcre2
     SET PCRE_PLATFORM=x64
     cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
-    -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
+    -DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
     cmake --build build --config Release --target install
     
     REM to test the exe


### PR DESCRIPTION
Following updates in #2138, I've run through the Windows CMake docs/build steps, and made the following changes:

- Updated (and tested) to Visual Studio 2019
- Updated and tested with Nuget 6.0
- Added some more hyperlinks to dependency docs
- Changed `-DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8.lib` to `pcre2-8-static.lib` - @jschueller does this make sense? Otherwise running `swig.exe` throws an error if `pcre.dll` is not on the system path. It also throws the error `LINK : fatal error LNK1181: cannot open input file 'C:\Tools\pcre2\lib\pcre2-8.lib' [C:\swig\build\swig.vcxproj]` unless PCRE2 is built with the `-DBUILD_SHARED_LIBS=ON` flag, which was not in the steps previously. 
- Makes the builds "out-of-source" - all CMake files are created in `/build` subfolders rather than mixed in with the source code
- Adds an install step to the CMake steps
- Adds the `-DCMAKE_CXX_FLAGS="/DPCRE2_STATIC"` to allow the static builds