### PR TITLE
Allow using snprintf() instead of sprintf() in wrappers

### DIFF
--- a/Lib/csharp/csharp.swg
+++ b/Lib/csharp/csharp.swg
@@ -579,7 +579,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
                  unsigned long, 
                  unsigned short
 %{ char error_msg[256];
-   sprintf(error_msg, "C++ $1_type exception thrown, value: %d", $1);
+   SWIG_snprintf(error_msg, sizeof(error_msg), "C++ $1_type exception thrown, value: %d", $1);
    SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, error_msg);
    return $null; %}
 

--- a/Lib/d/dexception.swg
+++ b/Lib/d/dexception.swg
@@ -15,7 +15,7 @@
                  unsigned long,
                  unsigned short
 %{ char error_msg[256];
-   sprintf(error_msg, "C++ $1_type exception thrown, value: %d", $1);
+   SWIG_snprintf(error_msg, sizeof(error_msg), "C++ $1_type exception thrown, value: %d", $1);
    SWIG_DSetPendingException(SWIG_DException, error_msg);
    return $null; %}
 

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1039,7 +1039,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
                  unsigned long, 
                  unsigned short
 %{ char error_msg[256];
-   sprintf(error_msg, "C++ $1_type exception thrown, value: %d", $1);
+   SWIG_snprintf(error_msg, sizeof(error_msg), "C++ $1_type exception thrown, value: %d", $1);
    SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, error_msg);
    return $null; %}
 

