### PR TITLE
Fix Python docstring for overloads with some Doxygen comments

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -730,6 +730,7 @@ DOXYGEN_TEST_CASES += \
 	doxygen_ignore \
 	doxygen_misc_constructs \
 	doxygen_nested_class \
+	doxygen_overloads \
 	doxygen_parsing \
 	doxygen_parsing_enums \
 	doxygen_translate \

--- a/Examples/test-suite/doxygen_overloads.i
+++ b/Examples/test-suite/doxygen_overloads.i
@@ -1,0 +1,95 @@
+%module doxygen_overloads
+
+%inline %{
+
+void overloadWithNoDoc(int) { }
+void overloadWithNoDoc(double) { }
+
+/// Doc for first overload.
+void overloadWithFirstDoc(int) { }
+void overloadWithFirstDoc(double) { }
+
+void overloadWithSecondDoc(int) { }
+/// Doc for second overload.
+void overloadWithSecondDoc(double) { }
+
+/// Doc for both overloads, first.
+void overloadWithBothDocs(int) { }
+/// Doc for both overloads, second.
+void overloadWithBothDocs(double) { }
+
+/// Doc for some overloads, first.
+void overloadWithSomeDocs(int) { }
+void overloadWithSomeDocs(double) { }
+/// Doc for some overloads, third.
+void overloadWithSomeDocs(char) { }
+
+/// Doc for some other overloads, first.
+void overloadWithSomeOtherDocs(int) { }
+/// Doc for some other overloads, second.
+void overloadWithSomeOtherDocs(double) { }
+void overloadWithSomeOtherDocs(char) { }
+
+
+// Also test different kinds of member functions.
+
+struct S {
+    /// Doc for first static overload.
+    static void staticOverloadWithFirstDoc(int) { }
+    static void staticOverloadWithFirstDoc(double) { }
+
+    /// Doc for first member overload.
+    void memberOverloadWithFirstDoc(int) { }
+    void memberOverloadWithFirstDoc(double) { }
+};
+
+// Class ctors are handled differently from the other functions, so check them too.
+
+struct ClassWithNoDoc {
+    ClassWithNoDoc(int) { }
+    ClassWithNoDoc(double) { }
+};
+
+struct ClassWithFirstDoc {
+    /// Doc for first ctor.
+    ClassWithFirstDoc(int) { }
+    ClassWithFirstDoc(double) { }
+};
+
+struct ClassWithSecondDoc {
+    ClassWithSecondDoc(int) { }
+    /// Doc for second ctor.
+    ClassWithSecondDoc(double) { }
+};
+
+struct ClassWithBothDocs {
+    /// Doc for both ctors, first.
+    ClassWithBothDocs(int) { }
+    /// Doc for both ctors, second.
+    ClassWithBothDocs(double) { }
+};
+
+struct ClassWithSomeDocs {
+    /// Doc for some ctors, first.
+    ClassWithSomeDocs(int) { }
+    ClassWithSomeDocs(double) { }
+    /// Doc for some ctors, third.
+    ClassWithSomeDocs(char) { }
+};
+
+struct ClassWithSomeOtherDocs {
+    /// Doc for some other ctors, first.
+    ClassWithSomeOtherDocs(int) { }
+    /// Doc for some other ctors, second.
+    ClassWithSomeOtherDocs(double) { }
+    ClassWithSomeOtherDocs(char) { }
+};
+
+
+#ifdef SWIGPYTHON_BUILTIN
+bool is_python_builtin() { return true; }
+#else
+bool is_python_builtin() { return false; }
+#endif
+
+%}

