### PR TITLE
Python use MSVC from older GitHub Windows 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,12 +55,14 @@ jobs:
         - SWIGLANG: java
           COMPILER: gcc
           VER: 11
-       # Next two are ignored due to new visual c++ not handling containers of enums
+       # Next two are using old VC++ as the new visual c++ not handling containers of enums
        # See https://github.com/swig/swig/issues/3008
-       #- SWIGLANG: python
-       #  VER: '3.7'
-       #- SWIGLANG: python
-       #  VER: '3.12'
+        - SWIGLANG: python
+          VER: '3.7'
+          os: 'windows-2019'
+        - SWIGLANG: python
+          VER: '3.12'
+          os: 'windows-2019'
        #  TODO require fixing of probing in configure.ac
        #- SWIGLANG: python
        #  INSTALL: 'true'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,15 +21,17 @@ environment:
     VSVER: 16
     VER: 39
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-  - SWIGLANG: python
-    VSVER: 17
-    VER: 310
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-  - SWIGLANG: python
-    VSVER: 17
-    VER: 310
-    Platform: x86
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+ # Next two are ignored due to new visual c++ not handling containers of enums
+ # See https://github.com/swig/swig/issues/3008
+ #- SWIGLANG: python
+ #  VSVER: 17
+ #  VER: 310
+ #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+ #- SWIGLANG: python
+ #  VSVER: 17
+ #  VER: 310
+ #  Platform: x86
+ #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
   - SWIGLANG: python
     OSVARIANT: cygwin
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022


### PR DESCRIPTION
Once VC++ issue is resolved we can revert.