### PR TITLE
[Tcl] Use `Tcl_GetString()` instead of `Tcl_GetStringFromObj(…, NULL)`

### DIFF
--- a/Doc/Manual/Tcl.html
+++ b/Doc/Manual/Tcl.html
@@ -2780,7 +2780,7 @@ used as a <tt>char **</tt> object.
   }
   $1 = (char **) malloc((nitems+1)*sizeof(char *));
   for (i = 0; i &lt; nitems; i++) {
-    $1[i] = Tcl_GetStringFromObj(listobjv[i], 0);
+    $1[i] = Tcl_GetString(listobjv[i]);
   }
   $1[i] = 0;
 }

--- a/Examples/tcl/multimap/example.i
+++ b/Examples/tcl/multimap/example.i
@@ -25,7 +25,7 @@ extern int    gcd(int x, int y);
   }
   $2 = (char **) malloc(($1+1)*sizeof(char *));
   for (i = 0; i < $1; i++) {
-    $2[i] = Tcl_GetStringFromObj(listobjv[i],0);
+    $2[i] = Tcl_GetString(listobjv[i]);
   }
   $2[i] = 0;
 }

--- a/Lib/tcl/argcargv.i
+++ b/Lib/tcl/argcargv.i
@@ -12,7 +12,7 @@
   $1 = ($1_ltype) nitems;
   $2 = (char **) malloc((nitems+1)*sizeof(char *));
   for (i = 0; i < nitems; i++) {
-    $2[i] = Tcl_GetStringFromObj(listobjv[i], NULL);
+    $2[i] = Tcl_GetString(listobjv[i]);
   }
   $2[i] = NULL;
 }

