### PR TITLE
Lib/csharp: Resolve a few warnings about unused parameters

### DIFF
--- a/Lib/csharp/std_map.i
+++ b/Lib/csharp/std_map.i
@@ -269,12 +269,14 @@
       }
 
       const key_type& get_next_key(std::map< K, T, C >::iterator *swigiterator) {
+        (void)self;
         std::map< K, T, C >::iterator iter = *swigiterator;
         (*swigiterator)++;
         return (*iter).first;
       }
 
       void destroy_iterator(std::map< K, T, C >::iterator *swigiterator) {
+        (void)self;
         delete swigiterator;
       }
     }
@@ -309,4 +311,3 @@ namespace std {
 %define specialize_std_map_on_both(K,CHECK_K,CONVERT_K_FROM,CONVERT_K_TO, T,CHECK_T,CONVERT_T_FROM,CONVERT_T_TO)
 #warning "specialize_std_map_on_both ignored - macro is deprecated and no longer necessary"
 %enddef
-

--- a/Lib/csharp/std_set.i
+++ b/Lib/csharp/std_set.i
@@ -297,12 +297,14 @@ class set {
       }
 
       const key_type& get_next(std::set<T>::iterator *swigiterator) {
+        (void)self;
         std::set<T>::iterator iter = *swigiterator;
         (*swigiterator)++;
         return *iter;
       }
 
       void destroy_iterator(std::set<T>::iterator *swigiterator) {
+        (void)self;
         delete swigiterator;
       }
     }


### PR DESCRIPTION
This is a minor PR. There are some methods that lead to generated code where a parameter is unused. When compiled with pedantic compiler settings, this leads to a warning or error.
This PR declares the additional parameter `self` as optional (or unused).