### PR TITLE
Report errors in preprocessor expressions by default

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,23 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.1.0 (in progress)
 ===========================
 
+2022-10-05: olly
+	    #1465 Report errors in preprocessor expressions by default
+
+	    Until now SWIG quietly ignored such errors unless -Wextra (or -Wall
+	    which implies -Wextra) was passed, but this is unhelpful as it hides
+	    problems.  To illustrate this point, enabling this warning by
+	    default revealled a typo in the preproc_defined.i testcase in
+	    SWIG's own testsuite.
+
+	    If you really don't want to see this warning, you can suppress it
+	    with command line option -w202 or by using this in your interface
+	    file:
+
+	    %warnfilter(SWIGWARN_PP_EVALUATION);
+
+	    Both will work with older versions of SWIG too.
+
 2022-10-04: olly
 	    #1050 Consistently define SWIG_VERSION both at SWIG-time and in
 	    the generated wrapper.  Best practice remains to check at SWIG-time

--- a/Doc/Manual/SWIG.html
+++ b/Doc/Manual/SWIG.html
@@ -219,7 +219,7 @@ General Options
      -Wall           - Remove all warning suppression, also implies -Wextra
      -Wallkw         - Enable keyword warnings for all the supported languages
      -Werror         - Treat warnings as errors
-     -Wextra         - Adds the following additional warnings: 202,309,403,405,512,321,322
+     -Wextra         - Adds the following additional warnings: 309,403,405,512,321,322
      -w&lt;list&gt;        - Suppress/add warning messages, eg -w401,+321 - see Warnings.html
      -xmlout &lt;file&gt;  - Write XML version of the parse tree to &lt;file&gt; after normal processing
 </pre></div>

--- a/Doc/Manual/Warnings.html
+++ b/Doc/Manual/Warnings.html
@@ -165,6 +165,15 @@ to provide additional diagnostics.  These warnings can be turned on using the
 </div>
 
 <p>
+Preprocessor warning 202 ("Could not evaluate expression <em>expr</em>.") was
+formally off by default and enabled by <tt>-Wextra</tt>, but since SWIG 4.2.0
+this warning is on by default because it tends to hide problems.  If you
+really don't want to see it, you can suppress it with <tt>-w202</tt> or
+using <tt>%warnfilter</tt> as described below. Both will work with older
+versions of SWIG too.
+</p>
+
+<p>
 To selectively turn on extra warning messages, you can use the directives and options in the
 previous section--simply add a "+" to all warning numbers.  For example:
 </p>

--- a/Examples/test-suite/errors/cpp_pp_expressions_bad.i
+++ b/Examples/test-suite/errors/cpp_pp_expressions_bad.i
@@ -1,5 +1,5 @@
 %module xxx
-/* Note: needs -Wextra to see these warnings */
+
 
 /* Spaceship operator doesn't seem to be allowed in preprocessor expressions. */
 #if (4 <=> 2) < 0

--- a/Examples/test-suite/errors/pp_expressions_bad.i
+++ b/Examples/test-suite/errors/pp_expressions_bad.i
@@ -1,5 +1,5 @@
 %module xxx
-/* Note: needs -Wextra to see these warnings */
+
 
 /* Divide by zero */
 #define ZERO 0

--- a/Examples/test-suite/preproc_defined.i
+++ b/Examples/test-suite/preproc_defined.i
@@ -86,7 +86,7 @@ struct Defined {
 void defined_not(TYPE);
 #endif
 
-#if !( defined(AAA) \
+#if !( defined(AAA) &&\
  defined(BBB) \\
 && defined(CCC) )
 void bumpf_not(TYPE);

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -41,8 +41,9 @@ extern "C" {
   int UseWrapperSuffix = 0;	// If 1, append suffix to non-overloaded functions too.
 }
 
-/* Suppress warning messages for private inheritance, preprocessor evaluation etc...
-   WARN_PP_EVALUATION                           202
+/* Suppress warning messages for private inheritance, etc by default.
+   These are enabled by command line option -Wextra.
+
    WARN_PARSE_PRIVATE_INHERIT                   309
    WARN_PARSE_BUILTIN_NAME                      321
    WARN_PARSE_REDUNDANT                         322
@@ -50,7 +51,7 @@ extern "C" {
    WARN_TYPE_RVALUE_REF_QUALIFIER_IGNORED       405
    WARN_LANG_OVERLOAD_CONST                     512
  */
-#define EXTRA_WARNINGS "202,309,403,405,512,321,322"
+#define EXTRA_WARNINGS "309,403,405,512,321,322"
 
 extern "C" {
   extern String *ModuleName;


### PR DESCRIPTION
Until now SWIG quietly ignored such errors unless -Wextra (or -Wall which implies -Wextra) was passed, but this is unhelpful as it hides problems.  To illustrate this point, enabling this warning by default revealled a typo in the preproc_defined.i testcase in SWIG's own testsuite.

If you really don't want to see this warning, you can suppress it with command line option -w202 or by using this in your interface file:

%warnfilter(SWIGWARN_PP_EVALUATION);

Both will work with older versions of SWIG too.

Fixes #1465