--- a/Lib/tcl/tclrun.swg
+++ b/Lib/tcl/tclrun.swg
@@ -138,7 +138,7 @@ SWIG_Tcl_ConvertPtrFromString(Tcl_Interp *interp, const char *c, void **ptr, swi
     /* from being called when c is not a command, firing the unknown proc */
     if (Tcl_VarEval(interp,"info commands ", c, (char *) NULL) == TCL_OK) {
       Tcl_Obj *result = Tcl_GetObjResult(interp);
-      if (*(Tcl_GetStringFromObj(result, NULL)) == 0) {
+      if (*(Tcl_GetString(result)) == 0) {
         /* It's not a command, so it can't be a pointer */
         Tcl_ResetResult(interp);
         return SWIG_ERROR;
@@ -156,7 +156,7 @@ SWIG_Tcl_ConvertPtrFromString(Tcl_Interp *interp, const char *c, void **ptr, swi
       return SWIG_ERROR;
     }
 
-    c = Tcl_GetStringFromObj(Tcl_GetObjResult(interp), NULL);
+    c = Tcl_GetString(Tcl_GetObjResult(interp));
   }
   cmd_name = c;
 
@@ -200,7 +200,7 @@ SWIG_Tcl_ConvertPtrFromString(Tcl_Interp *interp, const char *c, void **ptr, swi
 /* Convert a pointer value */
 SWIGRUNTIMEINLINE int
 SWIG_Tcl_ConvertPtr(Tcl_Interp *interp, Tcl_Obj *oc, void **ptr, swig_type_info *ty, int flags) {
-  return SWIG_Tcl_ConvertPtrFromString(interp, Tcl_GetStringFromObj(oc,NULL), ptr, ty, flags);
+  return SWIG_Tcl_ConvertPtrFromString(interp, Tcl_GetString(oc), ptr, ty, flags);
 }
 
 /* Convert a pointer value */
@@ -227,7 +227,7 @@ SWIG_Tcl_ConvertPacked(Tcl_Interp *SWIGUNUSEDPARM(interp) , Tcl_Obj *obj, void *
   const char  *c;
 
   if (!obj) goto type_error;
-  c = Tcl_GetStringFromObj(obj,NULL);
+  c = Tcl_GetString(obj);
   /* Pointer values must start with leading underscore */
   if (*c != '_') goto type_error;
   c++;
@@ -346,7 +346,7 @@ SWIG_Tcl_MethodCommand(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_
     Tcl_SetResult(interp, (char *) "wrong # args.", TCL_STATIC);
     return TCL_ERROR;
   }
-  method = Tcl_GetStringFromObj(objv[1],NULL);
+  method = Tcl_GetString(objv[1]);
   if (strcmp(method,"-acquire") == 0) {
     inst->destroy = 1;
     SWIG_Acquire(inst->thisvalue);
@@ -409,7 +409,7 @@ SWIG_Tcl_MethodCommand(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_
         Tcl_SetResult(interp, (char *) "wrong # args.", TCL_STATIC);
         return TCL_ERROR;
       }
-      attrname = Tcl_GetStringFromObj(objv[2],NULL);
+      attrname = Tcl_GetString(objv[2]);
       attr = cls->attributes;
       while (attr && attr->name) {
         if ((strcmp(attr->name, attrname) == 0) && (attr->getmethod)) {
@@ -443,7 +443,7 @@ SWIG_Tcl_MethodCommand(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_
       }
       i = 2;
       while (i < objc) {
-        attrname = Tcl_GetStringFromObj(objv[i],NULL);
+        attrname = Tcl_GetString(objv[i]);
         attr = cls->attributes;
         while (attr && attr->name) {
           if ((strcmp(attr->name, attrname) == 0) && (attr->setmethod)) {
@@ -512,7 +512,7 @@ SWIG_Tcl_NewInstanceObj(Tcl_Interp *interp, void *thisvalue, swig_type_info *typ
     Tcl_CmdInfo    ci;
     int has_command;
     char          *name;
-    name = Tcl_GetStringFromObj(robj,NULL);
+    name = Tcl_GetString(robj);
     has_command = Tcl_GetCommandInfo(interp, name, &ci);
     if (!has_command || flags) {
       swig_instance *newinst = (swig_instance *) malloc(sizeof(swig_instance));
@@ -521,7 +521,7 @@ SWIG_Tcl_NewInstanceObj(Tcl_Interp *interp, void *thisvalue, swig_type_info *typ
       newinst->thisvalue = thisvalue;
       newinst->classptr = (swig_class *) type->clientdata;
       newinst->destroy = flags;
-      newinst->cmdtok = Tcl_CreateObjCommand(interp, Tcl_GetStringFromObj(robj,NULL), (swig_wrapper_func) SWIG_MethodCommand, (ClientData) newinst, (swig_delete_func) SWIG_ObjectDelete);
+      newinst->cmdtok = Tcl_CreateObjCommand(interp, Tcl_GetString(robj), (swig_wrapper_func) SWIG_MethodCommand, (ClientData) newinst, (swig_delete_func) SWIG_ObjectDelete);
       if (flags) {
         SWIG_Acquire(thisvalue);
       }
@@ -558,7 +558,7 @@ SWIG_Tcl_ObjectConstructor(ClientData clientData, Tcl_Interp *interp, int objc, 
   }
   cons = classptr->constructor;
   if (objc > 1) {
-    char *s = Tcl_GetStringFromObj(objv[1],NULL);
+    char *s = Tcl_GetString(objv[1]);
     if (strcmp(s,"-this") == 0) {
       thisarg = 2;
       cons = 0;
@@ -570,7 +570,7 @@ SWIG_Tcl_ObjectConstructor(ClientData clientData, Tcl_Interp *interp, int objc, 
     } else if (objc >= 3) {
       char *s1;
       name = s;
-      s1 = Tcl_GetStringFromObj(objv[2],NULL);
+      s1 = Tcl_GetString(objv[2]);
       if (strcmp(s1,"-this") == 0) {
 	thisarg = 3;
 	cons = 0;
@@ -586,12 +586,12 @@ SWIG_Tcl_ObjectConstructor(ClientData clientData, Tcl_Interp *interp, int objc, 
       return result;
     }
     newObj = Tcl_DuplicateObj(Tcl_GetObjResult(interp));
-    if (!name) name = Tcl_GetStringFromObj(newObj,NULL);
+    if (!name) name = Tcl_GetString(newObj);
   } else if (thisarg > 0) {
     if (thisarg < objc) {
       destroy = 0;
       newObj = Tcl_DuplicateObj(objv[thisarg]);
-      if (!name) name = Tcl_GetStringFromObj(newObj,NULL);
+      if (!name) name = Tcl_GetString(newObj);
     } else {
       Tcl_SetResult(interp, (char *) "wrong # args.", TCL_STATIC);
       return TCL_ERROR;
@@ -650,7 +650,7 @@ SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[], const char
     vptr = va_arg(ap,void *);
     if (vptr) {
       if (isupper(*c)) {
-        obj = SWIG_Tcl_GetConstantObj(Tcl_GetStringFromObj(objv[argno+1],0));
+        obj = SWIG_Tcl_GetConstantObj(Tcl_GetString(objv[argno+1]));
         if (!obj) obj = objv[argno+1];
       } else {
         obj = objv[argno+1];
@@ -678,11 +678,11 @@ SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[], const char
           *((char **) vptr) = Tcl_GetStringFromObj(obj, vlptr);
           c++;
         } else {
-          *((char **)vptr) = Tcl_GetStringFromObj(obj,NULL);
+          *((char **)vptr) = Tcl_GetString(obj);
         }
         break;
       case 'c': case 'C':
-        *((char *)vptr) = *(Tcl_GetStringFromObj(obj,NULL));
+        *((char *)vptr) = *(Tcl_GetString(obj));
         break;
       case 'p': case 'P':
         ty = (swig_type_info *) va_arg(ap, void *);

--- a/Lib/tcl/typemaps.i
+++ b/Lib/tcl/typemaps.i
@@ -164,14 +164,14 @@ or you can use the %apply directive :
 %typemap(in) long long *INPUT($*1_ltype temp), 
              long long &INPUT($*1_ltype temp)
 {
-  temp = ($*1_ltype) strtoll(Tcl_GetStringFromObj($input,NULL),0,0);
+  temp = ($*1_ltype) strtoll(Tcl_GetString($input),0,0);
   $1 = &temp;
 }
 
 %typemap(in) unsigned long long *INPUT($*1_ltype temp), 
              unsigned long long &INPUT($*1_ltype temp)
 {
-  temp = ($*1_ltype) strtoull(Tcl_GetStringFromObj($input,NULL),0,0);
+  temp = ($*1_ltype) strtoull(Tcl_GetString($input),0,0);
   $1 = &temp;
 }
   

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -572,7 +572,7 @@ public:
       /* Printf(getf->code, "%s\n",tm); */
       addfail = emit_action_code(n, getf->code, tm);
       Printf(getf->code, "if (value) {\n");
-      Printf(getf->code, "Tcl_SetVar2(interp,name1,name2,Tcl_GetStringFromObj(value,NULL), flags);\n");
+      Printf(getf->code, "Tcl_SetVar2(interp,name1,name2,Tcl_GetString(value), flags);\n");
       Printf(getf->code, "Tcl_DecrRefCount(value);\n");
       Printf(getf->code, "}\n");
       Printf(getf->code, "return NULL;\n");


### PR DESCRIPTION
I notice that there is currently no usage of `Tcl_GetString()` in SWIG, but I am not aware if it that was intentional.

Future Tcl introduces the `Tcl_Size` type for use in C APIs. In Tcl 8.7, it is defined as `int` for binary compatibility, while in Tcl 9.0, it is defined to `ptrdiff_t` to support ≥32-bit sized things.

`Tcl_GetStringFromObj()` will expect its second parameter to have type `Tcl_Size *`. There is currently a compatibility approach in place which allows `int *` to be passed instead, but disallows `Tcl_GetStringFromObj(…, 0)`, and makes `Tcl_GetStringFromObj(…, NULL)` non-portable. The alternative to using `Tcl_GetString()` to avoid this problem would be to use casts, i.e. `Tcl_GetStringFromObj(…, (Tcl_Size *)NULL)` (see 6c46ff3800350b5da241557ca9d95222348e1790).