### PR TITLE
Improve #include guard macros

### DIFF
--- a/Doc/Manual/Preprocessor.html
+++ b/Doc/Manual/Preprocessor.html
@@ -189,15 +189,15 @@ is also used to try and detect constants.  Therefore, if you have something like
 
 <div class="code">
 <pre>
-#ifndef _FOO_H 1
-#define _FOO_H 1
+#ifndef FOO_H 1
+#define FOO_H 1
 ...
 #endif
 </pre>
 </div>
 
 <p>
-you may get some extra constants such as <tt>_FOO_H</tt> showing up in the scripting interface.
+you may get some extra constants such as <tt>FOO_H</tt> showing up in the scripting interface.
 </p>
 
 <p>

--- a/Examples/javascript/nspace/example.h
+++ b/Examples/javascript/nspace/example.h
@@ -1,5 +1,5 @@
-#ifndef _example_guardian_
-#define _example_guardian_
+#ifndef EXAMPLE_H
+#define EXAMPLE_H
 
 int module_function() { return 7; }
 int module_variable = 9;

--- a/Examples/lua/nspace/example.h
+++ b/Examples/lua/nspace/example.h
@@ -1,5 +1,5 @@
-#ifndef _example_guardian_
-#define _example_guardian_
+#ifndef EXAMPLE_H
+#define EXAMPLE_H
 
 int module_function() { return 7; }
 int module_variable = 9;

--- a/Examples/ruby/free_function/example.h
+++ b/Examples/ruby/free_function/example.h
@@ -1,5 +1,5 @@
-#ifndef _EXAMPLE_H_
-#define _EXAMPLE_H_
+#ifndef EXAMPLE_H
+#define EXAMPLE_H
 
 #include <vector>
 #include <string>
@@ -46,4 +46,4 @@ public:
 	Animal* get_animal(size_t i) const;
 };
 
-#endif /*_EXAMPLE_H_*/
+#endif /* EXAMPLE_H */

--- a/Examples/ruby/mark_function/example.h
+++ b/Examples/ruby/mark_function/example.h
@@ -1,5 +1,5 @@
-#ifndef _EXAMPLE_H_
-#define _EXAMPLE_H_
+#ifndef EXAMPLE_H
+#define EXAMPLE_H
 
 #include <vector>
 #include <string>
@@ -46,4 +46,4 @@ public:
 	Animal* get_animal(size_t i) const;
 };
 
-#endif /*_EXAMPLE_H_*/
+#endif /* EXAMPLE_H */

