### PR TITLE
Use swig -Werror for test suite

### DIFF
--- a/Examples/test-suite/c/Makefile.in
+++ b/Examples/test-suite/c/Makefile.in
@@ -104,6 +104,9 @@ include $(srcdir)/../common.mk
 
 # Overridden variables here
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Suppress warnings about experimental status and unsupported features -- there are just too many of those for now for these warnings to be useful.
 SWIGOPT += -w524 -w761
 

--- a/Examples/test-suite/constant_directive.i
+++ b/Examples/test-suite/constant_directive.i
@@ -2,6 +2,13 @@
 
 // %constant and struct
 
+#ifdef SWIGGUILE
+// Suppress warnings for constants SWIG/Guile doesn't currently handle.
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) TYPE1_CONSTANT1;
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) TYPE1_CONSTANT2;
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) TYPE1CFPTR1DEF_CONSTANT1;
+#endif
+
 #ifdef SWIGOCAML
 %warnfilter(SWIGWARN_PARSE_KEYWORD) val;
 #endif

--- a/Examples/test-suite/cpp11_alternate_function_syntax.i
+++ b/Examples/test-suite/cpp11_alternate_function_syntax.i
@@ -8,6 +8,8 @@
 %ignore addAlternateMemberPtrConstParm(int x, int (SomeStruct::*mp)(int, int) const) const;
 // SWIG/C doesn't currently support wrapping rvalue reference return types.
 %ignore SomeStruct::output(short);
+#elif defined SWIGGO
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) output_rvalueref;
 #endif
 
 %inline %{

--- a/Examples/test-suite/cpp11_assign_rvalue_reference.i
+++ b/Examples/test-suite/cpp11_assign_rvalue_reference.i
@@ -1,5 +1,10 @@
 %module cpp11_assign_rvalue_reference
 
+#if defined SWIGGO
+// Several: Warning 507: No Go typemap defined for int &&
+# pragma SWIG nowarn=SWIGWARN_LANG_NATIVE_UNIMPL
+#endif
+
 // Copy of assign_reference.i testcase replacing reference member variables with rvalue reference member variables
 
 %rename(Assign) *::operator=;

--- a/Examples/test-suite/cpp11_brackets_expression.i
+++ b/Examples/test-suite/cpp11_brackets_expression.i
@@ -1,7 +1,19 @@
 %module cpp11_brackets_expression
 
+#ifdef SWIGGUILE
+// Suppress warnings SWIG/Guile emits because these constants have type size_t
+// which we don't show SWIG a definition of.
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) Piece::kOk2;
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) Piece::SimpleAsYouExpect123;
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) Piece::SimpleJust123;
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) Piece::AsYouExpect123;
+%warnfilter(SWIGWARN_PARSE_ASSIGNED_VALUE,SWIGWARN_TYPEMAP_CONST_UNDEF) Piece::kMaxSize;
+%warnfilter(SWIGWARN_PARSE_ASSIGNED_VALUE,SWIGWARN_TYPEMAP_CONST_UNDEF) Piece::Just123;
+#else
 %warnfilter(SWIGWARN_PARSE_ASSIGNED_VALUE) Piece::kMaxSize;
 %warnfilter(SWIGWARN_PARSE_ASSIGNED_VALUE) Piece::Just123;
