### PR TITLE
feature("cs:defaultargs")

### DIFF
--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -42,7 +42,7 @@
 <li><a href="#CSharp_director_caveats">Director caveats</a>
 </ul>
 <li><a href="#CSharp_multiple_modules">Multiple modules</a>
-<li><a href="#CSharp_argdef">Named arguments</a>
+<li><a href="#CSharp_argdef">C# Named arguments</a>
 <li><a href="#CSharp_typemap_examples">C# Typemap examples</a>
 <ul>
 <li><a href="#CSharp_memory_management_member_variables">Memory management when returning references to member variables</a>
@@ -2154,6 +2154,7 @@ if you don't want users to easily stumble upon these so called 'internal working
 
 <H2><a name="CSharp_argdef">23.8 C# Named arguments</a></H2>
 
+
 <p>
   In C++ you can specify default arguments for functions, methods, and constructors.  C# offers named arguments.  This feature, specific to csharp, lets you bind default argument functions with default arguments in C#.  You can also add default arguments to functions which don't have default arguments.
 </p>
@@ -2204,7 +2205,7 @@ might look at the files "<tt>csharp.swg</tt>" and "<tt>typemaps.i</tt>" in
 the SWIG library.
 
 
-<H3><a name="CSharp_memory_management_member_variables">23.8.1 Memory management when returning references to member variables</a></H3>
+<H3><a name="CSharp_memory_management_member_variables">23.9.1 Memory management when returning references to member variables</a></H3>
 
 
 <p>
