### PR TITLE
Add SWIG_fail to java

### DIFF
--- a/Doc/Manual/Java.html
+++ b/Doc/Manual/Java.html
@@ -4329,7 +4329,7 @@ For example, you can just ignore them:
   if ($error) {
     $directorthrowshandlers
     jenv-&gt;ExceptionClear();
-    return $null; // exception is ignored
+    SWIG_fail; // exception is ignored
   }
 %}
 </pre>
@@ -4380,7 +4380,7 @@ You can copy the code below into an interface file and run SWIG on it and examin
     std::cout &lt;&lt; "Generic std::exception catch handler" &lt;&lt; std::endl;
     jclass clazz = jenv-&gt;FindClass("java/lang/RuntimeException");
     jenv-&gt;ThrowNew(clazz, e.what()); 
-    return $null;
+    SWIG_fail;
   }
 %}
 
@@ -4413,7 +4413,7 @@ namespace MyNS {
     std::cout &lt;&lt; "$1_type class found (throws typemap)" &lt;&lt; std::endl;
     jenv-&gt;ThrowNew(excep, $1.whatsup());
   }
-  return $null;
+  SWIG_fail;
 %}
 
 // These are the exceptions that the director method MyClass::dirmethod will have catch handlers for.
@@ -5115,7 +5115,7 @@ or a NULL pointer perhaps).  Here is a simple example of how you might handle th
   if (!result) {
     jclass clazz = (*jenv)-&gt;FindClass(jenv, "java/lang/OutOfMemoryError");
     (*jenv)-&gt;ThrowNew(jenv, clazz, "Not enough memory");
-    return $null;
+    SWIG_fail;
   }
 }
 void *malloc(size_t nbytes);
@@ -5157,7 +5157,7 @@ that.  For example:
   if (err_occurred()) {
     jclass clazz = (*jenv)-&gt;FindClass(jenv, "java/lang/OutOfMemoryError");
     (*jenv)-&gt;ThrowNew(jenv, clazz, "Not enough memory");
-    return $null;
+    SWIG_fail;
   }
 }
 void *malloc(size_t nbytes);
@@ -5167,7 +5167,7 @@ void *malloc(size_t nbytes);
 <p>
 If no declaration name is given to <tt>%exception</tt>, it is applied to all wrapper functions.
 The <tt>$action</tt> is a SWIG special variable and is replaced by the C/C++ function call being wrapped.
-The <tt>return $null;</tt> handles all native method return types, namely those that have a void return and those that do not.
+The <tt>SWIG_fail;</tt> handles all native method return types, namely those that have a void return and those that do not.
 This is useful for typemaps that will be used in native method returning all return types. 
 See the section on
 <a href="#Java_special_variables">Java special variables</a> for further explanation.
@@ -5185,7 +5185,7 @@ We can catch the C++ exception and rethrow it as a Java exception like this:</p>
   } catch (std::out_of_range &amp;e) {
     jclass clazz = jenv-&gt;FindClass("java/lang/Exception");
     jenv-&gt;ThrowNew(clazz, "Range error");
-    return $null;
+    SWIG_fail;
   }
 }
 
@@ -5214,7 +5214,7 @@ See <a href="Customization.html#Customization_clearing_features">Clearing featur
   } catch (std::out_of_range &amp;e) {
     jclass clazz = jenv-&gt;FindClass("java/lang/Exception");
     jenv-&gt;ThrowNew(clazz, "Range error");
-    return $null;
+    SWIG_fail;
   }
 }
 
@@ -5245,6 +5245,14 @@ public class FooClass {
 The examples above first use the C JNI calling syntax then the C++ JNI calling syntax. The C++ calling syntax will not compile as C and also vice versa.
 It is however possible to write JNI calls which will compile under both C and C++ and is covered in the <a href="#Java_typemaps_for_c_and_cpp">Typemaps for both C and C++ compilation</a> section. 
 </p>
+
+<p>
+<tt>SWIG_fail</tt> is a C macro which when called within the context of SWIG wrapper function,
+will jump to the error handler code. This will call any cleanup code (freeing any temp variables)
+and then return from the wrapper function so that the JVM can raise the Java exception.
+This macro should always be called after setting a Java error in code snippets, such as typemaps and <tt>%exception</tt>, that are ultimately generated into the wrapper function.
+</p>
+
 
 <p>
 The language-independent <tt>exception.i</tt> library file can also be used
@@ -6425,6 +6433,13 @@ The "argout" typemap sometimes sets values in function parameters which are pass
 </p>
 
 <p>
+If you need an intermediate variable in your "in" typemap that also needs a "freearg" you need to
+put its declaration in an "initarg" typemap. This is so that its initialization happens before
+any "SWIG_fail" lines (as SWIG_fail does a "goto", and gotos may not skip variable initialization).
+You can look at the predefined "std::string_view" typemaps for examples.
+</p>
+
+<p>
 Note that the "in" typemap marshals the JNI type held in the "jni" typemap to the real C/C++ type and for the opposite direction,
 the "out" typemap marshals the real C/C++ type to the JNI type held in the "jni" typemap.
 For <a href="#Java_default_non_primitive_typemaps">non-primitive types</a> 
@@ -6683,7 +6698,7 @@ Used in input typemaps to return early from JNI functions that have either void 
 %typemap(check) int * %{ 
   if (error) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array element error");
-    return $null;
+    SWIG_fail;
   }
 %}
 </pre></div>