+#endif
+
 %warnfilter(SWIGWARN_PARSE_ASSIGNED_VALUE) ::kMaxSizeGlobal;
 
 %inline %{

--- a/Examples/test-suite/cpp11_default_delete.i
+++ b/Examples/test-suite/cpp11_default_delete.i
@@ -4,6 +4,11 @@
 %warnfilter(SWIGWARN_LANG_OVERLOAD_IGNORED, SWIGWARN_LANG_OVERLOAD_SHADOW) trivial::trivial(trivial&&);
 %warnfilter(SWIGWARN_LANG_OVERLOAD_IGNORED, SWIGWARN_LANG_OVERLOAD_SHADOW) trivial::operator =(trivial&&);
 
+#if defined SWIGGO
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) trivial&&;
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) moveonly&&;
+#endif
+
 %rename(Assignment) *::operator=;
 
 %inline %{

--- a/Examples/test-suite/cpp11_move_only.i
+++ b/Examples/test-suite/cpp11_move_only.i
@@ -2,7 +2,9 @@
 
 %include "cpp11_move_only_helper.i"
 
-#if defined(SWIGOCAML)
+#if defined(SWIGGO)
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) MoveOnly&&;
+#elif defined(SWIGOCAML)
 %rename(valu) val;
 #endif
 

--- a/Examples/test-suite/cpp11_rvalue_reference.i
+++ b/Examples/test-suite/cpp11_rvalue_reference.i
@@ -1,6 +1,11 @@
 // This testcase checks whether SWIG correctly parses C++11 rvalue references.
 %module cpp11_rvalue_reference
 
