### PR TITLE
Fix issues with exception_memory_leak testcase

### DIFF
--- a/Examples/test-suite/exception_memory_leak.i
+++ b/Examples/test-suite/exception_memory_leak.i
@@ -1,6 +1,7 @@
 %module exception_memory_leak
 
 %include <std_string.i>
+%include <exception.i>
 
 %typemap(in) Foo* foo
 {
@@ -11,10 +12,14 @@
   Foo::inc_freearg_count();
   delete $1;
 }
-%typemap(out) Foo* verify_no_memory_leak
+%typemap(out) Foo* trigger_internal_swig_exception
 {
-  if ($1 == NULL)
-    SWIG_exception_fail(SWIG_RuntimeError, "Let's see how the bindings manage this exception!");
+  if ($1 == NULL) {
+    SWIG_exception(SWIG_RuntimeError, "Let's see how the bindings manage this exception!");
+#ifdef SWIG_fail
+    SWIG_fail;
+#endif
+  }
   $1 = NULL;
 }
 

--- a/Examples/test-suite/php/exception_memory_leak_runme.php
+++ b/Examples/test-suite/php/exception_memory_leak_runme.php
@@ -18,6 +18,10 @@ check::equal(Foo::get_count(), 2, "Should have 2 Foo objects");
 check::equal(Foo::get_freearg_count(), 1, "freearg should have been used once");
 
 // SWIG exception triggered and handled.
-trigger_internal_swig_exception("null", $b);
+try {
+    trigger_internal_swig_exception("null", $b);
+    check::fail("Expected exception not thrown");
+} catch (Exception $e) {
+}
 check::equal(Foo::get_count(), 2, "Should have 2 Foo objects");
 check::equal(Foo::get_freearg_count(), 2, "freearg should have been used twice");


### PR DESCRIPTION
The out typemap uses a function name which doesn't match the name of the function we want it to apply to, so this testcase wasn't actually triggering an exception so wasn't actually testing anything!

With that fixed, the testcase fails to compile for PHP due to use of SWIG_exception_fail() (which not all target languages implement), and with that fixed, the _runme.php needs a try ... catch adding to handle the raised exception.