### PR TITLE
Fix cstrings.swg cstring_output_allocate example freeing

### DIFF
--- a/Lib/typemaps/cstrings.swg
+++ b/Lib/typemaps/cstrings.swg
@@ -236,7 +236,7 @@
  * This macro is used to return Character data that was
  * allocated with new or malloc.
  *
- *     %cstring_output_allocate(Char **outx, free($1));
+ *     %cstring_output_allocate(Char **outx, free(*$1));
  *     void foo(Char **outx) {
  *         *outx = (Char *) malloc(512);
  *         strcpy(outx,"blah blah\n");
@@ -263,7 +263,7 @@
  * This macro is used to return Character data that was
  * allocated with new or malloc.
  *
- *     %cstring_output_allocate_size(Char **outx, int *sz, free($1));
+ *     %cstring_output_allocate_size(Char **outx, int *sz, free(*$1));
  *     void foo(Char **outx, int *sz) {
  *         *outx = (Char *) malloc(512);
  *         strcpy(outx,"blah blah\n");


### PR DESCRIPTION
The memory freeing needs to be done with `free(*$1)` instead of `free($1)`: because $1 is a `char**` (a pointer to a heap-allocated string), one dereference is required to peel back a layer of pointer indirection and pass the correct heap-allocated pointer to `free`.

Also noting that the examples at https://swig.org/Doc4.2/Library.html#Library_nn12 have the correct invocation of `free`.