@@ -7211,7 +7226,7 @@ A typemap for C character strings is:
   $input = 0;
   if ($1) {
     $input = JCALL1(NewStringUTF, jenv, (const char *)$1);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
   }
   Swig::LocalRefGuard $1_refguard(jenv, $input);
 }
@@ -7266,7 +7281,7 @@ A typemap for C character strings is:
   $1 = 0;
   if ($input) {
     $result = (char *)jenv-&gt;GetStringUTFChars($input, 0);
-    if (!$1) return $null;
+    if (!$1) SWIG_fail;
   }
 }
 </pre>
@@ -7585,7 +7600,7 @@ The default generic "throws" typemap looks like this:
 %typemap(throws) SWIGTYPE, SWIGTYPE &amp;, SWIGTYPE *, SWIGTYPE [ANY] %{
   SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException,
                           "C++ $1_type exception thrown");
-  return $null;
+  SWIG_fail;
 %}
 </pre>
 </div>
@@ -7603,7 +7618,7 @@ If, however, we wanted to throw a checked exception, say <tt>java.io.IOException
   jclass excep = jenv-&gt;FindClass("java/io/IOException");
   if (excep)
     jenv-&gt;ThrowNew(excep, $1.what().c_str());
-  return $null;
+  SWIG_fail;
 }
 </pre>
 </div>

--- a/Examples/java/multimap/example.i
+++ b/Examples/java/multimap/example.i
@@ -24,7 +24,7 @@ int i;
   $1 = (*jenv)->GetArrayLength(jenv, $input);
   if ($1 == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   $2 = (char **) malloc(($1+1)*sizeof(char *));
   jsarray = (jstring *) malloc($1*sizeof(jstring));

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -28,6 +28,7 @@ CPP_TEST_CASES = \
 	enum_thorough_simple \
 	enum_thorough_typeunsafe \
 	exception_partial_info \
+	exception_memory_leak \
 	intermediary_classname \
 	java_constants \
 	java_director \

--- a/Examples/test-suite/java/exception_memory_leak_runme.java
+++ b/Examples/test-suite/java/exception_memory_leak_runme.java
@@ -1,0 +1,47 @@
+import exception_memory_leak.*;
+
+public class exception_memory_leak_runme {
+  static {
+    try {
+      System.loadLibrary("exception_memory_leak");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+  public static void main(String argv[]) {
+    Foo a = new Foo();
+    if (a.get_count() != 1) throw new RuntimeException("Should have 1 Foo objects");
+
+    Foo b = new Foo();
+    if (a.get_count() != 2) throw new RuntimeException("Should have 2 Foo objects");
+
+    // Normal behaviour
+    exception_memory_leak.trigger_internal_swig_exception("no problem", a);
+    if (a.get_count() != 2) throw new RuntimeException("Should have 2 Foo objects");
+    if (a.get_freearg_count() != 1) throw new RuntimeException("freearg should have been used once");
+
+    // SWIG exception triggered and handled (return new object case).
+    String message = null;
+    try {
+        exception_memory_leak.trigger_internal_swig_exception("null", b);
+    } catch (Throwable t) {
+        message = t.getMessage();
+    }
+    if (!message.equals("Let's see how the bindings manage this exception!")) throw new RuntimeException("Didn't throw the right exception");
+
+    if (a.get_count() != 2) throw new RuntimeException("Should have 2 Foo objects (got " + String.valueOf(a.get_count()) + ")");
+    if (a.get_freearg_count() != 2) throw new RuntimeException("freearg should have been used twice");
+
+    // SWIG exception triggered and handled (return by value case).
+    message = null;
+    try {
+        exception_memory_leak.trigger_internal_swig_exception("null", b);
+    } catch (Throwable t) {
+        message = t.getMessage();
+    }
+    if (!message.equals("Let's see how the bindings manage this exception!")) throw new RuntimeException("Didn't throw the right exception");
+
+    if (a.get_count() != 2) throw new RuntimeException("Should have 2 Foo objects (got " + String.valueOf(a.get_count()) + ")");
+  }
+}

--- a/Examples/test-suite/java_director_exception_feature.i
+++ b/Examples/test-suite/java_director_exception_feature.i
@@ -76,7 +76,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, $1.what());
    }
-  return $null;
+  SWIG_fail;
 %}
 
 %typemap(throws,throws="MyJavaException1") int %{
@@ -85,7 +85,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, "Threw some integer");
   }
-  return $null;
+  SWIG_fail;
 %}
 
 %typemap(throws,throws="MyJavaException2") MyNS::Exception2 %{
@@ -93,7 +93,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, $1.what());
   }
-  return $null;
+  SWIG_fail;
 %}
 
 %typemap(throws,throws="MyJavaUnexpected") MyNS::Unexpected %{
@@ -101,7 +101,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, $1.what());
   }
-  return $null;
+  SWIG_fail;
 %}
 
 // Use generic exception translation approach like python, ruby
@@ -126,7 +126,7 @@
     $action
   } catch (Swig::DirectorException & direxcp) {
     direxcp.throwException(jenv);  // jenv always available in JNI code
-    return $null;
+    SWIG_fail;
   }
 %}
 

--- a/Examples/test-suite/java_director_exception_feature_nspace.i
+++ b/Examples/test-suite/java_director_exception_feature_nspace.i
@@ -82,7 +82,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, $1.what());
    }
-  return $null;
+  SWIG_fail;
 %}
 
 %typemap(throws,throws=PACKAGEDOT"MyNS.MyJavaException1") int %{
@@ -91,7 +91,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, "Threw some integer");
   }
