### PR TITLE
Replace nullptr with NULL (javascript.cxx)

### DIFF
--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1425,7 +1425,7 @@ String *JSEmitter::emitInputTypemap(Node *n, Parm *p, Wrapper *wrapper, String *
 String *JSEmitter::emitCheckTypemap(Node *, Parm *p, Wrapper *wrapper, String *arg) {
   String *tm = Getattr(p, "tmap:check");
 
-  if (tm != nullptr) {
+  if (tm != NULL) {
     Replaceall(tm, "$input", arg);
     Printf(wrapper->code, "%s\n", tm);
   }


### PR DESCRIPTION
When replacing nullptr by NULL, SWIG 4.2.0 can still be compiled with gcc 4.9.X (ex. Debian Jessie).