### PR TITLE
[python] Prevent a potential multithreading crash

### DIFF
--- a/Lib/python/pythreads.swg
+++ b/Lib/python/pythreads.swg
@@ -28,7 +28,7 @@
          bool status;
          PyThreadState *save;
        public:
-         void end() { if (status) { PyEval_RestoreThread(save); status = false; }}
+         void end() { if (status) { status = false; PyEval_RestoreThread(save); }}
          SWIG_Python_Thread_Allow() : status(true), save(PyEval_SaveThread()) {}
          ~SWIG_Python_Thread_Allow() { end(); }
        };


### PR DESCRIPTION
If there are daemon thread(s) running, and the main thread exits, there is a chance of a SIGABRT happening if one of the daemon threads happens to be returning from a C call back to Python code. This is partly because of how the unwinder works (it uses a special exception `abi::__forced_unwind` to unwind the stack). If this exception happens to pass through the destructor of a C++ class (specifically, the `SWIG_Python_Thread_Allow` class here), then that is considered an error, and the unwinder will call `std::terminate`, resulting in a SIGABRT.

More details about this issue are in #2396.

Fixes #2396.