### PR TITLE
Add more argc and argv multi-argument typemaps.

### DIFF
--- a/Examples/test-suite/argcargvtest.i
+++ b/Examples/test-suite/argcargvtest.i
@@ -1,9 +1,14 @@
 %module argcargvtest
 
-#if !defined(SWIGCSHARP) && !defined(SWIGD) && !defined(SWIGGUILE) && !defined(SWIGJAVA) && !defined(SWIGJAVASCRIPT) && !defined(SWIGMZSCHEME) && !defined(SWIGOCAML) && !defined(SWIGR) && !defined(SWIGSCILAB)
+#if !defined(SWIGD) && !defined(SWIGMZSCHEME) && !defined(SWIGOCAML) && !defined(SWIGR)
+#define SWIGCSHARP_ARGCARGV_PARAM_IDX "0"
 %include <argcargv.i>
 
+#ifndef SWIGCSHARP
 %apply (int ARGC, char **ARGV) { (size_t argc, const char **argv) }
+#else
+%apply (char **ARGV) { const char **argv }
+#endif
 #endif
 
 %inline %{

--- a/Examples/test-suite/csharp/argcargvtest_runme.cs
+++ b/Examples/test-suite/csharp/argcargvtest_runme.cs
@@ -1,0 +1,22 @@
+using System;
+using argcargvtestNamespace;
+
+public class argcargvtest_runme {
+
+  public static void Main() {
+    string[] largs = {"hi", "hola", "hello"};
+    if (argcargvtest.mainc((uint)largs.Length, largs) != 3)
+        throw new Exception("bad main typemap");
+
+    string[] targs = {"hi", "hola"};
+    if (!argcargvtest.mainv((uint)targs.Length, targs, 1).Equals("hola"))
+        throw new Exception("bad main typemap");
+
+// For dynamically typed languages we test this throws an exception or similar
+// at runtime, but for C# this doesn't even compile (but we can't easily
+// test for that here).
+//  argcargvtest.mainv("hello", 1);
+
+    argcargvtest.initializeApp((uint)targs.Length, largs);
+  }
+}

--- a/Examples/test-suite/guile/argcargvtest_runme.scm
+++ b/Examples/test-suite/guile/argcargvtest_runme.scm
@@ -1,0 +1,6 @@
+;; The SWIG modules have "passive" Linkage, i.e., they don't generate
+;; Guile modules (namespaces) but simply put all the bindings into the
+;; current module.  That's enough for such a simple test.
+(dynamic-call "scm_init_argcargvtest_module" (dynamic-link "./libargcargvtest"))
+(load "testsuite.scm")
+(load "../schemerunme/argcargvtest.scm")

--- a/Examples/test-suite/java/argcargvtest_runme.java
+++ b/Examples/test-suite/java/argcargvtest_runme.java
@@ -1,0 +1,32 @@
+import argcargvtest.*;
+
+public class argcargvtest_runme {
+
+  static {
+    try {
+      System.loadLibrary("argcargvtest");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) {
+    argcargvtest test = new argcargvtest();
+
+    String[] largs = {"hi", "hola", "hello"};
+    if (test.mainc(largs) != 3)
+        throw new RuntimeException("bad main typemap");
+
+    String[] targs = {"hi", "hola"};
+    if (!test.mainv(targs, 1).equals("hola"))
+        throw new RuntimeException("bad main typemap");
+
+// For dynamically typed languages we test this throws an exception or similar
+// at runtime, but for Java this doesn't even compile (but we can't easily
+// test for that here).
+//  test.mainv("hello", 1);
+
+    test.initializeApp(largs);
+  }
+}

--- a/Examples/test-suite/javascript/argcargvtest_runme.js
+++ b/Examples/test-suite/javascript/argcargvtest_runme.js
@@ -1,0 +1,21 @@
+var test = require("argcargvtest");
+
+const largs = ["hi", "hola", "hello"];
+if (test.mainc(largs) != 3)
+   throw "calling mainc failed";
+
+const targs = ["hi", "hola"];
+if (test.mainv(targs, 1) != "hola")
+   throw "calling mainv failed";
+
+caughtException = false;
+try {
+   test.mainv("hello", 1);
+} catch (err) {
+   caughtException = true;
+}
+if (!caughtException) {
+   throw "mainv without array should fail"
+}
+
+test.initializeApp(largs);

--- a/Examples/test-suite/schemerunme/argcargvtest.scm
+++ b/Examples/test-suite/schemerunme/argcargvtest.scm
@@ -1,0 +1,14 @@
+(define largs #("hi" "hola" "hello"))
+(when (not (= (mainc largs) 3))
+    (error "calling mainc failed"))
+
+(define targs #("hi" "hola"))
+(when (not (string=? (mainv targs 1) "hola"))
+    (error "calling mainv failed"))
+
+(expect-throw 'swig-contract-assertion-failed
+    (mainv "hello"  1))
+
+(initializeApp largs)
+
+(exit 0)

--- a/Examples/test-suite/scilab/argcargvtest_runme.sci
+++ b/Examples/test-suite/scilab/argcargvtest_runme.sci
@@ -1,0 +1,19 @@
+exec("swigtest.start", -1);
+
+largs = ["hi" "hola" "hello"];
+checkequal(mainc(largs), 3, "calling mainc");
+
+targs = ["hi" "hola"]
+checkequal(mainv(targs, 1), "hola", "calling mainv");
+
+checkequal(mainv("hi", 0), "hi", "calling mainv with a single string");
+
+try
+  mainv(1, 1);
+  swigtesterror();
+catch
+end
+
+initializeApp(largs);
+
+exec("swigtest.quit", -1);

--- a/Lib/csharp/argcargv.i
+++ b/Lib/csharp/argcargv.i
@@ -1,0 +1,18 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+/*
+ * Follow main(int argc, char *argv[]) function
+ * Note: SWIGCSHARP_ARGCARGV_PARAM_IDX set the 'argc' parameter location.
+ * The C# Marshaling use the argc parameter to determin the array size.
+ * See: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshalasattribute.sizeparamindex
+ */
+
+#ifndef SWIGCSHARP_ARGCARGV_PARAM_IDX
+#define SWIGCSHARP_ARGCARGV_PARAM_IDX "0"
+#endif SWIGCSHARP_ARGCARGV_PARAM_IDX
+
+%typemap(csin) char **ARGV "$csinput"
+%typemap(cstype) char **ARGV "string[]"
+%typemap(imtype, inattributes="[global::System.Runtime.InteropServices.In,global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType=global::System.Runtime.InteropServices.UnmanagedType.LPStr, SizeParamIndex="SWIGCSHARP_ARGCARGV_PARAM_IDX")]") char **ARGV "string[]"

--- a/Lib/guile/argcargv.i
+++ b/Lib/guile/argcargv.i
@@ -1,0 +1,49 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+%typemap(in) (int ARGC, char **ARGV) {
+  $1_ltype i, len;
+  SWIG_contract_assert($input != (SCM)0 &&
+                       !scm_is_null($input) &&
+                       scm_is_array($input),
+                       "you must pass array of strings");
+  len = scm_c_array_length($input);
+  SWIG_contract_assert(len > 1, "array must contain at least 1 element");
+  $1 = len;
+  $2 = ($2_ltype) malloc((len+1)*sizeof($*2_ltype));
+  if ($2 == NULL) {
+    scm_misc_error(FUNC_NAME, "fail allocating memory for array", SCM_EOL);
+  }
+  for (i = 0; i < len; i++) {
+    SCM args = scm_list_1(scm_from_long(i));
+    SCM str = scm_array_ref($input, args);
+    SWIG_contract_assert(scm_is_string(str), "elements in array must be strings");
+    $2[i] = ($*2_ltype)SWIG_scm2str(str);
+  }
+  $2[i] = NULL;
+}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
+  if ($input != (SCM)0 && !scm_is_null($input) && scm_is_array($input)) {
+    size_t len = scm_c_array_length($input);
+    if (len > 0) {
+      size_t i;
+      for(i = 0; i < len; i++) {
+        SCM args = scm_list_1(scm_from_long(i));
+        SCM str = scm_array_ref($input, args);
+        if (!scm_is_string(str)) {
+          break;
+        }
+      }
+      /* All elements are strings! */
+      $1 = (i == len);
+    }
+  }
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != NULL) {
+    free((void *)$2);
+  }
+}

--- a/Lib/java/argcargv.i
+++ b/Lib/java/argcargv.i
@@ -1,0 +1,38 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+%typemap(jni) (int ARGC, char **ARGV) "jobjectArray"
+%typemap(jtype) (int ARGC, char **ARGV) "String[]"
+%typemap(jstype) (int ARGC, char **ARGV) "String[]"
+
+%typemap(in) (int ARGC, char **ARGV) {
+  $1_ltype i, len;
+  if ($input == (jobjectArray)0) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null array");
+    return $null;
+  }
+  len = ($1_ltype)JCALL1(GetArrayLength, jenv, $input);
+  if (len <= 0) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, "array must contain at least 1 element");
+    return $null;
+  }
+  $2 = ($2_ltype) malloc((len+1)*sizeof($*2_ltype));
+  if ($2 == NULL) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaOutOfMemoryError, "memory allocation failed");
+    return $null;
+  }
+  $1 = len;
+  for (i = 0; i < len; i++) {
+    jstring j_string = (jstring)JCALL2(GetObjectArrayElement, jenv, $input, (jsize)i);
+    const char *c_string = JCALL2(GetStringUTFChars, jenv, j_string, 0);
+    $2[i] = ($*2_ltype)c_string;
+  }
+  $2[i] = NULL;
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != NULL) {
+    free((void *)$2);
+  }
+}

