### PR TITLE
Python: avoid unused SwigMethods_proxydocs var

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -819,7 +819,8 @@ public:
     Printf(f_wrappers, "%s\n", methods);
     Append(methods_proxydocs, "\t { NULL, NULL, 0, NULL }\n");
     Append(methods_proxydocs, "};\n");
-    Printf(f_wrappers, "%s\n", methods_proxydocs);
+    if ((fastproxy && !builtin) || have_fast_proxy_static_member_method_callback)
+      Printf(f_wrappers, "%s\n", methods_proxydocs);
 
     if (builtin) {
       Dump(f_builtins, f_wrappers);


### PR DESCRIPTION
Avoids a warning since 3aa302c:
```
...PYTHON_wrap.cxx:4556:20: error: ‘SwigMethods_proxydocs’ defined but not used [-Werror=unused-variable]
 4556 | static PyMethodDef SwigMethods_proxydocs[] = {
```

cc @wsfulton 