@@ -2328,7 +2329,7 @@ public class Bike : global::System.IDisposable {
 Note the <tt>addReference</tt> call.
 </p>
 
-<H3><a name="CSharp_memory_management_objects">23.8.2 Memory management for objects passed to the C++ layer</a></H3>
+<H3><a name="CSharp_memory_management_objects">23.9.2 Memory management for objects passed to the C++ layer</a></H3>
 
 
 <p>
@@ -2460,7 +2461,7 @@ as mentioned earlier, <tt>setElement</tt> is actually:
 </div>
 
 
-<H3><a name="CSharp_date_marshalling">23.8.3 Date marshalling using the csin typemap and associated attributes</a></H3>
+<H3><a name="CSharp_date_marshalling">23.9.3 Date marshalling using the csin typemap and associated attributes</a></H3>
 
 
 <p>
@@ -2746,7 +2747,7 @@ public class example {
 </pre>
 </div>
 
-<H3><a name="CSharp_date_properties">23.8.4 A date example demonstrating marshalling of C# properties</a></H3>
+<H3><a name="CSharp_date_properties">23.9.4 A date example demonstrating marshalling of C# properties</a></H3>
 
 
 <p>
@@ -2846,7 +2847,7 @@ Some points to note:
   <li>The 'csin' typemap has 'pre', 'post' and 'cshin' attributes, and these are all ignored in the property set. The code in these attributes must instead be replicated within the 'csvarin' typemap. The line creating the <tt>temp$csinput</tt> variable is such an example; it is identical to what is in the 'pre' attribute.
 </ul>
 
-<H3><a name="CSharp_date_pre_post_directors">23.8.5 Date example demonstrating the 'pre' and 'post' typemap attributes for directors</a></H3>
+<H3><a name="CSharp_date_pre_post_directors">23.9.5 Date example demonstrating the 'pre' and 'post' typemap attributes for directors</a></H3>
 
 
 <p>
@@ -2908,7 +2909,7 @@ Pay special attention to the memory management issues, using these attributes.
 </p>
 
 
-<H3><a name="CSharp_partial_classes">23.8.6 Turning proxy classes into partial classes</a></H3>
+<H3><a name="CSharp_partial_classes">23.9.6 Turning proxy classes into partial classes</a></H3>
 
 
 <p>
@@ -3008,7 +3009,7 @@ demonstrating that the class contains methods calling both unmanaged code - <tt>
 The following example is an alternative approach to adding managed code to the generated proxy class.
 </p>
 
-<H3><a name="CSharp_sealed_proxy_class">23.8.7 Turning proxy classes into sealed classes</a></H3>
+<H3><a name="CSharp_sealed_proxy_class">23.9.7 Turning proxy classes into sealed classes</a></H3>
 
 
 <p>
@@ -3098,7 +3099,7 @@ Either suppress the warning or modify the generated code by copying and tweaking
 'csbody' typemap code in csharp.swg by modifying swigCMemOwn to not be protected.
 </p>
 
-<H3><a name="CSharp_extending_proxy_class">23.8.8 Extending proxy classes with additional C# code</a></H3>
+<H3><a name="CSharp_extending_proxy_class">23.9.8 Extending proxy classes with additional C# code</a></H3>
 
 
 <p>
@@ -3137,7 +3138,7 @@ public class ExtendMe : global::System.IDisposable {
 </pre>
 </div>
 
-<H3><a name="CSharp_enum_underlying_type">23.8.9 Underlying type for enums</a></H3>
+<H3><a name="CSharp_enum_underlying_type">23.9.9 Underlying type for enums</a></H3>
 
 
 <P>

--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -42,6 +42,7 @@
 <li><a href="#CSharp_director_caveats">Director caveats</a>
 </ul>
 <li><a href="#CSharp_multiple_modules">Multiple modules</a>
+<li><a href="#CSharp_argdef">Named arguments</a>
 <li><a href="#CSharp_typemap_examples">C# Typemap examples</a>
 <ul>
 <li><a href="#CSharp_memory_management_member_variables">Memory management when returning references to member variables</a>
@@ -2150,7 +2151,52 @@ the <tt>[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrows
 if you don't want users to easily stumble upon these so called 'internal workings' of the wrappers.
 </p>
 
-<H2><a name="CSharp_typemap_examples">23.8 C# Typemap examples</a></H2>
+
+<H2><a name="CSharp_argdef">23.8 C# Named arguments</a></H2>
+
+<p>
+  In C++ you can specify default arguments for functions, methods, and constructors.  C# offers named arguments.  This feature, specific to csharp, lets you bind default argument functions with default arguments in C#.  You can also add default arguments to functions which don't have default arguments.
+</p>
+
+<p>Please note, using this on a function will turn off the default handling of default arguments, which would create an override for each defaulted argument, so that they could be called the same way they could in C++.  So you'll want to specify defaults for every argument when you use this.</p>
+
+<div class="code">
+  <pre>
+    %feature("cs:defaultargs") Foo::Foo;
+    %feature("cs:defaultargs", z=4) Foo::bar;
+    %feature("cs:defaultargs", x="\"five\"") Foo::zoo;
+
+    %inline %{
+    class Foo {
+    public:
+        virtual ~Foo() {}
+        Foo(int a, int b=1, int c=2)
+        {
+        }
+        int bar(int x, int y=2, int z=3)
+        {
+            return x+y+z;
+        }
+        int bat(int x=1, int y=2, int z=3)
+        {
+            return x+y+z;
+        }
+        int zoo(std::string x="four")
+        {
+            return (int)x.size();
+        }
+    };
+    %}
+  </pre>
+</div>
+
+<p>For this feature, you first specify the function/constructor you want it to impact.  Inside the feature
+  call you specify each argument you want to override.  If you specify none, it will take the literal text from c++
+  for each argument and apply that in csharp.  That often works fine, but when it doesn't you can supply a string literal
+  with a csharp expression to be used.  Or you can supply an int literal, or a float literal.  If you want to give a literal
+string you need to include an escaped quote at the start and end of the literal:  "\"a string\"".</p>
+
+<H2><a name="CSharp_typemap_examples">23.9 C# Typemap examples</a></H2>
 
 
 This section includes a few examples of typemaps.  For more examples, you

--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -824,6 +824,7 @@
 <li><a href="CSharp.html#CSharp_director_caveats">Director caveats</a>
 </ul>
 <li><a href="CSharp.html#CSharp_multiple_modules">Multiple modules</a>
+<li><a href="CSharp.html#CSharp_argdef">C# Named arguments</a>
 <li><a href="CSharp.html#CSharp_typemap_examples">C# Typemap examples</a>
 <ul>
 <li><a href="CSharp.html#CSharp_memory_management_member_variables">Memory management when returning references to member variables</a>

--- a/Doc/Manual/SWIGPlus.html
+++ b/Doc/Manual/SWIGPlus.html
@@ -1829,6 +1829,7 @@ such as C# and Java,
 which don't have optional arguments in the language, 
 Another restriction of this feature is that it cannot handle default arguments that are not public.
 The following example illustrates this:
+
 </p>
 
 <div class="code">
@@ -1848,6 +1849,10 @@ This produces uncompilable wrapper code because default values in C++ are
 evaluated in the same scope as the member function whereas SWIG
 evaluates them in the scope of a wrapper function (meaning that the
 values have to be public). 
+</p>
+
+<p>
+For C# there is a feature "cs:defaultargs" which allows you to get a single proxy function and lets you specify the  arguments in C#.
 </p>
 
 <p>

--- a/Doc/Manual/SWIGPlus.html
+++ b/Doc/Manual/SWIGPlus.html
@@ -1804,6 +1804,11 @@ use the <tt>compactdefaultargs</tt> feature flag as mentioned below.
 </p>
 
 <p>
+For C# please see the <a href="CSharp.html#CSharp_argdef">named arguments</a> section for information on alternative
+handling of named arguments for C#.
+</p>
+
+<p>
 <b>Compatibility note:</b> Versions of SWIG prior to SWIG-1.3.23 wrapped default arguments slightly differently.
 Instead a single wrapper method was generated and the default values were copied into the C++ wrappers
 so that the method being wrapped was then called with all the arguments specified.

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -121,7 +121,6 @@ CPP_TEST_CASES += \
 	apply_strings \
 	argcargvtest \
 	argout \
-	csharp_argument_defaults_feature \
 	array_member \
 	array_typedef_memberin \
 	arrayref \

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -121,6 +121,7 @@ CPP_TEST_CASES += \
 	apply_strings \
 	argcargvtest \
 	argout \
+	csharp_argument_defaults_feature \
 	array_member \
 	array_typedef_memberin \
 	arrayref \

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -36,6 +36,8 @@ CPP_TEST_CASES = \
 	nested_scope \
 	li_boost_intrusive_ptr \
 	li_std_list \
+	csharp_argument_defaults_feature \
+
 
 CPP11_TEST_CASES = \
 	cpp11_shared_ptr_const \

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -18,6 +18,7 @@ top_builddir = ../@top_builddir@
 
 CPP_TEST_CASES = \
 	complextest \
+	csharp_argument_defaults_feature \
 	csharp_attributes \
 	csharp_swig2_compatibility \
 	csharp_director_typemaps \
@@ -36,7 +37,6 @@ CPP_TEST_CASES = \
 	nested_scope \
 	li_boost_intrusive_ptr \
 	li_std_list \
-	csharp_argument_defaults_feature \
 
 
 CPP11_TEST_CASES = \

--- a/Examples/test-suite/csharp/csharp_argument_defaults_feature_runme.cs
+++ b/Examples/test-suite/csharp/csharp_argument_defaults_feature_runme.cs
@@ -1,0 +1,27 @@
+using System;
+using csharp_argument_defaults_featureNamespace;
+
+public class runme {
+    static void Main() {
+        Foo foo = new Foo(1);
+        foo.bar(1); //shutup compiler warning
+        Foo bar = new Foo(1, c:3);
+
+        if(bar.bar(1) != 7)
+            throw new ApplicationException("bar.bar(1) != 7");
+        if(bar.bar(1, 4, 4) != 9)
+            throw new ApplicationException("bar.bar(1, 4, 4) != 9");
+        if(bar.bar(1, y:3) != 8)
+            throw new ApplicationException("bar.bar(1, y:3) != 8");
+        if(bar.bat() != 6)
+            throw new ApplicationException("bar.bat() != 6");
+        if(bar.bat(3,3) != 9)
+            throw new ApplicationException("bar.bat(3,3) != 9");
+        if(bar.zoo() != 5)
+            throw new ApplicationException("bar.zoo() != 5");
+        if(bar.zoo(x:"to") != 2)
+            throw new ApplicationException("bar.zoo(x:\"to\" != 2");
+        if(bar.pi() != System.Math.PI)
+            throw new ApplicationException("bar.pi() != Math.PI");
+    }
+}

--- a/Examples/test-suite/csharp/csharp_argument_defaults_feature_runme.cs
+++ b/Examples/test-suite/csharp/csharp_argument_defaults_feature_runme.cs
@@ -19,9 +19,41 @@ public class runme {
             throw new ApplicationException("bar.bat(3,3) != 9");
         if(bar.zoo() != 5)
             throw new ApplicationException("bar.zoo() != 5");
+        if(bar.lengthOfString() != 5)
+            throw new ApplicationException("bar.lengthOfString() != 5");
         if(bar.zoo(x:"to") != 2)
             throw new ApplicationException("bar.zoo(x:\"to\" != 2");
         if(bar.pi() != System.Math.PI)
             throw new ApplicationException("bar.pi() != Math.PI");
+        if(bar.valueofenum(t:EnumerationType.three) != 3)
+            throw new ApplicationException("bar.valueofenum(t:EnumerationType.three) != 3");
+        if(bar.valueofenum() != 2)
+            throw new ApplicationException("bar.valueofenum() != 2");
+        if(bar.valueofchar() != 99)
+            throw new ApplicationException("bar.valueofchar() != 99");
+        if(bar.valueofchar(c:'d') != 100)
+            throw new ApplicationException("bar.valueofchar(c:'d') != 100");
+
+        if(Foo.sbar(1) != 7)
+            throw new ApplicationException("Foo.sbar(1) != 7");
+        if(Foo.sbar(1, 4, 4) != 9)
+            throw new ApplicationException("Foo.sbar(1, 4, 4) != 9");
+        if(Foo.sbar(1, y:3) != 8)
+            throw new ApplicationException("Foo.sbar(1, y:3) != 8");
+        if(Foo.sbat() != 6)
+            throw new ApplicationException("Foo.sbat() != 6");
+        if(Foo.sbat(3,3) != 9)
+            throw new ApplicationException("Foo.sbat(3,3) != 9");
+
+        if(csharp_argument_defaults_feature.gbar(1) != 7)
+            throw new ApplicationException("gbar(1) != 7");
+        if(csharp_argument_defaults_feature.gbar(1, 4, 4) != 9)
+            throw new ApplicationException("gbar(1, 4, 4) != 9");
+        if(csharp_argument_defaults_feature.gbar(1, y:3) != 8)
+            throw new ApplicationException("gbar(1, y:3) != 8");
+        if(csharp_argument_defaults_feature.gbat() != 6)
+            throw new ApplicationException("gbat() != 6");
+        if(csharp_argument_defaults_feature.gbat(3,3) != 9)
+            throw new ApplicationException("gbat(3,3) != 9");
     }
 }

--- a/Examples/test-suite/csharp/csharp_argument_defaults_feature_runme.cs
+++ b/Examples/test-suite/csharp/csharp_argument_defaults_feature_runme.cs
@@ -55,5 +55,11 @@ public class runme {
             throw new ApplicationException("gbat() != 6");
         if(csharp_argument_defaults_feature.gbat(3,3) != 9)
             throw new ApplicationException("gbat(3,3) != 9");
+
+        var iface = new AnImplementation();
+        if(iface.foo() != 6)
+            throw new ApplicationException("AnImplementation::foo() != 6");
+        if(iface.foo(z:5) != 7)
+            throw new ApplicationException("AnImplementation::foo(z:4) != 7");
     }
 }

--- a/Examples/test-suite/csharp_argument_defaults_feature.i
+++ b/Examples/test-suite/csharp_argument_defaults_feature.i
@@ -1,6 +1,6 @@
 %module csharp_argument_defaults_feature
 %include "std_string.i"
-
+%include <swiginterface.i>
 
 %feature("cs:defaultargs") Foo::Foo;
 %feature("cs:defaultargs", z=4) Foo::bar;
@@ -10,6 +10,7 @@
 %feature("cs:defaultargs", z=4) ::gbar;
 %feature("cs:defaultargs", z=4) Foo::sbar;
 %feature("cs:defaultargs", z=4) AnInterface::foo;
+%interface(AnInterface)
 
 //intentionally don't touch bat, leave it to normal handling
 
@@ -76,6 +77,22 @@ public:
     }
 };
 
