### PR TITLE
[java] Suppress removal warnings for finalize()

### DIFF
--- a/Examples/test-suite/java_director.i
+++ b/Examples/test-suite/java_director.i
@@ -7,7 +7,7 @@
 %module(directors="1") java_director
 
 %typemap(javafinalize) SWIGTYPE %{
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
 //    System.out.println("Finalizing " + this);
     delete();

--- a/Examples/test-suite/java_throws.i
+++ b/Examples/test-suite/java_throws.i
@@ -183,7 +183,7 @@ try {
 
 // Need to handle the checked exception in NoExceptTest.delete()
 %typemap(javafinalize) SWIGTYPE %{
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     try {
       delete();

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -1304,7 +1304,7 @@ SWIG_JAVABODY_PROXY(protected, protected, SWIGTYPE)
 SWIG_JAVABODY_TYPEWRAPPER(protected, protected, protected, SWIGTYPE)
 
 %typemap(javafinalize) SWIGTYPE %{
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "removal"})
   protected void finalize() {
     delete();
   }


### PR DESCRIPTION
#1240 suppressed "deprecation" warnings for `finalize()` methods, but these changes to "removal" warnings with a newer JDK version

@wsfulton OK?

Without this I'm finding running the testsuite to be unusably noisy with the JDK version I have:

```
$ java -version
openjdk version "18.0.2-ea" 2022-07-19
OpenJDK Runtime Environment (build 18.0.2-ea+9-Debian-2)
OpenJDK 64-Bit Server VM (build 18.0.2-ea+9-Debian-2, mixed mode, sharing)
```

I could just keep this locally, but that would be a bit of a pain to do.