### PR TITLE
[Python] Improve handling of SWIG_Py*Method_New

### DIFF
--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -8,6 +8,8 @@
 %fragment("<stddef.h>"); // For offsetof
 #endif
 
+#if defined SWIGPYTHON_FASTPROXY && !defined SWIGPYTHON_BUILTIN
+
 %insert(runtime) %{
 #ifdef __cplusplus
 extern "C" {
@@ -23,6 +25,8 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 }
 #endif
 %}
+
+#endif
 
 %init %{
 
@@ -103,6 +107,8 @@ SWIG_Python_FixMethods(PyMethodDef *methods, const swig_const_info *const_table,
   }
 } 
 
+#if defined SWIGPYTHON_FASTPROXY && !defined SWIGPYTHON_BUILTIN
+
 /* -----------------------------------------------------------------------------
  * Method creation and docstring support functions
  * ----------------------------------------------------------------------------- */
@@ -160,6 +166,8 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
   }
   return PyStaticMethod_New(func);
 }
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -452,6 +452,10 @@ public:
       SWIG_exit(EXIT_FAILURE);
     }
 
+    if (fastproxy) {
+      Preprocessor_define("SWIGPYTHON_FASTPROXY", 0);
+    }
+
     if (doxygen)
       doxygenTranslator = new PyDocConverter(doxygen_translator_flags);
 
@@ -617,6 +621,10 @@ public:
 
     if (builtin) {
       Printf(f_runtime, "#define SWIGPYTHON_BUILTIN\n");
+    }
+
+    if (fastproxy) {
+      Printf(f_runtime, "#define SWIGPYTHON_FASTPROXY\n");
     }
 
     Printf(f_runtime, "\n");
@@ -922,15 +930,15 @@ public:
    * as a replacement of new.instancemethod in Python 3.
    * ------------------------------------------------------------ */
   int add_pyinstancemethod_new() {
-    String *name = NewString("SWIG_PyInstanceMethod_New");
-    String *line = NewString("");
-    Printf(line, "\t { \"%s\", %s, METH_O, NULL},\n", name, name);
-    Append(methods, line);
-    if (fastproxy) {
+    if (!builtin && fastproxy) {
+      String *name = NewString("SWIG_PyInstanceMethod_New");
+      String *line = NewString("");
+      Printf(line, "\t { \"%s\", %s, METH_O, NULL},\n", name, name);
+      Append(methods, line);
       Append(methods_proxydocs, line);
+      Delete(line);
+      Delete(name);
     }
-    Delete(line);
-    Delete(name);
     return 0;
   }
 
@@ -940,7 +948,7 @@ public:
    * generated for static methods when using -fastproxy
    * ------------------------------------------------------------ */
   int add_pystaticmethod_new() {
-    if (fastproxy) {
+    if (!builtin && fastproxy) {
       String *name = NewString("SWIG_PyStaticMethod_New");
       String *line = NewString("");
       Printf(line, "\t { \"%s\", %s, METH_O, NULL},\n", name, name);


### PR DESCRIPTION
The SWIG_PyInstanceMethod_New method is no longer added to wrapped
classes except when it's actually needed, which is when
(!builtin && fastproxy) is true (which it isn't by default).

The SWIG_PyStaticMethod_New method is no longer is now similarly
gated - previously only (fastproxy) was checked.

Finally the C/C++ functions that implement these were always compiled
into the module, but now they're only included if
(!builtin && fastproxy) is true.

Issue noted by vadz in #2190.