### PR TITLE
[Python] Always define SwigMethods_proxydocs

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -817,8 +817,7 @@ public:
     Printf(f_wrappers, "%s\n", methods);
     Append(methods_proxydocs, "\t { NULL, NULL, 0, NULL }\n");
     Append(methods_proxydocs, "};\n");
-    if ((fastproxy && !builtin) || have_fast_proxy_static_member_method_callback)
-      Printf(f_wrappers, "%s\n", methods_proxydocs);
+    Printf(f_wrappers, "%s\n", methods_proxydocs);
 
     if (builtin) {
       Dump(f_builtins, f_wrappers);


### PR DESCRIPTION
This reverts #2222 as now with 4.1 I get:
error: use of undeclared identifier 'SwigMethods_proxydocs'