### PR TITLE
Rework testing of C++14 and C++17 and add C++20

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.1.0 (in progress)
 ===========================
 
+2022-07-25: olly
+	    Support for C++14 binary integer literals in preprocessor expressions.
+
 2022-07-20: wsfulton
             [C#, Java] Ensure the order of interfaces generated in proxy interfaces for the
             %interface family of macros is the same as that parsed from the bases in C++.

--- a/Examples/test-suite/cffi/Makefile.in
+++ b/Examples/test-suite/cffi/Makefile.in
@@ -7,6 +7,9 @@ CFFI         = @CFFIBIN@
 SCRIPTSUFFIX = _runme.lisp
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -91,7 +91,10 @@ CPP_TEST_BROKEN += \
 	template_default_pointer \
 	template_private_assignment \
 	template_expr \
-	$(CPP11_TEST_BROKEN)
+	$(CPP11_TEST_BROKEN) \
+	$(CPP14_TEST_BROKEN) \
+	$(CPP17_TEST_BROKEN) \
+	$(CPP20_TEST_BROKEN)
 
 
 # Broken C test cases. (Can be run individually using: make testcase.ctest)
@@ -632,6 +635,24 @@ CPP11_TEST_BROKEN = \
 #	cpp11_variadic_templates \    # Broken for some languages (such as Java)
 #	cpp11_reference_wrapper \     # No typemaps
 
+# C++14 test cases.
+CPP14_TEST_CASES += \
+
+# Broken C++14 test cases.
+CPP14_TEST_BROKEN = \
+
+# C++17 test cases.
+CPP17_TEST_CASES += \
+
+# Broken C++17 test cases.
+CPP17_TEST_BROKEN = \
+
+# C++20 test cases.
+CPP20_TEST_CASES += \
+
+# Broken C++20 test cases.
+CPP20_TEST_BROKEN = \
+
 # Doxygen support test cases: can only be used with languages supporting
 # Doxygen comment translation (currently Python and Java) and only if not
 # disabled by configure via SKIP_DOXYGEN_TEST_CASES.
@@ -697,6 +718,18 @@ endif
 
 ifeq (1,$(HAVE_CXX11))
 CPP_TEST_CASES += $(CPP11_TEST_CASES)
+endif
+
+ifeq (1,$(HAVE_CXX14))
+CPP_TEST_CASES += $(CPP14_TEST_CASES)
+endif
+
+ifeq (1,$(HAVE_CXX17))
+CPP_TEST_CASES += $(CPP17_TEST_CASES)
+endif
+
+ifeq (1,$(HAVE_CXX20))
+CPP_TEST_CASES += $(CPP20_TEST_CASES)
 endif
 
 # C test cases. (Can be run individually using: make testcase.ctest)
@@ -783,6 +816,9 @@ command_line_define.ctest: SWIGOPT += -DFOO
 C_TEST_CASES := $(filter-out $(FAILING_C_TESTS),$(C_TEST_CASES))
 CPP_TEST_CASES := $(filter-out $(FAILING_CPP_TESTS),$(CPP_TEST_CASES))
 CPP11_TEST_CASES := $(filter-out $(FAILING_CPP_TESTS),$(CPP11_TEST_CASES))
+CPP14_TEST_CASES := $(filter-out $(FAILING_CPP_TESTS),$(CPP14_TEST_CASES))
+CPP17_TEST_CASES := $(filter-out $(FAILING_CPP_TESTS),$(CPP17_TEST_CASES))
+CPP20_TEST_CASES := $(filter-out $(FAILING_CPP_TESTS),$(CPP20_TEST_CASES))
 MULTI_CPP_TEST_CASES := $(filter-out $(FAILING_MULTI_CPP_TESTS),$(MULTI_CPP_TEST_CASES))
 
 
@@ -796,6 +832,9 @@ BROKEN_TEST_CASES = 	$(CPP_TEST_BROKEN:=.cpptest) \
 
 ALL_CLEAN = 		$(CPP_TEST_CASES:=.clean) \
 			$(CPP11_TEST_CASES:=.clean) \
+			$(CPP14_TEST_CASES:=.clean) \
+			$(CPP17_TEST_CASES:=.clean) \
+			$(CPP20_TEST_CASES:=.clean) \
 			$(C_TEST_CASES:=.clean) \
 			$(MULTI_CPP_TEST_CASES:=.clean) \
 			$(CPP_TEST_BROKEN:=.clean) \
@@ -823,6 +862,12 @@ check-c: $(C_TEST_CASES:=.ctest)
 check-cpp: $(CPP_TEST_CASES:=.cpptest)
 
 check-cpp11: $(CPP11_TEST_CASES:=.cpptest)
+
+check-cpp14: $(CPP14_TEST_CASES:=.cpptest)
+
+check-cpp17: $(CPP17_TEST_CASES:=.cpptest)
+
+check-cpp20: $(CPP20_TEST_CASES:=.cpptest)
 
 check-multicpp: $(MULTI_CPP_TEST_CASES:=.multicpptest)
 

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -168,11 +168,6 @@ CPP_TEST_CASES += \
 	cpp_parameters \
 	cpp_static \
 	cpp_typedef \
-	cpp14_binary_integer_literals \
-	cpp17_hex_floating_literals \
-	cpp17_nested_namespaces \
-	cpp17_nspace_nested_namespaces \
-	cpp17_u8_char_literals \
 	curiously_recurring_template_pattern \
 	default_args \
 	default_arg_expressions \
@@ -637,12 +632,17 @@ CPP11_TEST_BROKEN = \
 
 # C++14 test cases.
 CPP14_TEST_CASES += \
+	cpp14_binary_integer_literals \
 
 # Broken C++14 test cases.
 CPP14_TEST_BROKEN = \
 
 # C++17 test cases.
 CPP17_TEST_CASES += \
+	cpp17_hex_floating_literals \
+	cpp17_nested_namespaces \
+	cpp17_nspace_nested_namespaces \
+	cpp17_u8_char_literals \
 
 # Broken C++17 test cases.
 CPP17_TEST_BROKEN = \

--- a/Examples/test-suite/cpp11_raw_string_literals.i
+++ b/Examples/test-suite/cpp11_raw_string_literals.i
@@ -1,7 +1,7 @@
 /* This module tests whether SWIG correctly parses:
-   -    ordinary strings (char_t)
+   -    ordinary strings (char)
    - L  wide strings (wchar_t)
-   - u8 unicode8 strings (char_t)
+   - u8 unicode8 strings (char / char8_t since C++20)
    - u  unicode16 strings (char16_t)
    - U  unicode32 strings (char32_t)
 
@@ -49,7 +49,8 @@ struct URStruct {
 
 // New string literals
 wstring         aa =  L"Wide string";
-const char     *bb = u8"UTF-8 string";
+// u8"" is const char8_t[N] in C++20; const char[N] from C++11 until then.
+const char     *bb = reinterpret_cast<const char*>(u8"UTF-8 string");
 const char16_t *cc =  u"UTF-16 string";
 const char32_t *dd =  U"UTF-32 string";
 // New char literals
@@ -62,7 +63,7 @@ char32_t char32_t_char = U'b';
 const char      *xx =        ")I'm an \"ascii\" \\ string.";
 const char      *ee =   R"XXX()I'm an "ascii" \ string.)XXX";
 wstring          ff =  LR"XXX(I'm a "raw wide" \ string.)XXX";
-const char      *gg = u8R"XXX(I'm a "raw UTF-8" \ string.)XXX";
+const char      *gg = reinterpret_cast<const char*>(u8R"XXX(I'm a "raw UTF-8" \ string.)XXX");
 const char16_t  *hh =  uR"XXX(I'm a "raw UTF-16" \ string.)XXX";
 const char32_t  *ii =  UR"XXX(I'm a "raw UTF-32" \ string.)XXX";
 %}

--- a/Examples/test-suite/cpp11_result_of.i
+++ b/Examples/test-suite/cpp11_result_of.i
@@ -55,10 +55,10 @@ std::result_of< fn_ptr(double) >::type test_result_alternative1(double(*fun)(dou
 #include <iostream>
 
 void cpp_testing() {
-  std::cout << "result: " << test_result_impl(square, 3) << std::endl;
-  std::cout << "result: " << test_result_impl<double(*)(double), double>(square, 4) << std::endl;
-  std::cout << "result: " << test_result_impl< fn_ptr, double >(square, 5) << std::endl;
-  std::cout << "result: " << test_result_alternative1(square, 6) << std::endl;
+  std::cout << "result: " << test_result_impl(square, 3.0) << std::endl;
+  std::cout << "result: " << test_result_impl<double(*)(double), double>(square, 4.0) << std::endl;
+  std::cout << "result: " << test_result_impl< fn_ptr, double >(square, 5.0) << std::endl;
+  std::cout << "result: " << test_result_alternative1(square, 6.0) << std::endl;
 }
 %}
 

--- a/Examples/test-suite/cpp11_userdefined_literals.i
+++ b/Examples/test-suite/cpp11_userdefined_literals.i
@@ -30,6 +30,9 @@ OutputType operator "" _mySuffixFloat(long double) { return OutputType(30); }
 
 // Cooked string literals
 OutputType operator "" _mySuffix1(const char * string_values, size_t num_chars) { return OutputType(100); }
+#ifdef __cpp_lib_char8_t // For C++20
+OutputType operator "" _mySuffix1(const char8_t * string_values, size_t num_chars) { return OutputType(100); }
+#endif
 OutputType operator "" _mySuffix2(const wchar_t * string_values, size_t num_chars) { return OutputType(200); }
 OutputType operator "" _mySuffix3(const char16_t * string_values, size_t num_chars) { return OutputType(300); }
 OutputType operator "" _mySuffix4(const char32_t * string_values, size_t num_chars) { return OutputType(400); }

--- a/Examples/test-suite/cpp14_binary_integer_literals.i
+++ b/Examples/test-suite/cpp14_binary_integer_literals.i
@@ -1,31 +1,9 @@
 %module cpp14_binary_integer_literals
 
-// Tests are designed so that code compiles with C++98 compilers
-
-%{
-#if __cplusplus >= 201402L
-#define CPP14 1
-#endif
-%}
-
+%inline %{
 int b1 = 0b1;
 int b2 = 0b10;
 long b3 = 0b11l;
 unsigned long b4 = 0b100ul;
 unsigned long b5 = 0B101UL;
-
-%{
-#if defined(CPP14)
-int b1 = 0b1;
-int b2 = 0b10;
-long b3 = 0b11l;
-unsigned long b4 = 0b100ul;
-unsigned long b5 = 0B101UL;
-#else
-int b1 = 1;
-int b2 = 2;
-long b3 = 3;
-unsigned long b4 = 4;
-unsigned long b5 = 5;
-#endif
 %}

--- a/Examples/test-suite/cpp14_binary_integer_literals.i
+++ b/Examples/test-suite/cpp14_binary_integer_literals.i
@@ -1,5 +1,9 @@
 %module cpp14_binary_integer_literals
 
+#if 0b100 < 4
+# error binary constant in preprocessor expression failed
+#endif
+
 %inline %{
 int b1 = 0b1;
 int b2 = 0b10;

--- a/Examples/test-suite/cpp14_binary_integer_literals.i
+++ b/Examples/test-suite/cpp14_binary_integer_literals.i
@@ -10,4 +10,8 @@ int b2 = 0b10;
 long b3 = 0b11l;
 unsigned long b4 = 0b100ul;
 unsigned long b5 = 0B101UL;
+#define b6 0b110
+const int b7 = 0b111;
 %}
+
+%constant int b8 = 0b1000;

--- a/Examples/test-suite/cpp17_hex_floating_literals.i
+++ b/Examples/test-suite/cpp17_hex_floating_literals.i
@@ -1,13 +1,6 @@
 %module cpp17_hex_floating_literals
 
-// Tests are designed so that code compiles with C++98 compilers
-
-%{
-#if __cplusplus >= 201703L
-#define CPP17 1
-#endif
-%}
-
+%inline %{
 double f1 = 0x.0p1;
 double f2 = 0x0.p1;
 double f3 = 0x0.0p-1;
@@ -17,27 +10,4 @@ double f6 = 0x0.10P+10;
 double f7 = 0xb2F.p2;
 float f8 = 0x1234AP1F;
 float f9 = 0x45A1.D1A2p+10f;
-
-%{
-#if defined(CPP17)
-double f1 = 0x.0p1;
-double f2 = 0x0.p1;
-double f3 = 0x0.0p-1;
-double f4 = 0xf.p-1;
-double f5 = 0xA.0p1;
-double f6 = 0x0.10P+10;
-double f7 = 0xb2F.p2;
-float f8 = 0x1234AP1F;
-float f9 = 0x45A1.D1A2p+10f;
-#else
-double f1 = 0.;
-double f2 = 0.;
-double f3 = 0.;
-double f4 = 7.5;
-double f5 = 20.;
-double f6 = 64.;
-double f7 = 11452.;
-float f8 = 149140.f;
-float f9 = 18253638.f;
-#endif
 %}

--- a/Examples/test-suite/cpp17_nested_namespaces.i
+++ b/Examples/test-suite/cpp17_nested_namespaces.i
@@ -1,13 +1,5 @@
 %module cpp17_nested_namespaces
 // Tests c++17 style nested namespaces
-// Tests are designed so that code compiles with C++98 compilers
-
-#define CPP17 1
-%{
-#if __cplusplus >= 201703L
-#define CPP17 1
-#endif
-%}
 
 %inline %{
 // Tests with namespaces already defined using C++98 style (non-nested) namespaces
@@ -21,20 +13,10 @@ namespace A1 {
     };
   }
 }
-#if defined(CPP17)
 namespace A1::B1 {
-#else
-namespace A1 {
- namespace B1 {
-#endif
   A1Struct createA1Struct() { return ::A1::A1Struct(); }
   B1Struct createB1Struct() { return ::A1::B1::B1Struct(); }
-#if !defined(CPP17)
- }
 }
-#else
-}
-#endif
 
 namespace A1 {
   namespace B1 {
@@ -46,154 +28,54 @@ namespace A1 {
   }
 }
 
-#if defined(CPP17)
 namespace A1::B1::C1 {
-#else
-namespace A1 {
- namespace B1 {
-  namespace C1 {
-#endif
   C1Struct createC1Struct() { return ::A1::B1::C1::C1Struct(); }
-#if !defined(CPP17)
-  }
- }
 }
-#else
-}
-#endif
 %}
 
 %inline %{
 // Tests with namespaces already defined using C++17 style (nested) namespaces
-#if defined(CPP17)
 namespace A2::B2 {
-#else
-namespace A2 {
- namespace B2 {
-#endif
   struct B2Struct {
     void B2Method() {}
   };
-#if !defined(CPP17)
- }
 }
-#else
-}
-#endif
 
-#if defined(CPP17)
 namespace A2::B2 {
-#else
-namespace A2 {
- namespace B2 {
-#endif
   B2Struct createB2Struct() { return ::A2::B2::B2Struct(); }
-#if !defined(CPP17)
- }
 }
-#else
-}
-#endif
 
-#if defined(CPP17)
 namespace A2::B2::C2 {
-#else
-namespace A2 {
- namespace B2 {
-  namespace C2 {
-#endif
     struct C2Struct {
       void C2Method() {}
     };
-#if !defined(CPP17)
-  }
- }
 }
-#else
-}
-#endif
 
-#if defined(CPP17)
 namespace A2::B2::C2 {
-#else
-namespace A2 {
- namespace B2 {
-  namespace C2 {
-#endif
   C2Struct createC2Struct() { return ::A2::B2::C2::C2Struct(); }
-#if !defined(CPP17)
-  }
- }
 }
-#else
-}
-#endif
 %}
 
 
 %inline %{
 // Tests with namespaces already defined using C++17 style (nested) namespaces to 3 levels
-#if defined(CPP17)
 namespace A3::B3::C3 {
-#else
-namespace A3 {
- namespace B3 {
-  namespace C3 {
-#endif
     struct C3Struct {
       void C3Method() {}
     };
-#if !defined(CPP17)
-  }
- }
 }
-#else
-}
-#endif
 
-#if defined(CPP17)
 namespace A3::B3::C3 {
-#else
-namespace A3 {
- namespace B3 {
-  namespace C3 {
-#endif
   C3Struct createC3Struct() { return ::A3::B3::C3::C3Struct(); }
-#if !defined(CPP17)
-  }
- }
 }
-#else
-}
-#endif
 
-#if defined(CPP17)
 namespace A3::B3 {
-#else
-namespace A3 {
- namespace B3 {
-#endif
   struct B3Struct {
     void B3Method() {}
   };
-#if !defined(CPP17)
- }
 }
-#else
-}
-#endif
 
-#if defined(CPP17)
 namespace A3::B3 {
-#else
-namespace A3 {
- namespace B3 {
-#endif
   B3Struct createB3Struct() { return ::A3::B3::B3Struct(); }
-#if !defined(CPP17)
- }
 }
-#else
-}
-#endif
 %}

--- a/Examples/test-suite/cpp17_u8_char_literals.i
+++ b/Examples/test-suite/cpp17_u8_char_literals.i
@@ -8,7 +8,8 @@
 #endif
 %}
 
-// UTF-8 character literals will (apparently) have type char8_t in C++20.
+// UTF-8 character literals are type `char` in C++17 but `char8_t` in C++20,
+// but the latter can be assigned to `char`.
 char a = u8'a';
 char u = u8'u';
 char u8 = u8'8';

--- a/Examples/test-suite/cpp17_u8_char_literals.i
+++ b/Examples/test-suite/cpp17_u8_char_literals.i
@@ -1,27 +1,9 @@
 %module cpp17_u8_char_literals
 
-// Tests are designed so that code compiles with C++98 compilers
-
-%{
-#if __cplusplus >= 201703L
-#define CPP17 1
-#endif
-%}
-
 // UTF-8 character literals are type `char` in C++17 but `char8_t` in C++20,
 // but the latter can be assigned to `char`.
+%inline %{
 char a = u8'a';
 char u = u8'u';
 char u8 = u8'8';
-
-%{
-#if defined(CPP17)
-char a = u8'a';
-char u = u8'u';
-char u8 = u8'8';
-#else
-char a = 'a';
-char u = 'u';
-char u8 = '8';
-#endif
 %}

--- a/Examples/test-suite/cpp_typedef.i
+++ b/Examples/test-suite/cpp_typedef.i
@@ -30,7 +30,6 @@ public:
 // Test that the correct types are used for typedef struct declarations
 typedef struct {
   int something;
-  void m() {}
 } UnnamedStruct;
 
 typedef struct NamedStruct {

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -9,6 +9,9 @@ CSHARPCILINTERPRETER_FLAGS = @CSHARPCILINTERPRETER_FLAGS@
 CSHARPCONVERTPATH     = @top_srcdir@/@CSHARPCONVERTPATH@
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = ../@top_srcdir@
 top_builddir = ../@top_builddir@

--- a/Examples/test-suite/d/Makefile.in
+++ b/Examples/test-suite/d/Makefile.in
@@ -5,6 +5,9 @@
 LANGUAGE     = d
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = ../@top_srcdir@
 top_builddir = ../@top_builddir@

--- a/Examples/test-suite/errors/Makefile.in
+++ b/Examples/test-suite/errors/Makefile.in
@@ -17,6 +17,9 @@ LANGUAGE     = errors
 ERROR_EXT    = newerr
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -13,6 +13,9 @@ SCRIPTSUFFIX	= _runme.go
 SO = @SO@
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir         = @srcdir@
 top_srcdir     = @top_srcdir@
 top_builddir   = @top_builddir@

--- a/Examples/test-suite/guile/Makefile.in
+++ b/Examples/test-suite/guile/Makefile.in
@@ -9,6 +9,9 @@ VARIANT      =
 SCRIPTSUFFIX = _runme.scm
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -12,6 +12,9 @@ SCRIPTSUFFIX = _runme.java
 SKIP_DOXYGEN_TEST_CASES = @JAVA_SKIP_DOXYGEN_TEST_CASES@
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = ../@top_srcdir@
 top_builddir = ../@top_builddir@

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -10,6 +10,9 @@ OBJEXT = @OBJEXT@
 SO = @SO@
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/lua/Makefile.in
+++ b/Examples/test-suite/lua/Makefile.in
@@ -7,6 +7,9 @@ LUA          = @LUABIN@
 SCRIPTSUFFIX = _runme.lua
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/mzscheme/Makefile.in
+++ b/Examples/test-suite/mzscheme/Makefile.in
@@ -7,6 +7,9 @@ MZSCHEME     = mzscheme
 SCRIPTSUFFIX = _runme.scm
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/nested_class.i
+++ b/Examples/test-suite/nested_class.i
@@ -133,8 +133,13 @@ struct Outer {
     Integer x;
   } InnerClass4Typedef;
 
-#ifdef _MSC_VER
-  int Outer::foo(){ return 1; } // should correctly ignore qualification here (#508)
+#ifdef SWIG
+  // SWIG should ignore the redundant qualification here (#508)...
+  int Outer::foo(){ return 1; }
+#else
+  // ..but that redundant qualification is actually invalid and many compilers
+  // now reject it with an error, so feed a valid version to the compiler.
+  int foo(){ return 1; }
 #endif
 
   typedef struct {

--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -10,6 +10,9 @@ VARIANT      = _static
 SCRIPTSUFFIX = _runme.ml
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/octave/Makefile.in
+++ b/Examples/test-suite/octave/Makefile.in
@@ -8,6 +8,9 @@ SCRIPTSUFFIX = _runme.m
 PCHSUPPORT   = @PCHSUPPORT@
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/perl5/Makefile.in
+++ b/Examples/test-suite/perl5/Makefile.in
@@ -8,6 +8,9 @@ SCRIPTSUFFIX = _runme.pl
 TEST_RUNNER  = $(srcdir)/run-perl-test.pl
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -6,6 +6,9 @@ LANGUAGE     = php
 SCRIPTSUFFIX = _runme.php
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -15,6 +15,9 @@ PYCODESTYLE       = @PYCODESTYLE@
 PYCODESTYLE_FLAGS = --ignore=E252,E30,E402,E501,E731,E741,W291,W391
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/python/cpp14_binary_integer_literals_runme.py
+++ b/Examples/test-suite/python/cpp14_binary_integer_literals_runme.py
@@ -14,3 +14,12 @@ if cvar.b4 != 4:
 
 if cvar.b5 != 5:
     raise RuntimeError
+
+if b6 != 6:
+    raise RuntimeError
+
+if b7 != 7:
+    raise RuntimeError
+
+if b8 != 8:
+    raise RuntimeError

--- a/Examples/test-suite/r/Makefile.in
+++ b/Examples/test-suite/r/Makefile.in
@@ -9,6 +9,9 @@ R_OPT        = --quiet --no-save --no-restore
 RUNR         = R CMD BATCH $(R_OPT) '--args $(SCRIPTDIR)'
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -7,6 +7,9 @@ RUBY         = @RUBY@
 SCRIPTSUFFIX = _runme.rb
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/scilab/Makefile.in
+++ b/Examples/test-suite/scilab/Makefile.in
@@ -8,6 +8,9 @@ SCILAB_OPT   = @SCILABOPT@
 SCRIPTSUFFIX = _runme.sci
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = ../@top_srcdir@
 top_builddir = ../@top_builddir@

--- a/Examples/test-suite/tcl/Makefile.in
+++ b/Examples/test-suite/tcl/Makefile.in
@@ -7,6 +7,9 @@ TCLSH        = tclsh
 SCRIPTSUFFIX = _runme.tcl
 
 HAVE_CXX11   = @HAVE_CXX11@
+HAVE_CXX14   = @HAVE_CXX14@
+HAVE_CXX17   = @HAVE_CXX17@
+HAVE_CXX20   = @HAVE_CXX20@
 srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@

--- a/Examples/test-suite/template_construct.i
+++ b/Examples/test-suite/template_construct.i
@@ -7,7 +7,13 @@ template<class T>
 class Foo {
     T y;
 public:
+#ifdef SWIG
     Foo<T>(T x) : y(x) { }
+#else
+    // Modern compilers reject this, so feed the compiler the corrected
+    // version.
+    Foo(T x) : y(x) { }
+#endif
 };
 
 %}

--- a/Examples/test-suite/valuewrapper_opaque.i
+++ b/Examples/test-suite/valuewrapper_opaque.i
@@ -14,7 +14,7 @@ class C;
 %{
 template<typename T> class TemplateClass {
 public:
-TemplateClass<T>(T a) {}
+TemplateClass(T a) {}
 };
 
 struct B

--- a/Source/Preprocessor/expr.c
+++ b/Source/Preprocessor/expr.c
@@ -318,7 +318,12 @@ int Preprocessor_expr(DOH *s, int *error) {
       if ((token == SWIG_TOKEN_INT) || (token == SWIG_TOKEN_UINT) || (token == SWIG_TOKEN_LONG) || (token == SWIG_TOKEN_ULONG)) {
 	/* A number.  Reduce EXPR_TOP to an EXPR_VALUE */
 	char *c = Char(Scanner_text(scan));
-	stack[sp].value = (long) strtol(c, 0, 0);
+	if (c[0] == '0' && (c[1] == 'b' || c[1] == 'B')) {
+	  // strtol() doesn't handle binary constants.
+	  stack[sp].value = (long) strtol(c + 2, 0, 2);
+	} else {
+	  stack[sp].value = (long) strtol(c, 0, 0);
+	}
 	stack[sp].svalue = 0;
 	stack[sp].op = EXPR_VALUE;
       } else if ((token == SWIG_TOKEN_MINUS) || (token == SWIG_TOKEN_PLUS) || (token == SWIG_TOKEN_LNOT) || (token == SWIG_TOKEN_NOT)) {

--- a/Tools/config/m4_ax_cxx_compile_stdcxx.m4
+++ b/Tools/config/m4_ax_cxx_compile_stdcxx.m4
@@ -10,8 +10,8 @@
 #
 #   Check for baseline language coverage in the compiler for the specified
 #   version of the C++ standard.  If necessary, add switches to CXX and
-#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
-#   or '14' (for the C++14 standard).
+#   CXXCPP to enable support.  VERSION may be '11', '14', '17', or '20' for
+#   the respective C++ standard version.
 #
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
@@ -36,13 +36,14 @@
 #   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
 #   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
 #   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
+#   Copyright (c) 2021 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 12
+#serial 14
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -51,6 +52,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
         [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
         [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [$1], [20], [ax_cxx_compile_alternatives="20"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -151,7 +153,6 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
 )
 
-
 dnl  Test body for checking C++14 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
@@ -159,11 +160,23 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
 )
 
+dnl  Test body for checking C++17 support
+
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
 )
+
+dnl  Test body for checking C++20 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+)
+
 
 dnl  Tests for new features in C++11
 
