### PR TITLE
Enable nullable reference types in C# (Recreated PR)

### DIFF
--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -111,6 +111,11 @@ swig -csharp -help
 </tr>
 
 <tr>
+<td>-enablenullable</td>
+<td>Enable <a href="https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references">nullable reference types</a> in the C# code. This inserts the <tt>#nullable enable</tt> directive into all C# files, because otherwise <a href="https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code"> nullable is disabled for all generated files.</a></td>
+</tr>
+
+<tr>
 <td>-namespace &lt;nm&gt;</td>
 <td>Generate wrappers into C# namespace &lt;nm&gt;</td>
 </tr>

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -46,6 +46,7 @@ class CSHARP:public Language {
   bool global_variable_flag;	// Flag for when wrapping a global variable
   bool old_variable_names;	// Flag for old style variable names in the intermediary class
   bool generate_property_declaration_flag;	// Flag for generating properties
+  bool enable_nullable_flag;
 
   String *imclass_name;		// intermediary class name
   String *module_class_name;	// module class name
@@ -122,6 +123,7 @@ public:
       global_variable_flag(false),
       old_variable_names(false),
       generate_property_declaration_flag(false),
+      enable_nullable_flag(false),
       imclass_name(NULL),
       module_class_name(NULL),
       imclass_class_code(NULL),
@@ -254,6 +256,9 @@ public:
 	} else if (strcmp(argv[i], "-oldvarnames") == 0) {
 	  Swig_mark_arg(i);
 	  old_variable_names = true;
+	} else if (strcmp(argv[i], "-enablenullable") == 0) {
+	  Swig_mark_arg(i);
+	  enable_nullable_flag = true;
 	} else if (strcmp(argv[i], "-outfile") == 0) {
 	  if (argv[i + 1]) {
 	    output_file = NewString("");
@@ -649,6 +654,9 @@ public:
     Printf(f, "//\n");
     Swig_banner_target_lang(f, "//");
     Printf(f, "//------------------------------------------------------------------------------\n\n");
+    if (enable_nullable_flag) {
+      Printf(f, "#nullable enable\n\n");
+    }
   }
 
   /* -----------------------------------------------------------------------------
@@ -4610,6 +4618,7 @@ extern "C" Language *swig_csharp(void) {
 const char *CSHARP::usage = "\
 C# Options (available with -csharp)\n\
      -dllimport <dl> - Override DllImport attribute name to <dl>\n\
+     -enablenullable - Enable nullable in all C# generated files\n\
      -namespace <nm> - Generate wrappers into C# namespace <nm>\n\
      -noproxy        - Generate the low-level functional interface instead\n\
                        of proxy classes\n\


### PR DESCRIPTION
This was originally in: https://github.com/swig/swig/pull/1713

In C# 8 nullable reference types are [disabled in generated files](https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code) by default, and generators should enable them by inserting `#nullable enable` or `#nullable restore` into each file.

I added the CLI option `-enablenullable` to insert `#nullable enable` into all generated C# files after the banner. This allows people to use nullable references types without breaking backward compatibility.