### PR TITLE
Support parsing arbitrary expression in decltype

### DIFF
--- a/Examples/test-suite/cpp11_template_parameters_decltype.i
+++ b/Examples/test-suite/cpp11_template_parameters_decltype.i
@@ -6,14 +6,12 @@
 
 #pragma SWIG nowarn=SWIGWARN_CPP11_DECLTYPE
 
-#if 0
 // to fix (non-template expression equivalent to template expression further down):
 %inline %{
 #include <utility>
 #include <vector>
   void f(bool c = std::is_constructible<std::string, decltype(std::declval<std::vector<std::pair<int, int>>>().begin()->first)>::value) {}
 %}
-#endif
 
 %inline %{
 // Github issue #1590
@@ -26,14 +24,11 @@ struct Json {
     Json(const T & t) : Json(t.to_json()) {}
 
 // Github issue #1589
-// To fix
-#if !defined(SWIG)
   // Implicit constructor: map-like objects (std::map, std::unordered_map, etc)
   template <class M, typename std::enable_if<
       std::is_constructible<std::string, decltype(std::declval<M>().begin()->first)>::value,
       int>::type = 0>
           Json(const M & m) : Json(object(m.begin(), m.end())) {}
-#endif
 };
 %}
 


### PR DESCRIPTION
Use parser error recovery to skip to the closing matching `)` and issue a warning that we can't deduce the decltype for the expression (like we already do for any expression which isn't a simple variable or similar).

Fixes #1589
Helps #2335 (fixes the decltype-related examples)