### PR TITLE
Use PyObject instead of PySliceObject throughout with Python 3.2+

### DIFF
--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -15,9 +15,9 @@
 #include <iostream>
 
 #if PY_VERSION_HEX >= 0x03020000
-# define SWIGPY_SLICE_ARG(obj) ((PyObject*) (obj))
+# define SWIGPY_SLICEOBJECT PyObject
 #else
-# define SWIGPY_SLICE_ARG(obj) ((PySliceObject*) (obj))
+# define SWIGPY_SLICEOBJECT PySliceObject
 #endif
 %}
 
@@ -781,7 +781,7 @@ namespace swig
 #if 1
   %newobject __getslice__;
 #endif
-  %newobject __getitem__(PySliceObject *slice);
+  %newobject __getitem__(SWIGPY_SLICEOBJECT *slice);
 
 #if defined(SWIGPYTHON_BUILTIN)
   %feature("python:slot", "nb_nonzero", functype="inquiry") __nonzero__;
@@ -829,13 +829,13 @@ namespace swig
 
   %extend {
     /* typemap for slice object support */
-    %typemap(in) PySliceObject* {
+    %typemap(in) SWIGPY_SLICEOBJECT* {
       if (!PySlice_Check($input)) {
         %argument_fail(SWIG_TypeError, "$type", $symname, $argnum);
       }
-      $1 = (PySliceObject *) $input;
+      $1 = (SWIGPY_SLICEOBJECT *) $input;
     }
-    %typemap(typecheck,precedence=SWIG_TYPECHECK_POINTER) PySliceObject* {
+    %typemap(typecheck,precedence=SWIG_TYPECHECK_POINTER) SWIGPY_SLICEOBJECT* {
       $1 = PySlice_Check($input);
     }
 
@@ -865,49 +865,49 @@ namespace swig
     /* Overloaded methods for Python 3 compatibility 
      * (Also useful in Python 2.x)
      */
-    Sequence* __getitem__(PySliceObject *slice) throw (std::out_of_range, std::invalid_argument) {
+    Sequence* __getitem__(SWIGPY_SLICEOBJECT *slice) throw (std::out_of_range, std::invalid_argument) {
       Py_ssize_t i, j, step;
       if( !PySlice_Check(slice) ) {
         SWIG_Error(SWIG_TypeError, "Slice object expected.");
         return NULL;
       }
-      PySlice_GetIndices(SWIGPY_SLICE_ARG(slice), (Py_ssize_t)self->size(), &i, &j, &step);
+      PySlice_GetIndices(slice, (Py_ssize_t)self->size(), &i, &j, &step);
       Sequence::difference_type id = i;
       Sequence::difference_type jd = j;
       return swig::getslice(self, id, jd, step);
     }
 
-    void __setitem__(PySliceObject *slice, const Sequence& v) throw (std::out_of_range, std::invalid_argument) {
+    void __setitem__(SWIGPY_SLICEOBJECT *slice, const Sequence& v) throw (std::out_of_range, std::invalid_argument) {
       Py_ssize_t i, j, step;
       if( !PySlice_Check(slice) ) {
         SWIG_Error(SWIG_TypeError, "Slice object expected.");
         return;
       }
-      PySlice_GetIndices(SWIGPY_SLICE_ARG(slice), (Py_ssize_t)self->size(), &i, &j, &step);
+      PySlice_GetIndices(slice, (Py_ssize_t)self->size(), &i, &j, &step);
       Sequence::difference_type id = i;
       Sequence::difference_type jd = j;
       swig::setslice(self, id, jd, step, v);
     }
 
-    void __setitem__(PySliceObject *slice) throw (std::out_of_range, std::invalid_argument) {
+    void __setitem__(SWIGPY_SLICEOBJECT *slice) throw (std::out_of_range, std::invalid_argument) {
       Py_ssize_t i, j, step;
       if( !PySlice_Check(slice) ) {
         SWIG_Error(SWIG_TypeError, "Slice object expected.");
         return;
       }
-      PySlice_GetIndices(SWIGPY_SLICE_ARG(slice), (Py_ssize_t)self->size(), &i, &j, &step);
+      PySlice_GetIndices(slice, (Py_ssize_t)self->size(), &i, &j, &step);
       Sequence::difference_type id = i;
       Sequence::difference_type jd = j;
       swig::delslice(self, id, jd, step);
     }
 
-    void __delitem__(PySliceObject *slice) throw (std::out_of_range, std::invalid_argument) {
+    void __delitem__(SWIGPY_SLICEOBJECT *slice) throw (std::out_of_range, std::invalid_argument) {
       Py_ssize_t i, j, step;
       if( !PySlice_Check(slice) ) {
         SWIG_Error(SWIG_TypeError, "Slice object expected.");
         return;
       }
-      PySlice_GetIndices(SWIGPY_SLICE_ARG(slice), (Py_ssize_t)self->size(), &i, &j, &step);
+      PySlice_GetIndices(slice, (Py_ssize_t)self->size(), &i, &j, &step);
       Sequence::difference_type id = i;
       Sequence::difference_type jd = j;
       swig::delslice(self, id, jd, step);


### PR DESCRIPTION
Note: this also eliminates many compile errors when attempting to define Py_LIMITED_API.

See also #2190 where a new #ifdef/#endif section was created to solve this same problem.
Here, we leverage an already existing ifdef in pycontainer.swg.