### PR TITLE
Remove redundant NULL checks before free()/delete

### DIFF
--- a/Doc/Manual/SWIG.html
+++ b/Doc/Manual/SWIG.html
@@ -1470,14 +1470,14 @@ SWIG generates the following code:
 <pre>
 /* C mode */
 void foo_set(char *value) {
-  if (foo) free(foo);
+  free(foo);
   foo = (char *) malloc(strlen(value)+1);
   strcpy(foo, value);
 }
 
 /* C++ mode.  When -c++ option is used */
 void foo_set(char *value) {
-  if (foo) delete [] foo;
+  delete [] foo;
   foo = new char[strlen(value)+1];
   strcpy(foo, value);
 }
@@ -2616,8 +2616,7 @@ char *Foo_name_get(Foo *obj) {
 }
 
 char *Foo_name_set(Foo *obj, char *c) {
-  if (obj-&gt;name)
-    free(obj-&gt;name);
+  free(obj-&gt;name);
   obj-&gt;name = (char *) malloc(strlen(c)+1);
   strcpy(obj-&gt;name, c);
   return obj-&gt;name;

--- a/Doc/Manual/Tcl.html
+++ b/Doc/Manual/Tcl.html
@@ -2811,9 +2811,7 @@ used as a <tt>char **</tt> object.
 
 // This gives SWIG some cleanup code that will get called after the function call
 %typemap(freearg) char ** {
-  if ($1) {
-    free($1);
-  }
+  free($1);
 }
 
 // Now a test functions

--- a/Doc/Manual/Typemaps.html
+++ b/Doc/Manual/Typemaps.html
@@ -3103,7 +3103,7 @@ as shown.   To work with heap allocated data, the following technique can be use
   }
 }
 %typemap(freearg) float value[ANY] {
-  if ($1) free($1);
+  free($1);
 }
 </pre>
 </div>
@@ -3556,7 +3556,7 @@ maps perform the conversion described for the above example:
 }
 
 %typemap(freearg) (int argc, char *argv[]) {
-  if ($2) free($2);
+  free($2);
 }
 
 /* Required for C++ method overloading */

--- a/Examples/guile/multimap/example.i
+++ b/Examples/guile/multimap/example.i
@@ -78,7 +78,7 @@ extern int count(char *bytes, int len, char c);
 
 %typemap(argout) (char *str, int len) {
   SWIG_APPEND_VALUE(scm_from_locale_stringn($1,$2));
-  if ($1) SWIG_free($1);
+  SWIG_free($1);
 }   
 
 extern void capitalize(char *str, int len);

--- a/Examples/test-suite/namespace_typemap.i
+++ b/Examples/test-suite/namespace_typemap.i
@@ -15,7 +15,7 @@ namespace test {
 	strcpy(data,s);
       }
      ~string_class() {
-        if (data) delete [] data;
+        delete [] data;
       }
       char *c_str() {
         return data;

--- a/Examples/xml/example_apply.expected-xml
+++ b/Examples/xml/example_apply.expected-xml
@@ -409,7 +409,7 @@ static void _ptrset(SV *_PTRVALUE, SV *value, int index, char *type) {
   } else if (strcmp(type,"char *") == 0) {
     char *c = SvPV(value,PL_na);
     char **ca = (char **) ptr;
-    if (ca[index]) free(ca[index]);
+    free(ca[index]);
     if (strcmp(c,"NULL") == 0) {
       ca[index] = 0;
     } else {
@@ -500,8 +500,7 @@ void _ptrfree(SV *_PTRVALUE) {
       }
     }
   }
-  if (ptr)
-    free((char *) ptr);
+  free((char *) ptr);
 }
 
                     </swigxml:code>

--- a/Examples/xml/example_xml.expected-xml
+++ b/Examples/xml/example_xml.expected-xml
@@ -441,7 +441,7 @@ static void _ptrset(SV *_PTRVALUE, SV *value, int index, char *type) {
   } else if (strcmp(type,"char *") == 0) {
     char *c = SvPV(value,PL_na);
     char **ca = (char **) ptr;
-    if (ca[index]) free(ca[index]);
+    free(ca[index]);
     if (strcmp(c,"NULL") == 0) {
       ca[index] = 0;
     } else {
@@ -532,8 +532,7 @@ void _ptrfree(SV *_PTRVALUE) {
       }
     }
   }
