### PR TITLE
fix and test member pointers in javascript

### DIFF
--- a/Examples/test-suite/javascript/member_pointer_const_runme.js
+++ b/Examples/test-suite/javascript/member_pointer_const_runme.js
@@ -11,7 +11,7 @@ function check(what, expected, actual) {
 // Get the pointers
 
 area_pt = member_pointer_const.areapt();
-//perim_pt = member_pointer_const.perimeterpt();
+perim_pt = member_pointer_const.perimeterpt();
 
 // Create some objects
 
@@ -20,33 +20,31 @@ s = new member_pointer_const.Square(10);
 // Do some calculations
 
 check("Square area ", 100.0, member_pointer_const.do_op(s, area_pt));
-/*check("Square perim", 40.0, member_pointer_const.do_op(s, perim_pt));
+check("Square perim", 40.0, member_pointer_const.do_op(s, perim_pt));
 
-memberPtr = cvar.areavar;
-memberPtr = cvar.perimetervar;
+memberPtr = member_pointer_const.areavar;
+memberPtr = member_pointer_const.perimetervar;
 
 // Try the variables
-check("Square area ", 100.0, member_pointer_const.do_op(s, cvar.areavar));
-check("Square perim", 40.0, member_pointer_const.do_op(s, cvar.perimetervar));
+check("Square area ", 100.0, member_pointer_const.do_op(s, member_pointer_const.areavar));
+check("Square perim", 40.0, member_pointer_const.do_op(s, member_pointer_const.perimetervar));
 
 // Modify one of the variables
 member_pointer_const.areavar = perim_pt;
 
-check("Square perimeter", 40.0, member_pointer_const.do_op(s, cvar.areavar));
+check("Square perimeter", 40.0, member_pointer_const.do_op(s, member_pointer_const.areavar));
 
 // Try the constants
+memberPtr = member_pointer_const.AREAPT;
+memberPtr = member_pointer_const.PERIMPT;
+memberPtr = member_pointer_const.NULLPT;
 
-memberPtr = AREAPT;
-memberPtr = PERIMPT;
-memberPtr = NULLPT;
-
-check("Square area ", 100.0, member_pointer_const.do_op(s, AREAPT));
-check("Square perim", 40.0, member_pointer_const.do_op(s, PERIMPT));
+check("Square area ", 100.0, member_pointer_const.do_op(s, member_pointer_const.AREAPT));
+check("Square perim", 40.0, member_pointer_const.do_op(s, member_pointer_const.PERIMPT));
 
 // Typedefs
 check("Square perim", 40.0, member_pointer_const.do_op_td(s, perim_pt));
 
-check("Add by value", 3, member_pointer_const.call1(ADD_BY_VALUE, 1, 2));
-check("Add by pointer", 7, member_pointer_const.call2(ADD_BY_POINTER, 3, 4));
-check("Add by reference", 11, member_pointer_const.call3(ADD_BY_REFERENCE, 5, 6));
-*/
+check("Add by value", 3, member_pointer_const.call1(member_pointer_const.ADD_BY_VALUE, 1, 2));
+check("Add by pointer", 7, member_pointer_const.call2(member_pointer_const.ADD_BY_POINTER, 3, 4));
+check("Add by reference", 11, member_pointer_const.call3(member_pointer_const.ADD_BY_REFERENCE, 5, 6));

--- a/Examples/test-suite/javascript/member_pointer_const_runme.js
+++ b/Examples/test-suite/javascript/member_pointer_const_runme.js
@@ -46,5 +46,6 @@ check("Square perim", 40.0, member_pointer_const.do_op(s, member_pointer_const.P
 check("Square perim", 40.0, member_pointer_const.do_op_td(s, perim_pt));
 
 check("Add by value", 3, member_pointer_const.call1(member_pointer_const.ADD_BY_VALUE, 1, 2));
-check("Add by pointer", 7, member_pointer_const.call2(member_pointer_const.ADD_BY_POINTER, 3, 4));
-check("Add by reference", 11, member_pointer_const.call3(member_pointer_const.ADD_BY_REFERENCE, 5, 6));
+// TODO: For some reason, these are commented out in the shared interface file?
+//check("Add by pointer", 7, member_pointer_const.call2(member_pointer_const.ADD_BY_POINTER, 3, 4));
+//check("Add by reference", 11, member_pointer_const.call3(member_pointer_const.ADD_BY_REFERENCE, 5, 6));

--- a/Examples/test-suite/javascript/member_pointer_const_runme.js
+++ b/Examples/test-suite/javascript/member_pointer_const_runme.js
@@ -1,0 +1,52 @@
+// Example using pointers to member functions
+var member_pointer_const = require("member_pointer_const");
+
+function check(what, expected, actual) {
+    if (expected != actual) {
+        throw new Error(
+            "Failed: ", what, " Expected: ", expected, " Actual: ", actual);
+    }
+}
+
+// Get the pointers
+
+area_pt = member_pointer_const.areapt();
+//perim_pt = member_pointer_const.perimeterpt();
+
+// Create some objects
+
+s = new member_pointer_const.Square(10);
+
+// Do some calculations
+
+check("Square area ", 100.0, member_pointer_const.do_op(s, area_pt));
+/*check("Square perim", 40.0, member_pointer_const.do_op(s, perim_pt));
+
+memberPtr = cvar.areavar;
+memberPtr = cvar.perimetervar;
+
+// Try the variables
+check("Square area ", 100.0, member_pointer_const.do_op(s, cvar.areavar));
+check("Square perim", 40.0, member_pointer_const.do_op(s, cvar.perimetervar));
+
+// Modify one of the variables
+member_pointer_const.areavar = perim_pt;
+
+check("Square perimeter", 40.0, member_pointer_const.do_op(s, cvar.areavar));
+
+// Try the constants
+
+memberPtr = AREAPT;
+memberPtr = PERIMPT;
+memberPtr = NULLPT;
+
+check("Square area ", 100.0, member_pointer_const.do_op(s, AREAPT));
+check("Square perim", 40.0, member_pointer_const.do_op(s, PERIMPT));
+
+// Typedefs
+check("Square perim", 40.0, member_pointer_const.do_op_td(s, perim_pt));
+
+check("Add by value", 3, member_pointer_const.call1(ADD_BY_VALUE, 1, 2));
+check("Add by pointer", 7, member_pointer_const.call2(ADD_BY_POINTER, 3, 4));
+check("Add by reference", 11, member_pointer_const.call3(ADD_BY_REFERENCE, 5, 6));
+*/

--- a/Examples/test-suite/javascript/member_pointer_runme.js
+++ b/Examples/test-suite/javascript/member_pointer_runme.js
@@ -1,0 +1,51 @@
+// Example using pointers to member functions
+
+var member_pointer = require("member_pointer");
+
+function check(what, expected, actual) {
+    if (expected != actual) {
+        throw new Error(
+            "Failed: ", what, " Expected: ", expected, " Actual: ", actual);
+    }
+}
+
+// Get the pointers
+
+area_pt = member_pointer.areapt();
+perim_pt = member_pointer.perimeterpt();
+
+// Create some objects
+
+s = new member_pointer.Square(10);
+
+// Do some calculations
+
+check("Square area ", 100.0, member_pointer.do_op(s, area_pt));
+check("Square perim", 40.0, member_pointer.do_op(s, perim_pt));
+
+memberPtr = member_pointer.areavar;
+memberPtr = member_pointer.perimetervar;
+
+// Try the variables
+check("Square area ", 100.0, member_pointer.do_op(s, member_pointer.areavar));
+check("Square perim", 40.0, member_pointer.do_op(s, member_pointer.perimetervar));
+
+// Modify one of the variables
+member_pointer.areavar = perim_pt;
+
+check("Square perimeter", 40.0, member_pointer.do_op(s, member_pointer.areavar));
+
+// Try the constants
+memberPtr = member_pointer.AREAPT;
+memberPtr = member_pointer.PERIMPT;
+memberPtr = member_pointer.NULLPT;
+
+check("Square area ", 100.0, member_pointer.do_op(s, member_pointer.AREAPT));
+check("Square perim", 40.0, member_pointer.do_op(s, member_pointer.PERIMPT));
+
+// Typedefs
+check("Square perim", 40.0, member_pointer.do_op_td(s, perim_pt));
+
+check("Add by value", 3, member_pointer.call1(member_pointer.ADD_BY_VALUE, 1, 2));
+check("Add by pointer", 7, member_pointer.call2(member_pointer.ADD_BY_POINTER, 3, 4));
+check("Add by reference", 11, member_pointer.call3(member_pointer.ADD_BY_REFERENCE, 5, 6));

--- a/Examples/test-suite/javascript/memberin_extend_c_runme.js
+++ b/Examples/test-suite/javascript/memberin_extend_c_runme.js
@@ -1,0 +1,7 @@
+var memberin_extend_c = require("memberin_extend_c");
+
+t = new memberin_extend_c.Person();
+t.name = "Fred Bloggs";
+if (t.name != "FRED BLOGGS") {
+    throw new Error("name wrong");
+}

--- a/Lib/javascript/jsc/javascriptrun.swg
+++ b/Lib/javascript/jsc/javascriptrun.swg
@@ -273,11 +273,12 @@ int SWIG_JSC_ConvertPacked(JSContextRef context, JSValueRef valRef, void *ptr, s
 SWIGRUNTIME
 JSValueRef SWIG_JSC_NewPackedObj(JSContextRef context, void *data, size_t size, swig_type_info *type) {
 
-  JSClassRef classRef = _SwigObject_classRef;
+  JSClassRef classRef = _SwigPackedData_classRef;
   JSObjectRef result = JSObjectMake(context, classRef, NULL);
 
   SwigPackedData* cdata = (SwigPackedData*) malloc(sizeof(SwigPackedData));
-  cdata->data = data;
+  cdata->data = malloc(size);
+  memcpy(cdata->data, data, size);
   cdata->size = size;
   cdata->type = type;
 

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -438,6 +438,7 @@ int SWIGV8_ConvertPacked(SWIGV8_VALUE valRef, void *ptr, size_t sz, swig_type_in
 
 SWIGRUNTIME void _wrap_SwigV8PackedData_delete(const v8::WeakCallbackInfo<SwigV8PackedData> &data) {
   SwigV8PackedData *cdata = data.GetParameter();
+  cdata->handle.Reset();
   delete cdata;
 }
 

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -53,6 +53,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_FUNCTION_TEMPLATE v8::Local<v8::FunctionTemplate>
 #define SWIGV8_OBJECT v8::Local<v8::Object>
 #define SWIGV8_OBJECT_TEMPLATE v8::Local<v8::ObjectTemplate>
+#define SWIGV8_OBJECT_TEMPLATE_NEW() v8::ObjectTemplate::New(v8::Isolate::GetCurrent())
 #define SWIGV8_VALUE v8::Local<v8::Value>
 #define SWIGV8_NULL() v8::Null(v8::Isolate::GetCurrent())
 #define SWIGV8_ARRAY_GET(array, index) (array)->Get(SWIGV8_CURRENT_CONTEXT(), index).ToLocalChecked()
@@ -68,6 +69,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue()
 #define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(buffer, len)
 #define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length()
+#define SWIGV8_OBJECT_TEMPLATE_INSTACE(tmpl) tmpl->NewInstance();
 #else
 #define SWIGV8_TO_OBJECT(handle) (handle)->ToObject(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
 #define SWIGV8_TO_STRING(handle) (handle)->ToString(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked()
@@ -75,6 +77,7 @@ typedef v8::PropertyCallbackInfo<v8::Value> SwigV8PropertyCallbackInfo;
 #define SWIGV8_INTEGER_VALUE(handle) (handle)->IntegerValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
 #define SWIGV8_WRITE_UTF8(handle, buffer, len) (handle)->WriteUtf8(v8::Isolate::GetCurrent(), buffer, len)
 #define SWIGV8_UTF8_LENGTH(handle) (handle)->Utf8Length(v8::Isolate::GetCurrent())
+#define SWIGV8_OBJECT_TEMPLATE_INSTACE(tmpl) tmpl->NewInstance(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked();
 #if (SWIG_V8_VERSION < 0x0704)
 #define SWIGV8_BOOLEAN_VALUE(handle) (handle)->BooleanValue(SWIGV8_CURRENT_CONTEXT()).ToChecked()
 #else
@@ -370,9 +373,15 @@ fail:
 
 class SwigV8PackedData {
 public:
-  SwigV8PackedData(void *data, size_t size, swig_type_info *type): data(data), size(size), type(type) {};
+  SwigV8PackedData(void *data, size_t size, swig_type_info *type): data(nullptr), size(size), type(type) {
+    this->data = malloc(size);
+    if (this->data != nullptr)
+      memcpy(this->data, data, size);
+  };
 
   ~SwigV8PackedData() {
+    if (this->data)
+      free(this->data);
   };
 
   void *data;
@@ -437,8 +446,9 @@ SWIGV8_VALUE SWIGV8_NewPackedObj(void *data, size_t size, swig_type_info *type) 
   SWIGV8_HANDLESCOPE_ESC();
 
   SwigV8PackedData *cdata = new SwigV8PackedData(data, size, type);
-//  v8::Handle<v8::Object> obj = SWIGV8_OBJECT_NEW();
-  v8::Local<v8::Object> obj = SWIGV8_OBJECT_NEW();
+  SWIGV8_OBJECT_TEMPLATE tmpl = SWIGV8_OBJECT_TEMPLATE_NEW();
+  tmpl->SetInternalFieldCount(1);
+  v8::Local<v8::Object> obj = SWIGV8_OBJECT_TEMPLATE_INSTACE(tmpl);
 
   v8::Local<v8::Private> privateKey = v8::Private::ForApi(v8::Isolate::GetCurrent(), SWIGV8_STRING_NEW("__swig__packed_data__"));
   obj->SetPrivate(SWIGV8_CURRENT_CONTEXT(), privateKey, SWIGV8_BOOLEAN_NEW(true));

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -380,8 +380,7 @@ public:
   };
 
   ~SwigV8PackedData() {
-    if (this->data)
-      free(this->data);
+    free(this->data);
   };
 
   void *data;


### PR DESCRIPTION
Class member pointers were broken in both V8 and JSC:
 - `NewPackedObj` did not properly create the object
 - The data was not copied but referenced a variable allocated on the stack (JSC even deleted it after using it!)

Fixes #2618 