### PR TITLE
[ccache] Use CFLAGS when running testsuite

### DIFF
--- a/CCache/Makefile.in
+++ b/CCache/Makefile.in
@@ -65,7 +65,7 @@ clean-docs:
 	rm -f $(srcdir)/$(PACKAGE_NAME).1 $(srcdir)/web/$(PACKAGE_NAME)-man.html
 
 test: test.sh
-	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='../$(PACKAGE_NAME)' CCACHE_PROG=$(PROGRAM_NAME) $(srcdir)/test.sh
+	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' CFLAGS='$(CFLAGS)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='../$(PACKAGE_NAME)' CCACHE_PROG=$(PROGRAM_NAME) $(srcdir)/test.sh
 
 check: test
 

--- a/CCache/test.sh
+++ b/CCache/test.sh
@@ -4,7 +4,7 @@
 # tridge@samba.org
 
 if test -n "$CC"; then
- COMPILER="$CC"
+ COMPILER="$CC $CFLAGS"
 else
  COMPILER=cc
 fi


### PR DESCRIPTION
This is required on AIX when building with -maix64.

Closes #1924