@@ -958,5 +971,35 @@ namespace cxx17
 }  // namespace cxx17
 
 #endif  // __cplusplus < 201703L
+
+]])
+
+
+dnl  Tests for new features in C++20
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 202002L
+
+#error "This is not a C++20 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx20
+{
+
+// As C++20 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx20
+
+#endif  // __cplusplus < 202002L
 
 ]])

--- a/configure.ac
+++ b/configure.ac
@@ -304,40 +304,52 @@ if test x"$enable_cpp11_testing" = xyes; then
   CXX_SAVED=$CXX
   CXXCPP_SAVED=$CXXCPP
 
-  # Test for c++17
+  # Test for c++20
   CXXCPP=" "
-  AX_CXX_COMPILE_STDCXX(17, [noext], [optional])
-  AC_MSG_CHECKING([whether C++11 to C++17 testing is enabled])
-  if test "$HAVE_CXX17" = "1"; then
+  AX_CXX_COMPILE_STDCXX(20, [noext], [optional])
+  AC_MSG_CHECKING([whether C++11 to C++20 testing is enabled])
+  if test "$HAVE_CXX20" = "1"; then
     AC_MSG_RESULT([yes])
     PLATCXXFLAGS="$CXXCPP $PLATCXXFLAGS"
+    HAVE_CXX17="1"
     HAVE_CXX14="1"
     HAVE_CXX11="1"
   else