+class AnInterface
+{
+public:
+    AnInterface()=default;
+    virtual int foo(int x=1, int y=2, int z=3) = 0;
+    virtual ~AnInterface() {}
+};
+
+class AnImplementation: public AnInterface
+{
+public:
+    int foo(int x=1, int y=2, int z=3) override
+    {
+        return x*y+z;
+    }
+};
 %}
 
 

--- a/Examples/test-suite/csharp_argument_defaults_feature.i
+++ b/Examples/test-suite/csharp_argument_defaults_feature.i
@@ -6,11 +6,31 @@
 %feature("cs:defaultargs", z=4) Foo::bar;
 %feature("cs:defaultargs", x="\"fives\"") Foo::zoo;
 %feature("cs:defaultargs", value="System.Math.PI") Foo::pi;
+%feature("cs:defaultargs", s=R"--("fives")--") Foo::lengthOfString;
+%feature("cs:defaultargs", z=4) ::gbar;
+%feature("cs:defaultargs", z=4) Foo::sbar;
+%feature("cs:defaultargs", z=4) AnInterface::foo;
 
 //intentionally don't touch bat, leave it to normal handling
 
 %inline %{
 #include <string>
+
+enum class EnumerationType {
+    one=1,
+    two,
+    three
+};
+
+int gbar(int x, int y=2, int z=3)
+{
+    return x+y+z;
+}
+int gbat(int x=1, int y=2, int z=3)
+{
+    return x+y+z;
+}
+
 class Foo {
 public:
     virtual ~Foo() {}
@@ -33,7 +53,29 @@ public:
     {
         return value;
     }
+    int lengthOfString(const std::string& s="four")
+    {
+        return (int)s.size();
+    }
+    int valueofenum(EnumerationType t=EnumerationType::two)
+    {
+        return (int)t;
+    }
+    int valueofchar(char c='c')
+    {
+        return (int)c;
+    }
+
+    static int sbar(int x, int y=2, int z=3)
+    {
+        return x+y+z;
+    }
+    static int sbat(int x=1, int y=2, int z=3)
+    {
+        return x+y+z;
+    }
 };
+
 %}
 
 

