### PR TITLE
[lua] Fix C++ memory leaks on SWIG_fail

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,11 @@ Version 4.1.0 (in progress)
 ===========================
 
 2022-10-14: olly
+	    [R] Arrange that destructors of local C++ objects in the wrapper
+	    function get run on SWIG_fail (which calls Rf_error() which calls
+	    longjmp()).
+
+2022-10-14: olly
 	    [Lua] Arrange that destructors of local C++ objects in the wrapper
 	    function get run on SWIG_fail (which calls lua_error() which calls
 	    longjmp()).

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,11 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.1.0 (in progress)
 ===========================
 
+2022-10-14: olly
+	    [Lua] Arrange that destructors of local C++ objects in the wrapper
+	    function get run on SWIG_fail (which calls lua_error() which calls
+	    longjmp()).
+
 2022-10-13: wsfulton
             [R] Add missing SWIGTYPE *const& typemaps for supporting pointers
             by const reference.

--- a/Examples/test-suite/exception_memory_leak.i
+++ b/Examples/test-suite/exception_memory_leak.i
@@ -22,6 +22,13 @@
   }
   $1 = NULL;
 }
+%typemap(out) Foo trigger_internal_swig_exception
+{
+  SWIG_exception(SWIG_RuntimeError, "Let's see how the bindings manage this exception!");
+#ifdef SWIG_fail
+  SWIG_fail;
+#endif
+}
 
 %inline %{
   #include <string>
@@ -45,6 +52,11 @@
   static Foo* trigger_internal_swig_exception(const std::string& message, Foo* foo)
   {
     return (message == "null") ? NULL : foo;
+  }
+
+  static Foo trigger_internal_swig_exception(const std::string& message)
+  {
+    return Foo();
   }
 
 %}

--- a/Examples/test-suite/lua/exception_memory_leak_runme.lua
+++ b/Examples/test-suite/lua/exception_memory_leak_runme.lua
@@ -1,0 +1,29 @@
+require("import")	-- the import fn
+import("exception_memory_leak")	-- import code
+eml=exception_memory_leak --alias
+
+-- catch "undefined" global variables
+local env = _ENV -- Lua 5.2
+if not env then env = getfenv () end -- Lua 5.1
+setmetatable(env, {__index=function (t,i) error("undefined global variable `"..i.."'",2) end})
+
+a = eml.Foo()
+assert(eml.Foo_get_count() == 1)
+b = eml.Foo()
+assert(eml.Foo_get_count() == 2)
+
+-- Normal behaviour
+eml.trigger_internal_swig_exception("no problem", a)
+assert(eml.Foo_get_count() == 2)
+assert(eml.Foo_get_freearg_count() == 1)
+
+-- SWIG exception triggered and handled (return new object case)
+ok,ex=pcall(eml.trigger_internal_swig_exception, "null", b)
+assert(ok==false)
+assert(eml.Foo_get_count() == 2)
+assert(eml.Foo_get_freearg_count() == 2)
+
+-- SWIG exception triggered and handled (return by value case).
+ok,ex=pcall(eml.trigger_internal_swig_exception, "null")
+assert(ok==false)
+assert(eml.Foo_get_count() == 2)

--- a/Examples/test-suite/php/exception_memory_leak_runme.php
+++ b/Examples/test-suite/php/exception_memory_leak_runme.php
@@ -17,7 +17,7 @@ trigger_internal_swig_exception("no problem", $a);
 check::equal(Foo::get_count(), 2, "Should have 2 Foo objects");
 check::equal(Foo::get_freearg_count(), 1, "freearg should have been used once");
 
-// SWIG exception triggered and handled.
+// SWIG exception triggered and handled (return new object case).
 try {
     trigger_internal_swig_exception("null", $b);
     check::fail("Expected exception not thrown");
@@ -25,3 +25,11 @@ try {
 }
 check::equal(Foo::get_count(), 2, "Should have 2 Foo objects");
 check::equal(Foo::get_freearg_count(), 2, "freearg should have been used twice");
+
+// SWIG exception triggered and handled (return by value case).
+try {
+    trigger_internal_swig_exception("null");
+    check::fail("Expected exception not thrown");
+} catch (Exception $e) {
+}
+check::equal(Foo::get_count(), 2, "Should have 2 Foo objects");

--- a/Examples/test-suite/r/exception_memory_leak_runme.R
+++ b/Examples/test-suite/r/exception_memory_leak_runme.R
@@ -14,7 +14,7 @@ unittest(Foo_get_count(), 2);
 invisible(trigger_internal_swig_exception("no problem", a));
 unittest(Foo_get_count(), 2);
 unittest(Foo_get_freearg_count(), 1);
-# SWIG exception introduced
+# SWIG exception introduced (return new object case).
 result <- tryCatch({
   trigger_internal_swig_exception("null", b);
 }, warning = function(w) {
@@ -26,3 +26,14 @@ result <- tryCatch({
 })
 unittest(Foo_get_count(), 2);
 unittest(Foo_get_freearg_count(), 2);
+# SWIG exception introduced (return by value case).
+result <- tryCatch({
+  trigger_internal_swig_exception("null");
+}, warning = function(w) {
+  # print("        Hum... We received a warning, but this should be an error");
+  unittest(1,0);
+}, error = function(e) {
+  # print("        Gotcha!");
+  unittest(1,1);
+})
+unittest(Foo_get_count(), 2);


### PR DESCRIPTION
SWIG_fail in lua leads to a call to lua_error() which calls longjmp() which means the destructors of any live function-local C++ objects won't get run.

To avoid this happening, we now wrap almost everything in the function in a block, and end that right before lua_error() at which point those destructors will get called.

I don't see how to add a regression test for this within SWIG's testsuite, but it's observable with valgrind.

@wsfulton I'd like to merge this for SWIG 4.1.0 if possible.