### PR TITLE
Lib/csharp: Better standardized std_vector.i and std_array.i

### DIFF
--- a/Lib/csharp/std_array.i
+++ b/Lib/csharp/std_array.i
@@ -24,6 +24,17 @@
     }
   }
 
+  public $csclassname(global::System.Collections.Generic.IEnumerable<$typemap(cstype, CTYPE)> c) : this() {
+    if (c == null)
+      throw new global::System.ArgumentNullException("c");
+    int i = 0;
+    foreach ($typemap(cstype, CTYPE) element in c) {
+      if (i >= this.Count)
+        break;
+      this[i++] = element;
+    }
+  }
+
   public bool IsFixedSize {
     get {
       return true;
@@ -47,7 +58,7 @@
 
   public bool IsEmpty {
     get {
-      return empty();
+      return (size() == 0);
     }
   }
 
@@ -185,9 +196,6 @@
     typedef value_type& reference;
     typedef const value_type& const_reference;
 
-    array();
-    array(const array &other);
-
     size_type size() const;
     bool empty() const;
 
@@ -196,6 +204,9 @@
 
     %rename(Swap) swap;
     void swap(array& other);
+
+    array();
+    array(const array &other);
 
     %extend {
       CTYPE getitemcopy(int index) throw (std::out_of_range) {


### PR DESCRIPTION
This PR is only a minor change. I compared the sources of std_vector.i and std_array.i, and have copied items that could be implemented more concise between the two. Let me know if this is useful?