### PR TITLE
Fixing compile problem in std_array.i.

### DIFF
--- a/Lib/csharp/std_array.i
+++ b/Lib/csharp/std_array.i
@@ -26,7 +26,7 @@
     foreach ($typemap(cstype, T) elem in c) {
       if (i >= end)
         break;
-      this[i++] = elem;
+      this[i++] = element;
     }
   }
 


### PR DESCRIPTION
This small PR fixes a build problem when using `std::array` in C#. It seems the current master version is broken.