### PR TITLE
Define PY_SSIZE_T_CLEAN only when not defined yet

### DIFF
--- a/Lib/python/embed.i
+++ b/Lib/python/embed.i
@@ -29,7 +29,7 @@ As far as I know, this module is C++ safe.
 #endif
 
 %wrapper %{
-#ifndef SWIG_NO_PY_SSIZE_T_CLEAN
+#if !defined(PY_SSIZE_T_CLEAN) && !defined(SWIG_NO_PY_SSIZE_T_CLEAN)
 #define PY_SSIZE_T_CLEAN
 #endif
 

--- a/Lib/python/pyruntime.swg
+++ b/Lib/python/pyruntime.swg
@@ -4,7 +4,7 @@
 # include <math.h>
 #endif
 
-#ifndef SWIG_NO_PY_SSIZE_T_CLEAN
+#if !defined(PY_SSIZE_T_CLEAN) && !defined(SWIG_NO_PY_SSIZE_T_CLEAN)
 #define PY_SSIZE_T_CLEAN
 #endif
 


### PR DESCRIPTION
Users of swig 4.0.2 and python 3.10 will likely define the PY_SSIZE_T_CLEAN macro by hand when relevant because their bindings won't build otherwise.

Unconditionally defining PY_SSIZE_T_CLEAN in swig 4.10 will lead to macro redefinition warning.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>