### PR TITLE
Differences in C# long handling

### DIFF
--- a/Lib/csharp/arrays_csharp.i
+++ b/Lib/csharp/arrays_csharp.i
@@ -116,10 +116,6 @@ CSHARP_ARRAYS(unsigned long, uint)
 CSHARP_ARRAYS(long, long)
 CSHARP_ARRAYS(unsigned long, ulong)
 #endif
-%typemap(in, fragment="long_check_wordsize") long INPUT[], unsigned long INPUT[] "$1 = $input;"
-%typemap(in, fragment="long_check_wordsize") long OUTPUT[], unsigned long OUTPUT[] "$1 = $input;"
-%typemap(in, fragment="long_check_wordsize") long INOUT[], unsigned long INOUT[] "$1 = $input;"
-
 // By default C# will marshal bools as 4 bytes
 // UnmanagedType.I1 will change this to 1 byte
 // FIXME - When running on mono ArraySubType appears to be ignored and bools will be marshalled as 4-byte
@@ -192,11 +188,10 @@ CSHARP_ARRAYS_FIXED(double, double)
 CSHARP_ARRAYS_FIXED(bool, bool)
 
 // 32-bit/64-bit architecture specific typemaps - special handling to ensure sizeof(long) on C side matches size used on C# side
-#ifdef !SWIGWORDSIZE64
+#if !defined(SWIGWORDSIZE64)
 CSHARP_ARRAYS_FIXED(long, int)
 CSHARP_ARRAYS_FIXED(unsigned long, uint)
 #else
 CSHARP_ARRAYS_FIXED(long, long)
 CSHARP_ARRAYS_FIXED(unsigned long, ulong)
 #endif
-%typemap(in, fragment="long_check_wordsize") long FIXED[], unsigned long FIXED[] "$1 = $input;"

--- a/Lib/csharp/csharp.swg
+++ b/Lib/csharp/csharp.swg
@@ -82,8 +82,8 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(ctype) unsigned short,     const unsigned short &     "unsigned short"
 %typemap(ctype) int,                const int &                "int"
 %typemap(ctype) unsigned int,       const unsigned int &       "unsigned int"
-%typemap(ctype) long,               const long &               "int"
-%typemap(ctype) unsigned long,      const unsigned long &      "unsigned int"
+%typemap(ctype) long,               const long &               "long"
+%typemap(ctype) unsigned long,      const unsigned long &      "unsigned long"
 %typemap(ctype) long long,          const long long &          "long long"
 %typemap(ctype) unsigned long long, const unsigned long long & "unsigned long long"
 %typemap(ctype) float,              const float &              "float"
@@ -98,8 +98,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(imtype) unsigned short,     const unsigned short &     "ushort"
 %typemap(imtype) int,                const int &                "int"
 %typemap(imtype) unsigned int,       const unsigned int &       "uint"
+#if defined(SWIGWORDSIZE64)
+%typemap(imtype) long,               const long &               "long"
+%typemap(imtype) unsigned long,      const unsigned long &      "ulong"
+#else
 %typemap(imtype) long,               const long &               "int"
 %typemap(imtype) unsigned long,      const unsigned long &      "uint"
+#endif
 %typemap(imtype) long long,          const long long &          "long"
 %typemap(imtype) unsigned long long, const unsigned long long & "ulong"
 %typemap(imtype) float,              const float &              "float"
@@ -114,8 +119,13 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(cstype) unsigned short,     const unsigned short &     "ushort"
 %typemap(cstype) int,                const int &                "int"
 %typemap(cstype) unsigned int,       const unsigned int &       "uint"
+#if defined(SWIGWORDSIZE64)
+%typemap(cstype) long,               const long &               "long"
+%typemap(cstype) unsigned long,      const unsigned long &      "ulong"
+#else
 %typemap(cstype) long,               const long &               "int"
 %typemap(cstype) unsigned long,      const unsigned long &      "uint"
+#endif
 %typemap(cstype) long long,          const long long &          "long"
 %typemap(cstype) unsigned long long, const unsigned long long & "ulong"
 %typemap(cstype) float,              const float &              "float"
@@ -201,9 +211,9 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(directorin) short              "$input = $1;"
 %typemap(directorin) unsigned short     "$input = $1;"
 %typemap(directorin) int                "$input = $1;"