-  if (ptr)
-    free((char *) ptr);
+  free((char *) ptr);
 }
 
                     </swigxml:code>

--- a/Lib/cpointer.i
+++ b/Lib/cpointer.i
@@ -55,14 +55,14 @@ NAME() {
   return new TYPE();
 }
 ~NAME() {
-  if ($self) delete $self;
+  delete $self;
 }
 #else
 NAME() {
   return (TYPE *) calloc(1,sizeof(TYPE));
 }
 ~NAME() {
-  if ($self) free($self);
+  free($self);
 }
 #endif
 }
@@ -134,9 +134,9 @@ static TYPE *copy_##NAME(TYPE value) { %}
 
 static void delete_##NAME(TYPE *obj) { %}
 #ifdef __cplusplus
-%{  if (obj) delete obj; %}
+%{  delete obj; %}
 #else
-%{  if (obj) free(obj); %}
+%{  free(obj); %}
 #endif
 %{}
 

--- a/Lib/d/cpointer.i
+++ b/Lib/d/cpointer.i
@@ -54,14 +54,14 @@ NAME() {
   return new TYPE();
 }
 ~NAME() {
-  if (self) delete self;
+  delete self;
 }
 #else
 NAME() {
   return (TYPE *) calloc(1,sizeof(TYPE));
 }
 ~NAME() {
-  if (self) free(self);
+  free(self);
 }
 #endif
 }
@@ -133,9 +133,9 @@ static TYPE *copy_##NAME(TYPE value) { %}
 
 static void delete_##NAME(TYPE *self) { %}
 #ifdef __cplusplus
-%{  if (self) delete self; %}
+%{  delete self; %}
 #else
-%{  if (self) free(self); %}
+%{  free(self); %}
 #endif
 %{}
 

--- a/Lib/guile/list-vector.i
+++ b/Lib/guile/list-vector.i
@@ -107,7 +107,7 @@
                      (size_t VECTORLENINPUT, C_TYPE *VECTORINPUT),
                      (int LISTLENINPUT, C_TYPE *LISTINPUT),
                      (size_t LISTLENINPUT, C_TYPE *LISTINPUT)
-       {if ($2!=NULL) SWIG_free($2);}
+       SWIG_free($2);}
 
 %enddef
 
@@ -173,7 +173,7 @@
 	  (int *LISTLENOUTPUT, C_TYPE **LISTOUTPUT),
 	  (size_t *LISTLENOUTPUT, C_TYPE **LISTOUTPUT)
      {
-        if ((*$2)!=NULL) free(*$2);
+       free(*$2);
      }
 
 %enddef
@@ -231,7 +231,7 @@ TYPEMAP_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02scm, stri
 	 if ((*$2)!=NULL) {
 	     int i;
 	     for (i = 0; i < *$1; i++) {
-		 if ((*$2)[i] != NULL) free((*$2)[i]);
+		 free((*$2)[i]);
 	     }
 	     free(*$2);
 	 }
@@ -249,7 +249,7 @@ TYPEMAP_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02scm, stri
     if (($2)!=NULL) {
 	int i;
 	for (i = 0; i< $1; i++)
-	    if (($2)[i] != NULL) free(($2)[i]);
+	    free(($2)[i]);
 	free($2);
     }
 }
@@ -360,7 +360,7 @@ TYPEMAP_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02scm, stri
 		       const C_TYPE *PARALLEL_VECTORINPUT,
 		       C_TYPE *PARALLEL_LISTINPUT, 
 		       const C_TYPE *PARALLEL_LISTINPUT
-       {if ($1!=NULL) SWIG_free($1);}
+       SWIG_free($1);}
 
 %enddef
 
@@ -422,7 +422,7 @@ TYPEMAP_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02scm, stri
      %typemap(freearg) C_TYPE **PARALLEL_VECTOROUTPUT, 
 		       C_TYPE **PARALLEL_LISTOUTPUT
      {
-        if ((*$1)!=NULL) free(*$1);
+       free(*$1);
      }
 
 %enddef
