### PR TITLE
Fix push/pop mismatch

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.2.0 (in progress)
 ===========================
 
+2022-11-29: bero
+            Fix mismatch between #pragma GCC diagnostic push and pop statements
+
 2022-11-26: wsfulton
             #2449 Fix undefined behaviour in ccache-swig calculating md4 hashes and possibly
             also handling errors when CCACHE_CPP2 is set.

--- a/Lib/perl5/perlhead.swg
+++ b/Lib/perl5/perlhead.swg
@@ -7,6 +7,7 @@ extern "C" {
 
 #if __GNUC__ >= 10
 #if defined(__cplusplus)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvolatile"
 #endif
 #endif
@@ -16,7 +17,9 @@ extern "C" {
 #include "XSUB.h"
 
 #if __GNUC__ >= 10
+#if defined(__cplusplus)
 #pragma GCC diagnostic pop
+#endif
 #endif
 
 /* PERL_REVISION was added in Perl 5.6. */


### PR DESCRIPTION
Without this, perlhead.swg does
`#pragma GCC diagnostic push` only if `__GNUC__ >= 10` and `defined(__cplusplus)`, but does `#pragma GCC diagnostic pop` if `__GNUC__ >= 10` without the check for __cplusplus.

This results in a `#pragma GCC diagnostic pop` without a prior push in the `__GNUC__ >= 10` and not `__cplusplus` case, triggering compiler warnings.