### PR TITLE
Fix Ruby 3.2 warning "undefining the allocator of T_DATA class swig_runtime_data"

### DIFF
--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -413,6 +413,7 @@ SWIG_Ruby_SetModule(swig_module_info *pointer)
 {
   /* register a new class */
   VALUE cl = rb_define_class("swig_runtime_data", rb_cObject);
+  rb_undef_alloc_func(cl);
   /* create and store the structure pointer to a global variable */
   swig_runtime_data_type_pointer = Data_Wrap_Struct(cl, 0, 0, pointer);
   rb_define_readonly_variable("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME, &swig_runtime_data_type_pointer);


### PR DESCRIPTION
Ruby 3.2 (still in development) started warning about this, see https://bugs.ruby-lang.org/issues/18007.

Note that the extension docs mention it in https://ruby-doc.org/core-3.1.1/doc/extension_rdoc.html#label-C+struct+to+Ruby+object:

> The klass argument is the class for the object. The klass should
> derive from `rb_cObject`, and the allocator must be set by calling
> `rb_define_alloc_func` or `rb_undef_alloc_func`.

So in this case we call `rb_undef_alloc_func` to fix the warning. Verified that this works in robinst/taglib-ruby#115.

Fixes #2257.