### PR TITLE
Fail cleanly on allocation failures

### DIFF
--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -32,7 +32,7 @@
 
 /* We do this for portability */
 #undef alloca
-#define alloca malloc
+#define alloca Malloc
 
 /* -----------------------------------------------------------------------------
  *                               Externals

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -620,7 +620,7 @@ static Node *template_locate(String *name, Parm *tparms, Symtab *tscope) {
 	int parms_len = ParmList_len(parms);
 	int *priorities_row;
 	max_possible_partials = Len(partials);
-	priorities_matrix = (int *)malloc(sizeof(int) * max_possible_partials * parms_len); /* slightly wasteful allocation for max possible matches */
+	priorities_matrix = (int *)Malloc(sizeof(int) * max_possible_partials * parms_len); /* slightly wasteful allocation for max possible matches */
 	priorities_row = priorities_matrix;
 	for (pi = First(partials); pi.item; pi = Next(pi)) {
 	  Parm *p = parms;
@@ -818,7 +818,7 @@ success:
     Printf(stdout, "    chosen template:'%s'\n", Getattr(n, "name"));
   }
   Delete(parms);
-  free(priorities_matrix);
+  Free(priorities_matrix);
   return n;
 }
 

--- a/Source/DOH/doh.h
+++ b/Source/DOH/doh.h
@@ -122,6 +122,10 @@
 #define DohIterator        DOH_NAMESPACE(Iterator)
 #define DohFirst           DOH_NAMESPACE(First)
 #define DohNext            DOH_NAMESPACE(Next)
+#define DohMalloc          DOH_NAMESPACE(Malloc)
+#define DohRealloc         DOH_NAMESPACE(Realloc)
+#define DohCalloc          DOH_NAMESPACE(Calloc)
+#define DohFree            DOH_NAMESPACE(Free)
 #endif
 
 #define DOH_MAJOR_VERSION 0
