### PR TITLE
Drop support for raw type strings in interface files

### DIFF
--- a/Doc/Devel/scanner.html
+++ b/Doc/Devel/scanner.html
@@ -253,7 +253,6 @@ SWIG_TOKEN_BOOL              Boolean literal (true or false)
 SWIG_TOKEN_CHAR              Character literal in single quotes ('c')
 SWIG_TOKEN_WCHAR             Wide character literal (L'c')
 SWIG_TOKEN_STRING            String literal in double quotes ("str")
-SWIG_TOKEN_RSTRING           Reverse quote string (`str`)
 SWIG_TOKEN_CODEBLOCK         SWIG code literal block %{ ... %}
 SWIG_TOKEN_COMMENT           C or C++ comment  (// or /* ... */)
 SWIG_TOKEN_WSTRING           Wide string literal (L"str")

--- a/Doc/Manual/Extending.html
+++ b/Doc/Manual/Extending.html
@@ -1893,35 +1893,10 @@ special base type of <tt>v(...)</tt>.
 </p>
 
 <p>
-If you want to experiment with type encodings, the raw type strings can
-be inserted into an interface file using backticks `` wherever a type
-is expected.  For instance, here is
-an extremely perverted example:
-</p>
-
-<div class="diagram">
-<pre>
-`p.a(10).p.f(int, p.f(int).int)` foo(int, int (*x)(int));
-</pre>
-</div>
-
-<p>
-This corresponds to the immediately obvious C declaration:
-</p>
-
-<div class="diagram">
-<pre>
-(*(*foo(int, int (*)(int)))[10])(int, int (*)(int));
-</pre>
-</div>
-
-<p>
-Aside from the potential use of this declaration on a C programming quiz,
-it motivates the use of the special SWIG encoding of types.   The SWIG
-encoding is much easier to work with because types can be easily examined,
-modified, and constructed using simple string operations (comparison,
-substrings, concatenation, etc.).   For example, in the parser, a declaration
-like this
+SWIG's encoding as it is much easier to work with than the C/C++ type syntax -
+types can be easily examined, modified, and constructed using simple string
+operations (comparison, substrings, concatenation, etc.).   For
+example, in the parser, a declaration like this
 </p>
 
 <div class="code">

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -377,10 +377,6 @@ static int yylook(void) {
 
       /* Look for multi-character sequences */
       
-    case SWIG_TOKEN_RSTRING:
-      yylval.type = NewString(Scanner_text(scan));
-      return TYPE_RAW;
-      
     case SWIG_TOKEN_STRING:
       yylval.str = NewString(Scanner_text(scan));
       return STRING;

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -1721,7 +1721,7 @@ static String *add_qualifier_to_declarator(SwigType *type, SwigType *qualifier) 
 %token <str> CHARCONST WCHARCONST
 %token <dtype> NUM_INT NUM_DOUBLE NUM_FLOAT NUM_LONGDOUBLE NUM_UNSIGNED NUM_LONG NUM_ULONG NUM_LONGLONG NUM_ULONGLONG NUM_BOOL
 %token TYPEDEF
-%token <type> TYPE_INT TYPE_UNSIGNED TYPE_SHORT TYPE_LONG TYPE_FLOAT TYPE_DOUBLE TYPE_CHAR TYPE_WCHAR TYPE_VOID TYPE_SIGNED TYPE_BOOL TYPE_COMPLEX TYPE_RAW TYPE_NON_ISO_INT8 TYPE_NON_ISO_INT16 TYPE_NON_ISO_INT32 TYPE_NON_ISO_INT64
+%token <type> TYPE_INT TYPE_UNSIGNED TYPE_SHORT TYPE_LONG TYPE_FLOAT TYPE_DOUBLE TYPE_CHAR TYPE_WCHAR TYPE_VOID TYPE_SIGNED TYPE_BOOL TYPE_COMPLEX TYPE_NON_ISO_INT8 TYPE_NON_ISO_INT16 TYPE_NON_ISO_INT32 TYPE_NON_ISO_INT64
 %token LPAREN RPAREN COMMA SEMI EXTERN LBRACE RBRACE PERIOD ELLIPSIS
 %token CONST_QUAL VOLATILE REGISTER STRUCT UNION EQUAL SIZEOF ALIGNOF MODULE LBRACKET RBRACKET
 %token BEGINFILE ENDOFFILE
@@ -3541,7 +3541,6 @@ initializer   : def_args
 cpp_alternate_rettype : primitive_type
               | TYPE_BOOL
               | TYPE_VOID
-              | TYPE_RAW
               | idcolon { $$ = $idcolon; }
               | idcolon AND {
                 $$ = $idcolon;
@@ -5094,7 +5093,6 @@ anonymous_bitfield :  storage_class anon_bitfield_type COLON expr SEMI { Delete(
 anon_bitfield_type : primitive_type
                | TYPE_BOOL
                | TYPE_VOID
-               | TYPE_RAW
 
                | idcolon { $$ = $idcolon; }
                ;
@@ -6179,7 +6177,6 @@ type_right     : primitive_type
                | TYPE_BOOL
                | TYPE_VOID
                | c_enum_key idcolon { $$ = NewStringf("enum %s", $idcolon); }
-               | TYPE_RAW
 
                | idcolon %expect 1 {
 		  $$ = $idcolon;

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -697,58 +697,6 @@ static String *Swig_string_schemify(String *s) {
   return ns;
 }
 
-/* -----------------------------------------------------------------------------
- * Swig_string_typecode()
- *
- * Takes a string with possible type-escapes in it and replaces them with
- * real C datatypes.
- * ----------------------------------------------------------------------------- */
-
-static String *Swig_string_typecode(String *s) {
-  String *ns;
-  int c;
-  String *tc;
-  ns = NewStringEmpty();
-  while ((c = Getc(s)) != EOF) {
-    if (c == '`') {
-      String *str = 0;
-      tc = NewStringEmpty();
-      while ((c = Getc(s)) != EOF) {
-	if (c == '`')
-	  break;
-	Putc(c, tc);
-      }
-      str = SwigType_str(tc, 0);
-      Append(ns, str);
-      Delete(str);
-    } else {
-      Putc(c, ns);
-      if (c == '\'') {
-	while ((c = Getc(s)) != EOF) {
-	  Putc(c, ns);
-	  if (c == '\'')
-	    break;
-	  if (c == '\\') {
-	    c = Getc(s);
-	    Putc(c, ns);
-	  }
-	}
-      } else if (c == '\"') {
-	while ((c = Getc(s)) != EOF) {
-	  Putc(c, ns);
-	  if (c == '\"')
-	    break;
-	  if (c == '\\') {
-	    c = Getc(s);
-	    Putc(c, ns);
-	  }
-	}
-      }
-    }
-  }
-  return ns;
-}
-
 static String *string_mangle(String *s) {
   return Swig_name_mangle_string(s);
 }
@@ -1472,7 +1420,6 @@ void Swig_init(void) {
   DohEncoding("ctitle", Swig_string_ccase);
   DohEncoding("lctitle", Swig_string_lccase);
   DohEncoding("utitle", Swig_string_ucase);
-  DohEncoding("typecode", Swig_string_typecode);
   DohEncoding("mangle", string_mangle);
   DohEncoding("command", Swig_string_command);
   DohEncoding("schemify", Swig_string_schemify);

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -633,10 +633,6 @@ static int look(Scanner *s) {
 	s->start_line = s->line;
 	Clear(s->text);
 	state = 9;		/* A character constant */
-      } else if (c == '`') {
-	s->start_line = s->line;
-	Clear(s->text);
-	state = 900;
       }
 
       else if (c == '.')
@@ -1495,18 +1491,6 @@ static int look(Scanner *s) {
       else {
 	retract(s, 1);
 	return SWIG_TOKEN_RSHIFT;
-      }
-      break;
-
-      /* Reverse string */
-    case 900:
-      if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
-	return SWIG_TOKEN_ERROR;
-      }
-      if (c == '`') {
-	Delitem(s->text, DOH_END);
-	return (SWIG_TOKEN_RSTRING);
       }
       break;
 

--- a/Source/Swig/swigscan.h
+++ b/Source/Swig/swigscan.h
@@ -63,7 +63,6 @@ extern void         Scanner_locator(Scanner *, String *loc);
 #define   SWIG_TOKEN_AT           25       /* @ */
 #define   SWIG_TOKEN_DOLLAR       26       /* $ */
 #define   SWIG_TOKEN_CODEBLOCK    27       /* %{ ... %} ... */
-#define   SWIG_TOKEN_RSTRING      28       /* `charconst` */
 #define   SWIG_TOKEN_LONGLONG     29       /* 314LL */
 #define   SWIG_TOKEN_ULONGLONG    30       /* 314ULL */
 #define   SWIG_TOKEN_QUESTION     31       /* ? */


### PR DESCRIPTION
This is described in CHANGES as a "Secret developer feature" and a "SICK HACK".  It was only documented in developer documentation, and had no test coverage.

It allowed specifying an SWIG internal syntax type string, e.g.

```
  `p.a(10).p.f(int, p.f(int).int)` foo(int, int (*x)(int));
```

However there seems to be no good reason to support this - it's better to use the C/C++ syntax:

```
  (*(*foo(int, int (*)(int)))[10])(int, int (*)(int));
```

Fixes #2998