### PR TITLE
Fix and add additional tests to test suite

### DIFF
--- a/Examples/test-suite/abstract_basecast.i
+++ b/Examples/test-suite/abstract_basecast.i
@@ -1,0 +1,20 @@
+%module abstract_basecast
+
+%inline %{
+class BaseClass {
+public:
+    virtual ~BaseClass() { }
+
+    virtual void g() = 0;
+};
+
+class DerivedClass : public BaseClass {
+public:
+
+    virtual void g() { }
+
+    BaseClass& f() {
+        return *this;
+    }
+};
+%}

--- a/Examples/test-suite/callback.i
+++ b/Examples/test-suite/callback.i
@@ -13,6 +13,7 @@
 %callback("%s") A::foom;
 #endif
 %callback("%(uppercase)s_Cb_Ptr") foo_T;  // this works in Python too
+%callback("%s_cb") identity_finger;
 
 %inline %{
 
@@ -85,6 +86,15 @@
   const T& ident(const T& x) {
     return x;
   }
+
+  // Test callbacks for enum types
+  typedef enum {One, Two, Three, Four, Five} finger;
+  typedef finger (*finger_finger)(finger);
+  finger identity_finger(finger f) { return f; }
+  finger apply_finger_cb(finger f, finger_finger cb) {
+      return cb(f);
+  }
+
 %}
 
 %template(foo_i) foo_T<int>;

--- a/Examples/test-suite/class_scope_namespace.i
+++ b/Examples/test-suite/class_scope_namespace.i
@@ -15,6 +15,7 @@ namespace Space1 {
     void aaa(Space1::SubSpace1::A, SubSpace1::A, A) {}
   }
 }
+void global_namespace_a(A*) {}
 
 namespace Space2 {
   struct B;

--- a/Examples/test-suite/clientdata_prop_a.h
+++ b/Examples/test-suite/clientdata_prop_a.h
@@ -6,7 +6,7 @@ class A {
 
 typedef A tA;
 
-void test_A(A *a) {}
-void test_tA(tA *a) {}
+inline void test_A(A *a) {}
+inline void test_tA(tA *a) {}
 
-tA *new_tA() { return new tA(); }
+inline tA *new_tA() { return new tA(); }

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -102,6 +102,7 @@ C_TEST_BROKEN += \
 # C++ test cases. (Can be run individually using: make testcase.cpptest)
 CPP_TEST_CASES += \
 	abstract_access \
+	abstract_basecast \
 	abstract_inherit \
 	abstract_inherit_ok \
 	abstract_signature \

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -695,6 +695,7 @@ C_TEST_CASES += \
 	command_line_define \
 	const_const \
 	constant_expr_c \
+	contract_c \
 	default_args_c \
 	empty_c \
 	enums \

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -214,6 +214,7 @@ CPP_TEST_CASES += \
 	director_protected_overloaded \
 	director_redefined \
 	director_ref \
+	director_simple \
 	director_smartptr \
 	director_thread \
 	director_unroll \

--- a/Examples/test-suite/contract.i
+++ b/Examples/test-suite/contract.i
@@ -48,6 +48,7 @@ int test_prepost(int x, int y) {
 }
 %}
 
+#ifdef __cplusplus
 /* Class tests */
 
 %contract Foo::test_preassert(int x, int y) {
@@ -235,4 +236,4 @@ class myClass
 };
 
 }
-
+#endif

--- a/Examples/test-suite/contract_c.i
+++ b/Examples/test-suite/contract_c.i
@@ -1,0 +1,5 @@
+%module contract_c;
+
+%include <exception.i>
+
+%include "contract.i"

--- a/Examples/test-suite/cpp_basic.i
+++ b/Examples/test-suite/cpp_basic.i
@@ -45,6 +45,9 @@ class FooSubSub : public FooSub {
     const char* __str__() const { return "FooSubSub"; }
 };
 
