### PR TITLE
Partial support for auto without trailing return type

### DIFF
--- a/Doc/Manual/CPlusPlus14.html
+++ b/Doc/Manual/CPlusPlus14.html
@@ -15,6 +15,7 @@
 <li><a href="#CPlusPlus14_core_language_changes">Core language changes</a>
 <ul>
 <li><a href="#CPlusPlus14_binary_literals">Binary integer literals</a>
+<li><a href="#CPlusPlus14_return_type_deduction">Return type deduction</a>
 </ul>
 <li><a href="#CPlusPlus14_standard_library_changes">Standard library changes</a>
 </ul>
@@ -52,6 +53,50 @@ Example:
 int b = 0b101011;
 </pre>
 </div>
+
+<H3><a href="CPlusPlus14_return_type_deduction">8.2.2 Return type deduction</a>
+
+<p>
+C++14 added the ability to specify <tt>auto</tt> for the return type of a function
+and have the compiler deduce it from the body of the function (in C++11 you had
+to explicitly specify a trailing return type if you used <tt>auto</tt> for the
+return type.
+</p>
+
+<p>
+SWIG 4.2.0 added support for this with some limitations.  The major one is that
+SWIG can't actually deduce the return type so if you want to wrap such a function
+you need to tell SWIG the return type explicitly.  The other limitation is that
+SWIG can currently only parse such functions when there's either nothing or
+only `const` between the `)` and the end of the parameter list and the `{` at
+the start of the body.  Hopefully this second limitation will be removed in
+the future.
+</p>
+
+<p>
+The trick for specifying the return type is to use <tt>%ignore</tt> to tell
+SWIG to ignore the function with the deduced return type, but first provide
+SWIG with an alternative declaration of the function with an explicit return
+type.  The generated wrapper will wrap this alternative declaration, and the
+call in the wrapper to the function will call the actual declaration.  Here is
+an actual example:
+</p>
+
+<div class="code"><pre>
+std::tuple<int, int> va_static_cast();
+%ignore va_static_cast();
+#pragma SWIG nowarn=SWIGWARN_CPP14_AUTO
+
+%inline %{
+#include <tuple>
+
+auto va_static_cast()
+{
+    return std::make_tuple(0, 0);
+}
+%}
+</pre></div>
+
 
 <H2><a name="CPlusPlus14_standard_library_changes">8.3 Standard library changes</a></H2>
 

--- a/Doc/Manual/Warnings.html
+++ b/Doc/Manual/Warnings.html
@@ -440,6 +440,7 @@ example.i(4) : Syntax error in input(1).
 <li>327. Extern template ignored.
 <li>340. Lambda expressions and closures are not fully supported yet.
 <li>344. Unable to deduce decltype for '<em>expr</em>'.
+<li>345. Unable to deduce return type for '<em>name</em>'.
 <li>350. operator new ignored.
 <li>351. operator delete ignored.
 <li>352. operator+ ignored.

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -646,6 +646,7 @@ CPP11_TEST_BROKEN = \
 
 # C++14 test cases.
 CPP14_TEST_CASES += \
+	cpp14_auto_return_type \
 	cpp14_binary_integer_literals \
 
 # Broken C++14 test cases.

--- a/Examples/test-suite/cpp14_auto_return_type.i
+++ b/Examples/test-suite/cpp14_auto_return_type.i
@@ -1,0 +1,24 @@
+// This testcase checks SWIG's support for `auto` as the return type of a
+// function with no trailing return type, introduced in C++14.
+%module cpp14_auto_return_type
+
+// SWIG can't deduce the return type, so we ignore the `auto`-using declaration
+// (which would typically be in a header being wrapped) and provide a
+// declaration with an explicit return type in the interface file.
+
+namespace teca_variant_array_util {
+int va_static_cast();
+%ignore va_static_cast();
+}
+#pragma SWIG nowarn=SWIGWARN_CPP14_AUTO
+
+%inline %{
+namespace teca_variant_array_util
+{
+// Parse error in SWIG < 4.2.0.
+auto va_static_cast()
+{
+    return 42;
+}
+}
+%}

--- a/Examples/test-suite/php/cpp14_auto_return_type_runme.php
+++ b/Examples/test-suite/php/cpp14_auto_return_type_runme.php
@@ -1,0 +1,10 @@
+<?php
+
+require "tests.php";
+
+check::functions(array('va_static_cast'));
+check::classes(array('cpp14_auto_return_type'));
+// No new vars
+check::globals(array());
+
+check::equal(va_static_cast(), 42);

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -3328,7 +3328,11 @@ c_decl  : storage_class type declarator cpp_const initializer c_decl_tail {
 	      if ($4.qualifier && $1 && Strstr($1, "static"))
 		Swig_error(cparse_file, cparse_line, "Static function %s cannot have a qualifier.\n", Swig_name_decl($$));
            }
-           ;
+	   | storage_class AUTO declarator cpp_const LBRACE {
+	      skip_balanced('{','}');
+	      Swig_warning(WARN_CPP14_AUTO, cparse_file, cparse_line, "Unable to deduce return type for '%s'.\n", $3.id);
+	   }
+	   ;
 
 /* Allow lists of variables and functions to be built up */
 

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -100,6 +100,7 @@
 #define WARN_CPP11_ALIAS_TEMPLATE     342  /* redundant now */
 #define WARN_CPP11_VARIADIC_TEMPLATE  343  /* redundant now */
 #define WARN_CPP11_DECLTYPE           344
+#define WARN_CPP14_AUTO               345
 
 #define WARN_IGNORE_OPERATOR_NEW        350	/* new */
 #define WARN_IGNORE_OPERATOR_DELETE     351	/* delete */


### PR DESCRIPTION
This is a C++14 feature.

SWIG can now parse some cases of this.  The limitation is that there can either be nothing or `const` between the `)` and the end of the parameter list and the `{` at the start of the body.

Fixes #2446