### PR TITLE
add the last bulk batch of Python tests to JS

### DIFF
--- a/Examples/test-suite/javascript/template_class_reuse_name_runme.js
+++ b/Examples/test-suite/javascript/template_class_reuse_name_runme.js
@@ -1,0 +1,42 @@
+var template_class_reuse_name = require("template_class_reuse_name");
+
+new template_class_reuse_name.Bool1().tt()
+new template_class_reuse_name.Bool1False().ff()
+
+new template_class_reuse_name.Bool2().tt()
+new template_class_reuse_name.Bool2False().ff()
+
+new template_class_reuse_name.Bool3().tt()
+new template_class_reuse_name.Bool3False().ff()
+
+new template_class_reuse_name.Bool4().tt()
+new template_class_reuse_name.Bool4False().ff()
+
+
+new template_class_reuse_name.BoolForward1().tt()
+new template_class_reuse_name.BoolForward1False().ff()
+
+new template_class_reuse_name.BoolForward2().tt()
+new template_class_reuse_name.BoolForward2False().ff()
+
+new template_class_reuse_name.BoolForward3().tt()
+new template_class_reuse_name.BoolForward3False().ff()
+
+new template_class_reuse_name.BoolForward4().tt()
+new template_class_reuse_name.BoolForward4False().ff()
+
+
+new template_class_reuse_name.IntBool1().tt()
+new template_class_reuse_name.IntBool1False().ff()
+
+new template_class_reuse_name.IntBool2().tt()
+new template_class_reuse_name.IntBool2False().ff()
+
+new template_class_reuse_name.IntBool3().tt()
+new template_class_reuse_name.IntBool3False().ff()
+
+new template_class_reuse_name.IntBool4().tt()
+new template_class_reuse_name.IntBool4False().ff()
+
+new template_class_reuse_name.Duplicate2_0().n()
+new template_class_reuse_name.Duplicate3().n()

--- a/Examples/test-suite/javascript/template_classes_runme.js
+++ b/Examples/test-suite/javascript/template_classes_runme.js
@@ -1,0 +1,52 @@
+var template_classes = require("template_classes");
+
+// This test is just testing incorrect number of arguments/parameters checking
+
+point = new template_classes.PointInt();
+
+rectangle = new template_classes.RectangleInt();
+rectangle.setPoint(point);
+rectangle.getPoint();
+template_classes.RectangleInt.static_noargs();
+template_classes.RectangleInt.static_onearg(1);
+
+fail = true;
+try {
+    rectangle.setPoint();
+} catch {
+    fail = false;
+}
+if (fail) {
+    throw new Error("argument count check failed");
+}
+
+
+fail = true;
+try {
+    rectangle.getPoint(0);
+} catch {
+    fail = false;
+}
+if (fail) {
+    throw new Error("argument count check failed");
+}
+
+fail = true;
+try {
+    RectangleInt.static_noargs(0);
+} catch {
+    fail = false;
+}
+if (fail) {
+    throw new Error("argument count check failed");
+}
+
+fail = true;
+try {
+    RectangleInt.static_onearg();
+} catch {
+    fail = false;
+}
+if (fail) {
+    throw new Error("argument count check failed");
+}

--- a/Examples/test-suite/javascript/template_construct_runme.js
+++ b/Examples/test-suite/javascript/template_construct_runme.js
@@ -1,0 +1,3 @@
+var template_construct = require("template_construct")
+
+f = new template_construct.Foo_int(2);

--- a/Examples/test-suite/javascript/template_default_arg_overloaded_extend_runme.js
+++ b/Examples/test-suite/javascript/template_default_arg_overloaded_extend_runme.js
@@ -1,0 +1,22 @@
+var template_default_arg_overloaded_extend = require("template_default_arg_overloaded_extend");
+
+function check(flag) {
+  if (!flag) {
+    throw new Error("failed");
+  }
+}
+
+rs = new template_default_arg_overloaded_extend.ResultSet();
+
+check(rs.go_get_method(0, new template_default_arg_overloaded_extend.SearchPoint()) == -1);
+check(rs.go_get_method(0, new template_default_arg_overloaded_extend.SearchPoint(), 100) == 100);
+
+check(rs.go_get_template(0, new template_default_arg_overloaded_extend.SearchPoint()) == -2);
+check(rs.go_get_template(0, new template_default_arg_overloaded_extend.SearchPoint(), 100) == 100);
+
+check(rs.over() == "over(int)");
+check(rs.over(10) == "over(int)");
+check(rs.over(new template_default_arg_overloaded_extend.SearchPoint()) == "over(giai2::SearchPoint, int)");
+check(rs.over(new template_default_arg_overloaded_extend.SearchPoint(), 10) == "over(giai2::SearchPoint, int)");
+check(rs.over(true, new template_default_arg_overloaded_extend.SearchPoint()) == "over(bool, gaia2::SearchPoint, int)");
+check(rs.over(true, new template_default_arg_overloaded_extend.SearchPoint(), 10) == "over(bool, gaia2::SearchPoint, int)");

