### PR TITLE
add more JS run tests

### DIFF
--- a/Examples/test-suite/javascript/multivalue_runme.js
+++ b/Examples/test-suite/javascript/multivalue_runme.js
@@ -1,0 +1,25 @@
+var multivalue = require("multivalue");
+
+var [q, r] = multivalue.divide_l(37, 5);
+if (q != 7) {
+    throw new Error("Test divide_l quotient");
+}
+if (r != 2) {
+    throw new Error("Test divide_l remainder");
+}
+
+var [q, r] = multivalue.divide_v(41, 7);
+if (q != 5) {
+    throw new Error("Test divide_v quotient");
+}
+if (r != 6) {
+    throw new Error("Test divide_v remainder");
+}
+
+var [q, r] = multivalue.divide_l(91, 13);
+if (q != 7) {
+    throw new Error("Test divide_mv quotient");
+}
+if (r != 0) {
+    throw new Error("Test divide_mv remainder");
+}

--- a/Examples/test-suite/javascript/name_warnings_runme.js
+++ b/Examples/test-suite/javascript/name_warnings_runme.js
@@ -1,0 +1,10 @@
+var name_warnings = require("name_warnings");
+
+function check(flag) {
+    if (!flag) {
+        throw new Error("Test failed");
+    }
+}
+
+four = name_warnings.double_an_int(2);
+check(four == 4);

--- a/Examples/test-suite/javascript/namespace_class_runme.js
+++ b/Examples/test-suite/javascript/namespace_class_runme.js
@@ -1,0 +1,45 @@
+var namespace_class = require("namespace_class");
+
+try {
+    p = namespace_class.Private1();
+    error = 1;
+} catch {
+    error = 0;
+}
+
+if ((error)) {
+    throw new Error("Private1 is private");
+}
+
+try {
+    p = namespace_class.Private2();
+    error = 1;
+} catch {
+    error = 0;
+}
+
+if ((error)) {
+    throw new Error("Private2 is private");
+}
+
+namespace_class.EulerT3D.toFrame(1, 1, 1);
+
+b = new namespace_class.BooT_i();
+b = new namespace_class.BooT_H();
+
+
+f = new namespace_class.FooT_i();
+f.quack(1);
+
+f = new namespace_class.FooT_d();
+f.moo(1);
+
+f = new namespace_class.FooT_H();
+f.foo(namespace_class.Hi);
+
+// This test works only in Node.js
+if (typeof process !== 'undefined') {
+    if (!f.constructor.name.includes("FooT_H") || !(f instanceof namespace_class.FooT_H)) {
+        throw new Error("Incorrect type: " + f.toString());
+    }
+}

