### PR TITLE
[python] Define SWIG_HEAPTYPES for limited api mode

### DIFF
--- a/Examples/python/check.list
+++ b/Examples/python/check.list
@@ -9,6 +9,7 @@ enum
 exception
 exceptproxy
 extend
+external_runtime
 funcptr
 funcptr2
 functor

--- a/Examples/python/external_runtime/Makefile
+++ b/Examples/python/external_runtime/Makefile
@@ -1,0 +1,26 @@
+TOP        = ../..
+SWIGEXE    = $(TOP)/../swig
+SWIG_LIB_DIR = $(TOP)/../$(TOP_BUILDDIR_TO_TOP_SRCDIR)Lib
+CXXSRCS    = example.cxx
+TARGET     = example
+INTERFACE  = example.i
+LIBS       = -lm
+SWIGOPT    =
+
+check: build
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' python_run
+
+build:
+	SWIG_LIB='$(SWIG_LIB_DIR)' $(SWIGEXE) -python $(SWIGOPT) -external-runtime swig_runtime.hxx
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' $(SWIGLIB) CXXSRCS='$(CXXSRCS)' \
+	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
+	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' python_cpp
+
+static:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' $(SWIGLIB) CXXSRCS='$(CXXSRCS)' \
+	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
+	SWIGOPT='$(SWIGOPT)' TARGET='mypython' INTERFACE='$(INTERFACE)' python_cpp_static
+
+clean:
+	rm -f swig_runtime.hxx
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' python_clean

--- a/Examples/python/external_runtime/example.cxx
+++ b/Examples/python/external_runtime/example.cxx
@@ -5,24 +5,5 @@
 Function::Function(PyObject * pyCallable)
 : pyObj_(pyCallable), meshValue_(0)
 {
-  if (pyCallable)
-  {
-    Py_XINCREF(pyCallable);
-    PyObject * pyMesh = PyObject_CallMethod(pyObj_, const_cast<char *>("mesh"), const_cast<char *>("()"));
-    if (!pyMesh)
-      throw std::runtime_error("null pyMesh");
-    void * ptr = 0;
-    if (SWIG_IsOK(SWIG_ConvertPtr(pyMesh, &ptr, SWIG_TypeQuery("Mesh *"), 0)))
-    {
-      Mesh *mesh = reinterpret_cast< Mesh * >(ptr);
-      if (!mesh)
-        throw std::runtime_error("null mesh");
-      meshValue_ = mesh->value();
-    }
-    else
-    {
-      throw;
-    }
-    Py_XDECREF(pyMesh);
-  }
+  // stuff happens in the typemap of PyObject * pyCallable
 }

--- a/Examples/python/external_runtime/example.cxx
+++ b/Examples/python/external_runtime/example.cxx
@@ -1,0 +1,28 @@
+#include <Python.h>
+#include "swig_runtime.hxx"
+#include "example.h"
+
+Function::Function(PyObject * pyCallable)
+: pyObj_(pyCallable), meshValue_(0)
+{
+  if (pyCallable)
+  {
+    Py_XINCREF(pyCallable);
+    PyObject * pyMesh = PyObject_CallMethod(pyObj_, const_cast<char *>("mesh"), const_cast<char *>("()"));
+    if (!pyMesh)
+      throw std::runtime_error("null pyMesh");
+    void * ptr = 0;
+    if (SWIG_IsOK(SWIG_ConvertPtr(pyMesh, &ptr, SWIG_TypeQuery("Mesh *"), 0)))
+    {
+      Mesh *mesh = reinterpret_cast< Mesh * >(ptr);
+      if (!mesh)
+        throw std::runtime_error("null mesh");
+      meshValue_ = mesh->value();
+    }
+    else
+    {
+      throw;
+    }
+    Py_XDECREF(pyMesh);
+  }
+}

--- a/Examples/python/external_runtime/example.h
+++ b/Examples/python/external_runtime/example.h
@@ -17,8 +17,8 @@ class Function
 {
 public:
 	explicit Function(PyObject * pyCallable = 0);
-	int meshValue() { return meshValue_;}
+	int meshValue() { return meshValue_;}	int meshValue_;
+
 private:
 	PyObject * pyObj_;
-	int meshValue_;
 };

