### PR TITLE
Adjust code for Octave v9

### DIFF
--- a/Lib/octave/octcontainer.swg
+++ b/Lib/octave/octcontainer.swg
@@ -66,7 +66,11 @@ namespace std {
     bool
     operator()(const octave_value& v, const octave_value& w) const
     { 
+%#if SWIG_OCTAVE_PREREQ(7,0,0)
+      octave_value res = octave::binary_op(octave_value::op_le,v,w);
+%#else
       octave_value res = do_binary_op(octave_value::op_le,v,w);
+%#endif
       return res.is_true();
     }
   };

--- a/Lib/octave/octrun.swg
+++ b/Lib/octave/octrun.swg
@@ -402,7 +402,11 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
     }
 
     static octave_value make_value_hack(const octave_base_value &x) {
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+      ((octave_swig_type &) x).m_count++;
+#else
       ((octave_swig_type &) x).count++;
+#endif
       return octave_value((octave_base_value *) &x);
     }
 
@@ -427,7 +431,11 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
 
     ~octave_swig_type() {
       if (thisown) {
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+	++m_count;
+#else
 	++count;
+#endif
 	for (unsigned int j = 0; j < types.size(); ++j) {
 	  if (!types[j].first || !types[j].first->clientdata)
 	    continue;
@@ -515,16 +523,28 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
     }
 
     octave_value as_value() {
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+      ++m_count;
+#else
       ++count;
+#endif
       return Swig::swig_value_ref(this);
     }
 
     void incref() {
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+      ++m_count;
+#else
       ++count;
+#endif
     }
 
     void decref() {
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+      if (!--m_count)
+#else
       if (!--count)
+#endif
 	delete this;
     }
 

--- a/Lib/octave/octrun.swg
+++ b/Lib/octave/octrun.swg
@@ -1123,8 +1123,13 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
       :ptr(_ptr)
       {
         // Ensure type_id() is set correctly
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+        if (s_t_id == -1) {
+          s_t_id = octave_swig_ref::static_type_id();
+#else
         if (t_id == -1) {
           t_id = octave_swig_ref::static_type_id();
+#endif
         }
       }
 
@@ -1254,8 +1259,12 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
 #endif
       { return ptr->print(os, pr_as_read_syntax); }
 
-#if SWIG_OCTAVE_PREREQ(4,4,0)
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+      static void set_type_id(int type_id) { s_t_id=type_id; }
+#else
+# if SWIG_OCTAVE_PREREQ(4,4,0)
       static void set_type_id(int type_id) { t_id=type_id; }
+# endif
 #endif
 
     virtual type_conv_info numeric_conversion_function(void) const {
@@ -1288,8 +1297,13 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
       :	type(_type), buf((const char*)_buf, (const char*)_buf + _buf_len)
       {
         // Ensure type_id() is set correctly
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+        if (s_t_id == -1) {
+          s_t_id = octave_swig_packed::static_type_id();
+#else
         if (t_id == -1) {
           t_id = octave_swig_packed::static_type_id();
+#endif
         }
       }
 
@@ -1369,8 +1383,12 @@ SWIGRUNTIME void swig_acquire_ownership_obj(void *vptr, int own);
 # endif
 #endif
 
-#if SWIG_OCTAVE_PREREQ(4,4,0)
+#if SWIG_OCTAVE_PREREQ(9,0,0)
+    static void set_type_id(int type_id) { s_t_id=type_id; }
+#else
+# if SWIG_OCTAVE_PREREQ(4,4,0)
     static void set_type_id(int type_id) { t_id=type_id; }
+# endif
 #endif
 
   private:


### PR DESCRIPTION
In version 9 of Octave, t_id has been replaced by s_t_id.

The proposed changes also work with previous versions of Octave.