### PR TITLE
[JS] remove hacks and implement default arguments

### DIFF
--- a/Examples/test-suite/default_args.i
+++ b/Examples/test-suite/default_args.i
@@ -229,7 +229,7 @@ struct Except {
 %}
 
 // Default parameters in static class methods
-#ifdef SWIGPYTHON
+#if defined(SWIGPYTHON) || defined(SWIGJAVASCRIPT)
 %rename(staticMethod) staticmethod;
 #endif
 

--- a/Examples/test-suite/javascript/default_args_c_runme.js
+++ b/Examples/test-suite/javascript/default_args_c_runme.js
@@ -1,0 +1,28 @@
+var default_args_c = require("default_args_c");
+
+if (default_args_c.foo1() != 1) {
+  throw new Error("failed");
+}
+if (default_args_c.foo43() != 43) {
+  throw new Error("failed");
+}
+
+f = new default_args_c.FooStruct();
+f.no_arg();
+f.one_req(null);
+f.one_opt();
+f.one_opt(null);
+f.two_arg(null);
+f.two_arg(null, null);
+
+default_args_c.StaticStruct.no_arg();
+default_args_c.StaticStruct.one_req(null);
+default_args_c.StaticStruct.one_opt();
+default_args_c.StaticStruct.one_opt(null);
+default_args_c.StaticStruct.two_arg(null);
+default_args_c.StaticStruct.two_arg(null, null);
+
+default_args_c.global_opts1();
+default_args_c.global_opts1(null);
+default_args_c.global_opts2(null);
+default_args_c.global_opts2(null, null);

