### PR TITLE
Fix "undefining the allocator of T_DATA" error seen in Ruby 3.2

### DIFF
--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -157,7 +157,8 @@ SWIG_Ruby_define_class(swig_type_info *type)
     _cSWIG_Pointer = rb_define_class_under(_mSWIG, "Pointer", rb_cObject);
     rb_undef_method(CLASS_OF(_cSWIG_Pointer), "new");
   }
-  VALUE cl = rb_define_class_under(_mSWIG, klass_name, _cSWIG_Pointer);
+  VALUE cl;
+  cl = rb_define_class_under(_mSWIG, klass_name, _cSWIG_Pointer);
   rb_undef_alloc_func(cl);
   free((void *) klass_name);
 }

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -157,7 +157,8 @@ SWIG_Ruby_define_class(swig_type_info *type)
     _cSWIG_Pointer = rb_define_class_under(_mSWIG, "Pointer", rb_cObject);
     rb_undef_method(CLASS_OF(_cSWIG_Pointer), "new");
   }
-  rb_define_class_under(_mSWIG, klass_name, _cSWIG_Pointer);
+  VALUE cl = rb_define_class_under(_mSWIG, klass_name, _cSWIG_Pointer);
+  rb_undef_alloc_func(cl);
   free((void *) klass_name);
 }
 


### PR DESCRIPTION
See comment: https://github.com/swig/swig/issues/2257#issuecomment-1499135189

Ruby 3.2 issue: https://bugs.ruby-lang.org/issues/18007 
Similar to https://github.com/robinst/swig/commit/9b5d37fd174331fa2b7113fe968fcf0570de43bf