### PR TITLE
[ruby] Fix implementation of container

### DIFF
--- a/Examples/test-suite/ruby/li_std_list_runme.rb
+++ b/Examples/test-suite/ruby/li_std_list_runme.rb
@@ -6,3 +6,6 @@ include Li_std_list
 
 x = DoubleList.new([1,2,3])
 swig_assert_equal("[1.0]", "x.find_all{|e| e == 1 }", binding)
+
+k = IntList.new([1,2,3,4,5,6,7,8])
+swig_assert_equal("k.select {|v| v%2 == 1 }.to_s", "\"1357\"", binding)

--- a/Examples/test-suite/ruby/li_std_map_runme.rb
+++ b/Examples/test-suite/ruby/li_std_map_runme.rb
@@ -44,6 +44,11 @@ m.each_key { |k| swig_assert_equal("pm[#{k.inspect}]", "m[#{k.inspect}]", bindin
 EOF
 
 
+lmap = Li_std_map::LanguageMap.new
+lmap[1] = 3
+lmap[8] = 9
+swig_assert("lmap.select {|k, v| k == 8}.to_s == \"[8, 9]\"", binding)
+
 Li_std_map::populate(Li_std_map.MyMap)
 Li_std_map.MyMap["eeeeee"] = 6
 swig_assert( "Li_std_map.MyMap['a'] == 1", binding )

--- a/Examples/test-suite/ruby/li_std_vector_runme.rb
+++ b/Examples/test-suite/ruby/li_std_vector_runme.rb
@@ -261,6 +261,8 @@ begin
 rescue
 end
 
+swig_assert_equal("IntVector.new([1,2,3,4,5,6,7,8]).select {|x| x%2 == 1 }.to_s", "\"1357\"", binding)
+
 # Variables
 vh = VariableHolder.new
 vector_append(vh.instance_variable, 10)

--- a/Lib/ruby/rubycontainer.swg
+++ b/Lib/ruby/rubycontainer.swg
@@ -678,7 +678,7 @@ namespace swig
 	{
 	  VALUE v = swig::from< Sequence::value_type >(*i);
 	  if ( RTEST( rb_yield(v) ) )
-	    $self->insert( r->end(), *i);
+	    r->insert( r->end(), *i);
 	}
 	
       return r;

--- a/Lib/ruby/std_map.i
+++ b/Lib/ruby/std_map.i
@@ -214,7 +214,7 @@
 	  VALUE k = swig::from<Map::key_type>(i->first);
 	  VALUE v = swig::from<Map::mapped_type>(i->second);
 	  if ( RTEST( rb_yield_values(2, k, v) ) )
-	    $self->insert(r->end(), *i);
+	    r->insert(r->end(), *i);
 	}
 	
       return r;


### PR DESCRIPTION
This fix the misuse of `std::vector::insert( const_iterator pos, const T& value )` describe in issue #2906.

The error come from `std::vector` when the address of insertion is outside the memory of the result object.
That lead to segmentation fault.

