### PR TITLE
CMake: Bump required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required (VERSION 3.2)
+cmake_minimum_required (VERSION 3.13)
 
-if (NOT DEFINED CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
-endif ()
+set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 
 project (swig)
 


### PR DESCRIPTION
Recent cmake versions warn that support for version <3.5 is deprecated
We bump to 3.13, that is the version in debian buster and should still be way old enough