### PR TITLE
Mark 'externc' storage for variables

### DIFF
--- a/Examples/test-suite/cpp11_thread_local.i
+++ b/Examples/test-suite/cpp11_thread_local.i
@@ -16,9 +16,9 @@ thread_local static int tsval;
 extern thread_local int etval;
 thread_local extern int teval;
 extern "C" thread_local int ectval;
-extern "C" { thread_local int ectval2; }
+extern "C" { thread_local int ectval2 = 56; }
 extern "C++" thread_local int ecpptval;
-extern "C++" { thread_local int ecpptval2; }
+extern "C++" { thread_local int ecpptval2 = 67; }
 
 thread_local int ThreadLocals::stval = 11;
 thread_local int ThreadLocals::tsval = 22;
@@ -32,8 +32,6 @@ thread_local const int ThreadLocals::tscval99;
 // externs
 thread_local int etval = 33;
 thread_local int teval = 44;
-thread_local int ectval = 55;
-thread_local int ectval2 = 56;
+extern "C" thread_local int ectval = 55;
 thread_local int ecpptval = 66;
-thread_local int ecpptval2 = 67;
 %}

--- a/Examples/test-suite/cpp11_thread_local.i
+++ b/Examples/test-suite/cpp11_thread_local.i
@@ -18,6 +18,7 @@ thread_local extern int teval;
 extern "C" thread_local int ectval;
 extern "C" { thread_local int ectval2; }
 extern "C++" thread_local int ecpptval;
+extern "C++" { thread_local int ecpptval2; }
 
 thread_local int ThreadLocals::stval = 11;
 thread_local int ThreadLocals::tsval = 22;
@@ -34,4 +35,5 @@ thread_local int teval = 44;
 thread_local int ectval = 55;
 thread_local int ectval2 = 56;
 thread_local int ecpptval = 66;
+thread_local int ecpptval2 = 67;
 %}

--- a/Examples/test-suite/cpp11_thread_local.i
+++ b/Examples/test-suite/cpp11_thread_local.i
@@ -32,6 +32,10 @@ thread_local const int ThreadLocals::tscval99;
 // externs
 thread_local int etval = 33;
 thread_local int teval = 44;
-extern "C" thread_local int ectval = 55;
+extern "C" {
+thread_local int ectval = 55;
+}
+extern "C++" {
 thread_local int ecpptval = 66;
+}
 %}

--- a/Examples/test-suite/cpp11_thread_local.i
+++ b/Examples/test-suite/cpp11_thread_local.i
@@ -16,6 +16,7 @@ thread_local static int tsval;
 extern thread_local int etval;
 thread_local extern int teval;
 extern "C" thread_local int ectval;
+extern "C" { thread_local int ectval2; }
 extern "C++" thread_local int ecpptval;
 
 thread_local int ThreadLocals::stval = 11;
@@ -31,5 +32,6 @@ thread_local const int ThreadLocals::tscval99;
 thread_local int etval = 33;
 thread_local int teval = 44;
 thread_local int ectval = 55;
+thread_local int ectval2 = 56;
 thread_local int ecpptval = 66;
 %}

--- a/Examples/test-suite/extern_c.i
+++ b/Examples/test-suite/extern_c.i
@@ -5,6 +5,7 @@ extern "C" {
 void RealFunction(int value);
 typedef void Function1(int value); // Fails
 typedef int Integer1;
+int Integer3;
 }
 typedef void Function2(int value); // Works
 typedef int Integer2;
@@ -27,5 +28,14 @@ Hook2_t hook2;
 
 extern "C" typedef int Integer;
 Integer int1;
+extern "C" int int2;
+extern "C" { extern int int3; }
+extern "C" { int int4 = 789; }
 %}
 
+%{
+extern "C" {
+  int int2 = 123;
+  int int3 = 456;
+}
+%}

--- a/Examples/test-suite/extern_c.i
+++ b/Examples/test-suite/extern_c.i
@@ -31,6 +31,8 @@ Integer int1;
 extern "C" int int2;
 extern "C" { extern int int3; }
 extern "C" { int int4 = 789; }