--- a/Lib/javascript/jsc/argcargv.i
+++ b/Lib/javascript/jsc/argcargv.i
@@ -1,0 +1,71 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+%{
+SWIGINTERN int SWIG_AsVal_string SWIG_JSC_AS_DECL_ARGS(JSValueRef obj, JSStringRef* str)
+{
+  if (!JSValueIsString SWIG_JSC_FROM_CALL_ARGS(obj)) {
+    return SWIG_TypeError;
+  }
+  if(str != SWIG_NULLPTR) {
+    *str = JSValueToStringCopy SWIG_JSC_AS_CALL_ARGS(obj, SWIG_NULLPTR);
+  }
+  return SWIG_OK;
+}
+%}
+
+%typemap(in) (int ARGC, char **ARGV) {
+  int i, len;
+  size_t arraysize;
+  JSObjectRef array;
+  if (!JSValueIsArray SWIG_JSC_FROM_CALL_ARGS($input)) {
+    SWIG_exception_fail(SWIG_ERROR, "not array");
+  }
+  array = JSValueToObject SWIG_JSC_AS_CALL_ARGS($input, SWIG_NULLPTR);
+  len = SWIGJSC_ArrayLength SWIG_JSC_FROM_CALL_ARGS(array);
+  SWIG_contract_assert(len > 0, "array must contain at least 1 element");
+  arraysize = (len+1)*sizeof($*2_ltype);
+  $1 = len;
+  $2 = ($2_ltype) malloc(arraysize);
+  if ($2 == SWIG_NULLPTR) {
+    SWIG_exception_fail(SWIG_ERROR, "memory allocation of array failed");
+  }
+  memset($2, 0, arraysize);
+  for (i = 0; i < len; i++) {
+    int res, slen;
+    $*2_ltype pstr;
+    JSStringRef str;
+    JSValueRef jsvalue = JSObjectGetPropertyAtIndex(context, array, i, SWIG_NULLPTR);
+    res = SWIG_AsVal_string SWIG_JSC_AS_CALL_ARGS(jsvalue, &str);
+    if (!SWIG_IsOK(res)) {
+      SWIG_exception_fail(SWIG_ERROR, "failed to convert to string");
+    }
+    slen = JSStringGetMaximumUTF8CStringSize(str);
+    if (slen <= 0) {
+      SWIG_exception_fail(SWIG_ERROR, "empty string");
+    }
+    pstr = ($*2_ltype) malloc(slen);
+    if (pstr == SWIG_NULLPTR) {
+      SWIG_exception_fail(SWIG_ERROR, "memory allocation of a string failed");
+    }
+    res = JSStringGetUTF8CString(str, pstr, slen);
+    if (res > slen) {
+      SWIG_exception_fail(SWIG_ERROR, "wrong string length");
+    }
+    $2[i] = pstr;
+  }
+  $2[i] = SWIG_NULLPTR;
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != SWIG_NULLPTR) {
+    $1_ltype i;
+    for (i = 0; i < $1; i++) {
+      if ($2[i] != SWIG_NULLPTR) {
+        free((void *)$2[i]);
+      }
+    }
+    free((void *)$2);
+  }
+}

