### PR TITLE
[OCaml] Runtime tests for rename_rstrip_encoder and using2

### DIFF
--- a/Examples/test-suite/ocaml/rename_rstrip_encoder_runme.ml
+++ b/Examples/test-suite/ocaml/rename_rstrip_encoder_runme.ml
@@ -1,0 +1,5 @@
+open Swig
+open Rename_rstrip_encoder
+
+let s = new_SomeThing '()
+let a = new_AnotherThing '()

--- a/Examples/test-suite/ocaml/using2_runme.ml
+++ b/Examples/test-suite/ocaml/using2_runme.ml
@@ -1,0 +1,4 @@
+open Swig
+open Using2
+
+let _ = assert (_spam '(37) as int = 37)


### PR DESCRIPTION
Add runtime tests for rename_rstrip_encoder and using2.

They are based on the runtime tests that already exist for other languages.