### PR TITLE
Add possibility to use only stable Python ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
           PY3: 3
           VER: '3.10'
         - SWIGLANG: python
+          PY3: 3
+          SWIG_FEATURES: -py3-stable-abi
+        - SWIGLANG: python
           SWIG_FEATURES: -builtin
         - SWIGLANG: python
           SWIG_FEATURES: -builtin -O

--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -14,6 +14,24 @@
 #include <vector>
 #include <map>
 
+#if defined(SWIG_PYTHON_THREADS)
+/*  __THREAD__ is the old macro to activate some thread support */
+# if !defined(__THREAD__)
+#   define __THREAD__ 1
+# endif
+#endif
+
+#ifdef __THREAD__
+#ifndef Py_LIMITED_API
+# include "pythread.h"
+#else
+# if defined(_WIN32)
+#   include <windows.h>
+# else
+#   include <pthread.h>
+# endif
+#endif
+#endif
 
 /*
   Use -DSWIG_PYTHON_DIRECTOR_NO_VTABLE if you don't want to generate a 'virtual
@@ -244,25 +262,89 @@ namespace Swig {
   };
 
 
-#if defined(SWIG_PYTHON_THREADS)
-/*  __THREAD__ is the old macro to activate some thread support */
-# if !defined(__THREAD__)
-#   define __THREAD__ 1
-# endif
-#endif
-
 #ifdef __THREAD__
-# include "pythread.h"
+#ifndef Py_LIMITED_API
+   class Mutex
+   {
+   public:
+       Mutex() {
+           mutex_ = PyThread_allocate_lock();
+       }
+
+       ~Mutex() {
+           PyThread_release_lock(mutex_);
+       }
+
+   private:
+       void Lock() {
+           PyThread_acquire_lock(mutex_, WAIT_LOCK);
+       }
+
+       void Unlock() {
+           PyThread_free_lock(mutex_);
+       }
+
+       PyThread_type_lock mutex_;
+
+       friend class Guard;
+   };
+#elif defined(_WIN32)
+    class Mutex : private CRITICAL_SECTION {
+    public:
+        Mutex() {
+            InitializeCriticalSection(this);
+        }
+
+        ~Mutex() {
+            DeleteCriticalSection(this);
+        }
+
+    private:
+        void Lock() {
+            EnterCriticalSection(this);
+        }
+
+        void Unlock() {
+            LeaveCriticalSection(this);
+        }
+
+        friend class Guard;
+    };
+#else
+    class Mutex {
+    public:
+        Mutex() {
+            pthread_mutex_init(&mutex_, NULL);
+        }
+
+        ~Mutex() {
+            pthread_mutex_destroy(&mutex_);
+        }
+
+    private:
+        void Lock() {
+            pthread_mutex_lock(&mutex_);
+        }
+
+        void Unlock() {
+            pthread_mutex_unlock(&mutex_);
+        }
+
+        friend class Guard;
+
+        pthread_mutex_t mutex_;
+    };
+#endif
   class Guard {
-    PyThread_type_lock &mutex_;
+    Mutex &mutex_;
 
   public:
-    Guard(PyThread_type_lock & mutex) : mutex_(mutex) {
-      PyThread_acquire_lock(mutex_, WAIT_LOCK);
+    Guard(Mutex & mutex) : mutex_(mutex) {
+      mutex_.Lock();
     }
 
     ~Guard() {
-      PyThread_release_lock(mutex_);
+      mutex_.Unlock();
     }
   };
 # define SWIG_GUARD(mutex) Guard _guard(mutex)
@@ -330,7 +412,7 @@ namespace Swig {
     typedef std::map<void *, GCItem_var> swig_ownership_map;
     mutable swig_ownership_map swig_owner;
 #ifdef __THREAD__
-    static PyThread_type_lock swig_mutex_own;
+    static Mutex swig_mutex_own;
 #endif
 
   public:
@@ -382,7 +464,7 @@ namespace Swig {
   };
 
 #ifdef __THREAD__
-  PyThread_type_lock Director::swig_mutex_own = PyThread_allocate_lock();
+  Mutex Director::swig_mutex_own;
 #endif
 }
 

--- a/Lib/python/pybuffer.i
+++ b/Lib/python/pybuffer.i
@@ -12,18 +12,43 @@
  *      }
  */
 
