### PR TITLE
[D] ARGC ARGV: D empty array translate to null in C.

### DIFF
--- a/Examples/test-suite/d/argcargvtest_runme.2.d
+++ b/Examples/test-suite/d/argcargvtest_runme.2.d
@@ -18,9 +18,9 @@ void main() {
 
   initializeApp(largs);
 
-  // An empty array doesn't seem to be valid in D so we can't test that here.
-  // string[] empty_args;
-  // enforce(mainc(empty_args) == 0, "calling mainc failed");
+  // Check that an empty array works.
+  string[] empty_args;
+  enforce(mainc(empty_args) == 0, "calling mainc failed");
 
   // Check that empty strings are handled.
   auto empty_string = ["hello", "", "world"];

--- a/Lib/d/argcargv.i
+++ b/Lib/d/argcargv.i
@@ -7,26 +7,23 @@
 %typemap(dtype) (int ARGC, char **ARGV) "string[]"
 
 %typemap(in, canthrow=1) (int ARGC, char **ARGV) {
-  $1_ltype i, len;
-  if ($input.array == SWIG_NULLPTR) {
-    SWIG_DSetPendingException(SWIG_DIllegalArgumentException, "null array");
-    return $null;
+  if ($input.array == SWIG_NULLPTR || $input.len <= 0) {
+    $1 = 0;
+    $2 = ($2_ltype) malloc(sizeof($*2_ltype));
+    $2[0] = SWIG_NULLPTR;
+  } else {
+    $1_ltype i;
+    $1 = $input.len;
+    $2 = ($2_ltype) malloc(($1+1)*sizeof($*2_ltype));
+    if ($2 == SWIG_NULLPTR) {
+      SWIG_DSetPendingException(SWIG_DException, "memory allocation failed");
+      return $null;
+    }
+    for (i = 0; i < $1; i++) {
+      $2[i] = $input.array[i].str;
+    }
+    $2[i] = SWIG_NULLPTR;
   }
-  len = $input.len;
-  if (len <= 0) {
-    SWIG_DSetPendingException(SWIG_DIllegalArgumentException, "array must contain at least 1 element");
-    return $null;
-  }
-  $2 = ($2_ltype) malloc((len+1)*sizeof($*2_ltype));
-  if ($2 == SWIG_NULLPTR) {
-    SWIG_DSetPendingException(SWIG_DException, "memory allocation failed");
-    return $null;
-  }
-  $1 = len;
-  for (i = 0; i < len; i++) {
-    $2[i] = $input.array[i].str;
-  }
-  $2[i] = SWIG_NULLPTR;
 }
 
 %typemap(freearg) (int ARGC, char **ARGV) {


### PR DESCRIPTION
It seems D pass array in a very simple way.
Empty arrays are null.
<del>And all arrays have the `str` properties, regardless of their type.
I do not see any point to do more checks on the matter.</del>
D compiler ensure we pass string array.
No further check is needed in `argcargv.i`.

Unharm side effect:
`mainc(null) == 0` pass.
But  `int[] empty_ints; mainc(empty_ints) ;` fail compilation.

Just pass to C.
The only exception is on memory allocation, obviously.