### PR TITLE
[Tcl] Add missing casts to NULL sentinel

### DIFF
--- a/Lib/tcl/tclerrors.swg
+++ b/Lib/tcl/tclerrors.swg
@@ -51,15 +51,15 @@ SWIG_Tcl_SetErrorObj(Tcl_Interp *interp, const char *ctype, Tcl_Obj *obj)
 {
   Tcl_ResetResult(interp);
   Tcl_SetObjResult(interp, obj);
-  Tcl_SetErrorCode(interp, "SWIG", ctype, NULL);
+  Tcl_SetErrorCode(interp, "SWIG", ctype, (char *)NULL);
 }
 
 SWIGINTERN void
 SWIG_Tcl_SetErrorMsg(Tcl_Interp *interp, const char *ctype, const char *mesg)
 {
   Tcl_ResetResult(interp);
-  Tcl_SetErrorCode(interp, "SWIG", ctype, NULL);
-  Tcl_AppendResult(interp, ctype, " ", mesg, NULL);
+  Tcl_SetErrorCode(interp, "SWIG", ctype, (char *)NULL);
+  Tcl_AppendResult(interp, ctype, " ", mesg, (char *)NULL);
   /*
   Tcl_AddErrorInfo(interp, ctype);
   Tcl_AddErrorInfo(interp, " ");

--- a/Lib/tcl/tclrun.swg
+++ b/Lib/tcl/tclrun.swg
@@ -711,7 +711,7 @@ SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[], const char
     c = strchr(fmt,':');
     if (!c) c = strchr(fmt,';');
     if (!c) c = (char *)"";
-    Tcl_AppendResult(interp,c," argument ", temp, NULL);
+    Tcl_AppendResult(interp,c," argument ", temp, (char *)NULL);
     va_end(ap);
     return TCL_ERROR;
   }


### PR DESCRIPTION
Not all platforms define `NULL` as having pointer type, so passing `NULL` to variadic functions `Tcl_SetErrorCode()` and `Tcl_AppendResult()` without casting is non-portable.