### PR TITLE
Use different capsule names with and without -builtin

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -847,9 +847,10 @@ swig_and_compile_c =  \
 
 swig_and_compile_multi_cpp = \
 	for f in `cat $(top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)/$*.list` ; do \
+	  swigopt=$$(name=SWIGOPT_$$f; eval echo \$$$$name); \
 	  $(MAKE) -f $(top_builddir)/$(EXAMPLES)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' \
 	  SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
-	  LIBS='$(LIBS)' INCLUDES='$(INCLUDES)' SWIGOPT='$(SWIGOPT)' NOLINK=true \
+	  LIBS='$(LIBS)' INCLUDES='$(INCLUDES)' SWIGOPT="$${swigopt:-$(SWIGOPT)}" NOLINK=true \
 	  TARGET="$(TARGETPREFIX)$${f}$(TARGETSUFFIX)" INTERFACEDIR='$(INTERFACEDIR)' INTERFACE="$$f.i" \
 	  $(LANGUAGE)$(VARIANT)_cpp; \
 	done

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -93,6 +93,9 @@ C_TEST_CASES += \
 	python_nondynamic \
 	python_varargs_typemap \
 
+MULTI_CPP_TEST_CASES += \
+	python_runtime_data \
+
 include $(srcdir)/../common.mk
 
 # Overridden variables here
@@ -101,6 +104,10 @@ VALGRIND_OPT += --suppressions=pythonswig.supp
 
 # Custom tests - tests with additional commandline options
 #python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
+
+python_runtime_data.multicpptest: override SWIG_FEATURES := $(filter-out -builtin,$(SWIG_FEATURES))
+python_runtime_data.multicpptest: override SWIGOPT := $(filter-out -builtin,$(SWIGOPT))
+python_runtime_data.multicpptest: export SWIGOPT_python_runtime_data_builtin = $(SWIGOPT) -builtin
 
 # Rules for the different types of tests
 %.cpptest:
@@ -149,7 +156,7 @@ clean:
 	rm -f hugemod.h hugemod_a.i hugemod_b.i hugemod_a.py hugemod_b.py hugemod_runme.py
 	rm -f imports_a.py imports_b.py mod_a.py mod_b.py multi_import_a.py
 	rm -f multi_import_b.py multi_import_d.py packageoption_a.py packageoption_b.py packageoption_c.py
-	rm -f template_typedef_cplx2.py
+	rm -f template_typedef_cplx2.py python_runtime_data_builtin.py python_runtime_data_nobuiltin.py
 
 hugemod_runme = hugemod$(SCRIPTPREFIX)
 

--- a/Examples/test-suite/python/python_runtime_data_runme.py
+++ b/Examples/test-suite/python/python_runtime_data_runme.py
@@ -1,0 +1,11 @@
+import python_runtime_data_builtin as builtin
+import python_runtime_data_nobuiltin as nobuiltin
+
+assert builtin.is_python_builtin()
+assert not nobuiltin.is_python_builtin()
+
+for i in range(1, 5):
+    v1 = builtin.vectord([1.] * i)
+    assert len(v1) == i
+    v2 = nobuiltin.vectord([1.] * i)
+    assert len(v2) == i

--- a/Examples/test-suite/python_runtime_data.list
+++ b/Examples/test-suite/python_runtime_data.list
@@ -1,0 +1,2 @@
+python_runtime_data_builtin
+python_runtime_data_nobuiltin

--- a/Examples/test-suite/python_runtime_data_builtin.i
+++ b/Examples/test-suite/python_runtime_data_builtin.i
@@ -1,0 +1,15 @@
+// Test swig_runtime_data with and without -builtin
+
+%module python_runtime_data_builtin
+
+%inline %{
+#ifdef SWIGPYTHON_BUILTIN
+bool is_python_builtin() { return true; }
+#else
+bool is_python_builtin() { return false; }
+#endif
+%}
+
+%include std_vector.i
+
+%template(vectord) std::vector<double>;

--- a/Examples/test-suite/python_runtime_data_nobuiltin.i
+++ b/Examples/test-suite/python_runtime_data_nobuiltin.i
@@ -1,0 +1,3 @@
+%module python_runtime_data_nobuiltin
+
+%include "python_runtime_data_builtin.i"

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -80,7 +80,12 @@ SWIG_Python_str_FromChar(const char *c)
 
 /* SWIGPY_USE_CAPSULE is no longer used within SWIG itself, but some user interface files check for it. */
 # define SWIGPY_USE_CAPSULE
-# define SWIGPY_CAPSULE_NAME ("swig_runtime_data" SWIG_RUNTIME_VERSION ".type_pointer_capsule" SWIG_TYPE_TABLE_NAME)
+#ifdef SWIGPYTHON_BUILTIN
+# define SWIGPY_CAPSULE_ATTR_NAME "type_pointer_capsule_builtin" SWIG_TYPE_TABLE_NAME
+#else
+# define SWIGPY_CAPSULE_ATTR_NAME "type_pointer_capsule" SWIG_TYPE_TABLE_NAME
+#endif
+# define SWIGPY_CAPSULE_NAME ("swig_runtime_data" SWIG_RUNTIME_VERSION "." SWIGPY_CAPSULE_ATTR_NAME)
 
 #if PY_VERSION_HEX < 0x03020000
 #define PyDescr_TYPE(x) (((PyDescrObject *)(x))->d_type)

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1686,7 +1686,7 @@ SWIG_Python_SetModule(swig_module_info *swig_module) {
 #endif
   PyObject *pointer = PyCapsule_New((void *) swig_module, SWIGPY_CAPSULE_NAME, SWIG_Python_DestroyModule);
   if (pointer && module) {
-    if (PyModule_AddObject(module, "type_pointer_capsule" SWIG_TYPE_TABLE_NAME, pointer) == 0) {
+    if (PyModule_AddObject(module, SWIGPY_CAPSULE_ATTR_NAME, pointer) == 0) {
       Swig_Capsule_global = pointer;
     } else {
       Py_DECREF(pointer);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4234,6 +4234,9 @@ public:
     printSlot(f, getSlot(n, "feature:python:am_await"), "am_await", "unaryfunc");
     printSlot(f, getSlot(n, "feature:python:am_aiter"), "am_aiter", "unaryfunc");
     printSlot(f, getSlot(n, "feature:python:am_anext"), "am_anext", "unaryfunc");
+    Printv(f, "# if PY_VERSION_HEX >= 0x030a0000\n", NIL);
+    printSlot(f, getSlot(n, "feature:python:am_send"), "am_send", "sendfunc");
+    Printv(f, "# endif\n", NIL);
     Printf(f, "  },\n");
     Printv(f, "#endif\n", NIL);
 


### PR DESCRIPTION
Types generated with and without -builtin are not compatible. Mixing
them in a common type list leads to crashes. Avoid this by using
different capsule names: "type_pointer_capsule" without -builtin and
"type_pointer_capsule_builtin" with.

See #1684