### PR TITLE
Fix missing-field-initializers warning with Py3.13

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -273,6 +273,9 @@ SwigPyStaticVar_Type(void) {
 #if PY_VERSION_HEX >= 0x030c0000
       0,                                        /* tp_watched */
 #endif
+#if PY_VERSION_HEX >= 0x030d00a4
+      0,                                        /* tp_versions_used */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                        /* tp_allocs */
       0,                                        /* tp_frees */
@@ -363,6 +366,9 @@ SwigPyObjectType(void) {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
       0,                                        /* tp_watched */
+#endif
+#if PY_VERSION_HEX >= 0x030d00a4
+      0,                                        /* tp_versions_used */
 #endif
 #ifdef COUNT_ALLOCS
       0,                                        /* tp_allocs */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -392,6 +392,9 @@ swig_varlink_type(void) {
 #if PY_VERSION_HEX >= 0x030C0000
       0,                                  /* tp_watched */
 #endif
+#if PY_VERSION_HEX >= 0x030d00a4
+      0,                                  /* tp_versions_used */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                  /* tp_allocs */
       0,                                  /* tp_frees */
@@ -1025,6 +1028,9 @@ SwigPyObject_TypeOnce(void) {
 #if PY_VERSION_HEX >= 0x030C0000
       0,                                    /* tp_watched */
 #endif
+#if PY_VERSION_HEX >= 0x030d00a4
+      0,                                    /* tp_versions_used */
+#endif
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */
       0,                                    /* tp_frees */
@@ -1243,6 +1249,9 @@ SwigPyPacked_TypeOnce(void) {
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
       0,                                    /* tp_watched */
+#endif
+#if PY_VERSION_HEX >= 0x030d00a4
+      0,                                    /* tp_versions_used */
 #endif
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4215,6 +4215,9 @@ public:
     Printv(f, "#if PY_VERSION_HEX >= 0x030c0000\n", NIL);
     printSlot(f, getSlot(n, "feature:python:tp_watched"), "tp_watched", "char");
     Printv(f, "#endif\n", NIL);
+    Printv(f, "#if PY_VERSION_HEX >= 0x030d00a4\n", NIL);
+    printSlot(f, getSlot(n, "feature:python:tp_versions_used"), "tp_versions_used", "uint16_t");
+    Printv(f, "#endif\n", NIL);
 
     Printv(f, "#ifdef COUNT_ALLOCS\n", NIL);
     printSlot(f, getSlot(n, "feature:python:tp_allocs"), "tp_allocs", "Py_ssize_t");


### PR DESCRIPTION
Introduced https://github.com/python/cpython/pull/114900