### PR TITLE
Test director guard

### DIFF
--- a/Examples/test-suite/director_guard.i
+++ b/Examples/test-suite/director_guard.i
@@ -1,4 +1,4 @@
-%module(directors="1") director_guard;
+%module(directors="1", threads) director_guard;
 
 %feature("director") Callback;
 

--- a/Examples/test-suite/director_guard.i
+++ b/Examples/test-suite/director_guard.i
@@ -1,0 +1,22 @@
+%module(directors="1") director_guard;
+
+%feature("director") Callback;
+
+%inline %{
+
+class Callback {
+public:
+  virtual const char *run() const { return "tst1"; }
+  virtual ~Callback() {}
+
+};
+
+class Caller {
+private:
+  Callback *_callback;
+public:
+  Caller(Callback *cb): _callback(cb) { }
+  const char *call() { return _callback->run(); }
+};
+
+%}

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -37,6 +37,7 @@ CPP_TEST_CASES += \
 	callback \
 	complextest \
 	director_stl \
+	director_guard \
 	director_wstring \
 	file_test \
 	iadd \
@@ -122,6 +123,7 @@ VALGRIND_OPT += --suppressions=pythonswig.supp
 
 # Custom tests - tests with additional commandline options
 python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
+director_guard.cpptest: SWIGOPT += -threads
 
 # Make sure just python_runtime_data_builtin.i uses the -builtin option. Note: does not use python_runtime_data.list for all steps.
 # PY_ABI_VER is unset for python_runtime_data_builtin because stable ABI is not supported by builtin

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -36,8 +36,8 @@ endif
 CPP_TEST_CASES += \
 	callback \
 	complextest \
-	director_stl \
 	director_guard \
+	director_stl \
 	director_wstring \
 	file_test \
 	iadd \
@@ -123,7 +123,6 @@ VALGRIND_OPT += --suppressions=pythonswig.supp
 
 # Custom tests - tests with additional commandline options
 python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
-director_guard.cpptest: SWIGOPT += -threads
 
 # Make sure just python_runtime_data_builtin.i uses the -builtin option. Note: does not use python_runtime_data.list for all steps.
 # PY_ABI_VER is unset for python_runtime_data_builtin because stable ABI is not supported by builtin

--- a/Examples/test-suite/python/director_guard_runme.py
+++ b/Examples/test-suite/python/director_guard_runme.py
@@ -17,7 +17,7 @@ class CallThread(threading.Thread):
         for x in range(100):
             if self.caller.call() != "tst2":
                 raise RuntimeError("Should return true")
-            time.sleep(0.001)
+            time.sleep(0.001) # 1 millisecond
 
 callback = MinCallback()
 caller = director_guard.Caller(callback)

--- a/Examples/test-suite/python/director_guard_runme.py
+++ b/Examples/test-suite/python/director_guard_runme.py
@@ -1,0 +1,32 @@
+import director_guard
+import threading
+import time
+
+str2 = "tst2"
+
+class MinCallback(director_guard.Callback):
+    def run(self):
+        return str2
+
+class CallThread(threading.Thread):
+    def __init__(self, caller):
+        super(CallThread, self).__init__()
+        self.caller = caller
+
+    def run(self):
+        for x in range(100):
+            if self.caller.call() != "tst2":
+                raise RuntimeError("Should return true")
+            time.sleep(0.001)
+
+callback = MinCallback()
+caller = director_guard.Caller(callback)
+threads = [ ]
+for x in range(10):
+    threads.append(CallThread(caller))
+
+for t in threads:
+    t.start()
+
+for t in threads:
+    t.join()


### PR DESCRIPTION
Adding a test to verify guard code added in #2870.

The test use threads with `director_guard.cpptest: SWIGOPT += -threads`

The other option is to add `threads` option to the `%module` deceleration in the interface file.