### PR TITLE
Specifying __cplusplus

### DIFF
--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -53,6 +53,12 @@ extern "C" {
  */
 #define EXTRA_WARNINGS "309,403,405,512,321,322"
 
+/* Indirect stringification. Doing two levels allows the argument to be a macro itself.
+ * Example: STRINGIFY(MY_INT_VAL) expands to "10", when we have #define MY_INT_VAL 10
+ */
+#define STRINGIFY_1(x, ...) #x
+#define STRINGIFY(x, ...) STRINGIFY_1(x)
+
 extern "C" {
   extern String *ModuleName;
   extern int ignore_nested_classes;
@@ -498,7 +504,7 @@ static void getoptions(int argc, char *argv[]) {
 	Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-c++") == 0) {
 	CPlusPlus = 1;
-	Preprocessor_define((DOH *) "__cplusplus __cplusplus", 0);
+	Preprocessor_define((DOH *) "__cplusplus " STRINGIFY(__cplusplus), 0);
 	Swig_cparse_cplusplus(1);
 	Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-c++out") == 0) {
@@ -957,7 +963,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   // Define the __cplusplus symbol
   if (CPlusPlus)
-    Preprocessor_define((DOH *) "__cplusplus __cplusplus", 0);
+    Preprocessor_define((DOH *) "__cplusplus " STRINGIFY(__cplusplus), 0);
 
   // Parse language dependent options
   lang->main(argc, argv);


### PR DESCRIPTION
`Source/Modules/main.cxx` updates:
1. Added `STRINGIFY_1()` & `STRINGIFY()` macros,
2. Used `STRINGIFY()` macro in two places, for `Preprocessor_define((DOH *) "__cplusplus " STRINGIFY(__cplusplus), 0)`. 

This makes the SWIG's built-in pre-processor expand / translate the value of the `__cplusplus` pre-processor symbol to the expected (long) integer numeric value, as set by the C++ compiler tool-chain that is used in conjunction with `swig.exe -c++` option. For example:
- `199711L` (C++98 compiler conformance level)
- `201402L` (C++14 compiler conformance level)
- `201703L` (C++17 compiler conformance level)
- `202002L` (C++20 compiler conformance level)

Without this change, the value of `__cplusplus` pre-processor symbol is set to ... its name, that is, exactly `__cplusplus`.
Any C++ logic conditional on either `#ifdef __cplusplus` or `#if defined (__cplusplus)`, succeeds without this change, but C++ logic that is conditional on specific _numeric ranges_ i.e via `#if (__cplusplus >= 202002L)` will pose problems.