@@ -471,7 +471,7 @@ TYPEMAP_PARALLEL_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02
     if (($1)!=NULL) {
 	int i;
 	for (i = 0; i<*_global_list_length; i++)
-	    if (($1)[i] != NULL) SWIG_free(($1)[i]);
+	    SWIG_free(($1)[i]);
 	SWIG_free($1);
     }
 }
@@ -482,7 +482,7 @@ TYPEMAP_PARALLEL_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02
     if ((*$1)!=NULL) {
 	int i;
 	for (i = 0; i<_global_arraylentemp; i++)
-	    if ((*$1)[i] != NULL) free((*$1)[i]);
+	    free((*$1)[i]);
 	free(*$1);
     }
 }

--- a/Lib/guile/list-vector.i
+++ b/Lib/guile/list-vector.i
@@ -107,7 +107,7 @@
                      (size_t VECTORLENINPUT, C_TYPE *VECTORINPUT),
                      (int LISTLENINPUT, C_TYPE *LISTINPUT),
                      (size_t LISTLENINPUT, C_TYPE *LISTINPUT)
-       SWIG_free($2);}
+       {SWIG_free($2);}
 
 %enddef
 
@@ -360,7 +360,7 @@ TYPEMAP_LIST_VECTOR_INPUT_OUTPUT(const char *, SWIG_scm2str, SWIG_str02scm, stri
 		       const C_TYPE *PARALLEL_VECTORINPUT,
 		       C_TYPE *PARALLEL_LISTINPUT, 
 		       const C_TYPE *PARALLEL_LISTINPUT
-       SWIG_free($1);}
+       {SWIG_free($1);}
 
 %enddef
 

--- a/Lib/guile/std_common.i
+++ b/Lib/guile/std_common.i
@@ -19,7 +19,7 @@ std::string SWIG_scm2string(SCM x) {
     char* temp;
     temp = SWIG_scm2str(x);
     std::string s(temp);
-    if (temp) SWIG_free(temp);
+    SWIG_free(temp);
     return s;
 }
 %}

