### PR TITLE
Avoid problems due to the use of "register" in Python 2.7 header

### DIFF
--- a/Lib/python/pyruntime.swg
+++ b/Lib/python/pyruntime.swg
@@ -11,6 +11,15 @@
 # include <corecrt.h>
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201703L
+/* Avoid using "register" keyword removed in C++17 in Python 2.7 headers. */
+# define register
+/* Additionally disable checks for redefined keywords when using MSVC. */
+# if defined(_MSC_VER)
+#  define _ALLOW_KEYWORD_MACROS
+# endif
+#endif
+
 #if defined(_DEBUG) && defined(SWIG_PYTHON_INTERPRETER_NO_DEBUG)
 /* Use debug wrappers with the Python release dll */
 # undef _DEBUG


### PR DESCRIPTION
Compiling SWIG-generated code using Python 2.7 in C++17 mode, which is
the default for recent compilers, such as gcc 11, results in a bunch of
annoying warnings like this:
```
/usr/include/python2.7/unicodeobject.h:534:24: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  534 |     register PyObject *obj,     /* Object */
      |                        ^~~
/usr/include/python2.7/unicodeobject.h:553:24: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  553 |     register PyObject *obj      /* Object */
      |                        ^~~
/usr/include/python2.7/unicodeobject.h:575:29: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  575 |     register const wchar_t *w,  /* wchar_t buffer */
      |                             ^
/usr/include/python2.7/unicodeobject.h:593:23: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  593 |     register wchar_t *w,        /* wchar_t buffer */
      |                       ^
In file included from /usr/include/python2.7/Python.h:97,
                 from ../../interface/swig/build/python/common_wrap.cxx:188:
/usr/include/python2.7/stringobject.h:173:24: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  173 |     register PyObject *obj,     /* string or Unicode object */
      |                        ^~~
/usr/include/python2.7/stringobject.h:174:21: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  174 |     register char **s,          /* pointer to buffer variable */
      |                     ^
/usr/include/python2.7/stringobject.h:175:26: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  175 |     register Py_ssize_t *len    /* pointer to length variable or NULL
      |                          ^~~
```
while using clang with -std=c++17 (or later) results in errors and not
even warnings.

Avoid them by simply defining "register" keyword as nothing, which is
enough to avoid the warnings/errors and shouldn't create any new
problems as SWIG-generated code doesn't use this keyword and any
user-defined code shouldn't use it neither when using C++17.