--- a/Lib/javascript/v8/argcargv.i
+++ b/Lib/javascript/v8/argcargv.i
@@ -1,0 +1,79 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+%{
+#ifndef SWIGV8_VALUE_TO_ARRAY
+# define SWIGV8_VALUE_TO_ARRAY(val) SWIGV8_ARRAY::Cast(val)
+#endif
+#ifndef SWIGV8_STRING
+# define SWIGV8_STRING v8::Local<v8::String>
+#endif
+
+SWIGINTERN int SWIG_AsVal_string (SWIGV8_VALUE valRef, SWIGV8_STRING *str)
+{
+  if (!valRef->IsString()) {
+    return SWIG_TypeError;
+  }
+  if(str != SWIG_NULLPTR)  {
+      *str = SWIGV8_TO_STRING(valRef);
+  }
+  return SWIG_OK;
+}
+%}
+
+%typemap(in) (int ARGC, char **ARGV) {
+  $1_ltype i, len;
+  size_t arraysize;
+  SWIGV8_ARRAY array;
+  if (!$input->IsArray()) {
+    SWIG_exception_fail(SWIG_ERROR, "not array");
+  }
+  array = SWIGV8_VALUE_TO_ARRAY($input);
+  len = array->Length();
+  SWIG_contract_assert(len > 0, "array must contain at least 1 element");
+  arraysize = (len+1)*sizeof($*2_ltype);
+  $1 = len;
+  $2 = ($2_ltype) malloc(arraysize);
+  if ($2 == SWIG_NULLPTR) {
+    SWIG_exception_fail(SWIG_ERROR, "memory allocation of array failed");
+  }
+  memset($2, 0, arraysize);
+  for (i = 0; i < len; i++) {
+    int res, slen;
+    $*2_ltype pstr;
+    SWIGV8_STRING str;
+    SWIGV8_VALUE jsvalue = SWIGV8_ARRAY_GET(array, i);
+    res = SWIG_AsVal_string(jsvalue, &str);
+    if (!SWIG_IsOK(res)) {
+      SWIG_exception_fail(SWIG_ERROR, "failed to convert to string");
+    }
+    slen = SWIGV8_UTF8_LENGTH(str);
+    if (slen <= 0) {
+      SWIG_exception_fail(SWIG_ERROR, "empty string");
+    }
+    pstr = ($*2_ltype) malloc(slen + 1);
+    if (pstr == SWIG_NULLPTR) {
+      SWIG_exception_fail(SWIG_ERROR, "memory allocation of a string failed");
+    }
+    res = SWIGV8_WRITE_UTF8(str, pstr, slen);
+    if (res != slen) {
+      SWIG_exception_fail(SWIG_ERROR, "wrong string length");
+    }
+    pstr[slen] = 0;
+    $2[i] = pstr;
+  }
+  $2[i] = SWIG_NULLPTR;
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != SWIG_NULLPTR) {
+    $1_ltype i;
+    for (i = 0; i < $1; i++) {
+      if ($2[i] != SWIG_NULLPTR) {
+        free((void *)$2[i]);
+      }
+    }
+    free((void *)$2);
+  }
+}