--- a/Lib/guile/std_string.i
+++ b/Lib/guile/std_string.i
@@ -30,7 +30,7 @@ namespace std {
         if (scm_is_string($input)) {
             tempptr = SWIG_scm2str($input);
             $1.assign(tempptr);
-            if (tempptr) SWIG_free(tempptr);
+            SWIG_free(tempptr);
         } else {
             SWIG_exception(SWIG_TypeError, "string expected");
         }
@@ -40,7 +40,7 @@ namespace std {
         if (scm_is_string($input)) {
             tempptr = SWIG_scm2str($input);
             temp.assign(tempptr);
-            if (tempptr) SWIG_free(tempptr);
+            SWIG_free(tempptr);
             $1 = &temp;
         } else {
             SWIG_exception(SWIG_TypeError, "string expected");
@@ -51,7 +51,7 @@ namespace std {
         if (scm_is_string($input)) {
             tempptr = SWIG_scm2str($input);
             $1 = new $*1_ltype(tempptr);
-            if (tempptr) SWIG_free(tempptr);
+            SWIG_free(tempptr);
         } else {
             SWIG_exception(SWIG_TypeError, "string expected");
         }
@@ -73,7 +73,7 @@ namespace std {
         if (scm_is_string($input)) {
 	    char *tempptr = SWIG_scm2str($input);
             $1.assign(tempptr);
-            if (tempptr) SWIG_free(tempptr);
+            SWIG_free(tempptr);
         } else {
             SWIG_exception(SWIG_TypeError, "string expected");
         }

--- a/Lib/guile/typemaps.i
+++ b/Lib/guile/typemaps.i
@@ -322,8 +322,8 @@ SIMPLE_MAP(unsigned long long, scm_to_ulong_long, scm_from_ulong_long, integer);
 /* SWIG_scm2str makes a malloc'ed copy of the string, so get rid of it after
    the function call. */
 
-%typemap (freearg) char * "if (must_free$argnum && $1) SWIG_free($1);";
-%typemap (freearg) char **INPUT, char **BOTH "if (must_free$argnum && (*$1)) SWIG_free(*$1);"
+%typemap (freearg) char * "if (must_free$argnum) SWIG_free($1);";
+%typemap (freearg) char **INPUT, char **BOTH "if (must_free$argnum) SWIG_free(*$1);"
 %typemap (freearg) char **OUTPUT "SWIG_free(*$1);"
   
 /* But this shall not apply if we try to pass a single char by
@@ -334,7 +334,7 @@ SIMPLE_MAP(unsigned long long, scm_to_ulong_long, scm_from_ulong_long, integer);
 /* If we set a string variable, delete the old result first, unless const. */
 
 %typemap (varin) char * {
-    if ($1) free($1);
+    free($1);
     $1 = ($1_ltype) SWIG_scm2str($input);
 }
 

--- a/Lib/lua/typemaps.i
+++ b/Lib/lua/typemaps.i
@@ -192,10 +192,10 @@ int SWIG_read_NAME_num_array(lua_State* L,int index,TYPE *array,int size);
 There probably is some compiler that its not true for, so the code is left here just in case.
 #ifdef __cplusplus	
 #define SWIG_ALLOC_ARRAY(TYPE,LEN) 	new TYPE[LEN]
-#define SWIG_FREE_ARRAY(PTR)		if(PTR){delete[] PTR;}
+#define SWIG_FREE_ARRAY(PTR)		delete[] PTR
 #else
 #define SWIG_ALLOC_ARRAY(TYPE,LEN) 	(TYPE *)malloc(LEN*sizeof(TYPE))
-#define SWIG_FREE_ARRAY(PTR)		if(PTR){free(PTR);}
+#define SWIG_FREE_ARRAY(PTR)		free(PTR)
 #endif
 */
 %{

--- a/Lib/scilab/scirun.swg
+++ b/Lib/scilab/scirun.swg
@@ -47,10 +47,8 @@ static char *SWIG_Scilab_GetFuncName(void) {
   return SwigFuncName;
 }
 static void SWIG_Scilab_SetFuncName(char *funcName) {
-  if (SwigFuncName != NULL) {
-    free(SwigFuncName);
-    SwigFuncName = NULL;
-  }
+  free(SwigFuncName);
+  SwigFuncName = NULL;
   if (funcName) {
     SwigFuncName = (char *)malloc(strlen(funcName) + 1);
     if (SwigFuncName)

--- a/Lib/typemaps/cpointer.swg
+++ b/Lib/typemaps/cpointer.swg
@@ -55,7 +55,7 @@ typedef struct {
     return %new_instance(TYPE);
   }
   ~NAME() {
-    if ($self) %delete($self);
+    %delete($self);
   }
 }
 
@@ -114,7 +114,7 @@ typedef struct {
   }
 
   static void delete_##NAME(TYPE *obj) { 
-    if (obj) %delete(obj);
+    %delete(obj);
   }
 
   static void NAME ##_assign(TYPE *obj, TYPE value) {

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -994,7 +994,7 @@ int JSEmitter::emitDtor(Node *n) {
      {
      SWIG_PRV_DATA* t = (SWIG_PRV_DATA*)JSObjectGetPrivate(thisObject);
      if(t && t->swigCMemOwn) free ((${type}*)t->swigCObject);
-     if(t) free(t);
+     free(t);
      }
      %}
 
@@ -1007,7 +1007,7 @@ int JSEmitter::emitDtor(Node *n) {
      ${type}* arg1 = (${type}*)t->swigCObject;
      ${destructor_action}
      }
-     if(t) free(t);
+     free(t);
 
      Based on what I saw in the Lua and Ruby modules, I use Getattr(n, "wrap:action")
      to decide if the user has a preferred destructor action.


### PR DESCRIPTION
The ISO C and C++ standard guarantee that it's safe to call these
on a NULL pointer, so it's not necessary for the calling code to
also check.

Fixes https://sourceforge.net/p/swig/feature-requests/70/