### PR TITLE
Fix returning null from functions with output parameters in Python

### DIFF
--- a/Examples/test-suite/inout.i
+++ b/Examples/test-suite/inout.i
@@ -55,4 +55,9 @@ void AddOne1r(double& INOUT);
   inline void CharNot(char* INOUT) {
     if (*INOUT) { *INOUT = '\0'; } else { *INOUT = '\xff'; }
   }
+
+  inline void* NonVoidOut(int* INOUT) {
+    *INOUT += 42;
+    return NULL;
+  }
 %}

--- a/Examples/test-suite/javascript/inout_runme.js
+++ b/Examples/test-suite/javascript/inout_runme.js
@@ -1,0 +1,13 @@
+var inout = require("inout");
+
+if (inout.AddOne1(1) != 2) {
+    throw new Error;
+}
+
+if (JSON.stringify(inout.AddOne3(1, 1, 1)) != JSON.stringify([2, 2, 2])) {
+    throw new Error;
+}
+
+if (JSON.stringify(inout.NonVoidOut(-42)) != JSON.stringify([null, 0])) {
+    throw new Error;
+}

--- a/Examples/test-suite/python/inout_runme.py
+++ b/Examples/test-suite/python/inout_runme.py
@@ -19,3 +19,9 @@ if a != [(2, 2), 2]:
 a = inout.AddOne3p(1, (1, 1), 1)
 if a != [2, (2, 2), 2]:
     raise RuntimeError
+
+ret, out = inout.NonVoidOut(-42)
+if ret is not None:
+    raise RuntimeError
+if out != 0:
+    raise RuntimeError

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -114,13 +114,16 @@ SWIG_Python_SetConstant(PyObject *d, const char *name, PyObject *obj) {
 
 #endif
 
+/* See "out" typemap for void in pytypemaps.swg */
+SWIGINTERN int swig_is_void = 0;
+
 /* Append a value to the result obj */
 
 SWIGINTERN PyObject*
-SWIG_Python_AppendOutput(PyObject* result, PyObject* obj) {
+SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
   if (!result) {
     result = obj;
-  } else if (result == Py_None) {
+  } else if (result == Py_None && is_void) {
     SWIG_Py_DECREF(result);
     result = obj;
   } else {

--- a/Lib/python/pytypemaps.swg
+++ b/Lib/python/pytypemaps.swg
@@ -25,7 +25,7 @@
 
 /* Backward compatibility output helper */
 %fragment("t_output_helper","header") %{
-#define t_output_helper SWIG_Python_AppendOutput
+#define t_output_helper(r, o) SWIG_Python_AppendOutput(r, o, swig_is_void)
 %}
 
 
@@ -50,7 +50,7 @@
 /* Overload of the output/constant/exception/dirout handling */
 
 /* append output */
-#define SWIG_AppendOutput(result, obj)  SWIG_Python_AppendOutput(result, obj)
+#define SWIG_AppendOutput(result, obj)  SWIG_Python_AppendOutput(result, obj, swig_is_void)
 
 /* set constant */
 #if defined(SWIGPYTHON_BUILTIN)
@@ -76,6 +76,12 @@
   $1 = &$self;
 }
 
+/* Hack to prevent SWIG_Python_AppendOutput() from dropping Py_None from the
+   output if it corresponds to a null pointer being returned to Python rather
+   than the return value of a void function. By intentionally shadowing the
+   global swig_is_void which is always 0 by this local variable set to 1 here,
+   we can tell it to do this only for void functions. */
+%typemap(out,noblock=1) void (int swig_is_void = 1) {$result = VOID_Object;}
 
 /* Consttab, needed for callbacks, it should be removed later */
 


### PR DESCRIPTION
Null pointers returned from functions also using output parameters or C strings typemaps were lost because the generated code didn't distinguish between Py_None corresponding to them and Py_None indicating the return value of a "void" function.

This doesn't seem to be easy to solve properly because the function return type and output parameters typemaps are independent and there is no way to customize the behaviour of the latter depending on the former.

So we do it using a hack involving a global variable which is always 0 and is passed to SWIG_Python_AppendOutput() from non-void functions, but is shadowed by a local variable with the same name set to 1 in the void ones. This allows us to only discard Py_None if it corresponds to a void function return value.

This is obviously ugly, but requires only minimal changes, doesn't impose much extra run-time overhead and is MT-safe (unlike any solution involving global variables).

Also add a unit test checking for this for Python and for JS, where the same function already worked correctly (unlike in some other languages, including at least Ruby and PHP).

Closes #2905.