### PR TITLE
Use noexcept instead of throw() in a number of places

### DIFF
--- a/Examples/test-suite/cpp11_default_delete.i
+++ b/Examples/test-suite/cpp11_default_delete.i
@@ -102,11 +102,11 @@ struct moveonly {
 };
 
 struct ConstructorThrow {
-  ConstructorThrow() throw() = default;
-  ConstructorThrow(const ConstructorThrow&) throw() = delete;
-  ConstructorThrow(ConstructorThrow&&) throw() = delete;
-  ConstructorThrow& operator=(const ConstructorThrow&) throw() = delete;
-  ~ConstructorThrow() throw() = default;
+  ConstructorThrow() noexcept = default;
+  ConstructorThrow(const ConstructorThrow&) noexcept = delete;
+  ConstructorThrow(ConstructorThrow&&) noexcept = delete;
+  ConstructorThrow& operator=(const ConstructorThrow&) noexcept = delete;
+  ~ConstructorThrow() noexcept = default;
 };
 
 %}

--- a/Examples/test-suite/cpp11_lambda_functions.i
+++ b/Examples/test-suite/cpp11_lambda_functions.i
@@ -27,7 +27,7 @@
 %warnfilter(SWIGWARN_CPP11_LAMBDA) Space1::Space2::lambda20;
 
 // throw is invalid in C++17 and later, only SWIG to use it
-#define TESTCASE_THROW0() throw()
+#define TESTCASE_THROW0() noexcept
 #define TESTCASE_THROW1(T1) throw(T1)
 %{
 #define TESTCASE_THROW0()
@@ -120,4 +120,3 @@ int(*lambda101notauto)(int, int) = [] (int a, int b) { return a + b; };
 int lambda102 = [] (int a, int b) mutable { return a + b; }(1, 2);
 void lambda_init(int = ([]{ return 0; })());
 %}
-

--- a/Examples/test-suite/cpp11_noexcept.i
+++ b/Examples/test-suite/cpp11_noexcept.i
@@ -39,7 +39,7 @@ struct NoExceptClass {
 // Undefined symbols for architecture x86_64: "___cxa_deleted_virtual", referenced from: vtable for NoExceptClass
 #if !(defined(__clang__) && __cplusplus >= 201703L)
   virtual void noo4() const noexcept = delete;
-  virtual void noo5() const throw() = delete;
+  virtual void noo5() const noexcept = delete;
 #endif
 };
 

--- a/Examples/test-suite/director_exception_nothrow.i
+++ b/Examples/test-suite/director_exception_nothrow.i
@@ -16,13 +16,13 @@
 class Base
 {
 public:
-  virtual ~Base() throw() {}
+  virtual ~Base() noexcept {}
 };
 
 
 class Bar : public Base
 {
 public:
-  virtual std::string pang() throw() { return "Bar::pang()"; }
+  virtual std::string pang() noexcept { return "Bar::pang()"; }
 };
 %}

