### PR TITLE
Add argcargv.i to more languages: Perl 5, Tcl, PHP

### DIFF
--- a/Examples/test-suite/perl5/argcargvtest_runme.pl
+++ b/Examples/test-suite/perl5/argcargvtest_runme.pl
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 8;
+BEGIN { use_ok('argcargvtest') }
+require_ok('argcargvtest');
+
+my $largs = ["hi", "hola", "hello"];
+is(argcargvtest::mainc($largs), 3, "test main typemap 1");
+
+my $targs = ["hi", "hola"];
+is(argcargvtest::mainv($targs, 1), "hola", "test main typemap 2");
+
+my $errorVal = 0;
+my $ret = eval qq(argcargvtest::mainv("hello", 1); \$errorVal = 1;);
+is($ret, undef, "test main typemap 3");
+is($errorVal, 0, "test main typemap 4");
+
+is(argcargvtest::initializeApp($largs), undef, "test main typemap 5");
+
+ok(1, "done");

--- a/Examples/test-suite/php/argcargvtest_runme.php
+++ b/Examples/test-suite/php/argcargvtest_runme.php
@@ -1,0 +1,29 @@
+<?php
+
+require "tests.php";
+
+// New functions
+check::functions(array('mainc', 'mainv', 'initializeapp'));
+// New classes
+check::classes(array('argcargvtest'));
+// No new vars
+check::globals(array());
+
+$largs = array('hi', 'hola', 'hello');
+check::equal(mainc($largs), 3, 'Test main typemap 1');
+
+$targs = array('hi', 'hola');
+check::equal(mainv($targs, 1), 'hola', 'Test main typemap 2');
+
+$error = 0;
+try {
+    mainv('hello', 1);
+    $error = 1;
+}
+catch (exception $e) {
+}
+check::equal($error, 0, 'Test main typemap 3');
+
+initializeApp($largs);
+
+check::done();

--- a/Examples/test-suite/ruby/argcargvtest_runme.rb
+++ b/Examples/test-suite/ruby/argcargvtest_runme.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require 'swig_assert'
+require 'argcargvtest'
+
+include Argcargvtest
+
+
+$largs = ["hi", "hola", "hello"]
+if mainc($largs) != 3
+    raise RuntimeError, "bad main typemap"
+end
+
+$targs = ["hi", "hola"]
+if mainv($targs, 1) != "hola"
+    raise RuntimeError, "bad main typemap"
+end
+
+$error = 0
+$ret = 0
+begin
+    mainv("hello", 1)
+    $error = 1
+rescue => e
+    $ret = 1
+end
+
+if $error == 1 or $ret != 1
+    raise RuntimeError, "bad main typemap"
+end
+
+initializeApp($largs)

--- a/Examples/test-suite/tcl/argcargvtest_runme.tcl
+++ b/Examples/test-suite/tcl/argcargvtest_runme.tcl
@@ -1,0 +1,28 @@
+if [ catch { load ./argcargvtest[info sharedlibextension] argcargvtest} err_msg ] {
+	puts stderr "Could not load shared object:\n$err_msg"
+}
+
+set largs {hi hola hello}
+if {[mainc $largs] != 3} {
+     puts stderr "bad main typemap"
+     exit 1
+}
+
+set targs {hi hola}
+if {[mainv $targs 1] != "hola"} {
+     puts stderr "bad main typemap"
+     exit 1
+}
+
+set targs " hi hola "
+if {[mainv $targs 1] != "hola"} {
+     puts stderr "bad main typemap"
+     exit 1
+}
+
+if { ! [ catch { mainv("hello", 1) } ] } {
+    puts stderr "bad main typemap"
+    exit 1
+}
+
+initializeApp $largs

--- a/Lib/perl5/argcargv.i
+++ b/Lib/perl5/argcargv.i
@@ -1,0 +1,31 @@
+/* ------------------------------------------------------------
+ * --- Argc & Argv ---
+ * ------------------------------------------------------------ */
+
+%typemap(default) (int ARGC, char **ARGV) {
+  $1 = 0; $2 = NULL;
+}
+
+%typemap(in) (int ARGC, char **ARGV) {
+  int i;
+  I32 len;
+  AV *av = (AV *)SvRV($input);
+  if (SvTYPE(av) != SVt_PVAV) {
+    SWIG_croak("in method '$symname', Expecting reference to argv array");
+    goto fail;
+  }
+  len = av_len(av) + 1;
+  $1 = ($1_ltype) len;
+  $2 = (char **) malloc((len+1)*sizeof(char *));
+  for (i = 0; i < len; i++) {
+    SV **tv = av_fetch(av, i, 0);
+    $2[i] = SvPV_nolen(*tv);
+  }
+  $2[i] = NULL;
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != NULL) {
+    free((void *)$2);
+  }
+}

