### PR TITLE
Relocatable SWIG: allow locating SwigLib relative to executable in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,8 @@ else ()
   message (SEND_ERROR "Could not parse version from configure.ac")
 endif ()
 
-set (SWIG_ROOT ${PROJECT_SOURCE_DIR})
+set(SWIG_ROOT ${PROJECT_SOURCE_DIR})
 
-if (WIN32)
-  set (SWIG_LIB bin/Lib)
-else ()
-  set (SWIG_LIB share/swig/${SWIG_VERSION})
-endif ()
 # Project wide configuration variables
 # ------------------------------------
 
@@ -81,6 +76,26 @@ if (WITH_PCRE)
   find_package (PCRE2 REQUIRED)
   set (HAVE_PCRE 1)
   include_directories (${PCRE2_INCLUDE_DIRS})
+endif()
+
+# SWIG LIB configuration
+# -----------------------
+set(SWIG_LIB_RELATIVE_PATH Lib CACHE STRING "SWIG Library relative folder location compared to root install, only used if SWIG_LIB_RELATIVE_TO_EXE is enabled on UNIX")
+
+if(WIN32)
+  # Always relative
+  set(SWIG_LIB_RELATIVE_TO_EXE ON)
+  set(SWIG_LIB ${SWIG_LIB_RELATIVE_PATH})
+else()
+  option(SWIG_LIB_RELATIVE_TO_EXE "Make SWIG_LIB relative to executable location" OFF)
+  if (SWIG_LIB_RELATIVE_TO_EXE)
+    if (NOT HAVE_UNISTD_H)
+      message(FATAL_ERROR "You don't have unistd.h available when it is required to enable SWIG_LIB_RELATIVE_PATH")
+    endif()
+    set(SWIG_LIB ${SWIG_LIB_RELATIVE_PATH})
+  else()
+    set(SWIG_LIB share/swig/${SWIG_VERSION})
+  endif()
 endif()
 
 #if (WIN32)
