### PR TITLE
Lib/csharp: Better standardized std_vector.i and std_array.i

### DIFF
--- a/Lib/csharp/std_array.i
+++ b/Lib/csharp/std_array.i
@@ -6,37 +6,47 @@
  * The C# wrapper is made to look and feel like a C# System.Collections.Generic.IReadOnlyList<> collection.
  * ----------------------------------------------------------------------------- */
 
-%{
-#include <algorithm>
-#include <array>
-#include <stdexcept>
-%}
-
 %include <std_common.i>
 
 
-%define SWIG_STD_ARRAY_INTERNAL(T, N)
-%typemap(csinterfaces) std::array< T, N > "global::System.IDisposable, global::System.Collections.IEnumerable\n    , global::System.Collections.Generic.IEnumerable<$typemap(cstype, T)>\n"
+%define SWIG_STD_ARRAY_INTERNAL(CTYPE, N)
+%typemap(csinterfaces) std::array< CTYPE, N > "global::System.IDisposable, global::System.Collections.IEnumerable\n    , global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>\n"
 %proxycode %{
   public $csclassname(global::System.Collections.ICollection c) : this() {
     if (c == null)
       throw new global::System.ArgumentNullException("c");
-    int end = global::System.Math.Min(this.Count, c.Count);
     int i = 0;
-    foreach ($typemap(cstype, T) elem in c) {
-      if (i >= end)
+    foreach ($typemap(cstype, CTYPE) element in c) {
+      if (i >= this.Count)
         break;
-      this[i++] = elem;
+      this[i++] = element;
     }
   }
 
-  public int Count {
+  public $csclassname(global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)> c) : this() {
+    if (c == null)
+      throw new global::System.ArgumentNullException("c");
+    int i = 0;
+    foreach ($typemap(cstype, CTYPE) element in c) {
+      if (i >= this.Count)
+        break;
+      this[i++] = element;
+    }
+  }
+
+  public bool IsFixedSize {
     get {
-      return (int)size();
+      return true;
     }
   }
 
-  public $typemap(cstype, T) this[int index]  {
+  public bool IsReadOnly {
+    get {
+      return false;
+    }
+  }
+
+  public $typemap(cstype, CTYPE) this[int index]  {
     get {
       return getitem(index);
     }
@@ -47,21 +57,33 @@
 
   public bool IsEmpty {
     get {
-      return empty();
+      return (size() == 0);
     }
   }
 
-  public void CopyTo($typemap(cstype, T)[] array)
+  public int Count {
+    get {
+      return (int)size();
+    }
+  }
+
+  public bool IsSynchronized {
+    get {
+      return false;
+    }
+  }
+
+  public void CopyTo($typemap(cstype, CTYPE)[] array)
   {
     CopyTo(0, array, 0, this.Count);
   }
 
-  public void CopyTo($typemap(cstype, T)[] array, int arrayIndex)
+  public void CopyTo($typemap(cstype, CTYPE)[] array, int arrayIndex)
   {
     CopyTo(0, array, arrayIndex, this.Count);
   }
 
-  public void CopyTo(int index, $typemap(cstype, T)[] array, int arrayIndex, int count)
+  public void CopyTo(int index, $typemap(cstype, CTYPE)[] array, int arrayIndex, int count)
   {
     if (array == null)
       throw new global::System.ArgumentNullException("array");
@@ -79,7 +101,13 @@
       array.SetValue(getitemcopy(index+i), arrayIndex+i);
   }
 
-  global::System.Collections.Generic.IEnumerator<$typemap(cstype, T)> global::System.Collections.Generic.IEnumerable<$typemap(cstype, T)>.GetEnumerator() {
+  public $typemap(cstype, CTYPE)[] ToArray() {
+    $typemap(cstype, CTYPE)[] array = new $typemap(cstype, CTYPE)[this.Count];
+    this.CopyTo(array);
+    return array;
+  }
+
+  global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)> global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)>.GetEnumerator() {
     return new $csclassnameEnumerator(this);
   }
 
@@ -97,7 +125,7 @@
   /// collection but not when one of the elements of the collection is modified as it is a bit
   /// tricky to detect unmanaged code that modifies the collection under our feet.
   public sealed class $csclassnameEnumerator : global::System.Collections.IEnumerator
-    , global::System.Collections.Generic.IEnumerator<$typemap(cstype, T)>
+    , global::System.Collections.Generic.IEnumerator<$typemap(cstype, CTYPE)>
   {
     private $csclassname collectionRef;
     private int currentIndex;
@@ -112,7 +140,7 @@
     }
 
     // Type-safe iterator Current
-    public $typemap(cstype, T) Current {
+    public $typemap(cstype, CTYPE) Current {
       get {
         if (currentIndex == -1)
           throw new global::System.InvalidOperationException("Enumeration not started.");
@@ -120,7 +148,7 @@
           throw new global::System.InvalidOperationException("Enumeration finished.");
         if (currentObject == null)
           throw new global::System.InvalidOperationException("Collection modified.");
-        return ($typemap(cstype, T))currentObject;
+        return ($typemap(cstype, CTYPE))currentObject;
       }
     }
 
@@ -161,14 +189,11 @@
   public:
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
-    typedef T value_type;
+    typedef CTYPE value_type;
     typedef value_type* pointer;
     typedef const value_type* const_pointer;
     typedef value_type& reference;
     typedef const value_type& const_reference;
-
-    array();
-    array(const array &other);
 
     size_type size() const;
     bool empty() const;
@@ -179,8 +204,11 @@
     %rename(Swap) swap;
     void swap(array& other);
 
+    array();
+    array(const array &other);
+
     %extend {
-      T getitemcopy(int index) throw (std::out_of_range) {
+      CTYPE getitemcopy(int index) throw (std::out_of_range) {
         if (index>=0 && index<(int)$self->size())
           return (*$self)[index];
         else
@@ -213,6 +241,11 @@
     }
 %enddef
 
+%{
+#include <array>
+#include <algorithm>
+#include <stdexcept>
+%}
 
 %csmethodmodifiers std::array::empty "private"
 %csmethodmodifiers std::array::getitemcopy "private"

--- a/Lib/csharp/std_vector.i
+++ b/Lib/csharp/std_vector.i
@@ -69,6 +69,12 @@
     }
   }
 
+  public bool IsEmpty {
+    get {
+      return empty();
+    }
+  }
+
   public int Count {
     get {
       return (int)size();
@@ -208,6 +214,7 @@
     %rename(Add) push_back;
     void push_back(CTYPE const& x);
     size_type size() const;
+    bool empty() const;
     size_type capacity() const;
     void reserve(size_type n);
     %newobject GetRange(int index, int count);
@@ -415,4 +422,3 @@ SWIG_STD_VECTOR_ENHANCED(float)
 SWIG_STD_VECTOR_ENHANCED(double)
 SWIG_STD_VECTOR_ENHANCED(std::string) // also requires a %include <std_string.i>
 SWIG_STD_VECTOR_ENHANCED(std::wstring) // also requires a %include <std_wstring.i>
-


### PR DESCRIPTION
This is a minor change that should mostly affect the whitespaces. I compared `std_vector.i` and `std_array.i` for csharp and found that the two files are closely related, yet different. Therefore I tried to unify and standardize the two files against each other, to help with maintenance. Is that reasonable?