--- a/Examples/test-suite/javascript/default_args_runme.js
+++ b/Examples/test-suite/javascript/default_args_runme.js
@@ -1,0 +1,216 @@
+var default_args = require('default_args');
+ec = new default_args.EnumClass();
+if (!ec.blah()) {
+    throw new Error("EnumClass::blah() default arguments don't work");
+}
+
+de = new default_args.DerivedEnumClass();
+de.accelerate();
+de.accelerate(default_args.EnumClass.SLOW);
+
+if (default_args.Statics.staticMethod() != 60) {
+    throw new Error;
+}
+
+if (default_args.cfunc1(1) != 2) {
+    throw new Error;
+}
+
+if (default_args.cfunc2(1) != 3) {
+    throw new Error;
+}
+
+if (default_args.cfunc3(1) != 4) {
+    throw new Error;
+}
+
+f = new default_args.Foo();
+
+f.newname();
+f.newname(1);
+f.defaulted1();
+f.defaulted2();
+
+if (f.double_if_void_ptr_is_null(2, null) != 4) {
+    throw new Error;
+}
+
+if (f.double_if_void_ptr_is_null(3) != 6) {
+    throw new Error;
+}
+
+if (f.double_if_handle_is_null(4, null) != 8) {
+    throw new Error;
+}
+
+if (f.double_if_handle_is_null(5) != 10) {
+    throw new Error;
+}
+
+if (f.double_if_dbl_ptr_is_null(6, null) != 12) {
+    throw new Error;
+}
+
+if (f.double_if_dbl_ptr_is_null(7) != 14) {
+    throw new Error;
+}
+
+try {
+    f = default_args.Foo(1);
+    error = 1;
+} catch {
+    error = 0;
+}
+if (error) {
+    throw new Error("Foo::Foo ignore is not working");
+}
+
+try {
+    f = default_args.Foo(1, 2);
+    error = 1;
+} catch {
+    error = 0;
+}
+if (error) {
+    throw new Error("Foo::Foo ignore is not working");
+}
+
+try {
+    f = default_args.Foo(1, 2, 3);
+    error = 1;
+} catch {
+    error = 0;
+}
+if (error) {
+    throw new Error("Foo::Foo ignore is not working");
+}
+
+try {
+    m = f.meth(1);
+    error = 1;
+} catch {
+    error = 0;
+}
+if (error) {
+    throw new Error("Foo::meth ignore is not working");
+}
+
+try {
+    m = f.meth(1, 2);
+    error = 1;
+} catch {
+    error = 0;
+}
+if (error) {
+    throw new Error("Foo::meth ignore is not working");
+}
+
+try {
+    m = f.meth(1, 2, 3);
+    error = 1;
+} catch {
+    error = 0;
+}
+if (error) {
+    throw new Error("Foo::meth ignore is not working");
+}
+
+Klass_inc = default_args.Klass.inc;
+
+if (Klass_inc(100, new default_args.Klass(22)).val != 122) {
+    throw new Error("Klass::inc failed");
+}
+
+if (Klass_inc(100).val != 99) {
+    throw new Error("Klass::inc failed");
+}
+
+if (Klass_inc().val != 0) {
+    throw new Error("Klass::inc failed");
+}
+
+tricky = new default_args.TrickyInPython();
+if (tricky.value_m1(10) != -1) {
+    throw new Error("trickyvalue_m1 failed");
+}
+if (tricky.value_m1(10, 10) != 10) {
+    throw new Error("trickyvalue_m1 failed");
+}
+if (tricky.value_0xabcdef(10) != 0xabcdef) {
+    throw new Error("trickyvalue_0xabcdef failed");
+}
+if (tricky.value_0644(10) != 420) {
+    throw new Error("trickyvalue_0644 failed");
+}
+if (tricky.value_perm(10) != 420) {
+    throw new Error("trickyvalue_perm failed");
+}
+if (tricky.value_m01(10) != -1) {
+    throw new Error("trickyvalue_m01 failed");
+}
+if (!tricky.booltest2()) {
+    throw new Error("booltest2 failed");
+}
+
+if (tricky.max_32bit_int1() != 0x7FFFFFFF) {
+    throw new Error("max_32bit_int1 failed");
+}
+if (tricky.min_32bit_int1() != -2147483648) {
+    throw new Error("min_32bit_int1 failed");
+}
+if (tricky.max_32bit_int2() != 0x7FFFFFFF) {
+    throw new Error("max_32bit_int2 failed");
+}
+
+tricky.too_big_32bit_int1();
+tricky.too_small_32bit_int1();
+tricky.too_big_32bit_int2();
+tricky.too_small_32bit_int2();
+
+default_args.seek();
+default_args.seek(10);
+
+if (!default_args.booltest()) {
+    throw new Error("booltest failed");
+}
+
+if (default_args.slightly_off_square(10) != 102) {
+    throw new Error;
+}
+
+if (default_args.slightly_off_square() != 291) {
+    throw new Error;
+}
+
+if ((new default_args.CDA()).cdefaultargs_test1() != 1) {
+    throw new Error;
+}
+
+if ((new default_args.CDA()).cdefaultargs_test2() != 1) {
+    throw new Error;
+}
+
+if (default_args.chartest1() != "x") {
+    throw new Error;
+}
+
+// JavaScriptCore cannot accept a '\0' string
+if (default_args.chartest2() != "\0" && default_args.chartest2() != '') {
+    throw new Error;
+}
+
+if (default_args.chartest3() != "\1") {
+    throw new Error;
+}
+
+if (default_args.chartest4() != "\n") {
+    throw new Error;
+}
+
+if (default_args.chartest5() != "B") {
+    throw new Error;
+}
+
+if (default_args.chartest6() != "C") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/overload_extend2_runme.js
+++ b/Examples/test-suite/javascript/overload_extend2_runme.js
@@ -1,0 +1,29 @@
+var overload_extend2 = require("overload_extend2");
+
+f = new overload_extend2.Foo();
+if (f.test(3) != 1) {
+    throw new Error;
+}
+if (f.test("hello") != 2) {
+    throw new Error;
+}
+if (f.test(3.5, 2.5) != 3) {
+    throw new Error;
+}
+if (f.test("hello", 20) != 1020) {
+    throw new Error;
+}
+if (f.test("hello", 20, 100) != 120) {
+    throw new Error;
+}
+
+// C default args
+if (f.test(f) != 30) {
+    throw new Error;
+}
+if (f.test(f, 100) != 120) {
+    throw new Error;
+}
+if (f.test(f, 100, 200) != 300) {
+    throw new Error;
+}

