### PR TITLE
per-language static overloading

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -424,6 +424,7 @@ CPP_TEST_CASES += \
 	static_array_member \
 	static_const_member \
 	static_const_member_2 \
+	static_member_overload \
 	stl_no_default_constructor \
 	string_constants \
 	struct_initialization_cpp \

--- a/Examples/test-suite/javascript/static_member_overload_runme.js
+++ b/Examples/test-suite/javascript/static_member_overload_runme.js
@@ -12,5 +12,5 @@ try {
 
 try {
   static_member_overload.Foo.sum(1, 2);
-  throw new Error('instance member should have failed');
+  throw new Error('static member should have failed');
 } catch {}

--- a/Examples/test-suite/javascript/static_member_overload_runme.js
+++ b/Examples/test-suite/javascript/static_member_overload_runme.js
@@ -1,0 +1,16 @@
+const static_member_overload = require('static_member_overload');
+
+const foo = new static_member_overload.Foo;
+
+if (foo.sum(1, 2) !== 3) throw new Error('instance member failed');
+if (static_member_overload.Foo.sum(1, 2, 3) !== 6) throw new Error('static member failed');
+
+try {
+  foo.sum(1, 2, 3);
+  throw new Error('instance member should have failed');
+} catch {}
+
+try {
+  static_member_overload.Foo.sum(1, 2);
+  throw new Error('instance member should have failed');
+} catch {}

--- a/Examples/test-suite/perl5/static_member_overload_runme.pl
+++ b/Examples/test-suite/perl5/static_member_overload_runme.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 5;
+BEGIN { use_ok('static_member_overload') }
+
+my $f;
+
+# static member
+is(static_member_overload::Foo::sum(1, 2, 3), 6);
+
+# should fail
+eval { static_member_overload::Foo::sum(1, 2) };
+like($@, qr/No matching function/);
+
+# instance member
+$f = static_member_overload::Foo->new();
+is($f->sum(1, 2), 3);
+
+# should fail
+eval { $f->sum(1, 2, 3) };
+like($@, qr/No matching function/);

--- a/Examples/test-suite/python/static_member_overload_runme.py
+++ b/Examples/test-suite/python/static_member_overload_runme.py
@@ -1,0 +1,24 @@
+from static_member_overload import *
+
+foo = Foo()
+
+# TODO
+# The current dispatcher is not able to handle both
+# instance and static methods
+if foo.sum(foo, 1, 2) != 3:
+  raise RuntimeError('instance member failed')
+
+if Foo.sum(1, 2, 3) != 6:
+  raise RuntimeError('static member failed')
+
+try:
+  foo.sum(1, 2, 3)
+  raise RuntimeError('instance member should have failed')
+except:
+  pass
+
+try:
+  Foo.sum(1, 2)
+  raise RuntimeError('static member should have failed')
+except:
+  pass

--- a/Examples/test-suite/static_member_overload.i
+++ b/Examples/test-suite/static_member_overload.i
@@ -1,0 +1,9 @@
+%module static_member_overload
+%inline %{
+class Foo { 
+ public: 
+  virtual ~Foo() {}
+  int sum(int i, int j) { return i+j; }
+  static int sum(int i, int j, int k) { return i+j+k; };
+}; 
+%}

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -75,6 +75,7 @@ static int      compact_default_args = 0;
 static int      template_reduce = 0;
 static int      cparse_externc = 0;
 int		ignore_nested_classes = 0;
+int             static_overloading = 1;
 int		kwargs_supported = 0;
 
 /* -----------------------------------------------------------------------------

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -308,6 +308,11 @@ public:
     delete emitter;
   }
 
+  virtual Language::StaticOverloadingSupport staticOverloadingSupport() const {
+    // In JS static and instance members do not share the same namespace
+    return Language::StaticOverloadingSupport::SOS_Separate;
+  }
+
   virtual int functionHandler(Node *n);
   virtual int globalfunctionHandler(Node *n);
   virtual int variableHandler(Node *n);
@@ -1190,6 +1195,9 @@ int JSEmitter::emitFunction(Node *n, bool is_member, bool is_static) {
   if (is_overloaded) {
     t_function = getTemplate("js_overloaded_function");
     Append(wrap_name, Getattr(n, "sym:overname"));
+  }
+  if (is_static) {
+    Append(wrap_name, "_static");
   }
   Setattr(n, "wrap:name", wrap_name);
   state.function(WRAPPER_NAME, wrap_name);

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -3462,6 +3462,16 @@ void Language::allow_overloading(int val) {
 }
 
 /* -----------------------------------------------------------------------------
+ * Language::staticOverloadingSupport()
+ * -----------------------------------------------------------------------------
+ */
+
+Language::StaticOverloadingSupport Language::staticOverloadingSupport() const {
+  // TODO: Maybe the default one should be SOS_NONE
+  return Language::StaticOverloadingSupport::SOS_Mixed;
+}
+
+/* -----------------------------------------------------------------------------
  * Language::allow_multiple_input()
  * ----------------------------------------------------------------------------- */
 

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -935,6 +935,9 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     case Language::SOS_Separate:
       static_overloading = 2;
       break;
+    case Language::SOS_NoMixing:
+      static_overloading = 3;
+      break;
   }
 
   kwargs_supported = lang->kwargsSupport() ? 1 : 0;

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -56,6 +56,7 @@ extern "C" {
 extern "C" {
   extern String *ModuleName;
   extern int ignore_nested_classes;
+  extern int static_overloading;
   extern int kwargs_supported;
 }
 
@@ -923,6 +924,18 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   // Inform the parser if the nested classes should be ignored unless explicitly told otherwise via feature:flatnested
   ignore_nested_classes = lang->nestedClassesSupport() == Language::NCS_Unknown ? 1 : 0;
+  switch (lang->staticOverloadingSupport()) {
+    case Language::SOS_None:
+      static_overloading = 0;
+      break;
+    default:
+    case Language::SOS_Mixed:
+      static_overloading = 1;
+      break;
+    case Language::SOS_Separate:
+      static_overloading = 2;
+      break;
+  }
 
   kwargs_supported = lang->kwargsSupport() ? 1 : 0;
 

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -2488,6 +2488,10 @@ public:
     }
     return SWIG_OK;
   }
