### PR TITLE
Do not use mkoctfile -p LIBS for linking - brings in too many deps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1683,11 +1683,7 @@ if test -n "$OCTAVE"; then
    for var in OCTLIBDIR; do
      OCTAVE_LDFLAGS="${OCTAVE_LDFLAGS} "-L`${mkoctfile} -p ${var}`
    done
-   for var in RDYNAMIC_FLAG RLD_FLAG OCTAVE_LIBS LIBS; do
-     # RLD_FLAG gives "mkoctfile: unknown variable 'RLD_FLAG'" on stderr
-     # with Octave 7.3 so just discard stderr here.  Apparently RLD_FLAG has
-     # reported an empty value since somewhere between 3.4.3 and 3.6.1 so
-     # can be removed below once we require Octave 4.
+   for var in RDYNAMIC_FLAG OCTAVE_LIBS; do
      OCTAVE_LDFLAGS="${OCTAVE_LDFLAGS} "`${mkoctfile} -p ${var} 2>/dev/null`
    done
    AC_MSG_RESULT([$OCTAVE_LDFLAGS])


### PR DESCRIPTION
octave 9.1.0 adds a bunch of dependent libraries to LIBS.  While this may be a mistake (see discussion at https://octave.discourse.group/t/change-in-mkoctfile-p-libs-output-with-octave-9-1-0/5381/2), I'm still not sure it's needed at all.

Another possibility would be to make use of the octave pkg-config configuration, which has been available since octave 5.1.