### PR TITLE
Fix JavaScript _wrap_getCPtr on 64-bit Windows

### DIFF
--- a/Lib/javascript/napi/javascriptrun.swg
+++ b/Lib/javascript/napi/javascriptrun.swg
@@ -372,7 +372,7 @@ SWIGRUNTIME Napi::Value _wrap_getCPtr(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::Value jsresult;
   void *arg1 = (void *) 0 ;
-  long result;
+  intptr_t result;
   int res1;
 
   res1 = SWIG_GetInstancePtr(info.This(), &arg1);
@@ -380,7 +380,7 @@ SWIGRUNTIME Napi::Value _wrap_getCPtr(const Napi::CallbackInfo &info) {
     SWIG_Error(SWIG_ArgError(res1), " in method '" "getCPtr" "', argument " "1"" of type '" "void *""'");
   }
 
-  result = (long)arg1;
+  result = (intptr_t)arg1;
   jsresult = Napi::Number::New(env, result);
 
   return jsresult;

--- a/Lib/javascript/v8/javascriptrun.swg
+++ b/Lib/javascript/v8/javascriptrun.swg
@@ -349,7 +349,7 @@ SWIGRUNTIME SwigV8ReturnValue _wrap_getCPtr(const SwigV8Arguments &args) {
   
   SWIGV8_VALUE jsresult;
   void *arg1 = (void *) 0 ;
-  long result;
+  intptr_t result;
   int res1;
 
   res1 = SWIG_GetInstancePtr(args.Holder(), &arg1);
@@ -357,7 +357,7 @@ SWIGRUNTIME SwigV8ReturnValue _wrap_getCPtr(const SwigV8Arguments &args) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "getCPtr" "', argument " "1"" of type '" "void *""'");
   }
 
-  result = (long)arg1;
+  result = (intptr_t)arg1;
   jsresult = SWIGV8_NUMBER_NEW(result);
 
   SWIGV8_RETURN(jsresult);


### PR DESCRIPTION
    C:\0>swig -javascript -node example.i

    C:\0>g++ -c -O2 -I C:/msys64/mingw64/include/node example_wrap.c
    example_wrap.c: In function 'SwigV8ReturnValue _wrap_getCPtr(const SwigV8Arguments&)':
    example_wrap.c:1149:12: error: cast from 'void*' to 'long int' loses precision [-fpermissive]
     1149 |   result = (long)arg1;
          |            ^~~~~~~~~~

    C:\0>g++ --version
    g++ (Rev5, Built by MSYS2 project) 13.2.0
    Copyright (C) 2023 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
