### PR TITLE
Improve parsing of sizeof(X)

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,11 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.3.0 (in progress)
 ===========================
 
+2024-06-06: olly
+	    #2919 Support parsing `sizeof(X)` for any expression or type X by
+	    skipping balanced parentheses.  We don't need to actually parse X
+	    since the type of sizeof is always size_t.
+
 2024-06-05: leakec
             #2873 Fix -fvirtual and using declarations for inheriting base class methods
             corner case.

--- a/Examples/test-suite/constant_expr.i
+++ b/Examples/test-suite/constant_expr.i
@@ -35,3 +35,25 @@ namespace fakestd {
 void bar(fakestd::array<int, (1<2? 100 : 50)> *x) { }
 
 %}
+
+// Regression test for #2919, fixed in 4.3.0.
+//
+// sizeof() didn't work on complex expressions or types.
+//
+// This is just a parsing test for SWIG as it uses C++11 features.
+#include <type_traits>
+template <typename T>
+class InternalHelper {
+public:
+// Original source: https://github.com/protocolbuffers/protobuf/blob/v20.2/src/google/protobuf/arena.h#L449-L458
+    template <typename U>
+    static char DestructorSkippable(const typename U::DestructorSkippable_*);
+    template <typename U>
+    static double DestructorSkippable(...);
+
+    typedef std::integral_constant<
+        bool, sizeof(DestructorSkippable<T>(static_cast<const T*>(0))) ==
+                      sizeof(char) ||
+                  std::is_trivially_destructible<T>::value>
+        is_destructor_skippable;
+};

--- a/Examples/test-suite/constant_expr_c.i
+++ b/Examples/test-suite/constant_expr_c.i
@@ -73,5 +73,7 @@ const int s7a = sizeof(3.14);
 const int s7b = sizeof 3.14;
 const int s8a = sizeof(2.1e-6);
 const int s8b = sizeof 2.1e-6;
+const int s9a = sizeof(-s8a);
+// const int s9b = sizeof -s8a; /* not currently supported */
 
 %}

--- a/Examples/test-suite/cpp11_decltype.i
+++ b/Examples/test-suite/cpp11_decltype.i
@@ -68,6 +68,9 @@
     enum e { E1 };
     decltype(+E1) should_be_int10;
 
+    decltype(sizeof(i+j)) should_be_ulong;
+    decltype(sizeof(-i)) should_be_ulong2;
+
     static constexpr decltype(*"abc") should_be_char = 0;
 
     static constexpr decltype(&hidden_global_char) should_be_string = "xyzzy";

--- a/Examples/test-suite/php/constant_expr_c_runme.php
+++ b/Examples/test-suite/php/constant_expr_c_runme.php
@@ -7,7 +7,7 @@ check::functions(array('xx', 'yy'));
 // New classes
 check::classes(array('constant_expr_c'));
 // New vars
-check::globals(array('X','d_array','s1a','s2a','s2b','s3a','s3b','s4a','s4b','s5a','s5b','s6a','s6b','s7a','s7b','s8a','s8b'));
+check::globals(array('X','d_array','s1a','s2a','s2b','s3a','s3b','s4a','s4b','s5a','s5b','s6a','s6b','s7a','s7b','s8a','s8b','s9a'));
 
 check::equal(XX, xx());
 check::equal(YY, yy());

--- a/Examples/test-suite/php/constant_expr_runme.php
+++ b/Examples/test-suite/php/constant_expr_runme.php
@@ -7,7 +7,7 @@ check::functions(array('bar', 'test2', 'xx', 'yy'));
 // New classes
 check::classes(array('constant_expr'));
 // New vars
-check::globals(array('X','a','d_array','s1a','s2a','s2b','s3a','s3b','s4a','s4b','s5a','s5b','s6a','s6b','s7a','s7b','s8a','s8b'));
+check::globals(array('X','a','d_array','s1a','s2a','s2b','s3a','s3b','s4a','s4b','s5a','s5b','s6a','s6b','s7a','s7b','s8a','s8b', 's9a'));
 
 check::equal(XX, xx());
 check::equal(YY, yy());

--- a/Examples/test-suite/php/cpp11_decltype_runme.php
+++ b/Examples/test-suite/php/cpp11_decltype_runme.php
@@ -51,6 +51,9 @@ check::equal(gettype($b->should_be_int8), "integer");
 check::equal(gettype($b->should_be_int9), "integer");
 check::equal(gettype($b->should_be_int10), "integer");
 
+check::equal(gettype($b->should_be_ulong), "integer");
+check::equal(gettype($b->should_be_ulong2), "integer");
+
 check::equal(gettype($b->should_be_bool), "boolean");
 check::equal(gettype($b->should_be_bool2), "boolean");
 


### PR DESCRIPTION
Support parsing `sizeof(X)` for any expression or type X by skipping balanced parentheses.  We don't need to actually parse X since the type of sizeof is always size_t.

Fixes #2919