### PR TITLE
Fix various typos

### DIFF
--- a/Examples/python/import_packages/from_init1/runme.py
+++ b/Examples/python/import_packages/from_init1/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/from_init2/runme.py
+++ b/Examples/python/import_packages/from_init2/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/from_init3/runme.py
+++ b/Examples/python/import_packages/from_init3/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/namespace_pkg/nonpkg.py
+++ b/Examples/python/import_packages/namespace_pkg/nonpkg.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print("  Finished running: " + commandline)
 

--- a/Examples/python/import_packages/namespace_pkg/normal.py
+++ b/Examples/python/import_packages/namespace_pkg/normal.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print("  Finished running: " + commandline)
 

--- a/Examples/python/import_packages/namespace_pkg/nstest.py
+++ b/Examples/python/import_packages/namespace_pkg/nstest.py
@@ -6,7 +6,7 @@ import zipfile
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print("  Finished running: " + commandline)
 

--- a/Examples/python/import_packages/namespace_pkg/split.py
+++ b/Examples/python/import_packages/namespace_pkg/split.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print("  Finished running: " + commandline)
 

--- a/Examples/python/import_packages/namespace_pkg/zipsplit.py
+++ b/Examples/python/import_packages/namespace_pkg/zipsplit.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print("  Finished running: " + commandline)
 

--- a/Examples/python/import_packages/relativeimport1/runme.py
+++ b/Examples/python/import_packages/relativeimport1/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/relativeimport2/runme.py
+++ b/Examples/python/import_packages/relativeimport2/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/relativeimport3/runme.py
+++ b/Examples/python/import_packages/relativeimport3/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/same_modnames1/runme.py
+++ b/Examples/python/import_packages/same_modnames1/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/same_modnames2/runme.py
+++ b/Examples/python/import_packages/same_modnames2/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/split_modules/vanilla/runme.py
+++ b/Examples/python/import_packages/split_modules/vanilla/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/python/import_packages/split_modules/vanilla_split/runme.py
+++ b/Examples/python/import_packages/split_modules/vanilla_split/runme.py
@@ -4,7 +4,7 @@ import sys
 
 def run_except_on_windows(commandline, env=None):
     if os.name != "nt" and sys.platform != "cygwin":
-        # Strange failures on windows/cygin/mingw
+        # Strange failures on windows/cygwin/mingw
         subprocess.check_call(commandline, env=env, shell=True)
         print(("  Finished running: " + commandline))
 

--- a/Examples/ruby/exceptproxy/example.i
+++ b/Examples/ruby/exceptproxy/example.i
@@ -16,7 +16,7 @@
 
 /* The EmptyError doesn't appear in a throw declaration, and hence
   we need to tell SWIG that the dequeue method throws it.  This can
-  now be done via the %catchs feature. */
+  now be done via the %catches feature. */
 %catches(FullError) *::enqueue;
 %catches(EmptyError) *::dequeue();
 

--- a/Examples/test-suite/php/director_extend_runme.php
+++ b/Examples/test-suite/php/director_extend_runme.php
@@ -17,6 +17,6 @@ class MyObject extends SpObject{
 
 $m = new MyObject();
 check::equal($m->dummy(), 666, "1st call");
-check::equal($m->dummy(), 666, "2st call"); // Locked system
+check::equal($m->dummy(), 666, "2nd call"); // Locked system
 
 check::done();

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -25,7 +25,7 @@
 %{
 #define yylex yylex
 
-/* doh.h uses #pragma GCC posion with GCC to prevent direct calls to certain
+/* doh.h uses #pragma GCC poison with GCC to prevent direct calls to certain
  * standard C library functions being introduced, but those cause errors due
  * to checks like `#if defined YYMALLOC || defined malloc` in the bison
  * template code.  We can't easily arrange to include headers after that

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -940,7 +940,7 @@ int R::OutputClassMethodsTable(File *) {
  * The entries are indexed by <class name>_set and
  * <class_name>_get. Each entry is a List *.
 
- * out - the stram where the code is to be written. This is the S
+ * out - the stream where the code is to be written. This is the S
  * code stream as we generate only S code here.
  * --------------------------------------------------------------*/
 


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,anumber,ba,bae,chello,clos,cmo,coo,dout,fo,funktion,goin,inout,methid,nd,nin,nnumber,object,objekt,od,ois,packag,parm,parms,pres,statics,strack,struc,tempdate,te,thru,uint,upto,writen`