### PR TITLE
Call swig_msg.c_str() directly rather than virtual method

### DIFF
--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -173,7 +173,7 @@ namespace Swig {
         swig_msg += msg;
       }
       if (!PyErr_Occurred()) {
-        PyErr_SetString(error, what());
+        PyErr_SetString(error, swig_msg.c_str());
       }
       SWIG_PYTHON_THREAD_END_BLOCK;
     }


### PR DESCRIPTION
This is faster and does not call virtual method during construction