### PR TITLE
Add an example for unignoring everything

### DIFF
--- a/Doc/Manual/SWIG.html
+++ b/Doc/Manual/SWIG.html
@@ -2249,6 +2249,8 @@ the following approach could be taken:
 %rename("%s") Star::shine; // named method
 
 %include "myheader.h"
+
+%rename("%s") ""; // Undo the %ignore
 </pre>
 </div>
 


### PR DESCRIPTION
In the example for ignoring everything, it didn't show how to undo the
ignore all, and the obvious '%rename("") ""' didnt work.
'"%rename("%s") ""' is the right way to do that, so add it to the
example.

Fixes #2173