--- a/Examples/test-suite/javascript/template_default_arg_overloaded_runme.js
+++ b/Examples/test-suite/javascript/template_default_arg_overloaded_runme.js
@@ -1,0 +1,49 @@
+var template_default_arg_overloaded = require("template_default_arg_overloaded");
+
+function check(expected, got) {
+  if (expected != got) {
+    throw new Error("Expected: " + str(expected) + " got: " + str(got));
+  }
+}
+
+
+pl = new template_default_arg_overloaded.PropertyList();
+check(1, pl.setInt("int", 10));
+check(1, pl.setInt("int", 10, false));
+
+check(2, pl.set("int", pl));
+check(2, pl.set("int", pl, false));
+
+check(3, pl.setInt("int", 10, "int"));
+check(3, pl.setInt("int", 10, "int", false));
+
+
+pl = new template_default_arg_overloaded.PropertyListGlobal();
+check(1, pl.setIntGlobal("int", 10));
+check(1, pl.setIntGlobal("int", 10, false));
+
+check(2, pl.set("int", pl));
+check(2, pl.set("int", pl, false));
+
+check(3, pl.setIntGlobal("int", 10, "int"));
+check(3, pl.setIntGlobal("int", 10, "int", false));
+
+
+check(1, template_default_arg_overloaded.GoopIntGlobal(10));
+check(1, template_default_arg_overloaded.GoopIntGlobal(10, true));
+
+check(2, template_default_arg_overloaded.goopGlobal(3));
+check(2, template_default_arg_overloaded.goopGlobal());
+
+check(3, template_default_arg_overloaded.GoopIntGlobal("int", false));
+check(3, template_default_arg_overloaded.GoopIntGlobal("int"));
+
+
+check(1, template_default_arg_overloaded.GoopInt(10));
+check(1, template_default_arg_overloaded.GoopInt(10, true));
+
+check(2, template_default_arg_overloaded.goop(3));
+check(2, template_default_arg_overloaded.goop());
+
+check(3, template_default_arg_overloaded.GoopInt("int", false));
+check(3, template_default_arg_overloaded.GoopInt("int"));

--- a/Examples/test-suite/javascript/template_default_arg_runme.js
+++ b/Examples/test-suite/javascript/template_default_arg_runme.js
@@ -1,0 +1,112 @@
+var template_default_arg = require("template_default_arg");
+
+
+helloInt = new template_default_arg.Hello_int();
+helloInt.foo(template_default_arg.Hello_int.hi);
+
+
+x = new template_default_arg.X_int();
+if ((x.meth(20, 200) != 200)) {
+    throw new Error(("X_int test 1 failed"));
+}
+if ((x.meth(20) != 0)) {
+    throw new Error(("X_int test 2 failed"));
+}
+if ((x.meth() != 0)) {
+    throw new Error(("X_int test 3 failed"));
+}
+
+
+y = new template_default_arg.Y_unsigned();
+if ((y.meth(20.0, 200) != 200)) {
+    throw new Error(("Y_unsigned test 1 failed"));
+}
+if ((y.meth(20) != 0)) {
+    throw new Error(("Y_unsigned test 2 failed"));
+}
+if ((y.meth() != 0)) {
+    throw new Error(("Y_unsigned test 3 failed"));
+}
+
+
+x = new template_default_arg.X_longlong();
+x = new template_default_arg.X_longlong(20.0);
+x = new template_default_arg.X_longlong(20.0, 200);
+
+
+x = new template_default_arg.X_int();
+x = new template_default_arg.X_int(20.0);
+x = new template_default_arg.X_int(20.0, 200);
+
+
+x = new template_default_arg.X_hello_unsigned();
+x = new template_default_arg.X_hello_unsigned(20.0);
+x = new template_default_arg.X_hello_unsigned(
+    20.0, new template_default_arg.Hello_int());
+
+
+y = new template_default_arg.Y_hello_unsigned();
+y.meth(20.0, new template_default_arg.Hello_int());
+y.meth(new template_default_arg.Hello_int());
+y.meth();
+
+
+fz = new template_default_arg.Foo_Z_8();
+x = new template_default_arg.X_Foo_Z_8();
+fzc = x.meth(fz);
+
+
+// Templated functions
+
+// plain function: int ott(Foo<int>)
+if ((template_default_arg.ott(new template_default_arg.Foo_int()) != 30)) {
+    throw new Error(("ott test 1 failed"));
+}
+
+// %template(ott) ott<int, int>
+if ((template_default_arg.ott() != 10)) {
+    throw new Error(("ott test 2 failed"));
+}
+if ((template_default_arg.ott(1) != 10)) {
+    throw new Error(("ott test 3 failed"));
+}
+if ((template_default_arg.ott(1, 1) != 10)) {
+    throw new Error(("ott test 4 failed"));
+}
+
+if ((template_default_arg.ott("hi") != 20)) {
+    throw new Error(("ott test 5 failed"));
+}
+if ((template_default_arg.ott("hi", 1) != 20)) {
+    throw new Error(("ott test 6 failed"));
+}
+if ((template_default_arg.ott("hi", 1, 1) != 20)) {
+    throw new Error(("ott test 7 failed"));
+}
+
+// %template(ott) ott<const char *>
+if ((template_default_arg.ottstring(new template_default_arg.Hello_int(), "hi") != 40)) {
+    throw new Error(("ott test 8 failed"));
+}
+
+if ((template_default_arg.ottstring(new template_default_arg.Hello_int()) != 40)) {
+    throw new Error(("ott test 9 failed"));
+}
+
+// %template(ott) ott<int>
+if ((template_default_arg.ottint(new template_default_arg.Hello_int(), 1) != 50)) {
+    throw new Error(("ott test 10 failed"));
+}
+
+if ((template_default_arg.ottint(new template_default_arg.Hello_int()) != 50)) {
+    throw new Error(("ott test 11 failed"));
+}
+
+// %template(ott) ott<double>
+if ((template_default_arg.ott(new template_default_arg.Hello_int(), 1.0) != 60)) {
+    throw new Error(("ott test 12 failed"));
+}
+
+if ((template_default_arg.ott(new template_default_arg.Hello_int()) != 60)) {
+    throw new Error(("ott test 13 failed"));
+}

