### PR TITLE
Improve c# ARGC ARGV

### DIFF
--- a/Examples/test-suite/argcargvtest.i
+++ b/Examples/test-suite/argcargvtest.i
@@ -1,14 +1,9 @@
 %module argcargvtest
 
 #if !defined(SWIGMZSCHEME) && !defined(SWIGOCAML) && !defined(SWIGR)
-#define SWIGCSHARP_ARGCARGV_PARAM_IDX "0"
 %include <argcargv.i>
 
-#ifndef SWIGCSHARP
 %apply (int ARGC, char **ARGV) { (size_t argc, const char **argv) }
-#else
-%apply (char **ARGV) { const char **argv }
-#endif
 #endif
 
 %inline %{

--- a/Examples/test-suite/csharp/argcargvtest_runme.cs
+++ b/Examples/test-suite/csharp/argcargvtest_runme.cs
@@ -5,11 +5,11 @@ public class argcargvtest_runme {
 
   public static void Main() {
     string[] largs = {"hi", "hola", "hello"};
-    if (argcargvtest.mainc((uint)largs.Length, largs) != 3)
+    if (argcargvtest.mainc(largs) != 3)
         throw new Exception("bad main typemap");
 
     string[] targs = {"hi", "hola"};
-    if (!argcargvtest.mainv((uint)targs.Length, targs, 1).Equals("hola"))
+    if (!argcargvtest.mainv(targs, 1).Equals("hola"))
         throw new Exception("bad main typemap");
 
 // For dynamically typed languages we test this throws an exception or similar
@@ -17,6 +17,6 @@ public class argcargvtest_runme {
 // test for that here).
 //  argcargvtest.mainv("hello", 1);
 
-    argcargvtest.initializeApp((uint)targs.Length, largs);
+    argcargvtest.initializeApp(largs);
   }
 }

--- a/Lib/csharp/argcargv.i
+++ b/Lib/csharp/argcargv.i
@@ -2,17 +2,62 @@
  * SWIG library containing argc and argv multi-argument typemaps
  * ------------------------------------------------------------ */
 
-/*
- * Follow main(int argc, char *argv[]) function
- * Note: SWIGCSHARP_ARGCARGV_PARAM_IDX set the 'argc' parameter location.
- * The C# Marshaling use the argc parameter to determine the array size.
- * See: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshalasattribute.sizeparamindex
- */
+%typemap(cstype) (int ARGC, char **ARGV) "string[]"
+%typemap(imtype) (int ARGC, char **ARGV) "global::System.IntPtr"
+%typemap(ctype) (int ARGC, char **ARGV) "void*"
+%typemap(csin) (int ARGC, char **ARGV) "$modulePINVOKE.Swig_strings_array_to_c($csinput.Length, $csinput)"
+%pragma(csharp) imclasscode=%{
+  [global::System.Runtime.InteropServices.DllImport("$module", EntryPoint="C_Swig_strings_array_to_c")]
+  public static extern global::System.IntPtr Swig_strings_array_to_c(int len, [global::System.Runtime.InteropServices.In,global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType=global::System.Runtime.InteropServices.UnmanagedType.LPStr, SizeParamIndex=0)] string[] array);
+%}
+%insert(wrapper) %{
+typedef struct { int len; char* array[1]; } c_csstrings_array;
+static void* C_Swig_strings_array_free(c_csstrings_array *arr) {
+  if (arr != SWIG_NULLPTR) {
+    int i;
+    for(i = 0; i < arr->len; i++) {
+      free(arr->array[i]);
+    }
+    free(arr);
+  }
+  return SWIG_NULLPTR;
+}
+SWIGEXPORT void* SWIGSTDCALL C_Swig_strings_array_to_c(int len, void *array) {
+  int i;
+  size_t alen, slen;
+  char *p, **ptr;
+  c_csstrings_array *ret;
+  SWIG_contract_assert(SWIG_NULLPTR, len >= 1, "Strings array can not be empty.");
+  alen = sizeof(c_csstrings_array) + sizeof(char *) * (len - 1);
+  ret = (c_csstrings_array *)malloc(alen);
+  if (ret == SWIG_NULLPTR) {
+    SWIG_CSharpSetPendingException(SWIG_CSharpOutOfMemoryException, "fail to duplicate array.");
+    return SWIG_NULLPTR;
+  }
+  memset(ret, 0, alen);
+  ret->len = len;
+  ptr = (char **)array;
+  for(i = 0; i < len; i++) {
+    slen = strlen(ptr[i]) + 1;
+    SWIG_contract_assert(C_Swig_strings_array_free(ret), slen > 1, "String can not be empty");
+    p = (char*)malloc(slen);
+    if (p == SWIG_NULLPTR) {
+      SWIG_CSharpSetPendingException(SWIG_CSharpOutOfMemoryException, "fail to alloc a string.");
+      return C_Swig_strings_array_free(ret);
+    }
+    memcpy(p, ptr[i], slen);
+    ret->array[i] = p;
+  }
+  return ret;
+}
+%}
 
-#ifndef SWIGCSHARP_ARGCARGV_PARAM_IDX
-#define SWIGCSHARP_ARGCARGV_PARAM_IDX "0"
-#endif
+%typemap(in, canthrow=1) (int ARGC, char **ARGV) {
+  c_csstrings_array *arr = (c_csstrings_array*)$input;
+  if (arr != SWIG_NULLPTR) {
+    $1 = ($1_ltype)arr->len;
+    $2 = ($2_ltype)arr->array;
+  }
+}
 
-%typemap(csin) char **ARGV "$csinput"
-%typemap(cstype) char **ARGV "string[]"
-%typemap(imtype, inattributes="[global::System.Runtime.InteropServices.In,global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType=global::System.Runtime.InteropServices.UnmanagedType.LPStr, SizeParamIndex="SWIGCSHARP_ARGCARGV_PARAM_IDX")]") char **ARGV "string[]"
+%typemap(freearg) (int ARGC, char **ARGV) "C_Swig_strings_array_free((c_csstrings_array*)$input);"


### PR DESCRIPTION
Change SWIGCSHARP_ARGCARGV_PARAM_IDX from string to number.

And
Remove more redundant NULL checks before free()