### PR TITLE
Fix handling of template in array size

### DIFF
--- a/Examples/test-suite/cpp11_constexpr.i
+++ b/Examples/test-suite/cpp11_constexpr.i
@@ -45,9 +45,7 @@ struct ConstExpressions {
   constexpr friend bool operator==(ConstExpressions,ConstExpressions) { return true; }
   friend constexpr bool operator!=(ConstExpressions,ConstExpressions) { return false; }
 };
-%}
 
-%{
 int Array10[AAA];
 int Array20[BBB];
 int Array30[CCC()];
@@ -61,9 +59,12 @@ int Array300[ConstExpressions::LLL];
 // Regression test for https://github.com/swig/swig/issues/2486 fixed in 4.2.0
 // (the array size is constexpr in C++11):
 unsigned char myarray[std::numeric_limits<unsigned char>::max()];
-%}
+// Also check that `<(` and `)>` in the expression are handled, since these have
+// special meanings for SWIG's type system.  SWIG should rewrite them as `< (`
+// and `) >` here to avoid problems.
+template<int N> constexpr int inc() { return N + 1; };
+unsigned char myarray2[inc<(1)>()];
 
-%{
 // Test handling of ID PERIOD ID in constant expressions (supported since 4.1.0).
 struct A {
     int i;

--- a/Examples/test-suite/cpp11_constexpr.i
+++ b/Examples/test-suite/cpp11_constexpr.i
@@ -11,6 +11,8 @@
 // For MMM() and NNN()
 #pragma clang diagnostic ignored "-Wconstexpr-not-const"
 #endif
+
+#include <limits>
 %}
 
 %inline %{
@@ -55,6 +57,10 @@ int Array200[ConstExpressions::KKK];
 int Array300[ConstExpressions::LLL];
 //int Array400[ConstExpressions::MMM()];
 //int Array500[ConstExpressions::NNN()];
+
+// Regression test for https://github.com/swig/swig/issues/2486 fixed in 4.2.0
+// (the array size is constexpr in C++11):
+unsigned char myarray[std::numeric_limits<unsigned char>::max()];
 %}
 
 %{

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1697,20 +1697,6 @@ void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr cl
   /*Printf(stdout,"t = '%s'\n", t);
      Printf(stdout,"fr= '%s'\n\n", fr); */
 
-  if (t) {
-    char *ct = Char(t);
-    const char *lt = strchr(ct, '<');
-    /* Allow for `<<` operator in constant expression for array size. */
-    if (lt && lt[1] != '(' && lt[1] != '<') {
-      /* We special case `<<` above, but most cases aren't handled, for example:
-       *
-       * unsigned char myarray[std::numeric_limits<unsigned char>::max()]; // #2486
-       */
-      Swig_error(Getfile(t), Getline(t), "Array size expressions containing a '<' character not fully supported\n");
-      Exit(EXIT_FAILURE);
-    }
-  }
-
   h = Getattr(r_mangled, mt);
   if (!h) {
     h = NewHash();


### PR DESCRIPTION
This was being rejected by SWIG because the type string contains '<' not followed by '('.  That check seems too strict given types can contain constant expressions which can contain '<' characters in several ways, so let's just try removing the check and see what happens.

Fixes #2486