### PR TITLE
Minor fixes to Boost detection in autoconf

### DIFF
--- a/Tools/config/ax_boost_base.m4
+++ b/Tools/config/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 54
+#serial 55
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -289,6 +289,8 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
         else
             AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
         fi
+        BOOST_LDFLAGS=""
+        BOOST_CPPFLAGS=""
         # execute ACTION-IF-NOT-FOUND (if present):
         ifelse([$3], , :, [$3])
     else

--- a/Tools/config/ax_boost_base.m4
+++ b/Tools/config/ax_boost_base.m4
@@ -11,9 +11,9 @@
 #   Test for the Boost C++ libraries of a particular version (or newer)
 #
 #   If no path to the installed boost library is given the macro searches
-#   under /usr, /usr/local, /opt and /opt/local and evaluates the
-#   $BOOST_ROOT environment variable. Further documentation is available at
-#   <http://randspringer.de/boost/index.html>.
+#   under /usr, /usr/local, /opt, /opt/local and /opt/homebrew and evaluates
+#   the $BOOST_ROOT environment variable. Further documentation is available
+#   at <http://randspringer.de/boost/index.html>.
 #
 #   This macro calls:
 #
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 45
+#serial 54
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -113,7 +113,8 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are found, e.g. when only header-only libraries are installed!
     AS_CASE([${host_cpu}],
       [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
-      [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64],[libsubdirs="lib64 lib lib64"],
+      [mips*64*],[libsubdirs="lib64 lib32 lib lib64"],
+      [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64|e2k|loongarch64],[libsubdirs="lib64 lib lib64"],
       [libsubdirs="lib"]
     )
 
@@ -122,11 +123,12 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are almost assuredly the ones desired.
     AS_CASE([${host_cpu}],
       [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [armv7l],[multiarch_libsubdir="lib/arm-${host_os}"],
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
 
     dnl first we check the system location for boost libraries
-    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl this location is chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
     AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
         AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])
@@ -149,7 +151,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
         else
             search_libsubdirs="$multiarch_libsubdir $libsubdirs"
         fi
-        for _AX_BOOST_BASE_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+        for _AX_BOOST_BASE_boost_path_tmp in /usr /usr/local /opt /opt/local /opt/homebrew ; do
             if test -d "$_AX_BOOST_BASE_boost_path_tmp/include/boost" && test -r "$_AX_BOOST_BASE_boost_path_tmp/include/boost" ; then
                 for libsubdir in $search_libsubdirs ; do
                     if ls "$_AX_BOOST_BASE_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
@@ -181,7 +183,8 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
         AC_MSG_RESULT(yes)
     succeeded=yes
     found_system=yes
-        ],[])
+        ],[
+        ])
     AC_LANG_POP([C++])
 
 
@@ -224,7 +227,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
             fi
         else
             if test "x$cross_compiling" != "xyes" ; then
-                for _AX_BOOST_BASE_boost_path in /usr /usr/local /opt /opt/local ; do
+                for _AX_BOOST_BASE_boost_path in /usr /usr/local /opt /opt/local /opt/homebrew ; do
                     if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path" ; then
                         for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
                             _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
@@ -275,7 +278,8 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
             AC_MSG_RESULT(yes)
         succeeded=yes
         found_system=yes
-            ],[])
+            ],[
+            ])
         AC_LANG_POP([C++])
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -112,11 +112,6 @@ echo ""
 dnl Some test cases require Boost
 AX_BOOST_BASE(,,,)
 
-dnl Don't set flags to nonsensical values if Boost is not found.
-if test "x$BOOST_CPPFLAGS" = "x-I/include/boost-0"; then
-    BOOST_CPPFLAGS=
-fi
-
 dnl Info for building shared libraries ... in order to run the examples
 
 # SO is the extension of shared libraries (including the dot!)

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,6 @@ echo ""
 
 dnl Some test cases require Boost
 AX_BOOST_BASE(,,,)
-AC_SUBST(BOOST_CPPFLAGS)
 
 dnl Info for building shared libraries ... in order to run the examples
 

--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,11 @@ echo ""
 dnl Some test cases require Boost
 AX_BOOST_BASE(,,,)
 
+dnl Don't set flags to nonsensical values if Boost is not found.
+if test "x$BOOST_CPPFLAGS" = "x-I/include/boost-0"; then
+    BOOST_CPPFLAGS=
+fi
+
 dnl Info for building shared libraries ... in order to run the examples
 
 # SO is the extension of shared libraries (including the dot!)


### PR DESCRIPTION
I got tired of seeing `-I/include/boost-0` in the generated makefiles and in the compilation command lines and so fixed it in several different ways, so that you could choose what to apply:

1. If you'd like the minimal fix, please apply the second commit, which adds a minimal workaround to SWIG's own configure.
2. If you'd like to fix it at the source, please apply the last commit, which I've also submitted to the upstream.
3. In any case, please apply the first commit, as it's just a minor cleanup removing an unnecessary line.
4. And please also apply third commit just to keep our macro in sync with the upstream version (as of right now).