### PR TITLE
[JS] Use `CanCastAsInteger` in JSC and V8

### DIFF
--- a/Examples/test-suite/javascript/overload_numeric_runme.js
+++ b/Examples/test-suite/javascript/overload_numeric_runme.js
@@ -1,0 +1,43 @@
+
+var overload_numeric = require("overload_numeric");
+
+nums = new overload_numeric.Nums();
+limits = new overload_numeric.Limits();
+
+function check(got, expected) {
+    if (got != expected) {
+        throw new Error("got: " + got + " expected: " + expected);
+    }
+}
+
+check(nums.over(0), "signed char");
+
+check(nums.over(limits.schar_min()), "signed char");
+check(nums.over(limits.schar_max()), "signed char");
+
+check(nums.over(limits.schar_min() - 1), "short");
+check(nums.over(limits.schar_max() + 1), "short");
+check(nums.over(limits.shrt_min()), "short");
+check(nums.over(limits.shrt_max()), "short");
+
+check(nums.over(limits.shrt_min() - 1), "int");
+check(nums.over(limits.shrt_max() + 1), "int");
+check(nums.over(limits.int_min()), "int");
+check(nums.over(limits.int_max()), "int");
+
+check(nums.over(limits.flt_min()), "float");
+check(nums.over(limits.flt_max()), "float");
+
+check(nums.over(limits.flt_max() * 10), "double");
+check(nums.over(-limits.flt_max() * 10), "double");
+check(nums.over(limits.dbl_max()), "double");
+check(nums.over(-limits.dbl_max()), "double");
+
+check(nums.over(Infinity), "float");
+check(nums.over(-Infinity), "float");
+check(nums.over(NaN), "float");
+
+// Just check if the following are accepted without exceptions being thrown;
+nums.doublebounce(Infinity);
+nums.doublebounce(-Infinity);
+nums.doublebounce(NaN);