+extern "C" thread_local int int_tl;
+extern "C" { thread_local int int_tl2; }
 %}
 
 %{

--- a/Examples/test-suite/extern_c.i
+++ b/Examples/test-suite/extern_c.i
@@ -31,8 +31,6 @@ Integer int1;
 extern "C" int int2;
 extern "C" { extern int int3; }
 extern "C" { int int4 = 789; }
-extern "C" thread_local int int_tl;
-extern "C" { thread_local int int_tl2; }
 %}
 
 %{

--- a/Examples/test-suite/python/extern_c_runme.py
+++ b/Examples/test-suite/python/extern_c_runme.py
@@ -1,3 +1,6 @@
 import extern_c
 
 extern_c.RealFunction(2)
+assert extern_c.cvar.int2 == 123
+assert extern_c.cvar.int3 == 456
+assert extern_c.cvar.int4 == 789

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -5094,7 +5094,13 @@ extern_string :  EXTERN string {
 
 storage_class  : EXTERN { $$ = "extern"; }
 	       | extern_string { $$ = $1; }
-	       | extern_string THREAD_LOCAL { $$ = "thread_local"; }
+	       | extern_string THREAD_LOCAL {
+                if (Equal($1, "extern")) {
+                  $$ = "extern thread_local";
+                } else {
+                  $$ = "externc thread_local";
+                }
+	       }
 	       | extern_string TYPEDEF { $$ = "typedef"; }
                | STATIC { $$ = "static"; }
                | TYPEDEF { $$ = "typedef"; }

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -3133,8 +3133,7 @@ c_declaration   : c_decl {
 		    Setattr($$,"name",$2);
 		    appendChild($$,n);
 		    while (n) {
-		      SwigType *decl = Getattr(n,"decl");
-		      if (SwigType_isfunction(decl) && !Equal(Getattr(n, "storage"), "typedef")) {
+		      if (!Equal(Getattr(n, "storage"), "typedef")) {
 			Setattr(n,"storage","externc");
 		      }
 		      n = nextSibling(n);

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -3133,15 +3133,22 @@ c_declaration   : c_decl {
 		    Setattr($$,"name",$2);
 		    appendChild($$,n);
 		    while (n) {
-		      if (!Equal(Getattr(n, "storage"), "typedef")) {
+		      String *s = Getattr(n, "storage");
+		      if (s) {
+			if (Strstr(s, "thread_local")) {
+			  Insert(s,0,"externc ");
+			} else if (!Equal(s, "typedef")) {
+			  Setattr(n,"storage","externc");
+			}
+		      } else {
 			Setattr(n,"storage","externc");
 		      }
 		      n = nextSibling(n);
 		    }
 		  } else {
-            if (!Equal($2,"C++")) {
+		    if (!Equal($2,"C++")) {
 		      Swig_warning(WARN_PARSE_UNDEFINED_EXTERN,cparse_file, cparse_line,"Unrecognized extern type \"%s\".\n", $2);
-            }
+		    }
 		    $$ = new_node("extern");
 		    Setattr($$,"name",$2);
 		    appendChild($$,firstChild($5));

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -3139,7 +3139,9 @@ c_declaration   : c_decl {
 		      n = nextSibling(n);
 		    }
 		  } else {
-		     Swig_warning(WARN_PARSE_UNDEFINED_EXTERN,cparse_file, cparse_line,"Unrecognized extern type \"%s\".\n", $2);
+            if (!Equal($2,"C++")) {
+		      Swig_warning(WARN_PARSE_UNDEFINED_EXTERN,cparse_file, cparse_line,"Unrecognized extern type \"%s\".\n", $2);
+            }
 		    $$ = new_node("extern");
 		    Setattr($$,"name",$2);
 		    appendChild($$,firstChild($5));


### PR DESCRIPTION
Fixes #2198 . The example code there now is  correctly tagged with `externc` for both declarations:

```
+++ cdecl - 0x7fc2b5931be0 ----------------------------------------
| sym:name     - "int1"
| name         - "int1"
| decl         - ""
| storage      - "externc"
| kind         - "variable"
| type         - "int"
| sym:symtab   - 0x7fc2b5800620
| sym:overname - "__SWIG_0"
| 
+++ extern - 0x7fc2b5931fe0 ----------------------------------------
| name         - "C"

      +++ cdecl - 0x7fc2b5931f00 ----------------------------------------
      | sym:name     - "int2"
      | name         - "int2"
      | decl         - ""
      | storage      - "externc"
      | kind         - "variable"
      | type         - "int"
      | sym:symtab   - 0x7fc2b5800620
      | sym:overname - "__SWIG_0"
```

I don't think this is currently possible to test in mainline SWIG because no languages rely on the feature, but without this change a Fortran module language test fails.