### PR TITLE
[Python] Replace tp_print with tp_vectorcall_offset slot from Python 3.8

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -211,7 +211,11 @@ SwigPyStaticVar_Type(void) {
       sizeof(PyGetSetDescrObject),              /* tp_basicsize */
       0,                                        /* tp_itemsize */
       (destructor)SwigPyStaticVar_dealloc,      /* tp_dealloc */
-      0,                                        /* tp_print */
+#if PY_VERSION_HEX < 0x030800b4
+      (printfunc)0,                             /*tp_print*/
+#else
+      (Py_ssize_t)0,                            /*tp_vectorcall_offset*/
+#endif
       0,                                        /* tp_getattr */
       0,                                        /* tp_setattr */
       0,                                        /* tp_compare */
@@ -295,7 +299,11 @@ SwigPyObjectType(void) {
       PyType_Type.tp_basicsize,                 /* tp_basicsize */
       0,                                        /* tp_itemsize */
       0,                                        /* tp_dealloc */
-      0,                                        /* tp_print */
+#if PY_VERSION_HEX < 0x030800b4
+      (printfunc)0,                             /*tp_print*/
+#else
+      (Py_ssize_t)0,                            /*tp_vectorcall_offset*/
+#endif
       0,                                        /* tp_getattr */
       0,                                        /* tp_setattr */
       0,                                        /* tp_compare */

--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -212,9 +212,9 @@ SwigPyStaticVar_Type(void) {
       0,                                        /* tp_itemsize */
       (destructor)SwigPyStaticVar_dealloc,      /* tp_dealloc */
 #if PY_VERSION_HEX < 0x030800b4
-      (printfunc)0,                             /*tp_print*/
+      (printfunc)0,                             /* tp_print */
 #else
-      (Py_ssize_t)0,                            /*tp_vectorcall_offset*/
+      (Py_ssize_t)0,                            /* tp_vectorcall_offset */
 #endif
       0,                                        /* tp_getattr */
       0,                                        /* tp_setattr */
@@ -300,9 +300,9 @@ SwigPyObjectType(void) {
       0,                                        /* tp_itemsize */
       0,                                        /* tp_dealloc */
 #if PY_VERSION_HEX < 0x030800b4
-      (printfunc)0,                             /*tp_print*/
+      (printfunc)0,                             /* tp_print */
 #else
-      (Py_ssize_t)0,                            /*tp_vectorcall_offset*/
+      (Py_ssize_t)0,                            /* tp_vectorcall_offset */
 #endif
       0,                                        /* tp_getattr */
       0,                                        /* tp_setattr */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -348,7 +348,11 @@ swig_varlink_type(void) {
       sizeof(swig_varlinkobject),         /* tp_basicsize */
       0,                                  /* tp_itemsize */
       (destructor) swig_varlink_dealloc,  /* tp_dealloc */
-      0,                                  /* tp_print */
+#if PY_VERSION_HEX < 0x030800b4
+      (printfunc)0,                       /*tp_print*/
+#else
+      (Py_ssize_t)0,                      /*tp_vectorcall_offset*/
+#endif
       (getattrfunc) swig_varlink_getattr, /* tp_getattr */
       (setattrfunc) swig_varlink_setattr, /* tp_setattr */
       0,                                  /* tp_compare */
@@ -914,7 +918,11 @@ SwigPyObject_TypeOnce(void) {
       sizeof(SwigPyObject),                 /* tp_basicsize */
       0,                                    /* tp_itemsize */
       (destructor)SwigPyObject_dealloc,     /* tp_dealloc */
-      0,                                    /* tp_print */
+#if PY_VERSION_HEX < 0x030800b4
+      (printfunc)0,                         /*tp_print*/
+#else
+      (Py_ssize_t)0,                        /*tp_vectorcall_offset*/
+#endif
       (getattrfunc)0,                       /* tp_getattr */
       (setattrfunc)0,                       /* tp_setattr */
 #if PY_VERSION_HEX >= 0x03000000
@@ -1090,7 +1098,11 @@ SwigPyPacked_TypeOnce(void) {
       sizeof(SwigPyPacked),                 /* tp_basicsize */
       0,                                    /* tp_itemsize */
       (destructor)SwigPyPacked_dealloc,     /* tp_dealloc */
-      0,                                    /* tp_print */
+#if PY_VERSION_HEX < 0x030800b4
+      (printfunc)0,                         /*tp_print*/
+#else
+      (Py_ssize_t)0,                        /*tp_vectorcall_offset*/
+#endif
       (getattrfunc)0,                       /* tp_getattr */
       (setattrfunc)0,                       /* tp_setattr */
 #if PY_VERSION_HEX>=0x03000000

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4145,7 +4145,11 @@ public:
     printSlot(f, getSlot(n, "feature:python:tp_basicsize", tp_basicsize), "tp_basicsize");
     printSlot(f, getSlot(n, "feature:python:tp_itemsize"), "tp_itemsize");
     printSlot(f, getSlot(n, "feature:python:tp_dealloc", tp_dealloc_bad), "tp_dealloc", "destructor");
+    Printv(f, "#if PY_VERSION_HEX < 0x030800b4\n", NIL);
     printSlot(f, getSlot(n, "feature:python:tp_print"), "tp_print", "printfunc");
+    Printv(f, "#else\n", NIL);
+    printSlot(f, getSlot(n, "feature:python:tp_vectorcall_offset"), "tp_vectorcall_offset", "Py_ssize_t");
+    Printv(f, "#endif\n", NIL);
     printSlot(f, getSlot(n, "feature:python:tp_getattr"), "tp_getattr", "getattrfunc");
     printSlot(f, getSlot(n, "feature:python:tp_setattr"), "tp_setattr", "setattrfunc");
     Printv(f, "#if PY_VERSION_HEX >= 0x03000000\n", NIL);


### PR DESCRIPTION
The `tp_print` slot is no longer supported and replaced with `tp_vectorcall_offset`. The `(printfunc)` cast that we used caused problems on PyPy.

Fixes #2262