--- a/Examples/python/external_runtime/example.h
+++ b/Examples/python/external_runtime/example.h
@@ -1,0 +1,24 @@
+/* File : example.h */
+
+#include <iostream>
+#include "Python.h"
+
+class Mesh
+{
+public:
+	Mesh(const int value = 0)
+	: value_(value) {}
+	int value() { return value_;}
+private:
+	int value_;
+};
+
+class Function
+{
+public:
+	explicit Function(PyObject * pyCallable = 0);
+	int meshValue() { return meshValue_;}
+private:
+	PyObject * pyObj_;
+	int meshValue_;
+};

--- a/Examples/python/external_runtime/example.i
+++ b/Examples/python/external_runtime/example.i
@@ -4,6 +4,28 @@
 #include "example.h"
 %}
 
+%typemap(in) PyObject * pyCallable
+{
+  if ($input)
+  {
+    PyObject * pyMesh = PyObject_CallMethod($input, const_cast<char *>("mesh"), const_cast<char *>("()"));
+    if (!pyMesh)
+      throw std::runtime_error("null pyMesh");
+    void * ptr = 0;
+    if (SWIG_IsOK(SWIG_ConvertPtr(pyMesh, &ptr, SWIG_TypeQuery("Mesh *"), 0)))
+    {
+      Mesh *mesh = reinterpret_cast< Mesh * >(ptr);
+      if (!mesh)
+        throw std::runtime_error("null mesh");
+      const int value = mesh->value();
+      std::cout << "value="<<value<<std::endl;
+      if (value != 42)
+        throw std::runtime_error("wrong value");
+    }
+  }
+}
+
+
 %include "example.h"
 
 %inline %{

--- a/Examples/python/external_runtime/example.i
+++ b/Examples/python/external_runtime/example.i
@@ -1,0 +1,16 @@
+/* File : example.i */
+%module(docstring="external runtime") example
+%{
+#include "example.h"
+%}
+
+%include "example.h"
+
+%inline %{
+// The -builtin SWIG option results in SWIGPYTHON_BUILTIN being defined
+#ifdef SWIGPYTHON_BUILTIN
+bool is_python_builtin() { return true; }
+#else
+bool is_python_builtin() { return false; }
+#endif
+%}

--- a/Examples/python/external_runtime/runme.py
+++ b/Examples/python/external_runtime/runme.py
@@ -14,9 +14,6 @@ class PyFunction(object):
 if not example.is_python_builtin():
     obj = PyFunction()
     f = example.Function(obj)
-    value = f.meshValue()
-    print(value)
-    assert value == 42
     print('OK')
 
 # All done.

--- a/Examples/python/external_runtime/runme.py
+++ b/Examples/python/external_runtime/runme.py
@@ -1,0 +1,25 @@
+# file: runme.py
+
+# This file illustrates the external runtime feature.
+
+import example
+
+
+class PyFunction(object):
+    def __init__(self):
+        self.__mesh = example.Mesh(42)
+    def mesh(self):
+        return self.__mesh
+
+if not example.is_python_builtin():
+    obj = PyFunction()
+    f = example.Function(obj)
+    value = f.meshValue()
+    print(value)
+    assert value == 42
+    print('OK')
+
+# All done.
+
+print("")
+print("python exit")

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -335,6 +335,10 @@ swig_varlink_setattr(PyObject *o, char *n, PyObject *p) {
   return res;
 }
 
+#if defined(Py_LIMITED_API)
+# define SWIG_HEAPTYPES
+#endif
+
 SWIGINTERN PyTypeObject*
 swig_varlink_type(void) {
   static char varlink__doc__[] = "Swig var link object";


### PR DESCRIPTION
Fixes 500d3e1, Seems SWIG_HEAPTYPES is needed when compiling with Py_LIMITED_API (py3.9) else I get this error:
swigpyrun.h:1415:23: error: variable has incomplete type 'PyTypeObject' (aka '_typeobject')
  static PyTypeObject varlink_type;

/cc @ojwb