### PR TITLE
[Go] Use sync.RWMutex for director feature

### DIFF
--- a/Lib/go/goruntime.swg
+++ b/Lib/go/goruntime.swg
@@ -174,7 +174,7 @@ type _ sync.Mutex
 %insert(go_director) %{
 
 var swigDirectorTrack struct {
-	sync.Mutex
+	sync.RWMutex
 	m map[int]interface{}
 	c int
 }
@@ -192,8 +192,8 @@ func swigDirectorAdd(v interface{}) int {
 }
 
 func swigDirectorLookup(c int) interface{} {
-	swigDirectorTrack.Lock()
-	defer swigDirectorTrack.Unlock()
+	swigDirectorTrack.RLock()
+	defer swigDirectorTrack.RUnlock()
 	ret := swigDirectorTrack.m[c]
 	if ret == nil {
 		panic("C++ director pointer not found (possible	use-after-free)")


### PR DESCRIPTION
Hi!. I've been using swig for golang for sometimes and there's something about the Swig director features that I think we can improve.

```go
// file: /Lib/go/goruntime.swg

var swigDirectorTrack struct {
	sync.Mutex
	m map[int]interface{}
	c int
}

func swigDirectorLookup(c int) interface{} {
	swigDirectorTrack.Lock()
	defer swigDirectorTrack.Unlock()
	ret := swigDirectorTrack.m[c]
	if ret == nil {
		panic("C++ director pointer not found (possible	use-after-free)")
	}
	return ret
}
```

I notice that the swigDirectorTrack variable is using `sync.Mutex` rather than `sync.RWMutex`. I think it would be beneficial in term of performance if we can implement the swigDirectorTrack using sync.RWMutex since it will allow concurrent read. So, this PR aims to change sync.Mutex to sync.RWMutex in the swig's director feature.
