### PR TITLE
do not emit static const variables twice

### DIFF
--- a/Examples/test-suite/javascript/smart_pointer_const_runme.js
+++ b/Examples/test-suite/javascript/smart_pointer_const_runme.js
@@ -1,0 +1,11 @@
+var smart_pointer_const = require('smart_pointer_const');
+
+var f = new smart_pointer_const.Foo;
+var b = new smart_pointer_const.Bar(f);
+
+b.x = 3;
+if (b.getx() != 3) throw new Error('Failed');
+
+var fp = b.__deref__();
+fp.x = 4;
+if (b.getx() != 4) throw new Error('Failed');

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1707,6 +1707,14 @@ int JSCEmitter::enterVariable(Node *n) {
 }
 
 int JSCEmitter::exitVariable(Node *n) {
+  // Due to special handling of C++ "static const" member variables
+  // (refer to the comment in lang.cxx:Language::staticmembervariableHandler)
+  // a static const member variable may get transformed into a constant
+  // and be emitted by emitConstant which will result calling exitVariable twice
+  if (GetFlag(n, "symbol_emitted"))
+    return SWIG_OK;
+  SetFlag(n, "symbol_emitted");
+
   Template t_variable(getTemplate("jsc_variable_declaration"));
   t_variable.replace("$jsname", state.variable(NAME))
       .replace("$jsgetter", state.variable(GETTER))
@@ -2085,6 +2093,14 @@ int V8Emitter::enterVariable(Node *n) {
 }
 
 int V8Emitter::exitVariable(Node *n) {
+  // Due to special handling of C++ "static const" member variables
+  // (refer to the comment in lang.cxx:Language::staticmembervariableHandler)
+  // a static const member variable may get transformed into a constant
+  // and be emitted by emitConstant which will result calling exitVariable twice
+  if(GetFlag(n, "symbol_emitted"))
+    return SWIG_OK;
+  SetFlag(n, "symbol_emitted");
+
   if (GetFlag(n, "ismember")) {
     if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {
       Template t_register = getTemplate("jsv8_register_static_variable");

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -834,6 +834,7 @@ int JSEmitter::enterFunction(Node *n) {
 int JSEmitter::enterVariable(Node *n) {
   // reset the state information for variables.
   state.variable(RESET);
+  UnsetFlag(n, "js_constant");
 
   // Retrieve a pure symbol name. Using 'sym:name' as a basis, as it considers %renamings.
   if (Equal(Getattr(n, "view"), "memberconstantHandler")) {
@@ -1173,6 +1174,7 @@ int JSEmitter::emitConstant(Node *n) {
       .pretty_print(f_wrappers);
 
   exitVariable(n);
+  SetFlag(n, "js_constant");
 
   DelWrapper(wrapper);
 
@@ -1711,9 +1713,8 @@ int JSCEmitter::exitVariable(Node *n) {
   // (refer to the comment in lang.cxx:Language::staticmembervariableHandler)
   // a static const member variable may get transformed into a constant
   // and be emitted by emitConstant which will result calling exitVariable twice
-  if (GetFlag(n, "symbol_emitted"))
+  if (GetFlag(n, "js_constant"))
     return SWIG_OK;
-  SetFlag(n, "symbol_emitted");
 
   Template t_variable(getTemplate("jsc_variable_declaration"));
   t_variable.replace("$jsname", state.variable(NAME))

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -2098,9 +2098,8 @@ int V8Emitter::exitVariable(Node *n) {
   // (refer to the comment in lang.cxx:Language::staticmembervariableHandler)
   // a static const member variable may get transformed into a constant
   // and be emitted by emitConstant which will result calling exitVariable twice
-  if(GetFlag(n, "symbol_emitted"))
+  if(GetFlag(n, "js_constant"))
     return SWIG_OK;
-  SetFlag(n, "symbol_emitted");
 
   if (GetFlag(n, "ismember")) {
     if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {


### PR DESCRIPTION
It is an ugly solution, but it is low-risk and it works

#2534