### PR TITLE
CI: Add c99/c++98 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,9 @@ jobs:
           CPPSTD: c++11
           CSTD: gnu11
         - SWIGLANG: python
+          CPPSTD: c++98
+          CSTD: gnu99
+        - SWIGLANG: python
           CPPSTD: c++11
         - SWIGLANG: r
           CPPSTD: c++11


### PR DESCRIPTION
Makes sure swig can still be compiled on old distros.
See #2628