### PR TITLE
[Tcl] Prepare `load` command usage for TIP 595

### DIFF
--- a/Examples/tcl/class/runme.tcl
+++ b/Examples/tcl/class/runme.tcl
@@ -3,7 +3,7 @@
 # This file illustrates the high level C++ interface.
 # In this case C++ classes work kind of like Tk widgets
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # ----- Object creation -----
 

--- a/Examples/tcl/class/runme2.tcl
+++ b/Examples/tcl/class/runme2.tcl
@@ -4,7 +4,7 @@
 # created by SWIG.  In this case, all of our C++ classes
 # get converted into function calls.
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # ----- Object creation -----
 

--- a/Examples/tcl/constants/runme.tcl
+++ b/Examples/tcl/constants/runme.tcl
@@ -1,6 +1,6 @@
 # file: runme.tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 puts "ICONST  = $ICONST (should be 42)"
 puts "FCONST  = $FCONST (should be 2.1828)"

--- a/Examples/tcl/contract/runme.tcl
+++ b/Examples/tcl/contract/runme.tcl
@@ -1,7 +1,7 @@
 # file: runme.tcl
 # Try to load as a dynamic module.
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # Call our gcd() function
 set x 42

--- a/Examples/tcl/enum/runme.tcl
+++ b/Examples/tcl/enum/runme.tcl
@@ -1,6 +1,6 @@
 # file: runme.tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # ----- Object creation -----
 

--- a/Examples/tcl/funcptr/runme.tcl
+++ b/Examples/tcl/funcptr/runme.tcl
@@ -1,6 +1,6 @@
 # file: runme.tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 set a 37
 set b 42

--- a/Examples/tcl/import/runme.tcl
+++ b/Examples/tcl/import/runme.tcl
@@ -2,10 +2,10 @@
 # Test various properties of classes defined in separate modules
 
 puts "Testing the %import directive"
-catch { load ./base[info sharedlibextension] base}
-catch { load ./foo[info sharedlibextension] foo}
-catch { load ./bar[info sharedlibextension] bar}
-catch { load ./spam[info sharedlibextension] spam}
+catch { load ./base[info sharedlibextension] Base}
+catch { load ./foo[info sharedlibextension] Foo}
+catch { load ./bar[info sharedlibextension] Bar}
+catch { load ./spam[info sharedlibextension] Spam}
 
 # Create some objects
 

--- a/Examples/tcl/multimap/runme.tcl
+++ b/Examples/tcl/multimap/runme.tcl
@@ -1,7 +1,7 @@
 # file: runme.tcl
 # Try to load as a dynamic module.
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # Call our gcd() function
 set x 42

--- a/Examples/tcl/operator/runme.tcl
+++ b/Examples/tcl/operator/runme.tcl
@@ -1,6 +1,6 @@
 # Operator overloading example
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 set a [Complex -args 2 3]
 set b [Complex -args -5 10]

--- a/Examples/tcl/pointer/runme.tcl
+++ b/Examples/tcl/pointer/runme.tcl
@@ -1,6 +1,6 @@
 # file: runme.tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # First create some objects using the pointer library.
 puts "Testing the pointer library"

--- a/Examples/tcl/reference/runme.tcl
+++ b/Examples/tcl/reference/runme.tcl
@@ -2,7 +2,7 @@
 
 # This file illustrates the manipulation of C++ references in Tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # ----- Object creation -----
 

--- a/Examples/tcl/simple/runme.tcl
+++ b/Examples/tcl/simple/runme.tcl
@@ -1,7 +1,7 @@
 # file: runme.tcl
 # Try to load as a dynamic module.
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # Call our gcd() function
 set x 42

--- a/Examples/tcl/std_vector/runme.tcl
+++ b/Examples/tcl/std_vector/runme.tcl
@@ -1,6 +1,6 @@
 # file: runme.tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # Exercise IntVector
 

--- a/Examples/tcl/value/runme.tcl
+++ b/Examples/tcl/value/runme.tcl
@@ -1,7 +1,7 @@
 # file: runme.tcl
 # Try to load as a dynamic module.
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # Create a couple of a vectors
 

--- a/Examples/tcl/variables/runme.tcl
+++ b/Examples/tcl/variables/runme.tcl
@@ -1,6 +1,6 @@
 # file: runme.tcl
 
-catch { load ./example[info sharedlibextension] example}
+catch { load ./example[info sharedlibextension] Example}
 
 # Try to set the values of some global variables
 