--- a/Examples/test-suite/javascript/template_default_cache_runme.js
+++ b/Examples/test-suite/javascript/template_default_cache_runme.js
@@ -1,0 +1,11 @@
+var template_default_cache = require("template_default_cache");
+
+ap = template_default_cache.get_mp_a();
+bp = template_default_cache.get_mp_b();
+
+if (!ap instanceof template_default_cache.AModelPtr) {
+    throw new Error("get_mp_a fail");
+}
+if (!bp instanceof template_default_cache.BModelPtr) {
+    throw new Error("get_mp_b fail");
+}

--- a/Examples/test-suite/javascript/template_extend1_runme.js
+++ b/Examples/test-suite/javascript/template_extend1_runme.js
@@ -1,0 +1,12 @@
+var template_extend1 = require("template_extend1");
+
+a = new template_extend1.lBaz();
+b = new template_extend1.dBaz();
+
+if (a.foo() != "lBaz::foo") {
+    throw new Error;
+}
+
+if (b.foo() != "dBaz::foo") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_extend2_runme.js
+++ b/Examples/test-suite/javascript/template_extend2_runme.js
@@ -1,0 +1,12 @@
+var template_extend2 = require("template_extend2");
+
+a = new template_extend2.lBaz();
+b = new template_extend2.dBaz();
+
+if (a.foo() != "lBaz::foo") {
+    throw new Error;
+}
+
+if (b.foo() != "dBaz::foo") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_inherit_runme.js
+++ b/Examples/test-suite/javascript/template_inherit_runme.js
@@ -1,0 +1,67 @@
+var template_inherit = require("template_inherit");
+a = new template_inherit.FooInt();
+b = new template_inherit.FooDouble();
+c = new template_inherit.BarInt();
+d = new template_inherit.BarDouble();
+e = new template_inherit.FooUInt();
+f = new template_inherit.BarUInt();
+
+if (a.blah() != "Foo") {
+    throw new Error;
+}
+
+if (b.blah() != "Foo") {
+    throw new Error;
+}
+
+if (e.blah() != "Foo") {
+    throw new Error;
+}
+
+if (c.blah() != "Bar") {
+    throw new Error;
+}
+
+if (d.blah() != "Bar") {
+    throw new Error;
+}
+
+if (f.blah() != "Bar") {
+    throw new Error;
+}
+
+if (c.foomethod() != "foomethod") {
+    throw new Error;
+}
+
+if (d.foomethod() != "foomethod") {
+    throw new Error;
+}
+
+if (f.foomethod() != "foomethod") {
+    throw new Error;
+}
+
+if (template_inherit.invoke_blah_int(a) != "Foo") {
+    throw new Error;
+}
+
+if (template_inherit.invoke_blah_int(c) != "Bar") {
+    throw new Error;
+}
+
+if (template_inherit.invoke_blah_double(b) != "Foo") {
+    throw new Error;
+}
+
+if (template_inherit.invoke_blah_double(d) != "Bar") {
+    throw new Error;
+}
+
+if (template_inherit.invoke_blah_uint(e) != "Foo") {
+    throw new Error;
+}
+
+if (template_inherit.invoke_blah_uint(f) != "Bar") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_ns4_runme.js
+++ b/Examples/test-suite/javascript/template_ns4_runme.js
@@ -1,0 +1,6 @@
+var template_ns4 = require("template_ns4");
+
+d = template_ns4.make_Class_DD();
+if (d.test() != "test") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_ns_runme.js
+++ b/Examples/test-suite/javascript/template_ns_runme.js
@@ -1,0 +1,21 @@
+var template_ns = require("template_ns");
+p1 = new template_ns.pairii(2, 3);
+p2 = new template_ns.pairii(p1);
+
+if (p2.first != 2) {
+    throw new Error;
+}
+if (p2.second != 3) {
+    throw new Error;
+}
+
+p3 = new template_ns.pairdd(3.5, 2.5);
+p4 = new template_ns.pairdd(p3);
+
+if (p4.first != 3.5) {
+    throw new Error;
+}
+
+if (p4.second != 2.5) {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_opaque_runme.js
+++ b/Examples/test-suite/javascript/template_opaque_runme.js
@@ -1,0 +1,5 @@
+var template_opaque = require("template_opaque");
+
+v = new template_opaque.OpaqueVectorType(10);
+
+template_opaque.FillVector(v);

--- a/Examples/test-suite/javascript/template_ref_type_runme.js
+++ b/Examples/test-suite/javascript/template_ref_type_runme.js
@@ -1,0 +1,5 @@
+var template_ref_type = require("template_ref_type");
+
+xr = new template_ref_type.XC();
+y = new template_ref_type.Y();
+y.find(xr);

--- a/Examples/test-suite/javascript/template_rename_runme.js
+++ b/Examples/test-suite/javascript/template_rename_runme.js
@@ -1,0 +1,12 @@
+var template_rename = require("template_rename");
+
+i = new template_rename.iFoo();
+d = new template_rename.dFoo();
+
+a = i.blah_test(4);
+b = i.spam_test(5);
+c = i.groki_test(6);
+
+x = d.blah_test(7);
+y = d.spam(8);
+z = d.grok_test(9);

--- a/Examples/test-suite/javascript/template_tbase_template_runme.js
+++ b/Examples/test-suite/javascript/template_tbase_template_runme.js
@@ -1,0 +1,6 @@
+var template_tbase_template = require("template_tbase_template");
+
+a = template_tbase_template.make_Class_dd();
+if (a.test() != "test") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_template_parameters_runme.js
+++ b/Examples/test-suite/javascript/template_template_parameters_runme.js
@@ -28,7 +28,7 @@ if (intContainer1.x != 91) {
 if (intTestStruct.x.x != 91) {
   throw new Error("Failed");
 }
-intTestStructReturned = new template_template_parameters.TestStructContainer1Method(intTestStruct);
+intTestStructReturned = template_template_parameters.TestStructContainer1Method(intTestStruct);
 if (intTestStructReturned.x.x != 101) {
   throw new Error("Failed");
 }

--- a/Examples/test-suite/javascript/template_template_parameters_runme.js
+++ b/Examples/test-suite/javascript/template_template_parameters_runme.js
@@ -1,0 +1,38 @@
+var template_template_parameters = require("template_template_parameters");
+
+// Test part 1
+listBool = new template_template_parameters.ListFastBool();
+listBool.item = true;
+x_boolean = listBool.allotype;
+if (listBool.item != true) {
+  throw new Error("Failed");
+}
+
+listDouble = new template_template_parameters.ListDefaultDouble();
+listDouble.item = 10.2;
+x_double = listDouble.allotype;
+if (listDouble.item != 10.2) {
+  throw new Error("Failed");
+}
+
+// Test part 2
+floatTestStruct = new template_template_parameters.FloatTestStruct();
+floatContainer2 = floatTestStruct.x;
+floatContainer2.x = 8.1;
+intTestStruct = new template_template_parameters.IntTestStruct();
+intContainer1 = intTestStruct.x;
+intContainer1.x = 91;
+if (intContainer1.x != 91) {
+  throw new Error("Failed");
+}
+if (intTestStruct.x.x != 91) {
+  throw new Error("Failed");
+}
+intTestStructReturned = new template_template_parameters.TestStructContainer1Method(intTestStruct);
+if (intTestStructReturned.x.x != 101) {
+  throw new Error("Failed");
+}
+
+// Test part 3
+mfi99 = new template_template_parameters.MyFootInt99();
+mfi99.addTo(mfi99); // __iadd__

--- a/Examples/test-suite/javascript/template_type_namespace_runme.js
+++ b/Examples/test-suite/javascript/template_type_namespace_runme.js
@@ -1,0 +1,5 @@
+var template_type_namespace = require("template_type_namespace");
+
+if (template_type_namespace.foo().get(0) != "foo") {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/template_typedef_cplx2_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx2_runme.js
@@ -1,0 +1,21 @@
+var template_typedef_cplx2 = require("template_typedef_cplx2");
+
+//
+// double case
+//
+
+var d, e;
+
+try {
+    d = template_typedef_cplx2.make_Identity_double();
+    if (!d.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+} catch {
+    throw new Error(`${d} is not an ArithUnaryFunction`);
+}
+
+try {
+    e = template_typedef_cplx2.make_Multiplies_double_double_double_double(d, d);
+    if (!e.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+} catch {
+    throw new Error(`${e} is not an ArithUnaryFunction`);
+}

--- a/Examples/test-suite/javascript/template_typedef_cplx2_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx2_runme.js
@@ -8,14 +8,17 @@ var d, e;
 
 try {
     d = template_typedef_cplx2.make_Identity_double();
-    if (!d.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+    // This test is not possible in JSC where all SWIG proxies inherit from Object
+    if (typeof print === 'undefined')
+        if (!d.constructor.name.includes('ArithUnaryFunction')) throw new Error;
 } catch {
     throw new Error(`${d} is not an ArithUnaryFunction`);
 }
 
 try {
     e = template_typedef_cplx2.make_Multiplies_double_double_double_double(d, d);
-    if (!e.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+    if (typeof print === 'undefined')
+        if (!e.constructor.name.includes('ArithUnaryFunction')) throw new Error;
 } catch {
     throw new Error(`${e} is not an ArithUnaryFunction`);
 }

--- a/Examples/test-suite/javascript/template_typedef_cplx3_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx3_runme.js
@@ -1,0 +1,19 @@
+var template_typedef_cplx3 = require("template_typedef_cplx3");
+
+//
+// this is OK
+//
+
+
+s = new template_typedef_cplx3.Sin();
+s.get_base_value();
+s.get_value();
+s.get_arith_value();
+template_typedef_cplx3.my_func_r(s);
+template_typedef_cplx3.make_Multiplies_double_double_double_double(s, s);
+
+//
+// Here we fail
+//
+d = new template_typedef_cplx3.make_Identity_double();
+template_typedef_cplx3.my_func_r(d);

--- a/Examples/test-suite/javascript/template_typedef_cplx3_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx3_runme.js
@@ -15,5 +15,5 @@ template_typedef_cplx3.make_Multiplies_double_double_double_double(s, s);
 //
 // Here we fail
 //
-d = new template_typedef_cplx3.make_Identity_double();
+d = template_typedef_cplx3.make_Identity_double();
 template_typedef_cplx3.my_func_r(d);

--- a/Examples/test-suite/javascript/template_typedef_cplx4_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx4_runme.js
@@ -1,0 +1,19 @@
+var template_typedef_cplx4 = require("template_typedef_cplx4");
+
+//
+// this is OK
+//
+
+
+s = new template_typedef_cplx4.Sin();
+s.get_base_value();
+s.get_value();
+s.get_arith_value();
+template_typedef_cplx4.my_func_r(s);
+template_typedef_cplx4.make_Multiplies_double_double_double_double(s, s);
+
+//
+// Here we fail
+//
+d = new template_typedef_cplx4.make_Identity_double();
+template_typedef_cplx4.my_func_r(d);

--- a/Examples/test-suite/javascript/template_typedef_cplx4_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx4_runme.js
@@ -15,5 +15,5 @@ template_typedef_cplx4.make_Multiplies_double_double_double_double(s, s);
 //
 // Here we fail
 //
-d = new template_typedef_cplx4.make_Identity_double();
+d = template_typedef_cplx4.make_Identity_double();
 template_typedef_cplx4.my_func_r(d);

--- a/Examples/test-suite/javascript/template_typedef_cplx_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx_runme.js
@@ -1,0 +1,21 @@
+var template_typedef_cplx = require("template_typedef_cplx");
+
+//
+// double case
+//
+
+var d, e;
+
+try {
+    d = template_typedef_cplx.make_Identity_double();
+    if (!d.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+} catch {
+    throw new Error(`${d} is not an ArithUnaryFunction`);
+}
+
+try {
+    e = template_typedef_cplx.make_Multiplies_double_double_double_double(d, d);
+    if (!e.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+} catch {
+    throw new Error(`${e} is not an ArithUnaryFunction`);
+}

--- a/Examples/test-suite/javascript/template_typedef_cplx_runme.js
+++ b/Examples/test-suite/javascript/template_typedef_cplx_runme.js
@@ -8,14 +8,17 @@ var d, e;
 
 try {
     d = template_typedef_cplx.make_Identity_double();
-    if (!d.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+    // This test is not possible in JSC where all SWIG proxies inherit from Object
+    if (typeof print === 'undefined')
+        if (!d.constructor.name.includes('ArithUnaryFunction')) throw new Error;
 } catch {
     throw new Error(`${d} is not an ArithUnaryFunction`);
 }
 
 try {
     e = template_typedef_cplx.make_Multiplies_double_double_double_double(d, d);
-    if (!e.constructor.name.includes('ArithUnaryFunction')) throw new Error;
+    if (typeof print === 'undefined')
+        if (!e.constructor.name.includes('ArithUnaryFunction')) throw new Error;
 } catch {
     throw new Error(`${e} is not an ArithUnaryFunction`);
 }

--- a/Examples/test-suite/javascript/template_typemaps_typedef2_runme.js
+++ b/Examples/test-suite/javascript/template_typemaps_typedef2_runme.js
@@ -1,0 +1,42 @@
+var template_typemaps_typedef2 = require("template_typemaps_typedef2");
+
+m1 = new template_typemaps_typedef2.MultimapIntA();
+
+dummy_pair = m1.make_dummy_pair();
+val = m1.typemap_test(dummy_pair).val;
+if (val != 1234) {
+    throw new Error("typemaps not working");
+}
+
+m2 = new template_typemaps_typedef2.MultimapAInt();
+
+// TODO: typemaps and specializations not quite working as expected. T needs expanding, but at least the right typemap is being picked up.
+//dummy_pair = m2.make_dummy_pair()
+//val = m2.typemap_test(dummy_pair)
+
+// if (val != 4321) {
+//    throw new Error, "typemaps not working"
+
+if (template_typemaps_typedef2.typedef_test1(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef2.typedef_test1 not working");
+}
+
+if (template_typemaps_typedef2.typedef_test2(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef2.typedef_test2 not working");
+}
+
+if (template_typemaps_typedef2.typedef_test3(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef2.typedef_test3 not working");
+}
+
+if (template_typemaps_typedef2.typedef_test4(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef2.typedef_test4 not working");
+}
+
+if (template_typemaps_typedef2.typedef_test5(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef2.typedef_test5 not working");
+}
+
+if (template_typemaps_typedef2.typedef_test6(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef2.typedef_test6 not working");
+}

--- a/Examples/test-suite/javascript/template_typemaps_typedef_runme.js
+++ b/Examples/test-suite/javascript/template_typemaps_typedef_runme.js
@@ -1,0 +1,42 @@
+var template_typemaps_typedef = require("template_typemaps_typedef");
+
+m1 = new template_typemaps_typedef.MultimapIntA();
+
+dummy_pair = m1.make_dummy_pair();
+val = m1.typemap_test(dummy_pair).val;
+if (val != 1234) {
+    throw new Error("typemaps not working");
+}
+
+m2 = new template_typemaps_typedef.MultimapAInt();
+
+// TODO: typemaps and specializations not quite working as expected. T needs expanding, but at least the right typemap is being picked up.
+//dummy_pair = m2.make_dummy_pair()
+//val = m2.typemap_test(dummy_pair)
+
+// if (val != 4321) {
+//    throw new Error, "typemaps not working"
+
+if (template_typemaps_typedef.typedef_test1(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef.typedef_test1 not working");
+}
+
+if (template_typemaps_typedef.typedef_test2(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef.typedef_test2 not working");
+}
+
+if (template_typemaps_typedef.typedef_test3(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef.typedef_test3 not working");
+}
+
+if (template_typemaps_typedef.typedef_test4(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef.typedef_test4 not working");
+}
+
+if (template_typemaps_typedef.typedef_test5(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef.typedef_test5 not working");
+}
+
+if (template_typemaps_typedef.typedef_test6(dummy_pair).val != 1234) {
+    throw new Error("template_typemaps_typedef.typedef_test6 not working");
+}

--- a/Examples/test-suite/javascript/template_using_directive_typedef_runme.js
+++ b/Examples/test-suite/javascript/template_using_directive_typedef_runme.js
@@ -1,0 +1,15 @@
+var template_using_directive_typedef = require("template_using_directive_typedef")
+
+vo = new template_using_directive_typedef.Vector_Obj();
+
+h = new template_using_directive_typedef.Holder();
+h.holder_use1(vo, vo, vo);
+h.holder_use2(vo, vo, vo);
+h.holder_use3(vo, vo, vo);
+
+template_using_directive_typedef.tns_holder_use(vo, vo);
+template_using_directive_typedef.tns_use(vo, vo, vo);
+template_using_directive_typedef.global_holder_use(vo);
+template_using_directive_typedef.global_use(vo, vo, vo);
+template_using_directive_typedef.ns1_holder_use(vo);
+template_using_directive_typedef.ns2_holder_use(vo, vo, vo, vo);

--- a/Examples/test-suite/javascript/typedef_classforward_same_name_runme.js
+++ b/Examples/test-suite/javascript/typedef_classforward_same_name_runme.js
@@ -1,0 +1,13 @@
+var typedef_classforward_same_name = require("typedef_classforward_same_name");
+
+foo = new typedef_classforward_same_name.Foo();
+foo.x = 5;
+if (typedef_classforward_same_name.extractFoo(foo) != 5) {
+    throw new Error("unexpected value");
+}
+
+boo = new typedef_classforward_same_name.Boo();
+boo.x = 5;
+if (typedef_classforward_same_name.extractBoo(boo) != 5) {
+    throw new Error("unexpected value");
+}

--- a/Examples/test-suite/javascript/typedef_funcptr_runme.js
+++ b/Examples/test-suite/javascript/typedef_funcptr_runme.js
@@ -1,0 +1,25 @@
+var typedef_funcptr = require("typedef_funcptr");
+
+a = 100;
+b = 10;
+
+if (typedef_funcptr.do_op(a, b, typedef_funcptr.addf) != 110) {
+  throw new Error("addf failed");
+}
+if (typedef_funcptr.do_op(a, b, typedef_funcptr.subf) != 90) {
+  throw new Error("subf failed");
+}
+
+if (typedef_funcptr.do_op_typedef_int(a, b, typedef_funcptr.addf) != 110) {
+  throw new Error("addf failed");
+}
+if (typedef_funcptr.do_op_typedef_int(a, b, typedef_funcptr.subf) != 90) {
+  throw new Error("subf failed");
+}
+
+if (typedef_funcptr.do_op_typedef_Integer(a, b, typedef_funcptr.addf) != 110) {
+  throw new Error("addf failed");
+}
+if (typedef_funcptr.do_op_typedef_Integer(a, b, typedef_funcptr.subf) != 90) {
+  throw new Error("subf failed");
+}

--- a/Examples/test-suite/javascript/typedef_typedef_runme.js
+++ b/Examples/test-suite/javascript/typedef_typedef_runme.js
@@ -1,0 +1,6 @@
+var typedef_typedef = require("typedef_typedef");
+
+b = new typedef_typedef.B();
+if (b.getValue(123) != 1234) {
+    throw new Error("Failed");
+}

--- a/Examples/test-suite/javascript/typemap_documentation_runme.js
+++ b/Examples/test-suite/javascript/typemap_documentation_runme.js
@@ -1,0 +1,27 @@
+var typemap_documentation = require("typemap_documentation");
+
+f = new typemap_documentation.Foo();
+f.x = 55;
+b = new typemap_documentation.Bar();
+b.y = 44;
+
+if (55 != typemap_documentation.GrabVal(f)) {
+    throw new Error("bad value");
+}
+
+try {
+    typemap_documentation.GrabVal(b);
+} catch (e) {
+    // This is working only in NAPI, other backends throw generic errors
+    //if (!(e instanceof TypeError))
+    //    throw e;
+    if (!e.message.includes('expecting type Foo'))
+        throw e;
+}
+
+if (55 != typemap_documentation.GrabValFooBar(f)) {
+    throw new Error("bad f value");
+}
+if (44 != typemap_documentation.GrabValFooBar(b)) {
+    throw new Error("bad b value");
+}

--- a/Examples/test-suite/javascript/typemap_out_optimal_runme.js
+++ b/Examples/test-suite/javascript/typemap_out_optimal_runme.js
@@ -1,0 +1,5 @@
+var typemap_out_optimal = require("typemap_out_optimal");
+
+typemap_out_optimal.XX_trace = false;
+x = typemap_out_optimal.XX.create();
+x = typemap_out_optimal.XX.createConst();

--- a/Examples/test-suite/javascript/typemap_qualifier_strip_runme.js
+++ b/Examples/test-suite/javascript/typemap_qualifier_strip_runme.js
@@ -1,0 +1,69 @@
+var typemap_qualifier_strip = require("typemap_qualifier_strip");
+
+val = typemap_qualifier_strip.create_int(111);
+if (typemap_qualifier_strip.testA1(val) != 1234) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testA2(val) != 1234) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testA3(val) != 1234) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testA4(val) != 1234) {
+    throw new Error;
+}
+
+
+if (typemap_qualifier_strip.testB1(val) != 111) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testB2(val) != 111) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testB3(val) != 111) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testB4(val) != 111) {
+    throw new Error;
+}
+
+
+if (typemap_qualifier_strip.testC1(val) != 5678) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testC2(val) != 111) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testC3(val) != 5678) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testC4(val) != 111) {
+    throw new Error;
+}
+
+
+if (typemap_qualifier_strip.testD1(val) != 111) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testD2(val) != 3456) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testD3(val) != 111) {
+    throw new Error;
+}
+
+if (typemap_qualifier_strip.testD4(val) != 111) {
+    throw new Error;
+}

--- a/Examples/test-suite/javascript/typemap_template_typedef_runme.js
+++ b/Examples/test-suite/javascript/typemap_template_typedef_runme.js
@@ -1,0 +1,33 @@
+var typemap_template_typedef = require("typemap_template_typedef");
+
+function check(got, expected) {
+    if (got != expected) {
+        throw new Error("got: " + got.toString() + " expected: " + expected.toString());
+    }
+}
+
+x = new typemap_template_typedef.XXXInt();
+
+check(x.aa1(0), 0);
+check(x.aa2(0), 55);
+check(x.aa3(0), 0);
+check(typemap_template_typedef.aa1(0), 0);
+check(typemap_template_typedef.aa2(0), 0);
+
+check(x.bb1(0), 0);
+check(x.bb2(0), 66);
+check(x.bb3(0), 0);
+check(typemap_template_typedef.bb1(0), 0);
+check(typemap_template_typedef.bb2(0), 0);
+
+check(x.cc1(0), 0);
+check(x.cc2(0), 77);
+check(x.cc3(0), 77);
+check(typemap_template_typedef.cc1(0), 0);
+check(typemap_template_typedef.cc2(0), 0);
+
+check(x.dd1(0), 0);
+check(x.dd2(0), 88);
+check(x.dd3(0), 0);
+check(typemap_template_typedef.dd1(0), 0);
+check(typemap_template_typedef.dd2(0), 0)

--- a/Examples/test-suite/javascript/typename_runme.js
+++ b/Examples/test-suite/javascript/typename_runme.js
@@ -1,0 +1,12 @@
+var typename = require("typename");
+f = new typename.Foo();
+b = new typename.Bar();
+
+x = typename.twoFoo(f);
+if (typeof x !== 'number') {
+    throw new Error("Wrong return type (FloatType) !");
+}
+y = typename.twoBar(b);
+if (typeof y !== 'number') {
+    throw new Error("Wrong return type (IntType)!");
+}

--- a/Examples/test-suite/javascript/unicode_strings_runme.js
+++ b/Examples/test-suite/javascript/unicode_strings_runme.js
@@ -1,0 +1,27 @@
+var unicode_strings = require("unicode_strings");
+
+// This uses slightly different encoding than the Python test
+// but AFAIK, it is the V8 handling that is the correct one
+
+function check(s1, s2) {
+    for (let i in s1) {
+        if (s1[i] !== s2[i])
+            console.error(`Character number ${i}, ${s1.charCodeAt(i)} != ${s2.charCodeAt(i)}`);
+    }
+    if (s1 != s2) {
+        throw new Error(`'${s1}' != '${s2}'`);
+    }
+}
+
+// The C++ string contains an invalid UTF-8 character
+// V8 transforms it to \ufffd
+// JSC silently refuses it
+test_string = "h\ufffdllo w\u00f6rld";
+
+if (typeof print === 'undefined') {
+    check(unicode_strings.non_utf8_c_str(), test_string);
+    check(unicode_strings.non_utf8_std_string(), test_string);
+} else {
+    check(unicode_strings.non_utf8_c_str(), '');
+    check(unicode_strings.non_utf8_std_string(), '');
+}

--- a/Examples/test-suite/javascript/using_private_runme.js
+++ b/Examples/test-suite/javascript/using_private_runme.js
@@ -1,0 +1,16 @@
+var using_private = require("using_private");
+
+f = new using_private.FooBar();
+f.x = 3;
+
+if (f.blah(4) != 4) {
+    throw new Error("blah(int)");
+}
+
+if (f.defaulted() != -1) {
+    throw new Error("defaulted()");
+}
+
+if (f.defaulted(222) != 222) {
+    throw new Error("defaulted(222)");
+}

--- a/Examples/test-suite/javascript/using_protected_runme.js
+++ b/Examples/test-suite/javascript/using_protected_runme.js
@@ -1,0 +1,8 @@
+var using_protected = require("using_protected");
+
+f = new using_protected.FooBar();
+f.x = 3;
+
+if (f.blah(4) != 4) {
+    throw new Error("blah(int)");
+}

--- a/Examples/test-suite/javascript/varargs_overload_runme.js
+++ b/Examples/test-suite/javascript/varargs_overload_runme.js
@@ -1,0 +1,79 @@
+var varargs_overload = require("varargs_overload");
+
+if (varargs_overload.vararg_over1("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over1(2) != "2") {
+    throw new Error("Failed");
+}
+
+
+if (varargs_overload.vararg_over2("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over2(2, 2.2) != "2 2.2") {
+    throw new Error("Failed");
+}
+
+
+if (varargs_overload.vararg_over3("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over3(2, 2.2, "hey") != "2 2.2 hey") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over4("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over4(123) != "123") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over4("Hello", 123) != "Hello") {
+    throw new Error("Failed");
+}
+
+
+// Same as above but non-vararg function declared first
+
+if (varargs_overload.vararg_over6("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over6(2) != "2") {
+    throw new Error("Failed");
+}
+
+
+if (varargs_overload.vararg_over7("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over7(2, 2.2) != "2 2.2") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over8("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over8(2, 2.2, "hey") != "2 2.2 hey") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over9("Hello") != "Hello") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over9(123) != "123") {
+    throw new Error("Failed");
+}
+
+if (varargs_overload.vararg_over9("Hello", 123) != "Hello") {
+    throw new Error("Failed");
+}

--- a/Examples/test-suite/javascript/virtual_poly_runme.js
+++ b/Examples/test-suite/javascript/virtual_poly_runme.js
@@ -1,0 +1,44 @@
+var virtual_poly = require("virtual_poly");
+
+d = new virtual_poly.NDouble(3.5);
+i = new virtual_poly.NInt(2);
+
+//
+// the copy methods return the right polymorphic types
+//
+dc = d.copy();
+ic = i.copy();
+
+if (d.get() != dc.get()) {
+    throw new Error;
+}
+
+if (i.get() != ic.get()) {
+    throw new Error;
+}
+
+virtual_poly.incr(ic);
+
+if ((i.get() + 1) != ic.get()) {
+    throw new Error;
+}
+
+
+dr = d.ref_this();
+if (d.get() != dr.get()) {
+    throw new Error;
+}
+
+
+//
+// 'narrowing' also works
+//
+ddc = virtual_poly.NDouble.narrow(d.nnumber());
+if (d.get() != ddc.get()) {
+    throw new Error;
+}
+
+dic = virtual_poly.NInt.narrow(i.nnumber());
+if (i.get() != dic.get()) {
+    throw new Error;
+}

--- a/Examples/test-suite/template_template_parameters.i
+++ b/Examples/test-suite/template_template_parameters.i
@@ -73,7 +73,11 @@ TestStruct<int, Container1> TestStructContainer1Method(TestStruct<int, Container
 
 // part 3 - from #624
 
+#ifdef SWIGJAVASCRIPT
+%rename("addTo") operator+=;
+#else
 %rename("") operator+=; // For Ruby and Octave that ignore operator+=
+#endif
 
 %inline %{
 template<typename T, int dim> struct Foot {


### PR DESCRIPTION
This is the last bulk batch of Python run tests translated to JS

There are about 100 remaining tests most of which are blocked by one of these:
* directors do not work in JS
* nested struct/unions do not work in JS
* overloading between integers and floats do not work in JS (there is a separate PR #2624 with this)
* the `std` containers are less evolved and there is no `std::list`
* there is no automatic implicit conversion between language builtin containers and `std` containers - this is a priority
* there are no built-in complex numbers in JS
* there is no Doxygen support
* lots of cases related to renaming, especially renaming constructors
* some tests related to reference counting - alas with JS engines it is impossible to force the GC to run which is always a problem when testing mixed JS/C++ code