+#if defined SWIGGO
+// Several: Warning 507: No Go typemap defined for int &&
+# pragma SWIG nowarn=SWIGWARN_LANG_NATIVE_UNIMPL
+#endif
+
 %inline %{
 #include <utility>
 class A {

--- a/Examples/test-suite/cpp11_rvalue_reference2.i
+++ b/Examples/test-suite/cpp11_rvalue_reference2.i
@@ -2,6 +2,11 @@
 
 %warnfilter(SWIGWARN_TYPEMAP_SWIGTYPELEAK) globalrrval;
 
+#if defined SWIGGO
+// Several: Warning 507: No Go typemap defined for int &&
+# pragma SWIG nowarn=SWIGWARN_LANG_NATIVE_UNIMPL
+#endif
+
 // This testcase tests lots of different places that rvalue reference syntax can be used
 
 %typemap(in) Something && "/*in Something && typemap*/"

--- a/Examples/test-suite/cpp11_rvalue_reference3.i
+++ b/Examples/test-suite/cpp11_rvalue_reference3.i
@@ -2,6 +2,12 @@
 
 %warnfilter(SWIGWARN_TYPEMAP_SWIGTYPELEAK);
 
+#if defined SWIGGO
+// Several: Warning 507: No Go typemap defined for int &&
+// and other rvalue reference types
+# pragma SWIG nowarn=SWIGWARN_LANG_NATIVE_UNIMPL
+#endif
+
 %inline %{
 #include <utility>
 struct Thing {};

--- a/Examples/test-suite/cpp11_rvalue_reference_move.i
+++ b/Examples/test-suite/cpp11_rvalue_reference_move.i
@@ -2,6 +2,10 @@
 
 // Testcase for testing rvalue reference input typemaps which assume the object is moved during a function call
 
+#if defined SWIGGO
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) MovableCopyable&&;
+#endif
+
 %include "cpp11_move_only_helper.i"
 
 %catches(std::string) MovableCopyable::check_numbers_match;

--- a/Examples/test-suite/cpp11_template_templated_methods.i
+++ b/Examples/test-suite/cpp11_template_templated_methods.i
@@ -3,7 +3,10 @@
 // Testing templated methods in a template
 // Including variadic templated method reported in https://github.com/swig/swig/issues/2794
 
-#if defined(SWIGLUA) || defined(SWIGOCAML)
+#if defined(SWIGGO)
+// Several: Warning 507: No Go typemap defined for eprosima::fastrtps::rtps::octet &&
+# pragma SWIG nowarn=SWIGWARN_LANG_NATIVE_UNIMPL
+#elif defined(SWIGLUA) || defined(SWIGOCAML)
 %rename(end_renamed) end;
 %rename(begin_renamed) begin;
 #endif

--- a/Examples/test-suite/cpp11_using_constructor.i
+++ b/Examples/test-suite/cpp11_using_constructor.i
@@ -2,6 +2,16 @@
 
 // Note: this testcase is also used by cpp11_director_using_constructor.i
 
+#ifdef SWIGLUA
+// Lua does now have a separate integer type, but didn't used to
+// and SWIG doesn't yet know about it (see #1918) so for now suppress
+// warnings about functions with overloads on int vs double, etc.
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) TemplateConstructor1Base::TemplateConstructor1Base(double,char const *);
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) TemplateConstructor1Derived::TemplateConstructor1Derived(double,char const *);
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) TemplateConstructor1Base::TemplateConstructor1Base(double,char const *);
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) TemplateConstructor1Derived::TemplateConstructor1Derived(double,char const *);
+#endif
+
 %inline %{
 // Public base constructors
 struct PublicBase1 {

--- a/Examples/test-suite/cpp11_variadic_function_templates.i
+++ b/Examples/test-suite/cpp11_variadic_function_templates.i
@@ -1,5 +1,9 @@
 %module cpp11_variadic_function_templates
 
+#if defined SWIGGO
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) EmplaceContainer::emplace;
+#endif
+
 // Some tests for variadic function templates
 %inline %{
 class A {

--- a/Examples/test-suite/cpp11_variadic_templates.i
+++ b/Examples/test-suite/cpp11_variadic_templates.i
@@ -20,6 +20,11 @@
 	    SWIGWARN_PHP_MULTIPLE_INHERITANCE,
 	    SWIGWARN_RUBY_MULTIPLE_INHERITANCE) LotsInherit;
 
+#if defined SWIGGO
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) ParmsPtrRValueRef;
+%warnfilter(SWIGWARN_LANG_NATIVE_UNIMPL) ParmsRValueRef;
+#endif
+
 ////////////////////////
 // Variadic templates //
 ////////////////////////

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -58,6 +58,9 @@ SWIGOPT += -namespace $*Namespace
 
 CSHARPFLAGSSPECIAL =
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 complextest.cpptest: CSHARPFLAGSSPECIAL = -r:System.Numerics.dll
 csharp_lib_arrays.cpptest: CSHARPFLAGSSPECIAL = -unsafe

--- a/Examples/test-suite/d/Makefile.in
+++ b/Examples/test-suite/d/Makefile.in
@@ -56,6 +56,9 @@ SRCDIR       = ../$(srcdir)/
 TARGETSUFFIX = _wrap
 SWIGOPT+=-splitproxy -package $*
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Rules for the different types of tests
 %.cpptest:
 	$(setup)

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -32,6 +32,9 @@ include $(srcdir)/../common.mk
 
 INCLUDES = -I$(abs_top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 .SUFFIXES: .cpptest .ctest .multicpptest
 
 # Rules for the different types of tests

--- a/Examples/test-suite/guile/Makefile.in
+++ b/Examples/test-suite/guile/Makefile.in
@@ -30,6 +30,9 @@ include $(srcdir)/../common.mk
 # Overridden variables here
 INCLUDES    += -I$(top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)/guile
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 %.multicpptest: SWIGOPT += $(GUILE_RUNTIME)
 

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -78,6 +78,9 @@ JAVA_PACKAGE = $*
 JAVA_PACKAGEOPT = -package $(JAVA_PACKAGE)
 SWIGOPT += $(JAVA_PACKAGEOPT)
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 cpp17_nspace_nested_namespaces.%: JAVA_PACKAGE = $*Package
 director_nspace.%: JAVA_PACKAGE = $*Package

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -55,6 +55,9 @@ endif
 
 include $(srcdir)/../common.mk
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 _setup = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) ]; then	  \
 	  $(ECHO_PROGRESS) "$(ACTION)ing $(LANGUAGE) ($(JSENGINE)) testcase $* (with run test)" ; \

--- a/Examples/test-suite/li_std_string.i
+++ b/Examples/test-suite/li_std_string.i
@@ -1,6 +1,12 @@
 %module li_std_string
 %include <std_string.i>
 
