### PR TITLE
Update Windows CMake builds to use NuGet package for PCRE2

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -44,4 +44,4 @@ jobs:
       shell: cmd
       working-directory: install2/bin
       run: |
-          swig.exe -help
+          swig.exe -version

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -25,23 +25,30 @@ jobs:
         submodules: recursive
 
     - name: Install Dependencies
+      shell: powershell
       run: |
           nuget install CMake-win64 -Version 3.15.5 -OutputDirectory C:\Tools\CMake
           nuget install Bison -Version 3.7.4 -OutputDirectory C:\Tools\bison
           nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2
 
     - name: Build
-      shell: cmd
+      shell: powershell
       run: |
-          SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;%PATH%
-          SET PCRE_ROOT=C:\Tools\pcre2\PCRE2.10.39.0
-          SET PCRE_PLATFORM=x64
-          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
-          -DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
+          $env:PATH="C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;" + $env:PATH
+          $PCRE_ROOT="C:\Tools\pcre2\PCRE2.10.39.0"
+          $PCRE_PLATFORM="x64"
+          $WORKING_DIR=(Get-Location).ToString() -replace "\\","/"
+          cmake -G "Visual Studio 16 2019" -A "x64" `
+          -DCMAKE_INSTALL_PREFIX="$WORKING_DIR/install2" `
+          -DCMAKE_C_FLAGS="/DPCRE2_STATIC" `
+          -DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" `
+          -DPCRE2_INCLUDE_DIR="$PCRE_ROOT/include" `
+          -DPCRE2_LIBRARY="$PCRE_ROOT/lib/pcre2-8-static.lib" `
+          -S . -B build
           cmake --build build --config Release --target install
 
     - name: Test
-      shell: cmd
+      shell: powershell
       working-directory: install2/bin
       run: |
           swig.exe -version

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -45,6 +45,10 @@ jobs:
           -DPCRE2_INCLUDE_DIR="$PCRE_ROOT/include" `
           -DPCRE2_LIBRARY="$PCRE_ROOT/lib/pcre2-8-static.lib" `
           -S . -B build
+
+    - name: Install
+      shell: powershell
+      run: |
           cmake --build build --config Release --target install
 
     - name: Test

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -31,7 +31,7 @@ jobs:
           nuget install Bison -Version 3.7.4 -OutputDirectory C:\Tools\bison
           nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2
 
-    - name: Build
+    - name: Build and Install
       shell: powershell
       run: |
           $env:PATH="C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;" + $env:PATH
@@ -45,10 +45,6 @@ jobs:
           -DPCRE2_INCLUDE_DIR="$PCRE_ROOT/include" `
           -DPCRE2_LIBRARY="$PCRE_ROOT/lib/pcre2-8-static.lib" `
           -S . -B build
-
-    - name: Install
-      shell: powershell
-      run: |
           cmake --build build --config Release --target install
 
     - name: Test

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -31,7 +31,7 @@ jobs:
           nuget install Bison -Version 3.7.4 -OutputDirectory C:\Tools\bison
           nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2
 
-    - name: Build and Install
+    - name: Build
       shell: powershell
       run: |
           $env:PATH="C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;" + $env:PATH
@@ -45,7 +45,12 @@ jobs:
           -DPCRE2_INCLUDE_DIR="$PCRE_ROOT/include" `
           -DPCRE2_LIBRARY="$PCRE_ROOT/lib/pcre2-8-static.lib" `
           -S . -B build
-          cmake --build build --config Release --target install
+          cmake --build build --config Release
+
+    - name: Install
+      shell: powershell
+      run: |
+          cmake --install build --config Release
 
     - name: Test
       shell: powershell

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,47 @@
+name: Windows Nuget Build
+
+on:
+  push:
+    paths-ignore:
+      - 'CHANGES*'
+      - 'Doc/**'
+      - 'appveyor.yml'
+  pull_request:
+    branches: master
+    paths-ignore:
+      - 'CHANGES*'
+      - 'Doc/**'
+      - 'appveyor.yml'
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install Dependencies
+      run: |
+          nuget install CMake-win64 -Version 3.15.5 -OutputDirectory C:\Tools\CMake
+          nuget install Bison -Version 3.7.4 -OutputDirectory C:\Tools\bison
+          nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2
+
+    - name: Build
+      shell: cmd
+      run: |
+          SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;%PATH%
+          SET PCRE_ROOT=C:\Tools\pcre2\PCRE2.10.39.0
+          SET PCRE_PLATFORM=x64
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
+          -DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
+          cmake --build build --config Release --target install
+
+    - name: Test
+      shell: cmd
+      working-directory: install2/bin
+      run: |
+          swig.exe -help

