### PR TITLE
Fix specialization without primary template

### DIFF
--- a/Examples/test-suite/template_specialization.i
+++ b/Examples/test-suite/template_specialization.i
@@ -27,6 +27,13 @@
       
     };
     
+    // Also test specialization without the primary template.
+    template <typename T> struct OnlySpecialized;
+
+    template <> struct OnlySpecialized<int>
+    {
+        void bar(const OnlySpecialized& other) { }
+    };
   }
 %}
 

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -1362,7 +1362,8 @@ static void expand_defaults(ParmList *expanded_templateparms) {
 ParmList *Swig_cparse_template_parms_expand(ParmList *instantiated_parms, Node *primary, Node *templ) {
   ParmList *expanded_templateparms = CopyParmList(instantiated_parms);
 
-  if (Equal(Getattr(primary, "templatetype"), "class")) {
+  String *templatetype = Getattr(primary, "templatetype");
+  if (Equal(templatetype, "class") || Equal(templatetype, "classforward")) {
     /* Class template */
     ParmList *templateparms = Getattr(primary, "templateparms");
     int variadic = merge_parameters(expanded_templateparms, templateparms);


### PR DESCRIPTION
Due to a regression in 817c700 (Template partial specialization improvements, 2023-01-30), specializations of templates without a primary template definition were not handled correctly any more and, notably, resulted in misparsing the injected name inside such specializations.

Fix this by handling the nodes with template type "classforward" created for the template declaration in the same way as those created for the primary template definition.

Add a trivial test case which works (again) now but doesn't work without the fix in this commit.

Closes #2934.