### PR TITLE
Python - fix compilation error with the latest MSVC (version 14.41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,7 @@ Examples/r/*/.RData
 Examples/test-suite/scilab/*/
 loader.sce
 
+vcpkg.json
+CMakePresets.json
+.cache
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -225,7 +225,3 @@ Examples/r/*/.RData
 Examples/test-suite/scilab/*/
 loader.sce
 
-vcpkg.json
-CMakePresets.json
-.cache
-.vscode

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -504,7 +504,7 @@ namespace swig {
     if (!SWIG_IsOK(res) || !iter) {
       %argument_fail(SWIG_TypeError, "$type", $symname, $argnum);
     } else {
-      swig::SwigPyIterator_T<$type > *iter_t = dynamic_cast<swig::SwigPyIterator_T<$type > *>(iter);
+      swig::SwigPyIterator_T< typename $type > *iter_t = dynamic_cast<swig::SwigPyIterator_T< typename $type > *>(iter);
       if (iter_t) {
 	$1 = iter_t->get_current();
       } else {
@@ -572,7 +572,7 @@ namespace swig {
     // Although __getitem__, front, back actually use a const value_type& return type, the typemaps below
     // use non-const so that they can be easily overridden by users if necessary.
     %typemap(ret, fragment="reference_container_owner", noblock=1) value_type& __getitem__, value_type& front, value_type& back {
-      (void)swig::container_owner<swig::traits<$*1_ltype>::category>::back_reference($result, $self);
+      (void)swig::container_owner< typename swig::traits< typename $*1_ltype>::category>::back_reference($result, $self);
     }
   }
 %enddef

--- a/Lib/python/pycontainer.swg
+++ b/Lib/python/pycontainer.swg
@@ -473,15 +473,15 @@ namespace swig {
 
   %typemap(out,noblock=1,fragment="SwigPyIterator_T")
     iterator, reverse_iterator, const_iterator, const_reverse_iterator {
-    $result = SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const $type &)),
+    $result = SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const typename $type &)),
 				 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN);
   }
   %typemap(out,noblock=1,fragment="SwigPyIterator_T")
     std::pair<iterator, iterator>, std::pair<const_iterator, const_iterator> {
     $result = PyTuple_New(2);
-    PyTuple_SetItem($result,0,SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const $type &).first),
+    PyTuple_SetItem($result,0,SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const typename $type &).first),
 						 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));
-    PyTuple_SetItem($result,1,SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const $type &).second),
+    PyTuple_SetItem($result,1,SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const typename $type &).second),
 						 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));    
   }
 
@@ -490,9 +490,9 @@ namespace swig {
   %typemap(out,noblock=1,fragment="SwigPyPairBoolOutputIterator")
     std::pair<iterator, bool>, std::pair<const_iterator, bool> {
     $result = PyTuple_New(2);
-    PyTuple_SetItem($result,0,SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const $type &).first),
+    PyTuple_SetItem($result,0,SWIG_NewPointerObj(Make_output_iterator(%static_cast($1,const typename $type &).first),
 					       swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));    
-    PyTuple_SetItem($result,1,SWIG_From(bool)(%static_cast($1,const $type &).second));
+    PyTuple_SetItem($result,1,SWIG_From(bool)(%static_cast($1,const typename $type &).second));
   }
 
   %typemap(in,noblock=1,fragment="SwigPyIterator_T")
