### PR TITLE
Javascript check typemap fix

### DIFF
--- a/Examples/test-suite/csharp/li_constraints_runme.cs
+++ b/Examples/test-suite/csharp/li_constraints_runme.cs
@@ -1,0 +1,57 @@
+using System;
+using li_constraintsNamespace;
+
+public class runme {
+    static void check_double(bool except, Action<double> f, double val, string ex) {
+      bool actual = true;
+      bool proper = false;
+      try {
+        f(val);
+      } catch(Exception e) {
+        actual = false;
+        proper = e.Message.Equals(string.Join(" ", "Expected", "a", ex, "value."));
+      }
+      if (actual) {
+        if (!except)
+          throw new Exception(string.Join("", "function '", ex, "' with ", val.ToString(), " should perform an exception"));
+      } else {
+        if (except)
+          throw new Exception(string.Join("", "function '", ex, "' with ", val.ToString(), " should not perform an exception"));
+        else if (!proper)
+          throw new Exception(string.Join("", "function '", ex, "' with ", val.ToString(), " should perform a proper exception"));
+      }
+    }
+
+    static void Main() {
+      check_double(true, li_constraints.test_nonnegative, 10, "non-negative");
+      check_double(true, li_constraints.test_nonnegative, 0, "non-negative");
+      check_double(false, li_constraints.test_nonnegative, -10, "non-negative");
+
+      check_double(false, li_constraints.test_nonpositive, 10, "non-positive");
+      check_double(true, li_constraints.test_nonpositive, 0, "non-positive");
+      check_double(true, li_constraints.test_nonpositive, -10, "non-positive");
+
+      check_double(true, li_constraints.test_positive, 10, "positive");
+      check_double(false, li_constraints.test_positive, 0, "positive");
+      check_double(false, li_constraints.test_positive, -10, "positive");
+
+      check_double(false, li_constraints.test_negative, 10, "negative");
+      check_double(false, li_constraints.test_negative, 0, "negative");
+      check_double(true, li_constraints.test_negative, -10, "negative");
+
+      check_double(true, li_constraints.test_nonzero, 10, "nonzero");
+      check_double(false, li_constraints.test_nonzero, 0, "nonzero");
+      check_double(true, li_constraints.test_nonzero, -10, "nonzero");
+
+      bool have_exception = false;
+      try {
+        li_constraints.test_nonnull(null);
+      } catch(Exception e) {
+        have_exception = e.Message.Equals("Received a NULL pointer.");
+      }
+      if (!have_exception)
+          throw new Exception("test_nonnull should perform proper exception with 'null' value");
+      SWIGTYPE_p_void nonnull = li_constraints.get_nonnull();
+      li_constraints.test_nonnull(nonnull);
+    }
+}

