### PR TITLE
Allow suppressing progress messages when running test suite

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -71,6 +71,9 @@ INTERFACEDIR = ../
 SRCDIR     = $(srcdir)/
 SCRIPTDIR  = $(srcdir)
 
+# This can be set to ":" on make command line to suppress progress messages.
+ECHO_PROGRESS := echo
+
 # Regenerate Makefile if Makefile.in or config.status have changed.
 Makefile: $(srcdir)/Makefile.in ../../../config.status
 	cd ../../../ && $(SHELL) ./config.status $(EXAMPLES)/$(TEST_SUITE)/$(LANGUAGE)/Makefile
@@ -985,9 +988,9 @@ swig_and_compile_runtime = \
 
 setup = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) ]; then	  \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
 	else								  \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $*" ;		  \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $*" ;		  \
 	fi
 
 #######################################################################

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -84,9 +84,9 @@ csharp_swig2_compatibility.cpptest: SWIGOPT += -DSWIG2_CSHARP
 # Makes a directory for the testcase if it does not exist
 setup = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) ]; then	  \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
 	else								  \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $*" ;		  \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $*" ;	  \
 	fi;								  \
 	if [ ! -d $* ]; then						  \
 	  mkdir $*;							  \

--- a/Examples/test-suite/d/Makefile.in
+++ b/Examples/test-suite/d/Makefile.in
@@ -75,9 +75,9 @@ SWIGOPT+=-splitproxy -package $*
 # Makes a directory for the testcase if it does not exist
 setup = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*_runme.2.d ]; then			\
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ;	\
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ;	\
 	else									\
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $*" ;			\
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $*" ;		\
 	fi;									\
 	if [ ! -d $*.2 ]; then					\
 	  mkdir $*.2;						\

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -110,9 +110,9 @@ nspacemove_stl.%: JAVA_PACKAGE = $*Package
 # Makes a directory for the testcase if it does not exist
 setup = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) ]; then	  \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
 	else								  \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $*" ;			  \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $*" ;	  \
 	fi;								  \
 	if [ ! -d $(JAVA_PACKAGE) ]; then						  \
 	  mkdir $(JAVA_PACKAGE);							  \

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -65,9 +65,9 @@ SWIGOPT += -DV8_VERSION=$(JSV8_VERSION)
 
 _setup = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) ]; then	  \
-	  echo "$(ACTION)ing $(LANGUAGE) ($(JSENGINE)) testcase $* (with run test)" ; \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) ($(JSENGINE)) testcase $* (with run test)" ; \
 	else								  \
-	  echo "$(ACTION)ing $(LANGUAGE) ($(JSENGINE)) testcase $*" ;     \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) ($(JSENGINE)) testcase $*" ;     \
 	fi;
 
 SWIGOPT += -$(JSENGINE)

--- a/Examples/test-suite/scilab/Makefile.in
+++ b/Examples/test-suite/scilab/Makefile.in
@@ -66,7 +66,7 @@ setup = \
 	  mkdir $(TEST_DIR); \
 	fi; \
 	if [ -f $(SRC_RUNME_SCRIPT) ]; then	\
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $* (with run test)" ; \
 	  if [ ! -f $(TEST_DIR) ]; then	\
 	    cp $(SRC_RUNME_SCRIPT) $(TEST_DIR); \
 	  fi; \
@@ -77,7 +77,7 @@ setup = \
 	    cp $(srcdir)/swigtest.quit $(TEST_DIR); \
 	  fi; \
 	else \
-	  echo "$(ACTION)ing $(LANGUAGE) testcase $*" ; \
+	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) testcase $*" ; \
 	fi; \
 
 # Runs the testcase. A testcase is only run if


### PR DESCRIPTION
Use $(ECHO_PROGRESS) instead of the hard-coded "echo" to allow setting ECHO_PROGRESS=: on make command line to suppress the (many hundreds of) messages given when running every unit test.

This makes it much easier to see any warnings given during the test suite execution.

----

This is just a cosmetic change, but I find it quite useful and it should be completely harmless as it doesn't change anything by default.