--- a/Lib/c/cexcept.swg
+++ b/Lib/c/cexcept.swg
@@ -21,17 +21,17 @@ extern "C" SWIGEXPORTC void SWIG_CException_Raise(int code, const char* msg);
 #ifndef SWIG_CException_DEFINED
 class SWIG_CException {
 public:
-  SWIG_CException(const SWIG_CException& ex) throw() : code(ex.code), msg(strdup(ex.msg)) { }
+  SWIG_CException(const SWIG_CException& ex) noexcept : code(ex.code), msg(strdup(ex.msg)) { }
   ~SWIG_CException() { free(const_cast<char*>(msg)); }
 
   const int code;
   const char* const msg;
 
-  static SWIG_CException* get_pending() throw() {
+  static SWIG_CException* get_pending() noexcept {
     return PendingException;
   }
 
-  static void reset_pending() throw() {
+  static void reset_pending() noexcept {
     if (PendingException) {
       delete PendingException;
       PendingException = 0;

--- a/Lib/csharp/director.swg
+++ b/Lib/csharp/director.swg
@@ -28,10 +28,10 @@ namespace Swig {
     DirectorException(const std::string &msg) : swig_msg(msg) {
     }
 
-    virtual ~DirectorException() throw() {
+    virtual ~DirectorException() noexcept {
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return swig_msg.c_str();
     }
   };
@@ -47,4 +47,3 @@ namespace Swig {
     }
   };
 }
-

--- a/Lib/d/director.swg
+++ b/Lib/d/director.swg
@@ -26,10 +26,10 @@ namespace Swig {
     DirectorException(const std::string &msg) : swig_msg(msg) {
     }
 
-    virtual ~DirectorException() throw() {
+    virtual ~DirectorException() noexcept {
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return swig_msg.c_str();
     }
   };
@@ -46,4 +46,3 @@ namespace Swig {
     }
   };
 }
-

--- a/Lib/java/director.swg
+++ b/Lib/java/director.swg
@@ -428,12 +428,12 @@ namespace Swig {
     DirectorException(const char *msg) : jenv_(SWIG_NULLPTR), throwable_(SWIG_NULLPTR), classname_(SWIG_NULLPTR), msg_(msg ? copystr(msg) : SWIG_NULLPTR) {
     }
 
-    ~DirectorException() throw() {
+    ~DirectorException() noexcept {
       delete[] classname_;
       delete[] msg_;
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return msg_ ? msg_ : "Unspecified DirectorException message";
     }
 
@@ -538,4 +538,3 @@ namespace Swig {
     return matches;
   }
 }
-

--- a/Lib/lua/std_except.i
+++ b/Lib/lua/std_except.i
@@ -19,9 +19,9 @@ namespace std
   class exception 
   {
   public:
-    exception() throw() { }
-    virtual ~exception() throw();
-    virtual const char* what() const throw();
+    exception() noexcept { }
+    virtual ~exception() noexcept;
+    virtual const char* what() const noexcept;
   }; 
 }
 

--- a/Lib/ocaml/director.swg
+++ b/Lib/ocaml/director.swg
@@ -20,10 +20,10 @@ namespace Swig {
       DirectorException(const char *msg="") : swig_msg(msg) {
       }
 
-      virtual ~DirectorException() throw() {
+      virtual ~DirectorException() noexcept {
       }
 
-      const char *what() const throw() {
+      const char *what() const noexcept {
         return swig_msg.c_str();
       }
   };
@@ -84,4 +84,3 @@ namespace Swig {
       }
   };
 }
-

--- a/Lib/perl5/director.swg
+++ b/Lib/perl5/director.swg
@@ -151,7 +151,7 @@ namespace Swig {
       SvREFCNT_inc(err);
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return SvPV_nolen(err);
     }
 
@@ -172,10 +172,10 @@ namespace Swig {
     }
 
   public:
-    virtual ~DirectorWrapException() throw() {
+    virtual ~DirectorWrapException() noexcept {
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return msg.c_str();
     }
 
@@ -314,4 +314,3 @@ namespace Swig {
 }
 
 #endif
-

--- a/Lib/php/director.swg
+++ b/Lib/php/director.swg
@@ -136,10 +136,10 @@ namespace Swig {
       if (!EG(exception)) zend_throw_exception(NULL, swig_msg.c_str(), code);
     }
 
-    virtual ~DirectorException() throw() {
+    virtual ~DirectorException() noexcept {
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return swig_msg.c_str();
     }
 

--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -177,7 +177,7 @@ namespace Swig {
       SWIG_PYTHON_THREAD_END_BLOCK;
     }
 
-    virtual ~DirectorException() throw() {
+    virtual ~DirectorException() noexcept {
     }
 
     /* Deprecated, use what() instead */
@@ -185,7 +185,7 @@ namespace Swig {
       return what();
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return swig_msg.c_str();
     }
 

--- a/Lib/ruby/director.swg
+++ b/Lib/ruby/director.swg
@@ -132,7 +132,7 @@ namespace Swig {
     }
 
   public:
-    virtual ~DirectorException() throw() {
+    virtual ~DirectorException() noexcept {
     }
 
     VALUE getType() const {
@@ -148,7 +148,7 @@ namespace Swig {
       return swig_msg;
     }
 
-    const char *what() const throw() {
+    const char *what() const noexcept {
       return swig_msg.c_str();
     }
   };
@@ -276,4 +276,3 @@ namespace Swig {
   };
   SWIG_GUARD_DEFINITION(Director, swig_mutex_own);
 }
-

--- a/Lib/std/std_alloc.i
+++ b/Lib/std/std_alloc.i
@@ -29,12 +29,12 @@ namespace std
       template<typename _Tp1>
         struct rebind;
 
-      allocator() throw();
+      allocator() noexcept;
       
-      allocator(const allocator& other) throw();
+      allocator(const allocator& other) noexcept;
       template<typename _Tp1>
-        allocator(const allocator<_Tp1>& other) throw();
-      ~allocator() throw();
+        allocator(const allocator<_Tp1>& other) noexcept;
+      ~allocator() noexcept;
       
 
       pointer
@@ -55,7 +55,7 @@ namespace std
       deallocate(pointer __p, size_type __n);
 
       size_type
-      max_size() const throw();
+      max_size() const noexcept;
 
       void construct(pointer __p, const _Tp& __val);
       void destroy(pointer __p);

--- a/Lib/std/std_except.i
+++ b/Lib/std/std_except.i
@@ -12,8 +12,8 @@
 namespace std {
   struct exception 
   {
-    virtual ~exception() throw();
-    virtual const char* what() const throw();
+    virtual ~exception() noexcept;
+    virtual const char* what() const noexcept;
   };
 
   struct bad_cast : exception 

--- a/Lib/std/std_ios.i
+++ b/Lib/std/std_ios.i
@@ -35,7 +35,7 @@ namespace std {
     class failure : public exception
     {
     public:
-      explicit failure(const string& __str) throw();
+      explicit failure(const string& __str) noexcept;
     };
 #endif
 
@@ -137,7 +137,7 @@ namespace std {
 
     // Storage:
     static int 
-    xalloc() throw();
+    xalloc() noexcept;
 
     inline long& 
     iword(int __ix);

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -3603,7 +3603,7 @@ cpp_alternate_rettype : primitive_type
    auto myFunc = [] { return something; };
    auto myFunc = [](int x, int y) { return x+y; };
    auto myFunc = [](int x, int y) -> int { return x+y; };
-   auto myFunc = [](int x, int y) throw() -> int { return x+y; };
+   auto myFunc = [](int x, int y) noexcept -> int { return x+y; };
    auto six = [](int x, int y) { return x+y; }(4, 2);
    ------------------------------------------------------------ */
 cpp_lambda_decl : storage_class AUTO idcolon EQUAL lambda_introducer lambda_template LPAREN parms RPAREN cpp_const lambda_body lambda_tail {
@@ -7737,4 +7737,3 @@ ParmList *Swig_cparse_parms(String *s, Node *file_line_node) {
    /*   Printf(stdout,"parmsparse: '%s' ---> '%s'\n", s, top); */
    return (ParmList *)top;
 }
-

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -4635,8 +4635,8 @@ public:
       Printf(f_directors_h, "    virtual ~%s() noexcept;\n", dirclassname);
       Printf(w->def, "%s::~%s() noexcept {\n", dirclassname, dirclassname);
     } else if (Getattr(n, "throw")) {
-      Printf(f_directors_h, "    virtual ~%s() throw();\n", dirclassname);
-      Printf(w->def, "%s::~%s() throw() {\n", dirclassname, dirclassname);
+      Printf(f_directors_h, "    virtual ~%s() noexcept;\n", dirclassname);
+      Printf(w->def, "%s::~%s() noexcept {\n", dirclassname, dirclassname);
     } else {
       Printf(f_directors_h, "    virtual ~%s();\n", dirclassname);
       Printf(w->def, "%s::~%s() {\n", dirclassname, dirclassname);

--- a/Source/Modules/d.cxx
+++ b/Source/Modules/d.cxx
@@ -2498,8 +2498,8 @@ public:
       Printf(f_directors_h, "    virtual ~%s() noexcept;\n", dirclassname);
       Printf(w->def, "%s::~%s() noexcept {\n", dirclassname, dirclassname);
     } else if (Getattr(n, "throw")) {
-      Printf(f_directors_h, "    virtual ~%s() throw();\n", dirclassname);
-      Printf(w->def, "%s::~%s() throw() {\n", dirclassname, dirclassname);
+      Printf(f_directors_h, "    virtual ~%s() noexcept;\n", dirclassname);
+      Printf(w->def, "%s::~%s() noexcept {\n", dirclassname, dirclassname);
     } else {
       Printf(f_directors_h, "    virtual ~%s();\n", dirclassname);
       Printf(w->def, "%s::~%s() {\n", dirclassname, dirclassname);

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -4746,8 +4746,8 @@ public:
       Printf(f_directors_h, "    virtual ~%s() noexcept;\n", dirClassName);
       Printf(w->def, "%s::~%s() noexcept {\n", dirClassName, dirClassName);
     } else if (Getattr(n, "throw")) {
-      Printf(f_directors_h, "    virtual ~%s() throw();\n", dirClassName);
-      Printf(w->def, "%s::~%s() throw() {\n", dirClassName, dirClassName);
+      Printf(f_directors_h, "    virtual ~%s() noexcept;\n", dirClassName);
+      Printf(w->def, "%s::~%s() noexcept {\n", dirClassName, dirClassName);
     } else {
       Printf(f_directors_h, "    virtual ~%s();\n", dirClassName);
       Printf(w->def, "%s::~%s() {\n", dirClassName, dirClassName);

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -2192,8 +2192,8 @@ int Language::classDirectorDestructor(Node *n) {
   File *f_directors = Swig_filebyname("director");
   File *f_directors_h = Swig_filebyname("director_h");
   if (Getattr(n, "throw")) {
-    Printf(f_directors_h, "    virtual ~%s() throw();\n", DirectorClassName);
-    Printf(f_directors, "%s::~%s() throw() {\n}\n\n", DirectorClassName, DirectorClassName);
+    Printf(f_directors_h, "    virtual ~%s() noexcept;\n", DirectorClassName);
+    Printf(f_directors, "%s::~%s() noexcept {\n}\n\n", DirectorClassName, DirectorClassName);
   } else {
     Printf(f_directors_h, "    virtual ~%s();\n", DirectorClassName);
     Printf(f_directors, "%s::~%s() {\n}\n\n", DirectorClassName, DirectorClassName);
@@ -3765,4 +3765,3 @@ Language *Language::instance() {
 Hash *Language::getClassHash() const {
   return classhash;
 }
-

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -2489,8 +2489,8 @@ public:
       Printf(f_directors_h, "    virtual ~%s() noexcept;\n", DirectorClassName);
       Printf(f_directors, "%s::~%s() noexcept {%s}\n\n", DirectorClassName, DirectorClassName, body);
     } else if (Getattr(n, "throw")) {
-      Printf(f_directors_h, "    virtual ~%s() throw();\n", DirectorClassName);
-      Printf(f_directors, "%s::~%s() throw() {%s}\n\n", DirectorClassName, DirectorClassName, body);
+      Printf(f_directors_h, "    virtual ~%s() noexcept;\n", DirectorClassName);
+      Printf(f_directors, "%s::~%s() noexcept {%s}\n\n", DirectorClassName, DirectorClassName, body);
     } else {
       Printf(f_directors_h, "    virtual ~%s();\n", DirectorClassName);
       Printf(f_directors, "%s::~%s() {%s}\n\n", DirectorClassName, DirectorClassName, body);


### PR DESCRIPTION
[Dynamic throw specifications](https://en.cppreference.com/w/cpp/language/except_spec) (denoted by `throw()`) are being removed from C++. [`noexcept`](https://en.cppreference.com/w/cpp/language/noexcept_spec) is the appropriate replacement.

This PR makes the `throw()` -> `noexcept` switch in a number of places.