--- a/Lib/javascript/jsc/javascripthelpers.swg
+++ b/Lib/javascript/jsc/javascripthelpers.swg
@@ -46,7 +46,7 @@ SWIGINTERN bool JS_veto_set_variable(JSContextRef context, JSObjectRef thisObjec
     int res;
     
     JSStringGetUTF8CString(propertyName, buffer, 256);
-    res = sprintf(msg, "Tried to write read-only variable: %s.", buffer);
+    res = SWIG_snprintf(msg, sizeof(msg), "Tried to write read-only variable: %s.", buffer);
     
     if(res<0) {
       SWIG_exception(SWIG_ERROR, "Tried to write read-only variable.");

--- a/Lib/javascript/v8/javascripthelpers.swg
+++ b/Lib/javascript/v8/javascripthelpers.swg
@@ -70,7 +70,7 @@ SWIGRUNTIME void JS_veto_set_variable(v8::Local<v8::Name> property, v8::Local<v8
     v8::Local<v8::String> sproperty;
     if (property->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocal(&sproperty)) {
       SWIGV8_WRITE_UTF8(sproperty, buffer, 256);
-      res = sprintf(msg, "Tried to write read-only variable: %s.", buffer);
+      res = SWIG_snprintf(msg, sizeof(msg), "Tried to write read-only variable: %s.", buffer);
     }
     else {
       res = -1;

--- a/Lib/mzscheme/mzrun.swg
+++ b/Lib/mzscheme/mzrun.swg
@@ -25,9 +25,10 @@ extern "C" {
 #define SWIG_contract_assert(expr,msg) \
   do { \
     if (!(expr)) { \
-      char *m=(char *) scheme_malloc(strlen(msg)+1000); \
-      sprintf(m,"SWIG contract, assertion failed: function=%s, message=%s", \
-              (char *) FUNC_NAME,(char *) msg); \
+      size_t len=strlen(msg)+1000; \
+      char *m=(char *) scheme_malloc(len); \
+      SWIG_snprintf2(m, len, "SWIG contract, assertion failed: function=%s, message=%s", \
+		     (char *) FUNC_NAME,(char *) msg); \
       scheme_signal_error(m); \
     } \
   } while (0)
@@ -420,10 +421,10 @@ SWIG_MzScheme_new_scheme_struct (Scheme_Env* env, const char* basename,
 	      int L=strlen(mz_dynload_libpaths[k])+strlen("\\")+strlen(mz_dlopen_libraries[i])+1;
 	      libp=(char *) malloc(L*sizeof(char));
 #ifdef __OS_WIN32
-	      sprintf(libp,"%s\\%s",mz_dynload_libpaths[k],mz_dlopen_libraries[i]);
+	      SWIG_snprintf2(libp,L,"%s\\%s",mz_dynload_libpaths[k],mz_dlopen_libraries[i]);
 	      mz_libraries[i]=(void *) LoadLibrary(libp); 
 #else
-	      sprintf(libp,"%s/%s",mz_dynload_libpaths[k],mz_dlopen_libraries[i]);
+	      SWIG_snprintf2(libp,L,"%s/%s",mz_dynload_libpaths[k],mz_dlopen_libraries[i]);
 	      mz_libraries[i]=(void *) dlopen(libp,RTLD_LAZY); 
 #endif
 	      if (mz_dynload_debug) {

--- a/Lib/ocaml/cstring.i
+++ b/Lib/ocaml/cstring.i
@@ -25,7 +25,7 @@
  *
  *     %cstring_bounded_output(char *outx, 512);
  *     void foo(char *outx) {
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *     }
  *
  */
@@ -144,7 +144,7 @@
  *
  *     %cstring_output_maxsize(char *outx, int max) {
  *     void foo(char *outx, int max) {
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *     }
  */
 
@@ -175,7 +175,7 @@
  *
  *     %cstring_output_maxsize(char *outx, int *max) {
  *     void foo(char *outx, int *max) {
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *         *max = strlen(outx);  
  *     }
  */
@@ -213,7 +213,7 @@
  *     %cstring_output_allocated(char **outx, free($1));
  *     void foo(char **outx) {
  *         *outx = (char *) malloc(512);
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *     }
  */
 
@@ -241,7 +241,7 @@
  *     %cstring_output_allocated(char **outx, int *sz, free($1));
  *     void foo(char **outx, int *sz) {
  *         *outx = (char *) malloc(512);
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *         *sz = strlen(outx);
  *     }
  */

--- a/Lib/ocaml/typecheck.i
+++ b/Lib/ocaml/typecheck.i
@@ -183,7 +183,7 @@
                   unsigned long, 
                   unsigned short {
   char error_msg[256];
-  sprintf(error_msg, "C++ $1_type exception thrown, value: %d", $1);
+  SWIG_snprintf(error_msg, sizeof(error_msg), "C++ $1_type exception thrown, value: %d", $1);
   SWIG_OCamlThrowException(SWIG_OCamlRuntimeException, error_msg);
 }
 

--- a/Lib/octave/octcontainer.swg
+++ b/Lib/octave/octcontainer.swg
@@ -198,7 +198,7 @@ namespace swig
 	return swig::as<T>(item);
       } catch (const std::exception& e) {
 	char msg[1024];
-	sprintf(msg, "in sequence element %d ", _index);
+	SWIG_snprintf(msg, sizeof(msg), "in sequence element %d ", _index);
 	if (!Octave_Error_Occurred()) {
 	  %type_error(swig::type_name<T>());
 	}

--- a/Lib/perl5/perlprimtypes.swg
+++ b/Lib/perl5/perlprimtypes.swg
@@ -179,7 +179,7 @@ SWIG_From_dec(long long)(long long value)
   else {
     //sv = newSVpvf("%lld", value); doesn't work in non 64bit Perl
     char temp[256];
-    sprintf(temp, "%lld", value);
+    SWIG_snprintf(temp, sizeof(temp), "%lld", value);
     sv = newSVpv(temp, 0);
   }
   return sv_2mortal(sv);
@@ -259,7 +259,7 @@ SWIG_From_dec(unsigned long long)(unsigned long long value)
   else {
     //sv = newSVpvf("%llu", value); doesn't work in non 64bit Perl
     char temp[256];
-    sprintf(temp, "%llu", value);
+    SWIG_snprintf(temp, sizeof(temp), "%llu", value);
     sv = newSVpv(temp, 0);
   }
   return sv_2mortal(sv);

--- a/Lib/perl5/typemaps.i
+++ b/Lib/perl5/typemaps.i
@@ -206,7 +206,7 @@ output values.
     if (argvi >= items) {
 	EXTEND(sp, argvi+1);
     }
-    sprintf(temp,"%lld", (long long)*($1));
+    SWIG_snprintf(temp, sizeof(temp),"%lld", (long long)*($1));
     $result = sv_newmortal();
     sv_setpv($result,temp);
     argvi++;
@@ -217,7 +217,7 @@ output values.
     if (argvi >= items) {
 	EXTEND(sp, argvi+1);
     }
-    sprintf(temp,"%llu", (unsigned long long)*($1));
+    SWIG_snprintf(temp, sizeof(temp),"%llu", (unsigned long long)*($1));
     $result = sv_newmortal();
     sv_setpv($result,temp);
     argvi++;

--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -186,7 +186,7 @@ namespace swig
 	return swig::as<T>(item);
       } catch (const std::invalid_argument& e) {
 	char msg[1024];
-	sprintf(msg, "in sequence element %d ", _index);
+	SWIG_snprintf(msg, sizeof(msg), "in sequence element %d ", _index);
 	VALUE lastErr = rb_gv_get("$!");
 	if ( lastErr == Qnil ) {
 	  %type_error(swig::type_name<T>());

--- a/Lib/ruby/rubyerrors.swg
+++ b/Lib/ruby/rubyerrors.swg
@@ -110,7 +110,7 @@ const char* Ruby_Format_TypeError( const char* msg,
     }
 
   str = rb_str_cat2( str, "Expected argument " );
-  sprintf( buf, "%d of type ", argn-1 );
+  SWIG_snprintf( buf, sizeof( buf), "%d of type ", argn-1 );
   str = rb_str_cat2( str, buf );
   str = rb_str_cat2( str, type );
   str = rb_str_cat2( str, ", but got " );

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -151,8 +151,9 @@ SWIG_Ruby_InitRuntime(void)
 SWIGRUNTIME void
 SWIG_Ruby_define_class(swig_type_info *type)
 {
-  char *klass_name = (char *) malloc(4 + strlen(type->name) + 1);
-  sprintf(klass_name, "TYPE%s", type->name);
+  size_t klass_len = 4 + strlen(type->name) + 1;
+  char *klass_name = (char *) malloc(klass_len);
+  SWIG_snprintf(klass_name, klass_len, "TYPE%s", type->name);
   if (NIL_P(_cSWIG_Pointer)) {
     _cSWIG_Pointer = rb_define_class_under(_mSWIG, "Pointer", rb_cObject);
     rb_undef_method(CLASS_OF(_cSWIG_Pointer), "new");
@@ -208,8 +209,9 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
       SWIG_RubyAddTracking(ptr, obj);
     }
   } else {
-    klass_name = (char *) malloc(4 + strlen(type->name) + 1);
-    sprintf(klass_name, "TYPE%s", type->name);
+    size_t klass_len = 4 + strlen(type->name) + 1;
+    klass_name = (char *) malloc(klass_len);
+    SWIG_snprintf(klass_name, klass_len, "TYPE%s", type->name);
     klass = rb_const_get(_mSWIG, rb_intern(klass_name));
     free((void *) klass_name);
     obj = Data_Wrap_Struct(klass, 0, 0, ptr);

--- a/Lib/scilab/sciarray.swg
+++ b/Lib/scilab/sciarray.swg
@@ -40,8 +40,8 @@
   }
   else {
     char errmsg[100];
-    sprintf(errmsg, "Size of input data (%d) is too big (maximum is %d)",
-      iRows*iCols, $1_dim0);
+    SWIG_snprintf2(errmsg, sizeof(errmsg), "Size of input data (%d) is too big (maximum is %d)",
+                   iRows*iCols, $1_dim0);
     SWIG_exception_fail(SWIG_OverflowError, errmsg);
   }
 }

--- a/Lib/scilab/sciexception.swg
+++ b/Lib/scilab/sciexception.swg
@@ -17,20 +17,20 @@
                             size_t, size_t&,
                             ptrdiff_t, ptrdiff_t& {
   char obj[20];
-  sprintf(obj, "%d", (int)$1);
+  SWIG_snprintf(obj, sizeof(obj), "%d", (int)$1);
   SWIG_Scilab_Raise_Ex(obj, "$type", $descriptor);
 }
 
 %typemap(throws, noblock=1) enum SWIGTYPE {
   char obj[20];
-  sprintf(obj, "%d", (int)$1);
+  SWIG_snprintf(obj, sizeof(obj), "%d", (int)$1);
   SWIG_Scilab_Raise_Ex(obj, "$type", $descriptor);
 }
 
 %typemap(throws, noblock=1) float, double,
                             float&, double& {
   char obj[20];
-  sprintf(obj, "%5.3f", (double)$1);
+  SWIG_snprintf(obj, sizeof(obj), "%5.3f", (double)$1);
   SWIG_Scilab_Raise_Ex(obj, "$type", $descriptor);
 }
 
@@ -44,7 +44,8 @@
 
 %typemap(throws, noblock=1) char, char& {
   char obj[2];
-  sprintf(obj, "%c", (char)$1);
+  obj[0] = (char)$1;
+  obj[1] = 0;
   SWIG_Scilab_Raise_Ex(obj, "$type", $descriptor);
 }
 

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -727,3 +727,23 @@ template <typename T> T SwigValueInit() {
 %}
 #endif
 
+%insert("runtime") %{
+/* C99 and C++11 should provide snprintf, but define SWIG_NO_SNPRINTF
+ * if you're missing it.
+ */
+#if ((defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L) || \
+     (defined __cplusplus && __cplusplus >= 201103L) || \
+     defined SWIG_HAVE_SNPRINTF) && \
+    !defined SWIG_NO_SNPRINTF
+# define SWIG_snprintf(O,S,F,A) snprintf(O,S,F,A)
+# define SWIG_snprintf2(O,S,F,A,B) snprintf(O,S,F,A,B)
+#else
+/* Fallback versions ignore the buffer size, but most of our uses either have a
+ * fixed maximum possible size or dynamically allocate a buffer that's large
+ * enough.
+ */
+# define SWIG_snprintf(O,S,F,A) sprintf(O,F,A)
+# define SWIG_snprintf2(O,S,F,A,B) sprintf(O,F,A,B)
+#endif
+
+%}

--- a/Lib/tcl/tclprimtypes.swg
+++ b/Lib/tcl/tclprimtypes.swg
@@ -61,7 +61,7 @@ SWIG_From_dec(unsigned long)(unsigned long value)
     return SWIG_From(long)(%numeric_cast(value, long));
   } else {
     char temp[256]; 
-    sprintf(temp, "%lu", value);
+    SWIG_snprintf(temp, sizeof(temp), "%lu", value);
     return Tcl_NewStringObj(temp,-1);
   }
 }
@@ -122,7 +122,7 @@ SWIG_From_dec(long long)(long long value)
     return SWIG_From(long)(%numeric_cast(value,long));
   } else {    
     char temp[256]; 
-    sprintf(temp, "%lld", value);
+    SWIG_snprintf(temp, sizeof(temp), "%lld", value);
     return Tcl_NewStringObj(temp,-1);
   }
 }
@@ -163,7 +163,7 @@ SWIG_From_dec(unsigned long long)(unsigned long long value)
     return SWIG_From(long long)(%numeric_cast(value, long long));
   } else {
     char temp[256]; 
-    sprintf(temp, "%llu", value);
+    SWIG_snprintf(temp, sizeof(temp), "%llu", value);
     return Tcl_NewStringObj(temp,-1);
   }
 }

--- a/Lib/tcl/tclrun.swg
+++ b/Lib/tcl/tclrun.swg
@@ -707,7 +707,7 @@ SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], const char
  argerror:
   {
     char temp[32];
-    sprintf(temp,"%d", argno+1);
+    SWIG_snprintf(temp, sizeof(temp), "%d", argno+1);
     c = strchr(fmt,':');
     if (!c) c = strchr(fmt,';');
     if (!c) c = (char *)"";

--- a/Lib/tcl/typemaps.i
+++ b/Lib/tcl/typemaps.i
@@ -275,7 +275,7 @@ output values.
 {
   char temp[256];
   Tcl_Obj *o;
-  sprintf(temp,"%lld",(long long)*($1));
+  SWIG_snprintf(temp,sizeof(temp),"%lld",(long long)*($1));
   o = Tcl_NewStringObj(temp,-1);
   Tcl_ListObjAppendElement(interp,Tcl_GetObjResult(interp),o);
 }
@@ -284,7 +284,7 @@ output values.
 {
   char temp[256];
   Tcl_Obj *o;
-  sprintf(temp,"%llu",(unsigned long long)*($1));
+  SWIG_snprintf(temp,sizeof(temp),"%llu",(unsigned long long)*($1));
   o = Tcl_NewStringObj(temp,-1);
   Tcl_ListObjAppendElement(interp,Tcl_GetObjResult(interp),o);
 }

--- a/Lib/typemaps/cstrings.swg
+++ b/Lib/typemaps/cstrings.swg
@@ -50,7 +50,7 @@
  *
  *     %cstring_bounded_output(Char *outx, 512);
  *     void foo(Char *outx) {
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *     }
  *
  */
@@ -175,7 +175,7 @@
  *
  *     %cstring_output_maxsize(Char *outx, int max) {
  *     void foo(Char *outx, int max) {
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *     }
  */
 
@@ -205,7 +205,7 @@
  *
  *     %cstring_output_withsize(Char *outx, int *max) {
  *     void foo(Char *outx, int *max) {
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *         *max = strlen(outx);  
  *     }
  */
@@ -239,7 +239,7 @@
  *     %cstring_output_allocate(Char **outx, free($1));
  *     void foo(Char **outx) {
  *         *outx = (Char *) malloc(512);
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *     }
  */
  
@@ -266,7 +266,7 @@
  *     %cstring_output_allocate_size(Char **outx, int *sz, free($1));
  *     void foo(Char **outx, int *sz) {
  *         *outx = (Char *) malloc(512);
- *         sprintf(outx,"blah blah\n");
+ *         strcpy(outx,"blah blah\n");
  *         *sz = strlen(outx);
  *     }
  */


### PR DESCRIPTION
We aim to produce code that works with C90 or C++98 so we can't assume snprintf() is available, but it almost always is (even on systems from before it was standardised) so having a way to use it is helpful.

Enable this automatically if the compiler claims conformance with at least C90 or C++98 and check SWIG_HAVE_SNPRINTF to allow turning on manually, but disable is SWIG_NO_SNPRINTF if defined.

The fallback is to call sprintf() without a buffer size check - checking after the call is really shutting the stable door after the horse has bolted, and most of our uses either have a fixed maximum possible size or dynamically allocate a buffer that's large enough.

Fixes #2502 (sprintf deprecation warnings on macos)