### PR TITLE
[Go] Run C++ destructors before we panic

### DIFF
--- a/Examples/test-suite/go/exception_memory_leak_runme.go
+++ b/Examples/test-suite/go/exception_memory_leak_runme.go
@@ -1,0 +1,57 @@
+package main
+
+import "strings"
+import . "swigtests/exception_memory_leak"
+
+func main() {
+	a := NewFoo()
+	if FooGet_count() != 1 {
+		panic("Foo count not 1")
+	}
+	b := NewFoo()
+	if FooGet_count() != 2 {
+		panic("Foo count not 2")
+	}
+
+	// Normal behaviour
+	Trigger_internal_swig_exception("no problem", a)
+	if FooGet_count() != 2 {
+		panic("Foo count not 2")
+	}
+	if FooGet_freearg_count() != 1 {
+		panic("Foo count not 1")
+	}
+
+	// SWIG exception triggered and handled (return new object case)
+	func() {
+		defer func() {
+			e := recover()
+			if strings.Index(e.(string), "Let's") != 0 {
+				panic(e.(string))
+			}
+		}()
+		Trigger_internal_swig_exception("null", b)
+		panic("Trigger_internal_swig_exception didn't panic")
+	}()
+	if FooGet_count() != 2 {
+		panic("Foo count not 2")
+	}
+	if FooGet_freearg_count() != 2 {
+		panic("Foo count not 2")
+	}
+
+	// SWIG exception triggered and handled (return by value case).
+	func() {
+		defer func() {
+			e := recover()
+			if strings.Index(e.(string), "Let's") != 0 {
+				panic(e.(string))
+			}
+		}()
+		Trigger_internal_swig_exception("null")
+		panic("Trigger_internal_swig_exception didn't panic")
+	}()
+	if FooGet_count() != 2 {
+		panic("Foo count not 2")
+	}
+}

--- a/Lib/go/goruntime.swg
+++ b/Lib/go/goruntime.swg
@@ -105,10 +105,14 @@ extern void _cgo_panic(const char *);
 #endif
 
 #define _swig_goallocate _cgo_allocate
-#define _swig_gopanic _cgo_panic
+#define _swig_gopanic_impl _cgo_panic
 %}
 
 #endif
+
+%{
+#define _swig_gopanic(M) do { _swig_gopanic_message = (M); goto fail; } while (0)
+%}
 
 #ifndef SWIGGO_GCCGO
 


### PR DESCRIPTION
Arrange that destructors of local C++ objects in the wrapper function get run before we panic.

WIP: Causes some testcases to fail.

Fixes #1981