### PR TITLE
Octave: argcargv.i

### DIFF
--- a/Examples/test-suite/argcargvtest.i
+++ b/Examples/test-suite/argcargvtest.i
@@ -1,6 +1,6 @@
 %module argcargvtest
 
-#if !defined(SWIGCSHARP) && !defined(SWIGD) && !defined(SWIGGO) && !defined(SWIGGUILE) && !defined(SWIGJAVA) && !defined(SWIGJAVASCRIPT) && !defined(SWIGMZSCHEME) && !defined(SWIGOCTAVE) && !defined(SWIGR) && !defined(SWIGSCILAB)
+#if !defined(SWIGCSHARP) && !defined(SWIGD) && !defined(SWIGGO) && !defined(SWIGGUILE) && !defined(SWIGJAVA) && !defined(SWIGJAVASCRIPT) && !defined(SWIGMZSCHEME) && !defined(SWIGR) && !defined(SWIGSCILAB)
 %include <argcargv.i>
 
 %apply (int ARGC, char **ARGV) { (size_t argc, const char **argv) }

--- a/Examples/test-suite/octave/argcargvtest_runme.m
+++ b/Examples/test-suite/octave/argcargvtest_runme.m
@@ -1,0 +1,29 @@
+argcargvtest
+
+largs={'hi','hola','hello'};
+if (mainc(largs) != 3)
+  error("bad main typemap");
+endif
+
+targs={'hi','hola'};
+if (mainv(targs,1) != 'hola')
+  error("bad main typemap");
+endif
+
+targs={'hi', 'hola'};
+if (mainv(targs,1) != 'hola')
+  error("bad main typemap");
+endif
+
+try
+  error_flag = 0;
+  mainv('hello',1);
+  error_flag = 1;
+catch
+end_try_catch
+if (error_flag)
+  error("bad main typemap")
+endif
+
+
+initializeApp(largs);

--- a/Lib/octave/argcargv.i
+++ b/Lib/octave/argcargv.i
@@ -1,0 +1,33 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+%typemap(in) (int ARGC, char **ARGV) {
+  if ($input.is_scalar_type()) {
+      $1 = 0; $2 = NULL;
+      %argument_fail(SWIG_TypeError, "'int ARGC, char **ARGV' is not a list", $symname, $argnum);
+  }
+  octave_value_list list = $input.list_value();
+  int i, len = list.length();
+  $1 = ($1_ltype) len;
+  $2 = (char **) malloc((len+1)*sizeof(char *));
+  for (i = 0; i < len; i++) {
+    if(!list(i).is_string()) {
+      $1 = 0;
+      %argument_fail(SWIG_TypeError, "'int ARGC, char **ARGV' use a non-string", $symname, $argnum);
+    }
+    $2[i] = (char *)list(i).string_value().c_str();
+  }
+  $2[i] = NULL;
+}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
+  const octave_value& ov = $input;
+  $1 = !ov.is_scalar_type();
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != NULL) {
+    free((void *)$2);
+  }
+}


### PR DESCRIPTION
Took the opportunity that octave already have the argcargv test and add the wrote the argcargv.i.
The Octave documentation is very bad, their Doxygen contains the declarations but without any description.
I do hope I did not do any dumb mistakes as result.

The `make argcargvtest.cpptest` test pass.
As Octave uses C++ API, `make argcargvtest.ctest` pass as well :-)