### PR TITLE
Avoid duplicating std::vector<> declaration for JavaScript

### DIFF
--- a/Lib/javascript/v8/std_vector.i
+++ b/Lib/javascript/v8/std_vector.i
@@ -10,14 +10,14 @@
 %}
 
 
-%define SWIG_STD_VECTOR_INTERNAL(CTYPE, REFERENCE, CONST_REFERENCE)
+%define SWIG_STD_VECTOR_INTERNAL(CTYPE, CONST_REFERENCE)
       public:
         typedef size_t size_type;
         typedef ptrdiff_t difference_type;
         typedef CTYPE value_type;
         typedef value_type* pointer;
         typedef const value_type* const_pointer;
-        typedef REFERENCE reference;
+        typedef CTYPE& reference;
         typedef CONST_REFERENCE const_reference;
 
         vector();
@@ -53,12 +53,12 @@
 namespace std {
 
     template<class T> class vector {
-        SWIG_STD_VECTOR_INTERNAL(T, value_type&, const value_type&)
+        SWIG_STD_VECTOR_INTERNAL(T, const value_type&)
     };
 
     // bool specialization
     template<> class vector<bool> {
-        SWIG_STD_VECTOR_INTERNAL(bool, bool, bool)
+        SWIG_STD_VECTOR_INTERNAL(bool, bool)
     };
 }
 

--- a/Lib/javascript/v8/std_vector.i
+++ b/Lib/javascript/v8/std_vector.i
@@ -9,17 +9,16 @@
 #include <stdexcept>
 %}
 
-namespace std {
-    
-    template<class T> class vector {
+
+%define SWIG_STD_VECTOR_INTERNAL(CTYPE, REFERENCE, CONST_REFERENCE)
       public:
         typedef size_t size_type;
         typedef ptrdiff_t difference_type;
-        typedef T value_type;
+        typedef CTYPE value_type;
         typedef value_type* pointer;
         typedef const value_type* const_pointer;
-        typedef value_type& reference;
-        typedef const value_type& const_reference;
+        typedef REFERENCE reference;
+        typedef CONST_REFERENCE const_reference;
 
         vector();
         vector(size_type n);
@@ -34,7 +33,7 @@ namespace std {
         %rename(add) push_back;
         void push_back(const value_type& x);
         %extend {
-            const_reference get(int i) throw (std::out_of_range) {
+            CONST_REFERENCE get(int i) throw (std::out_of_range) {
                 int size = int(self->size());
                 if (i>=0 && i<size)
                     return (*self)[i];
@@ -49,47 +48,17 @@ namespace std {
                     throw std::out_of_range("vector index out of range");
             }
         }
+%enddef
+
+namespace std {
+
+    template<class T> class vector {
+        SWIG_STD_VECTOR_INTERNAL(T, value_type&, const value_type&)
     };
 
     // bool specialization
     template<> class vector<bool> {
-      public:
-        typedef size_t size_type;
-        typedef ptrdiff_t difference_type;
-        typedef bool value_type;
-        typedef value_type* pointer;
-        typedef const value_type* const_pointer;
-        typedef value_type& reference;
-        typedef bool const_reference;
-
-        vector();
-        vector(size_type n);
-        vector(const vector& other);
-
-        size_type size() const;
-        size_type capacity() const;
-        void reserve(size_type n);
-        %rename(isEmpty) empty;
-        bool empty() const;
-        void clear();
-        %rename(add) push_back;
-        void push_back(const value_type& x);
-        %extend {
-            bool get(int i) throw (std::out_of_range) {
-                int size = int(self->size());
-                if (i>=0 && i<size)
-                    return (*self)[i];
-                else
-                    throw std::out_of_range("vector index out of range");
-            }
-            void set(int i, const value_type& val) throw (std::out_of_range) {
-                int size = int(self->size());
-                if (i>=0 && i<size)
-                    (*self)[i] = val;
-                else
-                    throw std::out_of_range("vector index out of range");
-            }
-        }
+        SWIG_STD_VECTOR_INTERNAL(bool, bool, bool)
     };
 }
 


### PR DESCRIPTION
Use a helper macro abstracting the difference between the generic version and the bool specialization of std::vector<> instead of duplicating the entire class declaration.

No real changes, but this will help with future modifications by allowing to make them only once instead of twice.