### PR TITLE
Fix UTF16 to UTF32 string coverting for C#

### DIFF
--- a/Lib/csharp/std_wstring.i
+++ b/Lib/csharp/std_wstring.i
@@ -31,8 +31,22 @@ static std::wstring Swig_csharp_UTF16ToWString(const unsigned short *str) {
 
     std::wstring result;
     result.reserve(ptr - pBegin);
-    while(pBegin != ptr)
-      result.push_back(*pBegin++);
+    while (pBegin != ptr) {
+      unsigned short uc = *pBegin++;
+      if (uc <= 0xD7FFu || uc >= 0xE000u) {
+        result.push_back(uc);
+      }
+      else if (pBegin != ptr && (uc & 0xFC00u) == 0xD800u) {
+        unsigned short uc1 = *pBegin++;
+        if ((uc1 & 0xFC00u) == 0xDC00u) {
+          unsigned int u32c = uc & 0x03FFu;
+          u32c <<= 10;
+          u32c += uc1 & 0x03FFu;
+          u32c += 0x10000u;
+          result.push_back(u32c);
+        }
+      }
+    }
 
     return result;
   }

--- a/Lib/csharp/wchar.i
+++ b/Lib/csharp/wchar.i
@@ -171,8 +171,21 @@ static wchar_t * Swig_csharp_UTF16ToWCharPtr(const unsigned short *str) {
 #else
       result = ptr = (wchar_t *)malloc(sizeof(wchar_t) * (pEnd - pBegin + 1));
 #endif
-      while(pBegin != pEnd)
-        *ptr++ = *pBegin++;
+      while (pBegin != pEnd) {
+        unsigned short uc = *pBegin++;
+        if (uc <= 0xD7FFu || uc >= 0xE000u) {
+          *ptr++ = uc;
+        } else if (pBegin != pEnd && (uc & 0xFC00u) == 0xD800u) {
+          unsigned short uc1 = *pBegin++;
+          if ((uc1 & 0xFC00u) == 0xDC00u) {
+            unsigned int u32c = uc & 0x03FFu;
+            u32c <<= 10;
+            u32c += uc1 & 0x03FFu;
+            u32c += 0x10000u;
+            *ptr++ = u32c;
+          }
+        }
+      }
       *ptr++ = 0;
     }
 


### PR DESCRIPTION
Code points from U+010000 to U+10FFFF should not cast directly
See https://github.com/swig/swig/issues/2369