--- a/Examples/test-suite/python/doxygen_overloads_runme.py
+++ b/Examples/test-suite/python/doxygen_overloads_runme.py
@@ -1,0 +1,83 @@
+import doxygen_overloads
+import inspect
+import comment_verifier
+
+if inspect.getdoc(doxygen_overloads.overloadWithNoDoc) is not None:
+    raise Exception("No docstring expected for overloadWithNoDoc.")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.overloadWithFirstDoc),
+    "Doc for first overload.")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.overloadWithSecondDoc),
+    "Doc for second overload.")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.overloadWithBothDocs),
+    r"""*Overload 1:*
+Doc for both overloads, first.
+
+|
+
+*Overload 2:*
+Doc for both overloads, second.""")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.overloadWithSomeDocs),
+    r"""*Overload 1:*
+Doc for some overloads, first.
+
+|
+
+*Overload 2:*
+Doc for some overloads, third.""")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.overloadWithSomeOtherDocs),
+    r"""*Overload 1:*
+Doc for some other overloads, first.
+
+|
+
+*Overload 2:*
+Doc for some other overloads, second.""")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.S.staticOverloadWithFirstDoc),
+    "Doc for first static overload.")
+
+comment_verifier.check(inspect.getdoc(doxygen_overloads.S.memberOverloadWithFirstDoc),
+    "Doc for first member overload.")
+
+# As mentioned in doxygen_parsing_runme.py, docstrings for __init__ can't be specified when using "-builtin", so skip these checks in this case.
+if not doxygen_overloads.is_python_builtin():
+    # Do not check for ClassWithNoDoc ctor docstring, as Python provides a standard one
+    # ('Initialize self.  See help(type(self)) for accurate signature.') if none is explicitly specified.
+
+    comment_verifier.check(inspect.getdoc(doxygen_overloads.ClassWithFirstDoc.__init__),
+        "Doc for first ctor.")
+
+    comment_verifier.check(inspect.getdoc(doxygen_overloads.ClassWithSecondDoc.__init__),
+        "Doc for second ctor.")
+
+    comment_verifier.check(inspect.getdoc(doxygen_overloads.ClassWithBothDocs.__init__),
+        r"""*Overload 1:*
+Doc for both ctors, first.
+
+|
+
+*Overload 2:*
+Doc for both ctors, second.""")
+
+    comment_verifier.check(inspect.getdoc(doxygen_overloads.ClassWithSomeDocs.__init__),
+        r"""*Overload 1:*
+Doc for some ctors, first.
+
+|
+
+*Overload 2:*
+Doc for some ctors, third.""")
+
+    comment_verifier.check(inspect.getdoc(doxygen_overloads.ClassWithSomeOtherDocs.__init__),
+        r"""*Overload 1:*
+Doc for some other ctors, first.
+
+|
+
+*Overload 2:*
+Doc for some other ctors, second.""")

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2525,14 +2525,14 @@ public:
       if (fastproxy) {
 	Append(methods_proxydocs, "NULL");
       }
-    } else if (have_docstring(n)) {
+    } else if (Node* node_with_doc = find_overload_with_docstring(n)) {
       /* Use the low-level docstring here since this is the docstring that will be used for the C API */
-      String *ds = cdocstring(n, Getattr(n, "memberfunction") ? AUTODOC_METHOD : AUTODOC_FUNC, true);
+      String *ds = cdocstring(node_with_doc, Getattr(n, "memberfunction") ? AUTODOC_METHOD : AUTODOC_FUNC, true);
       Printf(methods, "\"%s\"", ds);
       if (fastproxy) {
 	/* In the fastproxy case, we must also record the high-level docstring for use in the Python shadow API */
 	Delete(ds);
-        ds = cdocstring(n, Getattr(n, "memberfunction") ? AUTODOC_METHOD : AUTODOC_FUNC);
+        ds = cdocstring(node_with_doc, Getattr(n, "memberfunction") ? AUTODOC_METHOD : AUTODOC_FUNC);
 	Printf(methods_proxydocs, "\"%s\"", ds);
       }
       Delete(ds);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2661,9 +2661,8 @@ public:
     }
     Printv(f->code, "}\n", NIL);
     Wrapper_print(f, f_wrappers);
-    Node *p = Getattr(n, "sym:previousSibling");
     if (!builtin_self && (use_static_method || !builtin))
-      add_method(symname, wname, 0, p);
+      add_method(symname, wname, 0, Getattr(n, "sym:previousSibling") ? n : NULL);
 
     /* Create a shadow for this function (if enabled and not in a member function) */
     if (!builtin && shadow && !(shadow & PYSHADOW_MEMBER) && use_static_method) {


### PR DESCRIPTION
The existing code didn't work correctly if the last element of the overload set didn't have a Doxygen comment: in this case, no docstring was generated at all.

Fix this by trying to find any overload with a Doxygen comment, as Python docstring is common for all of them: add a helper function to do it and use it for both all kinds of ordinary functions (global, member and static) and __init__ functions generated for C++ ctors, as docstring was generated in the same wrong way for all of them in different places.

Note that currently the overloads without Doxygen comments are not documented at all at Python level, as saying "there exist other overloads but there is no documentation for them" doesn't seem very useful and there doesn't seem anything else that we could do.

Add a new unit test for testing all the different combinations of overloaded functions with and without Doxygen comments.

----

This is a simple change which should hopefully be uncontroversial: we need to pass a node with some Doxygen comment to get any docstring out of it, but for overloaded functions (including ctors), we always passed it the node corresponding to the last element of the overload set, which might not have had any Doxygen comment, unlike the other elements.

Before this change, the unit test would fail because having a Doxygen comment for the first function but not the second one didn't generate any docstring at all.