--- a/Lib/perl5/argcargv.i
+++ b/Lib/perl5/argcargv.i
@@ -24,6 +24,11 @@
   $2[i] = NULL;
 }
 
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
+  AV *av = (AV *)SvRV($input);
+  $1 = SvTYPE(av) == SVt_PVAV;
+}
+
 %typemap(freearg) (int ARGC, char **ARGV) {
   if ($2 != NULL) {
     free((void *)$2);

--- a/Lib/php/argcargv.i
+++ b/Lib/php/argcargv.i
@@ -33,6 +33,10 @@
   $2[i] = NULL;
 }
 
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
+  $1 = Z_TYPE($input) == IS_ARRAY;
+}
+
 %typemap(freearg) (int ARGC, char **ARGV) {
   if ($2 != NULL) {
     free((void *)$2);

--- a/Lib/php/argcargv.i
+++ b/Lib/php/argcargv.i
@@ -1,0 +1,40 @@
+/* ------------------------------------------------------------
+ * --- Argc & Argv ---
+ * ------------------------------------------------------------ */
+
+%typemap(default) (int ARGC, char **ARGV) {
+  $1 = 0; $2 = NULL;
+}
+
+%typemap(in) (int ARGC, char **ARGV) {
+  int len, i;
+  zval *val;
+  zend_array *ar;
+  if (Z_TYPE($input) != IS_ARRAY) {
+    SWIG_PHP_Error(E_ERROR, "Type error in '$symname'. Expected array");
+    goto fail;
+  }
+  ar = Z_ARR($input);
+  len = zend_array_count(ar);
+  $1 = ($1_ltype) len;
+  $2 = (char **) malloc((len+1)*sizeof(char *));
+  i = 0;
+  ZEND_HASH_FOREACH_VAL(ar, val) {
+    if (Z_TYPE(*val) != IS_STRING) {
+      SWIG_PHP_Error(E_ERROR, "Array must use strings only, in '$symname'.");
+      goto fail;
+    }
+    if (i == len) {
+      SWIG_PHP_Error(E_ERROR, "Array is bigger than zend report in '$symname'.");
+      goto fail;
+    }
+    $2[i++] = Z_STRVAL(*val);
+  } ZEND_HASH_FOREACH_END();
+  $2[i] = NULL;
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != NULL) {
+    free((void *)$2);
+  }
+}

--- a/Lib/tcl/argcargv.i
+++ b/Lib/tcl/argcargv.i
@@ -21,6 +21,11 @@
   $2[i] = NULL;
 }
 
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
+  int len;
+  $1 = Tcl_ListObjLength(interp, $input, &len) == TCL_OK;
+}
+
 %typemap(freearg) (int ARGC, char **ARGV) {
   if ($2 != NULL) {
     free((void *)$2);

--- a/Lib/tcl/argcargv.i
+++ b/Lib/tcl/argcargv.i
@@ -1,0 +1,28 @@
+/* ------------------------------------------------------------
+ * --- Argc & Argv ---
+ * ------------------------------------------------------------ */
+
+%typemap(default) (int ARGC, char **ARGV) {
+  $1 = 0; $2 = NULL;
+}
+
+%typemap(in) (int ARGC, char **ARGV) {
+  int i, nitems;
+  Tcl_Obj **listobjv;
+  if (Tcl_ListObjGetElements(interp, $input, &nitems, &listobjv) == TCL_ERROR) {
+     SWIG_exception_fail(SWIG_ValueError, "in method '$symname', Expecting list of argv");
+     goto fail;
+  }
+  $1 = ($1_ltype) nitems;
+  $2 = (char **) malloc((nitems+1)*sizeof(char *));
+  for (i = 0; i < nitems; i++) {
+    $2[i] = Tcl_GetStringFromObj(listobjv[i], NULL);
+  }
+  $2[i] = NULL;
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != NULL) {
+    free((void *)$2);
+  }
+}


### PR DESCRIPTION
Add argcargv.i to Perl 5, Tcl 8, PHP 7

Test them on my Debian 11.3 using amd64 

Versions on swig and languages:
- swig 4.0.2-1
- php 7.4.28-1+deb11u1
- perl 5.32.1-4+deb11u2
- tcl 8.6.11+dfsg-1

Testing also Lua argcargv.i from  [Add argcargv.i to Lua #2275](https://github.com/swig/swig/pull/2275)
With: lua 5.1, 5.2, 5.3