@@ -517,7 +517,7 @@ namespace swig {
     iterator, reverse_iterator, const_iterator, const_reverse_iterator {
     swig::SwigPyIterator *iter = 0;
     int res = SWIG_ConvertPtr($input, %as_voidptrptr(&iter), swig::SwigPyIterator::descriptor(), 0);
-    $1 = (SWIG_IsOK(res) && iter && (dynamic_cast<swig::SwigPyIterator_T<$type > *>(iter) != 0));
+    $1 = (SWIG_IsOK(res) && iter && (dynamic_cast<swig::SwigPyIterator_T< typename $type > *>(iter) != 0));
   }
 
   %fragment("SwigPyIterator_T");

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -162,7 +162,7 @@ extern "C" {
   extern int SwigType_ismutable(const SwigType *t);
   extern int SwigType_isvarargs(const SwigType *t);
   extern int SwigType_istemplate(const SwigType *t);
-  extern int SwigType_template_parameter_isiterator(const SwigType *t);
+  extern int SwigType_isiterator(const SwigType *t);
   extern int SwigType_isenum(const SwigType *t);
   extern int SwigType_check_decl(const SwigType *t, const_String_or_char_ptr decl);
   extern SwigType *SwigType_strip_qualifiers(const SwigType *t);

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -162,7 +162,7 @@ extern "C" {
   extern int SwigType_ismutable(const SwigType *t);
   extern int SwigType_isvarargs(const SwigType *t);
   extern int SwigType_istemplate(const SwigType *t);
-  extern int SwigType_is_iterator(const SwigType *t);
+  extern int SwigType_template_parameter_isiterator(const SwigType *t);
   extern int SwigType_isenum(const SwigType *t);
   extern int SwigType_check_decl(const SwigType *t, const_String_or_char_ptr decl);
   extern SwigType *SwigType_strip_qualifiers(const SwigType *t);

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -162,6 +162,7 @@ extern "C" {
   extern int SwigType_ismutable(const SwigType *t);
   extern int SwigType_isvarargs(const SwigType *t);
   extern int SwigType_istemplate(const SwigType *t);
+  extern int SwigType_is_iterator(const SwigType *t);
   extern int SwigType_isenum(const SwigType *t);
   extern int SwigType_check_decl(const SwigType *t, const_String_or_char_ptr decl);
   extern SwigType *SwigType_strip_qualifiers(const SwigType *t);

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -1201,6 +1201,14 @@ int SwigType_istemplate(const SwigType *t) {
   return 0;
 }
 
+
+int SwigType_is_iterator(const SwigType *t){
+  char *ct = Char(t);
+  if (strstr(ct, "iterator") != NULL) 
+    return 1;
+  return 0;
+}
+
 /* -----------------------------------------------------------------------------
  * SwigType_base()
  *

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -1202,16 +1202,13 @@ int SwigType_istemplate(const SwigType *t) {
 }
 
 /* -----------------------------------------------------------------------------
- * SwigType_template_parameter_isiterator()
+ * SwigType_isiterator()
  *
  * Tests whether a type is a template whose parameter is an iterator.
- * For example: SwigValueWrapper< std::vector< enum EnumVector::numbers >::reverse_iterator >
+ * For example: std::vector< enum EnumVector::numbers >::reverse_iterator
  * ----------------------------------------------------------------------------- */
 
-int SwigType_template_parameter_isiterator(const SwigType *t){
-  if (!SwigType_istemplate(t))
-    return 0;
-
+int SwigType_isiterator(const SwigType *t){
   char *ct = Char(t);
 
   if (strstr(ct, "iterator"))

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -1213,9 +1213,8 @@ int SwigType_template_parameter_isiterator(const SwigType *t){
     return 0;
 
   char *ct = Char(t);
-  char* pFound = strstr(ct, "iterator");
 
-  if (pFound && strlen(t) - (pFound - ct) == 9)
+  if (strstr(ct, "iterator"))
     return 1;
 
   return 0;

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -1201,11 +1201,23 @@ int SwigType_istemplate(const SwigType *t) {
   return 0;
 }
 
+/* -----------------------------------------------------------------------------
+ * SwigType_template_parameter_isiterator()
+ *
+ * Tests whether a type is a template whose parameter is an iterator.
+ * For example: SwigValueWrapper< std::vector< enum EnumVector::numbers >::reverse_iterator >
+ * ----------------------------------------------------------------------------- */
 
-int SwigType_is_iterator(const SwigType *t){
+int SwigType_template_parameter_isiterator(const SwigType *t){
+  if (!SwigType_istemplate(t))
+    return 0;
+
   char *ct = Char(t);
-  if (strstr(ct, "iterator") != NULL) 
+  char* pFound = strstr(ct, "iterator");
+
+  if (pFound && strlen(t) - (pFound - ct) == 9)
     return 1;
+
   return 0;
 }
 

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1566,7 +1566,7 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
   }
 
   if (use_wrapper) {
-    w = NewStringf("SwigValueWrapper<(%s)>", td);
+      w = NewStringf("SwigValueWrapper<( typename %s)>", td);
   }
   Delete(td);
   return w;

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1566,7 +1566,10 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
   }
 
   if (use_wrapper) {
-      w = NewStringf("SwigValueWrapper<( typename %s)>", td);
+    if(SwigType_is_iterator(t))
+        w = NewStringf("SwigValueWrapper<( typename %s)>", td);
+    else
+      w = NewStringf("SwigValueWrapper<(%s)>", td);
   }
   Delete(td);
   return w;

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1571,6 +1571,7 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
           SwigValueWrapper< std::vector< enum EnumVector::numbers >::reverse_iterator > result;
           MSVC (version 14.41) requires a typename prefix to compile, like this:
           SwigValueWrapper< typename std::vector< enum EnumVector::numbers >::reverse_iterator > result;
+          See issue https://github.com/swig/swig/issues/3008
       */
       w = NewStringf("SwigValueWrapper<( typename %s)>", td);
     } else {	

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1565,12 +1565,19 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
     }
   }
 
-  if (use_wrapper) {
-    if(SwigType_is_iterator(t))
-        w = NewStringf("SwigValueWrapper<( typename %s)>", td);
-    else
+	if (use_wrapper) {
+    if (SwigType_template_parameter_isiterator(t)) {
+      /*  For the original generated statement:
+          SwigValueWrapper< std::vector< enum EnumVector::numbers >::reverse_iterator > result;
+          MSVC (version 14.41) requires a typename prefix to compile, like this:
+          SwigValueWrapper< typename std::vector< enum EnumVector::numbers >::reverse_iterator > result;
+      */
+      w = NewStringf("SwigValueWrapper<( typename %s)>", td);
+    } else {	
       w = NewStringf("SwigValueWrapper<(%s)>", td);
-  }
+	  }
+	}
+
   Delete(td);
   return w;
 }

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1566,7 +1566,7 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
   }
 
 	if (use_wrapper) {
-    if (SwigType_template_parameter_isiterator(t)) {
+    if (SwigType_isiterator(t)) {
       /*  For the original generated statement:
           SwigValueWrapper< std::vector< enum EnumVector::numbers >::reverse_iterator > result;
           MSVC (version 14.41) requires a typename prefix to compile, like this:


### PR DESCRIPTION

Add the missing typename qualifier to the template parameter for swig::SwigPyIterator_T and swig::container_owner

Closes #3008