--- a/Examples/test-suite/javascript/namespace_typemap_runme.js
+++ b/Examples/test-suite/javascript/namespace_typemap_runme.js
@@ -1,0 +1,49 @@
+var namespace_typemap = require("namespace_typemap");
+
+if (namespace_typemap.stest1("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest2("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest3("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest4("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest5("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest6("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest7("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest8("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest9("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest10("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest11("hello") != "hello") {
+    throw new Error;
+}
+
+if (namespace_typemap.stest12("hello") != "hello") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/naturalvar_runme.js
+++ b/Examples/test-suite/javascript/naturalvar_runme.js
@@ -1,0 +1,13 @@
+var naturalvar = require("naturalvar");
+
+f = new naturalvar.Foo();
+b = new naturalvar.Bar();
+
+b.f = f;
+
+naturalvar.s = "hello";
+b.s = "hello";
+
+if (b.s != naturalvar.s) {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/nested_in_template_runme.js
+++ b/Examples/test-suite/javascript/nested_in_template_runme.js
@@ -1,0 +1,6 @@
+var nested_in_template = require("nested_in_template");
+
+cd = new nested_in_template.ConcreteDerived(88);
+if (cd.m_value != 88) {
+    throw new Error("ConcreteDerived not created correctly");
+}

--- a/Examples/test-suite/javascript/nested_template_base_runme.js
+++ b/Examples/test-suite/javascript/nested_template_base_runme.js
@@ -1,0 +1,14 @@
+var nested_template_base = require("nested_template_base");
+
+ois = new nested_template_base.InnerS(123);
+oic = new nested_template_base.InnerC();
+
+// Check base method is available
+if ((oic.outer(ois).val != 123)) {
+    throw new Error("Wrong value calling outer");
+}
+
+// Check non-derived class using base class
+if ((oic.innerc().outer(ois).val != 123)) {
+    throw new Error("Wrong value calling innerc");
+}

--- a/Examples/test-suite/javascript/nested_workaround_runme.js
+++ b/Examples/test-suite/javascript/nested_workaround_runme.js
@@ -1,0 +1,15 @@
+var nested_workaround = require("nested_workaround");
+
+inner = new nested_workaround.Inner(5);
+outer = new nested_workaround.Outer();
+newInner = outer.doubleInnerValue(inner);
+if (newInner.getValue() != 10) {
+    throw new Error;
+}
+
+outer = new nested_workaround.Outer();
+inner = outer.createInner(3);
+newInner = outer.doubleInnerValue(inner);
+if (outer.getInnerValue(newInner) != 6) {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/not_c_keywords_runme.js
+++ b/Examples/test-suite/javascript/not_c_keywords_runme.js
@@ -1,0 +1,8 @@
+var not_c_keywords = require("not_c_keywords");
+
+cs = new not_c_keywords.ComplexStruct();
+cs.init();
+if (cs.complex != 123) {
+    throw new Error("complex not correct");
+}
+cs.complex = 456;

--- a/Examples/test-suite/javascript/operator_overload_runme.js
+++ b/Examples/test-suite/javascript/operator_overload_runme.js
@@ -1,0 +1,111 @@
+var operator_overload = require("operator_overload");
+var { Op } = operator_overload;
+
+// first check all the operators are implemented correctly from pure C++ code
+Op.sanity_check();
+
+pop = (new Op(6)).Divide(new Op(3));
+
+// test routine
+a = new Op();
+b = new Op(5);
+c = new Op(b); // copy construct
+d = new Op(2);
+dd = new Op();
+dd.Equal(d); // assignment operator
+
+// test equality
+if (!a.NotEqual(b)) {
+  throw new Error("a!=b");
+}
+if (!b.EqualEqual(c)) {
+  throw new Error("b==c");
+}
+if (!a.NotEqual(d)) {
+  throw new Error("a!=d");
+}
+if (!d.EqualEqual(dd)) {
+  throw new Error("d==dd");
+}
+
+// test <
+if (!a.LessThan(b)) {
+  throw new Error("a<b");
+}
+if (!a.LessThanEqual(b)) {
+  throw new Error("a<=b");
+}
+if (!b.LessThanEqual(c)) {
+  throw new Error("b<=c");
+}
+if (!b.GreaterThanEqual(c)) {
+  throw new Error("b>=c");
+}
+if (!b.GreaterThan(d)) {
+  throw new Error("b>d");
+}
+if (!b.GreaterThanEqual(d)) {
+  throw new Error("b>=d");
+}
+
+// test +=
+e = new Op(3);
+e.PlusEqual(d);
+if (!e.EqualEqual(b)) {
+  throw new Error(`e==b (${e.i}==${b.i})`);
+}
+e.MinusEqual(c);
+if (!e.EqualEqual(a)) {
+  throw new Error("e==a");
+}
+e = new Op(1);
+e.MultiplyEqual(b);
+if (!e.EqualEqual(c)) {
+  throw new Error("e==c");
+}
+e.DivideEqual(d);
+if (!e.EqualEqual(d)) {
+  throw new Error("e==d");
+}
+e.PercentEqual(c);
+if (!e.EqualEqual(d)) {
+  throw new Error("e==d");
+}
+
+// test +
+f = new Op(1);
+g = new Op(1);
+if (!f.Plus(g).EqualEqual(new Op(2))) {
+  throw new Error("f+g==Op(2)");
+}
+if (!f.Minus(g).EqualEqual(new Op(0))) {
+  throw new Error("f-g==Op(0)");
+}
+if (!f.Multiply(g).EqualEqual(new Op(1))) {
+  throw new Error("f*g==Op(1)");
+}
+if (!f.Divide(g).EqualEqual(new Op(1))) {
+  throw new Error("f/g==Op(1)");
+}
+if (!f.Percent(g).EqualEqual(new Op(0))) {
+  throw new Error("f%g==Op(0)");
+}
+
+// test unary operators
+if (!a.Minus().EqualEqual(a)) {
+  throw new Error("-a==a");
+}
+if (!b.Minus().EqualEqual(new Op(-5))) {
+  throw new Error("-b==Op(-5)");
+}
+
+// test functors
+if (!b.Functor() == 5) {
+  throw new Error("functor");
+}
+if (!b.Functor(1) == 6) {
+  throw new Error("functor");
+}
+if (!b.Functor(1, 2) == 8) {
+  throw new Error("functor");
+}

--- a/Examples/test-suite/javascript/operbool_runme.js
+++ b/Examples/test-suite/javascript/operbool_runme.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+var operbool = require("operbool");
+const b = new operbool.Test();
+if (b.operator_bool()) {
+    throw new Error("operbool failed");
+}

--- a/Examples/test-suite/javascript/overload_bool_runme.js
+++ b/Examples/test-suite/javascript/overload_bool_runme.js
@@ -1,0 +1,60 @@
+var overload_bool = require("overload_bool");
+
+// Overloading bool, int, string
+if (overload_bool.overloaded(true) != "bool") {
+    throw new Error("wrong!");
+}
+if (overload_bool.overloaded(false) != "bool") {
+    throw new Error("wrong!");
+}
+
+if (overload_bool.overloaded(0) != "int") {
+    throw new Error("wrong!");
+}
+if (overload_bool.overloaded(1) != "int") {
+    throw new Error("wrong!");
+}
+if (overload_bool.overloaded(2) != "int") {
+    throw new Error("wrong!");
+}
+
+if (overload_bool.overloaded("1234") != "string") {
+    throw new Error("wrong!");
+}
+
+// Test bool masquerading as int
+// Not possible
+
+// Test int masquerading as bool
+// Not possible
+
+
+///////////////////////////////////////////////
+
+// Overloading bool, int, string
+if (overload_bool.overloaded_ref(true) != "bool") {
+    throw new Error("wrong!");
+}
+if (overload_bool.overloaded_ref(false) != "bool") {
+    throw new Error("wrong!");
+}
+
+if (overload_bool.overloaded_ref(0) != "int") {
+    throw new Error("wrong!");
+}
+if (overload_bool.overloaded_ref(1) != "int") {
+    throw new Error("wrong!");
+}
+if (overload_bool.overloaded_ref(2) != "int") {
+    throw new Error("wrong!");
+}
+
+if (overload_bool.overloaded_ref("1234") != "string") {
+    throw new Error("wrong!");
+}
+
+// Test bool masquerading as int
+// Not possible
+
+// Test int masquerading as bool
+// Not possible

--- a/Examples/test-suite/javascript/overload_complicated_runme.js
+++ b/Examples/test-suite/javascript/overload_complicated_runme.js
@@ -1,0 +1,58 @@
+var overload_complicated = require("overload_complicated");
+
+pInt = null;
+
+// Check the correct constructors are available
+p = new overload_complicated.Pop(pInt);
+
+p = new overload_complicated.Pop(pInt, false);
+
+// Check overloaded in const only and pointers/references which target
+// languages cannot disambiguate
+if (p.hip(false) != 701) {
+    throw new Error("Test 1 failed");
+}
+
+if (p.hip(pInt) != 702) {
+    throw new Error("Test 2 failed");
+}
+
+// Reverse the order for the above
+if (p.hop(pInt) != 805) {
+    throw new Error("Test 3 failed");
+}
+
+if (p.hop(false) != 801) {
+    throw new Error("Test 4 failed");
+}
+
+// Few more variations and order shuffled
+if (p.pop(false) != 901) {
+    throw new Error("Test 5 failed");
+}
+
+if (p.pop(pInt) != 902) {
+    throw new Error("Test 6 failed");
+}
+
+if (p.pop() != 905) {
+    throw new Error("Test 7 failed");
+}
+
+// Overload on const only
+if (p.bop(pInt) != 1001) {
+    throw new Error("Test 8 failed");
+}
+
+if (p.bip(pInt) != 2001) {
+    throw new Error("Test 9 failed");
+}
+
+// Globals
+if (overload_complicated.muzak(false) != 3001) {
+    throw new Error("Test 10 failed");
+}
+
+if (overload_complicated.muzak(pInt) != 3002) {
+    throw new Error("Test 11 failed");
+}

--- a/Examples/test-suite/javascript/overload_extend_c_runme.js
+++ b/Examples/test-suite/javascript/overload_extend_c_runme.js
@@ -1,0 +1,19 @@
+var overload_extend_c = require("overload_extend_c");
+
+f = new overload_extend_c.Foo();
+if (f.test() != 0) {
+    throw new Error;
+}
+if (f.test(3) != 1) {
+    throw new Error;
+}
+if (f.test("hello") != 2) {
+    throw new Error;
+}
+if (f.test(3, 2) != 5) {
+    throw new Error;
+}
+// In JavaScript there is no difference between 3.0 and 3
+if (f.test(3.0) != 1) {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/overload_extend_runme.js
+++ b/Examples/test-suite/javascript/overload_extend_runme.js
@@ -1,0 +1,19 @@
+var overload_extend = require("overload_extend")
+
+f = new overload_extend.Foo()
+if (f.test() != 0) {
+    throw new Error
+}
+if (f.test(3) != 1) {
+    throw new Error
+}
+if (f.test("hello") != 2) {
+    throw new Error
+}
+if (f.test(3, 2) != 5) {
+    throw new Error
+}
+// In JavaScript there is no difference between 3.0 and 3
+if (f.test(3.0) != 1) {
+    throw new Error
+}

--- a/Examples/test-suite/javascript/overload_simple_runme.js
+++ b/Examples/test-suite/javascript/overload_simple_runme.js
@@ -1,0 +1,105 @@
+var overload_simple = require("overload_simple");
+
+if (overload_simple.foo(3) != "foo:int") {
+    throw new Error("foo(int)");
+}
+
+if (overload_simple.foo("hello") != "foo:char *") {
+    throw new Error("foo(char *)");
+}
+
+f = new overload_simple.Foo();
+b = new overload_simple.Bar();
+
+if (overload_simple.foo(f) != "foo:Foo *") {
+    throw new Error("foo(Foo *)");
+}
+
+if (overload_simple.foo(b) != "foo:Bar *") {
+    throw new Error("foo(Bar *)");
+}
+
+v = overload_simple.malloc_void(32);
+
+if (overload_simple.foo(v) != "foo:void *") {
+    throw new Error("foo(void *)");
+}
+
+s = new overload_simple.Spam();
+
+if (s.foo(3) != "foo:int") {
+    throw new Error("Spam::foo(int)");
+}
+
+if (s.foo("hello") != "foo:char *") {
+    throw new Error("Spam::foo(char *)");
+}
+
+if (s.foo(f) != "foo:Foo *") {
+    throw new Error("Spam::foo(Foo *)");
+}
+
+if (s.foo(b) != "foo:Bar *") {
+    throw new Error("Spam::foo(Bar *)");
+}
+
+if (s.foo(v) != "foo:void *") {
+    throw new Error("Spam::foo(void *)");
+}
+
+if (overload_simple.Spam.bar(3) != "bar:int") {
+    throw new Error("Spam::bar(int)");
+}
+
+if (overload_simple.Spam.bar("hello") != "bar:char *") {
+    throw new Error("Spam::bar(char *)");
+}
+
+if (overload_simple.Spam.bar(f) != "bar:Foo *") {
+    throw new Error("Spam::bar(Foo *)");
+}
+
+if (overload_simple.Spam.bar(b) != "bar:Bar *") {
+    throw new Error("Spam::bar(Bar *)");
+}
+
+if (overload_simple.Spam.bar(v) != "bar:void *") {
+    throw new Error("Spam::bar(void *)");
+}
+
+// Test constructors
+
+s = new overload_simple.Spam();
+if (s.type != "none") {
+    throw new Error("Spam()");
+}
+
+s = new overload_simple.Spam(3);
+if (s.type != "int") {
+    throw new Error("Spam(int)");
+}
+
+s = new overload_simple.Spam("hello");
+if (s.type != "char *") {
+    throw new Error("Spam(char *)");
+}
+
+s = new overload_simple.Spam(f);
+if (s.type != "Foo *") {
+    throw new Error("Spam(Foo *)");
+}
+
+s = new overload_simple.Spam(b);
+if (s.type != "Bar *") {
+    throw new Error("Spam(Bar *)");
+}
+
+s = new overload_simple.Spam(v);
+if (s.type != "void *") {
+    throw new Error("Spam(void *)");
+}
+
+overload_simple.free_void(v);
+
+a = new overload_simple.ClassA();
+b = a.method1(1);

--- a/Examples/test-suite/javascript/overload_template_fast_runme.js
+++ b/Examples/test-suite/javascript/overload_template_fast_runme.js
@@ -1,0 +1,136 @@
+var overload_template_fast = require("overload_template_fast");
+
+f = overload_template_fast.foo();
+
+a = overload_template_fast.maximum(3, 4);
+b = overload_template_fast.maximum(3.4, 5.2);
+
+// overload_template_fast.mix 1
+if (overload_template_fast.mix1("hi") != 101) {
+    throw new Error("mix1(const char*)");
+}
+
+if (overload_template_fast.mix1(1.0, 1.0) != 102) {
+    throw new Error("mix1(double, const double &)");
+}
+
+if (overload_template_fast.mix1(1.0) != 103) {
+    throw new Error("mix1(double)");
+}
+// overload_template_fast.mix 2
+if (overload_template_fast.mix2("hi") != 101) {
+    throw new Error("mix2(const char*)");
+}
+if (overload_template_fast.mix2(1.0, 1.0) != 102) {
+    throw new Error("mix2(double, const double &)");
+}
+if (overload_template_fast.mix2(1.0) != 103) {
+    throw new Error("mix2(double)");
+}
+// overload_template_fast.mix 3
+if (overload_template_fast.mix3("hi") != 101) {
+    throw new Error("mix3(const char*)");
+}
+if (overload_template_fast.mix3(1.0, 1.0) != 102) {
+    throw new Error("mix3(double, const double &)");
+}
+if (overload_template_fast.mix3(1.0) != 103) {
+    throw new Error("mix3(double)");
+}
+// Combination 1
+if (overload_template_fast.overtparams1(100) != 10) {
+    throw new Error("overtparams1(int)");
+}
+if (overload_template_fast.overtparams1(100.0, 100) != 20) {
+    throw new Error("overtparams1(double, int)");
+}
+// Combination 2
+if (overload_template_fast.overtparams2(100.0, 100) != 40) {
+    throw new Error("overtparams2(double, int)");
+}
+// Combination 3
+if (overload_template_fast.overloaded() != 60) {
+    throw new Error("overloaded()");
+}
+if (overload_template_fast.overloaded(100.0, 100) != 70) {
+    throw new Error("overloaded(double, int)");
+}
+// Combination 4
+if (overload_template_fast.overloadedagain("hello") != 80) {
+    throw new Error("overloadedagain(const char *)");
+}
+if (overload_template_fast.overloadedagain() != 90) {
+    throw new Error("overloadedagain(double)");
+}
+// specializations
+if (overload_template_fast.specialization(10) != 202) {
+    throw new Error("specialization(int)");
+}
+if (overload_template_fast.specialization(10, 10) != 204) {
+    throw new Error("specialization(int, int)");
+}
+if (overload_template_fast.specialization("hi", "hi") != 201) {
+    throw new Error("specialization(const char *, const char *)");
+}
+
+// simple specialization
+overload_template_fast.xyz();
+overload_template_fast.xyz_int();
+overload_template_fast.xyz_double();
+
+// a bit of everything
+if (overload_template_fast.overload("hi") != 0) {
+    throw new Error("overload()");
+}
+if (overload_template_fast.overload(1) != 10) {
+    throw new Error("overload(int t)");
+}
+if (overload_template_fast.overload(1, 1) != 20) {
+    throw new Error("overload(int t, const int &)");
+}
+if (overload_template_fast.overload(1, "hello") != 30) {
+    throw new Error("overload(int t, const char *)");
+}
+k = new overload_template_fast.Klass();
+if (overload_template_fast.overload(k) != 10) {
+    throw new Error("overload(Klass t)");
+}
+if (overload_template_fast.overload(k, k) != 20) {
+    throw new Error("overload(Klass t, const Klass &)");
+}
+if (overload_template_fast.overload(k, "hello") != 30) {
+    throw new Error("overload(Klass t, const char *)");
+}
+if (overload_template_fast.overload() != 50) {
+    throw new Error("overload(const char *)");
+}
+
+// everything put in a namespace
+if (overload_template_fast.nsoverload("hi") != 1000) {
+    throw new Error("nsoverload()");
+}
+if (overload_template_fast.nsoverload(1) != 1010) {
+    throw new Error("nsoverload(int t)");
+}
+if (overload_template_fast.nsoverload(1, 1) != 1020) {
+    throw new Error("nsoverload(int t, const int &)");
+}
+if (overload_template_fast.nsoverload(1, "hello") != 1030) {
+    throw new Error("nsoverload(int t, const char *)");
+}
+if (overload_template_fast.nsoverload(k) != 1010) {
+    throw new Error("nsoverload(Klass t)");
+}
+if (overload_template_fast.nsoverload(k, k) != 1020) {
+    throw new Error("nsoverload(Klass t, const Klass &)");
+}
+if (overload_template_fast.nsoverload(k, "hello") != 1030) {
+    throw new Error("nsoverload(Klass t, const char *)");
+}
+if (overload_template_fast.nsoverload() != 1050) {
+    throw new Error("nsoverload(const char *)");
+}
+
+overload_template_fast.A.foo(1);
+b = new overload_template_fast.B();
+b.foo(1);

--- a/Examples/test-suite/javascript/overload_template_runme.js
+++ b/Examples/test-suite/javascript/overload_template_runme.js
@@ -1,0 +1,133 @@
+var overload_template = require("overload_template");
+f = overload_template.foo();
+
+a = overload_template.maximum(3, 4);
+b = overload_template.maximum(3.4, 5.2);
+
+// mix 1
+if (overload_template.mix1("hi") != 101) {
+    throw new Error("mix1(const char*)");
+}
+if (overload_template.mix1(1.0, 1.0) != 102) {
+    throw new Error("mix1(double, const double &)");
+}
+if (overload_template.mix1(1.0) != 103) {
+    throw new Error("mix1(double)");
+}
+// mix 2
+if (overload_template.mix2("hi") != 101) {
+    throw new Error("mix2(const char*)");
+}
+if (overload_template.mix2(1.0, 1.0) != 102) {
+    throw new Error("mix2(double, const double &)");
+}
+if (overload_template.mix2(1.0) != 103) {
+    throw new Error("mix2(double)");
+}
+// mix 3
+if (overload_template.mix3("hi") != 101) {
+    throw new Error("mix3(const char*)");
+}
+if (overload_template.mix3(1.0, 1.0) != 102) {
+    throw new Error("mix3(double, const double &)");
+}
+if (overload_template.mix3(1.0) != 103) {
+    throw new Error("mix3(double)");
+}
+// Combination 1
+if (overload_template.overtparams1(100) != 10) {
+    throw new Error("overtparams1(int)");
+}
+if (overload_template.overtparams1(100.0, 100) != 20) {
+    throw new Error("overtparams1(double, int)");
+}
+// Combination 2
+if (overload_template.overtparams2(100.0, 100) != 40) {
+    throw new Error("overtparams2(double, int)");
+}
+// Combination 3
+if (overload_template.overloaded() != 60) {
+    throw new Error("overloaded()");
+}
+if (overload_template.overloaded(100.0, 100) != 70) {
+    throw new Error("overloaded(double, int)");
+}
+// Combination 4
+if (overload_template.overloadedagain("hello") != 80) {
+    throw new Error("overloadedagain(const char *)");
+}
+if (overload_template.overloadedagain() != 90) {
+    throw new Error("overloadedagain(double)");
+}
+// specializations
+if (overload_template.specialization(10) != 202) {
+    throw new Error("specialization(int)");
+}
+if (overload_template.specialization(10, 10) != 204) {
+    throw new Error("specialization(int, int)");
+}
+if (overload_template.specialization("hi", "hi") != 201) {
+    throw new Error("specialization(const char *, const char *)");
+}
+
+// simple specialization
+overload_template.xyz();
+overload_template.xyz_int();
+overload_template.xyz_double();
+
+// a bit of everything
+if (overload_template.overload("hi") != 0) {
+    throw new Error("overload()");
+}
+if (overload_template.overload(1) != 10) {
+    throw new Error("overload(int t)");
+}
+if (overload_template.overload(1, 1) != 20) {
+    throw new Error("overload(int t, const int &)");
+}
+if (overload_template.overload(1, "hello") != 30) {
+    throw new Error("overload(int t, const char *)");
+}
+k = new overload_template.Klass();
+if (overload_template.overload(k) != 10) {
+    throw new Error("overload(Klass t)");
+}
+if (overload_template.overload(k, k) != 20) {
+    throw new Error("overload(Klass t, const Klass &)");
+}
+if (overload_template.overload(k, "hello") != 30) {
+    throw new Error("overload(Klass t, const char *)");
+}
+if (overload_template.overload() != 50) {
+    throw new Error("overload(const char *)");
+}
+
+// everything put in a namespace
+if (overload_template.nsoverload("hi") != 1000) {
+    throw new Error("nsoverload()");
+}
+if (overload_template.nsoverload(1) != 1010) {
+    throw new Error("nsoverload(int t)");
+}
+if (overload_template.nsoverload(1, 1) != 1020) {
+    throw new Error("nsoverload(int t, const int &)");
+}
+if (overload_template.nsoverload(1, "hello") != 1030) {
+    throw new Error("nsoverload(int t, const char *)");
+}
+if (overload_template.nsoverload(k) != 1010) {
+    throw new Error("nsoverload(Klass t)");
+}
+if (overload_template.nsoverload(k, k) != 1020) {
+    throw new Error("nsoverload(Klass t, const Klass &)");
+}
+if (overload_template.nsoverload(k, "hello") != 1030) {
+    throw new Error("nsoverload(Klass t, const char *)");
+}
+if (overload_template.nsoverload() != 1050) {
+    throw new Error("nsoverload(const char *)");
+}
+
+overload_template.A.foo(1);
+b = new overload_template.B();
+b.foo(1);

--- a/Examples/test-suite/namespace_typemap.i
+++ b/Examples/test-suite/namespace_typemap.i
@@ -124,7 +124,7 @@ namespace test {
   %fragment("SWIG_AsCharPtrAndSize");
 	%typemap(in) string_class * {
 			char *data;
-			SWIG_AsCharPtrAndSize($input, &data, nullptr, nullptr);
+			SWIG_AsCharPtrAndSize($input, &data, NULL, NULL);
 			$1 = new string_class(data);
 			free(data);
 	}

--- a/Examples/test-suite/namespace_typemap.i
+++ b/Examples/test-suite/namespace_typemap.i
@@ -120,6 +120,18 @@ namespace test {
 	    delete $1;
 	}
 #endif
+#ifdef SWIGJAVASCRIPT
+  %fragment("SWIG_AsCharPtrAndSize");
+	%typemap(in) string_class * {
+			char *data;
+			SWIG_AsCharPtrAndSize($input, &data, nullptr, nullptr);
+			$1 = new string_class(data);
+			free(data);
+	}
+	%typemap(freearg) string_class * {
+	    delete $1;
+	}
+#endif
 }
 
 %inline %{


### PR DESCRIPTION
Tests derived from the Python run tests with a few exceptions:
 - JS cannot resolve overloading based on the difference between integer and floating point types - as all numbers are floating point
 - complex numbers have been removed as there is no complex numbers support in the base language
 - the `overload_complicated.i` test has been adjusted to match the JS implementations - as described in #2621 both Python and JS have problems with this test
 - operator overloading uses renaming