### PR TITLE
Make method wrappers suffix optional and disabled by default

### DIFF
--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -77,6 +77,9 @@ static Hash *classhash;
 extern int GenerateDefault;
 extern int ForceExtern;
 extern int AddExtern;
+extern "C" {
+  extern int UseWrapperSuffix;
+}
 
 /* import modes */
 
@@ -1324,7 +1327,7 @@ int Language::staticmemberfunctionHandler(Node *n) {
       // See Swig_MethodToFunction() for the explanation of this code.
       if (Getattr(n, "sym:overloaded")) {
 	Append(cname, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
-      } else {
+      } else if (UseWrapperSuffix) {
 	Append(cname, "__SWIG");
       }
 

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -37,6 +37,9 @@ int Verbose = 0;
 int AddExtern = 0;
 int NoExcept = 0;
 int SwigRuntime = 0;		// 0 = no option, 1 = -runtime, 2 = -noruntime
+extern "C" {
+  int UseWrapperSuffix = 0;	// If 1, append suffix to non-overloaded functions too.
+}
 
 /* Suppress warning messages for private inheritance, preprocessor evaluation etc...
    WARN_PP_EVALUATION                           202

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -15,6 +15,8 @@
 #include "swig.h"
 #include "cparse.h"
 
+extern int UseWrapperSuffix; // from main.cxx
+
 static const char *cresult_variable_name = "result";
 
 static Parm *nonvoid_parms(Parm *p) {
@@ -1083,13 +1085,13 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
        in C.
 
        But when not using the suffix used for overloaded functions, we still need to ensure that the
-       wrapper name doesn't conflict with any wrapper functions, so make it sufficiently unique by
-       appending a suffix similar to the one used for overloaded functions to it.
+       wrapper name doesn't conflict with any wrapper functions for some languages, so optionally make
+       it sufficiently unique by appending a suffix similar to the one used for overloaded functions to it.
      */
     if (code) {
       if (Getattr(n, "sym:overloaded")) {
 	Append(mangled, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
-      } else {
+      } else if (UseWrapperSuffix) {
 	Append(mangled, "__SWIG");
       }
     }


### PR DESCRIPTION
Unfortunately the changes of 26bf86322 (Use SWIG-specific for non-overloaded synthesized functions too, 2021-11-09) did break some existing code bases using SWIG as they hardcoded the old wrapper function names.

So turn this off by default and add a global variable allowing to enable this, which can be done for a specific language only. This is ugly but, unfortunately, there is no way to use the Language object from the C function Swig_MethodToFunction(), so the only alternative would be to add another parameter to it, but it already has 6 of them, so it wouldn't really be that much better.

See #2366, #2368, #2370.

----

@wsfulton This fixes the breakage due to my commit above and needs to be applied before 4.1 to fix the regressions due to it.