--- a/Lib/scilab/argcargv.i
+++ b/Lib/scilab/argcargv.i
@@ -1,0 +1,106 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+%{
+SWIGINTERN int SWIG_AsVal_strings (SwigSciObject iVar, int **array) {
+  int iType = 0;
+  SciErr sciErr = getVarAddressFromPosition(pvApiCtx, iVar, array);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    return SWIG_ERROR;
+  }
+  sciErr = getVarType(pvApiCtx, *array, &iType);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    return SWIG_ERROR;
+  }
+  if (iType != sci_strings) {
+    SWIG_exception_fail(SWIG_TypeError, "not a string matrix");
+  }
+  return SWIG_OK;
+}
+%}
+
+%typemap(in) (int ARGC, char **ARGV) {
+  SciErr sciErr;
+  size_t memsize;
+  int i, rows, cols, res, len, *aLen, *array;
+  res = SWIG_AsVal_strings ($input, &array);
+  if (!SWIG_IsOK(res)) {
+    SWIG_fail;
+  }
+  /* first call to retrieve dimensions */
+  rows = 0;
+  cols = 0;
+  sciErr = getMatrixOfString(pvApiCtx, array, &rows, &cols, SWIG_NULLPTR, SWIG_NULLPTR);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    SWIG_fail;
+  }
+  len = rows * cols;
+  SWIG_contract_assert(len > 0, "array must contain at least 1 element");
+  memsize = sizeof(int) * len;
+  aLen = (int*)malloc(memsize);
+  if (aLen == SWIG_NULLPTR) {
+    SWIG_exception_fail(SWIG_MemoryError, "fail allocate sizes array");
+    SWIG_fail;
+  }
+  memset(aLen, 0, memsize);
+  /*second call to retrieve length of each string */
+  sciErr = getMatrixOfString(pvApiCtx, array, &rows, &cols, aLen, SWIG_NULLPTR);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    free((void *)aLen);
+    SWIG_fail;
+  }
+  memsize = sizeof($*2_ltype) * (len + 1);
+  $1 = ($1_ltype) len;
+  $2 = ($2_ltype) malloc(memsize);
+  if ($2 == SWIG_NULLPTR) {
+    SWIG_exception_fail(SWIG_MemoryError, "fail allocate array");
+    free((void *)aLen);
+    SWIG_fail;
+  }
+  memset($2, 0, memsize);
+  for(i = 0 ; i < len ; i++) {
+    $2[i] = ($*2_ltype)malloc(aLen[i] + 1);
+    if ($2[i] == SWIG_NULLPTR) {
+      SWIG_exception_fail(SWIG_MemoryError, "fail allocate array string element");
+      free((void *)aLen);
+      SWIG_fail;
+    }
+  }
+  /* third call to retrieve data */
+  sciErr = getMatrixOfString(pvApiCtx, array, &rows, &cols, aLen, $2);
+  if(sciErr.iErr) {
+      printError(&sciErr, 0);
+      free((void *)aLen);
+      SWIG_fail;
+  }
+  $2[len] = SWIG_NULLPTR;
+  free((void *)aLen);
+}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
+  int *array, res = SWIG_AsVal_strings ($input, &array);
+  if (SWIG_IsOK(res)) {
+    int rows = 0, cols = 0;
+    SciErr sciErr = getMatrixOfString(pvApiCtx, array, &rows, &cols, SWIG_NULLPTR, SWIG_NULLPTR);
+    if (!sciErr.iErr && (rows * cols) > 0) {
+      $1 = 1;
+    }
+  }
+}
+
+%typemap(freearg) (int ARGC, char **ARGV) {
+  if ($2 != SWIG_NULLPTR) {
+    $1_ltype i;
+    for (i = 0; i < $1; i++) {
+      if ($2[i] != SWIG_NULLPTR) {
+        free((void *)$2[i]);
+      }
+    }
+    free((void *)$2);
+  }
+}


### PR DESCRIPTION
Add argc and argv multi-argument typemap to
 Java, Guile, <del>MzScheme,</del> JavaScript, Scilab, <del>D language,</del> and C#. 

### Regarding the other languages:

<del>
D language can convert string array directly to C char pointer pointer.
Which means the developers do no need an argc argv typemap for D.
I did saw issue of converting C char pointer back to D string.
Seems it miss the null termination.
We may need a fix on convert strings from C back to D.</del><br/><br/>

<del>
C sharp can convert string array directly to C char pointer pointer.
No point to use an argc argv typemap.
However it seems we need some changes to convert string array to C char pointer pointer.
In the current state, the swig tries to use SWIGTYPE_p_p_char, which seems in the wrong direction.</del><br/><br/>

I wrote R language argc and argv typemap.
However initializeApp() fails as the rtypecheck need migration or fix in Source/Modules/r.cxx

<del>
As for OCaml, I simply do not understand how to pass a string array from OCaml through the wrapper.
I might miss it, or OCaml use only one dimension of arrays and lists?</del>
