### PR TITLE
Improved support for Tcl9

### DIFF
--- a/Examples/tcl/multimap/example.c
+++ b/Examples/tcl/multimap/example.c
@@ -3,6 +3,12 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+#include <tcl.h>
+
+#ifndef TCL_SIZE_MAX
+typedef int Tcl_Size;
+#endif
+
 /* Compute the greatest common divisor of positive integers */
 int gcd(int x, int y) {
   int g;
@@ -15,7 +21,7 @@ int gcd(int x, int y) {
   return g;
 }
 
-int gcdmain(int argc, char *argv[]) {
+int gcdmain(Tcl_Size argc, char *argv[]) {
   int x,y;
   if (argc != 3) {
     printf("usage: gcd x y\n");
@@ -27,7 +33,7 @@ int gcdmain(int argc, char *argv[]) {
   return 0;
 }
 
-int count(char *bytes, int len, char c) {
+int count(char *bytes, Tcl_Size len, char c) {
   int i;
   int count = 0;
   for (i = 0; i < len; i++) {
@@ -36,7 +42,7 @@ int count(char *bytes, int len, char c) {
   return count;
 }
 
-void capitalize(char *str, int len) {
+void capitalize(char *str, Tcl_Size len) {
   int i;
   for (i = 0; i < len; i++) {
     str[i] = (char)toupper(str[i]);

--- a/Examples/tcl/multimap/example.c
+++ b/Examples/tcl/multimap/example.c
@@ -3,12 +3,6 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-#include <tcl.h>
-
-#ifndef TCL_SIZE_MAX
-typedef int Tcl_Size;
-#endif
-
 /* Compute the greatest common divisor of positive integers */
 int gcd(int x, int y) {
   int g;
@@ -21,7 +15,7 @@ int gcd(int x, int y) {
   return g;
 }
 
-int gcdmain(Tcl_Size argc, char *argv[]) {
+int gcdmain(int argc, char *argv[]) {
   int x,y;
   if (argc != 3) {
     printf("usage: gcd x y\n");
@@ -33,7 +27,7 @@ int gcdmain(Tcl_Size argc, char *argv[]) {
   return 0;
 }
 
-int count(char *bytes, Tcl_Size len, char c) {
+int count(char *bytes, int len, char c) {
   int i;
   int count = 0;
   for (i = 0; i < len; i++) {
@@ -42,7 +36,7 @@ int count(char *bytes, Tcl_Size len, char c) {
   return count;
 }
 
-void capitalize(char *str, Tcl_Size len) {
+void capitalize(char *str, int len) {
   int i;
   for (i = 0; i < len; i++) {
     str[i] = (char)toupper(str[i]);

--- a/Examples/tcl/multimap/example.i
+++ b/Examples/tcl/multimap/example.i
@@ -1,11 +1,13 @@
 /* File : example.i */
 %module example
 
+#include <tcl.h>
+
 %{
 extern int gcd(int x, int y);
-extern int gcdmain(int argc, char *argv[]);
-extern int count(char *bytes, int len, char c);
-extern void capitalize (char *str, int len);
+extern int gcdmain(Tcl_Size argc, char *argv[]);
+extern int count(char *bytes, Tcl_Size len, char c);
+extern void capitalize (char *str, Tcl_Size len);
 extern void circle (double cx, double cy);
 extern int squareCubed (int n, int *OUTPUT);
 %}
@@ -14,11 +16,11 @@ extern int squareCubed (int n, int *OUTPUT);
 
 extern int    gcd(int x, int y);
 
-%typemap(arginit) (int argc, char *argv[]) "$2 = 0;"
+%typemap(arginit) (Tcl_Size argc, char *argv[]) "$2 = 0;"
 
-%typemap(in) (int argc, char *argv[]) {
+%typemap(in) (Tcl_Size argc, char *argv[]) {
   Tcl_Obj **listobjv = 0;
-  int i;
+  Tcl_Size i;
   if (Tcl_ListObjGetElements(interp,$input, &$1, &listobjv) == TCL_ERROR) {
     SWIG_exception(SWIG_ValueError,"Expected a list");
     return TCL_ERROR;
@@ -34,18 +36,18 @@ extern int    gcd(int x, int y);
   free($1);
 }
 
-extern int gcdmain(int argc, char *argv[]);
+extern int gcdmain(Tcl_Size argc, char *argv[]);
 
-%typemap(in) (char *bytes, int len) {
+%typemap(in) (char *bytes, Tcl_Size len) {
   $1 = Tcl_GetStringFromObj($input,&$2);
 }
 
-extern int count(char *bytes, int len, char c);
+extern int count(char *bytes, Tcl_Size len, char c);
 
 
 /* This example shows how to wrap a function that mutates a string */
 
-%typemap(in) (char *str, int len) {
+%typemap(in) (char *str, Tcl_Size len) {
   char *temp;
   temp = Tcl_GetStringFromObj($input,&$2);
   $1 = (char *) malloc($2+1);
@@ -54,14 +56,14 @@ extern int count(char *bytes, int len, char c);
 
 /* Return the mutated string as a new object.   */
 
-%typemap(argout) (char *str, int len) {
+%typemap(argout) (char *str, Tcl_Size len) {
  Tcl_Obj *o;
  o = Tcl_NewStringObj($1,$2);
  Tcl_ListObjAppendElement(interp,$result,o);
  free($1);
 }   
 
-extern void capitalize(char *str, int len);
+extern void capitalize(char *str, Tcl_Size len);
 
 
 /* A multi-valued constraint.  Force two arguments to lie

--- a/Examples/tcl/multimap/example.i
+++ b/Examples/tcl/multimap/example.i
@@ -1,13 +1,11 @@
 /* File : example.i */
 %module example
 
-#include <tcl.h>
-
 %{
 extern int gcd(int x, int y);
-extern int gcdmain(Tcl_Size argc, char *argv[]);
-extern int count(char *bytes, Tcl_Size len, char c);
-extern void capitalize (char *str, Tcl_Size len);
+extern int gcdmain(int argc, char *argv[]);
+extern int count(char *bytes, int len, char c);
+extern void capitalize (char *str, int len);
 extern void circle (double cx, double cy);
 extern int squareCubed (int n, int *OUTPUT);
 %}
@@ -16,15 +14,17 @@ extern int squareCubed (int n, int *OUTPUT);
 
 extern int    gcd(int x, int y);
 
-%typemap(arginit) (Tcl_Size argc, char *argv[]) "$2 = 0;"
+%typemap(arginit) (int argc, char *argv[]) "$2 = 0;"
 
-%typemap(in) (Tcl_Size argc, char *argv[]) {
+%typemap(in) (int argc, char *argv[]) {
   Tcl_Obj **listobjv = 0;
-  Tcl_Size i;
-  if (Tcl_ListObjGetElements(interp,$input, &$1, &listobjv) == TCL_ERROR) {
+  int i;
+  Tcl_Size tmpSize;
+  if (Tcl_ListObjGetElements(interp,$input, &tmpSize, &listobjv) == TCL_ERROR) {
     SWIG_exception(SWIG_ValueError,"Expected a list");
     return TCL_ERROR;
   }
+  $1 = (int)tmpSize;
   $2 = (char **) malloc(($1+1)*sizeof(char *));
   for (i = 0; i < $1; i++) {
     $2[i] = Tcl_GetString(listobjv[i]);
@@ -36,34 +36,38 @@ extern int    gcd(int x, int y);
   free($1);
 }
 
-extern int gcdmain(Tcl_Size argc, char *argv[]);
+extern int gcdmain(int argc, char *argv[]);
 
-%typemap(in) (char *bytes, Tcl_Size len) {
-  $1 = Tcl_GetStringFromObj($input,&$2);
+%typemap(in) (char *bytes, int len) {
+  Tcl_Size tmpSize;
+  $1 = Tcl_GetStringFromObj($input,&tmpSize);
+  $2 = (int)tmpSize;
 }
 
-extern int count(char *bytes, Tcl_Size len, char c);
+extern int count(char *bytes, int len, char c);
 
 
 /* This example shows how to wrap a function that mutates a string */
 
-%typemap(in) (char *str, Tcl_Size len) {
+%typemap(in) (char *str, int len) {
   char *temp;
-  temp = Tcl_GetStringFromObj($input,&$2);
+  Tcl_Size tmpSize;
+  temp = Tcl_GetStringFromObj($input,&tmpSize);
+  $2 = (int)tmpSize;
   $1 = (char *) malloc($2+1);
   memmove($1,temp,$2);
 }
 
 /* Return the mutated string as a new object.   */
 
-%typemap(argout) (char *str, Tcl_Size len) {
+%typemap(argout) (char *str, int len) {
  Tcl_Obj *o;
  o = Tcl_NewStringObj($1,$2);
  Tcl_ListObjAppendElement(interp,$result,o);
  free($1);
 }   
 
-extern void capitalize(char *str, Tcl_Size len);
+extern void capitalize(char *str, int len);
 
 
 /* A multi-valued constraint.  Force two arguments to lie

--- a/Examples/test-suite/tcl/cpp17_string_view_runme.tcl
+++ b/Examples/test-suite/tcl/cpp17_string_view_runme.tcl
@@ -1,5 +1,5 @@
 
-if [ catch { load ./cpp17_string_view[info sharedlibextension] cpp17_string_view} err_msg ] {
+if [ catch { load ./cpp17_string_view[info sharedlibextension] Cpp17_string_view} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Examples/test-suite/tcl/li_constraints_runme.tcl
+++ b/Examples/test-suite/tcl/li_constraints_runme.tcl
@@ -1,4 +1,4 @@
-if [ catch { load ./li_constraints[info sharedlibextension] li_constraints} err_msg ] {
+if [ catch { load ./li_constraints[info sharedlibextension] Li_constraints} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 

--- a/Lib/tcl/argcargv.i
+++ b/Lib/tcl/argcargv.i
@@ -3,7 +3,7 @@
  * ------------------------------------------------------------- */
 
 %typemap(in) (int ARGC, char **ARGV) {
-  int i, nitems;
+  Tcl_Size i, nitems;
   Tcl_Obj **listobjv;
   if (Tcl_ListObjGetElements(interp, $input, &nitems, &listobjv) == TCL_ERROR) {
      SWIG_exception_fail(SWIG_ValueError, "in method '$symname', Expecting list of argv");
@@ -18,7 +18,7 @@
 }
 
 %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) (int ARGC, char **ARGV) {
-  int len;
+  Tcl_Size len;
   $1 = Tcl_ListObjLength(interp, $input, &len) == TCL_OK;
 }
 

--- a/Lib/tcl/std_vector.i
+++ b/Lib/tcl/std_vector.i
@@ -35,7 +35,7 @@
 #include <vector>
 
 SWIGINTERN Tcl_Obj* SwigString_FromString(const std::string &s) {
-    return Tcl_NewStringObj(s.data(), (int)s.length());
+    return Tcl_NewStringObj(s.data(), (Tcl_Size)s.length());
 }
 
 SWIGINTERN int SWIG_Tcl_GetBoolFromObj(Tcl_Interp *interp, Tcl_Obj *o, bool *val) {
@@ -48,7 +48,7 @@ SWIGINTERN int SWIG_Tcl_GetBoolFromObj(Tcl_Interp *interp, Tcl_Obj *o, bool *val
 }
  
 SWIGINTERN int SwigString_AsString(Tcl_Interp *interp, Tcl_Obj *o, std::string *val) {
-    int len;
+    Tcl_Size len;
     const char* temp = Tcl_GetStringFromObj(o, &len);
     (void)interp;
     if (temp == NULL)
@@ -85,8 +85,8 @@ namespace std {
     template<class T> class vector {
         %typemap(in) vector< T > (std::vector< T > *v) {
             Tcl_Obj **listobjv;
-            int       nitems;
-            int       i;
+            Tcl_Size  nitems;
+            Tcl_Size  i;
             T*        temp;
 
             if (SWIG_ConvertPtr($input, (void **) &v,
@@ -114,8 +114,8 @@ namespace std {
         %typemap(in) const vector< T >* (std::vector< T > *v, std::vector< T > w),
                      const vector< T >& (std::vector< T > *v, std::vector< T > w) {
             Tcl_Obj **listobjv;
-            int       nitems;
-            int       i;
+            Tcl_Size  nitems;
+            Tcl_Size  i;
             T*        temp;
 
             if(SWIG_ConvertPtr($input, (void **) &v,
@@ -153,7 +153,7 @@ namespace std {
 
         %typecheck(SWIG_TYPECHECK_VECTOR) vector< T > {
             Tcl_Obj **listobjv;
-            int       nitems;
+            Tcl_Size  nitems;
             T*        temp;
             std::vector< T > *v;
             
@@ -182,7 +182,7 @@ namespace std {
         %typecheck(SWIG_TYPECHECK_VECTOR) const vector< T >&,
                                           const vector< T >* {
             Tcl_Obj **listobjv;
-            int       nitems;
+            Tcl_Size   nitems;
             T*         temp;
             std::vector< T > *v;
 
@@ -261,8 +261,8 @@ namespace std {
 
         %typemap(in) vector< T > (std::vector< T > *v){
             Tcl_Obj **listobjv;
-            int       nitems;
-            int       i;
+            Tcl_Size  nitems;
+            Tcl_Size  i;
             T         temp;
 
             if(SWIG_ConvertPtr($input, (void **) &v,
@@ -285,8 +285,8 @@ namespace std {
         %typemap(in) const vector< T >& (std::vector< T > *v,std::vector< T > w),
                      const vector< T >* (std::vector< T > *v,std::vector< T > w) {
             Tcl_Obj **listobjv;
-            int       nitems;
-            int       i;
+            Tcl_Size  nitems;
+            Tcl_Size  i;
             T         temp;
 
             if(SWIG_ConvertPtr($input, (void **) &v,
@@ -316,7 +316,7 @@ namespace std {
        
         %typecheck(SWIG_TYPECHECK_VECTOR) vector< T > {
             Tcl_Obj **listobjv;
-            int       nitems;
+            Tcl_Size  nitems;
             T         temp;
             std::vector< T > *v;
 
@@ -343,7 +343,7 @@ namespace std {
         %typecheck(SWIG_TYPECHECK_VECTOR) const vector< T >&,
 	                                      const vector< T >*{
             Tcl_Obj **listobjv;
-            int       nitems;
+            Tcl_Size  nitems;
             T         temp;
             std::vector< T > *v;
 

--- a/Lib/tcl/tclinit.swg
+++ b/Lib/tcl/tclinit.swg
@@ -24,7 +24,7 @@ SWIGEXPORT int SWIG_init(Tcl_Interp *);
 
 /* Compatibility version for TCL stubs */
 #ifndef SWIG_TCL_STUBS_VERSION
-#define SWIG_TCL_STUBS_VERSION "8.4"
+#define SWIG_TCL_STUBS_VERSION "8.4-"
 #endif
 
 %}

--- a/Lib/tcl/tclprimtypes.swg
+++ b/Lib/tcl/tclprimtypes.swg
@@ -82,7 +82,7 @@ SWIG_AsVal_dec(unsigned long)(Tcl_Obj *obj, unsigned long *val) {
        get it as a string so we can distinguish these cases. */
   }
   {
-    int len = 0;
+    Tcl_Size len = 0;
     const char *nptr = Tcl_GetStringFromObj(obj, &len);
     if (nptr && len > 0) {
       char *endptr;
@@ -183,7 +183,7 @@ SWIG_AsVal_dec(unsigned long long)(Tcl_Obj *obj, unsigned long long *val)
     if (val) *val = (unsigned long) v;
     return SWIG_OK;
   } else {
-    int len = 0;
+    Tcl_Size len = 0;
     const char *nptr = Tcl_GetStringFromObj(obj, &len);
     if (nptr && len > 0) {
       char *endptr;

--- a/Lib/tcl/tclrun.swg
+++ b/Lib/tcl/tclrun.swg
@@ -674,7 +674,7 @@ SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[], const char
         break;
       case 's': case 'S':
         if (*(c+1) == '#') {
-          int *vlptr = (int *) va_arg(ap, void *);
+          Tcl_Size *vlptr = (Tcl_Size *) va_arg(ap, void *);
           *((char **) vptr) = Tcl_GetStringFromObj(obj, vlptr);
           c++;
         } else {

--- a/Lib/tcl/tclruntime.swg
+++ b/Lib/tcl/tclruntime.swg
@@ -6,6 +6,22 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <ctype.h>
+
+/* Check, if Tcl version supports Tcl_Size,
+   which was introduced in Tcl 8.7 and 9.
+*/
+#ifndef TCL_SIZE_MAX
+    #include <limits.h>
+    #define TCL_SIZE_MAX INT_MAX
+
+    #ifndef Tcl_Size
+        typedef int Tcl_Size;
+    #endif
+
+    #define TCL_SIZE_MODIFIER ""
+    #define Tcl_GetSizeIntFromObj Tcl_GetIntFromObj
+    #define Tcl_NewSizeIntObj     Tcl_NewIntObj
+#endif
 %}
 
 %insert(runtime) "swigrun.swg";         /* Common C API type-checking code */

--- a/Lib/tcl/tclstrings.swg
+++ b/Lib/tcl/tclstrings.swg
@@ -6,7 +6,7 @@
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(Tcl_Obj *obj, char** cptr, size_t* psize, int *alloc)
 { 
-  int len = 0;
+  Tcl_Size len = 0;
   char *cstr = Tcl_GetStringFromObj(obj, &len);
   if (cstr) {
     if (cptr)  *cptr = cstr;
@@ -24,7 +24,7 @@ SWIG_AsCharPtrAndSize(Tcl_Obj *obj, char** cptr, size_t* psize, int *alloc)
 SWIGINTERNINLINE Tcl_Obj *
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {
-  return (size < INT_MAX) ? Tcl_NewStringObj(carray, %numeric_cast(size,int)) : NULL;
+  return (size < TCL_SIZE_MAX) ? Tcl_NewStringObj(carray, %numeric_cast(size,Tcl_Size)) : NULL;
 }
 }
 

--- a/Lib/tcl/tclwstrings.swg
+++ b/Lib/tcl/tclwstrings.swg
@@ -12,14 +12,14 @@
 SWIGINTERN int
 SWIG_AsWCharPtrAndSize(Tcl_Obj *obj, wchar_t** cptr, size_t* psize, int *alloc)
 { 
-  int len = 0;
+  Tcl_Size len = 0;
   Tcl_UniChar *ustr = Tcl_GetUnicodeFromObj(obj, &len);
   if (ustr) {
     if (cptr)  {
       Tcl_Encoding encoding = NULL;
       char *src = (char *) ustr;
-      int srcLen = (len)*sizeof(Tcl_UniChar);
-      int dstLen = sizeof(wchar_t)*(len + 1);
+      Tcl_Size srcLen = (len)*sizeof(Tcl_UniChar);
+      Tcl_Size dstLen = sizeof(wchar_t)*(len + 1);
       char *dst = %new_array(dstLen, char);
       int flags = 0;
       Tcl_EncodingState *statePtr = 0;
@@ -44,11 +44,11 @@ SWIGINTERNINLINE Tcl_Obj *
 SWIG_FromWCharPtrAndSize(const wchar_t* carray, size_t size)
 {
   Tcl_Obj *res = NULL;
-  if (size < INT_MAX) {
+  if (size < TCL_SIZE_MAX) {
     Tcl_Encoding encoding = NULL;
     char *src = (char *) carray;
-    int srcLen = (int)(size*sizeof(wchar_t));
-    int dstLen = (int)(size*sizeof(Tcl_UniChar));
+    Tcl_Size srcLen = (Tcl_Size)(size*sizeof(wchar_t));
+    Tcl_Size dstLen = (Tcl_Size)(size*sizeof(Tcl_UniChar));
     char *dst = %new_array(dstLen, char);
     int flags = 0;
     Tcl_EncodingState *statePtr = 0;
@@ -59,7 +59,7 @@ SWIG_FromWCharPtrAndSize(const wchar_t* carray, size_t size)
     Tcl_ExternalToUtf(0, encoding, src, srcLen, flags, statePtr, dst,
 		      dstLen, &srcRead, &dstWrote, &dstChars);
     
-    res = Tcl_NewUnicodeObj((Tcl_UniChar*)dst, (int)size);
+    res = Tcl_NewUnicodeObj((Tcl_UniChar*)dst, (Tcl_Size)size);
     %delete_array(dst);
   }
   return res;


### PR DESCRIPTION
Changes done as explained in chapters **Init stubs** and **64-bit data support** at the Tcl9 porting site:
https://core.tcl-lang.org/tcl/wiki?name=Migrating%20C%20extensions%20to%20Tcl%209

Replaced int with Tcl_Size where appropriate.
Replaced INT_MAX with TCL_SIZE_MAX.
Changed SWIG_TCL_STUB_VERSION from "8.4" to "8.4-". 
Corrected calls of load command in some examples.