### PR TITLE
Change logic relating to setting python:argcount

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2834,9 +2834,9 @@ public:
     int noargs = funpack && (tuple_required == 0 && tuple_arguments == 0);
     int onearg = funpack && (tuple_required == 1 && tuple_arguments == 1);
 
-    if (builtin && funpack && !overname && !builtin_ctor) {
+    if (builtin && funpack && (tuple_required == tuple_arguments) && !overname && !builtin_ctor) {
       int compactdefargs = ParmList_is_compactdefargs(l);
-      if (!(compactdefargs && (tuple_arguments > tuple_required || varargs))) {
+      if (!compactdefargs) {
 	String *argattr = NewStringf("%d", tuple_arguments);
 	Setattr(n, "python:argcount", argattr);
 	Delete(argattr);


### PR DESCRIPTION
This fixes a problem I've been having that appears to be related to bug #1126. The `python:argcount` value is used to select `METH_NOARGS`, `METH_O`, or `METH_VARARGS`. I've changed the logic to ensure that `METH_VARARGS` is always used if there are any optional parameters.