--- a/Doc/Manual/Windows.html
+++ b/Doc/Manual/Windows.html
@@ -282,7 +282,8 @@ cmake -G "Visual Studio 16 2019" -A "x64" `
 -DPCRE2_LIBRARY="$PCRE_ROOT/lib/pcre2-8-static.lib" `
 -S . -B build
 
-cmake --build build --config Release --target install
+cmake --build build --config Release
+cmake --install build --config Release
 
 # to test the exe built correctly
 cd install2/bin

--- a/Doc/Manual/Windows.html
+++ b/Doc/Manual/Windows.html
@@ -248,16 +248,9 @@ For fully working build steps always check the Continuous Integration (CI) setup
         and save to a folder e.g. <tt>C:\Tools\Bison</tt>
     </li>
     <li>
-        Unfortunately, PCRE2 is not yet available on Nuget. Instead we will use CMake to build and install <a href="https://www.pcre.org/">PCRE2</a> to <tt>C:\Tools\pcre2</tt> using the following commands:
-        <div class="shell"><pre>
-cd C:\
-SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;%PATH%
-git clone https://github.com/PhilipHazel/pcre2.git
-cd pcre2
-cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=C:/Tools/pcre2 -S . -B build
-cmake --build build --config Release --target install
-        </pre></div>
-        Alternatively, set <tt>WITH_PCRE=OFF</tt> to disable PCRE2 support if you are sure you do not require it.
+        Install the <a href="https://www.nuget.org/packages/pcre2/">PCRE2 Nuget package</a> using the following command: <pre>C:\Tools\nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2</pre>.
+        Note this is a x64 build, if this is not suitable PCRE2 can be built from source using <a href="https://github.com/PhilipHazel/pcre2/">https://github.com/PhilipHazel/pcre2/</a>.
+        Alternatively, set <tt>WITH_PCRE=OFF</tt> to disable PCRE2 support if you are sure you do not require it. 
     </li>
     <li>
         We will also need the SWIG source code. Either download a zipped archive from GitHub, or if git is installed clone the latest codebase
@@ -271,10 +264,12 @@ cmake --build build --config Release --target install
         architecture. We add the required build tools to the system PATH, and then
         build a Release version of SWIG. If all runs successfully a new swig.exe should be generated in the <tt>C:/swig/install2/bin</tt> folder.
     </p>
-    <div class="shell"> <pre>
+    </li>
+</ol>
+<div class="shell"><pre>
 cd C:\swig
 SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;%PATH%
-SET PCRE_ROOT=C:/Tools/pcre2
+SET PCRE_ROOT=C:\Tools\pcre2\PCRE2.10.39.0
 SET PCRE_PLATFORM=x64
 cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
 -DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
@@ -283,9 +278,8 @@ cmake --build build --config Release --target install
 REM to test the exe
 cd install2/bin
 swig.exe -help
-    </pre></div>
-    </li>
-</ol>
+</pre></div>
+
 <p>
     In addition to Release builds you can create a Debug build using:
 </p>

--- a/Doc/Manual/Windows.html
+++ b/Doc/Manual/Windows.html
@@ -230,7 +230,7 @@ SWIG can also be compiled and run using <a href="https://www.msys2.org/">MSYS2</
 <p>
 SWIG can be built using <a href="https://cmake.org/">CMake</a> and Visual Studio rather than autotools. As with the other approaches to 
 building SWIG the dependencies need to be installed. The steps below are one of a number of ways of installing the dependencies without requiring Cygwin or MinGW.
-For fully working build steps always check the Continuous Integration (CI) setups currently detailed in the <a href="https://github.com/swig/swig/blob/master/appveyor.yml">Appveyor YAML file</a>.
+For fully working build steps always check the Continuous Integration (CI) setups currently detailed in the <a href="https://github.com/swig/swig/tree/master/.github/workflows/nuget.yml">GitHub Actions YAML file</a>.
 </p>
 
 <ol>
@@ -240,6 +240,7 @@ For fully working build steps always check the Continuous Integration (CI) setup
     </li>
     <li>
         Install <a href="https://www.nuget.org/packages/CMake-win64/">CMake-win64 Nuget package</a> using the following command: <pre>C:\Tools\nuget install CMake-win64 -Version 3.15.5 -OutputDirectory C:\Tools\CMake</pre>