-    AC_MSG_RESULT([no])
-
-    # Test for c++14
+    # Test for c++17
     CXXCPP=" "
-    CXX=$CXX_SAVED
-    AX_CXX_COMPILE_STDCXX(14, [noext], [optional])
-    AC_MSG_CHECKING([whether C++11 to C++14 testing is enabled])
-    if test "$HAVE_CXX14" = "1"; then
+    AX_CXX_COMPILE_STDCXX(17, [noext], [optional])
+    AC_MSG_CHECKING([whether C++11 to C++17 testing is enabled])
+    if test "$HAVE_CXX17" = "1"; then
       AC_MSG_RESULT([yes])
       PLATCXXFLAGS="$CXXCPP $PLATCXXFLAGS"
+      HAVE_CXX14="1"
       HAVE_CXX11="1"
     else
       AC_MSG_RESULT([no])
 
-      # Test for c++11
+      # Test for c++14
       CXXCPP=" "
       CXX=$CXX_SAVED
-      AX_CXX_COMPILE_STDCXX(11, [noext], [optional])
-      AC_MSG_CHECKING([whether C++11 testing is enabled])
-      if test "$HAVE_CXX11" = "1"; then
+      AX_CXX_COMPILE_STDCXX(14, [noext], [optional])
+      AC_MSG_CHECKING([whether C++11 to C++14 testing is enabled])
+      if test "$HAVE_CXX14" = "1"; then
         AC_MSG_RESULT([yes])
         PLATCXXFLAGS="$CXXCPP $PLATCXXFLAGS"