--- a/Examples/test-suite/refcount.h
+++ b/Examples/test-suite/refcount.h
@@ -1,5 +1,5 @@
-#ifndef TEST_SUITE_REFCOUNT_H__
-#define TEST_SUITE_REFCOUNT_H__
+#ifndef TEST_SUITE_REFCOUNT_H
+#define TEST_SUITE_REFCOUNT_H
 
 struct RCObjBase  {
   /*!
@@ -195,4 +195,4 @@ RCPtr<T>& RCPtr<T>::operator=(const RCPtr& rhs)
 
 
 
-#endif //TEST_SUITE_REFCOUNT_H__
+#endif // TEST_SUITE_REFCOUNT_H

--- a/Examples/test-suite/template_typedef_cplx2.h
+++ b/Examples/test-suite/template_typedef_cplx2.h
@@ -1,5 +1,5 @@
-#ifndef ___typedef_import_h__
-#define ___typedef_import_h__
+#ifndef TEMPLATE_TYPEDEF_CPLX2_H
+#define TEMPLATE_TYPEDEF_CPLX2_H
 
 #ifdef SWIG
 %module template_typedef_cplx2;
@@ -174,4 +174,4 @@ namespace vfncs {
 
 #endif
 
-#endif //___template_typedef_h__
+#endif // TEMPLATE_TYPEDEF_CPLX2_H

--- a/Lib/allkw.swg
+++ b/Lib/allkw.swg
@@ -1,5 +1,5 @@
-#ifndef __Lib_allkw_swg__
-#define __Lib_allkw_swg__
+#ifndef SWIG_INCLUDED_LIB_ALLKW_SWG
+#define SWIG_INCLUDED_LIB_ALLKW_SWG
 
 
 /*  
@@ -30,4 +30,4 @@
 %include <tcl/tclkw.swg>
 
 
-#endif //__Lib_allkw_swg__
+#endif // SWIG_INCLUDED_LIB_ALLKW_SWG

--- a/Lib/octave/octheaders.hpp
+++ b/Lib/octave/octheaders.hpp
@@ -9,8 +9,8 @@
 //     g++ -c -include octheaders.hpp ...
 //
 
-#if !defined(_SWIG_OCTAVE_OCTHEADERS_HPP)
-#define _SWIG_OCTAVE_OCTHEADERS_HPP
+#if !defined(SWIG_OCTAVE_OCTHEADERS_HPP)
+#define SWIG_OCTAVE_OCTHEADERS_HPP
 
 // Required C++ headers
 #include <cstdlib>
@@ -127,4 +127,4 @@
 #include <octave/call-stack.h>
 #endif
 
-#endif // !defined(_SWIG_OCTAVE_OCTHEADERS_HPP)
+#endif // !defined(SWIG_OCTAVE_OCTHEADERS_HPP)

--- a/Source/CParse/cparse.h
+++ b/Source/CParse/cparse.h
@@ -11,8 +11,8 @@
  * SWIG parser module.
  * ----------------------------------------------------------------------------- */
 
-#ifndef SWIG_CPARSE_H_
-#define SWIG_CPARSE_H_
+#ifndef SWIG_CPARSE_H
+#define SWIG_CPARSE_H
 
 #include "swig.h"
 #include "swigwarn.h"

--- a/Source/DOH/doh.h
+++ b/Source/DOH/doh.h
@@ -11,8 +11,8 @@
  *     This file describes of the externally visible functions in DOH.
  * ----------------------------------------------------------------------------- */
 
-#ifndef _DOH_H
-#define _DOH_H
+#ifndef SWIG_DOH_H
+#define SWIG_DOH_H
 
 #ifndef MACSWIG
 #include "swigconfig.h"
@@ -503,4 +503,4 @@ extern void DohMemoryDebug(void);
 # pragma GCC poison abort exit
 #endif
 
-#endif				/* DOH_H */
+#endif				/* SWIG_DOH_H */

--- a/Source/DOH/dohint.h
+++ b/Source/DOH/dohint.h
@@ -11,8 +11,8 @@
  *     This file describes internally managed objects.
  * ----------------------------------------------------------------------------- */
 
-#ifndef _DOHINT_H
-#define _DOHINT_H
+#ifndef SWIG_DOHINT_H
+#define SWIG_DOHINT_H
 
 #include "doh.h"
 
@@ -128,4 +128,4 @@ typedef struct {
 extern DOH *DohObjMalloc(DohObjInfo *type, void *data);	/* Allocate a DOH object */
 extern void DohObjFree(DOH *ptr);	/* Free a DOH object     */
 
-#endif				/* DOHINT_H */
+#endif				/* SWIG_DOHINT_H */

--- a/Source/Doxygen/doxyentity.h
+++ b/Source/Doxygen/doxyentity.h
@@ -11,8 +11,8 @@
  * Part of the Doxygen comment translation module of SWIG.
  * ----------------------------------------------------------------------------- */
 
-#ifndef DOXYGENENTITY_H_
-#define DOXYGENENTITY_H_
+#ifndef SWIG_DOXYENTITY_H
+#define SWIG_DOXYENTITY_H
 
 #include <string>
 #include <list>

--- a/Source/Doxygen/doxyparser.h
+++ b/Source/Doxygen/doxyparser.h
@@ -9,8 +9,8 @@
  * doxyparser.h
  * ----------------------------------------------------------------------------- */
 
-#ifndef DOXYGENPARSER_H_
-#define DOXYGENPARSER_H_
+#ifndef SWIG_DOXYPARSER_H
+#define SWIG_DOXYPARSER_H
 #include <string>
 #include <list>
 #include <map>

--- a/Source/Doxygen/doxytranslator.h
+++ b/Source/Doxygen/doxytranslator.h
@@ -12,8 +12,8 @@
  * systems.
  * ----------------------------------------------------------------------------- */
 
-#ifndef DOXYGENTRANSLATOR_H_
-#define DOXYGENTRANSLATOR_H_
+#ifndef SWIG_DOXYTRANSLATOR_H
+#define SWIG_DOXYTRANSLATOR_H
 
 #include "swig.h"
 #include "doxyentity.h"

--- a/Source/Doxygen/javadoc.h
+++ b/Source/Doxygen/javadoc.h
@@ -11,8 +11,8 @@
  * Module to return documentation for nodes formatted for JavaDoc
  * ----------------------------------------------------------------------------- */
 
-#ifndef JAVADOCCONVERTER_H_
-#define JAVADOCCONVERTER_H_
+#ifndef SWIG_JAVADOC_H
+#define SWIG_JAVADOC_H
 
 #include "doxytranslator.h"
 #include <map>

--- a/Source/Doxygen/pydoc.h
+++ b/Source/Doxygen/pydoc.h
@@ -11,8 +11,8 @@
  * Module to return documentation for nodes formatted for PyDoc
  * ----------------------------------------------------------------------------- */
 
-#ifndef PYDOCCONVERTER_H_
-#define PYDOCCONVERTER_H_
+#ifndef SWIG_PYDOC_H
+#define SWIG_PYDOC_H
 
 #include <list>
 #include <string>

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -22,8 +22,8 @@
  * This file is used as the input for generating Lib/swigwarn.swg.
  * ----------------------------------------------------------------------------- */
 
-#ifndef SWIGWARN_H_
-#define SWIGWARN_H_
+#ifndef SWIG_SWIGWARN_H
+#define SWIG_SWIGWARN_H
 
 #define WARN_NONE                     0
 

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -11,8 +11,8 @@
  * Main header file for SWIG modules.
  * ----------------------------------------------------------------------------- */
 
-#ifndef SWIG_SWIGMOD_H_
-#define SWIG_SWIGMOD_H_
+#ifndef SWIG_SWIGMOD_H
+#define SWIG_SWIGMOD_H
 
 #include "swig.h"
 #include "preprocessor.h"

--- a/Source/Preprocessor/preprocessor.h
+++ b/Source/Preprocessor/preprocessor.h
@@ -11,8 +11,8 @@
  * SWIG preprocessor module.
  * ----------------------------------------------------------------------------- */
 
-#ifndef SWIG_PREPROCESSOR_H_
-#define SWIG_PREPROCESSOR_H_
+#ifndef SWIG_PREPROCESSOR_H
+#define SWIG_PREPROCESSOR_H
 
 #include "swigwarn.h"
 

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -11,8 +11,8 @@
  * Header file for the SWIG core.
  * ----------------------------------------------------------------------------- */
 
-#ifndef SWIGCORE_H_
-#define SWIGCORE_H_
+#ifndef SWIG_SWIG_H
+#define SWIG_SWIG_H
 
 #ifndef MACSWIG
 #include "swigconfig.h"


### PR DESCRIPTION
Avoid using reserved identifiers such as `_DOHINT_H` (fixes #1989),
fix cases where the name doesn't match the filename, and make the naming
more consistent and less likely to collide with include guards in other
headers.