### PR TITLE
Java director_thread forget to call stop.

### DIFF
--- a/Examples/test-suite/java/director_thread_runme.java
+++ b/Examples/test-suite/java/director_thread_runme.java
@@ -21,6 +21,7 @@ public class director_thread_runme {
     if (d.getVal() >= 0) {
         throw new RuntimeException("Failed. Val: " + d.getVal());
     }
+    d.stop();
   }
 }
 


### PR DESCRIPTION
This cause the test to sometimes to pass and sometimes to fail.
Depends if the thread exit before the main or the other way around.