+        Using PowerShell the equivalent syntax is: <pre>&"C:\Tools\nuget" install CMake-win64 -Version 3.15.5 -OutputDirectory C:\Tools\CMake</pre>
         Alternatively you can download CMake from <a href="https://cmake.org/download/">https://cmake.org/download/</a>.
     </li>
     <li>
@@ -248,18 +249,18 @@ For fully working build steps always check the Continuous Integration (CI) setup
         and save to a folder e.g. <tt>C:\Tools\Bison</tt>
     </li>
     <li>
-        Install the <a href="https://www.nuget.org/packages/pcre2/">PCRE2 Nuget package</a> using the following command: <pre>C:\Tools\nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2</pre>.
+        Install the <a href="https://www.nuget.org/packages/pcre2/">PCRE2 Nuget package</a> using the following command: <pre>C:\Tools\nuget install PCRE2 -Version 10.39 -OutputDirectory C:\Tools\pcre2</pre>
         Note this is a x64 build, if this is not suitable PCRE2 can be built from source using <a href="https://github.com/PhilipHazel/pcre2/">https://github.com/PhilipHazel/pcre2/</a>.
         Alternatively, set <tt>WITH_PCRE=OFF</tt> to disable PCRE2 support if you are sure you do not require it. 
     </li>
     <li>
         We will also need the SWIG source code. Either download a zipped archive from GitHub, or if git is installed clone the latest codebase
-        using <pre>git clone https://github.com/swig/swig.git</pre>
+        using: <pre>git clone https://github.com/swig/swig.git</pre>
         In this example we are assuming the source code is available at <tt>C:\swig</tt>
     </li>
     <li>
     <p>
-        Now we have all the required dependencies we can build SWIG using the commands below. We are assuming Visual Studio 2019 is installed. For other versions of Visual Studio change <tt>"Visual Studio 16 2019 -A x64"</tt> to the relevant
+        Now we have all the required dependencies we can build SWIG using PowerShell and the commands below. We are assuming Visual Studio 2019 is installed. For other versions of Visual Studio change <tt>"Visual Studio 16 2019 -A x64"</tt> to the relevant
         <a href="https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators">Visual Studio Generator</a> and
         architecture. We add the required build tools to the system PATH, and then
         build a Release version of SWIG. If all runs successfully a new swig.exe should be generated in the <tt>C:/swig/install2/bin</tt> folder.
@@ -268,16 +269,25 @@ For fully working build steps always check the Continuous Integration (CI) setup
 </ol>
 <div class="shell"><pre>
 cd C:\swig
-SET PATH=C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;%PATH%
-SET PCRE_ROOT=C:\Tools\pcre2\PCRE2.10.39.0
-SET PCRE_PLATFORM=x64
-cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="%CD:\=/%/install2" -DCMAKE_C_FLAGS="/DPCRE2_STATIC" ^
--DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" -DPCRE2_INCLUDE_DIR=%PCRE_ROOT%/include -DPCRE2_LIBRARY=%PCRE_ROOT%/lib/pcre2-8-static.lib -S . -B build
+
+$env:PATH="C:\Tools\CMake\CMake-win64.3.15.5\bin;C:\Tools\bison\Bison.3.7.4\bin;" + $env:PATH
+$PCRE_ROOT="C:\Tools\pcre2\PCRE2.10.39.0"
+$PCRE_PLATFORM="x64"
+
+cmake -G "Visual Studio 16 2019" -A "x64" `
+-DCMAKE_INSTALL_PREFIX="C:/swig/install2" `
+-DCMAKE_C_FLAGS="/DPCRE2_STATIC" `
+-DCMAKE_CXX_FLAGS="/DPCRE2_STATIC" `
+-DPCRE2_INCLUDE_DIR="$PCRE_ROOT/include" `
+-DPCRE2_LIBRARY="$PCRE_ROOT/lib/pcre2-8-static.lib" `
+-S . -B build
+
 cmake --build build --config Release --target install
 
-REM to test the exe
+# to test the exe built correctly
 cd install2/bin
-swig.exe -help
+./swig.exe -version
+./swig.exe -help
 </pre></div>
 
 <p>


### PR DESCRIPTION
Following on from #2178 and #2169 this updates the CMake Windows build instructions to use a newly created PCRE2 NuGet package, which simplifies the build steps.

References: 

+ https://www.nuget.org/packages/PCRE2/
+ https://github.com/geographika/nuget-pcre2

Let me know if it would be useful to add a new GitHub Action to test these builds steps as part of CI. 