-  return $null;
+  SWIG_fail;
 %}
 
 %typemap(throws,throws=PACKAGEDOT"MyNS.MyJavaException2") MyNS::Exception2 %{
@@ -99,7 +99,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, $1.what());
   }
-  return $null;
+  SWIG_fail;
 %}
 
 
@@ -108,7 +108,7 @@
   if (excpcls) {
     jenv->ThrowNew(excpcls, $1.what());
   }
-  return $null;
+  SWIG_fail;
 %}
 
 // Use generic exception translation approach like python, ruby
@@ -133,7 +133,7 @@
     $action
   } catch (Swig::DirectorException & direxcp) {
     direxcp.throwException(jenv);  // jenv always available in JNI code
-    return $null;
+    SWIG_fail;
   }
 %}
 

--- a/Examples/test-suite/java_throws.i
+++ b/Examples/test-suite/java_throws.i
@@ -20,7 +20,7 @@
         jclass excep = jenv->FindClass("java/lang/NoSuchFieldException");
         if (excep)
             jenv->ThrowNew(excep, "Value of 10 not acceptable");
-        return $null;
+        SWIG_fail;
     }
 }
 
@@ -42,7 +42,7 @@ short full_of_exceptions(int num) {
     if (excep) {
         jenv->ThrowNew(excep, "Test exception");
     }
-    return $null;
+    SWIG_fail;
 }
 %inline %{
 bool throw_spec_function(int value) TESTCASE_THROW1(int) { throw (int)0; }
@@ -106,7 +106,7 @@ try {
     jclass excep = jenv->FindClass("java_throws/MyException");
     if (excep)
         jenv->ThrowNew(excep, "exception message");
-    return $null;
+    SWIG_fail;
 }
 %}
 %enddef
@@ -155,7 +155,7 @@ try {
     jclass excep = jenv->FindClass("java_throws/MyException");
     if (excep)
         jenv->ThrowNew(excep, "exception message");
-    return $null;
+    SWIG_fail;
 }
 %}
 
@@ -174,7 +174,7 @@ try {
     jclass excep = jenv->FindClass("java_throws/MyException");
     if (excep)
         jenv->ThrowNew(excep, "exception message");
-    return $null;
+    SWIG_fail;
 }
 %}
 

--- a/Lib/exception.i
+++ b/Lib/exception.i
@@ -132,7 +132,7 @@ SWIGINTERN void SWIG_JavaException(JNIEnv *jenv, int code, const char *msg) {
 %}
 
 #define SWIG_exception(code, msg)\
-{ SWIG_JavaException(jenv, code, msg); return $null; }
+{ SWIG_JavaException(jenv, code, msg); SWIG_fail; }
 #endif // SWIGJAVA
 
 #ifdef SWIGOCAML

--- a/Lib/java/argcargv.i
+++ b/Lib/java/argcargv.i
@@ -10,17 +10,17 @@
   $1_ltype i, len;
   if ($input == (jobjectArray)0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null array");
-    return $null;
+    SWIG_fail;
   }
   len = ($1_ltype)JCALL1(GetArrayLength, jenv, $input);
   if (len < 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, "array length negative");
