### PR TITLE
Stop defining SWIGOPT_* preprocessor symbols

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,17 @@ Version 4.2.0 (in progress)
 ===========================
 
 2023-05-18: olly
+	    SWIG no longer defines preprocessor symbols corresponding to
+	    command line options (e.g. `-module blah` was resulting in
+	    `SWIGOPT_MODULE` being set to `blah`).  This feature was added in
+	    2001 so that "[m]odules can look for these symbols to alter their
+	    code generation if needed", but it's never been used for that
+	    purpose in over 20 years, and has never been documented outside of
+	    CHANGES.
+
+	    *** POTENTIAL INCOMPATIBILITY ***
+
+2023-05-18: olly
 	    #1589 #2335 Support parsing arbitrary expression in decltype.
 
 	    Use parser error recovery to skip to the closing matching `)` and

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -237,46 +237,6 @@ static bool check_extension(String *filename) {
 }
 
 /* -----------------------------------------------------------------------------
- * install_opts()
- *
- * Install all command line options as preprocessor symbols
- * ----------------------------------------------------------------------------- */
-
-static void install_opts(int argc, char *argv[]) {
-  int i;
-  int noopt = 0;
-  char *c;
-  for (i = 1; i < (argc - 1); i++) {
-    if (argv[i]) {
-      if ((*argv[i] == '-') && (!isupper(*(argv[i] + 1)))) {
-	String *opt = NewStringf("SWIGOPT%(upper)s", argv[i]);
-	Replaceall(opt, "-", "_");
-	c = Char(opt);
-	noopt = 0;
-	while (*c) {
-	  if (!(isalnum(*c) || (*c == '_'))) {
-	    noopt = 1;
-	    break;
-	  }
-	  c++;
-	}
-	if (((i + 1) < (argc - 1)) && (argv[i + 1]) && (*argv[i + 1] != '-')) {
-	  Printf(opt, " %s", argv[i + 1]);
-	  i++;
-	} else {
-	  Printf(opt, " 1");
-	}
-	if (!noopt) {
-	  /*      Printf(stdout,"%s\n", opt); */
-	  Preprocessor_define(opt, 0);
-	}
-	Delete(opt);
-      }
-    }
-  }
-}
-
-/* -----------------------------------------------------------------------------
  * decode_numbers_list()
  *
  * Decode comma separated list into a binary number of the inputs or'd together
@@ -975,8 +935,6 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     Printf(stderr, "The -c++out option is for C input but C++ input has been requested via -c++\n");
     Exit(EXIT_FAILURE);
   }
-
-  install_opts(argc, argv);
 
   // Add language dependent directory to the search path
   {


### PR DESCRIPTION
SWIG no longer defines preprocessor symbols corresponding to command line options (e.g. `-module blah` was resulting in `SWIGOPT_MODULE` being set to `blah`).  This feature was added in 2001 so that "[m]odules can look for these symbols to alter their code generation if needed", but it's never been used for that purpose in over 20 years, and has never been documented outside of CHANGES.