@@ -152,6 +167,9 @@ add_executable (swig
 if (PCRE2_FOUND)
   target_link_libraries (swig ${PCRE2_LIBRARIES})
 endif ()
+if (SWIG_LIB_RELATIVE_TO_EXE)
+  target_link_libraries(swig ${CMAKE_DL_LIBS})
+endif()
 install (TARGETS swig DESTINATION bin)
 
 # 'make package-source' creates tarballs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif ()
 if (SWIG_LIB_RELATIVE_TO_EXE)
   target_link_libraries(swig ${CMAKE_DL_LIBS})
 endif()
-install (TARGETS swig DESTINATION bin)
+install (TARGETS swig DESTINATION bin) # TODO: seems like the executable in the zipped swigwin is actually installed at the root...
 
 # 'make package-source' creates tarballs
 set (CPACK_PACKAGE_NAME ${PACKAGE_NAME})

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -813,6 +813,7 @@ static void SWIG_exit_handler(int status);
 static String *get_exe_path(void) {
   char buf[MAX_PATH];
   char *p;
+  // TODO: if this is actually in install/bin/, need another call to strrchr
   if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
     *(p + 1) = '\0';
     return NewStringf("%s%s", buf, SWIG_LIB_RELATIVE_PATH); // Native windows installation path

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -812,14 +812,19 @@ static void SWIG_exit_handler(int status);
 #if defined(_WIN32)
 static String *get_swig_lib_path(void) {
   char buf[MAX_PATH];
-  char *p;
   // TODO: if this is actually in install/bin/, need another call to strrchr
-  if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
-    *(p + 1) = '\0';
-    return NewStringf("%s%s", buf, SWIG_LIB_RELATIVE_PATH); // Native windows installation path
-  } else {
-    return NewStringf("");	// Unexpected error
+  if (GetModuleFileName(0, buf, MAX_PATH) != 0) {
+    char * p = strrchr(buf, '\\');
+    if (p != 0) {
+      *p = '\0';
+      p = strrchr(buf, '\\');
+      if (p != 0) {
+        *p = '\0';
+        return NewStringf("%s\\%s", buf, SWIG_LIB_RELATIVE_PATH); // Native windows installation path
+      }
+    }
   }
+  return NewStringf("");  // Unexpected error
 }
 #elif defined(SWIG_LIB_RELATIVE_TO_EXE) && defined(HAVE_UNISTD_H)
 #include <libgen.h>

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -810,6 +810,9 @@ static void getoptions(int argc, char *argv[]) {
 static void SWIG_exit_handler(int status);
 
 #if defined(_WIN32)
+#  ifndef SWIG_LIB_RELATIVE_PATH
+#    define SWIG_LIB_RELATIVE_PATH "Lib"
+#  endif
 static String *get_swig_lib_path(void) {
   char buf[MAX_PATH];
   // TODO: if this is actually in install/bin/, need another call to strrchr

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -809,6 +809,50 @@ static void getoptions(int argc, char *argv[]) {
 
 static void SWIG_exit_handler(int status);
 
+#if defined(_WIN32)
+static String *get_exe_path(void) {
+  char buf[MAX_PATH];
+  char *p;
+  if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
+    *(p + 1) = '\0';
+    return NewStringf("%s%s", buf, SWIG_LIB_RELATIVE_PATH); // Native windows installation path
+  } else {
+    return NewStringf("");	// Unexpected error
+  }
+}
+#elif defined(SWIG_LIB_RELATIVE_TO_EXE) && defined(HAVE_UNISTD_H)
+#include <libgen.h>
+#include <unistd.h>
+#include <dlfcn.h>
+
+static String *get_exe_path(void) {
+  Dl_info info;
+  if (dladdr("main", &info)) {
+    char realp_buffer[PATH_MAX];
+    char* res = NULL;
+
+    // this is /path/to/swig_install/bin/swig
+    res = realpath(info.dli_fname, realp_buffer);
+    if (!res) {
+      return NewString(SWIG_LIB);
+    }
+
+    // root dir
+    const char* dir = dirname(dirname(realp_buffer));
+    char dest_buf[PATH_MAX];
+    strcpy(dest_buf, dir);
+    strcat(dest_buf, "/");
+    strcat(dest_buf, SWIG_LIB_RELATIVE_PATH);
+    return NewStringWithSize(dest_buf, strlen(dest_buf));
+  }
+  return NewString(SWIG_LIB);
+}
+#else
+static String *get_exe_path(void) {
+  return NewString(SWIG_LIB);
+}
+#endif
+
 int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
   char *c;
 
@@ -843,19 +887,11 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   // Check for SWIG_LIB environment variable
   if ((c = getenv("SWIG_LIB")) == (char *) 0) {
+    SwigLib = get_exe_path();
 #if defined(_WIN32)
-    char buf[MAX_PATH];
-    char *p;
-    if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
-      *(p + 1) = '\0';
-      SwigLib = NewStringf("%sLib", buf); // Native windows installation path
-    } else {
-      SwigLib = NewStringf("");	// Unexpected error
-    }
-    if (Len(SWIG_LIB_WIN_UNIX) > 0)
+    if (Len(SWIG_LIB_WIN_UNIX) > 0) {
       SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
-#else
-    SwigLib = NewString(SWIG_LIB);
+    }
 #endif
   } else {
     SwigLib = NewString(c);

--- a/Tools/cmake/swigconfig.h.in
+++ b/Tools/cmake/swigconfig.h.in
@@ -74,6 +74,12 @@
 /* Compiler that built SWIG */
 #define SWIG_CXX "@CMAKE_CXX_COMPILER@"
 
+/* Whether the path to SWIG_LIB is supposed to be absolute or relative to the executable */
+#cmakedefine SWIG_LIB_RELATIVE_TO_EXE 1
+
+/* Relative path to SWIG system-independent libraries compared to root directory, used only if SWIG_LIB_RELATIVE_TO_EXE is enabled */
+#define SWIG_LIB_RELATIVE_PATH "@SWIG_LIB_RELATIVE_PATH@"
+
 /* Directory for SWIG system-independent libraries */
 #define SWIG_LIB "@CMAKE_INSTALL_PREFIX@/@SWIG_LIB@"
 


### PR DESCRIPTION
The idea is:
* This is opt-in, leaving the historical way untouched
* Allow customizing the location of that directory 
    * including on windows (where it was already relative).
    * On unix, via a `dladdr`

This is motivated by being able to use swig via `conan`, where the packages are by definition relocated. We had patched it on the conan recipe's side, but now that CMakeLists.txt has been added, I think there's a good case for cleaning and upstreaming the changes, so here it is. (I am terrible at autotools to be honest, so that was one of the roadblocks)

Example:

`SWIG_LIB_RELATIVE_TO_EXE` is only needed here, but I'm also choosing to override it's install PATH via SWIG_LIB_RELATIVE_PATH which would default to `<install_prefix>/Lib` otherwise

```shell
cd swig && cd .. && mkdir swig-build && cd swig-build
cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_INSTALL_PREFIX:PATH=$(pwd)/install \
      -DSWIG_LIB_RELATIVE_TO_EXE:BOOL=ON \
      -DSWIG_LIB_RELATIVE_PATH:STRING=bin/swiglib ../swig
ninja install
```

```shell
$ ls ./install/bin/
swig  swiglib

$ ./install/bin/swig -swiglib
/home/julien/Software/Others/swig-build/install/bin/swiglib
```

Relocate:

```shell
$ mv install relocated_install
$ ./relocated_install/bin/swig -swiglib
/home/julien/Software/Others/swig-build/relocated_install/bin/swiglib
```