### PR TITLE
[Python] Avoid unused parameter self warning

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2814,7 +2814,7 @@ public:
       Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args, PyObject *kwargs) {", NIL);
     }
 
-    if (builtin) {
+    if (!builtin) {
       /* Avoid warning if the self parameter is not used. */
       Append(f->code, "(void)self;\n");
     }


### PR DESCRIPTION
Avoids lots of warnings on regular functions (with gcc / -Wall -Wextra), like:
```
/home/schueller/projects/swig-cmake-example/build/CMakeFiles/openturns.dir/openturnsPYTHON_wrap.cxx:4632:47: warning: unused parameter 'self' [-Wunused-parameter]
SWIGINTERN PyObject *_wrap_Mesh_run(PyObject *self, PyObject *args) {
```

there is an instruction that uses the "self" argument only with the -builtin swig flag, so the condition must be inverted:
```
res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_OT__Mesh, 0 |  0 );
```

to reproduce: https://github.com/jschueller/swig-cmake-example (configure with cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra")

fixes https://github.com/swig/swig/commit/7cb2f46e06fef59a3fe2fb5283bc31326a091f8a

cc @ojwb 