--- a/Examples/test-suite/csharp_argument_defaults_feature.i
+++ b/Examples/test-suite/csharp_argument_defaults_feature.i
@@ -1,0 +1,40 @@
+%module csharp_argument_defaults_feature
+%include "std_string.i"
+
+
+%feature("cs:defaultargs") Foo::Foo;
+%feature("cs:defaultargs", z=4) Foo::bar;
+%feature("cs:defaultargs", x="\"fives\"") Foo::zoo;
+%feature("cs:defaultargs", value="System.Math.PI") Foo::pi;
+
+//intentionally don't touch bat, leave it to normal handling
+
+%inline %{
+#include <string>
+class Foo {
+public:
+    virtual ~Foo() {}
+    Foo(int a, int b=1, int c=2)
+    {
+    }
+    int bar(int x, int y=2, int z=3)
+    {
+        return x+y+z;
+    }
+    int bat(int x=1, int y=2, int z=3)
+    {
+        return x+y+z;
+    }
+    int zoo(std::string x="four")
+    {
+        return (int)x.size();
+    }
+    double pi(double value=3.14)
+    {
+        return value;
+    }
+};
+%}
+
+
+


### PR DESCRIPTION
We need a way to specify default arguments for functions.  Sometimes we can just take the arguments straight from c++ literals.  Sometimes you can't, and need to specify those by hand.

So to make this work we:

 1. Shutoff handling all "defaultargs" variants of methods and constructors which have cs:defaultargs defined for their node.  This gets us a single constructor or method and skips the variants.
 2. As we emit arguments in the function declaration, check if there is a definition for it it from cs:defaultargs, if so, use that.  If not, and the method has a cs:defaultargs declaration, then fall back to the literal expression from c++.