### PR TITLE
[Tcl] Avoid `warning: suggest braces around initialization of subobject [-Wmissing-braces]`

### DIFF
--- a/Lib/tcl/tclrun.swg
+++ b/Lib/tcl/tclrun.swg
@@ -68,7 +68,7 @@
 #define SWIG_Tcl_GetConstant    SWIG_Tcl_GetConstantObj
 
 #if TCL_MAJOR_VERSION > 8 || (TCL_MAJOR_VERSION == 8 && TCL_MINOR_VERSION >= 5)
-#define SWIG_TCL_HASHTABLE_INIT {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define SWIG_TCL_HASHTABLE_INIT {0, {0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #else
 #define SWIG_TCL_HASHTABLE_INIT {0}
 #endif


### PR DESCRIPTION
The warning is suggesting this for elements in `.staticBuckets` of a `Tcl_HashTable`.

Example warning seen in MacPorts base with swig 4.1.1 and LLVM.org Clang 17.0.5:
```
/opt/local/bin/clang-mp-17 -c -DUSE_TCL_STUBS -DTCL_NO_DEPRECATED -g -O2 -std=c99 -Wextra -Wall -pedantic  -fPIC -DHAVE_CONFIG_H -I/Users/user/git/macports-base/src -I/Users/user/git/macports-base/src -I. -I/Users/user/git/macports-base/vendor/vendor-destroot/opt/local/libexec/macports/include -I./../compat -fno-common machista_wrap.c -o machista_wrap.o
machista_wrap.c:1901:219: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 1901 | static swig_class _wrap_class_macho_handle = { "macho_handle", &SWIGTYPE_p_macho_handle,0,0, swig_macho_handle_methods, swig_macho_handle_attributes, swig_macho_handle_bases,swig_macho_handle_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };
      |                                                                                                                                                                                                                           ^~~~~~~~~~~~~~~~~~~~~~~
machista_wrap.c:998:37: note: expanded from macro 'SWIG_TCL_HASHTABLE_INIT'
  998 | #define SWIG_TCL_HASHTABLE_INIT {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
      |                                     ^~~~~~~~~~
machista_wrap.c:2020:226: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 2020 | static swig_class _wrap_class_macho_loadcmd = { "macho_loadcmd", &SWIGTYPE_p_macho_loadcmd,0,0, swig_macho_loadcmd_methods, swig_macho_loadcmd_attributes, swig_macho_loadcmd_bases,swig_macho_loadcmd_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };
      |                                                                                                                                                                                                                                  ^~~~~~~~~~~~~~~~~~~~~~~
machista_wrap.c:998:37: note: expanded from macro 'SWIG_TCL_HASHTABLE_INIT'
  998 | #define SWIG_TCL_HASHTABLE_INIT {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
      |                                     ^~~~~~~~~~
machista_wrap.c:2183:205: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 2183 | static swig_class _wrap_class_macho_arch = { "macho_arch", &SWIGTYPE_p_macho_arch,0,0, swig_macho_arch_methods, swig_macho_arch_attributes, swig_macho_arch_bases,swig_macho_arch_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };
      |                                                                                                                                                                                                             ^~~~~~~~~~~~~~~~~~~~~~~
machista_wrap.c:998:37: note: expanded from macro 'SWIG_TCL_HASHTABLE_INIT'
  998 | #define SWIG_TCL_HASHTABLE_INIT {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
      |                                     ^~~~~~~~~~
machista_wrap.c:2214:170: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 2214 | static swig_class _wrap_class_macho = { "macho", &SWIGTYPE_p_macho,0,0, swig_macho_methods, swig_macho_attributes, swig_macho_bases,swig_macho_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };
      |                                                                                                                                                                          ^~~~~~~~~~~~~~~~~~~~~~~
machista_wrap.c:998:37: note: expanded from macro 'SWIG_TCL_HASHTABLE_INIT'
  998 | #define SWIG_TCL_HASHTABLE_INIT {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
      |                                     ^~~~~~~~~~
4 warnings generated.
```