### PR TITLE
Fix qualify of "enum class" enumerator names

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,10 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.3.0 (in progress)
 ===========================
 
+2024-09-09: olly
+	    #197 #675 #1677 #2047 Fix incorrect inclusion of "enum " when
+	    qualifying C++11 "enum class" enumerator names.
+
 2024-09-07: wsfulton
             #2875 Fix swig-4.1.0 regression using the %interface family of macros
             for multiple inheritance and common bases.

--- a/Examples/test-suite/cpp11_strongly_typed_enumerations.i
+++ b/Examples/test-suite/cpp11_strongly_typed_enumerations.i
@@ -263,3 +263,37 @@ private:
     Val2 = 1172,
   };
 %}
+
+// Regression tests for cases where SWIG incorrectly included "enum " when
+// qualifying the emunerator name:
+
+// #197
+%include <std_vector.i>
+%inline %{
+template<Enum17 E> class Bar {};
+%}
+%template(Enum17Vector) std::vector<Bar<Enum17::Val1>>;
+
+// #675
+%template(Enum17Bar) Bar<Enum17::Val2>;
+%inline %{
+class SubEnum17Bar : public Bar<Enum17::Val2> {};
+%}
+
+// #1677
+%inline %{
+#include <bitset>
+typedef std::bitset<static_cast<unsigned>(Enum17::Val1)> type1677;
+type1677 classify(int a) { return type1677{}; }
+bool has_type(const type1677&, const Enum17&) { return false; }
+%}
+
+// #2047
+%feature("compactdefaultargs") MyClass::my_func;
+%inline %{
+class MyClass {
+  public:
+    enum class PRINT_SETUP { TO_CONSOLE, TO_CSV };
+    void my_func(const PRINT_SETUP& e = PRINT_SETUP::TO_CONSOLE) { (void)e; }
+};
+%}

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -502,6 +502,9 @@ static Typetab *SwigType_find_scope(Typetab *s, const SwigType *nameprefix) {
     String *qname = Getattr(ss, "qname");
     if (qname) {
       full = NewStringf("%s::%s", qname, nameprefix);
+      if (Strncmp(full, "enum ", 5) == 0) {
+	Delslice(full, 0, 5);
+      }
     } else {
       full = NewString(nameprefix);
     }
@@ -740,9 +743,11 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
 	    type = Copy(namebase);
 	    Insert(type, 0, "::");
 	    Insert(type, 0, rnameprefix);
-	    if (strncmp(Char(type), "::", 2) == 0) {
-	      Delitem(type, 0);
-	      Delitem(type, 0);
+	    if (Strncmp(type, "enum ", 5) == 0) {
+	      Delslice(type, 0, 5);
+	    }
+	    if (Strncmp(type, "::", 2) == 0) {
+	      Delslice(type, 0, 2);
 	    }
 	    newtype = 1;
 	  } else {


### PR DESCRIPTION
Fix incorrect inclusion of "enum " when qualifying C++11 "enum class" enumerator names.

Fixes #197
Fixes #675
Fixes #1677
Fixes #2047