### PR TITLE
[Go] Make -intgosize optional

### DIFF
--- a/Doc/Manual/Go.html
+++ b/Doc/Manual/Go.html
@@ -178,10 +178,10 @@ swig -go -help
 <td>-intgosize &lt;s&gt;</td>
 <td>Set the size for the Go type <tt>int</tt>.  This controls the size
   that the C/C++ code expects to see.  The &lt;s&gt; argument should
-  be 32 or 64.  This option is currently required during the
+  be 32 or 64.  This option was required during the
   transition from Go 1.0 to Go 1.1, as the size of <tt>int</tt> on
-  64-bit x86 systems changes between those releases (from 32 bits to
-  64 bits).  In the future the option may become optional, and SWIG
+  64-bit x86 systems changed between those releases (from 32 bits to
+  64 bits).  It was made optional in SWIG 4.1.0 and if not specified SWIG
   will assume that the size of <tt>int</tt> is the size of a C
   pointer.</td>
 </tr>

--- a/Lib/go/goruntime.swg
+++ b/Lib/go/goruntime.swg
@@ -24,6 +24,7 @@ static void* Swig_malloc(int c) {
 %}
 
 %insert(cgo_comment_typedefs) %{
+#include <stddef.h>
 #include <stdint.h>
 %}
 

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -351,14 +351,6 @@ private:
       Preprocessor_define("SWIGGO_GCCGO 1", 0);
     }
 
-    // This test may be removed in the future, when we can assume that
-    // everybody has upgraded to Go 1.1.  The code below is prepared
-    // for this test to simply be taken out.
-    if (intgo_type_size == 0 && !display_help) {
-      Printf(stderr, "SWIG -go: -intgosize option required but not specified\n");
-      Exit(EXIT_FAILURE);
-    }
-
     if (intgo_type_size == 32) {
       Preprocessor_define("SWIGGO_INTGO_SIZE 32", 0);
     } else if (intgo_type_size == 64) {

--- a/configure.ac
+++ b/configure.ac
@@ -2482,18 +2482,9 @@ else
     go1.[012]*)
       AC_MSG_RESULT([yes - minimum version is 1.3])
       GO=
-      GOOPT="-intgosize 32"
       ;;
     *)
       AC_MSG_RESULT([no])
-      case "$(go env GOARCH)" in
-      amd64 | arm64 | ppc64*)
-        GOOPT="-intgosize 64"
-	;;
-      *)
-        GOOPT="-intgosize 32"
-	;;
-      esac
       ;;
     esac
   fi
@@ -2514,13 +2505,6 @@ else
         AC_MSG_RESULT([no])
         if test "$go_version" -lt 480; then
           GCCGOOPT="-intgosize 32"
-        else
-          AC_CHECK_SIZEOF([void *], [4])
-          if test "$ac_cv_sizeof_void_p" = "8"; then
-            GCCGOOPT="-intgosize 64"
-          else
-            GCCGOOPT="-intgosize 32"
-          fi
         fi
       fi
     fi


### PR DESCRIPTION
We no longer support Go < 1.2 so we can default intgo to ptrdiff_t
and uintgo to size_t.

Fixes #683