### PR TITLE
Fix JS keyword rename test to actually test for renaming

### DIFF
--- a/Examples/test-suite/javascript/keyword_rename_runme.js
+++ b/Examples/test-suite/javascript/keyword_rename_runme.js
@@ -2,4 +2,11 @@ var keyword_rename = require("keyword_rename")
 keyword_rename._instanceof(1)
 keyword_rename._finally(1)
 keyword_rename._yield(0)
-keyword_rename.yield = 0
+
+var s = keyword_rename.make_S_with_yield(17);
+
+if (s.yield != 17)
+    throw new Error;
+
+if (s._yield == 17)
+    throw new Error;

--- a/Examples/test-suite/keyword_rename.i
+++ b/Examples/test-suite/keyword_rename.i
@@ -47,6 +47,12 @@ struct S {
   int yield;
 };
 
+struct S make_S_with_yield(int yield) {
+  struct S s;
+  s.yield = yield;
+  return s;
+}
+
 %}
 
 


### PR DESCRIPTION
Assigning to a property in JS always works, as it just creates a new property if there is no existing one, and so can't be used for testing for its existence.

Set the property value in C code and try accessing it from JS instead.

Also check that not only the property with the expected name exists, but also that the property with the renamed name does not.

See #2943.