### PR TITLE
Allow passing NULL value to sq_ass_item

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -540,8 +540,10 @@ SwigPyBuiltin_ternaryfunc_closure(SwigPyWrapperFunction wrapper, PyObject *a, Py
   assert(tuple);
   Py_INCREF(b);
   PyTuple_SET_ITEM(tuple, 0, b);
-  Py_INCREF(c);
-  PyTuple_SET_ITEM(tuple, 1, c);
+  if (c) {
+    Py_INCREF(c);
+    PyTuple_SET_ITEM(tuple, 1, c);
+  }
   result = wrapper(a, tuple);
   Py_DECREF(tuple);
   return result;

--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -656,8 +656,10 @@ SwigPyBuiltin_ssizeobjargproc_closure(SwigPyWrapperFunction wrapper, PyObject *a
   tuple = PyTuple_New(2);
   assert(tuple);
   PyTuple_SET_ITEM(tuple, 0, _PyLong_FromSsize_t(b));
-  Py_INCREF(c);
-  PyTuple_SET_ITEM(tuple, 1, c);
+  if (c) {
+    Py_INCREF(c);
+    PyTuple_SET_ITEM(tuple, 1, c);
+  }
   resultobj = wrapper(a, tuple);
   result = resultobj ? 0 : -1;
   Py_XDECREF(resultobj);


### PR DESCRIPTION
The `sq_ass_item` slot calls `PySequence_SetItem`, which can be used to delete an element by passing a `NULL` value. Calling `Py_INCREF` on a `NULL` value causes a segfault. This commit adds a `NULL` check similar to that in other closure functions.