--- a/Examples/test-suite/go/li_constraints_runme.go
+++ b/Examples/test-suite/go/li_constraints_runme.go
@@ -1,0 +1,70 @@
+package main
+
+import wrap "swigtests/li_constraints"
+import "fmt";
+
+func check_double(except bool, f func (float64), val float64, name string) {
+    actual := true
+    proper := false
+	func() {
+		defer func() {
+            r := recover();
+			if r != nil {
+                actual = false
+                proper = fmt.Sprintf("%s", r) == fmt.Sprintf("Expected a %s value.", name)
+			}
+		}()
+        f(val);
+	}()
+    if actual {
+      if !except {
+        panic(fmt.Sprintf("function '%s' with %d should perform an exception", name, val));
+      }
+    } else {
+      if except {
+        panic(fmt.Sprintf("function '%s' with %d should not perform an exception", name, val));
+      } else if !proper {
+        panic(fmt.Sprintf("function '%s' with %d should perform a proper exception", name, val));
+      }
+    }
+}
+
+func main() {
+    check_double(true, wrap.Test_nonnegative, 10, "non-negative");
+    check_double(true, wrap.Test_nonnegative, 0, "non-negative");
+    check_double(false, wrap.Test_nonnegative, -10, "non-negative");
+
+    check_double(false, wrap.Test_nonpositive, 10, "non-positive");
+    check_double(true, wrap.Test_nonpositive, 0, "non-positive");
+    check_double(true, wrap.Test_nonpositive, -10, "non-positive");
+
+    check_double(true, wrap.Test_positive, 10, "positive");
+    check_double(false, wrap.Test_positive, 0, "positive");
+    check_double(false, wrap.Test_positive, -10, "positive");
+
+    check_double(false, wrap.Test_negative, 10, "negative");
+    check_double(false, wrap.Test_negative, 0, "negative");
+    check_double(true, wrap.Test_negative, -10, "negative");
+
+    check_double(true, wrap.Test_nonzero, 10, "nonzero");
+    check_double(false, wrap.Test_nonzero, 0, "nonzero");
+    check_double(true, wrap.Test_nonzero, -10, "nonzero");
+
+    have_exception := false
+	func() {
+		defer func() {
+            r := recover()
+			if r != nil {
+                have_exception = "Received a NULL pointer." == fmt.Sprintf("%s", r)
+			}
+		}()
+        // The NULL value
+        // We can not use Go `nil` as is it can not be convert to a uintptr value.
+        wrap.Test_nonnull(uintptr(0));
+	}()
+    if !have_exception {
+        panic("test_nonnull should perform exception with 'null' value")
+    }
+    nonnull := wrap.Get_nonnull();
+    wrap.Test_nonnull(nonnull);
+}