-%typemap(directorin) unsigned int       "$input = (unsigned int)$1;"
+%typemap(directorin) unsigned int       "$input = $1;"
 %typemap(directorin) long               "$input = $1;"
-%typemap(directorin) unsigned long      "$input = $1;"
+%typemap(directorin) unsigned long      "$input = (unsigned long)$1;"
 %typemap(directorin) long long          "$input = $1;"
 %typemap(directorin) unsigned long long "$input = $1;"
 %typemap(directorin) float              "$input = $1;"
@@ -246,9 +256,9 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(out) short              %{ $result = $1; %}
 %typemap(out) unsigned short     %{ $result = $1; %}
 %typemap(out) int                %{ $result = $1; %}
-%typemap(out) unsigned int       %{ $result = (unsigned int)$1; %}
+%typemap(out) unsigned int       %{ $result = $1; %}
 %typemap(out) long               %{ $result = $1; %}
-%typemap(out) unsigned long      %{ $result = $1; %}
+%typemap(out) unsigned long      %{ $result = (unsigned long)$1; %}
 %typemap(out) long long          %{ $result = $1; %}
 %typemap(out) unsigned long long %{ $result = $1; %}
 %typemap(out) float              %{ $result = $1; %}
@@ -327,7 +337,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(directorin) const short &          "$input = $1;"
 %typemap(directorin) const unsigned short & "$input = $1;"
 %typemap(directorin) const int &            "$input = $1;"
-%typemap(directorin) const unsigned int &   "$input = (unsigned int)$1;"
+%typemap(directorin) const unsigned int &   "$input = $1;"
 %typemap(directorin) const long &           "$input = $1;"
 %typemap(directorin) const unsigned long &  "$input = $1;"
 %typemap(directorin) const long long &      "$input = $1;"
@@ -373,9 +383,9 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
 %typemap(out) const short &              %{ $result = *$1; %}
 %typemap(out) const unsigned short &     %{ $result = *$1; %}
 %typemap(out) const int &                %{ $result = *$1; %}
-%typemap(out) const unsigned int &       %{ $result = (unsigned int)*$1; %}
+%typemap(out) const unsigned int &       %{ $result = *$1; %}
 %typemap(out) const long &               %{ $result = *$1; %}
-%typemap(out) const unsigned long &      %{ $result = *$1; %}
+%typemap(out) const unsigned long &      %{ $result = (unsigned long)*$1; %}
 %typemap(out) const long long &          %{ $result = *$1; %}
 %typemap(out) const unsigned long long & %{ $result = *$1; %}
 %typemap(out) const float &              %{ $result = *$1; %}
@@ -519,6 +529,31 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     const unsigned short &
     ""
 
+#if defined(SWIGWORDSIZE64)
+%typecheck(SWIG_TYPECHECK_INT32)
+    int,
+    const int &
+    ""
+
+%typecheck(SWIG_TYPECHECK_UINT32)
+    unsigned int,
+    const unsigned int &
+    ""
+
+%typecheck(SWIG_TYPECHECK_INT64)
+    long, 
+    long long, 
+    const long &, 
+    const long long &
+    ""
+
+%typecheck(SWIG_TYPECHECK_UINT64)
+    unsigned long, 
+    unsigned long long, 
+    const unsigned long &, 
+    const unsigned long long &
+    ""
+#else
 %typecheck(SWIG_TYPECHECK_INT32)
     int, 
     long, 
@@ -542,6 +577,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     unsigned long long,
     const unsigned long long &
     ""
+#endif
 
 %typecheck(SWIG_TYPECHECK_FLOAT)
     float,
@@ -659,6 +695,24 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     uint ret = $imcall;$excode
     return ret;
   }
+#if defined(SWIGWORDSIZE64)
+%typemap(csout, excode=SWIGEXCODE) long,               const long &               {
+    long ret = $imcall;$excode
+    return ret;
+  }
+%typemap(csout, excode=SWIGEXCODE) unsigned long,      const unsigned long &      {
+    ulong ret = $imcall;$excode
+    return ret;
+  }
+%typemap(csout, excode=SWIGEXCODE) long long,          const long long &          {
+    long ret = $imcall;$excode
+    return ret;
+  }
+%typemap(csout, excode=SWIGEXCODE) unsigned long long, const unsigned long long & {
+    ulong ret = $imcall;$excode
+    return ret;
+  }
+#else
 %typemap(csout, excode=SWIGEXCODE) long,               const long &               {
     int ret = $imcall;$excode
     return ret;
@@ -675,6 +729,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
     ulong ret = $imcall;$excode
     return ret;
   }
