### PR TITLE
Include stdlib.h for recent Python Stable ABI

### DIFF
--- a/Lib/python/pyruntime.swg
+++ b/Lib/python/pyruntime.swg
@@ -36,6 +36,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 %}
 
 %insert(runtime) "swigrun.swg";         /* SWIG API */


### PR DESCRIPTION
Recent Python Stable ABI does not include this header:

https://github.com/python/cpython/blob/c43f6a4dfaa1c1974141e2f7014a7f98ca3a3f93/Include/Python.h#L29-L39

However, SWIG needs `free` and `malloc`. On Windows this will cause:

  error C3861: 'free': identifier not found
  error C3861: 'malloc': identifier not found