+        HAVE_CXX11="1"
       else
         AC_MSG_RESULT([no])
+
+        # Test for c++11
+        CXXCPP=" "
+        CXX=$CXX_SAVED
+        AX_CXX_COMPILE_STDCXX(11, [noext], [optional])
+        AC_MSG_CHECKING([whether C++11 testing is enabled])
+        if test "$HAVE_CXX11" = "1"; then
+          AC_MSG_RESULT([yes])
+          PLATCXXFLAGS="$CXXCPP $PLATCXXFLAGS"
+        else
+          AC_MSG_RESULT([no])
+        fi
       fi
     fi
   fi
@@ -346,6 +358,9 @@ if test x"$enable_cpp11_testing" = xyes; then
   CXXCPP=$CXXCPP_SAVED
 fi
 AC_SUBST(HAVE_CXX11)
+AC_SUBST(HAVE_CXX14)
+AC_SUBST(HAVE_CXX17)
+AC_SUBST(HAVE_CXX20)
 
 # On darwin 10.7,10.8,10.9 using clang++, need to ensure using
 # libc++ for tests and examples to run under mono. May affect


### PR DESCRIPTION
As discussed in #1622.

Automatically enabling C++20 support when the compiler supports it revealed a couple of existing testcases which didn't actually compile as C++20 - the first commit fixes these.