### PR TITLE
Python: define PY_SSIZE_T_CLEAN

### DIFF
--- a/Lib/python/embed.i
+++ b/Lib/python/embed.i
@@ -29,7 +29,9 @@ As far as I know, this module is C++ safe.
 #endif
 
 %wrapper %{
-
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#endif
 #include <Python.h>
 
 #ifdef __cplusplus

--- a/Lib/python/pyruntime.swg
+++ b/Lib/python/pyruntime.swg
@@ -11,6 +11,9 @@
 # include <corecrt.h>
 #endif
 
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#endif
 #if defined(_DEBUG) && defined(SWIG_PYTHON_INTERPRETER_NO_DEBUG)
 /* Use debug wrappers with the Python release dll */
 # undef _DEBUG


### PR DESCRIPTION
It is recommended to always define PY_SSIZE_T_CLEAN before including
Python.h. Cf. https://docs.python.org/3/c-api/intro.html

This avoids errors like:

    SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>