--- a/Lib/javascript/jsc/cmalloc.i
+++ b/Lib/javascript/jsc/cmalloc.i
@@ -1,0 +1,1 @@
+%include <typemaps/cmalloc.swg>

--- a/Lib/javascript/jsc/javascriptcode.swg
+++ b/Lib/javascript/jsc/javascriptcode.swg
@@ -4,6 +4,7 @@
  *   - $jslocals:         locals part of wrapper
  *   - $jscode:           code part of wrapper
  *   - $jsargcount:       number of arguments
+ *   - $jsargrequired:    required number of arguments
  *   - $jsmangledtype:    mangled type of class
  * ----------------------------------------------------------------------------- */
 %fragment ("js_ctor", "templates")
@@ -11,7 +12,7 @@
 static JSObjectRef $jswrapper(JSContextRef context, JSObjectRef thisObject, size_t argc, const JSValueRef argv[], JSValueRef* exception)
 {
     $jslocals
-    if(argc != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
+    if (argc < $jsargrequired || argc > $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
 
     $jscode
     return SWIG_JSC_NewPointerObj(context, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
@@ -67,6 +68,7 @@ static JSObjectRef $jswrapper(JSContextRef context, JSObjectRef ctorObject,
  *   - $jslocals:         locals part of wrapper
  *   - $jscode:           code part of wrapper
  *   - $jsargcount:       number of arguments
+ *   - $jsargrequired:    required number of arguments
  *   - $jsmangledtype:    mangled type of class
  * ----------------------------------------------------------------------------- */
 %fragment ("js_overloaded_ctor", "templates")
@@ -86,13 +88,14 @@ static JSObjectRef $jswrapper(JSContextRef context, JSObjectRef thisObject, size
 /* -----------------------------------------------------------------------------
  * js_ctor_dispatch_case:  template for a dispatch case for calling an overloaded ctor.
  *   - $jsargcount:       number of arguments of called ctor
+ *   - $jsargrequired:    required number of arguments
  *   - $jswrapper:        wrapper of called ctor
  *
  *  Note: a try-catch-like mechanism is used to switch cases
  * ----------------------------------------------------------------------------- */
 %fragment ("js_ctor_dispatch_case", "templates")
 %{
-  if(argc == $jsargcount) {
+  if(argc >= $jsargrequired && argc <= $jsargcount) {
     thisObject = $jswrapper(context, NULL, argc, argv, exception);
     if(thisObject != NULL) { *exception=0; return thisObject; } /* reset exception and return */
   }
@@ -187,9 +190,11 @@ static bool $jswrapper(JSContextRef context, JSObjectRef thisObject, JSStringRef
 
 /* -----------------------------------------------------------------------------
  * js_function:  template for function wrappers
- *   - $jswrapper:  wrapper function name
- *   - $jslocals:   locals part of wrapper
- *   - $jscode:     code part of wrapper
+ *   - $jswrapper:     wrapper function name
+ *   - $jslocals:      locals part of wrapper
+ *   - $jsargcount:    number of arguments
+ *   - $jsargrequired: required number of arguments
+ *   - $jscode:        code part of wrapper
  * ----------------------------------------------------------------------------- */
 %fragment ("js_function", "templates")
 %{
@@ -198,7 +203,7 @@ static JSValueRef $jswrapper(JSContextRef context, JSObjectRef function, JSObjec
   $jslocals
   JSValueRef jsresult;
 
-  if(argc != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
+  if (argc < $jsargrequired || argc > $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
 
   $jscode
   return jsresult;
@@ -236,9 +241,11 @@ static JSValueRef $jswrapper(JSContextRef context, JSObjectRef function, JSObjec
 
 /* -----------------------------------------------------------------------------
  * js_overloaded_function:  template for a overloaded function
- *   - $jswrapper:  wrapper function name
- *   - $jslocals:   locals part of wrapper
- *   - $jscode:     code part of wrapper
+ *   - $jswrapper:     wrapper function name
+ *   - $jslocals:      locals part of wrapper
+ *   - $jsargcount:    required number of arguments
+ *   - $jsargrequired: required number of arguments
+ *   - $jscode:        code part of wrapper
  * ----------------------------------------------------------------------------- */
 %fragment ("js_overloaded_function", "templates")
 %{
@@ -247,7 +254,7 @@ static int $jswrapper(JSContextRef context, JSObjectRef function, JSObjectRef th
   $jslocals
   JSValueRef jsresult;
 
-  if(argc != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
+  if (argc < $jsargrequired || argc > $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
 
   $jscode
   *p_result = jsresult;
@@ -261,17 +268,25 @@ static int $jswrapper(JSContextRef context, JSObjectRef function, JSObjectRef th
 
 /* -----------------------------------------------------------------------------
  * js_function_dispatch_case:  template for a case used in the function dispatcher
- *   - $jswrapper:  wrapper function name
- *   - $jsargcount: number of arguments of overloaded function
- *   - $jscode:     code part of wrapper
+ *   - $jswrapper:     wrapper function name
+ *   - $jsargcount:    number of arguments of overloaded function
+ *   - $jsargrequired: required number of arguments
+ *   - $jscode:        code part of wrapper
  * ----------------------------------------------------------------------------- */
 %fragment ("js_function_dispatch_case", "templates")
 %{
-  if(argc == $jsargcount) {
+  if(argc >= $jsargrequired && argc <= $jsargcount) {
      res = $jswrapper(context, function, thisObject, argc, argv, exception, &jsresult);
      if(res == SWIG_OK) { *exception = 0; return jsresult; }
   }
 %}
+
+/* -----------------------------------------------------------------------------
+ * js_check_arg:  template for checking if an argument exists
+ *   - $jsarg: number of argument
+ * ----------------------------------------------------------------------------- */
+%fragment ("js_check_arg", "templates")
+%{if(argc > $jsarg)%}
 
 /* -----------------------------------------------------------------------------
  * jsc_variable_declaration:  template for a variable table entry

--- a/Lib/javascript/v8/cmalloc.i
+++ b/Lib/javascript/v8/cmalloc.i
@@ -1,0 +1,1 @@
+%include <typemaps/cmalloc.swg>

--- a/Lib/javascript/v8/javascriptcode.swg
+++ b/Lib/javascript/v8/javascriptcode.swg
@@ -4,6 +4,7 @@
  *   - $jslocals:         locals part of wrapper
  *   - $jscode:           code part of wrapper
  *   - $jsargcount:       number of arguments
+ *   - $jsargrequired:    required number of arguments
  *   - $jsmangledtype:    mangled type of class
  * ----------------------------------------------------------------------------- */
 
@@ -14,7 +15,7 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   SWIGV8_OBJECT self = args.Holder();
   $jslocals
   if(self->InternalFieldCount() < 1) SWIG_exception_fail(SWIG_ERROR, "Illegal call of constructor $jswrapper.");
-  if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
+  if(args.Length() < $jsargrequired || args.Length() > $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
   $jscode
 
   SWIGV8_SetPrivateData(self, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
@@ -73,6 +74,7 @@ fail:
  *   - $jslocals:         locals part of wrapper
  *   - $jscode:           code part of wrapper
  *   - $jsargcount:       number of arguments
+ *   - $jsargrequired:    required number of arguments
  *   - $jsmangledtype:    mangled type of class
  * ----------------------------------------------------------------------------- */
 %fragment("js_overloaded_ctor", "templates") %{
@@ -82,7 +84,7 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args, V8ErrorHandler 
   SWIGV8_OBJECT self = args.Holder();
   $jslocals
   if(self->InternalFieldCount() < 1) SWIG_exception_fail(SWIG_ERROR, "Illegal call of constructor $jswrapper.");
-  if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
+  if(args.Length() < $jsargrequired || args.Length() > $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
   $jscode
 
   SWIGV8_SetPrivateData(self, result, SWIGTYPE_$jsmangledtype, SWIG_POINTER_OWN);
@@ -97,13 +99,14 @@ fail:
 /* -----------------------------------------------------------------------------
  * js_ctor_dispatch_case:  template for a dispatch case for calling an overloaded ctor.
  *   - $jsargcount:       number of arguments of called ctor
+ *   - $jsargrequired:    required number of arguments
  *   - $jswrapper:        wrapper of called ctor
  *
  *  Note: a try-catch-like mechanism is used to switch cases
  * ----------------------------------------------------------------------------- */
 %fragment ("js_ctor_dispatch_case", "templates")
 %{
-  if(args.Length() == $jsargcount) {
+  if(args.Length() >= $jsargrequired && args.Length() <= $jsargcount) {
     errorHandler.err.Clear();
     $jswrapper(args, errorHandler);
     if(errorHandler.err.IsEmpty()) {
@@ -195,9 +198,11 @@ fail:
 
 /* -----------------------------------------------------------------------------
  * js_function:  template for function wrappers
- *   - $jswrapper:  wrapper function name
- *   - $jslocals:   locals part of wrapper
- *   - $jscode:     code part of wrapper
+ *   - $jswrapper:        wrapper function name
+ *   - $jslocals:         locals part of wrapper
+ *   - $jscode:           code part of wrapper
+ *   - $jsargcount:       number of arguments
+ *   - $jsargrequired:    required number of arguments
  * ----------------------------------------------------------------------------- */
 %fragment("js_function", "templates")
 %{
@@ -206,7 +211,7 @@ static SwigV8ReturnValue $jswrapper(const SwigV8Arguments &args) {
   
   SWIGV8_VALUE jsresult;
   $jslocals
-  if(args.Length() != $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
+  if (args.Length() < $jsargrequired || args.Length() > $jsargcount) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for $jswrapper.");
 
   $jscode
   SWIGV8_RETURN(jsresult);
@@ -266,14 +271,15 @@ fail:
 
 /* -----------------------------------------------------------------------------
  * js_function_dispatch_case:  template for a case used in the function dispatcher
- *   - $jswrapper:  wrapper function name
- *   - $jsargcount: number of arguments of overloaded function
- *   - $jscode:     code part of wrapper
+ *   - $jswrapper:     wrapper function name
+ *   - $jsargcount:    number of arguments of overloaded function
+ *   - $jsargrequired: required number of arguments
+ *   - $jscode:        code part of wrapper
  * ----------------------------------------------------------------------------- */
 %fragment ("js_function_dispatch_case", "templates")
 %{
 
-  if(args.Length() == $jsargcount) {
+  if(args.Length() >= $jsargrequired && args.Length() <= $jsargcount) {
     errorHandler.err.Clear();
     $jswrapper(args, errorHandler);
     if(errorHandler.err.IsEmpty()) {
@@ -281,6 +287,13 @@ fail:
     }
   }
 %}
+
+/* -----------------------------------------------------------------------------
+ * js_check_arg:  template for checking if an argument exists
+ *   - $jsarg: number of argument
+ * ----------------------------------------------------------------------------- */
+%fragment ("js_check_arg", "templates")
+%{if(args.Length() > $jsarg)%}
 
 /* -----------------------------------------------------------------------------
  * jsv8_declare_class_template:  template for a class template declaration.


### PR DESCRIPTION
This removes a problematic hack from JSC/V8 and adds a proper implementation of default arguments in JavaScript compatible with the Python tests

Resolves #2622 