### PR TITLE
Straighten out handling of char and string constants

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,9 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.3.0 (in progress)
 ===========================
 
+2024-08-??: olly
+	    #904 #1907 #2579 Fix string literal and character literal wrapping bugs.
+
 2024-08-02: vadz
 	    [Python] #2966 Fix overloaded Doxygen comments. Sometimes the Doxygen
             comments were not combined into one Pydoc comment.

--- a/Examples/test-suite/char_constant.i
+++ b/Examples/test-suite/char_constant.i
@@ -21,6 +21,7 @@
 #define SPECIALCHARAE1 'Æ' // AE (latin1 encoded)
 #define SPECIALCHARAE2 '\306' // AE (latin1 encoded)
 #define SPECIALCHARAE3 '\xC6' // AE (latin1 encoded)
+#define SPECIALCHARPAREN (';')
 
 #if defined(SWIGJAVA)
 %javaconst(1);
@@ -42,9 +43,11 @@
 #define X_SPECIALCHARAE1 'Æ' // AE (latin1 encoded)
 #define X_SPECIALCHARAE2 '\306' // AE (latin1 encoded)
 #define X_SPECIALCHARAE3 '\xC6' // AE (latin1 encoded)
+#define X_SPECIALCHARPAREN (';')
 
 %inline 
 {
   const int ia = (int)'a';
   const int ib = 'b';
+  const int iparen = (';');
 }

--- a/Examples/test-suite/constant_expr.i
+++ b/Examples/test-suite/constant_expr.i
@@ -64,3 +64,6 @@ public:
                   std::is_trivially_destructible<T>::value>
         test_alignof_too;
 };
+
+%constant int WSTRING_LIT_LEN1 = (sizeof(L"1234")/sizeof(wchar_t) - 1);
+%constant int WSTRING_LIT_LEN2 = (sizeof(L"12" L"34")/sizeof(wchar_t) - 1);

--- a/Examples/test-suite/cpp11_auto_variable.i
+++ b/Examples/test-suite/cpp11_auto_variable.i
@@ -50,6 +50,13 @@ static constexpr auto Bad4 = &one;
 %}
 
 %inline %{
+// Concatenation of a literal with an encoding prefix and one without
+// was added in C++11.
+static auto wstring_lit_len1 = sizeof(L"123" "456") / sizeof(wchar_t) - 1;
+static auto wstring_lit_len2 = sizeof("123" L"456") / sizeof(wchar_t) - 1;
+%}
+
+%inline %{
 
 // FIXME: Not currently handled by SWIG's parser:
 //static auto constexpr greeting = "Hello";

--- a/Examples/test-suite/csharp/string_constants_runme.cs
+++ b/Examples/test-suite/csharp/string_constants_runme.cs
@@ -1,0 +1,13 @@
+using System;
+using string_constantsNamespace;
+
+public class runme {
+  static void Main() {
+    assert( string_constants.QQ1 == "\x000800! \x00018b00!" );
+    assert( string_constants.QQ2 == "\x000800! \x00018b00!" );
+  }
+  static void assert(bool assertion) {
+    if (!assertion)
+      throw new ApplicationException("test failed");
+  }
+}

--- a/Examples/test-suite/expressions.i
+++ b/Examples/test-suite/expressions.i
@@ -18,4 +18,8 @@ struct A
     // SWIG 4.2.0 and earlier.
     int g(bool b = (compl 1 or not 2) xor (3 and 4) xor (3 bitand 6) xor (3 bitor 5) xor (2 + 2 not_eq 5)) { return (int)b; }
 };
+
+const unsigned char LASTCHAR1 = "hello world"[sizeof"hello world" - 2];
+const unsigned char LASTCHAR2 = "bye"[sizeof("bye") - 2];
+
 %}

--- a/Examples/test-suite/li_std_string.i
+++ b/Examples/test-suite/li_std_string.i
@@ -174,3 +174,16 @@ public:
   }
 %}
 
+#if defined(SWIGJAVA)
+%javaconst(1);
+#elif SWIGCSHARP
+%csconst(1);
+#elif SWIGD
+%dmanifestconst;
+#endif
+
+%inline %{
+const std::string aString = "something";
+%}
+%constant std::string MY_STRING = "";
+%constant std::string MY_STRING_2 = "OK";

--- a/Examples/test-suite/php/constant_expr_runme.php
+++ b/Examples/test-suite/php/constant_expr_runme.php
@@ -15,4 +15,7 @@ check::equal(YY, yy());
 check::equal(constant_expr::XX, constant_expr::xx());
 check::equal(constant_expr::YY, constant_expr::yy());
 
+check::equal(WSTRING_LIT_LEN1, 4);
+check::equal(WSTRING_LIT_LEN2, 4);
+
 check::done();

--- a/Examples/test-suite/php/cpp11_auto_variable_runme.php
+++ b/Examples/test-suite/php/cpp11_auto_variable_runme.php
@@ -5,7 +5,7 @@ require "tests.php";
 // No new functions
 check::functions(array());
 check::classes(array('cpp11_auto_variable'));
-check::globals(array('f', 't', 'zero', 'one', 'la', 'da', 'fa', 'lc', 'dc', 'fc', 'pi_approx', 'Bar', 'Bar2', 'Bar3', 'Foo', 'Foo2', 'Foo3', 'NOEXCEPT_FUNC'));
+check::globals(array('f', 't', 'zero', 'one', 'la', 'da', 'fa', 'lc', 'dc', 'fc', 'pi_approx', 'wstring_lit_len1', 'wstring_lit_len2', 'Bar', 'Bar2', 'Bar3', 'Foo', 'Foo2', 'Foo3', 'NOEXCEPT_FUNC'));
 
 check::equal(f_get(), false);
 check::equal(gettype(f_get()), "boolean");
@@ -38,3 +38,6 @@ check::equal(dc_get(), 1.0);
 // PHP doesn't have a native "long double" type, so SWIG/PHP doesn't have
 // typemaps for it and so it should get wrapped as an opaque type.
 check::str_contains(lc_get(), "SWIGPointer(");
+
+check::equal(wstring_lit_len1_get(), 6);
+check::equal(wstring_lit_len2_get(), 6);

--- a/Examples/test-suite/string_constants.i
+++ b/Examples/test-suite/string_constants.i
@@ -19,6 +19,7 @@
 #define ZS1 "\0"
 #define ES1 ""
 #define QQ1 "\b00!"
+#define PR1 ("paren")
 %}
 %constant SS2="ÆÎOU\n";
 %constant AA2="A\rB\nC";
@@ -27,6 +28,7 @@
 %constant ZS2="\0";
 %constant ES2="";
 %constant QQ2="\b00!";
