### PR TITLE
Add argc and argv multi-argument typemap to C sharp.

### DIFF
--- a/Examples/test-suite/argcargvtest.i
+++ b/Examples/test-suite/argcargvtest.i
@@ -1,9 +1,14 @@
 %module argcargvtest
 
-#if !defined(SWIGCSHARP) && !defined(SWIGD) && !defined(SWIGGUILE) && !defined(SWIGJAVA) && !defined(SWIGJAVASCRIPT) && !defined(SWIGMZSCHEME) && !defined(SWIGOCAML) && !defined(SWIGR) && !defined(SWIGSCILAB)
+#if !defined(SWIGD) && !defined(SWIGGUILE) && !defined(SWIGJAVA) && !defined(SWIGJAVASCRIPT) && !defined(SWIGMZSCHEME) && !defined(SWIGOCAML) && !defined(SWIGR) && !defined(SWIGSCILAB)
 %include <argcargv.i>
 
+#ifndef SWIGCSHARP
 %apply (int ARGC, char **ARGV) { (size_t argc, const char **argv) }
+#else
+%apply int { size_t argc }
+%apply (char **ARGV) { const char **argv }
+#endif
 #endif
 
 %inline %{

--- a/Examples/test-suite/csharp/argcargvtest_runme.cs
+++ b/Examples/test-suite/csharp/argcargvtest_runme.cs
@@ -1,0 +1,22 @@
+using System;
+using argcargvtestNamespace;
+
+public class argcargvtest_runme {
+
+  public static void Main() {
+    string[] largs = {"hi", "hola", "hello"};
+    if (argcargvtest.mainc(largs.Length, largs) != 3)
+        throw new Exception("bad main typemap");
+
+    string[] targs = {"hi", "hola"};
+    if (!argcargvtest.mainv(targs.Length, targs, 1).Equals("hola"))
+        throw new Exception("bad main typemap");
+
+// For dynamically typed languages we test this throws an exception or similar
+// at runtime, but for C# this doesn't even compile (but we can't easily
+// test for that here).
+//  argcargvtest.mainv("hello", 1);
+
+    argcargvtest.initializeApp(targs.Length, largs);
+  }
+}

--- a/Lib/csharp/argcargv.i
+++ b/Lib/csharp/argcargv.i
@@ -1,0 +1,15 @@
+/* ------------------------------------------------------------
+ * SWIG library containing argc and argv multi-argument typemaps
+ * ------------------------------------------------------------ */
+
+/*
+ * Follow main(int argc, char *argv[]) function
+ * Note: 'int argc' must be first parameter!
+ * By setting 'SizeParamIndex=0'.
+ * The C# Marshaling use the argc parameter to determin the array size.
+ * See: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshalasattribute.sizeparamindex
+ */
+
+%typemap(csin) char **ARGV "$csinput"
+%typemap(cstype) char **ARGV "string[]"
+%typemap(imtype, inattributes="[global::System.Runtime.InteropServices.In,global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType=global::System.Runtime.InteropServices.UnmanagedType.LPStr, SizeParamIndex=0)]") char **ARGV "string[]"


### PR DESCRIPTION
We need it for: uniformity, protection on C/C++ code
 and proper mapping of string array directly to char pointer pointer.

Note:
I see an error on Windows CI.
As I do not use Windows, I can not debug it.