--- a/Lib/javascript/jsc/javascriptprimtypes.swg
+++ b/Lib/javascript/jsc/javascriptprimtypes.swg
@@ -46,12 +46,17 @@ SWIG_From_dec(long)(long value)
 }
 
 %fragment(SWIG_AsVal_frag(long),"header",
-          fragment="SWIG_CanCastAsInteger") {
+          fragment="SWIG_CanCastAsInteger",
+          fragment="<limits.h>") {
 SWIGINTERN int
 SWIG_AsVal_dec(long)(JSValueRef obj, long* val)
 {
   if (!JSValueIsNumber(context, obj)) {
     return SWIG_TypeError;
+  }
+  double n = (double) JSValueToNumber(context, obj, NULL);
+  if (!SWIG_CanCastAsInteger(&n, LONG_MIN, LONG_MAX)) {
+    return SWIG_OverflowError;
   }
   if(val) *val = (long) JSValueToNumber(context, obj, NULL);
 
@@ -72,13 +77,18 @@ SWIG_From_dec(unsigned long)(unsigned long value)
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long),"header",
-          fragment="SWIG_CanCastAsInteger") {
+          fragment="SWIG_CanCastAsInteger",
+          fragment="<limits.h>") {
 SWIGINTERN int
 SWIG_AsVal_dec(unsigned long)(JSValueRef obj, unsigned long *val)
 {
   long longVal;
   if(!JSValueIsNumber(context, obj)) {
     return SWIG_TypeError;
+  }
+  double n = (double) JSValueToNumber(context, obj, NULL);
+  if (!SWIG_CanCastAsInteger(&n, ULONG_MIN, ULONG_MAX)) {
+    return SWIG_OverflowError;
   }
 
   longVal = (long) JSValueToNumber(context, obj, NULL);
@@ -119,6 +129,10 @@ SWIG_AsVal_dec(long long)(JSValueRef obj, long long* val)
   if (!JSValueIsNumber(context, obj)) {
     return SWIG_TypeError;
   }
+  double n = (double) JSValueToNumber(context, obj, NULL);
+  if (!SWIG_CanCastAsInteger(&n, LLONG_MIN, LLONG_MAX)) {
+    return SWIG_OverflowError;
+  }
   if(val) *val = (long long) JSValueToNumber(context, obj, NULL);
 
   return SWIG_OK;
@@ -153,6 +167,10 @@ SWIG_AsVal_dec(unsigned long long)(JSValueRef obj, unsigned long long *val)
   long long longVal;
   if(!JSValueIsNumber(context, obj)) {
     return SWIG_TypeError;
+  }
+  double n = (double) JSValueToNumber(context, obj, NULL);
+  if (!SWIG_CanCastAsInteger(&n, ULLONG_MIN, ULLONG_MAX)) {
+    return SWIG_OverflowError;
   }
 
   longVal = (unsigned long long) JSValueToNumber(context, obj, NULL);

--- a/Lib/javascript/v8/javascriptprimtypes.swg
+++ b/Lib/javascript/v8/javascriptprimtypes.swg
@@ -2,6 +2,10 @@
  * Primitive Types
  * ------------------------------------------------------------ */
 
+%fragment("<limits>", "header") {
+  #include <limits>
+}
+
 /* boolean */
 
 %fragment(SWIG_From_frag(bool),"header") {
@@ -37,12 +41,18 @@ SWIGV8_VALUE SWIG_From_dec(int)(int value)
 }
 }
 
-%fragment(SWIG_AsVal_frag(int),"header") {
+%fragment(SWIG_AsVal_frag(int),"header",
+          fragment="SWIG_CanCastAsInteger",
+          fragment="<limits>") {
 SWIGINTERN
 int SWIG_AsVal_dec(int)(SWIGV8_VALUE valRef, int* val)
 {
   if (!valRef->IsNumber()) {
     return SWIG_TypeError;
+  }
+  double n = SWIGV8_NUMBER_VALUE(valRef);
+  if (!SWIG_CanCastAsInteger(&n, std::numeric_limits<int>::min(), std::numeric_limits<int>::max())) {
+    return SWIG_OverflowError;
   }
   if(val) *val = SWIGV8_INTEGER_VALUE(valRef);
 
@@ -61,12 +71,17 @@ SWIGV8_VALUE SWIG_From_dec(long)(long value)
 }
 
 %fragment(SWIG_AsVal_frag(long),"header",
-          fragment="SWIG_CanCastAsInteger") {
+          fragment="SWIG_CanCastAsInteger",
+          fragment="<limits>") {
 SWIGINTERN
 int SWIG_AsVal_dec(long)(SWIGV8_VALUE obj, long* val)
 {
   if (!obj->IsNumber()) {
     return SWIG_TypeError;
+  }
+  double n = SWIGV8_NUMBER_VALUE(obj);
+  if (!SWIG_CanCastAsInteger(&n, std::numeric_limits<long>::min(), std::numeric_limits<long>::max())) {
+    return SWIG_OverflowError;
   }
   if(val) *val = (long) SWIGV8_INTEGER_VALUE(obj);
 
@@ -86,12 +101,17 @@ SWIGV8_VALUE SWIG_From_dec(unsigned long)(unsigned long value)
 }
 
 %fragment(SWIG_AsVal_frag(unsigned long),"header",
-          fragment="SWIG_CanCastAsInteger") {
+          fragment="SWIG_CanCastAsInteger",
+          fragment="<limits>") {
 SWIGINTERN
 int SWIG_AsVal_dec(unsigned long)(SWIGV8_VALUE obj, unsigned long *val)
 {
   if(!obj->IsNumber()) {
     return SWIG_TypeError;
+  }
+  double n = SWIGV8_NUMBER_VALUE(obj);
+  if (!SWIG_CanCastAsInteger(&n, std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max())) {
+    return SWIG_OverflowError;
   }
 
   long longVal = (long) SWIGV8_NUMBER_VALUE(obj);
@@ -124,13 +144,18 @@ SWIGV8_VALUE SWIG_From_dec(long long)(long long value)
 %fragment(SWIG_AsVal_frag(long long),"header",
     fragment=SWIG_AsVal_frag(long),
     fragment="SWIG_CanCastAsInteger",
-    fragment="SWIG_LongLongAvailable") {
+    fragment="SWIG_LongLongAvailable",
+    fragment="<limits>") {
 %#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN
 int SWIG_AsVal_dec(long long)(SWIGV8_VALUE obj, long long* val)
 {
   if (!obj->IsNumber()) {
     return SWIG_TypeError;
+  }
+  double n = SWIGV8_NUMBER_VALUE(obj);
+  if (!SWIG_CanCastAsInteger(&n, std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max())) {
+    return SWIG_OverflowError;
   }
   if(val) *val = (long long) SWIGV8_INTEGER_VALUE(obj);
 
@@ -157,13 +182,18 @@ SWIGV8_VALUE SWIG_From_dec(unsigned long long)(unsigned long long value)
 %fragment(SWIG_AsVal_frag(unsigned long long),"header",
     fragment=SWIG_AsVal_frag(unsigned long),
     fragment="SWIG_CanCastAsInteger",
-    fragment="SWIG_LongLongAvailable") {
+    fragment="SWIG_LongLongAvailable",
+    fragment="<limits>") {
 %#ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN
 int SWIG_AsVal_dec(unsigned long long)(SWIGV8_VALUE obj, unsigned long long *val)
 {
   if(!obj->IsNumber()) {
     return SWIG_TypeError;
+  }
+  double n = SWIGV8_NUMBER_VALUE(obj);
+  if (!SWIG_CanCastAsInteger(&n, std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max())) {
+    return SWIG_OverflowError;
   }
 
   long long longVal = (long long) SWIGV8_NUMBER_VALUE(obj);

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -132,7 +132,7 @@ class OverloadErrorHandler: public V8ErrorHandler {
 public:
   virtual void error(int code, const char *msg) {
     err = v8::Exception::Error(SWIGV8_STRING_NEW(msg));
-    if(code != SWIG_TypeError) {
+    if(code != SWIG_TypeError && code != SWIG_OverflowError) {
         SWIGV8_THROW_EXCEPTION(err);
     }
   }


### PR DESCRIPTION
As everything is a floating point number in JS, use `CanCastAsInteger` to identify integer values.
Additionally, treat an `OverflowError` as a `TypeError` when overloading to allow (some form) of overloading between integers and floating point values.