+%constant PR2=("paren");
 
 %inline %{
 static const char *SS3 = "ÆÎOU\n";
@@ -36,6 +38,7 @@ static const char *XX3 = "\x57\x58\x59";
 static const char *ZS3 = "\0";
 static const char *ES3 = "";
 static const char *QQ3 = "\b00!";
+static const char *PR3 = ("paren");
 struct things {
   const char * defarguments1(const char *SS4 = "ÆÎOU\n") { return SS4; }
   const char * defarguments2(const char *AA4 = "A\rB\nC") { return AA4; }
@@ -44,5 +47,6 @@ struct things {
   const char * defarguments5(const char *ZS4 = "\0") { return ZS4; }
   const char * defarguments6(const char *ES4 = "") { return ES4; }
   const char * defarguments7(const char *QQ4 = "\b00!") { return QQ4; }
+  const char * defarguments8(const char *PR4 = ("paren")) { return PR4; }
 };
 %}

--- a/Source/CParse/cparse.h
+++ b/Source/CParse/cparse.h
@@ -80,6 +80,4 @@ extern "C" {
   if (wrnfilter) Swig_warnfilter(wrnfilter,0); \
  }
 
-#define COMPOUND_EXPR_VAL(dtype) \
-  ((dtype).type == T_CHAR || (dtype).type == T_WCHAR ? (dtype).rawval : (dtype).val)
 #endif

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -1638,8 +1638,11 @@ static String *add_qualifier_to_declarator(SwigType *type, SwigType *qualifier) 
     // "b\x61r"      bar         "bar"
     // "b\141r"      bar         "bar"
     // "b" "ar"      bar         "bar"
+    // u8"bar"       bar         "bar"     C++11
+    // R"bar"        bar         "bar"     C++11
     // "\228\22"     "8"         "\"8\""
     // "\\\"\'"      \"'         "\\\"\'"
+    // R"(\"')"      \"'         "\\\"\'"  C++11
     // L"bar"        bar         L"bar"
     // L"b" L"ar"    bar         L"bar"
     // L"b" "ar"     bar         L"bar"    C++11
@@ -1651,7 +1654,8 @@ static String *add_qualifier_to_declarator(SwigType *type, SwigType *qualifier) 
     // '\x22'        "           '\"'
     //
     // Zero bytes are allowed in stringval (DOH's String can hold a string
-    // with embedded zero bytes).
+    // with embedded zero bytes), but handling may currently be buggy in
+    // places.
     String *stringval;
     int     type;
     /* The type code for the argument when the top level operator is unary.

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1476,7 +1476,8 @@ public:
     String *tm;
     String *return_type = NewString("");
     String *constants_code = NewString("");
-    Swig_save("constantWrapper", n, "value", NIL);
+    // The value as C# code.
+    String *csvalue = Copy(Getattr(n, "value"));
     Swig_save("constantWrapper", n, "tmap:ctype:out", "tmap:imtype:out", "tmap:cstype:out", "tmap:out:null", "tmap:imtype:outattributes", "tmap:cstype:outattributes", NIL);
 
     bool is_enum_item = (Cmp(nodeType(n), "enumitem") == 0);
@@ -1538,9 +1539,8 @@ public:
       }
       if (quote) {
 	// Escape character literal for C#.
-	String *new_value = NewStringf("%c%(csharpescape)s%c", quote, Getattr(n, "stringval"), quote);
-	Setattr(n, "value", new_value);
-	Delete(new_value);
+	Delete(csvalue);
+	csvalue = NewStringf("%c%(csharpescape)s%c", quote, Getattr(n, "stringval"), quote);
       }
     }
 
@@ -1591,7 +1591,7 @@ public:
           Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
 	}
       } else {
-        Printf(constants_code, "%s;\n", Getattr(n, "value"));
+	Printf(constants_code, "%s;\n", csvalue);
       }
     }
 
@@ -1607,6 +1607,7 @@ public:
     Swig_restore(n);
     Delete(return_type);
     Delete(constants_code);
+    Delete(csvalue);
     return SWIG_OK;
   }
 

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1344,9 +1344,10 @@ public:
       const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
       Setattr(n, "enumvalue", val);
     } else if (swigtype == T_CHAR) {
-      if (Getattr(n, "enumstringval")) {
+      String *enumstringval = Getattr(n, "enumstringval");
+      if (enumstringval) {
 	// Escape character literal for C#.
-	String *val = NewStringf("'%(csharpescape)s'", Getattr(n, "enumstringval"));
+	String *val = NewStringf("'%(csharpescape)s'", enumstringval);
 	Setattr(n, "enumvalue", val);
 	Delete(val);
       }

--- a/Source/Modules/d.cxx
+++ b/Source/Modules/d.cxx
@@ -950,10 +950,6 @@ public:
     if (swigtype == T_BOOL) {
       const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
       Setattr(n, "enumvalue", val);
-    } else if (swigtype == T_CHAR) {
-      String *val = NewStringf("'%(escape)s'", Getattr(n, "enumvalue"));
-      Setattr(n, "enumvalue", val);
-      Delete(val);
     }
 
     // Emit the enum item.
@@ -1449,19 +1445,7 @@ public:
       // Note that this is only called for global constants, static member
       // constants are already handled in staticmemberfunctionHandler().
 
-      Swig_save("constantWrapper", n, "value", NIL);
       Swig_save("constantWrapper", n, "tmap:ctype:out", "tmap:imtype:out", "tmap:dtype:out", "tmap:out:null", "tmap:imtype:outattributes", "tmap:dtype:outattributes", NIL);
-
-      // Add the stripped quotes back in.
-      String *old_value = Getattr(n, "value");
-      SwigType *t = Getattr(n, "type");
-      if (SwigType_type(t) == T_STRING) {
-	Setattr(n, "value", NewStringf("\"%s\"", old_value));
-	Delete(old_value);
-      } else if (SwigType_type(t) == T_CHAR) {
-	Setattr(n, "value", NewStringf("\'%s\'", old_value));
-	Delete(old_value);
-      }
 
       SetFlag(n, "feature:immutable");
       int result = globalvariableHandler(n);
@@ -1472,7 +1456,6 @@ public:
 
     String *constants_code = NewString("");
     SwigType *t = Getattr(n, "type");
-    SwigType *valuetype = Getattr(n, "valuetype");
     ParmList *l = Getattr(n, "parms");
 
     // Attach the non-standard typemaps to the parameter list.
@@ -1505,20 +1488,9 @@ public:
     } else {
       // Just take the value from the C definition and hope it compiles in D.
       if (Getattr(n, "wrappedasconstant")) {
-	if (SwigType_type(valuetype) == T_CHAR)
-          Printf(constants_code, "\'%(escape)s\';\n", Getattr(n, "staticmembervariableHandler:value"));
-	else
-          Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
+	Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
       } else {
-	// Add the stripped quotes back in.
-	String* value = Getattr(n, "value");
-	if (SwigType_type(t) == T_STRING) {
-	  Printf(constants_code, "\"%s\";\n", value);
-	} else if (SwigType_type(t) == T_CHAR) {
-	  Printf(constants_code, "\'%s\';\n", value);
-	} else {
-	  Printf(constants_code, "%s;\n", value);
-	}
+	Printf(constants_code, "%s;\n", Getattr(n, "value"));
       }
     }
 

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1804,6 +1804,7 @@ private:
   virtual int constantWrapper(Node *n) {
     SwigType *type = Getattr(n, "type");
     String *value = Getattr(n, "value");
+    String *copy = NULL;
     int typecode = SwigType_type(type);
     if (typecode == T_STRING) {
       String *stringval = Getattr(n, "stringval");
@@ -1811,14 +1812,16 @@ private:
 	return goComplexConstant(n, type);
       }
       // Backslash sequences are somewhat different in Go and C/C++.
-      value = NewStringf("\"%(goescape)s\"", stringval); // FIXME leak
+      copy = NewStringf("\"%(goescape)s\"", stringval);
+      value = copy;
     } else if (typecode == T_CHAR) {
       String *stringval = Getattr(n, "stringval");
       if (!stringval || Len(stringval) != 1) {
 	return goComplexConstant(n, type);
       }
       // Backslash sequences are somewhat different in Go and C/C++.
-      value = NewStringf("'%(goescape)s'", stringval); // FIXME leak
+      copy = NewStringf("'%(goescape)s'", stringval);
+      value = copy;
     } else if (!SwigType_issimple(type)) {
       return goComplexConstant(n, type);
     } else if (Swig_storage_isstatic(n)) {
@@ -1829,7 +1832,6 @@ private:
       }
     }
 
-    String *copy = NULL;
     {
       // Accept a 0x prefix, and strip combinations of u and l
       // suffixes.  Otherwise accept digits, decimal point, and
@@ -1868,7 +1870,7 @@ private:
 	}
       }
       if (need_copy) {
-	copy = Copy(value);
+	if (!copy) copy = Copy(value);
 	Replaceall(copy, p + len, "");
 	value = copy;
       }

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1974,8 +1974,21 @@ private:
       return SWIG_NOWRAP;
     }
 
-    // FIXME: Check all this
-    {
+    if (!Getattr(n, "stringval") && !Getattr(n, "enumvalueDeclaration:sym:name")) {
+      // Based on Swig_VargetToFunction
+      String *nname = NewStringf("(%s)", Getattr(n, "value"));
+      String *call;
+      if (SwigType_isclass(type)) {
+	call = NewStringf("%s", nname);
+      } else {
+	call = SwigType_lcaststr(type, nname);
+      }
+      String *cres = Swig_cresult(type, Swig_cresult_name(), call);
+      Setattr(n, "wrap:action", cres);
+      Delete(nname);
+      Delete(call);
+      Delete(cres);
+    } else {
       String *get = NewString("");
       Printv(get, Swig_cresult_name(), " = ", NULL);
 

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1803,31 +1803,34 @@ private:
 
   virtual int constantWrapper(Node *n) {
     SwigType *type = Getattr(n, "type");
-
-    if (!SwigType_issimple(type) && SwigType_type(type) != T_STRING) {
-      return goComplexConstant(n, type);
-    }
-
-    if (Swig_storage_isstatic(n)) {
-      return goComplexConstant(n, type);
-    }
-
-    String *go_name = buildGoName(Getattr(n, "sym:name"), false, false);
-
-    String *tm = goType(n, type);
     String *value = Getattr(n, "value");
-
-    String *copy = NULL;
-    if (SwigType_type(type) == T_BOOL) {
+    int typecode = SwigType_type(type);
+    if (typecode == T_STRING) {
+      String *stringval = Getattr(n, "stringval");
+      if (!stringval) {
+	return goComplexConstant(n, type);
+      }
+      // Backslash sequences are somewhat different in Go and C/C++.
+      value = NewStringf("\"%(goescape)s\"", stringval); // FIXME leak
+    } else if (typecode == T_CHAR) {
+      String *stringval = Getattr(n, "stringval");
+      if (!stringval || Len(stringval) != 1) {
+	return goComplexConstant(n, type);
+      }
+      // Backslash sequences are somewhat different in Go and C/C++.
+      value = NewStringf("'%(goescape)s'", stringval); // FIXME leak
+    } else if (!SwigType_issimple(type)) {
+      return goComplexConstant(n, type);
+    } else if (Swig_storage_isstatic(n)) {
+      return goComplexConstant(n, type);
+    } else if (typecode == T_BOOL) {
       if (Cmp(value, "true") != 0 && Cmp(value, "false") != 0) {
 	return goComplexConstant(n, type);
       }
-    } else if (SwigType_type(type) == T_STRING || SwigType_type(type) == T_CHAR) {
-      // Backslash sequences are somewhat different in Go and C/C++.
-      if (Strchr(value, '\\') != 0) {
-	return goComplexConstant(n, type);
-      }
-    } else {
+    }
+
+    String *copy = NULL;
+    {
       // Accept a 0x prefix, and strip combinations of u and l
       // suffixes.  Otherwise accept digits, decimal point, and
       // exponentiation.  Treat anything else as too complicated to
@@ -1871,23 +1874,17 @@ private:
       }
     }
 
+    String *go_name = buildGoName(Getattr(n, "sym:name"), false, false);
+
     if (!checkNameConflict(go_name, n, NULL)) {
-      Delete(tm);
       Delete(go_name);
       Delete(copy);
       return SWIG_NOWRAP;
     }
 
-    Printv(f_go_wrappers, "const ", go_name, " ", tm, " = ", NULL);
-    if (SwigType_type(type) == T_STRING) {
-      Printv(f_go_wrappers, "\"", value, "\"", NULL);
-    } else if (SwigType_type(type) == T_CHAR) {
-      Printv(f_go_wrappers, "'", value, "'", NULL);
-    } else {
-      Printv(f_go_wrappers, value, NULL);
-    }
+    String *tm = goType(n, type);
 
-    Printv(f_go_wrappers, "\n", NULL);
+    Printv(f_go_wrappers, "const ", go_name, " ", tm, " = ", value, "\n", NIL);
 
     Delete(tm);
     Delete(go_name);
@@ -1977,46 +1974,16 @@ private:
       return SWIG_NOWRAP;
     }
 
-    String *rawval = Getattr(n, "rawval");
-    if (rawval && Len(rawval)) {
-      // Based on Swig_VargetToFunction
-      String *nname = NewStringf("(%s)", rawval);
-      String *call;
-      if (SwigType_isclass(type)) {
-	call = NewStringf("%s", nname);
-      } else {
-	call = SwigType_lcaststr(type, nname);
-      }
-      String *cres = Swig_cresult(type, Swig_cresult_name(), call);
-      Setattr(n, "wrap:action", cres);
-      Delete(nname);
-      Delete(call);
-      Delete(cres);
-    } else {
+    // FIXME: Check all this
+    {
       String *get = NewString("");
       Printv(get, Swig_cresult_name(), " = ", NULL);
 
-      char quote;
-      if (Getattr(n, "wrappedasconstant")) {
-        quote = '\0';
-      } else if (SwigType_type(type) == T_CHAR) {
-        quote = '\'';
-      } else if (SwigType_type(type) == T_STRING) {
+      if (SwigType_type(type) == T_STRING) {
         Printv(get, "(char *)", NULL);
-        quote = '"';
-      } else {
-        quote = '\0';
-      }
-
-      if (quote != '\0') {
-        Printf(get, "%c", quote);
       }
 
       Printv(get, Getattr(n, "value"), NULL);
-
-      if (quote != '\0') {
-        Printf(get, "%c", quote);
-      }
 
       Printv(get, ";\n", NULL);
 

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1830,9 +1830,7 @@ private:
       if (Cmp(value, "true") != 0 && Cmp(value, "false") != 0) {
 	return goComplexConstant(n, type);
       }
-    }
-
-    {
+    } else {
       // Accept a 0x prefix, and strip combinations of u and l
       // suffixes.  Otherwise accept digits, decimal point, and
       // exponentiation.  Treat anything else as too complicated to

--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -1262,8 +1262,7 @@ public:
     char *name = GetChar(n, "name");
     char *iname = GetChar(n, "sym:name");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     int constasvar = GetFlag(n, "feature:constasvar");
 
 

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1207,8 +1207,7 @@ int JSEmitter::emitConstant(Node *n) {
   SwigType *type = Getattr(n, "type");
   String *iname = Getattr(n, "sym:name");
   String *wname = Swig_name_get(Getattr(current_namespace, NAME_MANGLED), iname);
-  String *rawval = Getattr(n, "rawval");
-  String *value = rawval ? rawval : Getattr(n, "value");
+  String *value = Getattr(n, "value");
 
   // HACK: forcing usage of cppvalue for v8 (which turned out to fix typedef_struct.i, et. al)
   if (State::IsSet(state.globals(FORCE_CPP)) && Getattr(n, "cppvalue") != NULL) {

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -629,24 +629,9 @@ int Language::constantDirective(Node *n) {
 
   if (!ImportMode) {
     Swig_require("constantDirective", n, "name", "?value", NIL);
-    String *name = Getattr(n, "name");
-    String *value = Getattr(n, "value");
-    if (!value) {
-      value = Copy(name);
-    } else {
-      /*      if (checkAttribute(n,"type","char")) {
-         value = NewString(value);
-         } else {
-         value = NewStringf("%(escape)s", value);
-         }
-       */
-      Setattr(n, "rawvalue", value);
-      value = NewStringf("%(escape)s", value);
-      if (!Len(value))
-	Append(value, "\\0");
-      /*      Printf(stdout,"'%s' = '%s'\n", name, value); */
+    if (!Getattr(n, "value")) {
+      Setattr(n, "value", Copy(Getattr(n, "name")));
     }
-    Setattr(n, "value", value);
     this->constantWrapper(n);
     Swig_restore(n);
     return SWIG_OK;

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -630,7 +630,7 @@ int Language::constantDirective(Node *n) {
   if (!ImportMode) {
     Swig_require("constantDirective", n, "name", "?value", NIL);
     if (!Getattr(n, "value")) {
-      Setattr(n, "value", Copy(Getattr(n, "name")));
+      Setattr(n, "value", Getattr(n, "name"));
     }
     this->constantWrapper(n);
     Swig_restore(n);

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -1053,8 +1053,7 @@ public:
       lua_name = iname;
     String *nsname = Copy(iname);
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     String *tm;
     String *lua_name_v2 = 0;
     String *tm_v2 = 0;

--- a/Source/Modules/mzscheme.cxx
+++ b/Source/Modules/mzscheme.cxx
@@ -578,7 +578,7 @@ public:
     } else {
       // Create a static variable and assign it a value
       String *var_name = NewStringf("_wrap_const_%s", Swig_name_mangle_string(Getattr(n, "sym:name")));
-      Printf(f_header, "static %s = %s;", SwigType_lstr(type, var_name), value);
+      Printf(f_header, "static %s = %s;\n", SwigType_lstr(type, var_name), value);
 
       // Now create a variable declaration
 

--- a/Source/Modules/mzscheme.cxx
+++ b/Source/Modules/mzscheme.cxx
@@ -564,53 +564,21 @@ public:
     SwigType *type = Getattr(n, "type");
     String *value = Getattr(n, "value");
 
-    String *var_name = NewString("");
-    String *proc_name = NewString("");
-    String *rvalue = NewString("");
-    String *temp = NewString("");
     String *tm;
-
-    // Make a static variable;
-
-    Printf(var_name, "_wrap_const_%s", Swig_name_mangle_string(Getattr(n, "sym:name")));
-
-    // Build the name for scheme.
-    Printv(proc_name, iname, NIL);
-    Replaceall(proc_name, "_", "-");
 
     if ((SwigType_type(type) == T_USER) && (!is_a_pointer(type))) {
       Swig_warning(WARN_TYPEMAP_CONST_UNDEF, input_file, line_number, "Unsupported constant value.\n");
       return SWIG_NOWRAP;
     }
-    // See if there's a typemap
 
-    Printv(rvalue, value, NIL);
-    if ((SwigType_type(type) == T_CHAR) && (is_a_pointer(type) == 1)) {
-      temp = Copy(rvalue);
-      Clear(rvalue);
-      Printv(rvalue, "\"", temp, "\"", NIL);
-    }
-    if ((SwigType_type(type) == T_CHAR) && (is_a_pointer(type) == 0)) {
-      Delete(temp);
-      temp = Copy(rvalue);
-      Clear(rvalue);
-      Printv(rvalue, "'", temp, "'", NIL);
-    }
+    // See if there's a typemap
     if ((tm = Swig_typemap_lookup("constant", n, name, 0))) {
-      Replaceall(tm, "$value", rvalue);
+      Replaceall(tm, "$value", value);
       Printf(f_init, "%s\n", tm);
     } else {
-      // Create variable and assign it a value
-
-      Printf(f_header, "static %s = ", SwigType_lstr(type, var_name));
-      bool is_enum_item = (Cmp(nodeType(n), "enumitem") == 0);
-      if ((SwigType_type(type) == T_STRING)) {
-	Printf(f_header, "\"%s\";\n", value);
-      } else if (SwigType_type(type) == T_CHAR && !is_enum_item) {
-	Printf(f_header, "\'%s\';\n", value);
-      } else {
-	Printf(f_header, "%s;\n", value);
-      }
+      // Create a static variable and assign it a value
+      String *var_name = NewStringf("_wrap_const_%s", Swig_name_mangle_string(Getattr(n, "sym:name")));
+      Printf(f_header, "static %s = %s;", SwigType_lstr(type, var_name), value);
 
       // Now create a variable declaration
 
@@ -626,10 +594,8 @@ public:
 	variableWrapper(nn);
 	Delete(nn);
       }
+      Delete(var_name);
     }
-    Delete(proc_name);
-    Delete(rvalue);
-    Delete(temp);
     return SWIG_OK;
   }
 

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -898,8 +898,7 @@ public:
   virtual int constantWrapper(Node *n) {
     String *name = Getattr(n, "feature:symname");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     SwigType *qname = Getattr(n, "qualified:name");
 
     if (qname)

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -893,8 +893,7 @@ public:
     String *name = Getattr(n, "name");
     String *iname = Getattr(n, "sym:name");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     String *cppvalue = Getattr(n, "cppvalue");
     String *tm;
 

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -1079,8 +1079,7 @@ public:
     String *name = Getattr(n, "name");
     String *iname = Getattr(n, "sym:name");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     String *tm;
 
     if (!addSymbol(iname, n))

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -1696,8 +1696,7 @@ public:
     String *name = GetChar(n, "name");
     String *iname = GetChar(n, "sym:name");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     String *tm;
 
     if (!addSymbol(iname, n))

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3612,8 +3612,7 @@ public:
     String *name = Getattr(n, "name");
     String *iname = Getattr(n, "sym:name");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     String *tm;
     int have_tm = 0;
     int have_builtin_symname = 0;

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1186,9 +1186,11 @@ int R::enumvalueDeclaration(Node *n) {
     const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
     Setattr(n, "enumvalue", val);
   } else if (swigtype == T_CHAR) {
-    String *val = NewStringf("'%s'", Getattr(n, "enumvalue"));
-    Setattr(n, "enumvalue", val);
-    Delete(val);
+    if (Getattr(n, "enumstringval")) {
+      String *val = NewStringf("'%(escape)s'", Getattr(n, "enumstringval"));
+      Setattr(n, "enumvalue", val);
+      Delete(val);
+    }
   }
 
   if (GetFlag(parent, "scopedenum")) {

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -2296,8 +2296,7 @@ public:
 
     char *iname = GetChar(n, "sym:name");
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
 
     if (current == CLASS_CONST) {
       iname = klass->strip(iname);

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -690,8 +690,7 @@ public:
     String *nodeName = Getattr(node, "name");
     SwigType *type = Getattr(node, "type");
     String *constantName = Getattr(node, "sym:name");
-    String *rawValue = Getattr(node, "rawval");
-    String *constantValue = rawValue ? rawValue : Getattr(node, "value");
+    String *constantValue = Getattr(node, "value");
     String *constantTypemap = NULL;
 
     // If feature scilab:const enabled, constants & enums are wrapped to Scilab variables

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -661,8 +661,7 @@ public:
     String *iname = Getattr(n, "sym:name");
     String *nsname = !namespace_option ? Copy(iname) : NewStringf("%s::%s", ns_name, iname);
     SwigType *type = Getattr(n, "type");
-    String *rawval = Getattr(n, "rawval");
-    String *value = rawval ? rawval : Getattr(n, "value");
+    String *value = Getattr(n, "value");
     String *tm;
 
     if (!addSymbol(iname, n))

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -1645,9 +1645,7 @@ int Swig_VargetToFunction(Node *n, int flags) {
   } else {
     String *nname = 0;
     if (Equal(nodeType(n), "constant")) {
-      String *rawval = Getattr(n, "rawval");
-      String *value = rawval ? rawval : Getattr(n, "value");
-      nname = NewStringf("(%s)", value);
+      nname = NewStringf("(%s)", Getattr(n, "value"));
     } else {
       nname = SwigType_namestr(name);
     }

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -12,6 +12,7 @@
  * ----------------------------------------------------------------------------- */
 
 #include "swig.h"
+#include <assert.h>
 #include <errno.h>
 #include <ctype.h>
 #include <limits.h>
@@ -353,7 +354,8 @@ int Swig_storage_isstatic(Node *n) {
  * Swig_string_escape()
  *
  * Takes a string object and produces a string with escape codes added to it.
- * Octal escaping is used.
+ * Octal escaping is used.  The result is used for literal strings and characters
+ * in C/C++ and also Java and R.
  * ----------------------------------------------------------------------------- */
 
 String *Swig_string_escape(String *s) {
@@ -372,12 +374,11 @@ String *Swig_string_escape(String *s) {
       Printf(ns, "\\'");
     } else if (c == '\"') {
       Printf(ns, "\\\"");
-    } else if (c == ' ') {
+    } else if (c >= 32 && c < 127) {
       Putc(c, ns);
-    } else if (!isgraph(c)) {
+    } else {
       int next_c = Getc(s);
-      if (c < 0)
-	c += UCHAR_MAX + 1;
+      assert(c >= 0);
       if (next_c >= '0' && next_c < '8') {
 	/* We need to emit 3 octal digits. */
 	Printf(ns, "\\%03o", c);
@@ -386,8 +387,6 @@ String *Swig_string_escape(String *s) {
       }
       c = next_c;
       continue;
-    } else {
-      Putc(c, ns);
     }
     c = Getc(s);
   }
@@ -395,13 +394,13 @@ String *Swig_string_escape(String *s) {
 }
 
 /* -----------------------------------------------------------------------------
- * Swig_string_hexescape()
+ * Swig_string_csharpescape()
  *
- * Takes a string object and produces a string with escape codes added to it.
- * Hex escaping is used.
+ * Takes a string object and produces a string with escape codes added to it
+ * suitable for use as a C# string or character literal.
  * ----------------------------------------------------------------------------- */
 
-static String *Swig_string_hexescape(String *s) {
+static String *Swig_string_csharpescape(String *s) {
   String *ns;
   int c;
   ns = NewStringEmpty();
@@ -419,14 +418,47 @@ static String *Swig_string_hexescape(String *s) {
       Printf(ns, "\\'");
     } else if (c == '\"') {
       Printf(ns, "\\\"");
-    } else if (c == ' ') {
+    } else if (c >= 32 && c < 127) {
       Putc(c, ns);
-    } else if (!isgraph(c)) {
-      if (c < 0)
-	c += UCHAR_MAX + 1;
-      Printf(ns, "\\x%X", c);
     } else {
+      assert(c >= 0);
+      // Emit 4 hex digits in case the next character is a hex digit.
+      Printf(ns, "\\x%04X", c);
+    }
+  }
+  return ns;
+}
+
+/* -----------------------------------------------------------------------------
+ * Swig_string_goescape()
+ *
+ * Takes a string object and produces a string with escape codes added to it
+ * suitable for use as a Go string or character literal.
+ * ----------------------------------------------------------------------------- */
+
+static String *Swig_string_goescape(String *s) {
+  String *ns;
+  int c;
+  ns = NewStringEmpty();
+
+  while ((c = Getc(s)) != EOF) {
+    if (c == '\n') {
+      Printf(ns, "\\n");
+    } else if (c == '\r') {
+      Printf(ns, "\\r");
+    } else if (c == '\t') {
+      Printf(ns, "\\t");
+    } else if (c == '\\') {
+      Printf(ns, "\\\\");
+    } else if (c == '\'') {
+      Printf(ns, "\\'");
+    } else if (c == '\"') {
+      Printf(ns, "\\\"");
+    } else if (c >= 32 && c < 127) {
       Putc(c, ns);
+    } else {
+      assert(c >= 0);
+      Printf(ns, "\\x%02x", c);
     }
   }
   return ns;
@@ -1422,7 +1454,8 @@ Node *Swig_item_in_list(List *list, const_String_or_char_ptr name) {
 void Swig_init(void) {
   /* Set some useful string encoding methods */
   DohEncoding("escape", Swig_string_escape);
-  DohEncoding("hexescape", Swig_string_hexescape);
+  DohEncoding("csharpescape", Swig_string_csharpescape);
+  DohEncoding("goescape", Swig_string_goescape);
   DohEncoding("upper", Swig_string_upper);
   DohEncoding("lower", Swig_string_lower);
   DohEncoding("title", Swig_string_title);

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -450,13 +450,12 @@ static String *Swig_string_goescape(String *s) {
       Printf(ns, "\\t");
     } else if (c == '\\') {
       Printf(ns, "\\\\");
-    } else if (c == '\'') {
-      Printf(ns, "\\'");
-    } else if (c == '\"') {
-      Printf(ns, "\\\"");
-    } else if (c >= 32 && c < 127) {
+    } else if (c >= 32 && c < 127 && c != '\'' && c != '"') {
       Putc(c, ns);
     } else {
+      // In Go, \' isn't valid in a double quoted string, while \" isn't valid
+      // in a single quoted rune, so to avoid needing two different escaping
+      // functions we always escape both using hex escapes.
       assert(c >= 0);
       Printf(ns, "\\x%02x", c);
     }

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -209,26 +209,26 @@ void Scanner_idstart(Scanner *s, const char *id) {
 /* -----------------------------------------------------------------------------
  * nextchar()
  * 
- * Returns the next character from the scanner or EOF if end of the string.
+ * Returns the next character from the scanner or 0 if end of the string.
  * ----------------------------------------------------------------------------- */
-static int nextchar(Scanner *s) {
+static char nextchar(Scanner *s) {
   int nc;
   if (!s->str)
-    return EOF;
+    return 0;
   while ((nc = Getc(s->str)) == EOF) {
     Delete(s->str);
     s->str = 0;
     Delitem(s->scanobjs, 0);
     if (Len(s->scanobjs) == 0)
-      return EOF;
+      return 0;
     s->str = Getitem(s->scanobjs, 0);
     s->line = Getline(s->str);
     DohIncref(s->str);
   }
   if ((nc == '\n') && (!s->freeze_line)) 
     s->line++;
-  Putc(nc, s->text);
-  return nc;
+  Putc(nc,s->text);
+  return (char)nc;
 }
 
 /* -----------------------------------------------------------------------------
@@ -397,7 +397,7 @@ static void get_escape(Scanner *s) {
 
   while (1) {
     c = nextchar(s);
-    if (c == EOF)
+    if (c == 0)
       break;
     switch (state) {
     case 0:
@@ -530,7 +530,7 @@ static int look(Scanner *s) {
   while (1) {
     switch (state) {
     case 0:
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return (0);
 
       /* Process delimiters */
@@ -547,7 +547,7 @@ static int look(Scanner *s) {
       break;
 
     case 1000:
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
         return (0);
       if (c == '%')
 	state = 4;		/* Possibly a SWIG directive */
@@ -652,7 +652,7 @@ static int look(Scanner *s) {
       break;
 
     case 1:			/*  Comment block */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return (0);
       if (c == '/') {
 	state = 10;		/* C++ style comment */
@@ -674,7 +674,7 @@ static int look(Scanner *s) {
       }
       break;
     case 10:			/* C++ style comment */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -686,7 +686,7 @@ static int look(Scanner *s) {
       }
       break;
     case 11:			/* C style comment block */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -697,7 +697,7 @@ static int look(Scanner *s) {
       }
       break;
     case 12:			/* Still in C style comment */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -716,7 +716,7 @@ static int look(Scanner *s) {
 	break;
       }
       
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -730,7 +730,7 @@ static int look(Scanner *s) {
       break;
 
     case 20:			/* Inside the string */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -747,7 +747,7 @@ static int look(Scanner *s) {
 	if (c==')') {
 	  int i=0;
 	  String *end_delimiter = NewStringEmpty();
-	  while ((c = nextchar(s)) != EOF && c != '\"') {
+	  while ((c = nextchar(s)) != 0 && c!='\"') {
 	    Putc( (char)c, end_delimiter );
 	    i++;
 	  }
@@ -761,7 +761,7 @@ static int look(Scanner *s) {
 	    str_delimiter = 0;
 	    return SWIG_TOKEN_STRING;
 	  } else {                   /* Incorrect end delimiter occurred */
-	    if (c == EOF) {
+	    if (c == 0) {
 	      Swig_error(cparse_file, cparse_start_line, "Unterminated raw string, started with R\"%s( is not terminated by )%s\"\n", str_delimiter, str_delimiter);
 	      return SWIG_TOKEN_ERROR;
 	    }
@@ -774,7 +774,7 @@ static int look(Scanner *s) {
       break;
 
     case 3:			/* Maybe a not equals */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_LNOT;
       else if (c == '=')
 	return SWIG_TOKEN_NOTEQUAL;
@@ -785,7 +785,7 @@ static int look(Scanner *s) {
       break;
 
     case 31:			/* AND or Logical AND or ANDEQUAL */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_AND;
       else if (c == '&')
 	return SWIG_TOKEN_LAND;
@@ -798,7 +798,7 @@ static int look(Scanner *s) {
       break;
 
     case 32:			/* OR or Logical OR */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_OR;
       else if (c == '|')
 	return SWIG_TOKEN_LOR;
@@ -811,7 +811,7 @@ static int look(Scanner *s) {
       break;
 
     case 33:			/* EQUAL or EQUALTO */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_EQUAL;
       else if (c == '=')
 	return SWIG_TOKEN_EQUALTO;
@@ -822,7 +822,7 @@ static int look(Scanner *s) {
       break;
 
     case 4:			/* A wrapper generator directive (maybe) */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_PERCENT;
       if (c == '{') {
 	state = 40;		/* Include block */
@@ -845,7 +845,7 @@ static int look(Scanner *s) {
       break;
 
     case 40:			/* Process an include block */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated block\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -853,7 +853,7 @@ static int look(Scanner *s) {
 	state = 41;
       break;
     case 41:			/* Still processing include block */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	set_error(s,s->start_line,"Unterminated code block");
 	return 0;
       }
@@ -869,7 +869,7 @@ static int look(Scanner *s) {
 
     case 5:			/* Maybe a double colon */
 
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_COLON;
       if (c == ':')
 	state = 50;
@@ -880,7 +880,7 @@ static int look(Scanner *s) {
       break;
 
     case 50:			/* DCOLON, DCOLONSTAR */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_DCOLON;
       else if (c == '*')
 	return SWIG_TOKEN_DCOLONSTAR;
@@ -891,14 +891,14 @@ static int look(Scanner *s) {
       break;
 
     case 60:			/* shift operators */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	brackets_increment(s);
 	return SWIG_TOKEN_LESSTHAN;
       }
       if (c == '<')
 	state = 240;
       else if (c == '=') {
-	if ((c = nextchar(s)) == EOF) {
+	if ((c = nextchar(s)) == 0) {
 	  return SWIG_TOKEN_LTEQUAL;
 	} else if (c == '>' && cparse_cplusplus) { /* Spaceship operator */
 	  return SWIG_TOKEN_LTEQUALGT;
@@ -913,7 +913,7 @@ static int look(Scanner *s) {
       }
       break;
     case 61:
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
         brackets_decrement(s);
 	return SWIG_TOKEN_GREATERTHAN;
       }
@@ -942,7 +942,7 @@ static int look(Scanner *s) {
 	break;
       }
       
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	state = 76;
       }
       else if (c == '\"') { /* Definitely u, U or L string */
@@ -966,7 +966,7 @@ static int look(Scanner *s) {
       break;
 
     case 70:			/* Identifier */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	state = 76;
       else if (isalnum(c) || (c == '_') || (c == '$')) {
 	state = 70;
@@ -977,7 +977,7 @@ static int look(Scanner *s) {
       break;
     
     case 71:			/* Possibly u8 string/char */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	state = 76;
       }
       else if (c=='\"') {
@@ -1001,7 +1001,7 @@ static int look(Scanner *s) {
     case 72:			/* Possibly CUSTOM DELIMITER string */
     case 73:
     case 74:
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	state = 76;
       }
       else if (c=='\"') {
@@ -1025,7 +1025,7 @@ static int look(Scanner *s) {
       break;
 
     case 75:			/* Special identifier $ */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_DOLLAR;
       if (isalnum(c) || (c == '_') || (c == '*') || (c == '&')) {
 	state = 70;
@@ -1069,7 +1069,7 @@ static int look(Scanner *s) {
       return SWIG_TOKEN_ID;
 
     case 77: /*identifier or wide string literal*/
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_ID;
       else if (c == '\"') {
 	s->start_line = s->line;
@@ -1090,7 +1090,7 @@ static int look(Scanner *s) {
     break;
 
     case 78:			/* Processing a wide string literal*/
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1104,7 +1104,7 @@ static int look(Scanner *s) {
       break;
 
     case 79:			/* Processing a wide char literal */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated wide character constant\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1118,7 +1118,7 @@ static int look(Scanner *s) {
       break;
 
     case 8:			/* A numerical digit */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_INT;
       if (c == '.') {
 	state = 81;
@@ -1138,7 +1138,7 @@ static int look(Scanner *s) {
       }
       break;
     case 81:			/* A floating pointer number of some sort */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
 	state = 81;
@@ -1155,7 +1155,7 @@ static int look(Scanner *s) {
       }
       break;
     case 82:
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1169,7 +1169,7 @@ static int look(Scanner *s) {
       break;
     case 820:
       /* Like case 82, but we've seen a decimal point. */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1183,7 +1183,7 @@ static int look(Scanner *s) {
       break;
     case 83:
       /* Might be a hexadecimal, octal or binary number */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_INT;
       if (isdigit(c))
 	state = 84;
@@ -1209,7 +1209,7 @@ static int look(Scanner *s) {
       if (c == '8' || c == '9') {
 	Swig_error(Scanner_file(s), Scanner_line(s), "Invalid digit '%c' in octal constant\n", c);
       }
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_INT;
       if (isdigit(c))
 	state = 84;
@@ -1228,7 +1228,7 @@ static int look(Scanner *s) {
       break;
     case 85:
       /* This is an hex number */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_INT;
       if (isxdigit(c))
 	state = 85;
@@ -1247,7 +1247,7 @@ static int look(Scanner *s) {
       break;
     case 850:
       /* This is a binary number */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_INT;
       if ((c == '0') || (c == '1'))
 	state = 850;
@@ -1264,7 +1264,7 @@ static int look(Scanner *s) {
       break;
     case 860:
       /* hexadecimal float */
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Hexadecimal floating literals require an exponent\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1281,7 +1281,7 @@ static int look(Scanner *s) {
     case 86:
       /* Rest of floating point number */
 
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
 	state = 86;
@@ -1298,7 +1298,7 @@ static int look(Scanner *s) {
 
     case 87:
       /* A long integer of some sort */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_LONG;
       if ((c == 'u') || (c == 'U')) {
 	return SWIG_TOKEN_ULONG;
@@ -1313,7 +1313,7 @@ static int look(Scanner *s) {
       /* A long long integer */
 
     case 870:
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_LONGLONG;
       if ((c == 'u') || (c == 'U')) {
 	return SWIG_TOKEN_ULONGLONG;
@@ -1325,7 +1325,7 @@ static int look(Scanner *s) {
       /* An unsigned number */
     case 88:
 
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_UINT;
       if ((c == 'l') || (c == 'L')) {
 	state = 880;
@@ -1337,7 +1337,7 @@ static int look(Scanner *s) {
 
       /* Possibly an unsigned long long or unsigned long */
     case 880:
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_ULONG;
       if ((c == 'l') || (c == 'L'))
 	return SWIG_TOKEN_ULONGLONG;
@@ -1348,7 +1348,7 @@ static int look(Scanner *s) {
 
       /* A character constant */
     case 9:
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1364,7 +1364,7 @@ static int look(Scanner *s) {
       /* A period or an ellipsis or maybe a floating point number */
 
     case 100:
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return (0);
       if (isdigit(c))
 	state = 81;
@@ -1379,7 +1379,7 @@ static int look(Scanner *s) {
       /* An ellipsis */
 
     case 101:
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return (0);
       if (c == '.') {
 	return SWIG_TOKEN_ELLIPSIS;
@@ -1392,7 +1392,7 @@ static int look(Scanner *s) {
     /* A left bracket or a double left bracket */
     case 102:
 
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
         return SWIG_TOKEN_LBRACKET;
       } else if (c == '[') {
         return SWIG_TOKEN_LLBRACKET;
@@ -1404,7 +1404,7 @@ static int look(Scanner *s) {
 
     /* a right bracket or a double right bracket */
     case 103:
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
         return SWIG_TOKEN_RBRACKET;
       } else if (c == ']') {
         return SWIG_TOKEN_RRBRACKET;
@@ -1415,7 +1415,7 @@ static int look(Scanner *s) {
       break;
 
     case 200:			/* PLUS, PLUSPLUS, PLUSEQUAL */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_PLUS;
       else if (c == '+')
 	return SWIG_TOKEN_PLUSPLUS;
@@ -1428,7 +1428,7 @@ static int look(Scanner *s) {
       break;
 
     case 210:			/* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_MINUS;
       else if (c == '-')
 	return SWIG_TOKEN_MINUSMINUS;
@@ -1443,7 +1443,7 @@ static int look(Scanner *s) {
       break;
 
     case 211:			/* ARROW, ARROWSTAR */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_ARROW;
       else if (c == '*')
 	return SWIG_TOKEN_ARROWSTAR;
@@ -1455,7 +1455,7 @@ static int look(Scanner *s) {
 
 
     case 220:			/* STAR, TIMESEQUAL */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_STAR;
       else if (c == '=')
 	return SWIG_TOKEN_TIMESEQUAL;
@@ -1466,7 +1466,7 @@ static int look(Scanner *s) {
       break;
 
     case 230:			/* XOR, XOREQUAL */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_XOR;
       else if (c == '=')
 	return SWIG_TOKEN_XOREQUAL;
@@ -1477,7 +1477,7 @@ static int look(Scanner *s) {
       break;
 
     case 240:			/* LSHIFT, LSEQUAL */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_LSHIFT;
       else if (c == '=')
 	return SWIG_TOKEN_LSEQUAL;
@@ -1488,7 +1488,7 @@ static int look(Scanner *s) {
       break;
 
     case 250:			/* RSHIFT, RSEQUAL */
-      if ((c = nextchar(s)) == EOF)
+      if ((c = nextchar(s)) == 0)
 	return SWIG_TOKEN_RSHIFT;
       else if (c == '=')
 	return SWIG_TOKEN_RSEQUAL;
@@ -1500,7 +1500,7 @@ static int look(Scanner *s) {
 
       /* Reverse string */
     case 900:
-      if ((c = nextchar(s)) == EOF) {
+      if ((c = nextchar(s)) == 0) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1564,7 +1564,7 @@ void Scanner_skip_line(Scanner *s) {
   Setfile(s->text, Getfile(s->str));
   Setline(s->text, s->line);
   while (!done) {
-    if ((c = nextchar(s)) == EOF)
+    if ((c = nextchar(s)) == 0)
       return;
     if (c == '\\') {
       nextchar(s);

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -209,26 +209,26 @@ void Scanner_idstart(Scanner *s, const char *id) {
 /* -----------------------------------------------------------------------------
  * nextchar()
  * 
- * Returns the next character from the scanner or 0 if end of the string.
+ * Returns the next character from the scanner or EOF if end of the string.
  * ----------------------------------------------------------------------------- */
-static char nextchar(Scanner *s) {
+static int nextchar(Scanner *s) {
   int nc;
   if (!s->str)
-    return 0;
+    return EOF;
   while ((nc = Getc(s->str)) == EOF) {
     Delete(s->str);
     s->str = 0;
     Delitem(s->scanobjs, 0);
     if (Len(s->scanobjs) == 0)
-      return 0;
+      return EOF;
     s->str = Getitem(s->scanobjs, 0);
     s->line = Getline(s->str);
     DohIncref(s->str);
   }
   if ((nc == '\n') && (!s->freeze_line)) 
     s->line++;
-  Putc(nc,s->text);
-  return (char)nc;
+  Putc(nc, s->text);
+  return nc;
 }
 
 /* -----------------------------------------------------------------------------
@@ -397,7 +397,7 @@ static void get_escape(Scanner *s) {
 
   while (1) {
     c = nextchar(s);
-    if (c == 0)
+    if (c == EOF)
       break;
     switch (state) {
     case 0:
@@ -519,7 +519,7 @@ static int look(Scanner *s) {
   while (1) {
     switch (state) {
     case 0:
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return (0);
 
       /* Process delimiters */
@@ -536,7 +536,7 @@ static int look(Scanner *s) {
       break;
 
     case 1000:
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
         return (0);
       if (c == '%')
 	state = 4;		/* Possibly a SWIG directive */
@@ -641,7 +641,7 @@ static int look(Scanner *s) {
       break;
 
     case 1:			/*  Comment block */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return (0);
       if (c == '/') {
 	state = 10;		/* C++ style comment */
@@ -663,7 +663,7 @@ static int look(Scanner *s) {
       }
       break;
     case 10:			/* C++ style comment */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -675,7 +675,7 @@ static int look(Scanner *s) {
       }
       break;
     case 11:			/* C style comment block */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -686,7 +686,7 @@ static int look(Scanner *s) {
       }
       break;
     case 12:			/* Still in C style comment */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -705,7 +705,7 @@ static int look(Scanner *s) {
 	break;
       }
       
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -719,7 +719,7 @@ static int look(Scanner *s) {
       break;
 
     case 20:			/* Inside the string */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -736,7 +736,7 @@ static int look(Scanner *s) {
 	if (c==')') {
 	  int i=0;
 	  String *end_delimiter = NewStringEmpty();
-	  while ((c = nextchar(s)) != 0 && c!='\"') {
+	  while ((c = nextchar(s)) != EOF && c != '\"') {
 	    Putc( (char)c, end_delimiter );
 	    i++;
 	  }
@@ -750,7 +750,7 @@ static int look(Scanner *s) {
 	    str_delimiter = 0;
 	    return SWIG_TOKEN_STRING;
 	  } else {                   /* Incorrect end delimiter occurred */
-	    if (c == 0) {
+	    if (c == EOF) {
 	      Swig_error(cparse_file, cparse_start_line, "Unterminated raw string, started with R\"%s( is not terminated by )%s\"\n", str_delimiter, str_delimiter);
 	      return SWIG_TOKEN_ERROR;
 	    }
@@ -763,7 +763,7 @@ static int look(Scanner *s) {
       break;
 
     case 3:			/* Maybe a not equals */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_LNOT;
       else if (c == '=')
 	return SWIG_TOKEN_NOTEQUAL;
@@ -774,7 +774,7 @@ static int look(Scanner *s) {
       break;
 
     case 31:			/* AND or Logical AND or ANDEQUAL */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_AND;
       else if (c == '&')
 	return SWIG_TOKEN_LAND;
@@ -787,7 +787,7 @@ static int look(Scanner *s) {
       break;
 
     case 32:			/* OR or Logical OR */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_OR;
       else if (c == '|')
 	return SWIG_TOKEN_LOR;
@@ -800,7 +800,7 @@ static int look(Scanner *s) {
       break;
 
     case 33:			/* EQUAL or EQUALTO */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_EQUAL;
       else if (c == '=')
 	return SWIG_TOKEN_EQUALTO;
@@ -811,7 +811,7 @@ static int look(Scanner *s) {
       break;
 
     case 4:			/* A wrapper generator directive (maybe) */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_PERCENT;
       if (c == '{') {
 	state = 40;		/* Include block */
@@ -834,7 +834,7 @@ static int look(Scanner *s) {
       break;
 
     case 40:			/* Process an include block */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated block\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -842,7 +842,7 @@ static int look(Scanner *s) {
 	state = 41;
       break;
     case 41:			/* Still processing include block */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	set_error(s,s->start_line,"Unterminated code block");
 	return 0;
       }
@@ -858,7 +858,7 @@ static int look(Scanner *s) {
 
     case 5:			/* Maybe a double colon */
 
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_COLON;
       if (c == ':')
 	state = 50;
@@ -869,7 +869,7 @@ static int look(Scanner *s) {
       break;
 
     case 50:			/* DCOLON, DCOLONSTAR */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_DCOLON;
       else if (c == '*')
 	return SWIG_TOKEN_DCOLONSTAR;
@@ -880,14 +880,14 @@ static int look(Scanner *s) {
       break;
 
     case 60:			/* shift operators */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	brackets_increment(s);
 	return SWIG_TOKEN_LESSTHAN;
       }
       if (c == '<')
 	state = 240;
       else if (c == '=') {
-	if ((c = nextchar(s)) == 0) {
+	if ((c = nextchar(s)) == EOF) {
 	  return SWIG_TOKEN_LTEQUAL;
 	} else if (c == '>' && cparse_cplusplus) { /* Spaceship operator */
 	  return SWIG_TOKEN_LTEQUALGT;
@@ -902,7 +902,7 @@ static int look(Scanner *s) {
       }
       break;
     case 61:
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
         brackets_decrement(s);
 	return SWIG_TOKEN_GREATERTHAN;
       }
@@ -931,7 +931,7 @@ static int look(Scanner *s) {
 	break;
       }
       
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	state = 76;
       }
       else if (c == '\"') { /* Definitely u, U or L string */
@@ -955,7 +955,7 @@ static int look(Scanner *s) {
       break;
 
     case 70:			/* Identifier */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	state = 76;
       else if (isalnum(c) || (c == '_') || (c == '$')) {
 	state = 70;
@@ -966,7 +966,7 @@ static int look(Scanner *s) {
       break;
     
     case 71:			/* Possibly u8 string/char */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	state = 76;
       }
       else if (c=='\"') {
@@ -990,7 +990,7 @@ static int look(Scanner *s) {
     case 72:			/* Possibly CUSTOM DELIMITER string */
     case 73:
     case 74:
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	state = 76;
       }
       else if (c=='\"') {
@@ -1014,7 +1014,7 @@ static int look(Scanner *s) {
       break;
 
     case 75:			/* Special identifier $ */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_DOLLAR;
       if (isalnum(c) || (c == '_') || (c == '*') || (c == '&')) {
 	state = 70;
@@ -1058,7 +1058,7 @@ static int look(Scanner *s) {
       return SWIG_TOKEN_ID;
 
     case 77: /*identifier or wide string literal*/
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_ID;
       else if (c == '\"') {
 	s->start_line = s->line;
@@ -1079,7 +1079,7 @@ static int look(Scanner *s) {
     break;
 
     case 78:			/* Processing a wide string literal*/
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1087,15 +1087,13 @@ static int look(Scanner *s) {
 	Delitem(s->text, DOH_END);
 	return SWIG_TOKEN_WSTRING;
       } else if (c == '\\') {
-	if ((c = nextchar(s)) == 0) {
-	  Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
-	  return SWIG_TOKEN_ERROR;
-	}
+	Delitem(s->text, DOH_END);
+	get_escape(s);
       }
       break;
 
     case 79:			/* Processing a wide char literal */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated wide character constant\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1103,15 +1101,13 @@ static int look(Scanner *s) {
 	Delitem(s->text, DOH_END);
 	return (SWIG_TOKEN_WCHAR);
       } else if (c == '\\') {
-	if ((c = nextchar(s)) == 0) {
-	  Swig_error(cparse_file, cparse_start_line, "Unterminated wide character literal\n");
-	  return SWIG_TOKEN_ERROR;
-	}
+	Delitem(s->text, DOH_END);
+	get_escape(s);
       }
       break;
 
     case 8:			/* A numerical digit */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_INT;
       if (c == '.') {
 	state = 81;
@@ -1131,7 +1127,7 @@ static int look(Scanner *s) {
       }
       break;
     case 81:			/* A floating pointer number of some sort */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
 	state = 81;
@@ -1148,7 +1144,7 @@ static int look(Scanner *s) {
       }
       break;
     case 82:
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1162,7 +1158,7 @@ static int look(Scanner *s) {
       break;
     case 820:
       /* Like case 82, but we've seen a decimal point. */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1176,7 +1172,7 @@ static int look(Scanner *s) {
       break;
     case 83:
       /* Might be a hexadecimal or octal number */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_INT;
       if (isdigit(c))
 	state = 84;
@@ -1199,7 +1195,7 @@ static int look(Scanner *s) {
       break;
     case 84:
       /* This is an octal number */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_INT;
       if (isdigit(c))
 	state = 84;
@@ -1218,7 +1214,7 @@ static int look(Scanner *s) {
       break;
     case 85:
       /* This is an hex number */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_INT;
       if (isxdigit(c))
 	state = 85;
@@ -1237,7 +1233,7 @@ static int look(Scanner *s) {
       break;
     case 850:
       /* This is a binary number */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_INT;
       if ((c == '0') || (c == '1'))
 	state = 850;
@@ -1252,7 +1248,7 @@ static int look(Scanner *s) {
       break;
     case 860:
       /* hexadecimal float */
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Hexadecimal floating literals require an exponent\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1269,7 +1265,7 @@ static int look(Scanner *s) {
     case 86:
       /* Rest of floating point number */
 
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
 	state = 86;
@@ -1286,7 +1282,7 @@ static int look(Scanner *s) {
 
     case 87:
       /* A long integer of some sort */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_LONG;
       if ((c == 'u') || (c == 'U')) {
 	return SWIG_TOKEN_ULONG;
@@ -1301,7 +1297,7 @@ static int look(Scanner *s) {
       /* A long long integer */
 
     case 870:
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_LONGLONG;
       if ((c == 'u') || (c == 'U')) {
 	return SWIG_TOKEN_ULONGLONG;
@@ -1313,7 +1309,7 @@ static int look(Scanner *s) {
       /* An unsigned number */
     case 88:
 
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_UINT;
       if ((c == 'l') || (c == 'L')) {
 	state = 880;
@@ -1325,7 +1321,7 @@ static int look(Scanner *s) {
 
       /* Possibly an unsigned long long or unsigned long */
     case 880:
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_ULONG;
       if ((c == 'l') || (c == 'L'))
 	return SWIG_TOKEN_ULONGLONG;
@@ -1336,7 +1332,7 @@ static int look(Scanner *s) {
 
       /* A character constant */
     case 9:
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1352,7 +1348,7 @@ static int look(Scanner *s) {
       /* A period or an ellipsis or maybe a floating point number */
 
     case 100:
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return (0);
       if (isdigit(c))
 	state = 81;
@@ -1367,7 +1363,7 @@ static int look(Scanner *s) {
       /* An ellipsis */
 
     case 101:
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return (0);
       if (c == '.') {
 	return SWIG_TOKEN_ELLIPSIS;
@@ -1380,7 +1376,7 @@ static int look(Scanner *s) {
     /* A left bracket or a double left bracket */
     case 102:
 
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
         return SWIG_TOKEN_LBRACKET;
       } else if (c == '[') {
         return SWIG_TOKEN_LLBRACKET;
@@ -1392,7 +1388,7 @@ static int look(Scanner *s) {
 
     /* a right bracket or a double right bracket */
     case 103:
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
         return SWIG_TOKEN_RBRACKET;
       } else if (c == ']') {
         return SWIG_TOKEN_RRBRACKET;
@@ -1403,7 +1399,7 @@ static int look(Scanner *s) {
       break;
 
     case 200:			/* PLUS, PLUSPLUS, PLUSEQUAL */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_PLUS;
       else if (c == '+')
 	return SWIG_TOKEN_PLUSPLUS;
@@ -1416,7 +1412,7 @@ static int look(Scanner *s) {
       break;
 
     case 210:			/* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_MINUS;
       else if (c == '-')
 	return SWIG_TOKEN_MINUSMINUS;
@@ -1431,7 +1427,7 @@ static int look(Scanner *s) {
       break;
 
     case 211:			/* ARROW, ARROWSTAR */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_ARROW;
       else if (c == '*')
 	return SWIG_TOKEN_ARROWSTAR;
@@ -1443,7 +1439,7 @@ static int look(Scanner *s) {
 
 
     case 220:			/* STAR, TIMESEQUAL */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_STAR;
       else if (c == '=')
 	return SWIG_TOKEN_TIMESEQUAL;
@@ -1454,7 +1450,7 @@ static int look(Scanner *s) {
       break;
 
     case 230:			/* XOR, XOREQUAL */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_XOR;
       else if (c == '=')
 	return SWIG_TOKEN_XOREQUAL;
@@ -1465,7 +1461,7 @@ static int look(Scanner *s) {
       break;
 
     case 240:			/* LSHIFT, LSEQUAL */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_LSHIFT;
       else if (c == '=')
 	return SWIG_TOKEN_LSEQUAL;
@@ -1476,7 +1472,7 @@ static int look(Scanner *s) {
       break;
 
     case 250:			/* RSHIFT, RSEQUAL */
-      if ((c = nextchar(s)) == 0)
+      if ((c = nextchar(s)) == EOF)
 	return SWIG_TOKEN_RSHIFT;
       else if (c == '=')
 	return SWIG_TOKEN_RSEQUAL;
@@ -1488,7 +1484,7 @@ static int look(Scanner *s) {
 
       /* Reverse string */
     case 900:
-      if ((c = nextchar(s)) == 0) {
+      if ((c = nextchar(s)) == EOF) {
 	Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
 	return SWIG_TOKEN_ERROR;
       }
@@ -1552,7 +1548,7 @@ void Scanner_skip_line(Scanner *s) {
   Setfile(s->text, Getfile(s->str));
   Setline(s->text, s->line);
   while (!done) {
-    if ((c = nextchar(s)) == 0)
+    if ((c = nextchar(s)) == EOF)
       return;
     if (c == '\\') {
       nextchar(s);


### PR DESCRIPTION
Fixes #904
Fixes #1907
Fixes #2579

(Yes I know there's still a placeholder date in CHANGES.current...)

@wsfulton I'd welcome your input on this.

The basic idea is that `.val` in the parser and the `value` attribute are always the C/C++ source code for an expression, so if the target language just wants to emit that in the generated C/C++ wrapper then it can just write it out without needing to do anything special for `T_STRING`, `T_CHAR`, etc.

Then `.stringval` in the parser and the `stringval` attribute are always the actual value of the string or character in a DOH `String`.  If a backend wants to emit the string or character as a string or character in the target language it can take this and apply appropriate escaping and quoting.

I've split `%(hexescape)s` into `%(csharpescape)s` for C# and `%(goescape)s` for Go as both need hex escaping but with different rules.  Maybe the language-specific escaping should actually move to the relevant language module instead - we'd probably have to use something like

```
Printv(f, "\"", csharp_escape(stringval), "\"", NIL);
```

instead of

```
Printf(f, "\"%(csharpescape)s\"", stringval);
```

but that doesn't actually seem worse.