### PR TITLE
Fix missing-field-initializers warning with Py3.12

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -270,6 +270,9 @@ SwigPyStaticVar_Type(void) {
 #if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
       0,                                        /* tp_print */
 #endif
+#if PY_VERSION_HEX >= 0x030C0000
+      0,                                        /* tp_watched */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                        /* tp_allocs */
       0,                                        /* tp_frees */
@@ -357,6 +360,9 @@ SwigPyObjectType(void) {
 #endif
 #if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
       0,                                        /* tp_print */
+#endif
+#if PY_VERSION_HEX >= 0x030C0000
+      0,                                        /* tp_watched */
 #endif
 #ifdef COUNT_ALLOCS
       0,                                        /* tp_allocs */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -388,6 +388,9 @@ swig_varlink_type(void) {
 #if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
       0,                                  /* tp_print */
 #endif
+#if PY_VERSION_HEX >= 0x030C0000
+      0,                                  /* tp_watched */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                  /* tp_allocs */
       0,                                  /* tp_frees */
@@ -982,6 +985,9 @@ SwigPyObject_TypeOnce(void) {
 #if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
       0,                                    /* tp_print */
 #endif
+#if PY_VERSION_HEX >= 0x030C0000
+      0,                                    /* tp_watched */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */
       0,                                    /* tp_frees */
@@ -1161,6 +1167,9 @@ SwigPyPacked_TypeOnce(void) {
 #endif
 #if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)
       0,                                    /* tp_print */
+#endif
+#if PY_VERSION_HEX >= 0x030C0000
+      0,                                    /* tp_watched */
 #endif
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4203,6 +4203,9 @@ public:
     Printv(f, "#if (PY_VERSION_HEX >= 0x03080000) && (PY_VERSION_HEX < 0x03090000)\n", NIL);
     printSlot(f, getSlot(), "tp_print");
     Printv(f, "#endif\n", NIL);
+    Printv(f, "#if PY_VERSION_HEX >= 0x030C0000\n", NIL);
+    printSlot(f, getSlot(), "tp_watched");
+    Printv(f, "#endif\n", NIL);
 
     Printv(f, "#ifdef COUNT_ALLOCS\n", NIL);
     printSlot(f, getSlot(n, "feature:python:tp_allocs"), "tp_allocs", "Py_ssize_t");


### PR DESCRIPTION
https://docs.python.org/3.12/c-api/typeobj.html?highlight=tp_watched#c.PyTypeObject.tp_watched