### PR TITLE
Support boolean values in preprocessor expressions

### DIFF
--- a/Source/Preprocessor/expr.c
+++ b/Source/Preprocessor/expr.c
@@ -320,7 +320,17 @@ int Preprocessor_expr(DOH *s, int *error) {
 	*error = 1;
 	return 0;
       }
-      if ((token == SWIG_TOKEN_INT) || (token == SWIG_TOKEN_UINT) || (token == SWIG_TOKEN_LONG) || (token == SWIG_TOKEN_ULONG)) {
+      if (token == SWIG_TOKEN_BOOL) {
+	/* A boolean value.  Reduce EXPR_TOP to an EXPR_VALUE */
+	char *c = Char(Scanner_text(scan));
+	if (strcmp(c, "true") == 0) {
+	  stack[sp].value = (long) 1;
+	} else {
+	  stack[sp].value = (long) 0;
+	}
+	stack[sp].svalue = 0;
+	stack[sp].op = EXPR_VALUE;
+      } else if ((token == SWIG_TOKEN_INT) || (token == SWIG_TOKEN_UINT) || (token == SWIG_TOKEN_LONG) || (token == SWIG_TOKEN_ULONG)) {
 	/* A number.  Reduce EXPR_TOP to an EXPR_VALUE */
 	char *c = Char(Scanner_text(scan));
 	if (c[0] == '0' && (c[1] == 'b' || c[1] == 'B')) {


### PR DESCRIPTION
I think the SWIG preprocessor does currently not support statements including boolean values, for example:
```
#if false
```

I've added support for this, to the best of my knowledge, based on the preprocessor code for numeric values. In the code I assume that the char-pointer returned by `Char(Scanner_text(scan))` is zero-terminated, otherwise its unsafe to use `strcmp()`.

Is this a reasonable PR? Please guide me if the code should be improved.