-    return $null;
+    SWIG_fail;
   }
   $2 = ($2_ltype) malloc((len+1)*sizeof($*2_ltype));
   if ($2 == NULL) {
     SWIG_JavaThrowException(jenv, SWIG_JavaOutOfMemoryError, "memory allocation failed");
-    return $null;
+    SWIG_fail;
   }
   $1 = len;
   for (i = 0; i < len; i++) {

--- a/Lib/java/arrays_java.i
+++ b/Lib/java/arrays_java.i
@@ -147,13 +147,13 @@ JAVA_ARRAYS_IMPL(double, jdouble, Double, Double)     /* double[] */
 %typemap(jstype) CTYPE[ANY], CTYPE[]            %{JTYPE[]%}
 
 %typemap(in) CTYPE[] (JNITYPE *jarr)
-%{  if (!SWIG_JavaArrayIn##JFUNCNAME(jenv, &jarr, ($&1_ltype)&$1, $input)) return $null; %}
+%{  if (!SWIG_JavaArrayIn##JFUNCNAME(jenv, &jarr, ($&1_ltype)&$1, $input)) SWIG_fail; %}
 %typemap(in) CTYPE[ANY] (JNITYPE *jarr)
 %{  if ($input && JCALL1(GetArrayLength, jenv, $input) != $1_size) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "incorrect array size");
-    return $null;
+    SWIG_fail;
   }
-  if (!SWIG_JavaArrayIn##JFUNCNAME(jenv, &jarr, ($&1_ltype)&$1, $input)) return $null; %}
+  if (!SWIG_JavaArrayIn##JFUNCNAME(jenv, &jarr, ($&1_ltype)&$1, $input)) SWIG_fail; %}
 %typemap(argout) CTYPE[ANY], CTYPE[] 
 %{ SWIG_JavaArrayArgout##JFUNCNAME(jenv, jarr$argnum, ($1_ltype)$1, $input); %}
 %typemap(out) CTYPE[ANY]
@@ -255,12 +255,12 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
   int i;
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null array");
-    return $null;
+    SWIG_fail;
   }
   sz = JCALL1(GetArrayLength, jenv, $input);
   jarr = JCALL2(GetLongArrayElements, jenv, $input, 0);
   if (!jarr) {
-    return $null;
+    SWIG_fail;
   }
 #ifdef __cplusplus
   $1 = new $*1_ltype[sz];
@@ -269,7 +269,7 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
 #endif
   if (!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaOutOfMemoryError, "array memory allocation failed");
-    return $null;
+    SWIG_fail;
   }
   for (i=0; i<sz; i++) {
     $1[i] = **($&1_ltype)&jarr[i];
@@ -281,16 +281,16 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
   int i;
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null array");
-    return $null;
+    SWIG_fail;
   }
   sz = JCALL1(GetArrayLength, jenv, $input);
   if (sz != $1_size) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "incorrect array size");
-    return $null;
+    SWIG_fail;
   }
   jarr = JCALL2(GetLongArrayElements, jenv, $input, 0);
   if (!jarr) {
-    return $null;
+    SWIG_fail;
   }
 #ifdef __cplusplus
   $1 = new $*1_ltype[sz];
@@ -299,7 +299,7 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
 #endif
   if (!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaOutOfMemoryError, "array memory allocation failed");
-    return $null;
+    SWIG_fail;
   }
   for (i=0; i<sz; i++) {
     $1[i] = **($&1_ltype)&jarr[i];
@@ -321,11 +321,11 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
   int i;
   $result = JCALL1(NewLongArray, jenv, $1_dim0);
   if (!$result) {
-    return $null;
+    SWIG_fail;
   }
   arr = JCALL2(GetLongArrayElements, jenv, $result, 0);
   if (!arr) {
-    return $null;
+    SWIG_fail;
   }
   for (i=0; i<$1_dim0; i++) {
     arr[i] = 0;
@@ -377,13 +377,13 @@ JAVA_ARRAYS_TYPEMAPS(double, double, jdouble, Double, "[D")     /* double[ANY] *
   }
 
 %typemap(in) ARRAYSOFENUMS[] (jint *jarr)
-%{  if (!SWIG_JavaArrayInInt(jenv, &jarr, (int **)&$1, $input)) return $null; %}
+%{  if (!SWIG_JavaArrayInInt(jenv, &jarr, (int **)&$1, $input)) SWIG_fail; %}
 %typemap(in) ARRAYSOFENUMS[ANY] (jint *jarr) {
   if ($input && JCALL1(GetArrayLength, jenv, $input) != $1_size) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "incorrect array size");
-    return $null;
+    SWIG_fail;
   }
-  if (!SWIG_JavaArrayInInt(jenv, &jarr, (int **)&$1, $input)) return $null;
+  if (!SWIG_JavaArrayInInt(jenv, &jarr, (int **)&$1, $input)) SWIG_fail;
 }
 %typemap(argout) ARRAYSOFENUMS[ANY], ARRAYSOFENUMS[] 
 %{ SWIG_JavaArrayArgoutInt(jenv, jarr$argnum, (int *)$1, $input); %}

--- a/Lib/java/boost_intrusive_ptr.i
+++ b/Lib/java/boost_intrusive_ptr.i
@@ -27,7 +27,7 @@
   argp = (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input) ? (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input)->get() : 0;
   if (!argp) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null $1_type");
-    return $null;
+    SWIG_fail;
   }
   $1 = *argp;
 %}
@@ -62,7 +62,7 @@
   $1 = ($1_ltype)((*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input) ? (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input)->get() : 0);
   if(!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "$1_type reference is null");
-    return $null;
+    SWIG_fail;
   }
 %}
 %typemap(out, fragment="SWIG_intrusive_deleter,SWIG_null_deleter") CONST TYPE & %{
@@ -338,7 +338,7 @@
   argp = (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input) ? (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input)->get() : 0;
   if (!argp) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null $1_type");
-    return $null;
+    SWIG_fail;
   }
   $1 = *argp; %}
 %typemap(out) CONST TYPE
@@ -357,7 +357,7 @@
   $1 = ($1_ltype)((*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input) ? (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input)->get() : 0);
   if (!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "$1_type reference is null");
-    return $null;
+    SWIG_fail;
   } %}
 %typemap(out, fragment="SWIG_null_deleter") CONST TYPE &
 %{ *(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$result = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_$owner); %}

--- a/Lib/java/boost_shared_ptr.i
+++ b/Lib/java/boost_shared_ptr.i
@@ -25,7 +25,7 @@
   argp = (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input) ? (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input)->get() : 0;
   if (!argp) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null $1_type");
-    return $null;
+    SWIG_fail;
   }
   $1 = *argp; %}
 %typemap(out) CONST TYPE
@@ -38,7 +38,7 @@
 %typemap(directorout) CONST TYPE
 %{ if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null $1_type");
-    return $null;
+    SWIG_fail;
   }
   SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > *smartarg = *(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input;
   $result = *smartarg->get();
@@ -67,7 +67,7 @@
   $1 = ($1_ltype)((*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input) ? (*(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$input)->get() : 0);
   if (!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "$1_type reference is null");
-    return $null;
+    SWIG_fail;
   } %}
 %typemap(out, fragment="SWIG_null_deleter") CONST TYPE &
 %{ *(SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE > **)&$result = new SWIG_SHARED_PTR_QNAMESPACE::shared_ptr< CONST TYPE >($1 SWIG_NO_NULL_DELETER_$owner); %}

--- a/Lib/java/cdata.i
+++ b/Lib/java/cdata.i
@@ -30,7 +30,7 @@
   $input = 0;
   if ($1) {
     $input = JCALL1(NewByteArray, jenv, (jsize)$2);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
     JCALL4(SetByteArrayRegion, jenv, $input, 0, (jsize)$2, (jbyte *)$1);
   }
   Swig::LocalRefGuard $1_refguard(jenv, $input);

--- a/Lib/java/java.swg
+++ b/Lib/java/java.swg
@@ -326,7 +326,7 @@ SWIGINTERN jint SWIG_JavaIntFromSize_t(size_t size) {
 
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "BigInteger null");
-    return $null;
+    SWIG_fail;
   }
   clazz = JCALL1(GetObjectClass, jenv, $input);
   mid = JCALL3(GetMethodID, jenv, clazz, "toByteArray", "()[B");
@@ -353,7 +353,7 @@ SWIGINTERN jint SWIG_JavaIntFromSize_t(size_t size) {
 
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "BigInteger null");
-    return $null;
+    SWIG_fail;
   }
   clazz = JCALL1(GetObjectClass, jenv, $input);
   mid = JCALL3(GetMethodID, jenv, clazz, "toByteArray", "()[B");
@@ -421,7 +421,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
  $1 = 0;
   if ($input) {
     $1 = ($1_ltype)JCALL2(GetStringUTFChars, jenv, $input, 0);
-    if (!$1) return $null;
+    if (!$1) SWIG_fail;
   }
 }
 
@@ -429,7 +429,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
   $1 = 0;
   if ($input) {
     $result = ($1_ltype)JCALL2(GetStringUTFChars, jenv, $input, 0);
-    if (!$result) return $null;
+    if (!$result) SWIG_fail;
   }
 }
 
@@ -437,7 +437,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
   $input = 0;
   if ($1) {
     $input = JCALL1(NewStringUTF, jenv, (const char *)$1);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
   }
   Swig::LocalRefGuard $1_refguard(jenv, $input);
 }
@@ -452,7 +452,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
  $1 = 0;
   if ($input) {
     temp = ($*1_ltype)JCALL2(GetStringUTFChars, jenv, $input, 0);
-    if (!temp) return $null;
+    if (!temp) SWIG_fail;
   }
   $1 = &temp;
 }
@@ -577,7 +577,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "BigInteger null");
-    return $null;
+    SWIG_fail;
   }
   clazz = JCALL1(GetObjectClass, jenv, $input);
   mid = JCALL3(GetMethodID, jenv, clazz, "toByteArray", "()[B");
@@ -606,7 +606,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "BigInteger null");
-    return $null;
+    SWIG_fail;
   }
   clazz = JCALL1(GetObjectClass, jenv, $input);
   mid = JCALL3(GetMethodID, jenv, clazz, "toByteArray", "()[B");
@@ -651,7 +651,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 %{ argp = *($&1_ltype*)&$input; 
    if (!argp) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null $1_type");
-     return $null;
+     SWIG_fail;
    }
    $1 = *argp; %}
 
@@ -659,7 +659,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 %{ argp = *($&1_ltype*)&$input; 
    if (!argp) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Unexpected null return for type $1_type");
-     return $null;
+     SWIG_fail;
    }
    $result = *argp; %}
 
@@ -686,19 +686,19 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
   const char *temp = 0;
   if ($input) {
     temp = JCALL2(GetStringUTFChars, jenv, $input, 0);
-    if (!temp) return $null;
+    if (!temp) SWIG_fail;
   }
   SWIG_UnpackData(temp, (void *)&$1, sizeof($1));
 }
 %typemap(in) SWIGTYPE & %{ $1 = *($&1_ltype)&$input;
   if (!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "$1_type is null");
-    return $null;
+    SWIG_fail;
   } %}
 %typemap(in, fragment="<memory>") SWIGTYPE && (std::unique_ptr<$*1_ltype> rvrdeleter) %{ $1 = *($&1_ltype)&$input;
   if (!$1) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "$1_type is null");
-    return $null;
+    SWIG_fail;
   }
   rvrdeleter.reset($1); %}
 %typemap(out) SWIGTYPE *
@@ -727,13 +727,13 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 %typemap(directorout, warning=SWIGWARN_TYPEMAP_DIRECTOROUT_PTR_MSG) SWIGTYPE &
 %{ if (!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Unexpected null return for type $1_type");
-     return $null;
+     SWIG_fail;
    }
    $result = *($&1_ltype)&$input; %}
 %typemap(directorout, warning=SWIGWARN_TYPEMAP_DIRECTOROUT_PTR_MSG) SWIGTYPE &&
 %{ if (!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Unexpected null return for type $1_type");
-     return $null;
+     SWIG_fail;
    }
    $result = *($&1_ltype)&$input; %}
 %typemap(directorin,descriptor="L$packagepath/$javaclassname;") SWIGTYPE &
@@ -756,7 +756,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
   $1 = 0;
   if ($input) {
     $1 = ($1_ltype)JCALL2(GetStringUTFChars, jenv, $input, 0);
-    if (!$1) return $null;
+    if (!$1) SWIG_fail;
   }
 }
 
@@ -764,7 +764,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
   $1 = 0;
   if ($input) {
     $result = ($1_ltype)JCALL2(GetStringUTFChars, jenv, $input, 0);
-    if (!$result) return $null;
+    if (!$result) SWIG_fail;
   }
 }
 
@@ -772,7 +772,7 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
   $input = 0;
   if ($1) {
     $input = JCALL1(NewStringUTF, jenv, (const char *)$1);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
   }
   Swig::LocalRefGuard $1_refguard(jenv, $input);
 }
@@ -1041,21 +1041,21 @@ Swig::LocalRefGuard $1_refguard(jenv, $input); }
 %{ char error_msg[256];
    SWIG_snprintf(error_msg, sizeof(error_msg), "C++ $1_type exception thrown, value: %d", $1);
    SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, error_msg);
-   return $null; %}
+   SWIG_fail; %}
 
 %typemap(throws) SWIGTYPE, SWIGTYPE &, SWIGTYPE &&, SWIGTYPE *, SWIGTYPE [], SWIGTYPE [ANY]
 %{ (void)$1;
    SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, "C++ $1_type exception thrown");
-   return $null; %}
+   SWIG_fail; %}
 
 %typemap(throws) char *
 %{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1);
-   return $null; %}
+   SWIG_fail; %}
 
 /* For methods to raise/throw the original Java exception thrown in a director method */
 %typemap(throws) Swig::DirectorException
 %{  $1.throwException(jenv);
-    return $null; %}
+    SWIG_fail; %}
 
 /* Java to C++ DirectorException should already be handled. Suppress warning and do nothing in the
    event a user specifies a global: %catches(Swig::DirectorException); */
@@ -1443,7 +1443,7 @@ SWIG_PROXY_CONSTRUCTOR(true, true, SWIGTYPE)
   $input = 0;
   if ($1) {
     $input = JCALL1(NewByteArray, jenv, (jsize)$2);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
     JCALL4(SetByteArrayRegion, jenv, $input, 0, (jsize)$2, (jbyte *)$1);
   }
   Swig::LocalRefGuard $1_refguard(jenv, $input);

--- a/Lib/java/javahead.swg
+++ b/Lib/java/javahead.swg
@@ -29,7 +29,11 @@
 #   define JCALL7(func, jenv, ar1, ar2, ar3, ar4, ar5, ar6, ar7) (*jenv)->func(jenv, ar1, ar2, ar3, ar4, ar5, ar6, ar7)
 #endif
 
+#define SWIG_fail                 goto fail
+
 %insert(runtime) %{
+#define SWIG_fail                 goto fail
+
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>

--- a/Lib/java/std_except.i
+++ b/Lib/java/std_except.i
@@ -17,16 +17,16 @@ namespace std
   struct exception {};
 }
 
-%typemap(throws) std::bad_cast          "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n return $null;"
-%typemap(throws) std::bad_exception     "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n return $null;"
-%typemap(throws) std::domain_error      "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n return $null;"
-%typemap(throws) std::exception         "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n return $null;"
-%typemap(throws) std::invalid_argument  "SWIG_JavaThrowException(jenv, SWIG_JavaIllegalArgumentException, $1.what());\n return $null;"
-%typemap(throws) std::length_error      "SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, $1.what());\n return $null;"
-%typemap(throws) std::logic_error       "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n return $null;"
-%typemap(throws) std::out_of_range      "SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, $1.what());\n return $null;"
-%typemap(throws) std::overflow_error    "SWIG_JavaThrowException(jenv, SWIG_JavaArithmeticException, $1.what());\n return $null;"
-%typemap(throws) std::range_error       "SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, $1.what());\n return $null;"
-%typemap(throws) std::runtime_error     "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n return $null;"
-%typemap(throws) std::underflow_error   "SWIG_JavaThrowException(jenv, SWIG_JavaArithmeticException, $1.what());\n return $null;"
+%typemap(throws) std::bad_cast          "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::bad_exception     "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::domain_error      "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::exception         "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::invalid_argument  "SWIG_JavaThrowException(jenv, SWIG_JavaIllegalArgumentException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::length_error      "SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::logic_error       "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::out_of_range      "SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::overflow_error    "SWIG_JavaThrowException(jenv, SWIG_JavaArithmeticException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::range_error       "SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::runtime_error     "SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.what());\n SWIG_fail;"
+%typemap(throws) std::underflow_error   "SWIG_JavaThrowException(jenv, SWIG_JavaArithmeticException, $1.what());\n SWIG_fail;"
 

--- a/Lib/java/std_string.i
+++ b/Lib/java/std_string.i
@@ -29,10 +29,10 @@ class string;
 %typemap(in) string 
 %{ if(!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-     return $null;
+     SWIG_fail;
     } 
     const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
-    if (!$1_pstr) return $null;
+    if (!$1_pstr) SWIG_fail;
     $1.assign($1_pstr);
     jenv->ReleaseStringUTFChars($input, $1_pstr); %}
 
@@ -41,10 +41,10 @@ class string;
      if (!jenv->ExceptionCheck()) {
        SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      }
-     return $null;
+     SWIG_fail;
    } 
    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
-   if (!$1_pstr) return $null;
+   if (!$1_pstr) SWIG_fail;
    $result.assign($1_pstr);
    jenv->ReleaseStringUTFChars($input, $1_pstr); %}
 
@@ -65,7 +65,7 @@ class string;
 
 %typemap(throws) string
 %{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.c_str());
-   return $null; %}
+   SWIG_fail; %}
 
 // const string &
 %typemap(jni) const string & "jstring"