+/* Note that in Py_LIMITED_API case we have no choice, but to use deprecated
+ * functions, as they provides the only way to access buffer data with limited
+ * API, which doesn't include Py_buffer definition. We also disable the
+ * warnings about doing this because they're not useful in our case.
+ */
+
 %define %pybuffer_mutable_binary(TYPEMAP, SIZE)
 %typemap(in) (TYPEMAP, SIZE) {
   int res; Py_ssize_t size = 0; void *buf = 0;
+%#ifndef Py_LIMITED_API
   Py_buffer view;
   res = PyObject_GetBuffer($input, &view, PyBUF_WRITABLE);
+%#else
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic push
+    %#pragma GCC diagnostic ignored "-Wdeprecated"
+    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  %#elif defined(_MSC_VER)
+    %#pragma warning(push)
+    %#pragma warning(disable: 4996)
+  %#endif
+  res = PyObject_AsWriteBuffer($input, &buf, &size);
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic pop
+  %#elif defined(_MSC_VER)
+    %#pragma warning(pop)
+  %#endif
+%#endif
   if (res < 0) {
     PyErr_Clear();
     %argument_fail(res, "(TYPEMAP, SIZE)", $symname, $argnum);
   }
+%#ifndef Py_LIMITED_API
   size = view.len;
   buf = view.buf;
   PyBuffer_Release(&view);
+%#endif
   $1 = ($1_ltype) buf;
   $2 = ($2_ltype) (size/sizeof($*1_type));
 }
@@ -45,14 +70,34 @@
 %define %pybuffer_mutable_string(TYPEMAP)
 %typemap(in) (TYPEMAP) {
   int res; void *buf = 0;
+%#ifndef Py_LIMITED_API
   Py_buffer view;
   res = PyObject_GetBuffer($input, &view, PyBUF_WRITABLE);
+%#else
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic push
+    %#pragma GCC diagnostic ignored "-Wdeprecated"
+    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  %#elif defined(_MSC_VER)
+    %#pragma warning(push)
+    %#pragma warning(disable: 4996)
+  %#endif
+  Py_ssize_t size;
+  res = PyObject_AsWriteBuffer($input, &buf, &size);
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic pop
+  %#elif defined(_MSC_VER)
+    %#pragma warning(pop)
+  %#endif
+%#endif
   if (res < 0) {
     PyErr_Clear();
     %argument_fail(res, "(TYPEMAP)", $symname, $argnum);
   }
+%#ifndef Py_LIMITED_API
   buf = view.buf;
   PyBuffer_Release(&view);
+%#endif
   $1 = ($1_ltype) buf;
 }
 %enddef
@@ -74,15 +119,34 @@
 %define %pybuffer_binary(TYPEMAP, SIZE)
 %typemap(in) (TYPEMAP, SIZE) {
   int res; Py_ssize_t size = 0; const void *buf = 0;
+%#ifndef Py_LIMITED_API
   Py_buffer view;
   res = PyObject_GetBuffer($input, &view, PyBUF_CONTIG_RO);
+%#else
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic push
+    %#pragma GCC diagnostic ignored "-Wdeprecated"
+    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  %#elif defined(_MSC_VER)
+    %#pragma warning(push)
+    %#pragma warning(disable: 4996)
+  %#endif
+  res = PyObject_AsReadBuffer($input, &buf, &size);
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic pop
+  %#elif defined(_MSC_VER)
+    %#pragma warning(pop)
+  %#endif
+%#endif
   if (res < 0) {
     PyErr_Clear();
     %argument_fail(res, "(TYPEMAP, SIZE)", $symname, $argnum);
   }
+%#ifndef Py_LIMITED_API
   size = view.len;
   buf = view.buf;
   PyBuffer_Release(&view);
+%#endif
   $1 = ($1_ltype) buf;
   $2 = ($2_ltype) (size / sizeof($*1_type));
 }
