### PR TITLE
[guile] Improve constant wrapping

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,10 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.4.0 (in progress)
 ===========================
 
+2024-10-25: olly
+	    [Guile] Allow wrapping anything with a `varout` typemap as a
+	    constant.
+
 2024-10-24: olly
 	    [Perl] https://sourceforge.net/p/swig/bugs/1134/ Ensure C++
 	    local variables get destroyed before throwing a Perl exception.

--- a/Examples/test-suite/constant_directive.i
+++ b/Examples/test-suite/constant_directive.i
@@ -3,10 +3,8 @@
 // %constant and struct
 
 #ifdef SWIGGUILE
-// Suppress warnings for function pointer constants which SWIG/Guile doesn't
+// Suppress warning for function pointer constant which SWIG/Guile doesn't
 // currently handle.
-%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) TYPE1_CONSTANT1;
-%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) TYPE1_CONSTANT2;
 %warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) TYPE1CFPTR1DEF_CONSTANT1;
 #endif
 

--- a/Examples/test-suite/li_std_string.i
+++ b/Examples/test-suite/li_std_string.i
@@ -1,12 +1,6 @@
 %module li_std_string
 %include <std_string.i>
 
-#ifdef SWIGGUILE
-// Suppress warnings for constants SWIG/Guile doesn't currently handle.
-%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) MY_STRING;
-%warnfilter(SWIGWARN_TYPEMAP_CONST_UNDEF) MY_STRING_2;
-#endif
-
 #if defined(SWIGLUA) || defined(SWIGPHP) || defined(SWIGUTL)
 %apply std::string& INPUT { std::string &input }
 %apply std::string& INOUT { std::string &inout }

--- a/Examples/test-suite/schemerunme/li_std_string.scm
+++ b/Examples/test-suite/schemerunme/li_std_string.scm
@@ -61,4 +61,11 @@
 (if (not (string=? (get-null (stdstring-empty)) "non-null"))
   (error "get-null stdstring-empty test"))
 
+(if (not (string=? (aString) "something"))
+  (error "aString test"))
+(if (not (string=? (MY-STRING) ""))
+  (error "MY-STRING test"))
+(if (not (string=? (MY-STRING-2) "OK"))
+  (error "MY-STRING-2 test"))
+
 (exit 0)


### PR DESCRIPTION
Allow wrapping anything with a `varout` typemap as a constant.

See #3034