@@ -77,10 +77,10 @@ class string;
 %typemap(in) const string &
 %{ if(!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-     return $null;
+     SWIG_fail;
    }
    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
-   if (!$1_pstr) return $null;
+   if (!$1_pstr) SWIG_fail;
    $*1_ltype $1_str($1_pstr);
    $1 = &$1_str;
    jenv->ReleaseStringUTFChars($input, $1_pstr); %}
@@ -88,10 +88,10 @@ class string;
 %typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const string &
 %{ if(!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-     return $null;
+     SWIG_fail;
    }
    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
-   if (!$1_pstr) return $null;
+   if (!$1_pstr) SWIG_fail;
    /* possible thread/reentrant code problem */
    static $*1_ltype $1_str;
    $1_str = $1_pstr;
@@ -115,7 +115,7 @@ class string;
 
 %typemap(throws) const string &
 %{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, $1.c_str());
-   return $null; %}
+   SWIG_fail; %}
 
 }
 

--- a/Lib/java/std_string_view.i
+++ b/Lib/java/std_string_view.i
@@ -27,13 +27,16 @@ class string_view;
 %typemap(javadirectorin) string_view "$jniinput"
 %typemap(javadirectorout) string_view "$javacall"
 
+%typemap(arginit) string_view
+%{ const char *$1_pstr = 0; %}
+
 %typemap(in) string_view
 %{ if(!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-     return $null;
+     SWIG_fail;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
-   if (!$1_pstr) return $null;
+   $1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   if (!$1_pstr) SWIG_fail;
    $1 = std::string_view($1_pstr); %}
 
 /* std::string_view requires the string data to remain valid while the
@@ -46,10 +49,10 @@ class string_view;
      if (!jenv->ExceptionCheck()) {
        SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      }
-     return $null;
+     SWIG_fail;
    }
    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
-   if (!$1_pstr) return $null;
+   if (!$1_pstr) SWIG_fail;
    /* possible thread/reentrant code problem */
    static std::string $1_str;
    $1_str = $1_pstr;
@@ -77,7 +80,7 @@ class string_view;
 
 %typemap(throws) string_view
 %{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, std::string($1).c_str());
-   return $null; %}
+   SWIG_fail; %}
 
 // const string_view &
 %typemap(jni) const string_view & "jstring"
