### PR TITLE
Fix octave operator horzcat test

### DIFF
--- a/Doc/Manual/Octave.html
+++ b/Doc/Manual/Octave.html
@@ -625,6 +625,16 @@ On the C++ side, the default mappings are as follows:
 Octave can also utilise friend (i.e. non-member) operators with a simple %rename: see the example in the Examples/octave/operator directory.
 </p>
 
+<p>
+Octave has several operators for which no corresponding C++ operators exist. For example, the Octave code
+</p>
+<div class="targetlang"><pre>
+x=[a,b,c];
+</pre></div>
+<p>
+calls the Octave operator <tt>horzcat</tt> of the class of <tt>a</tt>. Hence, if <tt>a</tt> is of type <tt>swig_ref</tt> you can write an overload for this operator for your wrapped C++ class by placing a file <tt>@swig_ref/horzcat.m</tt> in the Octave load path (like for every Octave class, see <a href="https://docs.octave.org/latest/Creating-a-Class.html">Creating a Class</a>). This Octave function file is then called whenever the above Octave code is executed for a variable of type <tt>swig_ref</tt>.
+</p>
+
 <H3><a name="Octave_nn19">30.3.10 Class extension with %extend</a></H3>
 
 

--- a/Examples/octave/operator/@swig_ref/horzcat.m
+++ b/Examples/octave/operator/@swig_ref/horzcat.m
@@ -1,6 +1,9 @@
 % test octaves concatenation operator
-function ret=horzcat(a, b)
-  % return the concatenation of two ComplexVal values as a cell array.
+function ret=horzcat(varargin)
+  % return the concatenation of several ComplexVal values as a cell array.
   % (not really useful but it tests the concatenation of swig_ref objects)
-  ret={a, b};
+  ret={};
+  for i=1:length(varargin)
+    ret{i}=varargin{i};
+  end
 end

--- a/Examples/octave/operator/runme.m
+++ b/Examples/octave/operator/runme.m
@@ -47,6 +47,5 @@ if swig_octave_prereq(3,8,0)
 endif
 
 # concatenation operator, note: calls @swig_ref/horzcat.m
-# g = [a, b, c];
-# printf("g   = %s\n",disp(g));
-# Above temporarily removed as broken in octave-7.2.0, see https://github.com/swig/swig/issues/2353
+g = [a, b, c];
+printf("g   = %s\n",disp(g));


### PR DESCRIPTION
Fixed and reenable the octave horzcat operator test for Octave 7.1.

Added documentation about extending Octave operators not known by C++ using standard Octave object orientated programming methods.