+
+  virtual Language::StaticOverloadingSupport staticOverloadingSupport() const {
+    return Language::StaticOverloadingSupport::SOS_Mixed;
+  }
 };
 
 /* -----------------------------------------------------------------------------

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -2512,6 +2512,11 @@ public:
     wrapperType = standard;
     return result;
   }
+
+  virtual Language::StaticOverloadingSupport staticOverloadingSupport() const {
+    // In PHP static members cannot be overloaded
+    return Language::StaticOverloadingSupport::SOS_None;
+  }
 };				/* class PHP */
 
 static PHP *maininstance = 0;

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -2514,8 +2514,8 @@ public:
   }
 
   virtual Language::StaticOverloadingSupport staticOverloadingSupport() const {
-    // In PHP static members cannot be overloaded
-    return Language::StaticOverloadingSupport::SOS_None;
+    // In PHP static members cannot be overloaded with instance members
+    return Language::StaticOverloadingSupport::SOS_NoMixing;
   }
 };				/* class PHP */
 

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -316,6 +316,18 @@ public:
   */
   virtual NestedClassSupport nestedClassesSupport() const;
 
+  /* Does the target language support overloading of static members */
+  enum StaticOverloadingSupport {
+      SOS_None,  // Static members cannot be overloaded (like C++03)
+      SOS_Mixed, // Mixed overloading of static and instance members is allowed
+                 // (like Perl)
+      SOS_Separate // Static and instance members use different namespaces (like
+                   // JS and C++11)
+  };
+
+  /* Allow overloading of static functions */
+  virtual Language::StaticOverloadingSupport staticOverloadingSupport() const;
+
   /* Returns true if the target language supports key word arguments (kwargs) */
   virtual bool kwargsSupport() const;
 

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -318,11 +318,13 @@ public:
 
   /* Does the target language support overloading of static members */
   enum StaticOverloadingSupport {
-      SOS_None,  // Static members cannot be overloaded (like C++03)
-      SOS_Mixed, // Mixed overloading of static and instance members is allowed
-                 // (like Perl)
-      SOS_Separate // Static and instance members use different namespaces (like
-                   // JS and C++11)
+      SOS_None,     // Static members cannot be overloaded (like C++03)
+      SOS_Mixed,    // Mixed overloading of static and instance members is allowed
+                    // (like Perl)
+      SOS_Separate, // Static and instance members use different namespaces
+                    // (like JS and C++11)
+      SOS_NoMixing  // Static is allowed, but mixing static and instance is
+                    // is not (like PHP)
   };
 
   /* Allow overloading of static functions */

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -879,11 +879,6 @@ Node *Swig_symbol_add(const_String_or_char_ptr symname, Node *n) {
     /* Look at storage class to see if compatible */
     cstorage = Getattr(c, "storage");
     nstorage = Getattr(n, "storage");
-    Printf(stdout, "node=%s (%s), first=%s (%s)\n",
-        Getattr(n, "name"),
-        nstorage,
-        Getattr(c, "name"),
-        cstorage);
 
     /* If either one is declared as typedef, forget it. We're hosed */
     if (Cmp(cstorage, "typedef") == 0) {
@@ -896,6 +891,7 @@ Node *Swig_symbol_add(const_String_or_char_ptr symname, Node *n) {
     if (Cmp(cstorage, "static") == 0 || Cmp(nstorage, "static") == 0) {
       if (static_overloading == 0) {
         /* No static overloading at all */
+        /* TODO: Is this really necessary?? */
         return c;
       }
       if (static_overloading == 2 && Cmp(cstorage, nstorage) != 0) {

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -902,6 +902,10 @@ Node *Swig_symbol_add(const_String_or_char_ptr symname, Node *n) {
         /* When the storage classes do not match, this is not overloading */
         c = 0;
       }
+      if (static_overloading == 3 && Cmp(cstorage, nstorage) != 0) {
+        /* When the storage classes do not match, this is not allowed at all */
+        return c;
+      }
     }
 
     /* Okay. Walk down the list of symbols and see if we get a declarator match */


### PR DESCRIPTION
allow languages to specify their own static overloading rules
Resolves #2544 