### PR TITLE
[C#] Fix memory leak in directorin typemap for std::string.

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,10 @@ Version 4.1.0 (in progress)
 ===========================
 
 2022-02-03: olly
+	    [C#] #283 #998 Fix memory leak in directorin typemap for
+	    std::string.
+
+2022-02-03: olly
 	    [Python] #967 Make `self` parameter available to user typemaps.
 
 2022-02-03: teythoon

--- a/Lib/csharp/std_string.i
+++ b/Lib/csharp/std_string.i
@@ -20,7 +20,7 @@ namespace std {
 class string;
 
 // string
-%typemap(ctype) string "char *"
+%typemap(ctype) string "const char *"
 %typemap(imtype) string "string"
 %typemap(cstype) string "string"
 
@@ -42,7 +42,7 @@ class string;
    }
    $result.assign($input); %}
 
-%typemap(directorin) string %{ $input = SWIG_csharp_string_callback($1.c_str()); %}
+%typemap(directorin) string %{ $input = $1.c_str(); %}
 
 %typemap(csin) string "$csinput"
 %typemap(csout, excode=SWIGEXCODE) string {


### PR DESCRIPTION
Fixes #998