### PR TITLE
Restore C# empty() containers method but warn when using it

### DIFF
--- a/Lib/csharp/std_array.i
+++ b/Lib/csharp/std_array.i
@@ -47,7 +47,7 @@
 
   public bool IsEmpty {
     get {
-      return empty();
+      return $modulePINVOKE.$csclazznameempty(swigCPtr);
     }
   }
 
@@ -237,7 +237,8 @@
 #include <stdexcept>
 %}
 
-%csmethodmodifiers std::array::empty "private"
+%csattributes std::array::empty "[global::System.Obsolete(\"Use IsEmpty property instead\")]"
+
 %csmethodmodifiers std::array::getitemcopy "private"
 %csmethodmodifiers std::array::getitem "private"
 %csmethodmodifiers std::array::setitem "private"

--- a/Lib/csharp/std_map.i
+++ b/Lib/csharp/std_map.i
@@ -50,7 +50,7 @@
 
   public bool IsEmpty {
     get {
-      return empty();
+      return $modulePINVOKE.$csclazznameempty(swigCPtr);
     }
   }
 
@@ -294,7 +294,8 @@
 
 %enddef
 
-%csmethodmodifiers std::map::empty "private"
+%csattributes std::map::empty "[global::System.Obsolete(\"Use IsEmpty property instead\")]"
+
 %csmethodmodifiers std::map::size "private"
 %csmethodmodifiers std::map::getitem "private"
 %csmethodmodifiers std::map::setitem "private"

--- a/Lib/csharp/std_set.i
+++ b/Lib/csharp/std_set.i
@@ -16,7 +16,8 @@
 #include <stdexcept>
 %}
 
-%csmethodmodifiers std::set::empty "private"
+%csattributes std::set::empty "[global::System.Obsolete(\"Use IsEmpty property instead\")]"
+
 %csmethodmodifiers std::set::size "private"
 %csmethodmodifiers std::set::getitem "private"
 %csmethodmodifiers std::set::create_iterator_begin "private"
@@ -47,7 +48,7 @@ class set {
 
   public bool IsEmpty {
     get {
-      return empty();
+      return $modulePINVOKE.$csclazznameempty(swigCPtr);
     }
   }
 

--- a/Lib/csharp/std_unordered_map.i
+++ b/Lib/csharp/std_unordered_map.i
@@ -50,7 +50,7 @@
 
   public bool IsEmpty {
     get {
-      return empty();
+      return $modulePINVOKE.$csclazznameempty(swigCPtr);
     }
   }
 
@@ -290,7 +290,8 @@
 
 %enddef
 
-%csmethodmodifiers std::unordered_map::empty "private"
+%csattributes std::unordered_map::empty "[global::System.Obsolete(\"Use IsEmpty property instead\")]"
+
 %csmethodmodifiers std::unordered_map::size "private"
 %csmethodmodifiers std::unordered_map::getitem "private"
 %csmethodmodifiers std::unordered_map::setitem "private"

--- a/Lib/csharp/std_unordered_set.i
+++ b/Lib/csharp/std_unordered_set.i
@@ -16,7 +16,8 @@
 #include <stdexcept>
 %}
 
-%csmethodmodifiers std::unordered_set::empty "private"
+%csattributes std::unordered_set::empty "[global::System.Obsolete(\"Use IsEmpty property instead\")]"
+
 %csmethodmodifiers std::unordered_set::size "private"
 %csmethodmodifiers std::unordered_set::getitem "private"
 %csmethodmodifiers std::unordered_set::create_iterator_begin "private"
@@ -47,7 +48,7 @@ class unordered_set {
 
   public bool IsEmpty {
     get {
-      return empty();
+      return $modulePINVOKE.$csclazznameempty(swigCPtr);
     }
   }
 

--- a/Lib/csharp/std_vector.i
+++ b/Lib/csharp/std_vector.i
@@ -71,7 +71,7 @@
 
   public bool IsEmpty {
     get {
-      return empty();
+      return $modulePINVOKE.$csclazznameempty(swigCPtr);
     }
   }
 
@@ -370,7 +370,8 @@ namespace std {
 #include <stdexcept>
 %}
 
-%csmethodmodifiers std::vector::empty "private"
+%csattributes std::vector::empty "[global::System.Obsolete(\"Use IsEmpty property instead\")]"
+
 %csmethodmodifiers std::vector::getitemcopy "private"
 %csmethodmodifiers std::vector::getitem "private"
 %csmethodmodifiers std::vector::setitem "private"


### PR DESCRIPTION
In d8c21410e (Replace empty() method with IsEmpty C# property in STL containers, 2023-11-10) the previously existing empty() method was made private, making it impossible to use it by default and breaking existing code that called it and worked fine with the previous SWIG versions.

Instead of breaking it completely, still define this method but deprecate it using the standard Obsolete() attribute and a message pointing to IsEmpty property.

----

I found another way of making this work in a preferable (IMNSHO) way not requiring introducing an extra `is_empty()` private helper. AFAICS the changes of this PR don't have any drawbacks at all and provide much better migration path since SWIG < 4.2.