### PR TITLE
Fix code generation for OCaml 5.0.0

### DIFF
--- a/Lib/ocaml/ocamlrundec.swg
+++ b/Lib/ocaml/ocamlrundec.swg
@@ -14,7 +14,7 @@ SWIGEXT {
 #else
 #define SWIGEXT 
 #endif
-#define value caml_value_t
+#define caml_value_t value
 #define CAML_VALUE caml_value_t
 #define CAML_NAME_SPACE
 #include <caml/alloc.h>
@@ -80,11 +80,15 @@ SWIGEXT {
                                                  /* Also an l-value. */
 #endif
 
+#ifndef CAML_LOCAL_ROOTS
+#define CAML_LOCAL_ROOTS caml_local_roots
+#endif
+
 #ifdef CAMLreturn0
 #undef CAMLreturn0
 #endif
 #define CAMLreturn0 do{ \
-  caml_local_roots = caml__frame; \
+  CAML_LOCAL_ROOTS = caml__frame; \
   return; \
 }while (0)
 
@@ -93,12 +97,12 @@ SWIGEXT {
 #endif
 #define CAMLreturn(result) do{ \
   caml_value_t caml__temp_result = (result); \
-  caml_local_roots = caml__frame; \
+  CAML_LOCAL_ROOTS = caml__frame; \
   return (caml__temp_result); \
 }while(0)
 
 #define CAMLreturn_type(result) do{ \
-  caml_local_roots = caml__frame; \
+  CAML_LOCAL_ROOTS = caml__frame; \
   return result; \
 }while(0)
 


### PR DESCRIPTION
The Fedora Linux distribution is about to rebuild all OCaml packages with OCaml 5.0.0.  We encountered two problems with swig-generated code:
- The token `value` appears in included C++ headers; changing it to `caml_value_t` leads to compilation errors
- The name `caml_local_roots` has been replaced with an uppercase macro: `CAML_LOCAL_ROOTS`.
This commit addresses the first issue by reversing the `value` to `caml_value_t` replacement.  Instead of trying to replace `value` in all of the OCaml headers, replace `caml_value_t` in the generated code instead.  The fix for the second issue should work for all versions of OCaml.

I am no OCaml expert, but I can report that this patch leads to a successful build of the Fedora swig package with OCaml 5.0.0.