@@ -106,14 +170,34 @@
 %define %pybuffer_string(TYPEMAP)
 %typemap(in) (TYPEMAP) {
   int res; const void *buf = 0;
+%#ifndef Py_LIMITED_API
   Py_buffer view;
   res = PyObject_GetBuffer($input, &view, PyBUF_CONTIG_RO);
+%#else
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic push
+    %#pragma GCC diagnostic ignored "-Wdeprecated"
+    %#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  %#elif defined(_MSC_VER)
+    %#pragma warning(push)
+    %#pragma warning(disable: 4996)
+  %#endif
+  Py_ssize_t size;
+  res = PyObject_AsReadBuffer($input, &buf, &size);
+  %#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+    %#pragma GCC diagnostic pop
+  %#elif defined(_MSC_VER)
+    %#pragma warning(pop)
+  %#endif
+%#endif
   if (res < 0) {
     PyErr_Clear();
     %argument_fail(res, "(TYPEMAP)", $symname, $argnum);
   }
+%#ifndef Py_LIMITED_API
   buf = view.buf;
   PyBuffer_Release(&view);
+%#endif
   $1 = ($1_ltype) buf;
 }
 %enddef

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -87,3 +87,17 @@ SWIG_Python_str_FromChar(const char *c)
 #define PyDescr_NAME(x) (((PyDescrObject *)(x))->d_name)
 #define Py_hash_t long
 #endif
+
+#ifdef Py_LIMITED_API
+# define PyTuple_GET_ITEM PyTuple_GetItem
+/* Note that PyTuple_SetItem() has different semantics from PyTuple_SET_ITEM as it decref's the original tuple item, so in general they cannot be used
+  interchangeably. However in SWIG-generated code PyTuple_SET_ITEM is only used with newly initialized tuples without any items and for them this does work. */
+# define PyTuple_SET_ITEM PyTuple_SetItem
+# define PyTuple_GET_SIZE PyTuple_Size
+# define PyCFunction_GET_FLAGS PyCFunction_GetFlags
+# define PyCFunction_GET_FUNCTION PyCFunction_GetFunction
+# define PyCFunction_GET_SELF PyCFunction_GetSelf
+# define PyList_GET_ITEM PyList_GetItem
+# define PyList_SET_ITEM PyList_SetItem
+# define PySliceObject PyObject
+#endif

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -36,7 +36,7 @@
 SWIGINTERN char*
 SWIG_Python_str_AsChar(PyObject *str)
 {
-#if PY_VERSION_HEX >= 0x03030000
+#if PY_VERSION_HEX >= 0x03030000 && !defined(Py_LIMITED_API)
   return (char *)PyUnicode_AsUTF8(str);
 #elif PY_VERSION_HEX >= 0x03000000
   char *newstr = 0;
@@ -57,7 +57,7 @@ SWIG_Python_str_AsChar(PyObject *str)
 #endif
 }
 
