### PR TITLE
WIP: Skip declarations SWIG can't parse

### DIFF
--- a/Examples/test-suite/errors/c_missing_rbrace.stderr
+++ b/Examples/test-suite/errors/c_missing_rbrace.stderr
@@ -1,2 +1,1 @@
 c_missing_rbrace.i:3: Error: Missing '}'. Reached end of input.
-c_missing_rbrace.i:3: Error: Syntax error in input(1).

--- a/Examples/test-suite/errors/c_spaceship.stderr
+++ b/Examples/test-suite/errors/c_spaceship.stderr
@@ -1,1 +1,2 @@
-c_spaceship.i:3: Error: Syntax error in input(1).
+c_spaceship.i:3: Warning 999: Attempting to skip declaration SWIG can't parse
+c_spaceship.i:4: Error: Missing semicolon (';'). Reached end of input.

--- a/Examples/test-suite/errors/cpp_invalid_exponents1.stderr
+++ b/Examples/test-suite/errors/cpp_invalid_exponents1.stderr
@@ -1,2 +1,2 @@
 cpp_invalid_exponents1.i:3: Error: Exponent does not have any digits
-cpp_invalid_exponents1.i:3: Error: Syntax error in input(1).
+cpp_invalid_exponents1.i:3: Warning 999: Attempting to skip declaration SWIG can't parse

--- a/Examples/test-suite/errors/cpp_invalid_exponents2.stderr
+++ b/Examples/test-suite/errors/cpp_invalid_exponents2.stderr
@@ -1,2 +1,2 @@
 cpp_invalid_exponents2.i:3: Error: Exponent does not have any digits
-cpp_invalid_exponents2.i:3: Error: Syntax error in input(1).
+cpp_invalid_exponents2.i:3: Warning 999: Attempting to skip declaration SWIG can't parse

--- a/Examples/test-suite/errors/cpp_missing_rtemplate.i
+++ b/Examples/test-suite/errors/cpp_missing_rtemplate.i
@@ -2,10 +2,3 @@
 
 
 int foo(vector<int);
-
-
-
-
-
-
-

--- a/Examples/test-suite/errors/cpp_missing_rtemplate.stderr
+++ b/Examples/test-suite/errors/cpp_missing_rtemplate.stderr
@@ -1,1 +1,2 @@
-cpp_missing_rtemplate.i:4: Error: Syntax error in input(1).
+cpp_missing_rtemplate.i:4: Warning 999: Attempting to skip declaration SWIG can't parse
+cpp_missing_rtemplate.i:5: Error: Missing semicolon (';'). Reached end of input.

--- a/Examples/test-suite/errors/cpp_raw_string_termination.stderr
+++ b/Examples/test-suite/errors/cpp_raw_string_termination.stderr
@@ -1,2 +1,1 @@
 cpp_raw_string_termination.i:3: Error: Unterminated raw string, started with R"ABC( is not terminated by )ABC"
-cpp_raw_string_termination.i:3: Error: Syntax error in input(1).

--- a/Examples/test-suite/errors/pp_unknowndirective5.i
+++ b/Examples/test-suite/errors/pp_unknowndirective5.i
@@ -13,7 +13,7 @@
  * directive often enough, so a later syntax error could get incorrectly
  * reported.  Here the syntax error in the declaration of `c` was confusingly
  * reported as `Error: Unknown directive '%a'`.  This was found and fixed prior
- * to 4.1.0.
+ * to 4.1.0.  FIXME: change this testcase to still use a syntax error, but put the `void int c;` testcase somewhere.
  */
 int a;
 int test2(int b = 9%a) { return b; }

--- a/Examples/test-suite/errors/pp_unknowndirective5.stderr
+++ b/Examples/test-suite/errors/pp_unknowndirective5.stderr
@@ -1,1 +1,2 @@
-pp_unknowndirective5.i:20: Error: Syntax error in input(1).
+pp_unknowndirective5.i:20: Warning 999: Attempting to skip declaration SWIG can't parse
+pp_unknowndirective5.i:21: Error: Missing semicolon (';'). Reached end of input.