+#ifdef SWIGGUILE
+// Suppress warnings for constants SWIG/Guile doesn't currently handle.
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) MY_STRING;
+%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) MY_STRING_2;
+#endif
+
 #if defined(SWIGLUA) || defined(SWIGPHP) || defined(SWIGUTL)
 %apply std::string& INPUT { std::string &input }
 %apply std::string& INOUT { std::string &inout }

--- a/Examples/test-suite/li_std_string_extra.i
+++ b/Examples/test-suite/li_std_string_extra.i
@@ -1,5 +1,12 @@
 %module li_std_string_extra
 
+#if defined SWIGSCILAB
+// Not sure what's going on here but we get:
+// .././../li_std_string_extra.i:12: Warning 402: Base class 'std::string' is incomplete.
+// ../../../../Lib/typemaps/std_string.swg:16: Warning 402: Only forward declaration 'std::string' was found.
+%warnfilter(SWIGWARN_TYPE_INCOMPLETE) A;
+#endif
+
 %naturalvar A;
 
 

--- a/Examples/test-suite/lua/Makefile.in
+++ b/Examples/test-suite/lua/Makefile.in
@@ -31,6 +31,9 @@ include $(srcdir)/../common.mk
 # Overridden variables here
 LIBS       = -L.
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 lua_no_module_global.%: SWIGOPT += -nomoduleglobal
 

--- a/Examples/test-suite/mzscheme/Makefile.in
+++ b/Examples/test-suite/mzscheme/Makefile.in
@@ -84,6 +84,9 @@ include $(srcdir)/../common.mk
 # Overridden variables here
 SWIGOPT += -w524 # Suppress SWIGWARN_LANG_EXPERIMENTAL warning
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 # none!
 

--- a/Examples/test-suite/mzscheme/Makefile.in
+++ b/Examples/test-suite/mzscheme/Makefile.in
@@ -85,7 +85,9 @@ include $(srcdir)/../common.mk
 SWIGOPT += -w524 # Suppress SWIGWARN_LANG_EXPERIMENTAL warning
 
 # Ensure testsuite remains free from SWIG warnings.
-SWIGOPT += -Werror
+# Currently there are a lot of SWIG warnings for mzscheme, but it is marked
+# as "Experimental" and slated for removal in 4.4.0 (#2830).
+#SWIGOPT += -Werror
 
 # Custom tests - tests with additional commandline options
 # none!

--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -58,6 +58,10 @@ run_testcase = \
 include $(srcdir)/../common.mk
 
 # Overridden variables here
+
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 SWIGOPT += -w524 # Suppress SWIGWARN_LANG_EXPERIMENTAL warning
 
 # Custom tests - tests with additional commandline options

--- a/Examples/test-suite/octave/Makefile.in
+++ b/Examples/test-suite/octave/Makefile.in
@@ -34,6 +34,9 @@ include $(srcdir)/../common.mk
 LIBS       = -L.
 CSRCS      = octave_empty.c
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 # none!
 

--- a/Examples/test-suite/overload_numeric.i
+++ b/Examples/test-suite/overload_numeric.i
@@ -3,7 +3,8 @@
 // Tests overloading of integral and floating point types to verify the range checking required
 // for dispatch to the correct overloaded method
 
-#ifdef SWIGLUA
+#if defined SWIGGUILE || defined SWIGLUA
+// Guile seems to only have one integer type and one floating point type.
 // lua only has one numeric type, so most of the overloads shadow each other creating warnings
 %warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) Nums::over;
 #endif

--- a/Examples/test-suite/overload_numeric.i
+++ b/Examples/test-suite/overload_numeric.i
@@ -3,9 +3,10 @@
 // Tests overloading of integral and floating point types to verify the range checking required
 // for dispatch to the correct overloaded method
 