+#endif
 %typemap(csout, excode=SWIGEXCODE) float,              const float &              {
     float ret = $imcall;$excode
     return ret;
@@ -765,6 +820,28 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
       uint ret = $imcall;$excode
       return ret;
     } %}
+#if defined(SWIGWORDSIZE64)
+%typemap(csvarout, excode=SWIGEXCODE2) long,               const long &               %{
+    get {
+      long ret = $imcall;$excode
+      return ret;
+    } %}
+%typemap(csvarout, excode=SWIGEXCODE2) unsigned long,      const unsigned long &      %{
+    get {
+      ulong ret = $imcall;$excode
+      return ret;
+    } %}
+%typemap(csvarout, excode=SWIGEXCODE2) long long,          const long long &          %{
+    get {
+      long ret = $imcall;$excode
+      return ret;
+    } %}
+%typemap(csvarout, excode=SWIGEXCODE2) unsigned long long, const unsigned long long & %{
+    get {
+      ulong ret = $imcall;$excode
+      return ret;
+    } %}
+#else
 %typemap(csvarout, excode=SWIGEXCODE2) long,               const long &               %{
     get {
       int ret = $imcall;$excode
@@ -785,6 +862,7 @@ SWIGINTERN const char * SWIG_UnpackData(const char *c, void *ptr, size_t sz) {
       ulong ret = $imcall;$excode
       return ret;
     } %}
+#endif
 %typemap(csvarout, excode=SWIGEXCODE2) float,              const float &              %{
     get {
       float ret = $imcall;$excode
@@ -1062,17 +1140,23 @@ SWIG_CSBODY_TYPEWRAPPER(internal, protected, internal, SWIGTYPE)
 %pragma(csharp) imclassclassmodifiers="class"
 %pragma(csharp) moduleclassmodifiers="public class"
 
-/* 64-bit architecture specific typemaps */
-#if defined(SWIGWORDSIZE64)
-%apply long long { long };
-%apply unsigned long long { unsigned long };
-%apply const long long & { const long & };
-%apply const unsigned long long & { const unsigned long & };
+/* Some ANSI C typemaps */
+
+#if defined(SWIGWORDSIZE64) && !defined(SWIGINT64ISLONGLONG)
+%apply unsigned long int { size_t };
+%apply const unsigned long int & { const size_t & };
+#else
+%apply unsigned long long int { size_t };
+%apply const unsigned long long int & { const size_t & };
 #endif
 
-/* size_t maps to C# 32-bit uint type */
-%apply unsigned int { size_t };
-%apply const unsigned int & { const size_t & };
+#if defined(SWIGWORDSIZE64) && !defined(SWIGINT64ISLONGLONG)
+%apply long int { ptrdiff_t };
+%apply const long int & { const ptrdiff_t & };
+#else
+%apply long long int { ptrdiff_t };
+%apply const long long int & { const ptrdiff_t & };
+#endif
 
 /* Array reference typemaps */
 %apply SWIGTYPE & { SWIGTYPE ((&)[ANY]) }

--- a/Lib/csharp/typemaps.i
+++ b/Lib/csharp/typemaps.i
@@ -242,39 +242,24 @@ INOUT_TYPEMAP(double,             double,               double,   DOUBLE_PTR)
 
 // 32-bit/64-bit architecture specific typemaps - marshal as 32-bit by default
 #if !defined(SWIGWORDSIZE64)
-INPUT_TYPEMAP(long,               int,                 int)
-INPUT_TYPEMAP(unsigned long,      unsigned int,        uint)
+INPUT_TYPEMAP(long,               long,                 int)
+INPUT_TYPEMAP(unsigned long,      unsigned long,        uint)
 
-OUTPUT_TYPEMAP(long,              int,                 int,       INT32_PTR)
-OUTPUT_TYPEMAP(unsigned long,     unsigned int,        uint,      UINT32_PTR)
+OUTPUT_TYPEMAP(long,              long,                 int,      INT32_PTR)
+OUTPUT_TYPEMAP(unsigned long,     unsigned long,        uint,     UINT32_PTR)
 
-INOUT_TYPEMAP(long,               int,                 int,       INT32_PTR)
-INOUT_TYPEMAP(unsigned long,      unsigned int,        uint,      UINT32_PTR)
+INOUT_TYPEMAP(long,               long,                 int,      INT32_PTR)
+INOUT_TYPEMAP(unsigned long,      unsigned long,        uint,     UINT32_PTR)
 #else
-INPUT_TYPEMAP(long,               long long,           int)
-INPUT_TYPEMAP(unsigned long,      unsigned long long,  uint)
+INPUT_TYPEMAP(long,               long,                 long)
+INPUT_TYPEMAP(unsigned long,      unsigned long,        ulong)
 
-OUTPUT_TYPEMAP(long,              long long,           int,       INT64_PTR)
-OUTPUT_TYPEMAP(unsigned long,     unsigned long long,  uint,      UINT64_PTR)
+OUTPUT_TYPEMAP(long,              long,                 long,     INT64_PTR)
+OUTPUT_TYPEMAP(unsigned long,     unsigned long,        ulong,    UINT64_PTR)
 
-INOUT_TYPEMAP(long,               long long,           int,       INT64_PTR)
-INOUT_TYPEMAP(unsigned long,      unsigned long long,  uint,      UINT64_PTR)
+INOUT_TYPEMAP(long,               long,                 long,     INT64_PTR)
+INOUT_TYPEMAP(unsigned long,      unsigned long,        ulong,    UINT64_PTR)
 #endif
-%typemap(in) long INPUT[] ($*1_ltype tempinput), unsigned long INPUT[] ($*1_ltype tempinput)
-%{tempinput = ($*1_ltype)*$input;
-  $1 = &tempinput;%}
-
-%typemap(in) long OUTPUT[] ($*1_ltype tempoutput), unsigned long OUTPUT[] ($*1_ltype tempoutput)
-%{$1 = &tempoutput;%}
-
-%typemap(in) long INOUT[] ($*1_ltype tempinout), unsigned long INOUT[] ($*1_ltype tempinout)
-%{tempinout = ($*1_ltype)*$input;
-  $1 = &tempinout;%}
-
-%typemap(argout) long OUTPUT[], unsigned long OUTPUT[] "*$input = *$1;"
-%typemap(argout) long INOUT[], unsigned long INOUT[] "*$input = *$1;"
-
-
 #undef INPUT_TYPEMAP
 #undef OUTPUT_TYPEMAP
 #undef INOUT_TYPEMAP

--- a/Lib/stdint.i
+++ b/Lib/stdint.i
@@ -17,7 +17,7 @@
 typedef signed char		int8_t;
 typedef short int		int16_t;
 typedef int			int32_t;
-#if defined(SWIGWORDSIZE64)
+#if defined(SWIGWORDSIZE64) && !defined(SWIGINT64ISLONGLONG)
 typedef long int		int64_t;
 #else
 typedef long long int		int64_t;
@@ -27,7 +27,7 @@ typedef long long int		int64_t;
 typedef unsigned char		uint8_t;
 typedef unsigned short int	uint16_t;
 typedef unsigned int		uint32_t;
-#if defined(SWIGWORDSIZE64)
+#if defined(SWIGWORDSIZE64) && !defined(SWIGINT64ISLONGLONG)
 typedef unsigned long int	uint64_t;
 #else
 typedef unsigned long long int	uint64_t;
@@ -40,7 +40,7 @@ typedef unsigned long long int	uint64_t;
 typedef signed char		int_least8_t;
 typedef short int		int_least16_t;
 typedef int			int_least32_t;
-#if defined(SWIGWORDSIZE64)
+#if defined(SWIGWORDSIZE64) && !defined(SWIGINT64ISLONGLONG)
 typedef long int		int_least64_t;
 #else
 typedef long long int		int_least64_t;
@@ -50,7 +50,7 @@ typedef long long int		int_least64_t;
 typedef unsigned char		uint_least8_t;
 typedef unsigned short int	uint_least16_t;
 typedef unsigned int		uint_least32_t;
-#if defined(SWIGWORDSIZE64)
+#if defined(SWIGWORDSIZE64) && !defined(SWIGINT64ISLONGLONG)
 typedef unsigned long int	uint_least64_t;
 #else
 typedef unsigned long long int	uint_least64_t;
@@ -64,7 +64,11 @@ typedef signed char		int_fast8_t;
 #if defined(SWIGWORDSIZE64)
 typedef long int		int_fast16_t;
 typedef long int		int_fast32_t;
+#if !defined(SWIGINT64ISLONGLONG)
 typedef long int		int_fast64_t;
+#else
+typedef long long int		int_fast64_t;
+#endif
 #else
 typedef int			int_fast16_t;
 typedef int			int_fast32_t;
@@ -76,7 +80,11 @@ typedef unsigned char		uint_fast8_t;
 #if defined(SWIGWORDSIZE64)
 typedef unsigned long int	uint_fast16_t;
 typedef unsigned long int	uint_fast32_t;
+#if !defined(SWIGINT64ISLONGLONG)
 typedef unsigned long int	uint_fast64_t;
+#else
+typedef unsigned long long int	uint_fast64_t;
+#endif
 #else
 typedef unsigned int		uint_fast16_t;
 typedef unsigned int		uint_fast32_t;

--- a/Lib/swigfragments.swg
+++ b/Lib/swigfragments.swg
@@ -99,6 +99,9 @@
 
 %fragment("long_check_wordsize32", "header", fragment="<limits.h>") %{
 #if !defined(SWIG_NO_WORDSIZE32_CHECK)
+#ifndef LONG_MAX
+#include <limits.h>
+#endif
 #if (__WORDSIZE == 64) || (LONG_MAX != INT_MAX)
 # error "SWIG generated code is invalid on this 64-bit architecture, please regenerate without defining SWIGWORDSIZE32 or define SWIGWORDSIZE64"
 #endif
@@ -107,6 +110,9 @@
 
 %fragment("long_check_wordsize64", "header", fragment="<limits.h>") %{
 #if !defined(SWIG_NO_WORDSIZE64_CHECK)
+#ifndef LONG_MAX
+#include <limits.h>
+#endif
 #if (__WORDSIZE == 32) || (LONG_MAX == INT_MAX)
 # error "SWIG generated code is invalid on this 32-bit architecture, please regenerate without defining SWIGWORDSIZE64 or define SWIGWORDSIZE32"
 #endif


### PR DESCRIPTION
The current upstream swig features better support for long integral types in the C# bindings, thanks to https://github.com/swig/swig/commit/fb91d1fa25ba00f93b9870d84ec3cbc0739650d7. However sadly, my C++/C# binding does not build neither on Linux now Windows with current upstream alone. On the other hand, it *does* work with the previous changes from https://github.com/swig/swig/pull/2379.

Therefore I would like to better understand the differences between the two implementations, and see if my code needs to be fixed or if current upstream swig could use some improvement.

This PR is a continuation of the previous PR https://github.com/swig/swig/pull/2379. I have unified the changes that where first proposed in https://github.com/swig/swig/pull/2237 with the latest upstream code. However, where there have been differences, I preferred the older, unmerged PR, over the current latest upstream swig. This allows me to successfully build my larger C++/C# binding on Linux and Windows successfully.

I found that some definitions difficult to understand in the current latest upstream code. This PR is meant to provide the means for discussion.

It contains:
* Integrate https://github.com/swig/swig/pull/650/files
* Introduce INT64_IS_LONG_LONG
* Additional 'long' vs. 'long long' fixes
* Better standardize long type support with upstream

As an example of the differences in code that I get with current upstream swig: The following method should return the size of an array, which I think is correctly returned as `long` on a 64bit platform, but current upstream swig uses `int` instead:
```
SWIGEXPORT unsigned int SWIGSTDCALL CSharp_MyNameSpace_UInt64Size2Array_size(void * jarg1) {
  unsigned int jresult ;
  std::array< std::uint64_t,2 > *arg1 = (std::array< std::uint64_t,2 > *) 0 ;
  std::array< unsigned long,2 >::size_type result;
  
  arg1 = (std::array< std::uint64_t,2 > *)jarg1; 
  {
    try {
      result = ((std::array< std::uint64_t,2 > const *)arg1)->size();
    } catch(const std::exception& vEx) {
      {
        SWIG_CSharpException(SWIG_RuntimeError, vEx.what()); return 0; 
      };
    } catch(...) {
      {
        SWIG_CSharpException(SWIG_UnknownError, "Unknown exception"); return 0; 
      };
    }
  }
  jresult = (unsigned int)result; 
  return jresult;
}
```

Also, the C++ type `size_t` is mapped to `int` which is not what I would expect on a 64bit platform.