### PR TITLE
Auto-detect non-assignable classes

### DIFF
--- a/Examples/test-suite/apply_signed_char.i
+++ b/Examples/test-suite/apply_signed_char.i
@@ -35,7 +35,5 @@
     const char memberconstchar;
 
     virtual ~DirectorTest() {}
-  private:
-    DirectorTest& operator=(const DirectorTest &);
   };
 %}

--- a/Examples/test-suite/bools.i
+++ b/Examples/test-suite/bools.i
@@ -62,8 +62,6 @@ struct BoolStructure {
     m_rbool(m_bool2),
     m_const_pbool(m_pbool),
     m_const_rbool(m_rbool) {}
-private:
-  BoolStructure& operator=(const BoolStructure &);
 };
 %}
 

--- a/Examples/test-suite/constant_pointers.i
+++ b/Examples/test-suite/constant_pointers.i
@@ -53,8 +53,6 @@ public:
     int* array_member1[ARRAY_SIZE];
     ParametersTest* array_member2[ARRAY_SIZE];
     MemberVariablesTest() : member3(NULL), member4(NULL) {}
-private:
-  MemberVariablesTest& operator=(const MemberVariablesTest&);
 };
 void foofunction(const int *const i) {}
 
@@ -80,8 +78,6 @@ public:
     void ret8(int*const& a) {}
     int*const& ret9() {return GlobalIntPtr;}
     ReturnValuesTest() : int3(NULL) {}
-private:
-  ReturnValuesTest& operator=(const ReturnValuesTest&);
 };
 
 const int* globalRet1() {return &GlobalInt;}
@@ -113,8 +109,6 @@ int* const globalRet2() {return &GlobalInt;}
     A* ap;
     const A* cap;
     Acptr acptr;  
-  private:
-    B& operator=(const B&);
   };
 
   const B* bar(const B* b) {

--- a/Examples/test-suite/cpp_basic.i
+++ b/Examples/test-suite/cpp_basic.i
@@ -74,15 +74,15 @@ class Bar {
     Foo *testFoo(int a, Foo *f) {
       return new Foo(2 * a + (f ? f->num : 0) + fval.num);
     }
-/* Const member data means this class can't be assigned.
+/* Const member data and references mean this class can't be assigned.
 private:
     Bar& operator=(const Bar&);
 */
 };
 
-// This class is valid C++ but cannot be assigned to.
-struct JustConstMemberData {
-explicit JustConstMemberData(int i_inp) : i(i_inp) {}
+// This class is valid C++ but cannot be assigned to because it has const member data.
+struct JustConst {
+explicit JustConst(int i_inp) : i(i_inp) {}
 const int i;
 };
 

--- a/Examples/test-suite/cpp_basic.i
+++ b/Examples/test-suite/cpp_basic.i
@@ -74,8 +74,10 @@ class Bar {
     Foo *testFoo(int a, Foo *f) {
       return new Foo(2 * a + (f ? f->num : 0) + fval.num);
     }
+/* Const member data means this class can't be assigned.
 private:
     Bar& operator=(const Bar&);
+*/
 };
 
 %}

--- a/Examples/test-suite/cpp_basic.i
+++ b/Examples/test-suite/cpp_basic.i
@@ -80,6 +80,12 @@ private:
 */
 };
 
+// This class is valid C++ but cannot be assigned to.
+struct JustConstMemberData {
+explicit JustConstMemberData(int i_inp) : i(i_inp) {}
+const int i;
+};
+
 %}
 
 %{

--- a/Examples/test-suite/enum_thorough.i
+++ b/Examples/test-suite/enum_thorough.i
@@ -89,8 +89,6 @@ struct SpeedClass {
   const colour myColour2;
   speedtd1 mySpeedtd1;
   SpeedClass() : myColour2(red), mySpeedtd1(slow) { }
-private:
-  SpeedClass& operator=(const SpeedClass&);
 };
 
 int                            speedTest0(int s) { return s; }

--- a/Examples/test-suite/java_typemaps_proxy.i
+++ b/Examples/test-suite/java_typemaps_proxy.i
@@ -119,8 +119,6 @@ public:
   void const_member_method(const ConstWithout *p) const {}
   const ConstWithout * const_var;
   const ConstWithout * const var_const;
-private:
-  ConstWithout& operator=(const ConstWithout &);
 };
 const ConstWithout * global_constwithout = 0;
 void global_method_constwithout(const ConstWithout *p) {}

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -779,6 +779,15 @@ Allocate():
 
       if (Swig_storage_isstatic(n)) {
 	Setattr(n, "cplus:staticbase", inclass);
+      } else if (Cmp(Getattr(n, "kind"), "variable") == 0) {
+        /* Check member variable to determine whether assignment is valid */
+        if (GetFlag(n, "feature:immutable")) {
+          /* Can't assign a class with an immutable member variable */
+	  Setattr(inclass, "allocate:noassign", "1");
+        } else if (SwigType_isreference(Getattr(n, "type"))) {
+          /* Can't assign a class with reference member data */
+	  Setattr(inclass, "allocate:noassign", "1");
+        }
       }
 
       String *name = Getattr(n, "name");

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -781,10 +781,7 @@ Allocate():
 	Setattr(n, "cplus:staticbase", inclass);
       } else if (Cmp(Getattr(n, "kind"), "variable") == 0) {
         /* Check member variable to determine whether assignment is valid */
-        if (GetFlag(n, "feature:immutable")) {
-          /* Can't assign a class with an immutable member variable */
-	  Setattr(inclass, "allocate:noassign", "1");
-        } else if (SwigType_isreference(Getattr(n, "type"))) {
+        if (SwigType_isreference(Getattr(n, "type"))) {
           /* Can't assign a class with reference member data */
 	  Setattr(inclass, "allocate:noassign", "1");
         }


### PR DESCRIPTION
Classes with references or const data are now marked as 'noassign'. This removes the need for numerous explicit `private: operator=` declarations in SWIG.