-#if defined SWIGGUILE || defined SWIGLUA
+#if defined SWIGGUILE || defined SWIGLUA || defined SWIGR
 // Guile seems to only have one integer type and one floating point type.
 // lua only has one numeric type, so most of the overloads shadow each other creating warnings
+// R seems to only have one integer type.
 %warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) Nums::over;
 #endif
 

--- a/Examples/test-suite/perl5/Makefile.in
+++ b/Examples/test-suite/perl5/Makefile.in
@@ -34,7 +34,9 @@ C_TEST_CASES += \
 include $(srcdir)/../common.mk
 
 # Overridden variables here
-# none!
+
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
 
 # Custom tests - tests with additional commandline options
 cpp11_strongly_typed_enumerations_perl_const.cpptest: SWIGOPT += -const

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -33,6 +33,9 @@ include $(srcdir)/../common.mk
 # Overridden variables here
 TARGETPREFIX =# Should be php_ for Windows, empty otherwise
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 prefix.cpptest: SWIGOPT += -prefix Project
 

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -120,6 +120,9 @@ include $(srcdir)/../common.mk
 LIBS         = -L.
 VALGRIND_OPT += --suppressions=pythonswig.supp
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
 

--- a/Examples/test-suite/r/Makefile.in
+++ b/Examples/test-suite/r/Makefile.in
@@ -30,7 +30,9 @@ CPP_TEST_CASES += \
 include $(srcdir)/../common.mk
 
 # Overridden variables here
-# none!
+
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
 
 # Custom tests - tests with additional commandline options
 # none!

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -66,6 +66,9 @@ include $(srcdir)/../common.mk
 # Overridden variables here
 SWIGOPT += -w801 -noautorename -features autodoc=4
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Custom tests - tests with additional commandline options
 ruby_alias_global_function.ctest: SWIGOPT += -globalmodule
 ruby_global_immutable_vars.ctest: SWIGOPT += -globalmodule

--- a/Examples/test-suite/scilab/Makefile.in
+++ b/Examples/test-suite/scilab/Makefile.in
@@ -35,6 +35,9 @@ include $(srcdir)/../common.mk
 # Overridden variables
 SRCDIR = ../$(srcdir)/
 
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
+
 # Local variables
 TEST_DIR = $*.dir
 RUNME_SCRIPT = $(SCRIPTPREFIX)$*$(SCRIPTSUFFIX)

--- a/Examples/test-suite/tcl/Makefile.in
+++ b/Examples/test-suite/tcl/Makefile.in
@@ -26,7 +26,9 @@ C_TEST_CASES += \
 include $(srcdir)/../common.mk
 
 # Overridden variables here
-# none!
+
+# Ensure testsuite remains free from SWIG warnings.
+SWIGOPT += -Werror
 
 # Custom tests - tests with additional commandline options
 # none!

--- a/Examples/test-suite/using_member.i
+++ b/Examples/test-suite/using_member.i
@@ -9,6 +9,16 @@
 %rename(greater) one::DD::great;
 %rename(greaterstill) one::DD::great(bool);
 
+#ifdef SWIGLUA
+// Lua does now have a separate integer type, but didn't used to
+// and SWIG doesn't yet know about it (see #1918) so for now suppress
+// warnings about functions with overloads on int vs double, etc.
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) B::get(double);
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) one::two::three::interface1::AA::great(float);
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) one::CC::great;
+%warnfilter(SWIGWARN_LANG_OVERLOAD_SHADOW) one::DD::great(float);
+#endif
+
 %inline %{
 namespace interface1
 {


### PR DESCRIPTION
I'm really not sure what's going on with the scilab warnings:

```
.././../li_std_string_extra.i:12: Warning 402: Base class 'std::string' is incomplete.
../../../../Lib/typemaps/std_string.swg:16: Warning 402: Only forward declaration 'std::string' was found.
```

Makes me wonder if there's something not right in the SWIG/Scilab's `std::string` library support, but I'm not spotting what's different that's causing this compared to other languages.