--- a/Source/CParse/cparse.h
+++ b/Source/CParse/cparse.h
@@ -36,7 +36,7 @@ extern "C" {
   extern void scanner_next_token(int);
   extern void skip_balanced(int startchar, int endchar);
   extern String *get_raw_text_balanced(int startchar, int endchar);
-  extern void skip_decl(void);
+  extern int skip_decl(void);
   extern void scanner_check_typedef(void);
   extern void scanner_ignore_typedef(void);
   extern void scanner_last_id(int);

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -194,7 +194,7 @@ String *get_raw_text_balanced(int startchar, int endchar) {
 }
 
 /* ----------------------------------------------------------------------------
- * void skip_decl(void)
+ * int skip_decl(void)
  *
  * This tries to skip over an entire declaration.   For example
  *
@@ -203,9 +203,10 @@ String *get_raw_text_balanced(int startchar, int endchar) {
  * or
  *  friend ostream& operator<<(ostream&, const char *s) { }
  *
+ * Returns 0 if successfully skipped, -1 if EOF found first.
  * ------------------------------------------------------------------------- */
 
-void skip_decl(void) {
+int skip_decl(void) {
   int tok;
   int done = 0;
   int start_line = Scanner_line(scan);
@@ -216,11 +217,12 @@ void skip_decl(void) {
       if (!Swig_error_count()) {
 	Swig_error(cparse_file, start_line, "Missing semicolon (';'). Reached end of input.\n");
       }
-      return;
+      return -1;
     }
     if (tok == SWIG_TOKEN_LBRACE) {
       if (Scanner_skip_balanced(scan,'{','}') < 0) {
 	Swig_error(cparse_file, start_line, "Missing closing brace ('}'). Reached end of input.\n");
+	return -1;
       }
       break;
     }
@@ -230,6 +232,7 @@ void skip_decl(void) {
   }
   cparse_file = Scanner_file(scan);
   cparse_line = Scanner_line(scan);
+  return 0;
 }
 
 /* ----------------------------------------------------------------------------

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -1835,15 +1835,6 @@ declaration    : swig_directive { $$ = $1; }
                | c_declaration { $$ = $1; } 
                | cpp_declaration { $$ = $1; }
                | SEMI { $$ = 0; }
-               | error {
-                  $$ = 0;
-		  if (cparse_unknown_directive) {
-		      Swig_error(cparse_file, cparse_line, "Unknown directive '%s'.\n", cparse_unknown_directive);
-		  } else {
-		      Swig_error(cparse_file, cparse_line, "Syntax error in input(1).\n");
-		  }
-		  Exit(EXIT_FAILURE);
-               }
 /* Out of class constructor/destructor declarations */
                | c_constructor_decl { 
                   if ($$) {
@@ -1865,7 +1856,18 @@ declaration    : swig_directive { $$ = $1; }
                   $$ = 0;
                   skip_decl();
                }
-               ;
+	       | error {
+		  $$ = 0;
+		  if (cparse_unknown_directive) {
+		    Swig_error(cparse_file, cparse_line, "Unknown directive '%s'.\n", cparse_unknown_directive);
+		    Exit(EXIT_FAILURE);
+		  }
+		  if (skip_decl() == 0) {
+		    /* Don't emit warning if skip_decl() hit EOF. */
+		    Swig_warning(999, cparse_file, cparse_line, "Attempting to skip declaration SWIG can't parse\n");
+		  }
+	       }
+	       ;
 
 /* ======================================================================
  *                           SWIG DIRECTIVES 


### PR DESCRIPTION
There are still many valid C++ constructs which SWIG can't parse (typically from newer C++ standards) which currently halt SWIG with a parse error.

We've had quite a lot of user reports where this happens but the user doesn't actually want to wrap the problematic declaration, so let's try getting SWIG to emit a warning and skip to the next declaration.