### PR TITLE
Avoid warnings for %ignored using declarations

### DIFF
--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -1000,6 +1000,9 @@ Allocate():
 
   virtual int usingDeclaration(Node *n) {
 
+    if (GetFlag(n, "feature:ignore"))
+      return SWIG_OK;
+
     if (!Getattr(n, "namespace")) {
       Node *ns;
       /* using id */
@@ -1024,7 +1027,7 @@ Allocate():
       } else if (Equal(nodeType(ns), "constructor") && !GetFlag(n, "usingctor")) {
 	Swig_warning(WARN_PARSE_USING_CONSTRUCTOR, Getfile(n), Getline(n), "Using declaration '%s' for inheriting constructors uses base '%s' which is not an immediate base of '%s'.\n", SwigType_namestr(Getattr(n, "uname")), SwigType_namestr(Getattr(ns, "name")), SwigType_namestr(Getattr(parentNode(n), "name")));
       } else {
-	if (inclass && !GetFlag(n, "feature:ignore") && Getattr(n, "sym:name")) {
+	if (inclass && Getattr(n, "sym:name")) {
 	  {
 	    String *ntype = nodeType(ns);
 	    if (Equal(ntype, "cdecl") || Equal(ntype, "constructor") || Equal(ntype, "template") || Equal(ntype, "using")) {


### PR DESCRIPTION
It doesn't make sense to give WARN_PARSE_USING_UNDEF if the identifier being brought in scope by a using declaration is explicitly %ignored, but we still did it even in this case.

Just ignore the declaration completely instead in this case.

----

This is mostly cosmetic and I didn't add a test for this as I don't see any simple way to check for an absence of a warning, but the problem could be reproduced with e.g.

```
%module t

%feature("flatnested");

%ignore B::f;

%{
struct B {
  void f() { }
};
%}

%inline {
class C {
protected:
  struct D : B {
    using B::f;
  };
};
}
```

and JS backend: without this change, you'd get warning 315 for the using declaration which doesn't make much sense.