### PR TITLE
CMake: Fix -swiglib on win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,11 @@ endif ()
 
 set (SWIG_ROOT ${PROJECT_SOURCE_DIR})
 
-set (SWIG_LIB share/swig/${SWIG_VERSION})
-
+if (WIN32)
+  set (SWIG_LIB bin/Lib)
+else ()
+  set (SWIG_LIB share/swig/${SWIG_VERSION})
+endif ()
 # Project wide configuration variables
 # ------------------------------------
 
@@ -80,10 +83,10 @@ if (WITH_PCRE)
   include_directories (${PCRE2_INCLUDE_DIRS})
 endif()
 
-if (WIN32)
-  file (TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/${SWIG_LIB} SWIG_LIB_WIN_UNIX)
-  string (REGEX REPLACE "\\\\" "\\\\\\\\" SWIG_LIB_WIN_UNIX "${SWIG_LIB_WIN_UNIX}")
-endif ()
+#if (WIN32)
+#  file (TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/${SWIG_LIB} SWIG_LIB_WIN_UNIX)
+#  string (REGEX REPLACE "\\\\" "\\\\\\\\" SWIG_LIB_WIN_UNIX "${SWIG_LIB_WIN_UNIX}")
+#endif ()
 configure_file (${SWIG_ROOT}/Tools/cmake/swigconfig.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/Source/Include/swigconfig.h)
 


### PR DESCRIPTION
- swig library files must be installed relatively to the exe into ./Lib (=> PREFIX/bin/Lib), see main.cxx
- unset SWIG_LIB_WIN_UNIX else swiglib returns 2 paths which break cmake detection (and consistent to the provided windows binaries)