### PR TITLE
guard against applying in typemaps twice

### DIFF
--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -6,7 +6,7 @@
   static const char* hi = "hello";
   $1 = const_cast<char *>(hi);
   unique++;
-  if (unique != 1) SWIG_Error(SWIG_ERROR, "in typemap applied more than once");
+  if (unique != 1) SWIG_exception_fail(SWIG_ERROR, "in typemap applied more than once");
 }
 %typemap(in,numinputs=0) int bb "$1 = 101; called_argout = 0;"
 %typemap(in,numinputs=0) double ccc "$1 = 8.8;"

--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -2,7 +2,12 @@
 
 %module ignore_parameter
 
-%typemap(in,numinputs=0) char* a "static const char* hi = \"hello\"; $1 = const_cast<char *>(hi);"
+%typemap(in,numinputs=0) char* a (int unique = 0) {
+  static const char* hi = "hello";
+  $1 = const_cast<char *>(hi);
+  unique++;
+  if (unique != 1) SWIG_Error(SWIG_ERROR, "in typemap applied more than once");
+}
 %typemap(in,numinputs=0) int bb "$1 = 101; called_argout = 0;"
 %typemap(in,numinputs=0) double ccc "$1 = 8.8;"
 

--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -6,7 +6,10 @@
   static const char* hi = "hello";
   $1 = const_cast<char *>(hi);
   unique++;
-  if (unique != 1) SWIG_exception_fail(SWIG_ERROR, "in typemap applied more than once");
+  if (unique != 1) {
+    fprintf(stderr, "in typemap applied more than once\n");
+    abort();
+  }
 }
 %typemap(in,numinputs=0) int bb "$1 = 101; called_argout = 0;"
 %typemap(in,numinputs=0) double ccc "$1 = 8.8;"

--- a/Examples/test-suite/ignore_parameter.i
+++ b/Examples/test-suite/ignore_parameter.i
@@ -2,14 +2,12 @@
 
 %module ignore_parameter
 
-%typemap(in,numinputs=0) char* a (int unique = 0) {
+%typemap(in,numinputs=0) char* a {
+  // Ensure this typemap is applied only once
+  goto ignore_in_unique;
+ignore_in_unique:
   static const char* hi = "hello";
   $1 = const_cast<char *>(hi);
-  unique++;
-  if (unique != 1) {
-    fprintf(stderr, "in typemap applied more than once\n");
-    abort();
-  }
 }
 %typemap(in,numinputs=0) int bb "$1 = 101; called_argout = 0;"
 %typemap(in,numinputs=0) double ccc "$1 = 8.8;"

--- a/Examples/test-suite/javascript/ignore_parameter_runme.js
+++ b/Examples/test-suite/javascript/ignore_parameter_runme.js
@@ -1,20 +1,24 @@
 const ignore_parameter = require('ignore_parameter');
 
-function check(a, b) {
+function check(a, b, argout) {
   if (a !== b) throw new Error(`'${a}' != '${b}`);
+  if (argout) {
+    if (ignore_parameter.called_argout !== 1)
+      throw new Error('argout typemap not applied');
+  }
 }
 
 check(ignore_parameter.jaguar(200, 0), "hello");
-check(ignore_parameter.lotus("foo", 1), 101);
+check(ignore_parameter.lotus("foo", 1), 101, true);
 check(ignore_parameter.tvr("bar", 2), 8.8);
-check(ignore_parameter.ferrari(), 101);
+check(ignore_parameter.ferrari(), 101, true);
 check(ignore_parameter.fiat(17), 17);
 
 car = new ignore_parameter.SportsCars();
 check(car.daimler(200, 0), "hello");
-check(car.astonmartin("foo", 1), 101);
+check(car.astonmartin("foo", 1), 101, true);
 check(car.bugatti("bar", 2), 8.8);
-check(car.lamborghini(), 101);
+check(car.lamborghini(), 101, true);
 check(car.maseratti(289), 289);
 check(car.audi(), 8.8);
 

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -2915,7 +2915,11 @@ void NAPIEmitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, M
       Exit(EXIT_FAILURE);
     }
 
-    tm = emitInputTypemap(n, p, wrapper, arg);
+    if (GetInt(p, "tmap:in:numinputs") != 0) {
+      // in typemaps with numinputs=0 are a special case
+      // and are handled in emit.cxx:emit_attach_parmmaps()
+      tm = emitInputTypemap(n, p, wrapper, arg);
+    }
     Delete(arg);
 
     if (tm) {


### PR DESCRIPTION
Fix #2652
Add a check for applying `numinputs=0` twice for all generators since this is a special case in `emit.cxx:emit_attach_parmmaps()`