### PR TITLE
Fix issue with -fvirtual and using

### DIFF
--- a/Examples/test-suite/java/using_member_multiple_inherit_runme.java
+++ b/Examples/test-suite/java/using_member_multiple_inherit_runme.java
@@ -42,5 +42,10 @@ public class using_member_multiple_inherit_runme {
     mb.multmethod("hi");
     mb.multmethod(123, 234);
     mb.multmethod(123, 345, 567);
+
+    // Multiple inheritance, with no override on parent class. 
+    Vusing2 vu = new Vusing2();
+    vu.usingmethod(3);
+    vu.usingmethod("hi");
   }
 }

--- a/Examples/test-suite/python/using_member_multiple_inherit_runme.py
+++ b/Examples/test-suite/python/using_member_multiple_inherit_runme.py
@@ -30,3 +30,8 @@ mb.multmethod(123)
 mb.multmethod("hi")
 mb.multmethod(123, 234)
 mb.multmethod(123, 345, 567)
+
+# Multiple inheritance, with no override on parent class. 
+vu = Vusing2()
+vu.usingmethod(3)
+vu.usingmethod("hi")

--- a/Examples/test-suite/using_member_multiple_inherit.i
+++ b/Examples/test-suite/using_member_multiple_inherit.i
@@ -113,13 +113,16 @@ void cplusplus_testB() {
 class Vusing {
 public:
   virtual void usingmethod(int i) {}
+  virtual ~Vusing() {};
 };
 class Vusing1 : public Vusing {
 public:
   virtual void usingmethod(int i) {}
+  virtual ~Vusing1() {};
 };
 class Vusing2 : public Vusing1 {
 public:
+  virtual ~Vusing2() {};
   using Vusing1::usingmethod;
   virtual void usingmethod(const char* c) {};
 };

--- a/Examples/test-suite/using_member_multiple_inherit.i
+++ b/Examples/test-suite/using_member_multiple_inherit.i
@@ -107,6 +107,23 @@ void cplusplus_testB() {
   m.multmethod(123, 345, 567);
 }
 
+// Multiple inheritance, with no override on parent class. 
+// This checks a corner case with fvirtual and using
+// See #2872
+class Vusing {
+public:
+  virtual void usingmethod(int i) {}
+};
+class Vusing1 : public Vusing {
+public:
+  virtual void usingmethod(int i) {}
+};
+class Vusing2 : public Vusing1 {
+public:
+  using Vusing1::usingmethod;
+  virtual void usingmethod(const char* c) {};
+};
+
 /* TODO: fix when using declaration is declared before method, for example change MultMiddleA to:
 struct MultMiddleB : Mult1, Mult2 {
 protected: // Note!

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -234,6 +234,7 @@ class Allocate:public Dispatcher {
 			// Don't eliminate if an overloaded method as this hides the method
 			// in the scripting languages: the dispatch function will hide the base method if ignored.
 			SetFlag(n, "feature:ignore");
+            SetFlag(n, "feature:ignored_by_fvirtual");
 		      }
 	      } else {
 		// Some languages need to know about covariant return types
@@ -633,6 +634,14 @@ class Allocate:public Dispatcher {
  * ----------------------------------------------------------------------------- */
 
   void add_member_for_using_declaration(Node *c, Node *n, int &ccount, Node *&unodes, Node *&last_unodes) {
+    if (GetFlag(c, "feature:ignored_by_fvirtual"))
+    {
+        // This node was ignored by fvirtual. Thus, it has feature:ignore set. 
+        // However, we may have new sybling overrides that will make us want to keep it.
+        // Hence, temporarily unset the feature:ignore flag.
+        UnsetFlag(c, "feature:ignore");
+    }
+
     if (!(Swig_storage_isstatic(c)
 	  || checkAttribute(c, "storage", "typedef")
 	  || Strstr(Getattr(c, "storage"), "friend")
@@ -664,6 +673,10 @@ class Allocate:public Dispatcher {
 	Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(n), Getline(n), "Using declaration %s, with name '%s', is not actually using\n", SwigType_namestr(Getattr(n, "uname")), symname);
 	Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(c), Getline(c), "the method from %s, with name '%s', as the names are different.\n", Swig_name_decl(c), csymname);
       }
+    }
+    if (GetFlag(c, "feature:ignored_by_fvirtual"))
+    {
+        SetFlag(c, "feature:ignore");
     }
   }
 


### PR DESCRIPTION
#2872 is for a parsing problem for a corner case where:
* A member is included on a grandchild class (call this `D2` for derived 2) via a `using` directive that points to the parent class (let's call this `D1` for derived 1). The parent does not do any specialization, so it's version of this method is the same as the `base` class (this is the grandparent class of `D2` and the parent class of `D1`).
* The `-fvirtual` flag is used. As a result, when parsing `D1`, the method will pick up the `feature:ignore` flag.
* The `D2` class overloads the method that is including via the `using` directive.

What should happen here is a `_wrap_SWIG_0` for the version of the method included via `using`. `wrap_SWIG_n` wrapped versions of the method for any overloads. However, the `feature:ignore` flag set when parsing `D1` was keeping this from happening, so only the overloaded methods were being wrapped, i.e., the method included via the `using` directive was getting missed. This is all explained in more detail with an example in #2872.

This PR fixes this issue by temporarily unsetting the `feature:ignore` flag if and only if that flag was set as a result of `fvirtual`. The way this is tracked is via a new flag called `ignored_by_fvirtual`, which is set whenever `feature:ignore` is set as a result of `fvirtual`. 

There is also a test case included with #2872 that would be nice to include here so that this corner case can be unit tested going forward. I'm not sure of the best way to add this, e.g., the unit test is written for C++ and Python, is there a good way to adapt it so other languages can run the test case as well? Any feedback/pointers on this would be helpful. 