### PR TITLE
more robust out of source build detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2859,7 +2859,9 @@ AC_CONFIG_FILES([CCache/ccache_swig_config.h])
 # source directory, and provides a rule for updating the Makefile from
 # its original source.
 AC_CONFIG_COMMANDS([Examples],[
-  if test "x${srcdir}" != "x." ; then
+  CONFIG_SRC_DIR=`cd ${srcdir} && pwd`
+  CONFIG_TARGET_DIR=`pwd`
+  if test "x${CONFIG_SRC_DIR}" != "x${CONFIG_TARGET_DIR}" ; then
     AC_MSG_NOTICE([generating Examples build tree])
     for mkfile in `cd ${srcdir} && find Examples/ -type f -name Makefile`; do
       dir=`dirname ${mkfile}`

--- a/configure.ac
+++ b/configure.ac
@@ -2859,8 +2859,8 @@ AC_CONFIG_FILES([CCache/ccache_swig_config.h])
 # source directory, and provides a rule for updating the Makefile from
 # its original source.
 AC_CONFIG_COMMANDS([Examples],[
-  CONFIG_SRC_DIR=`cd ${srcdir} && pwd`
-  CONFIG_TARGET_DIR=`pwd`
+  CONFIG_SRC_DIR=`cd ${srcdir} && pwd | tr [A-Z] [a-z]`
+  CONFIG_TARGET_DIR=`pwd | tr [A-Z] [a-z]`
   if test "x${CONFIG_SRC_DIR}" != "x${CONFIG_TARGET_DIR}" ; then
     AC_MSG_NOTICE([generating Examples build tree])
     for mkfile in `cd ${srcdir} && find Examples/ -type f -name Makefile`; do


### PR DESCRIPTION
When `configure` is called with a full path, it will try to do an out-of-source build even if the current working directory is its own directory

https://github.com/conan-io/conan-center-index/pull/19058