### PR TITLE
Fix checking of "optimal" typemap attribute

### DIFF
--- a/Examples/test-suite/errors/cpp_typemap_out_optimal_bug.i
+++ b/Examples/test-suite/errors/cpp_typemap_out_optimal_bug.i
@@ -1,0 +1,45 @@
+%module x
+
+// Just the following languages tested
+#if defined (SWIGCSHARP) || defined (SWIGD)
+%typemap(out, optimal="1") SWIGTYPE %{
+  $result = new $1_ltype((const $1_ltype &)$1);
+%}
+#elif defined (SWIGJAVA)
+%typemap(out, optimal="1") SWIGTYPE %{
+  *($&1_ltype*)&$result = new $1_ltype((const $1_ltype &)$1);
+%}
+#elif defined (SWIGUTL)
+%typemap(out,noblock="1", optimal="1") SWIGTYPE {
+  %set_output(SWIG_NewPointerObj(%new_copy($1, $ltype), $&descriptor, SWIG_POINTER_OWN | %newpointer_flags));
+}
+#endif
+
+// This results in an action which SWIG should disable "optimal" for, but
+// it was failing to.  Fixed in SWIG 4.1.0.
+%exception XX::create() "$action\n{while(sleep(1)){}}"
+
+%ignore XX::operator=;
+
+#ifdef SWIGD
+%rename(trace) XX::debug;
+#endif
+
+%inline %{
+#include <iostream>
+using namespace std;
+
+struct XX {
+  XX() { if (debug) cout << "XX()" << endl; }
+  XX(int i) { if (debug) cout << "XX(" << i << ")" << endl; }
+  XX(const XX &other) { if (debug) cout << "XX(const XX &)" << endl; }
+  XX& operator =(const XX &other) { if (debug) cout << "operator=(const XX &)" << endl; return *this; }
+  ~XX() { if (debug) cout << "~XX()" << endl; }
+  static XX create() {
+    return XX(123);
+  }
+  static bool debug;
+};
+bool XX::debug = true;
+%}
+

--- a/Examples/test-suite/errors/cpp_typemap_out_optimal_bug.stderr
+++ b/Examples/test-suite/errors/cpp_typemap_out_optimal_bug.stderr
@@ -1,0 +1,4 @@
+cpp_typemap_out_optimal_bug.i:40: Warning 474: Method XX::create() usage of the optimal attribute ignored
+cpp_typemap_out_optimal_bug.i:15: Warning 474: in the out typemap as the following cannot be used to generate optimal code: result = XX::create();
+{while(sleep(1)){}}
+


### PR DESCRIPTION
Previously SWIG checked that the typemap action contained ";\n" not
followed by an identifier character, and that it contained no other
`;`, but that incorrectly allows some cases it shouldn't.

Instead check that the action ends with `;\n` and contains no other
`;`, which is simpler and correctly rejects these cases.