--- a/Examples/test-suite/java/li_constraints_runme.java
+++ b/Examples/test-suite/java/li_constraints_runme.java
@@ -1,0 +1,77 @@
+
+import java.util.function.*;
+import li_constraints.*;
+
+public class li_constraints_runme {
+
+  static {
+    try {
+	System.loadLibrary("li_constraints");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void check_double(boolean except, Consumer<Double> f, double val, String ex) {
+      boolean actual = true;
+      boolean proper = false;
+      try {
+        f.accept(val);
+      } catch(RuntimeException e) {
+        actual = false;
+        proper = e.getMessage().equals(String.join(" ", "Expected", "a", ex, "value."));
+      }
+      if (actual) {
+        if (!except) {
+          throw new RuntimeException(String.join("", "function '", ex, "' with ", String.valueOf(val), " should perform an exception"));
+        }
+      } else {
+        if (except) {
+          throw new RuntimeException(String.join("", "function '", ex, "' with ", String.valueOf(val), " should not perform an exception"));
+        } else if (!proper) {
+          throw new RuntimeException(String.join("", "function '", ex, "' with ", String.valueOf(val), " should perform a proper exception"));
+        }
+      }
+  }
+
+  public static void main(String argv[]) {
+
+      Consumer<Double> func = v -> li_constraints.test_nonnegative(v);
+      check_double(true, func, 10, "non-negative");
+      check_double(true, func, 0, "non-negative");
+      check_double(false, func, -10, "non-negative");
+
+      func = v -> li_constraints.test_nonpositive(v);
+      check_double(false, func, 10, "non-positive");
+      check_double(true, func, 0, "non-positive");
+      check_double(true, func, -10, "non-positive");
+
+      func = v -> li_constraints.test_positive(v);
+      check_double(true, func, 10, "positive");
+      check_double(false, func, 0, "positive");
+      check_double(false, func, -10, "positive");
+
+      func = v -> li_constraints.test_negative(v);
+      check_double(false, func, 10, "negative");
+      check_double(false, func, 0, "negative");
+      check_double(true, func, -10, "negative");
+
+      func = v -> li_constraints.test_nonzero(v);
+      check_double(true, func, 10, "nonzero");
+      check_double(false, func, 0, "nonzero");
+      check_double(true, func, -10, "nonzero");
+
+      boolean have_exception = false;
+      try {
+        li_constraints.test_nonnull(null);
+      } catch(Exception e) {
+        have_exception = e.getMessage().equals("Received a NULL pointer.");
+      }
+      if (!have_exception) {
+          throw new RuntimeException("test_nonnull should perform proper exception with 'null' value");
+      }
+      SWIGTYPE_p_void nonnull = li_constraints.get_nonnull();
+      li_constraints.test_nonnull(nonnull);
+  }
+}

--- a/Examples/test-suite/javascript/li_constraints_runme.js
+++ b/Examples/test-suite/javascript/li_constraints_runme.js
@@ -1,0 +1,58 @@
+var li_constraints = require("li_constraints");
+
+function check_double(except, f, val, name) {
+  var actual = true;
+  var proper = false;
+  try {
+    f(val);
+  } catch(e) {
+    actual = false;
+    proper = e.message === "Expected a " + name + " value.";
+  }
+  if (actual) {
+    if (!except)
+      throw new Error("function '" + name + "' with " + val + " should perform an exception");
+  } else {
+    if (except)
+      throw new Error("function '" + name + "' with " + val + " should not perform an exception");
+    else if (!proper)
+      throw new Error("function '" + name + "' with " + val + " should perform a proper exception");
+  }
+}
+
+const nonnegative = function (val) { li_constraints.test_nonnegative(val); };
+check_double(true, nonnegative, 10, "non-negative");
+check_double(true, nonnegative, 0, "non-negative");
+check_double(false, nonnegative, -10, "non-negative");
+
+const nonpositive = function (val) { li_constraints.test_nonpositive(val); };
+check_double(false, nonpositive, 10, "non-positive");
+check_double(true, nonpositive, 0, "non-positive");
+check_double(true, nonpositive, -10, "non-positive");
+
+const positive = function (val) { li_constraints.test_positive(val); };
+check_double(true, positive, 10, "positive");
+check_double(false, positive, 0, "positive");
+check_double(false, positive, -10, "positive");
+
+const negative = function (val) { li_constraints.test_negative(val); };
+check_double(false, negative, 10, "negative");
+check_double(false, negative, 0, "negative");
+check_double(true, negative, -10, "negative");
+
+const nonzero = function (val) { li_constraints.test_nonzero(val); };
+check_double(true, nonzero, 10, "nonzero");
+check_double(false, nonzero, 0, "nonzero");
+check_double(true, nonzero, -10, "nonzero");
+
+var have_exception = false;
+try {
+  li_constraints.test_nonnull(null);
+} catch(e) {
+  have_exception = e.message === "Received a NULL pointer.";
+}
+if (!have_exception) {
+    throw new Error("test_nonnull should perform a proper exception with 'null' value");
+}
+const nonnull = li_constraints.get_nonnull();
+li_constraints.test_nonnull(nonnull);

--- a/Examples/test-suite/li_constraints.i
+++ b/Examples/test-suite/li_constraints.i
@@ -11,13 +11,19 @@ void test_nonpositive(double NONPOSITIVE) {
 void test_positive(double POSITIVE) {
 }
 
-void test_negative(double POSITIVE) {
+void test_negative(double NEGATIVE) {
 }
 
 void test_nonzero(double NONZERO) {
 }
 
 void test_nonnull(void *NONNULL) {
+}
+
+/* Provide a non null void pointer for test_nonnull */
+void* get_nonnull() {
+    static int i;
+    return &i;
 }
 
 /* These generated non-portable code and there isn't an obvious fix

--- a/Examples/test-suite/lua/li_constraints_runme.lua
+++ b/Examples/test-suite/lua/li_constraints_runme.lua
@@ -1,0 +1,40 @@
+require('import')       -- the import fn
+import('li_constraints') -- import lib into global
+cn=li_constraints --alias
+
+function check_func(except, f, val, name)
+  actual, err = pcall(f, val);
+  assert(actual == except, 'function perform exception wrongly');
+  if name == nil then
+    r = 'SWIG_ValueError:Received a NULL pointer.';
+  else
+    r = 'SWIG_ValueError:Expected a ' .. name .. ' value.';
+  end
+  if not actual then
+    assert(err == r, 'function perform the wrong exception');
+  end
+end
+
+check_func(true, cn.test_nonnegative, 10, 'non-negative');
+check_func(true, cn.test_nonnegative, 0, 'non-negative');
+check_func(false, cn.test_nonnegative, -10, 'non-negative');
+
+check_func(false, cn.test_nonpositive, 10, 'non-positive');
+check_func(true, cn.test_nonpositive, 0, 'non-positive');
+check_func(true, cn.test_nonpositive, -10, 'non-positive');
+
+check_func(true, cn.test_positive, 10, 'positive');
+check_func(false, cn.test_positive, 0, 'positive');
+check_func(false, cn.test_positive, -10, 'positive');
+
+check_func(false, cn.test_negative, 10, 'negative');
+check_func(false, cn.test_negative, 0, 'negative');
+check_func(true, cn.test_negative, -10, 'negative');
+
+check_func(true, cn.test_nonzero, 10, 'nonzero');
+check_func(false, cn.test_nonzero, 0, 'nonzero');
+check_func(true, cn.test_nonzero, -10, 'nonzero');
+
+check_func(false, cn.test_nonnull, nil);
+nonnull = cn.get_nonnull();
+check_func(true, cn.test_nonnull, nonnull);

--- a/Examples/test-suite/octave/li_constraints_runme.m
+++ b/Examples/test-suite/octave/li_constraints_runme.m
@@ -1,0 +1,62 @@
+li_constraints
+
+function check_double(except, f, val, name)
+  actual = true;
+  proper = false;
+  try
+    f(val);
+  catch
+    actual = false;
+    proper = strcmp(lasterr, ["Expected a ", name , " value. (SWIG_ValueError)"]) == 1;
+  end
+  if (actual)
+    if (!except)
+      error(["function '", name, "' with ", num2str(val), " should perform an exception"]);
+    end
+  else
+    if (except)
+      error(["function '", name, "' with ", num2str(val), " should not perform an exception"]);
+    elseif (!proper)
+      error(["function '", name, "' with ", num2str(val), " should perform a proper exception"]);
+    end
+  end
+end
+
+function nonnegative(x);global li_constraints;li_constraints.test_nonnegative(x);end
+check_double(true, @nonnegative, 10, "non-negative");
+check_double(true, @nonnegative, 0, "non-negative");
+check_double(false, @nonnegative, -10, "non-negative");
+
+function nonpositive(x);global li_constraints;li_constraints.test_nonpositive(x);end
+check_double(false, @nonpositive, 10, "non-positive");
+check_double(true, @nonpositive, 0, "non-positive");
+check_double(true, @nonpositive, -10, "non-positive");
+
+function positive(x);global li_constraints;li_constraints.test_positive(x);end
+check_double(true, @positive, 10, "positive");
+check_double(false, @positive, 0, "positive");
+check_double(false, @positive, -10, "positive");
+
+function negative(x);global li_constraints;li_constraints.test_negative(x);end
+check_double(false, @negative, 10, "negative");
+check_double(false, @negative, 0, "negative");
+check_double(true, @negative, -10, "negative");
+
+function nonzero(x);global li_constraints;li_constraints.test_nonzero(x);end
+check_double(true, @nonzero, 10, "nonzero");
+check_double(false, @nonzero, 0, "nonzero");
+check_double(true, @nonzero, -10, "nonzero");
+
+have_exception = false;
+try
+  # Empty matrix translate to null pointer
+  li_constraints.test_nonnull([]);
+catch
+  have_exception = strcmp("Received a NULL pointer. (SWIG_ValueError)", lasterr) == 1;
+end
+if (!have_exception)
+    error("test_nonnull should perform exception with 'null' value");
+end
+
+nonnull = li_constraints.get_nonnull();
+li_constraints.test_nonnull(nonnull);

--- a/Examples/test-suite/perl5/li_constraints_runme.pl
+++ b/Examples/test-suite/perl5/li_constraints_runme.pl
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 27;
+BEGIN { use_ok('li_constraints') }
+require_ok('li_constraints');
+
+sub check_double {
+    my ($except, $func, $name, $val) = @_;
+    my $fname = "li_constraints::test_$name";
+    $fname =~ s/-//;
+    my $actual = eval { $func->($val); 1; };
+    my $err = $@;
+    $actual = 0 unless defined $actual;
+    if($actual) {
+      is($actual, $except, "$fname pass with $val");
+    } else {
+      is($actual, $except, "$fname throw exception with $val");
+      ok($err =~ "^ValueError Expected a $name value.", "$fname throw proper exception");
+    }
+}
+
+my $nonnegative = sub { li_constraints::test_nonnegative(shift); };
+check_double(1, $nonnegative, "non-negative", 10);
+check_double(1, $nonnegative, "non-negative", 0);
+check_double(0, $nonnegative, "non-negative", -10);
+
+my $nonpositive = sub { li_constraints::test_nonpositive(shift); };
+check_double(0, $nonpositive, "non-positive", 10);
+check_double(1, $nonpositive, "non-positive", 0);
+check_double(1, $nonpositive, "non-positive", -10);
+
+my $positive = sub { li_constraints::test_positive(shift); };
+check_double(1, $positive, "positive", 10);
+check_double(0, $positive, "positive", 0);
+check_double(0, $positive, "positive", -10);
+
+my $negative = sub { li_constraints::test_negative(shift); };
+check_double(0, $negative, "negative", 10);
+check_double(0, $negative, "negative", 0);
+check_double(1, $negative, "negative", -10);
+
+my $nonzero = sub { li_constraints::test_nonzero(shift); };
+check_double(1, $nonzero, "nonzero", 10);
+check_double(0, $nonzero, "nonzero", 0);
+check_double(1, $nonzero, "nonzero", -10);
+
+# Pass null value
+my $ret = eval { li_constraints::test_nonnull(undef); 1; };
+my $err = $@;
+is($ret, undef, "li_constraints::test_nonnull throw exception with null");
+ok($err =~ "^ValueError Received a NULL pointer.", "li_constraints::test_nonnull throw proper exception");
+my $ptr = li_constraints::get_nonnull();
+# There should be no exception, we can use Perl lambda function
+$ret = (sub { li_constraints::test_nonnull($ptr); 1; })->();
+is($ret, 1, "li_constraints::test_nonnull pass with non null value");

--- a/Examples/test-suite/php/li_constraints_runme.php
+++ b/Examples/test-suite/php/li_constraints_runme.php
@@ -1,0 +1,68 @@
+<?php
+
+require "tests.php";
+
+// New functions
+check::functions(array('test_nonnegative', 'test_nonpositive', 'test_positive',
+  'test_negative', 'test_nonzero', 'test_nonnull', 'get_nonnull'));
+// New classes
+check::classes(array('li_constraints'));
+// No new vars
+check::globals(array());
+
+function check_double(bool $except, $fn, string $f, $val) {
+  $actual = true;
+  $d = doubleval($val);
+  try {
+    $fn($d);
+  } catch(ValueError $e) {
+    $actual = false;
+    $msg = $e->getMessage();
+  }
+  $name = "test_" . str_replace("-", "", $f);
+  if($actual) {
+    check::equal($actual, $except, "Test '$name' with $val pass");
+  } else {
+    check::equal($actual, $except, "Test '$name' throw exception with $val");
+    check::equal($msg, "Expected a " . $f . " value.", "'$name' throw proper exception");
+  }
+}
+
+$nonnegative = function ($val) { test_nonnegative($val); };
+check_double(true, $nonnegative, "non-negative", 10);
+check_double(true, $nonnegative, "non-negative", 0);
+check_double(false, $nonnegative, "non-negative", -10);
+
+$nonpositive = function ($val) { test_nonpositive($val); };
+check_double(false, $nonpositive, "non-positive", 10);
+check_double(true, $nonpositive, "non-positive", 0);
+check_double(true, $nonpositive, "non-positive", -10);
+
+$positive = function ($val) { test_positive($val); };
+check_double(true, $positive, "positive", 10);
+check_double(false, $positive, "positive", 0);
+check_double(false, $positive, "positive", -10);
+
+$negative = function ($val) { test_negative($val); };
+check_double(false, $negative, "negative", 10);
+check_double(false, $negative, "negative", 0);
+check_double(true, $negative, "negative", -10);
+
+$nonzero = function ($val) { test_nonzero($val); };
+check_double(true, $nonzero, "nonzero", 10);
+check_double(false, $nonzero, "nonzero", 0);
+check_double(true, $nonzero, "nonzero", -10);
+
+$have_exception = false;
+try {
+  test_nonnull(null);
+} catch(ValueError $e) {
+  $msg = $e->getMessage();
+  $have_exception = strcmp($msg, "Received a NULL pointer.") === 0;
+}
+if (!$have_exception) {
+    throw new Exception("test_nonnull should perform a proper exception with 'null' value");
+}
+
+$non_null = get_nonnull();
+test_nonnull($non_null);

--- a/Examples/test-suite/python/li_constraints_runme.py
+++ b/Examples/test-suite/python/li_constraints_runme.py
@@ -1,0 +1,54 @@
+import li_constraints
+
+def check_double(et, fn, f, val):
+    actual = True
+    proper = False
+    try:
+      fn(val)
+    except ValueError as e:
+      actual = False
+      proper = "Expected a " + f + " value." == "%s"%(e)
+    if actual:
+      if not et:
+        raise Exception("function '%s' with %d should perform an exception"%(f, val))
+    else:
+      if et:
+        raise Exception("function '%s' with %d should not perform an exception"%(f, val))
+      elif not proper:
+        raise Exception("function '%s' with %d should perform a proper exception"%(f, val))
+    pass
+
+nonnegative = lambda v : li_constraints.test_nonnegative(v)
+check_double(True, nonnegative, "non-negative", 10)
+check_double(True, nonnegative, "non-negative", 0)
+check_double(False, nonnegative, "non-negative", -10)
+
+nonpositive = lambda v : li_constraints.test_nonpositive(v)
+check_double(False, nonpositive, "non-positive", 10)
+check_double(True, nonpositive, "non-positive", 0)
+check_double(True, nonpositive, "non-positive", -10)
+
+positive = lambda v : li_constraints.test_positive(v)
+check_double(True, positive, "positive", 10)
+check_double(False, positive, "positive", 0)
+check_double(False, positive, "positive", -10)
+
+negative = lambda v : li_constraints.test_negative(v)
+check_double(False, negative, "negative", 10)
+check_double(False, negative, "negative", 0)
+check_double(True, negative, "negative", -10)
+
+nonzero = lambda v : li_constraints.test_nonzero(v)
+check_double(True, nonzero, "nonzero", 10)
+check_double(False, nonzero, "nonzero", 0)
+check_double(True, nonzero, "nonzero", -10)
+
+have_exception = False
+try:
+   li_constraints.test_nonnull(None)
+except ValueError as e:
+   have_exception = "Received a NULL pointer." == "%s"%(e)
+if not have_exception:
+   raise Exception("test_nonnull should perform exception with 'null' value")
+nonnull = li_constraints.get_nonnull()
+li_constraints.test_nonnull(nonnull)

--- a/Examples/test-suite/ruby/li_constraints_runme.rb
+++ b/Examples/test-suite/ruby/li_constraints_runme.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+
+require 'li_constraints'
+include Li_constraints
+
+def check_double(except, fn, f, val)
+  actual = true
+  proper = false
+  begin
+    fn.call(val)
+  rescue => e
+    actual = false
+    proper = e.class == ArgumentError && e.message == "Expected a #{f} value."
+  end
+  if actual
+    if !except
+      raise RuntimeError, "function '#{f}' with #{val} should perform an exception"
+    end
+  else
+    if except
+      raise RuntimeError, "function '#{f}' with #{val} should not perform an exception"
+    elsif !proper
+      raise RuntimeError, "function '#{f}' with #{val} should perform a proper exception"
+    end
+  end
+end
+
+nonnegative = -> (v) { test_nonnegative(v) }
+check_double(true, nonnegative, "non-negative", 10)
+check_double(true, nonnegative, "non-negative", 0)
+check_double(false, nonnegative, "non-negative", -10)
+
+nonpositive = -> (v) { test_nonpositive(v) }
+check_double(false, nonpositive, "non-positive", 10)
+check_double(true, nonpositive, "non-positive", 0)
+check_double(true, nonpositive, "non-positive", -10)
+
+positive = -> (v) { test_positive(v) }
+check_double(true, positive, "positive", 10)
+check_double(false, positive, "positive", 0)
+check_double(false, positive, "positive", -10)
+
+negative = -> (v) { test_negative(v) }
+check_double(false, negative, "negative", 10)
+check_double(false, negative, "negative", 0)
+check_double(true, negative, "negative", -10)
+
+nonzero = -> (v) { test_nonzero(v) }
+check_double(true, nonzero, "nonzero", 10)
+check_double(false, nonzero, "nonzero", 0)
+check_double(true, nonzero, "nonzero", -10)
+
+have_exception = false
+begin
+  test_nonnull(nil)
+rescue => e
+  have_exception = e.class == ArgumentError && e.message == "Received a NULL pointer."
+end
+if not have_exception
+  raise RuntimeError, "test_nonnull should perform exception with 'null' value"
+end
+nonnull = get_nonnull()
+test_nonnull(nonnull)

--- a/Examples/test-suite/tcl/li_constraints_runme.tcl
+++ b/Examples/test-suite/tcl/li_constraints_runme.tcl
@@ -1,0 +1,51 @@
+if [ catch { load ./li_constraints[info sharedlibextension] li_constraints} err_msg ] {
+	puts stderr "Could not load shared object:\n$err_msg"
+}
+
+proc check_double {except fn f val} {
+	set actual [ catch { $fn $val } err_msg ]
+	if { $actual == 0 } {
+		if { $except != 0 } {
+			error "function '$f' with $val should perform an exception"
+		}
+	} else {
+		if { $except == 0 } {
+			error "function '$f' with $val should not perform an exception"
+		} elseif { [ string equal $err_msg "ValueError Expected a $f value." ] != 1 } {
+			error "function '$f' with $val should perform a proper exception"
+		}
+	}
+}
+
+proc nonnegative {val } { test_nonnegative $val }
+check_double 0 nonnegative "non-negative" 10
+check_double 0 nonnegative "non-negative" 0
+check_double 1 nonnegative "non-negative" -10
+
+proc nonpositive {val } { test_nonpositive $val }
+check_double 1 nonpositive "non-positive" 10
+check_double 0 nonpositive "non-positive" 0
+check_double 0 nonpositive "non-positive" -10
+
+proc positive {val } { test_positive $val }
+check_double 0 positive "positive" 10
+check_double 1 positive "positive" 0
+check_double 1 positive "positive" -10
+
+proc negative {val } { test_negative $val }
+check_double 1 negative "negative" 10
+check_double 1 negative "negative" 0
+check_double 0 negative "negative" -10
+
+proc nonzero {val } { test_nonzero $val }
+check_double 0 nonzero "nonzero" 10
+check_double 1 nonzero "nonzero" 0
+check_double 0 nonzero "nonzero" -10
+
+set actual [ catch { test_nonnull NULL } err_msg ]
+if { ($actual != 1) ||
+     ([ string equal $err_msg "ValueError Received a NULL pointer." ] != 1) } {
+	error "Test 'test_nonnull' with null value fail"
+}
+set nonnull [ get_nonnull ]
+test_nonnull $nonnull


### PR DESCRIPTION
Take the Javascript fix from #2562
Add li_constraints.i  test to  Javascript, C#, go, Java, Lua, Perl, PHP, python, Ruby, TCL and Octave.

Thanks @mmomtchev for the Javascript fix.