### PR TITLE
Python:  Use PyType_Modified() instead of modifying flags.

### DIFF
--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1515,7 +1515,7 @@ SWIG_Python_NewShadowInstance(SwigPyClientData *data, PyObject *swig_this)
             Py_DECREF(inst);
             inst = 0;
           } else {
-            Py_TYPE(inst)->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
+            PyType_Modified(Py_TYPE(inst));
           }
         }
       }


### PR DESCRIPTION
Closes #2345
Also supported with Py_LIMITED_API