### PR TITLE
Straighten out handling of integer constants

### DIFF
--- a/Examples/test-suite/d/enum_thorough_runme.2.d
+++ b/Examples/test-suite/d/enum_thorough_runme.2.d
@@ -5,6 +5,7 @@ import enum_thorough.enum_thorough;
 import enum_thorough.AnonStruct;
 import enum_thorough.colour;
 import enum_thorough.DifferentTypes;
+import enum_thorough.Enum2995;
 import enum_thorough.FirStruct;
 import enum_thorough.HairStruct;
 import enum_thorough.IgnoreTest;
@@ -444,5 +445,12 @@ void main() {
     enforce(cast(int)globalDifferentTypesTest(global_enum) == 'C', "global differentTypes 5 failed");
     global_enum = global_typedefaultint;
     enforce(cast(int)globalDifferentTypesTest(global_enum) == 'D', "global differentTypes 6 failed");
+  }
+  // Regression tests for bad handling of bool expressions (#2995)
+  {
+    enforce(cast(int)Enum2995.T1 == 1, "Enum2995 T1 failed");
+    enforce(cast(int)Enum2995.T2 == 1, "Enum2995 T2 failed");
+    enforce(cast(int)Enum2995.F1 == 0, "Enum2995 F1 failed");
+    enforce(cast(int)Enum2995.F2 == 0, "Enum2995 F2 failed");
   }
 }

--- a/Examples/test-suite/enum_thorough.i
+++ b/Examples/test-suite/enum_thorough.i
@@ -660,6 +660,16 @@ struct EnumCharStruct {
     enumcharAE3 = '\xC6' // AE (latin1 encoded)
   };
 };
+
+// We can't test this for C# and Java it seems.
+#if !defined(SWIGCSHARP) && !defined(SWIGJAVA)
+enum Enum2995 {
+   T1 = (1 == 1),
+   T2 = !false,
+   F1 = (1 != 1),
+   F2 = !true,
+};
+#endif
 %}
 
 #if defined(SWIGJAVA)

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -19,6 +19,7 @@
 #include "parser.h"
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
 
 /* Scanner object */
 static Scanner *scan = 0;
