### PR TITLE
add all template parameters to java unordered set

### DIFF
--- a/Lib/java/std_unordered_set.i
+++ b/Lib/java/std_unordered_set.i
@@ -43,7 +43,10 @@
 
 namespace std {
 
-template <class Key>
+template <class Key,
+	   typename _Hash = std::hash<Key>,
+	   typename _Pred = std::equal_to<Key>,
+	   typename _Alloc = std::allocator<Key>>
 class unordered_set {
 
 %typemap(javabase) std::unordered_set<Key> "java.util.AbstractSet<$typemap(jboxtype, Key)>"


### PR DESCRIPTION
When trying to use a `%template(MyEnumSet) std::unordered_set<MyEnum,std::hash<std::underlying_type<MyEnum>::type>>;`, swig errors out with `Too many template parameters. Maximum of 1.`.

This fixes this very specific issue.

Should I do this also for other types such as `std::unordered_map` ?
Should I do this also for other languages if necessary ?