@@ -86,13 +89,16 @@ class string_view;
 %typemap(javadirectorin) const string_view & "$jniinput"
 %typemap(javadirectorout) const string_view & "$javacall"
 
+%typemap(arginit) const string_view &
+%{ const char *$1_pstr = 0; %}
+
 %typemap(in) const string_view &
 %{ if(!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-     return $null;
+     SWIG_fail;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
-   if (!$1_pstr) return $null;
+   $1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   if (!$1_pstr) SWIG_fail;
    $*1_ltype $1_str($1_pstr);
    $1 = &$1_str; %}
 
@@ -104,10 +110,10 @@ class string_view;
 %typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const string_view &
 %{ if(!$input) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-     return $null;
+     SWIG_fail;
    }
    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
-   if (!$1_pstr) return $null;
+   if (!$1_pstr) SWIG_fail;
    /* possible thread/reentrant code problem */
    static std::string $1_str;
    $1_str = $1_pstr;
@@ -133,6 +139,6 @@ class string_view;
 
 %typemap(throws) const string_view &
 %{ SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, std::string($1).c_str());
-   return $null; %}
+   SWIG_fail; %}
 
 }

--- a/Lib/java/std_wstring.i
+++ b/Lib/java/std_wstring.i
@@ -28,10 +28,10 @@ class wstring;
 %typemap(in) wstring
 %{if(!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null std::wstring");
-    return $null;
+    SWIG_fail;
   }
   const jchar *$1_pstr = jenv->GetStringChars($input, 0);
-  if (!$1_pstr) return $null;
+  if (!$1_pstr) SWIG_fail;
   jsize $1_len = jenv->GetStringLength($input);
   if ($1_len) {
     $1.reserve($1_len);
@@ -45,10 +45,10 @@ class wstring;
 %typemap(directorout) wstring
 %{if(!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null std::wstring");
-    return $null;
+    SWIG_fail;
   }
   const jchar *$1_pstr = jenv->GetStringChars($input, 0);
-  if (!$1_pstr) return $null;
+  if (!$1_pstr) SWIG_fail;
   jsize $1_len = jenv->GetStringLength($input);
   if ($1_len) {
     $result.reserve($1_len);
@@ -93,7 +93,7 @@ class wstring;
     message[i] = (char)$1[i];
   }
   SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, message.c_str());
-  return $null; %}
+  SWIG_fail; %}
 
 // const wstring &
 %typemap(jni) const wstring & "jstring"
