### PR TITLE
CMake: Require bison 3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ endif()
 configure_file (${SWIG_ROOT}/Tools/cmake/swigconfig.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/Source/Include/swigconfig.h)
 
-find_package (BISON REQUIRED)
+find_package (BISON 3 REQUIRED)
 
 
 # Compiler flags


### PR DESCRIPTION
Lets require bison 3.x, this is old enough anyways and might avoid https://github.com/swig/swig/issues/2431