### PR TITLE
Fix running preproc_include test with JS+node more than once

### DIFF
--- a/Examples/test-suite/javascript/preproc_include_runme.js
+++ b/Examples/test-suite/javascript/preproc_include_runme.js
@@ -14,10 +14,3 @@ if (preproc_include.multiply40(10) != 400)
 
 if (preproc_include.multiply50(10) != 500)
   throw "RuntimeError";
-
-if (preproc_include.multiply60(10) != 600)
-  throw "RuntimeError";
-
-if (preproc_include.multiply70(10) != 700)
-  throw "RuntimeError";
-

--- a/Examples/test-suite/preproc_include.i
+++ b/Examples/test-suite/preproc_include.i
@@ -24,6 +24,8 @@ int multiply50(int a) { return a*50; }
 
 %include INCLUDE_E
 
+// node-gyp tool doesn't handle spaces in the dependencies correctly (see #2930), so skip this part when using it.
+#ifndef BUILDING_NODE_EXTENSION
 %inline %{
 #define INCLUDE_F /*comments*/ "preproc_include_f withspace.h"/*testing*/
 #include INCLUDE_F
@@ -34,6 +36,7 @@ int multiply50(int a) { return a*50; }
 int multiply60(int a) { return a*60; }
 int multiply70(int a) { return a*70; }
 %}
+#endif // !BUILDING_NODE_EXTENSION
 
 %define nested_include_1(HEADER)
 %include <HEADER>


### PR DESCRIPTION
At least when building in a separate build directory, building this test second time fails due to a syntax error in the makefile created by node-gyp which happens because it doesn't handle dependencies with spaces in them correctly.

Fix this by simply avoiding using such dependencies when using node-gyp, this is not a big loss as the goal here is to test SWIG preprocessor and not JS backend itself, and the preprocessor is still tested with the other languages.

Closes #2930.