-#if PY_VERSION_HEX >= 0x03030000 || PY_VERSION_HEX < 0x03000000
+#if (PY_VERSION_HEX >= 0x03030000 && !defined(Py_LIMITED_API)) || PY_VERSION_HEX < 0x03000000
 #  define SWIG_Python_str_DelForPy3(x)
 #else
 #  define SWIG_Python_str_DelForPy3(x) free( (void*) (x) )

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -334,6 +334,7 @@ swig_varlink_setattr(swig_varlinkobject *v, char *n, PyObject *p) {
 SWIGINTERN PyTypeObject*
 swig_varlink_type(void) {
   static char varlink__doc__[] = "Swig var link object";
+#ifndef Py_LIMITED_API
   static PyTypeObject varlink_type;
   static int type_init = 0;
   if (!type_init) {
@@ -394,12 +395,28 @@ swig_varlink_type(void) {
       return NULL;
   }
   return &varlink_type;
+#else // Py_LIMITED_API
+  PyType_Slot slots[] = {
+    { Py_tp_dealloc, (void*)swig_varlink_dealloc },
+    { Py_tp_repr, (void*)swig_varlink_repr },
+    { Py_tp_getattr, (void*)swig_varlink_getattr },
+    { Py_tp_setattr, (void*)swig_varlink_setattr },
+    { Py_tp_str, (void*)swig_varlink_str },
+    { Py_tp_doc, (void*)varlink__doc__ },
+    { 0, NULL }
+  };
+  PyType_Spec spec = {};
+  spec.name = "swigvarlink";
+  spec.basicsize = sizeof(swig_varlinkobject);
+  spec.slots = slots;
+  return (PyTypeObject*)PyType_FromSpec(&spec);
+#endif // Py_LIMITED_API
 }
 
 /* Create a variable linking object for use later */
 SWIGINTERN PyObject *
 SWIG_Python_newvarlink(void) {
-  swig_varlinkobject *result = PyObject_NEW(swig_varlinkobject, swig_varlink_type());
+  swig_varlinkobject *result = PyObject_New(swig_varlinkobject, swig_varlink_type());
   if (result) {
     result->vars = 0;
   }
@@ -710,6 +727,14 @@ SwigPyObject_Check(PyObject *op) {
   if (PyType_IsSubtype(op->ob_type, target_tp))
     return 1;
   return (strcmp(op->ob_type->tp_name, "SwigPyObject") == 0);
+#elif defined(Py_LIMITED_API)
+  int cmp;
+  PyObject *tp_name = PyObject_GetAttrString((PyObject*)Py_TYPE(op), "__name__");
+  if (!tp_name)
+    return 0;
+  cmp = PyUnicode_CompareWithASCIIString(tp_name, "SwigPyObject");
+  Py_DECREF(tp_name);
+  return cmp == 0;
 #else
   return (Py_TYPE(op) == SwigPyObject_type())
     || (strcmp(Py_TYPE(op)->tp_name,"SwigPyObject") == 0);
@@ -852,7 +877,7 @@ swigobject_methods[] = {
 SWIGRUNTIME PyTypeObject*
 SwigPyObject_TypeOnce(void) {
   static char swigobject_doc[] = "Swig object carries a C/C++ instance pointer";
-
+#ifndef Py_LIMITED_API
   static PyNumberMethods SwigPyObject_as_number = {
     (binaryfunc)0, /*nb_add*/
     (binaryfunc)0, /*nb_subtract*/
@@ -980,12 +1005,30 @@ SwigPyObject_TypeOnce(void) {
       return NULL;
   }
   return &swigpyobject_type;
+#else // Py_LIMITED_API
+  PyType_Slot slots[] = {
+    { Py_tp_dealloc, (void*)SwigPyObject_dealloc },
+    { Py_tp_repr, (void*)SwigPyObject_repr },
+    { Py_tp_getattro, (void*)PyObject_GenericGetAttr },
+    { Py_tp_doc, (void*)swigobject_doc },
+    { Py_tp_richcompare, (void*)SwigPyObject_richcompare },
+    { Py_tp_methods, (void*)swigobject_methods },
+    { Py_nb_int, (void*)SwigPyObject_long },
+    { 0, NULL }
+  };
+  PyType_Spec spec = {};
+  spec.name = "SwigPyObject";
+  spec.basicsize = sizeof(SwigPyObject);
+  spec.flags = Py_TPFLAGS_DEFAULT;
+  spec.slots = slots;
+  return (PyTypeObject*)PyType_FromSpec(&spec);
+#endif // Py_LIMITED_API
 }
 
 SWIGRUNTIME PyObject *
 SwigPyObject_New(void *ptr, swig_type_info *ty, int own)
 {
-  SwigPyObject *sobj = PyObject_NEW(SwigPyObject, SwigPyObject_type());
+  SwigPyObject *sobj = PyObject_New(SwigPyObject, SwigPyObject_type());
   if (sobj) {
     sobj->ptr  = ptr;
     sobj->ty   = ty;
@@ -1050,8 +1093,18 @@ SwigPyPacked_type(void) {
 
 SWIGRUNTIMEINLINE int
 SwigPyPacked_Check(PyObject *op) {
+#ifndef Py_LIMITED_API
   return ((op)->ob_type == SwigPyPacked_TypeOnce()) 
     || (strcmp((op)->ob_type->tp_name,"SwigPyPacked") == 0);
+#else
+  int cmp;
+  PyObject *tp_name = PyObject_GetAttrString((PyObject*)Py_TYPE(op), "__name__");
+  if (!tp_name)
+    return 0;
+  cmp = PyUnicode_CompareWithASCIIString(tp_name, "SwigPyPacked");
+  Py_DECREF(tp_name);
+  return cmp == 0;
+#endif
 }
 
 SWIGRUNTIME void
@@ -1067,6 +1120,7 @@ SwigPyPacked_dealloc(PyObject *v)
 SWIGRUNTIME PyTypeObject*
 SwigPyPacked_TypeOnce(void) {
   static char swigpacked_doc[] = "Swig object carries a C/C++ instance pointer";
+#ifndef Py_LIMITED_API
   static PyTypeObject swigpypacked_type;
   static int type_init = 0;
   if (!type_init) {
@@ -1150,12 +1204,28 @@ SwigPyPacked_TypeOnce(void) {
       return NULL;
   }
   return &swigpypacked_type;
+#else
+  PyType_Slot slots[] = {
+    { Py_tp_dealloc, (void*)SwigPyPacked_dealloc },
+    { Py_tp_repr, (void*)SwigPyPacked_repr },
+    { Py_tp_str, (void*)SwigPyPacked_str },
+    { Py_tp_getattro, (void*)PyObject_GenericGetAttr },
+    { Py_tp_doc, swigpacked_doc },
+    { 0, NULL }
+  };
+  PyType_Spec spec = {};
+  spec.name = "SwigPyPacked";
+  spec.basicsize = sizeof(SwigPyPacked);
+  spec.flags = Py_TPFLAGS_DEFAULT;
+  spec.slots = slots;
+  return (PyTypeObject*)PyType_FromSpec(&spec);
+#endif
 }
 
 SWIGRUNTIME PyObject *
 SwigPyPacked_New(void *ptr, size_t size, swig_type_info *ty)
 {
-  SwigPyPacked *sobj = PyObject_NEW(SwigPyPacked, SwigPyPacked_type());
+  SwigPyPacked *sobj = PyObject_New(SwigPyPacked, SwigPyPacked_type());
   if (sobj) {
     void *pack = malloc(size);
     if (pack) {
@@ -1400,10 +1470,18 @@ SWIG_Python_ConvertFunctionPtr(PyObject *obj, void **ptr, swig_type_info *ty) {
     swig_cast_info *tc;
 
     /* here we get the method pointer for callbacks */
+#ifndef Py_LIMITED_API
     const char *doc = (((PyCFunctionObject *)obj) -> m_ml -> ml_doc);
+#else
+    PyObject* pystr_doc = PyObject_GetAttrString(obj, "__doc__");
+    const char *doc = pystr_doc ? SWIG_Python_str_AsChar(pystr_doc) : 0;
+#endif
     const char *desc = doc ? strstr(doc, "swig_ptr: ") : 0;
     if (desc)
       desc = ty ? SWIG_UnpackVoidPtr(desc + 10, &vptr, ty->name) : 0;
+#ifdef Py_LIMITED_API
+    SWIG_Python_str_DelForPy3(doc);
+#endif
     if (!desc)
       return SWIG_ERROR;
     tc = SWIG_TypeCheck(desc,ty);
@@ -1479,14 +1557,23 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
     if (empty_args) {
       PyObject *empty_kwargs = PyDict_New();
       if (empty_kwargs) {
-        inst = ((PyTypeObject *)data->newargs)->tp_new((PyTypeObject *)data->newargs, empty_args, empty_kwargs);
+#ifndef Py_LIMITED_API
+        newfunc newfn = ((PyTypeObject *)data->newargs)->tp_new;
+#else
+        newfunc newfn = (newfunc)PyType_GetSlot((PyTypeObject *)data->newargs, Py_tp_new);
+#endif
+        inst = newfn((PyTypeObject *)data->newargs, empty_args, empty_kwargs);
         Py_DECREF(empty_kwargs);
         if (inst) {
           if (PyObject_SetAttr(inst, SWIG_This(), swig_this) == -1) {
             Py_DECREF(inst);
             inst = 0;
           } else {
+#ifndef Py_LIMITED_API
             Py_TYPE(inst)->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
+#else
+            PyType_Modified(Py_TYPE(inst));
+#endif
           }
         }
       }
@@ -1561,7 +1648,12 @@ SWIG_Python_NewPointerObj(PyObject *self, void *ptr, swig_type_info *type, int f
     if (flags & SWIG_BUILTIN_TP_INIT) {
       newobj = (SwigPyObject*) self;
       if (newobj->ptr) {
-        PyObject *next_self = clientdata->pytype->tp_alloc(clientdata->pytype, 0);
+#ifndef Py_LIMITED_API
+        allocfunc alloc = clientdata->pytype->tp_alloc;
+#else
+        allocfunc alloc = (allocfunc)PyType_GetSlot(clientdata->pytype, Py_tp_alloc);
+#endif
+        PyObject *next_self = alloc(clientdata->pytype, 0);
         while (newobj->next)
 	  newobj = (SwigPyObject *) newobj->next;
         newobj->next = next_self;
@@ -1779,6 +1871,7 @@ SWIG_Python_TypeError(const char *type, PyObject *obj)
     } else 
 #endif      
     {
+#ifndef Py_LIMITED_API // tp_name is not accessible
       const char *otype = (obj ? obj->ob_type->tp_name : 0); 
       if (otype) {
 	PyObject *str = PyObject_Str(obj);
@@ -1794,6 +1887,7 @@ SWIG_Python_TypeError(const char *type, PyObject *obj)
 	Py_XDECREF(str);
 	return;
       }
+#endif
     }   
     PyErr_Format(PyExc_TypeError, "a '%s' is expected", type);
   } else {

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -471,14 +471,6 @@ public:
       SWIG_exit(EXIT_FAILURE);
     }
 
-    if (py3_stable_abi && threads && directorsEnabled()) {
-      // directors + threads uses PyThread_* APIs, which are not exported from python3.dll on Windows,
-      // despite nominally being a part of the stable ABI. 
-      // To prevent confusing users with linker errors, we disable this combination.  
-      Printf(stderr, "-py3-stable-abi, -threads and -directors options are not compatible.\n");
-      SWIG_exit(EXIT_FAILURE);
-    }
-
     if (py3_stable_abi && fastproxy) {
       Printf(stderr, "-py3-stable-abi and -fastproxy options are not compatible.  Disabling -fastproxy.\n");
       fastproxy = 0;


### PR DESCRIPTION
This rebases the changes of #1613 on master (this is not just a trivial rebase because the code affected by the original changes has been changed/moved around several times in master), includes the additional changes of #1687 and #1727 that I had to do on top of it and, finally, adds a CI build using the new option.

@wsfulton Please consider merging this. This PR doesn't change anything for the existing use cases and just adds an extremely useful new option. And I've just spent a couple more hours on fixing this yet again, because it's too useful to not have it, but I simply can't keep doing it forever, it's too time/energy-consuming and morale-sapping.