@@ -654,11 +655,44 @@ int yylex(void) {
     yylval.dtype = default_dtype;
     yylval.dtype.type = T_ULONGLONG;
     goto num_common;
+num_common: {
+    yylval.dtype.val = NewString(Scanner_text(scan));
+    const char *c = Char(yylval.dtype.val);
+    if (c[0] == '0') {
+      // Convert to base 10 using strtoull().
+      unsigned long long value;
+      char *e;
+      errno = 0;
+      if (c[1] == 'b' || c[1] == 'B') {
+	/* strtoull(p, e, 0) doesn't handle binary constants. */
+	value = strtoull(c + 2, &e, 2);
+      } else {
+	value = strtoull(c, &e, 0);
+      }
+      if (errno != ERANGE) {
+	while (*e && strchr("ULul", *e)) ++e;
+      }
+      if (errno != ERANGE && *e == '\0') {
+	yylval.dtype.numval = NewStringf("%llu", value);
+      } else {
+	// Our unsigned long long isn't wide enough or this isn't an integer.
+      }
+    } else {
+      const char *e = c;
+      while (isdigit((unsigned char)*e)) ++e;
+      int len = e - c;
+      while (*e && strchr("ULul", *e)) ++e;
+      if (*e == '\0') {
+        yylval.dtype.numval = NewStringWithSize(c, len);
+      }
+    }
+    return (l);
+  }
   case NUM_BOOL:
     yylval.dtype = default_dtype;
     yylval.dtype.type = T_BOOL;
-num_common:
     yylval.dtype.val = NewString(Scanner_text(scan));
+    yylval.dtype.numval = NewString(Equal(yylval.dtype.val, "false") ? "0" : "1");
     return (l);
 
   case ID:

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -7079,7 +7079,19 @@ exprcompound   : expr[lhs] PLUS expr[rhs] {
 		 $$ = default_dtype;
 		 $$.val = NewStringf("-%s",$in.val);
 		 if ($in.numval) {
-		   $$.numval = NewStringf("-%s", $in.numval);
+		   switch ($in.type) {
+		     case T_CHAR: // Unsigned on some architectures.
+		     case T_UCHAR:
+		     case T_USHORT:
+		     case T_UINT:
+		     case T_ULONG:
+		     case T_ULONGLONG:
+		       // Avoid negative numval with an unsigned type.
+		       break;
+		     default:
+		       $$.numval = NewStringf("-%s", $in.numval);
+		       break;
+		   }
 		   Delete($in.numval);
 		 }
 		 $$.type = promote_type($in.type);

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1340,10 +1340,7 @@ public:
 
     // Deal with enum values that are not int
     int swigtype = SwigType_type(Getattr(n, "type"));
-    if (swigtype == T_BOOL) {
-      const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
-      Setattr(n, "enumvalue", val);
-    } else if (swigtype == T_CHAR) {
+    if (swigtype == T_CHAR) {
       String *enumstringval = Getattr(n, "enumstringval");
       if (enumstringval) {
 	// Escape character literal for C#.
@@ -1351,6 +1348,9 @@ public:
 	Setattr(n, "enumvalue", val);
 	Delete(val);
       }
+    } else {
+      String *numval = Getattr(n, "enumnumval");
+      if (numval) Setattr(n, "enumvalue", numval);
     }
 
     {

--- a/Source/Modules/d.cxx
+++ b/Source/Modules/d.cxx
@@ -946,10 +946,9 @@ public:
     Setattr(n, "value", tmpValue);
 
     // Deal with enum values that are not int
-    int swigtype = SwigType_type(Getattr(n, "type"));
-    if (swigtype == T_BOOL) {
-      const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
-      Setattr(n, "enumvalue", val);
+    {
+      String *numval = Getattr(n, "enumnumval");
+      if (numval) Setattr(n, "enumvalue", numval);
     }
 
     // Emit the enum item.

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -1418,15 +1418,15 @@ public:
 
     // Deal with enum values that are not int
     int swigtype = SwigType_type(Getattr(n, "type"));
-    if (swigtype == T_BOOL) {
-      const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
-      Setattr(n, "enumvalue", val);
-    } else if (swigtype == T_CHAR) {
+    if (swigtype == T_CHAR) {
       if (Getattr(n, "enumstringval")) {
 	String *val = NewStringf("'%(escape)s'", Getattr(n, "enumstringval"));
 	Setattr(n, "enumvalue", val);
 	Delete(val);
       }
+    } else {
+      String *numval = Getattr(n, "enumnumval");
+      if (numval) Setattr(n, "enumvalue", numval);
     }
 
     {

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -488,7 +488,7 @@ public:
       Append(decl_str, tex_name);
 
       if (value) {
-        String *new_value = convertValue(value, Getattr(p, "type"));
+        String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
         if (new_value) {
           value = new_value;
         } else {
@@ -517,23 +517,24 @@ public:
    *    Check if string v can be an Octave value literal,
    *    (eg. number or string), or translate it to an Octave literal.
    * ------------------------------------------------------------ */
-  String *convertValue(String *v, SwigType *t) {
-    if (v && Len(v) > 0) {
-      char fc = (Char(v))[0];
-      if (('0' <= fc && fc <= '9') || '\'' == fc || '"' == fc) {
-        /* number or string (or maybe NULL pointer) */
-        if (SwigType_ispointer(t) && Strcmp(v, "0") == 0)
-          return NewString("None");
-        else
-          return v;
-      }
-      if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
-        return SwigType_ispointer(t) ? NewString("nil") : NewString("0");
-      if (Strcmp(v, "true") == 0 || Strcmp(v, "TRUE") == 0)
-        return NewString("true");
-      if (Strcmp(v, "false") == 0 || Strcmp(v, "FALSE") == 0)
-        return NewString("false");
+  String *convertValue(String *v, String *numval, String *stringval, SwigType *t) {
+    if (stringval) {
+      return stringval;
     }
+    if (numval) {
+      if (SwigType_type(t) == T_BOOL) {
+	return NewString(*Char(numval) == '0' ? "false" : "true");
+      }
+      return numval;
+    }
+    if (Equal(v, "0") || Equal(v, "NULL") || Equal(v, "nullptr"))
+      return SwigType_ispointer(t) ? NewString("None") : NewString("0");
+#if 0 // FIXME: TRUE and FALSE are not standard and could be defined in other ways
+    if (Equal(v, "TRUE"))
+      return NewString("true");
+    if (Equal(v, "FALSE"))
+      return NewString("false");
+#endif
     return 0;
   }
 

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -529,12 +529,11 @@ public:
     }
     if (Equal(v, "0") || Equal(v, "NULL") || Equal(v, "nullptr"))
       return SwigType_ispointer(t) ? NewString("None") : NewString("0");
-#if 0 // FIXME: TRUE and FALSE are not standard and could be defined in other ways
+    // FIXME: TRUE and FALSE are not standard and could be defined in other ways
     if (Equal(v, "TRUE"))
       return NewString("true");
     if (Equal(v, "FALSE"))
       return NewString("false");
-#endif
     return 0;
   }
 

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1797,7 +1797,7 @@ public:
 
       // Write default value
       if (value && !calling) {
-	String *new_value = convertValue(value, Getattr(p, "type"));
+	String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
 	if (new_value) {
 	  value = new_value;
 	} else {
@@ -2035,32 +2035,12 @@ public:
   String *convertIntegerValue(String *v, SwigType *resolved_type) {
     const char *const s = Char(v);
     char *end;
-    String *result = NIL;
 
     // Check if this is an integer number in any base.
     errno = 0;
     long value = strtol(s, &end, 0);
-    if (errno == ERANGE || end == s)
+    if (errno == ERANGE || end == s || *end != '\0') {
       return NIL;
-
-    if (*end != '\0') {
-      // If there is a suffix after the number, we can safely ignore "l"
-      // and (provided the number is unsigned) "u", and also combinations of
-      // these, but not anything else.
-      for (char *p = end; *p != '\0'; ++p) {
-        switch (*p) {
-          case 'l':
-          case 'L':
-	    break;
-          case 'u':
-          case 'U':
-	    if (value < 0)
-	      return NIL;
-            break;
-          default:
-            return NIL;
-        }
-      }
     }
     // So now we are certain that we are indeed dealing with an integer
     // that has a representation as long given by value.
@@ -2073,30 +2053,14 @@ public:
     }
 #endif
 
-    if (Cmp(resolved_type, "bool") == 0)
+    if (Equal(resolved_type, "bool"))
       // Allow integers as the default value for a bool parameter.
       return NewString(value ? "True" : "False");
 
     if (value == 0)
       return NewString(SwigType_ispointer(resolved_type) ? "None" : "0");
 
-    // v may still be octal or hexadecimal:
-    const char *p = s;
-    if (*p == '+' || *p == '-')
-      ++p;
-    if (*p == '0' && *(p+1) != 'x' && *(p+1) != 'X') {
-      // This must have been an octal number. This is the only case we
-      // cannot use in Python directly, since Python 2 and 3 use non-
-      // compatible representations.
-      result = NewString(*s == '-' ? "int(\"-" : "int(\"");
-      String *octal_string = NewStringWithSize(p, (int) (end - p));
-      Append(result, octal_string);
-      Append(result, "\", 8)");
-      Delete(octal_string);
-      return result;
-    }
-    result = *end == '\0' ? Copy(v) : NewStringWithSize(s, (int) (end - s));
-    return result;
+    return Copy(v);
   }
 
   /* ------------------------------------------------------------
@@ -2151,30 +2115,34 @@ public:
    * constant. Return an equivalent Python representation,
    * or NIL if it isn't, or we are unsure.
    * ------------------------------------------------------------ */
-  String *convertValue(String *v, SwigType *type) {
-    const char *const s = Char(v);
-    String *result = NIL;
+  String *convertValue(String *v, String *numval, String *stringval, SwigType *type) {
+    if (stringval) {
+      return NewStringf("'%(escape)s'", stringval);
+    }
+    if (numval) {
+      SwigType *resolved_type = SwigType_typedef_resolve_all(type);
+      if (Equal(resolved_type, "bool")) {
+	Delete(resolved_type);
+	return NewString(*Char(numval) == '0' ? "False" : "True");
+      }
+      String *result = convertIntegerValue(numval, resolved_type);
+      Delete(resolved_type);
+      return result;
+    }
     SwigType *resolved_type = SwigType_typedef_resolve_all(type);
 
-    result = convertIntegerValue(v, resolved_type);
+    String *result = convertDoubleValue(v);
     if (!result) {
-      result = convertDoubleValue(v);
-      if (!result) {
-	if (Strcmp(v, "true") == 0)
-	  result = NewString("True");
-	else if (Strcmp(v, "false") == 0)
-	  result = NewString("False");
-	else if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
-	  result = SwigType_ispointer(resolved_type) ? NewString("None") : NewString("0");
-	// This could also be an enum type, default value of which could be
-	// representable in Python if it doesn't include any scope (which could,
-	// but currently is not, translated).
-	else if (!Strchr(s, ':')) {
-	  Node *lookup = Swig_symbol_clookup(v, 0);
-	  if (lookup) {
-	    if (Cmp(Getattr(lookup, "nodeType"), "enumitem") == 0)
-	      result = Copy(Getattr(lookup, "sym:name"));
-	  }
+      if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
+	result = SwigType_ispointer(resolved_type) ? NewString("None") : NewString("0");
+      // This could also be an enum type, default value of which could be
+      // representable in Python if it doesn't include any scope (which could,
+      // but currently is not, translated).
+      else if (!Strchr(v, ':')) {
+	Node *lookup = Swig_symbol_clookup(v, 0);
+	if (lookup) {
+	  if (Cmp(Getattr(lookup, "nodeType"), "enumitem") == 0)
+	    result = Copy(Getattr(lookup, "sym:name"));
 	}
       }
     }
@@ -2222,7 +2190,7 @@ public:
 
       String *value = Getattr(p, "value");
       if (value) {
-	String *convertedValue = convertValue(value, Getattr(p, "type"));
+	String *convertedValue = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
 	if (!convertedValue)
 	  return false;
 	Delete(convertedValue);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2117,7 +2117,9 @@ public:
    * ------------------------------------------------------------ */
   String *convertValue(String *v, String *numval, String *stringval, SwigType *type) {
     if (stringval) {
-      return NewStringf("'%(escape)s'", stringval);
+      return NIL;
+      // FIXME: This needs more careful testing.
+      // return NewStringf("'%(escape)s'", stringval);
     }
     if (numval) {
       SwigType *resolved_type = SwigType_typedef_resolve_all(type);

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -1182,15 +1182,15 @@ int R::enumvalueDeclaration(Node *n) {
   
   // Deal with enum values that are not int
   int swigtype = SwigType_type(Getattr(n, "type"));
-  if (swigtype == T_BOOL) {
-    const char *val = Equal(Getattr(n, "enumvalue"), "true") ? "1" : "0";
-    Setattr(n, "enumvalue", val);
-  } else if (swigtype == T_CHAR) {
+  if (swigtype == T_CHAR) {
     if (Getattr(n, "enumstringval")) {
       String *val = NewStringf("'%(escape)s'", Getattr(n, "enumstringval"));
       Setattr(n, "enumvalue", val);
       Delete(val);
     }
+  } else {
+    String *numval = Getattr(n, "enumnumval");
+    if (numval) Setattr(n, "enumvalue", numval);
   }
 
   if (GetFlag(parent, "scopedenum")) {

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -789,12 +789,11 @@ private:
     if (v && Len(v) > 0) {
       if (Equal(v, "NULL") || Equal(v, "nullptr"))
 	return SwigType_ispointer(type) ? NewString("nil") : NewString("0");
-#if 0 // FIXME: TRUE and FALSE are not standard and could be defined in other ways
+      // FIXME: TRUE and FALSE are not standard and could be defined in other ways
       if (Equal(v, "TRUE"))
 	return NewString("True");
       if (Equal(v, "FALSE"))
 	return NewString("False");
-#endif
     }
     return 0;
   }

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -398,7 +398,7 @@ private:
       }
 
       if (value) {
-	String *new_value = convertValue(value, Getattr(p, "type"));
+	String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
 	if (new_value) {
 	  value = new_value;
 	} else {
@@ -407,6 +407,9 @@ private:
 	    value = Getattr(lookup, "sym:name");
 	}
 	Printf(doc, "=%s", value);
+
+	if (new_value)
+	  Delete(new_value);
       }
       Delete(type_str);
       Delete(made_name);
@@ -768,22 +771,30 @@ private:
    *    Check if string v can be a Ruby value literal,
    *    (eg. number or string), or translate it to a Ruby literal.
    * ------------------------------------------------------------ */
-  String *convertValue(String *v, SwigType *t) {
-    if (v && Len(v) > 0) {
-      char fc = (Char(v))[0];
-      if (('0' <= fc && fc <= '9') || '\'' == fc || '"' == fc) {
-	/* number or string (or maybe NULL pointer) */
-	if (SwigType_ispointer(t) && Strcmp(v, "0") == 0)
-	  return NewString("None");
-	else
-	  return v;
+  String *convertValue(String *v, String *numval, String *stringval, SwigType *type) {
+    if (stringval) {
+      return NewStringf("\"%(escape)s\"", stringval);
+    }
+    if (numval) {
+      SwigType *resolved_type = SwigType_typedef_resolve_all(type);
+      if (Equal(resolved_type, "bool")) {
+	Delete(resolved_type);
+	return NewString(*Char(numval) == '0' ? "False" : "True");
       }
-      if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
-	return SwigType_ispointer(t) ? NewString("nil") : NewString("0");
-      if (Strcmp(v, "true") == 0 || Strcmp(v, "TRUE") == 0)
+      Delete(resolved_type);
+      if (SwigType_ispointer(type) && Equal(v, "0"))
+	return NewString("None");
+      return Copy(v);
+    }
+    if (v && Len(v) > 0) {
+      if (Equal(v, "NULL") || Equal(v, "nullptr"))
+	return SwigType_ispointer(type) ? NewString("nil") : NewString("0");
+#if 0 // FIXME: TRUE and FALSE are not standard and could be defined in other ways
+      if (Equal(v, "TRUE"))
 	return NewString("True");
-      if (Strcmp(v, "false") == 0 || Strcmp(v, "FALSE") == 0)
+      if (Equal(v, "FALSE"))
 	return NewString("False");
+#endif
     }
     return 0;
   }

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -355,7 +355,7 @@ int Swig_storage_isstatic(Node *n) {
  *
  * Takes a string object and produces a string with escape codes added to it.
  * Octal escaping is used.  The result is used for literal strings and characters
- * in C/C++ and also Java and R.
+ * in C/C++ and also Java, Python, R and Ruby.
  *
  * The result is suitable for wrapping in single or double quotes to form a
  * character or string literal.


### PR DESCRIPTION
This provides a generic framework to aid converting C/C++ integer and boolean literals to target language literals, replacing custom code in several target language backends.

This fixes some bugs in that code.

TODO: Add regression tests for these bugs.