### PR TITLE
Remove bogus parser grammar rule for unary &&

### DIFF
--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -6743,10 +6743,6 @@ valexpr        : exprsimple { $$ = $1; }
 		 $$ = $2;
                  $$.val = NewStringf("&%s",$2.val);
 	       }
-               | LAND expr {
-		 $$ = $2;
-                 $$.val = NewStringf("&&%s",$2.val);
-	       }
                | STAR expr {
 		 $$ = $2;
                  $$.val = NewStringf("*%s",$2.val);


### PR DESCRIPTION
This appears to have been accidentally added in
d8cc75946b236f08f9561a82867997e1021f96ab as part of the changes to
support C++11 rvalue references, presumably to match the existing
correct rule for unary &.

There is a non-standard GCC extension for taking the address of a label
using unary &&:

https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html

However this extension only works in an expression in a function body,
and SWIG doesn't parse the contents of function bodies so this grammar
rule isn't even providing any useful support for this extension.