@@ -105,10 +105,10 @@ class wstring;
 %typemap(in) const wstring &
 %{if(!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null std::wstring");
-    return $null;
+    SWIG_fail;
   }
   const jchar *$1_pstr = jenv->GetStringChars($input, 0);
-  if (!$1_pstr) return $null;
+  if (!$1_pstr) SWIG_fail;
   jsize $1_len = jenv->GetStringLength($input);
   std::wstring $1_str;
   if ($1_len) {
@@ -124,10 +124,10 @@ class wstring;
 %typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const wstring & 
 %{if(!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null std::wstring");
-    return $null;
+    SWIG_fail;
   }
   const jchar *$1_pstr = jenv->GetStringChars($input, 0);
-  if (!$1_pstr) return $null;
+  if (!$1_pstr) SWIG_fail;
   jsize $1_len = jenv->GetStringLength($input);
   /* possible thread/reentrant code problem */
   static std::wstring $1_str;
@@ -174,7 +174,7 @@ class wstring;
     message[i] = (char)$1[i];
   }
   SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException, message.c_str());
-  return $null; %}
+  SWIG_fail; %}
 
 }
 

--- a/Lib/java/swigmove.i
+++ b/Lib/java/swigmove.i
@@ -9,7 +9,7 @@
 %{ argp = *($&1_ltype*)&$input; 
    if (!argp) {
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null $1_type");
-     return $null;
+     SWIG_fail;
    }
   SwigValueWrapper< $1_ltype >::reset($1, argp); %}
 