+Foo& get_reference(Foo& other) { return other; }
+const Foo& get_const_reference(const Foo& other) { return other; }
+
 %}
 
 %{

--- a/Examples/test-suite/director_binary_string.i
+++ b/Examples/test-suite/director_binary_string.i
@@ -8,6 +8,7 @@
 
 %inline %{
 #include <stdlib.h>
+#include <string.h>
 
 #define BUFFER_SIZE_AA 8
 #define BUFFER_SIZE_BB 5

--- a/Examples/test-suite/director_simple.i
+++ b/Examples/test-suite/director_simple.i
@@ -1,0 +1,42 @@
+%module(directors="1") director_simple
+
+%feature("director") IntBase;
+%feature("director") BoolBase;
+
+%inline %{
+class IntBase {
+ public:
+  virtual ~IntBase() {}
+  IntBase(int i = 3) { (void)i; }
+  virtual int apply(int x) const { return x * 2; }
+};
+
+class IntDerived : public IntBase {
+ public:
+  virtual int apply(int x) const { return x * 3; }
+};
+
+int apply(const IntBase& b, int x)
+{
+  return b.apply(x);
+}
+
+class BoolBase {
+ public:
+  virtual ~BoolBase() {}
+  BoolBase() {}
+  virtual bool apply(bool a, bool b) const = 0;
+};
+
+class BoolDerived : public BoolBase {
+ public:
+  virtual bool apply(bool a, bool b) const { return a != b; }
+};
+
+bool apply(const BoolBase& base, bool a, bool b)
+{
+  return base.apply(a, b);
+}
+
+%}
+

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -67,7 +67,7 @@ multi_import.multicpptest:
 	if ! test -d gopath/multi_import/src/swigtests; then \
 	  (cd gopath/multi_import/src && ln -s . swigtests); \
 	fi
-	for f in multi_import_b multi_import_a; do \
+	for f in multi_import_d multi_import_b multi_import_a; do \
 	  $(MAKE) -f $(top_builddir)/$(EXAMPLES)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' \
 	  SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	  LIBS='$(LIBS)' INCLUDES='$(INCLUDES)' SWIGOPT='$(SWIGOPT)' NOLINK=true \
@@ -181,6 +181,7 @@ clean:
 	rm -f mod_a.go mod_a.gox mod_b.go mod_b.gox
 	rm -f multi_import_a.go multi_import_a.gox
 	rm -f multi_import_b.go multi_import_b.gox
+	rm -f multi_import_d.go multi_import_d.gox
 	rm -f packageoption_a.go packageoption_a.gox
 	rm -f packageoption_b.go packageoption_b.gox
 	rm -f packageoption_c.go packageoption_c.gox

--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -3,14 +3,19 @@
 %module ignore_parameter
 
 %typemap(in,numinputs=0) char* a "static const char* hi = \"hello\"; $1 = const_cast<char *>(hi);";
-%typemap(in,numinputs=0) int bb "$1 = 101;";
+%typemap(in,numinputs=0) int bb "$1 = 101; called_argout = 0;";
 %typemap(in,numinputs=0) double ccc "$1 = 8.8;";
 
 %typemap(freearg) char* a ""; // ensure freearg is not generated (needed for Java at least)
 
+%typemap(argout) int bb "called_argout = 1;"
+
 %ignore unignorable;
 
 %inline %{
+// constant for detecting correct "argout" call
+int called_argout = 0;
+
 // global function tests
 char* jaguar(char* a, int b, double c) { return a; }
 int lotus(char* aa, int bb, double cc) { return bb; }
@@ -25,6 +30,7 @@ struct SportsCars {
   double bugatti(char* aaa, int bbb, double ccc) { return ccc; }
   int lamborghini(int bb) { return bb; }
   int maseratti(int unignorable) { return unignorable; }
+  double audi(double ccc=9.5) { return ccc; }
 };
 
 // constructor tests

--- a/Examples/test-suite/integers.i
+++ b/Examples/test-suite/integers.i
@@ -17,6 +17,41 @@
   signed long long signed_long_long_identity(signed long long x) { return x; }
   unsigned long long unsigned_long_long_identity(unsigned long long x) { return x; }
 
+#ifdef __cplusplus
+  signed char        & signed_char_ref_identity(       signed char        & x) { return x; }
+  unsigned char      & unsigned_char_ref_identity(     unsigned char      & x) { return x; }
+  signed short       & signed_short_ref_identity(      signed short       & x) { return x; }
+  unsigned short     & unsigned_short_ref_identity(    unsigned short     & x) { return x; }
+  signed int         & signed_int_ref_identity(        signed int         & x) { return x; }
+  unsigned int       & unsigned_int_ref_identity(      unsigned int       & x) { return x; }
+  signed long        & signed_long_ref_identity(       signed long        & x) { return x; }
+  unsigned long      & unsigned_long_ref_identity(     unsigned long      & x) { return x; }
+  signed long long   & signed_long_long_ref_identity(  signed long long   & x) { return x; }
+  unsigned long long & unsigned_long_long_ref_identity(unsigned long long & x) { return x; }
+
+  const signed char        & const_signed_char_ref_identity(       const signed char        & x) { return x; }
+  const unsigned char      & const_unsigned_char_ref_identity(     const unsigned char      & x) { return x; }
+  const signed short       & const_signed_short_ref_identity(      const signed short       & x) { return x; }
+  const unsigned short     & const_unsigned_short_ref_identity(    const unsigned short     & x) { return x; }
+  const signed int         & const_signed_int_ref_identity(        const signed int         & x) { return x; }
+  const unsigned int       & const_unsigned_int_ref_identity(      const unsigned int       & x) { return x; }
+  const signed long        & const_signed_long_ref_identity(       const signed long        & x) { return x; }
+  const unsigned long      & const_unsigned_long_ref_identity(     const unsigned long      & x) { return x; }
+  const signed long long   & const_signed_long_long_ref_identity(  const signed long long   & x) { return x; }
+  const unsigned long long & const_unsigned_long_long_ref_identity(const unsigned long long & x) { return x; }
+#endif
+
+  signed char        * signed_char_ptr() { return NULL; }
+  unsigned char      * unsigned_char_ptr() { return NULL; }
+  signed short       * signed_short_ptr() { return NULL; }
+  unsigned short     * unsigned_short_ptr() { return NULL; }
+  signed int         * signed_int_ptr() { return NULL; }
+  unsigned int       * unsigned_int_ptr() { return NULL; }
+  signed long        * signed_long_ptr() { return NULL; }
+  unsigned long      * unsigned_long_ptr() { return NULL; }
+  signed long long   * signed_long_long_ptr() { return NULL; }
+  unsigned long long * unsigned_long_long_ptr() { return NULL; }
+
   size_t signed_char_size() { return sizeof (signed char); }
   size_t unsigned_char_size() { return sizeof (unsigned char); }
   size_t signed_short_size() { return sizeof (signed short); }

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -134,7 +134,7 @@ clean:
 		rm -f imports_a$${ext} imports_b$${ext}; \
 		rm -f import_stl_a$${ext} import_stl_b$${ext}; \
 		rm -f mod_a$${ext} mod_b$${ext}; \
-		rm -f multi_import_a$${ext} multi_import_b$${ext}; \
+		rm -f multi_import_a$${ext} multi_import_b$${ext} multi_import_d$${ext}; \
 		rm -f packageoption_a$${ext} packageoption_b$${ext} packageoption_c$${ext}; \
 		rm -f template_typedef_cplx2$${ext}; \
 	done

--- a/Examples/test-suite/kwargs_feature.i
+++ b/Examples/test-suite/kwargs_feature.i
@@ -128,6 +128,11 @@ struct ExtendingOptArgs1 {};
 struct ExtendingOptArgs2 {};
 %}
 
+// For strlen/strcpy
+%{
+#include <string.h>
+%}
+
 // Varargs
 %warnfilter(SWIGWARN_LANG_VARARGS_KEYWORD) VarargConstructor::VarargConstructor; // Can't wrap varargs with keyword arguments enabled
 %warnfilter(SWIGWARN_LANG_VARARGS_KEYWORD) VarargConstructor::vararg_method; // Can't wrap varargs with keyword arguments enabled

--- a/Examples/test-suite/li_boost_shared_ptr.i
+++ b/Examples/test-suite/li_boost_shared_ptr.i
@@ -242,6 +242,10 @@ std::string nullsmartpointerpointertest(SwigBoost::shared_ptr<Klass>* k) {
   else
     return "also not null";
 }
+
+SwigBoost::shared_ptr<Klass>* sp_pointer_null() { return NULL; }
+SwigBoost::shared_ptr<Klass>* null_sp_pointer() { static SwigBoost::shared_ptr<Klass> static_sp; return &static_sp; }
+SwigBoost::shared_ptr<Klass> sp_value_null() { return SwigBoost::shared_ptr<Klass>(); }
 // $owner
 Klass *pointerownertest() {
   return new Klass("pointerownertest");

--- a/Examples/test-suite/multi_import.h
+++ b/Examples/test-suite/multi_import.h
@@ -1,3 +1,11 @@
+#ifndef MULTI_IMPORT_H
+#define MULTI_IMPORT_H
+
+class WWW {
+  public:
+    void nullop() const {}
+};
+
 class XXX
 {
 	public:
@@ -15,3 +23,5 @@ class ZZZ : public XXX
 	public:
 		int testz() { return 2;}
 };
+
+#endif /* MULTI_IMPORT_H */

--- a/Examples/test-suite/multi_import.list
+++ b/Examples/test-suite/multi_import.list
@@ -1,2 +1,3 @@
-multi_import_a
+multi_import_d
 multi_import_b
+multi_import_a

--- a/Examples/test-suite/multi_import_a.i
+++ b/Examples/test-suite/multi_import_a.i
@@ -2,7 +2,8 @@
 
 %module multi_import_a
 
-%import multi_import_b.i
+%import multi_import_d.i
+%import "multi_import_b.i"
 
 %{
 #include "multi_import.h"

--- a/Examples/test-suite/multi_import_a.i
+++ b/Examples/test-suite/multi_import_a.i
@@ -14,3 +14,7 @@ class ZZZ : public XXX
 public:
    int testz();
 };
+
+%inline %{
+void use_www_a(const WWW& w) {w.nullop();}
+%}

--- a/Examples/test-suite/multi_import_b.i
+++ b/Examples/test-suite/multi_import_b.i
@@ -11,3 +11,7 @@ class YYY : public XXX
 public:
         int testy();
 };
+
+%inline %{
+void use_www_b(const WWW& w) {w.nullop();}
+%}

--- a/Examples/test-suite/multi_import_c.i
+++ b/Examples/test-suite/multi_import_c.i
@@ -1,5 +1,8 @@
 %import "multi_import_d.i"
 
+// NB: this module is only imported, never compiled, so it's not necessary to
+// include the header for testing purposes.
+
 class XXX
 {
 public:

--- a/Examples/test-suite/multi_import_c.i
+++ b/Examples/test-suite/multi_import_c.i
@@ -1,3 +1,5 @@
+%import "multi_import_d.i"
+
 class XXX
 {
 public:

--- a/Examples/test-suite/multi_import_d.i
+++ b/Examples/test-suite/multi_import_d.i
@@ -1,3 +1,12 @@
 %module multi_import_d
 
 %constant int myval = 1234;
+
+%{
+#include "multi_import.h"
+%}
+
+class WWW {
+  public:
+    void nullop() const;
+};

--- a/Examples/test-suite/multi_import_d.i
+++ b/Examples/test-suite/multi_import_d.i
@@ -1,0 +1,3 @@
+%module multi_import_d
+
+%constant int myval = 1234;

--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -106,6 +106,6 @@ clean:
 	rm -f import_stl_a.ml import_stl_b.ml
 	rm -f imports_a.ml imports_b.ml
 	rm -f mod_a.ml mod_b.ml
-	rm -f multi_import_a.ml multi_import_b.ml
+	rm -f multi_import_a.ml multi_import_b.ml multi_import_d.ml
 	rm -f packageoption_a.ml packageoption_b.ml packageoption_c.ml
 	rm -f template_typedef_cplx2.ml

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -86,6 +86,6 @@ clean:
 	rm -f import_stl_a.php import_stl_b.php php_import_stl_a.h php_import_stl_b.h
 	rm -f imports_a.php imports_b.php php_imports_a.h php_imports_b.h
 	rm -f mod_a.php mod_b.php php_mod_a.h php_mod_b.h
-	rm -f multi_import_a.php multi_import_b.php php_multi_import_a.h php_multi_import_b.h
+	rm -f multi_import_a.php multi_import_b.php multi_import_d.php php_multi_import_a.h php_multi_import_b.h php_multi_import_d.h
 	rm -f packageoption_a.php packageoption_b.php packageoption_c.php php_packageoption_a.h php_packageoption_b.h php_packageoption_c.h
 	rm -f template_typedef_cplx2.php php_template_typedef_cplx2.h

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -146,7 +146,7 @@ clean:
 	rm -f clientdata_prop_a.py clientdata_prop_b.py import_stl_a.py import_stl_b.py
 	rm -f hugemod.h hugemod_a.i hugemod_b.i hugemod_a.py hugemod_b.py hugemod_runme.py
 	rm -f imports_a.py imports_b.py mod_a.py mod_b.py multi_import_a.py
-	rm -f multi_import_b.py packageoption_a.py packageoption_b.py packageoption_c.py
+	rm -f multi_import_b.py multi_import_d.py packageoption_a.py packageoption_b.py packageoption_c.py
 	rm -f template_typedef_cplx2.py
 
 hugemod_runme = hugemod$(SCRIPTPREFIX)

--- a/Examples/test-suite/python/abstract_basecast_runme.py
+++ b/Examples/test-suite/python/abstract_basecast_runme.py
@@ -1,0 +1,15 @@
+from abstract_basecast import *
+
+def check(flag):
+    if not flag:
+        raise RuntimeError("Test failed")
+
+derived = DerivedClass()
+derived.g()
+check(isinstance(derived, BaseClass))
+check(isinstance(derived, DerivedClass))
+
+base = derived.f()
+base.g()
+check(isinstance(base, BaseClass))
+check(not isinstance(base, DerivedClass))

--- a/Examples/test-suite/python/li_boost_shared_ptr_runme.py
+++ b/Examples/test-suite/python/li_boost_shared_ptr_runme.py
@@ -168,6 +168,19 @@ class li_boost_shared_ptr_runme:
         except ValueError:
             pass
 
+        # test null pointers emitted from C++
+        k = li_boost_shared_ptr.sp_pointer_null()
+        if (li_boost_shared_ptr.smartpointertest(k) != None):
+            raise RuntimeError("return was not null")
+
+        k = li_boost_shared_ptr.null_sp_pointer()
+        if (li_boost_shared_ptr.smartpointertest(k) != None):
+            raise RuntimeError("return was not null")
+
+        k = li_boost_shared_ptr.sp_value_null()
+        if (li_boost_shared_ptr.smartpointertest(k) != None):
+            raise RuntimeError("return was not null")
+
         # $owner
         k = li_boost_shared_ptr.pointerownertest()
         val = k.getValue()

--- a/Examples/test-suite/template_typedef_cplx2.h
+++ b/Examples/test-suite/template_typedef_cplx2.h
@@ -113,6 +113,8 @@ namespace vfncs {
 #ifndef SWIG
 
 // Initialize these static class members
+// XXX Since this is a header file, the following creates the symbols in *each* SWIG _wrap.cxx file. Linking the resulting SWIG modules together may result in
+// duplicate symbol link errors.
 
 const char* const arith_traits< double, double >::arg_type = "double";
 const char* const arith_traits< double, double >::res_type = "double";

--- a/Examples/test-suite/typemap_various.i
+++ b/Examples/test-suite/typemap_various.i
@@ -58,6 +58,10 @@ void CheckRetTypemapUsed() {
    /* hello */ delete[] result;
 }
 
+%{
+#include <string.h>
+%}
+
 %inline {
   class FFoo {
   public:

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -172,7 +172,7 @@
 #define %novaluewrapper      %feature("novaluewrapper")
 #define %clearnovaluewrapper %feature("novaluewrapper","")
 
-/* Contract support - Experimental and undocumented */
+/* Contract support - Experimental */
 #define %contract      %feature("contract")
 #define %nocontract    %feature("contract","0")
 #define %clearcontract %feature("contract","")


### PR DESCRIPTION
There are a few "include what you use" errors on newer test cases that didn't get added in #1398, and I have also added some test cases that are used to help test the Fortran language but are not Fortran-specific. For example, the `director_simple` test would be helpful for packages trying to dip their feet into supporting director methods, since most of the existing tests are quite complex and meant to test edge cases rather than basic functionality.

