### PR TITLE
C#: Fix CS0034 in Capacity method of std::vector

### DIFF
--- a/Lib/csharp/std_vector.i
+++ b/Lib/csharp/std_vector.i
@@ -63,7 +63,7 @@
       return (int)capacity();
     }
     set {
-      if (value < size())
+      if (value < 0 || ($typemap(cstype, size_t))value < size())
         throw new global::System.ArgumentOutOfRangeException("Capacity");
       reserve(($typemap(cstype, size_t))value);
     }


### PR DESCRIPTION
On platforms where `size_t` maps to the `ulong` type in C#, the generated code for the `Capacity` setter of `std::vector<T>` typemaps generates:

`error CS0034: Operator '<' is ambiguous on operands of type 'int' and 'ulong'`

This relates to this discussion in the dotnet forum: https://github.com/dotnet/csharplang/discussions/2322

To fix this issue, a two-step comparison and a cast was introduced.