--- a/Examples/test-suite/tcl/argcargvtest_runme.tcl
+++ b/Examples/test-suite/tcl/argcargvtest_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./argcargvtest[info sharedlibextension] argcargvtest} err_msg ] {
+if [ catch { load ./argcargvtest[info sharedlibextension] Argcargvtest} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/bools_runme.tcl
+++ b/Examples/test-suite/tcl/bools_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./bools[info sharedlibextension] bools} err_msg ] {
+if [ catch { load ./bools[info sharedlibextension] Bools} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/catches_strings_runme.tcl
+++ b/Examples/test-suite/tcl/catches_strings_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./catches_strings[info sharedlibextension] catches_strings} err_msg ] {
+if [ catch { load ./catches_strings[info sharedlibextension] Catches_strings} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/clientdata_prop_runme.tcl
+++ b/Examples/test-suite/tcl/clientdata_prop_runme.tcl
@@ -1,9 +1,9 @@
 
-if [ catch { load ./clientdata_prop_b[info sharedlibextension] clientdata_prop_b} err_msg ] {
+if [ catch { load ./clientdata_prop_b[info sharedlibextension] Clientdata_prop_b} err_msg ] {
   puts stderr "Could not load shared object:\n$err_msg"
   exit 1
 }
-if [ catch { load ./clientdata_prop_a[info sharedlibextension] clientdata_prop_a} err_msg ] {
+if [ catch { load ./clientdata_prop_a[info sharedlibextension] Clientdata_prop_a} err_msg ] {
   puts stderr "Could not load shared object:\n$err_msg"
   exit 1
 }

--- a/Examples/test-suite/tcl/cpp11_move_typemaps_runme.tcl
+++ b/Examples/test-suite/tcl/cpp11_move_typemaps_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./cpp11_move_typemaps[info sharedlibextension] cpp11_move_typemaps} err_msg ] {
+if [ catch { load ./cpp11_move_typemaps[info sharedlibextension] Cpp11_move_typemaps} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/cpp11_rvalue_reference_move_runme.tcl
+++ b/Examples/test-suite/tcl/cpp11_rvalue_reference_move_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./cpp11_rvalue_reference_move[info sharedlibextension] cpp11_rvalue_reference_move} err_msg ] {
+if [ catch { load ./cpp11_rvalue_reference_move[info sharedlibextension] Cpp11_rvalue_reference_move} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/cpp11_std_unique_ptr_runme.tcl
+++ b/Examples/test-suite/tcl/cpp11_std_unique_ptr_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./cpp11_std_unique_ptr[info sharedlibextension] cpp11_std_unique_ptr} err_msg ] {
+if [ catch { load ./cpp11_std_unique_ptr[info sharedlibextension] Cpp11_std_unique_ptr} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/cpp11_strongly_typed_enumerations_runme.tcl
+++ b/Examples/test-suite/tcl/cpp11_strongly_typed_enumerations_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./cpp11_strongly_typed_enumerations[info sharedlibextension] cpp11_strongly_typed_enumerations} err_msg ] {
+if [ catch { load ./cpp11_strongly_typed_enumerations[info sharedlibextension] Cpp11_strongly_typed_enumerations} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/disown_runme.tcl
+++ b/Examples/test-suite/tcl/disown_runme.tcl
@@ -2,7 +2,7 @@
 # This is the union runtime testcase. It ensures that values within a 
 # union embedded within a struct can be set and read correctly.
 
-if [ catch { load ./disown[info sharedlibextension] disown} err_msg ] {
+if [ catch { load ./disown[info sharedlibextension] Disown} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/enum_thorough_runme.tcl
+++ b/Examples/test-suite/tcl/enum_thorough_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./enum_thorough[info sharedlibextension] enum_thorough} err_msg ] {
+if [ catch { load ./enum_thorough[info sharedlibextension] Enum_thorough} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/import_nomodule_runme.tcl
+++ b/Examples/test-suite/tcl/import_nomodule_runme.tcl
@@ -1,4 +1,4 @@
 
-if [ catch { load ./import_nomodule[info sharedlibextension] import_nomodule} err_msg ] {
+if [ catch { load ./import_nomodule[info sharedlibextension] Import_nomodule} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }

--- a/Examples/test-suite/tcl/imports_runme.tcl
+++ b/Examples/test-suite/tcl/imports_runme.tcl
@@ -1,11 +1,11 @@
 
 # This is the imports runtime testcase. 
 proc import {} {
-    if [ catch { load ./imports_b[info sharedlibextension] imports_b} err_msg ] {
+    if [ catch { load ./imports_b[info sharedlibextension] Imports_b} err_msg ] {
             puts stderr "Could not load shared object:\n$err_msg"
             exit 1
     }
-    if [ catch { load ./imports_a[info sharedlibextension] imports_a} err_msg ] {
+    if [ catch { load ./imports_a[info sharedlibextension] Imports_a} err_msg ] {
             puts stderr "Could not load shared object:\n$err_msg"
             exit 1
     }

--- a/Examples/test-suite/tcl/integers_runme.tcl
+++ b/Examples/test-suite/tcl/integers_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./integers[info sharedlibextension] integers} err_msg ] {
+if [ catch { load ./integers[info sharedlibextension] Integers} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/li_std_auto_ptr_runme.tcl
+++ b/Examples/test-suite/tcl/li_std_auto_ptr_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./li_std_auto_ptr[info sharedlibextension] li_std_auto_ptr} err_msg ] {
+if [ catch { load ./li_std_auto_ptr[info sharedlibextension] Li_std_auto_ptr} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/li_std_string_runme.tcl
+++ b/Examples/test-suite/tcl/li_std_string_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./li_std_string[info sharedlibextension] li_std_string} err_msg ] {
+if [ catch { load ./li_std_string[info sharedlibextension] Li_std_string} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/li_std_vector_runme.tcl
+++ b/Examples/test-suite/tcl/li_std_vector_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./li_std_vector[info sharedlibextension] li_std_vector} err_msg ] {
+if [ catch { load ./li_std_vector[info sharedlibextension] Li_std_vector} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/member_pointer_runme.tcl
+++ b/Examples/test-suite/tcl/member_pointer_runme.tcl
@@ -1,6 +1,6 @@
 # Example using pointers to member functions
 
-if [ catch { load ./member_pointer[info sharedlibextension] member_pointer} err_msg ] {
+if [ catch { load ./member_pointer[info sharedlibextension] Member_pointer} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/newobject1_runme.tcl
+++ b/Examples/test-suite/tcl/newobject1_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./newobject1[info sharedlibextension] newobject1} err_msg ] {
+if [ catch { load ./newobject1[info sharedlibextension] Newobject1} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/newobject2_runme.tcl
+++ b/Examples/test-suite/tcl/newobject2_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./newobject2[info sharedlibextension] newobject2} err_msg ] {
+if [ catch { load ./newobject2[info sharedlibextension] Newobject2} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/null_pointer_runme.tcl
+++ b/Examples/test-suite/tcl/null_pointer_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./null_pointer[info sharedlibextension] null_pointer} err_msg ] {
+if [ catch { load ./null_pointer[info sharedlibextension] Null_pointer} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/overload_copy_runme.tcl
+++ b/Examples/test-suite/tcl/overload_copy_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./overload_copy[info sharedlibextension] overload_copy} err_msg ] {
+if [ catch { load ./overload_copy[info sharedlibextension] Overload_copy} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/overload_null_runme.tcl
+++ b/Examples/test-suite/tcl/overload_null_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./overload_null[info sharedlibextension] overload_null} err_msg ] {
+if [ catch { load ./overload_null[info sharedlibextension] Overload_null} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/overload_simple_runme.tcl
+++ b/Examples/test-suite/tcl/overload_simple_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./overload_simple[info sharedlibextension] overload_simple} err_msg ] {
+if [ catch { load ./overload_simple[info sharedlibextension] Overload_simple} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/primitive_ref_runme.tcl
+++ b/Examples/test-suite/tcl/primitive_ref_runme.tcl
@@ -1,7 +1,7 @@
 # Primitive ref testcase.  Tests to make sure references to 
 # primitive types are passed by value
 
-if [ catch { load ./primitive_ref[info sharedlibextension] primitive_ref} err_msg ] {
+if [ catch { load ./primitive_ref[info sharedlibextension] Primitive_ref} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/primitive_types_runme.tcl
+++ b/Examples/test-suite/tcl/primitive_types_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./primitive_types[info sharedlibextension] primitive_types} err_msg ] {
+if [ catch { load ./primitive_types[info sharedlibextension] Primitive_types} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/profiletest_runme.tcl
+++ b/Examples/test-suite/tcl/profiletest_runme.tcl
@@ -1,4 +1,4 @@
-catch { load ./profiletest[info sharedlibextension] profiletest}
+catch { load ./profiletest[info sharedlibextension] Profiletest}
 
 set  a [new_A]
 set  b [new_B]

--- a/Examples/test-suite/tcl/reference_global_vars_runme.tcl
+++ b/Examples/test-suite/tcl/reference_global_vars_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./reference_global_vars[info sharedlibextension] reference_global_vars} err_msg ] {
+if [ catch { load ./reference_global_vars[info sharedlibextension] Reference_global_vars} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/union_parameter_runme.tcl
+++ b/Examples/test-suite/tcl/union_parameter_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./union_parameter[info sharedlibextension] union_parameter} err_msg ] {
+if [ catch { load ./union_parameter[info sharedlibextension] Union_parameter} err_msg ] {
         puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/unions_runme.tcl
+++ b/Examples/test-suite/tcl/unions_runme.tcl
@@ -2,7 +2,7 @@
 # This is the union runtime testcase. It ensures that values within a 
 # union embedded within a struct can be set and read correctly.
 
-if [ catch { load ./unions[info sharedlibextension] unions} err_msg ] {
+if [ catch { load ./unions[info sharedlibextension] Unions} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 


### PR DESCRIPTION
Proposed on behalf of @PaulObermeier.

The prefix specified to the `load` command is no longer case-insensitive in Tcl 9 due to [TIP 595](https://core.tcl-lang.org/tips/doc/trunk/tip/595.md). For usage to work in both Tcl 8 and 9, a prefix such as `example` should be replaced with `Example` (equivalent to `[string totitle example]`: b9a876cfb533af14aae6cc93f24f153bf0672d59).