@@ -163,12 +167,11 @@ typedef struct {
 
 /* Memory management */
 
-#ifndef DohMalloc
-#define DohMalloc malloc
-#endif
-#ifndef DohRealloc
-#define DohRealloc realloc
-#endif
+/* Wrappers around malloc(), realloc() and calloc() which never return NULL. */
+extern void *DohMalloc(size_t size);
+extern void *DohRealloc(void *ptr, size_t size);
+extern void *DohCalloc(size_t n, size_t size);
+
 #ifndef DohFree
 #define DohFree free
 #endif
@@ -440,6 +443,10 @@ extern void DohMemoryDebug(void);
 #define Next               DohNext
 #define Iterator           DohIterator
 #define SortList           DohSortList
+#define Malloc             DohMalloc
+#define Realloc            DohRealloc
+#define Calloc             DohCalloc
+#define Free               DohFree
 #endif
 
 #ifdef NIL

--- a/Source/DOH/file.c
+++ b/Source/DOH/file.c
@@ -291,10 +291,6 @@ DOH *DohNewFile(DOHString *filename, const char *mode, DOHList *newfiles) {
     return 0;
 
   f = (DohFile *) DohMalloc(sizeof(DohFile));
-  if (!f) {
-    fclose(file);
-    return 0;
-  }
   if (newfiles)
     Append(newfiles, filename);
   f->filep = file;
@@ -314,8 +310,6 @@ DOH *DohNewFile(DOHString *filename, const char *mode, DOHList *newfiles) {
 DOH *DohNewFileFromFile(FILE *file) {
   DohFile *f;
   f = (DohFile *) DohMalloc(sizeof(DohFile));
-  if (!f)
-    return 0;
   f->filep = file;
   f->fd = 0;
   f->closeondel = 0;
@@ -331,8 +325,6 @@ DOH *DohNewFileFromFile(FILE *file) {
 DOH *DohNewFileFromFd(int fd) {
   DohFile *f;
   f = (DohFile *) DohMalloc(sizeof(DohFile));
-  if (!f)
-    return 0;
   f->filep = 0;
   f->fd = fd;
   f->closeondel = 0;

--- a/Source/DOH/hash.c
+++ b/Source/DOH/hash.c
@@ -173,10 +173,7 @@ static void resize(Hash *h) {
     p = p + 2;
   }
 
-  table = (HashNode **) DohMalloc(newsize * sizeof(HashNode *));
-  for (i = 0; i < newsize; i++) {
-    table[i] = 0;
-  }
+  table = (HashNode **) DohCalloc(newsize, sizeof(HashNode *));
 
   /* Walk down the old set of nodes and re-place */
   h->hashsize = newsize;

--- a/Source/DOH/list.c
+++ b/Source/DOH/list.c
@@ -27,7 +27,6 @@ extern DohObjInfo DohListType;
 static
 void more(List *l) {
   l->items = (void **) DohRealloc(l->items, l->maxitems * 2 * sizeof(void *));
-  assert(l->items);
   l->maxitems *= 2;
 }
 
@@ -346,15 +345,10 @@ DohObjInfo DohListType = {
 #define MAXLISTITEMS 8
 
 DOH *DohNewList(void) {
-  List *l;
-  int i;
-  l = (List *) DohMalloc(sizeof(List));
+  List *l = (List *) DohMalloc(sizeof(List));
   l->nitems = 0;
   l->maxitems = MAXLISTITEMS;
-  l->items = (void **) DohMalloc(l->maxitems * sizeof(void *));
-  for (i = 0; i < MAXLISTITEMS; i++) {
-    l->items[i] = 0;
-  }
+  l->items = (void **) DohCalloc(l->maxitems, sizeof(void *));
   l->file = 0;
   l->line = 0;
   return DohObjMalloc(&DohListType, l);

--- a/Source/DOH/memory.c
+++ b/Source/DOH/memory.c
@@ -14,6 +14,9 @@
 
 #include "dohint.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #ifndef DOH_POOL_SIZE
 #define DOH_POOL_SIZE         4194304
 #endif
@@ -48,10 +51,7 @@ static int pools_initialized = 0;
 static void CreatePool() {
   Pool *p = 0;
   p = (Pool *) DohMalloc(sizeof(Pool));
-  assert(p);
-  p->ptr = (DohBase *) DohMalloc(sizeof(DohBase) * PoolSize);
-  assert(p->ptr);
-  memset(p->ptr, 0, sizeof(DohBase) * PoolSize);
+  p->ptr = (DohBase *) DohCalloc(PoolSize, sizeof(DohBase));
   p->len = PoolSize;
   p->blen = PoolSize * sizeof(DohBase);
   p->current = 0;
@@ -233,4 +233,41 @@ void DohMemoryDebug(void) {
   }
 #endif
 
+}
+
+static void allocation_failed(size_t n, size_t size) {
+  /* Report and exit as directly as possible to try to avoid further issues due
+   * to lack of memory. */
+  if (n == 1) {
+#if defined __STDC_VERSION__ && __STDC_VERSION__-0 >= 19901L
+    fprintf(stderr, "Failed to allocate %zu bytes\n", size);
+#else
+    fprintf(stderr, "Failed to allocate %lu bytes\n", (unsigned long)size);
+#endif
+  } else {
+#if defined __STDC_VERSION__ && __STDC_VERSION__-0 >= 19901L
+    fprintf(stderr, "Failed to allocate %zu*%zu bytes\n", n, size);
+#else
+    fprintf(stderr, "Failed to allocate %lu*%lu bytes\n", (unsigned long)n, (unsigned long)size);
+#endif
+  }
+  exit(EXIT_FAILURE);
+}
+
+void *DohMalloc(size_t size) {
+  void *p = malloc(size);
+  if (!p) allocation_failed(1, size);
+  return p;
+}
+
+void *DohRealloc(void *ptr, size_t size) {
+  void *p = realloc(ptr, size);
+  if (!p) allocation_failed(1, size);
+  return p;
+}
+
+void *DohCalloc(size_t n, size_t size) {
+  void *p = calloc(n, size);
+  if (!p) allocation_failed(n, size);
+  return p;
 }

--- a/Source/DOH/string.c
+++ b/Source/DOH/string.c
@@ -229,7 +229,6 @@ static void DohString_append(DOH *so, const DOHString_or_char *str) {
     if (newlen >= newmaxsize - 1)
       newmaxsize = newlen + 1;
     s->str = (char *) DohRealloc(s->str, newmaxsize);
-    assert(s->str);
     s->maxsize = newmaxsize;
   }
   tc = s->str;
@@ -296,7 +295,6 @@ static int String_insert(DOH *so, int pos, DOH *str) {
   while (s->maxsize <= s->len + len) {
     int newsize = 2 * s->maxsize;
     s->str = (char *) DohRealloc(s->str, newsize);
-    assert(s->str);
     s->maxsize = newsize;
   }
   memmove(s->str + pos + len, s->str + pos, (s->len - pos));
@@ -424,7 +422,6 @@ static int String_write(DOH *so, const void *buffer, int len) {
   newlen = s->sp + len + 1;
   if (newlen > s->maxsize) {
     s->str = (char *) DohRealloc(s->str, newlen);
-    assert(s->str);
     s->maxsize = newlen;
     s->len = s->sp + len;
   }
@@ -517,7 +514,6 @@ static int String_putc(DOH *so, int ch) {
     if (len > (maxsize - 2)) {
       maxsize *= 2;
       tc = (char *) DohRealloc(tc, maxsize);
-      assert(tc);
       s->maxsize = (int) maxsize;
       s->str = tc;
     }
@@ -923,7 +919,6 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       newsize *= 2;
 
     ns = (char *) DohMalloc(newsize);
-    assert(ns);
     t = ns;
     s = first;
 

--- a/Source/Modules/swigmain.cxx
+++ b/Source/Modules/swigmain.cxx
@@ -98,15 +98,15 @@ static TargetLanguageModule modules[] = {
 void SWIG_merge_envopt(const char *env, int oargc, char *oargv[], int *nargc, char ***nargv) {
   if (!env) {
     *nargc = oargc;
-    *nargv = (char **)malloc(sizeof(char *) * (oargc + 1));
+    *nargv = (char **)Malloc(sizeof(char *) * (oargc + 1));
     memcpy(*nargv, oargv, sizeof(char *) * (oargc + 1));
     return;
   }
 
   int argc = 1;
   int arge = oargc + 1024;
-  char **argv = (char **) malloc(sizeof(char *) * (arge + 1));
-  char *buffer = (char *) malloc(2048);
+  char **argv = (char **) Malloc(sizeof(char *) * (arge + 1));
+  char *buffer = (char *) Malloc(2048);
   char *b = buffer;
   char *be = b + 1023;
   const char *c = env;
@@ -139,11 +139,11 @@ static void insert_option(int *argc, char ***argv, int index, char const *start,
   size_t option_len = end - start;
 
   // Preserve the NULL pointer at argv[argc]
-  new_argv = (char **)realloc(new_argv, (new_argc + 2) * sizeof(char *));
+  new_argv = (char **)Realloc(new_argv, (new_argc + 2) * sizeof(char *));
   memmove(&new_argv[index + 1], &new_argv[index], sizeof(char *) * (new_argc + 1 - index));
   new_argc++;
 
-  new_argv[index] = (char *)malloc(option_len + 1);
+  new_argv[index] = (char *)Malloc(option_len + 1);
   memcpy(new_argv[index], start, option_len);
   new_argv[index][option_len] = '\0';
 

--- a/Source/Swig/error.c
+++ b/Source/Swig/error.c
@@ -209,14 +209,14 @@ void Swig_warnfilter(const_String_or_char_ptr wlist, int add) {
 	  Insert(filter, 0, "-");
 	}
       } else {
-	char *temp = (char *)malloc(sizeof(char)*strlen(c) + 2);
+	char *temp = (char *)Malloc(sizeof(char)*strlen(c) + 2);
 	if (isdigit((int) *c)) {
 	  sprintf(temp, "-%s", c);
 	} else {
 	  strcpy(temp, c);
 	}
 	Replace(filter, temp, "", DOH_REPLACE_FIRST);
-        free(temp);
+	Free(temp);
       }
     }
     c = strtok(NULL, ", ");

--- a/Source/Swig/getopt.c
+++ b/Source/Swig/getopt.c
@@ -32,16 +32,12 @@ static int *marked;
  * ----------------------------------------------------------------------------- */
 
 void Swig_init_args(int argc, char **argv) {
-  int i;
   assert(argc > 0);
   assert(argv);
 
   numargs = argc;
   args = argv;
-  marked = (int *) malloc(numargs * sizeof(int));
-  for (i = 0; i < argc; i++) {
-    marked[i] = 0;
-  }
+  marked = (int *) Calloc(numargs, sizeof(int));
   marked[0] = 1;
 }
 

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -36,7 +36,7 @@ static char *fake_version = 0;
 char *Swig_copy_string(const char *s) {
   char *c = 0;
   if (s) {
-    c = (char *) malloc(strlen(s) + 1);
+    c = (char *) Malloc(strlen(s) + 1);
     strcpy(c, s);
   }
   return c;
@@ -1251,7 +1251,7 @@ void Swig_offset_string(String *s, int number) {
   if ((Char(s))[len-1] == '\n')
     --lines;
   /* allocate a temporary storage for a padded string */
-  res = (char*)malloc(len + lines * number * 2 + 1);
+  res = (char*)Malloc(len + lines * number * 2 + 1);
   res[len + lines * number * 2] = 0;
 
   /* copy lines to res, prepending tabs to each line */
@@ -1275,7 +1275,7 @@ void Swig_offset_string(String *s, int number) {
   /* replace 's' contents with 'res' */
   Clear(s);
   Append(s, res);
-  free(res);
+  Free(res);
 }
 
 
@@ -1458,11 +1458,11 @@ String *Swig_string_regex(String *s) {
 
 String *Swig_pcre_version(void) {
   int len = pcre2_config(PCRE2_CONFIG_VERSION, NULL);
-  char *buf = malloc(len);
+  char *buf = Malloc(len);
   String *result;
   pcre2_config(PCRE2_CONFIG_VERSION, buf);
   result = NewStringf("PCRE2 Version: %s", buf);
-  free(buf);
+  Free(buf);
   return result;
 }
 

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -56,7 +56,7 @@ static void brackets_clear(Scanner *);
 
 Scanner *NewScanner(void) {
   Scanner *s;
-  s = (Scanner *) malloc(sizeof(Scanner));
+  s = (Scanner *) Malloc(sizeof(Scanner));
   s->line = 1;
   s->file = 0;
   s->nexttoken = -1;
@@ -88,8 +88,8 @@ void DelScanner(Scanner *s) {
   Delete(s->file);
   Delete(s->error);
   Delete(s->str);
-  free(s->idstart);
-  free(s); 
+  Free(s->idstart);
+  Free(s);
 }
 
 /* -----------------------------------------------------------------------------
@@ -202,7 +202,7 @@ int Scanner_start_line(Scanner *s) {
  * ----------------------------------------------------------------------------- */
 
 void Scanner_idstart(Scanner *s, const char *id) {
-  free(s->idstart);
+  Free(s->idstart);
   s->idstart = Swig_copy_string(id);
 }
 
@@ -336,9 +336,9 @@ static void brackets_reset(Scanner *s) {
  * Usually called when '(' is found.
  * ----------------------------------------------------------------------------- */
 static void brackets_push(Scanner *s) {
-  int *newInt = (int *)malloc(sizeof(int));
+  int *newInt = (int *)Malloc(sizeof(int));
   *newInt = 0;
-  Push(s->brackets, NewVoid(newInt, free));
+  Push(s->brackets, NewVoid(newInt, Free));
 }
 
 /* -----------------------------------------------------------------------------
@@ -1811,14 +1811,14 @@ void Scanner_locator(Scanner *s, String *loc) {
 	cparse_file = locs->filename;
 	cparse_line = locs->line_number;
 	l = locs->next;
-	free(locs);
+	Free(locs);
 	locs = l;
       }
       return;
     }
 
     /* We're going to push a new location */
-    l = (Locator *) malloc(sizeof(Locator));
+    l = (Locator *) Malloc(sizeof(Locator));
     l->filename = cparse_file;
     l->line_number = cparse_line;
     l->next = locs;

--- a/Source/Swig/wrapfunc.c
+++ b/Source/Swig/wrapfunc.c
@@ -27,7 +27,7 @@ static int Max_line_size = 128;
 
 Wrapper *NewWrapper(void) {
   Wrapper *w;
-  w = (Wrapper *) malloc(sizeof(Wrapper));
+  w = (Wrapper *) Malloc(sizeof(Wrapper));
   w->localh = NewHash();
   w->locals = NewStringEmpty();
   w->code = NewStringEmpty();
@@ -46,7 +46,7 @@ void DelWrapper(Wrapper *w) {
   Delete(w->locals);
   Delete(w->code);
   Delete(w->def);
-  free(w);
+  Free(w);
 }
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
Previously code in the SWIG tool didn't handle allocation failures
well.  Most places didn't check for NULL return from
malloc()/realloc()/calloc() at all, typically resulting in undefined
behaviour, and some places used assert() to check for a NULL return
(which is a misuse of assert() and such checks disappear if built with
NDEBUG defined leaving us back with undefined behaviour).

All C allocations are now done via wrapper functions (Malloc(),
Realloc() and Calloc()) which emit and error and exit with non-zero
status on failure, so a non-NULL return can be relied upon.

Fixes #1901.