--- a/Lib/java/typemaps.i
+++ b/Lib/java/typemaps.i
@@ -101,7 +101,7 @@ INPUT_TYPEMAP(double, jdouble, double, "D");
 
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "BigInteger null");
-    return $null;
+    SWIG_fail;
   }
   clazz = JCALL1(GetObjectClass, jenv, $input);
   mid = JCALL3(GetMethodID, jenv, clazz, "toByteArray", "()[B");
@@ -194,11 +194,11 @@ There are no char *OUTPUT typemaps, however you can apply the signed char * type
 {
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
-    return $null;
+    SWIG_fail;
   }
   if (JCALL1(GetArrayLength, jenv, $input) == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   temp = ($*1_ltype)0;
   $1 = &temp; 
@@ -214,13 +214,13 @@ There are no char *OUTPUT typemaps, however you can apply the signed char * type
 
 %typemap(directorin,descriptor=JNIDESC) TYPE &OUTPUT %{
   $input = JCALL1(New##JAVATYPE##Array, jenv, 1);
-  if (!$input) return $null;
+  if (!$input) SWIG_fail;
   Swig::LocalRefGuard $1_refguard(jenv, $input); %}
 
 %typemap(directorin,descriptor=JNIDESC) TYPE *OUTPUT %{
   if ($1) {
     $input = JCALL1(New##JAVATYPE##Array, jenv, 1);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
   }
   Swig::LocalRefGuard $1_refguard(jenv, $input); %}
 
@@ -264,11 +264,11 @@ OUTPUT_TYPEMAP(double, jdouble, double, Double, "[D", jdoubleArray);
 {
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
-    return $null;
+    SWIG_fail;
   }
   if (JCALL1(GetArrayLength, jenv, $input) == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   temp = false;
   $1 = &temp; 
@@ -384,11 +384,11 @@ There are no char *INOUT typemaps, however you can apply the signed char * typem
 %typemap(in) TYPE *INOUT, TYPE &INOUT {
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
-    return $null;
+    SWIG_fail;
   }
   if (JCALL1(GetArrayLength, jenv, $input) == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   $1 = ($1_ltype) JCALL2(Get##JAVATYPE##ArrayElements, jenv, $input, 0); 
 }
@@ -400,7 +400,7 @@ There are no char *INOUT typemaps, however you can apply the signed char * typem
 
 %typemap(directorin,descriptor=JNIDESC) TYPE &INOUT %{
   $input = JCALL1(New##JAVATYPE##Array, jenv, 1);
-  if (!$input) return $null;
+  if (!$input) SWIG_fail;
   JNITYPE $1_jvalue = (JNITYPE)$1;
   JCALL4(Set##JAVATYPE##ArrayRegion, jenv, $input, 0, 1, &$1_jvalue);
   Swig::LocalRefGuard $1_refguard(jenv, $input); %}
@@ -408,7 +408,7 @@ There are no char *INOUT typemaps, however you can apply the signed char * typem
 %typemap(directorin,descriptor=JNIDESC) TYPE *INOUT %{
   if ($1) {
     $input = JCALL1(New##JAVATYPE##Array, jenv, 1);
-    if (!$input) return $null;
+    if (!$input) SWIG_fail;
     JNITYPE $1_jvalue = (JNITYPE)*$1;
     JCALL4(Set##JAVATYPE##ArrayRegion, jenv, $input, 0, 1, &$1_jvalue);
   }
@@ -454,11 +454,11 @@ INOUT_TYPEMAP(double, jdouble, double, Double, "[D", jdoubleArray);
 %typemap(in) bool *INOUT (bool btemp, jboolean *jbtemp), bool &INOUT (bool btemp, jboolean *jbtemp) {
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
-    return $null;
+    SWIG_fail;
   }
   if (JCALL1(GetArrayLength, jenv, $input) == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   jbtemp = JCALL2(GetBooleanArrayElements, jenv, $input, 0);
   btemp = (*jbtemp) ? true : false;
@@ -498,16 +498,16 @@ INOUT_TYPEMAP(double, jdouble, double, Double, "[D", jdoubleArray);
 
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
-    return $null;
+    SWIG_fail;
   }
   if (JCALL1(GetArrayLength, jenv, $input) == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   bigint = JCALL2(GetObjectArrayElement, jenv, $input, 0);
   if (!bigint) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array element null");
-    return $null;
+    SWIG_fail;
   }
   clazz = JCALL1(GetObjectClass, jenv, bigint);
   mid = JCALL3(GetMethodID, jenv, clazz, "toByteArray", "()[B");

--- a/Lib/java/various.i
+++ b/Lib/java/various.i
@@ -108,11 +108,11 @@
 %typemap(in) char **STRING_OUT($*1_ltype temp) {
   if (!$input) {
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
-    return $null;
+    SWIG_fail;
   }
   if (JCALL1(GetArrayLength, jenv, $input) == 0) {
     SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
-    return $null;
+    SWIG_fail;
   }
   $1 = &temp; 
   *$1 = 0;


### PR DESCRIPTION
Allows removing memory leaks in early exit / error paths.

This would be great to have but is not trivially problem-free:

- This could cause existing code to break, esp. if users have worked around the lack of SWIG_fail in their freearg typemaps or exception handling.
- The way I'm ensuring that the locals that are used in the fail path are declared outside the main body of functions is a bit hacky. I wasn't able to follow how it's done in other languages like python.

See https://github.com/swig/swig/issues/1879 and
https://github.com/swig/swig/issues/2402