### PR TITLE
Added std::optional support for python

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -697,6 +697,7 @@ CPP17_TEST_CASES += \
 	cpp17_map_no_default_ctor \
 	cpp17_nested_namespaces \
 	cpp17_nspace_nested_namespaces \
+	cpp17_optional \
 	cpp17_string_view \
 	cpp17_u8_char_literals \
 

--- a/Examples/test-suite/cpp17_optional.i
+++ b/Examples/test-suite/cpp17_optional.i
@@ -1,5 +1,5 @@
 %module(directors="1") cpp17_optional
-#if defined SWIGCSHARP
+#if defined SWIGCSHARP || defined SWIGPYTHON
 #define SWIG_STD_OPTIONAL_DEFAULT_TYPES
 %include <std_optional.i>
 

--- a/Examples/test-suite/cpp17_optional.i
+++ b/Examples/test-suite/cpp17_optional.i
@@ -1,0 +1,317 @@
+%module(directors="1") cpp17_optional
+#if defined SWIGCSHARP
+%include <std_optional.i>
+
+%optional(test::Struct)
+%optional(test::Point)
+%optional(test::Circle)
+%optional(test::Rect)
+
+%feature("director") test::TestObjectDirected;
+
+%inline %{
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+struct NoNamespaceStruct
+{
+    int a;
+};
+using NoNamespaceStructOptional = std::optional<NoNamespaceStruct>;
+
+namespace test
+{
+    // Example using simple type (eg. std::uint32_t)
+    using SimpleOptional = std::optional<std::uint32_t>;
+
+    // Example using a string
+    using StringOptional = std::optional<std::string>;
+
+    // Example using a struct
+    struct Struct
+    {
+        std::uint32_t a;
+        std::uint32_t b;
+    };
+    using StructOptional = std::optional<Struct>;
+
+
+    // Define a class that uses all the above types (input and output parameters)
+    class TestOptionals
+    {
+    public:
+        TestOptionals() = default;
+
+        SimpleOptional getSimpleOptional() const
+        {
+            return _simpleOptional;
+        }
+        void setSimpleOptional(SimpleOptional const value)
+        {
+            _simpleOptional = value;
+        }
+
+        StringOptional getStringOptional() const
+        {
+            return _stringOptional;
+        }
+        void setStringOptional(StringOptional const& value)
+        {
+            _stringOptional = value;
+        }
+
+        StructOptional getStructOptional() const
+        {
+            return _structOptional;
+        }
+        void setStructOptional(StructOptional const& value)
+        {
+            _structOptional = value;
+        }
+
+    private:
+        SimpleOptional _simpleOptional {};
+        StringOptional _stringOptional {};
+        StructOptional _structOptional {};
+    };
+
+    // Examples/test-suite/cpp17_optional_primitive_types.i
+    class TestObjectPrimitives
+    {
+    
+    public:
+        TestObjectPrimitives(bool done, int i, float f, double d)
+            : _isDone(done)
+            , _numberInt(i)
+            , _numberFloat(f)
+            , _numberDouble(d)
+            , _isDoneOpt(done)
+            , _numberIntOpt(i)
+            , _numberFloatOpt(f)
+            , _numberDoubleOpt(d)
+            , _isNullopt(std::nullopt)
+        { }
+    
+        // Bool optional testing
+        bool                getBool() const { return _isDone; }
+        void                setBool(bool b) { _isDone = b; }
+        std::optional<bool> getBoolOpt() const { return _isDoneOpt; }
+        void                setBoolOpt(std::optional<bool> b) { _isDoneOpt = b; }
+        // Int optional testing
+        int                getInt() const { return _numberInt; }
+        void               setInt(int i) { _numberInt = i; }
+        std::optional<int> getIntOpt() const { return _numberIntOpt; }
+        void               setIntOpt(std::optional<int> i) { _numberIntOpt = i; }
+        // Flaot optional testing
+        float                getFloat() const { return _numberFloat; }
+        void                 setFloat(float f) { _numberFloat = f; }
+        std::optional<float> getFloatOpt() const { return _numberFloatOpt; }
+        void                 setFloatOpt(std::optional<float> f) { _numberFloatOpt = f; }
+        // Double optional testing
+        double                getDouble() const { return _numberDouble; }
+        void                  setDouble(double d) { _numberDouble = d; }
+        std::optional<double> getDoubleOpt() const { return _numberDoubleOpt; }
+        void                  setDoubleOpt(std::optional<double> d) { _numberDoubleOpt = d; }
+    
+        std::optional<bool> getNullopt() const { return _isNullopt; }
+    
+    private:
+        bool   _isDone;
+        int    _numberInt;
+        float  _numberFloat;
+        double _numberDouble;
+    
+        std::optional<bool>   _isDoneOpt;
+        std::optional<int>    _numberIntOpt;
+        std::optional<float>  _numberFloatOpt;
+        std::optional<double> _numberDoubleOpt;
+    
+        std::optional<bool> _isNullopt;
+    };
+    
+    // Examples/test-suite/cpp17_optional_std_types.i
+    class TestObjectString
+    {
+    
+    public:
+        TestObjectString(const std::string& n)
+            : _name(n)
+            , _nameOpt(n)
+        { }
+    
+        std::string getName() const { return _name; }
+        void        setName(std::string s) { _name = s; }
+        // optional
+        std::optional<std::string> getNameOpt() const { return _nameOpt; }
+        void                       setNameOpt(std::optional<std::string> const& s) { _nameOpt = s; }
+    
+    private:
+        std::string                _name;
+        std::optional<std::string> _nameOpt;
+    };
+    
+    // Examples/test-suite/cpp17_optional_custom_types.i
+    struct Point
+    {
+        Point(int xx, int yy)
+            : x(xx)
+            , y(yy)
+        { }
+    
+        Point()
+            : Point(0, 0)
+        { }
+    
+        bool isEqual(const Point& other) const
+        {
+            return (x == other.x && y == other.y);
+        }
+    
+        std::string toString() const
+        {
+            return "Point(" + std::to_string(x) + ", " + std::to_string(y) + ")";
+        }
+        int x;
+        int y;
+    };
+    
+    struct Circle
+    {
+        Circle(const Point& p, int r, const std::string& n)
+            : center(p)
+            , radius(r)
+            , name(n)
+        { }
+        Circle()
+            : center(std::nullopt)
+            , radius(std::nullopt)
+            , name(std::nullopt)
+        { }
+    
+        bool isEqual(const Circle& other) const
+        {
+            if (center.has_value() && other.center.has_value())
+            {
+                if (!center.value().isEqual(other.center.value()))
+                    return false;
+            }
+            if (radius.has_value() && other.radius.has_value())
+            {
+                if (radius.value() != other.radius.value())
+                    return false;
+            }
+            if (name.has_value() && other.name.has_value())
+            {
+                if (name.value() != other.name.value())
+                    return false;
+            }
+            return true;
+        }
+    
+        std::string toString() const
+        {
+            std::string cs = center.has_value() ? center.value().toString() : "";
+            std::string rs = radius.has_value() ? std::to_string(radius.value()) : "";
+            std::string ns = name.has_value() ? name.value() : "";
+            return "Circle(" + cs + ", " + rs + ", " + ns + ")";
+        }
+    
+        std::optional<Point>       center;
+        std::optional<int>         radius;
+        std::optional<std::string> name;
+    };
+    
+    class TestObjectCustom
+    {
+    
+    public:
+        TestObjectCustom(const Point& p, const Circle& c)
+            : _point(p)
+            , _pointOpt(p)
+            , _circleOpt(c)
+        { }
+    
+        Point getPoint() const { return _point; }
+        void  setPoint(const Point& p) { _point = p; }
+        // optional
+        std::optional<Point> getPointOpt() const { return _pointOpt; }
+        void                 setPointOpt(const std::optional<Point>& p) { _pointOpt = p; }
+    
+        const std::optional<Circle>& getCircleOpt() const { return _circleOpt; }
+        void                         setCircleOpt(const std::optional<Circle>& c) { _circleOpt = c; }
+    
+    private:
+        Point                _point;
+        std::optional<Point> _pointOpt;
+    
+        std::optional<Circle> _circleOpt;
+    };
+    
+    // Examples/test-suite/cpp17_directed_optional_callbacks.i
+    class Rect
+    {
+    public:
+        Rect(double w = 1.0, double h = 1.0)
+            : width(w)
+            , height(h)
+        { }
+    
+        double area() const
+        {
+            return width * height;
+        }
+    
+        double perimeter() const
+        {
+            return 2 * (width + height);
+        }
+    
+        std::string toString() const
+        {
+            return "Rect(" + std::to_string(width) + ", " + std::to_string(height) + ")";
+        }
+    
+        double width;
+        double height;
+    };
+    
+    class TestObjectDirected
+    {
+    public:
+        TestObjectDirected() {};
+        virtual ~TestObjectDirected() {};
+    
+        virtual std::string onValueOptionalChanged(const std::optional<std::uint32_t> value) const { return ""; }
+        virtual std::string onReferenceOptionalChanged(const std::optional<std::uint32_t>& reference) const { return ""; }
+    
+        const std::string doValueOptionalChanged(const std::optional<std::uint32_t> value) const
+        {
+            return onValueOptionalChanged(value);
+        }
+    
+        const std::string doReferenceOptionalChanged(const std::optional<std::uint32_t>& reference) const
+        {
+            return onReferenceOptionalChanged(reference);
+        }
+    
+        virtual std::string onClassReferenceOptionalChanged(const std::optional<Rect>& reference) const { return ""; }
+    
+        const std::string doClassReferenceOptionalChanged(const std::optional<Rect>& reference) const
+        {
+            return onClassReferenceOptionalChanged(reference);
+        }
+
+        virtual std::string onStringReferenceOptionalChanged(const std::optional<std::string>& reference) const { return ""; }
+
+        const std::string doStringReferenceOptionalChanged(const std::optional<std::string>& reference) const
+        {
+            return onStringReferenceOptionalChanged(reference);
+        }
+    };
+} // namespace test
+
+%}
+
+#endif

--- a/Examples/test-suite/cpp17_optional.i
+++ b/Examples/test-suite/cpp17_optional.i
@@ -1,5 +1,6 @@
 %module(directors="1") cpp17_optional
 #if defined SWIGCSHARP
+#define SWIG_STD_OPTIONAL_DEFAULT_TYPES
 %include <std_optional.i>
 
 %optional(test::Struct)
@@ -280,8 +281,8 @@ namespace test
     class TestObjectDirected
     {
     public:
-        TestObjectDirected() {};
-        virtual ~TestObjectDirected() {};
+        TestObjectDirected() = default;
+        virtual ~TestObjectDirected() = default;
     
         virtual std::string onValueOptionalChanged(const std::optional<std::uint32_t> value) const { return ""; }
         virtual std::string onReferenceOptionalChanged(const std::optional<std::uint32_t>& reference) const { return ""; }

--- a/Examples/test-suite/csharp/cpp17_optional_runme.cs
+++ b/Examples/test-suite/csharp/cpp17_optional_runme.cs
@@ -1,0 +1,236 @@
+using System;
+using cpp17_optionalNamespace;
+
+public class runme
+{
+	static void Main()
+	{
+		var testOptionals = new TestOptionals();
+
+		// Checking SimpleOptional
+		{
+			var optU32 = testOptionals.getSimpleOptional();
+			if (optU32 != null || optU32 is uint)
+				throw new Exception("TestOptionals.getSimpleOptional() failed");
+			testOptionals.setSimpleOptional(42u);
+			optU32 = testOptionals.getSimpleOptional();
+			if (optU32 == null || !(optU32 is uint))
+				throw new Exception("TestOptionals.setSimpleOptional() failed");
+			testOptionals.setSimpleOptional(null);
+			optU32 = testOptionals.getSimpleOptional();
+			if (optU32 != null || optU32 is uint)
+				throw new Exception("TestOptionals.setSimpleOptional() failed");
+		}
+
+		// Checking StringOptional
+		{
+			var optStr = testOptionals.getStringOptional();
+			if (optStr != null || optStr is string)
+				throw new Exception("TestOptionals.getStringOptional() failed");
+			testOptionals.setStringOptional("Hello, World!");
+			optStr = testOptionals.getStringOptional();
+			if (optStr == null || !(optStr is string))
+				throw new Exception("TestOptionals.setStringOptional() failed");
+			testOptionals.setStringOptional(null);
+			optStr = testOptionals.getStringOptional();
+			if (optStr != null || optStr is string)
+				throw new Exception("TestOptionals.setStringOptional() failed");
+		}
+
+		// Checking CustomOptional
+		{
+			// Empty StructOptional
+			{
+				var optStruct = testOptionals.getStructOptional();
+				if (optStruct != null)
+					throw new Exception("TestOptionals.getStructOptional() failed");
+			}
+			// setStructOptional()
+			{
+				var structObj = new Struct { a = 56u, b = 78u };
+				testOptionals.setStructOptional(structObj);
+				var optStruct = testOptionals.getStructOptional();
+				if (optStruct == null)
+					throw new Exception("TestOptionals.setStructOptional() failed");
+				if (optStruct.a != 56u || optStruct.b != 78u)
+					throw new Exception("TestOptionals.setStructOptional() failed");
+				// Clear the optional
+				testOptionals.setStructOptional(null);
+				optStruct = testOptionals.getStructOptional();
+				if (optStruct != null)
+					throw new Exception("TestOptionals.setStructOptional() failed");
+			}
+		}
+
+		// Checking TestObjectString
+		{
+			// getName()
+			{
+				// Initialize the object with a string value
+				var obj = new TestObjectString("InitialName");
+				// Test getName method
+				if (obj.getName() != "InitialName")
+					throw new Exception("TestObjectString.getName() failed");
+			}
+			// setName()
+			{
+				// Initialize with a different string value
+				var obj = new TestObjectString("AnotherName");
+				// Set a new name and verify the getName method
+				obj.setName("NewName");
+				if (obj.getName() != "NewName")
+					throw new Exception("TestObjectString.setName() failed");
+			}
+			// getName()/setName() with optional string
+			{
+				// Initialize with a string value
+				var obj = new TestObjectString("OptionalTest");
+				// Set and get an optional string
+				obj.setNameOpt("OptionalName");
+				if (obj.getNameOpt() != "OptionalName")
+					throw new Exception("TestObjectString.getNameOpt() failed");
+				// Clear the optional string by setting it to null
+				obj.setNameOpt(null);
+				// Verify that the optional string is empty
+				if (obj.getNameOpt() != null)
+					throw new Exception("TestObjectString.getNameOpt() failed");
+			}
+			// getName()/setName() with optional empty string
+			{
+				// Initialize with a string value
+				var obj = new TestObjectString("OptionalTest");
+				// Set and get an optional empty string
+				obj.setNameOpt("");
+				if (obj.getNameOpt() != "")
+					throw new Exception("TestObjectString.getNameOpt() failed");
+				// Clear the optional string by setting it to null
+				obj.setNameOpt(null);
+				// Verify that the optional string is empty
+				if (obj.getNameOpt() != null)
+					throw new Exception("TestObjectString.getNameOpt() failed");
+			}
+		}
+
+		// Checking TestObjectPrimitives
+		{
+			// get/set with primitive types
+			{
+				// Instantiate the object with initial values for bool, int, float, and double
+				var obj = new TestObjectPrimitives(done: true, i: 100, f: 5.55f, d: 9.999);
+				// Test get methods
+				if (obj.getBool() != true || obj.getInt() != 100 || obj.getFloat() != 5.55f || obj.getDouble() != 9.999)
+					throw new Exception("TestObjectPrimitives.get() failed");
+				// Test set methods
+				obj.setBool(false);
+				if (obj.getBool() != false)
+					throw new Exception("TestObjectPrimitives.setBool() failed");
+				obj.setInt(200);
+				if (obj.getInt() != 200)
+					throw new Exception("TestObjectPrimitives.setInt() failed");
+				obj.setFloat(6.66f);
+				if (obj.getFloat() != 6.66f)
+					throw new Exception("TestObjectPrimitives.setFloat() failed");
+				obj.setDouble(8.888);
+				if (obj.getDouble() != 8.888)
+					throw new Exception("TestObjectPrimitives.setDouble() failed");
+			}
+			// get/set with optional primitive types
+			{
+				// Instantiate the object with initial values for bool, int, float, and double
+				var obj = new TestObjectPrimitives(done: true, i: 100, f: 5.55f, d: 9.999);
+				// Test set methods with optional values
+				obj.setBoolOpt(false);
+				if (obj.getBoolOpt() != false)
+					throw new Exception("TestObjectPrimitives.setBoolOpt() failed");
+				obj.setBoolOpt(null);
+				if (obj.getBoolOpt() != null)
+					throw new Exception("TestObjectPrimitives.setBoolOpt() failed");
+				obj.setIntOpt(200);
+				if (obj.getIntOpt() != 200)
+					throw new Exception("TestObjectPrimitives.setIntOpt() failed");
+				obj.setIntOpt(null);
+				if (obj.getIntOpt() != null)
+					throw new Exception("TestObjectPrimitives.setIntOpt() failed");
+				obj.setFloatOpt(6.66f);
+				if (obj.getFloatOpt() != 6.66f)
+					throw new Exception("TestObjectPrimitives.setFloatOpt() failed");
+				obj.setFloatOpt(null);
+				if (obj.getFloatOpt() != null)
+					throw new Exception("TestObjectPrimitives.setFloatOpt() failed");
+				obj.setDoubleOpt(8.888);
+				if (obj.getDoubleOpt() != 8.888)
+					throw new Exception("TestObjectPrimitives.setDoubleOpt() failed");
+				obj.setDoubleOpt(null);
+				if (obj.getDoubleOpt() != null)
+					throw new Exception("TestObjectPrimitives.setDoubleOpt() failed");
+			}
+			// nullopt
+			{
+				// Instantiate the object with initial values for bool, int, float, and double
+				var obj = new TestObjectPrimitives(done: false, i: 109, f: 90.90f, d: 100.100);
+				// getNullopt
+				if (obj.getNullopt() != null)
+					throw new Exception("TestObjectPrimitives.getNullopt() failed");
+			}
+		}
+
+		// Checking DirectedDefault
+		{
+			var testDefaultDirected = new TestObjectDirected();
+			// Test with a valid integer (uint32_t)
+			{
+				string result = testDefaultDirected.doValueOptionalChanged(42);
+				if (result != "")
+					throw new Exception("TestObjectDirected.doValueOptionalChanged() failed");
+			}
+			// Test with null to simulate std::optional being empty
+			{
+				string result = testDefaultDirected.doValueOptionalChanged(null);
+				if (result != "")
+					throw new Exception("TestObjectDirected.doValueOptionalChanged() failed");
+			}
+			// Test with a valid integer (uint32_t) for reference
+			{
+				string result = testDefaultDirected.doReferenceOptionalChanged(42);
+				if (result != "")
+					throw new Exception("TestObjectDirected.doValueOptionalChangedRef() failed");
+			}
+			// Test with null to simulate std::optional reference being empty
+			{
+				string result = testDefaultDirected.doReferenceOptionalChanged(null);
+				if (result != "")
+					throw new Exception("TestObjectDirected.doValueOptionalChangedRef() failed");
+			}
+			// Create a Rect object and test with a valid Rect instance
+			{
+				var rect = new Rect(5.0, 3.0);
+				string result = testDefaultDirected.onClassReferenceOptionalChanged(rect);
+				if (result != "")
+					throw new Exception("TestObjectDirected.onClassReferenceOptionalChanged() failed");
+			}
+			// Test with null to simulate std::optional being empty
+			{
+				string result = testDefaultDirected.onClassReferenceOptionalChanged(null);
+				if (result != "")
+					throw new Exception("TestObjectDirected.onClassReferenceOptionalChanged() failed");
+			}
+		}
+
+		// Checking object instantiation
+		{
+			{
+				var stru = new NoNamespaceStruct();
+				stru.a = 42;
+				if (stru.a != 42)
+					throw new Exception("NoNamespaceStruct instantiation failed");
+			}
+			{
+				var stru = new Struct();
+				stru.a = 42;
+				stru.b = 84;
+				if (stru.a != 42 || stru.b != 84)
+					throw new Exception("Struct instantiation failed");
+			}
+		}
+	}
+}

--- a/Examples/test-suite/csharp/cpp17_optional_runme.cs
+++ b/Examples/test-suite/csharp/cpp17_optional_runme.cs
@@ -52,7 +52,7 @@ public class runme
 				var optStruct = testOptionals.getStructOptional();
 				if (optStruct == null)
 					throw new Exception("TestOptionals.setStructOptional() failed");
-				if (optStruct.a != 56u || optStruct.b != 78u)
+				if (optStruct?.a != 56u || optStruct?.b != 78u)
 					throw new Exception("TestOptionals.setStructOptional() failed");
 				// Clear the optional
 				testOptionals.setStructOptional(null);

--- a/Examples/test-suite/python/cpp17_optional_runme.py
+++ b/Examples/test-suite/python/cpp17_optional_runme.py
@@ -1,0 +1,17 @@
+from cpp17_optional import *
+
+
+test_optionals = TestOptionals()
+
+# Checking SimpleOptional
+
+# test_simple_optional_initial_get
+optU32 = test_optionals.getSimpleOptional()
+assert optU32 is None or isinstance(optU32, int), "test_optionals.getSimpleOptional(): Expected None or int, got {}".format(repr(optU32))
+
+# test_simple_optional_set
+optU32 = 32
+test_optionals.setSimpleOptional(optU32)
+
+optU32_after_set = test_optionals.getSimpleOptional()
+assert optU32_after_set == 32, "test_optionals.setSimpleOptional(): Expected 32, got {}".format(repr(optU32_after_set))

--- a/Examples/test-suite/python/cpp17_optional_runme.py
+++ b/Examples/test-suite/python/cpp17_optional_runme.py
@@ -1,17 +1,459 @@
 from cpp17_optional import *
 
-
 test_optionals = TestOptionals()
 
-# Checking SimpleOptional
 
-# test_simple_optional_initial_get
+# Simple Optional
+# -----------------------------------------------------------------------------
+
+# test get simple optional initial
 optU32 = test_optionals.getSimpleOptional()
+
 assert optU32 is None or isinstance(optU32, int), "test_optionals.getSimpleOptional(): Expected None or int, got {}".format(repr(optU32))
 
-# test_simple_optional_set
+# test set simple optional
 optU32 = 32
+
 test_optionals.setSimpleOptional(optU32)
 
 optU32_after_set = test_optionals.getSimpleOptional()
 assert optU32_after_set == 32, "test_optionals.setSimpleOptional(): Expected 32, got {}".format(repr(optU32_after_set))
+
+# test clear simple optional
+test_optionals.setSimpleOptional(32)
+
+test_optionals.setSimpleOptional(None)
+
+optU32_after_clear = test_optionals.getSimpleOptional()
+assert optU32_after_clear is None, "Expected None after clear, got {}".format(repr(optU32_after_clear))
+
+
+# String Optional
+# -----------------------------------------------------------------------------
+
+# test get string optional initial
+optStr = test_optionals.getStringOptional()
+assert optStr is None or isinstance(optStr, str), "Expected None or string, got {}".format(repr(optStr))
+
+# test set string optional
+optStr = "Hello, World!"
+
+test_optionals.setStringOptional(optStr)
+
+optStr_after_set = test_optionals.getStringOptional()
+assert optStr_after_set == "Hello, World!", "Expected 'Hello, World!', got {}".format(repr(optStr_after_set))
+
+# test clear string optional
+test_optionals.setStringOptional("Test String")
+
+test_optionals.setStringOptional(None)
+
+optStr_after_clear = test_optionals.getStringOptional()
+assert optStr_after_clear is None, "Expected None after clear, got {}".format(repr(optStr_after_clear))
+
+
+# Custom class Optional
+# -----------------------------------------------------------------------------
+
+# test initial get struct optional
+optStruct = test_optionals.getStructOptional()
+assert optStruct is None or isinstance(optStruct, Struct), "Expected None or Struct, got {}".format(repr(optStruct))
+
+# test set struct optional
+struct = Struct()
+struct.a = 56
+struct.b = 78
+
+test_optionals.setStructOptional(struct)
+
+optStruct_after_set = test_optionals.getStructOptional()
+assert isinstance(optStruct_after_set, Struct), "Expected Struct instance, got {}".format(repr(optStruct_after_set))
+assert optStruct_after_set.a == 56, "Expected struct.a to be 56, got {}".format(optStruct_after_set.a)
+assert optStruct_after_set.b == 78, "Expected struct.b to be 78, got {}".format(optStruct_after_set.b)
+
+# test clear struct optional
+struct = Struct()
+struct.a = 12
+struct.b = 34
+test_optionals.setStructOptional(struct)
+
+test_optionals.setStructOptional(None)
+
+optStruct_after_clear = test_optionals.getStructOptional()
+assert optStruct_after_clear is None, "Expected None after clear, got {}".format(repr(optStruct_after_clear))
+
+
+# Primitive type Optionals
+# -----------------------------------------------------------------------------
+
+# test primitive optionals initial values
+fpTolerance = 1e-6
+obj = TestObjectPrimitives(done=True, i=100, f=5.55, d=9.999)
+
+assert obj.getBool() == True, "Expected True, got {}".format(obj.getBool())
+assert obj.getInt() == 100, "Expected 100, got {}".format(obj.getInt())
+assert obj.getFloat() <= 5.55 + fpTolerance and obj.getFloat() >= 5.55 - fpTolerance, "Expected 5.55, got {}".format(obj.getFloat())
+assert obj.getDouble() <= 9.999 + fpTolerance and obj.getDouble() >= 9.999 - fpTolerance, "Expected 9.999, got {}".format(obj.getDouble())
+
+# test set and get bool optional
+obj = TestObjectPrimitives(done=False, i=101, f=10.10, d=20.202)
+
+obj.setBool(True)
+assert obj.getBool() == True, "Expected True, got {}".format(obj.getBool())
+
+obj.setBool(False)
+assert obj.getBool() == False, "Expected False, got {}".format(obj.getBool())
+
+# test set and get int optional
+obj = TestObjectPrimitives(done=True, i=102, f=20.20, d=30.303)
+
+obj.setInt(99)
+assert obj.getInt() == 99, "Expected 99, got {}".format(obj.getInt())
+
+# test set and get float optional
+tolerance = 1e-6
+obj = TestObjectPrimitives(done=False, i=103, f=30.30, d=40.404)
+
+obj.setFloat(1.23)
+assert obj.getFloat() <= 1.23 + tolerance and obj.getFloat() >= 1.23 - tolerance, "Expected 1.23, got {}".format(obj.getFloat())
+
+# test set and get double optional
+tolerance = 1e-6
+obj = TestObjectPrimitives(done=True, i=104, f=40.40, d=50.505)
+
+obj.setDouble(3.14159)
+assert obj.getDouble() == 3.14159, "Expected 3.14159, got {}".format(obj.getDouble()) #CHECKME tolerance?
+
+# test clear bool optional
+obj = TestObjectPrimitives(done=False, i=105, f=50.50, d=60.606)
+
+obj.setBoolOpt(True)
+assert obj.getBoolOpt() == True, "Expected True, got {}".format(obj.getBoolOpt())
+
+obj.setBoolOpt(None)
+assert obj.getBoolOpt() is None, "Expected None, got {}".format(obj.getBoolOpt())
+
+# test clear int optional
+obj = TestObjectPrimitives(done=True, i=106, f=60.60, d=70.707)
+
+obj.setIntOpt(123)
+assert obj.getIntOpt() == 123, "Expected 123, got {}".format(obj.getIntOpt())
+
+obj.setIntOpt(None)
+assert obj.getIntOpt() is None, "Expected None, got {}".format(obj.getIntOpt())
+
+# test clear float optional
+tolerance = 1e-6
+obj = TestObjectPrimitives(done=False, i=107, f=70.70, d=80.808)
+
+obj.setFloatOpt(4.56)
+assert obj.getFloatOpt() <= 4.56 + tolerance and obj.getFloatOpt() >= 4.56 - tolerance, "Expected 4.56, got {}".format(obj.getFloatOpt())
+
+obj.setFloatOpt(None)
+assert obj.getFloatOpt() is None, "Expected None, got {}".format(obj.getFloatOpt())
+
+# test clear double optional
+obj = TestObjectPrimitives(done=True, i=108, f=80.80, d=90.909)
+
+obj.setDoubleOpt(6.789)
+assert obj.getDoubleOpt() == 6.789, "Expected 6.789, got {}".format(obj.getDoubleOpt())
+
+obj.setDoubleOpt(None)
+assert obj.getDoubleOpt() is None, "Expected None, got {}".format(obj.getDoubleOpt())
+
+# test get nullopt optional
+obj = TestObjectPrimitives(done=False, i=109, f=90.90, d=100.100)
+
+assert obj.getNullopt() is None, "Expected None, got {}".format(obj.getNullopt())
+
+
+# std types Optionals
+# -----------------------------------------------------------------------------
+
+# test std::string initial optional
+obj = TestObjectString("InitialName")
+
+assert obj.getName() == "InitialName", "Expected 'InitialName', got {}".format(obj.getName())
+
+# test set and get std::string optional
+obj = TestObjectString("AnotherName")
+
+obj.setName("NewName")
+assert obj.getName() == "NewName", "Expected 'NewName', got {}".format(obj.getName())
+
+# test clear std::string optional
+obj = TestObjectString("OptionalTest")
+
+obj.setNameOpt("OptionalName")
+assert obj.getNameOpt() == "OptionalName", "Expected 'OptionalName', got {}".format(obj.getNameOpt())
+
+obj.setNameOpt(None)
+assert obj.getNameOpt() is None, "Expected None, got {}".format(obj.getNameOpt())
+
+# test set and get empty std::string optional
+obj = TestObjectString("")
+
+assert obj.getName() == "", "Expected empty string, got '{}'".format(obj.getName())
+
+obj.setName("")
+assert obj.getName() == "", "Expected empty string, got '{}'".format(obj.getName())
+
+# test empty std::string optional
+obj = TestObjectString("NonEmpty")
+
+obj.setNameOpt("")
+assert obj.getNameOpt() == "", "Expected empty string, got {}".format(obj.getNameOpt())
+
+obj.setNameOpt(None)
+assert obj.getNameOpt() is None, "Expected None, got {}".format(obj.getNameOpt())
+
+
+# Custom types Optionals
+# -----------------------------------------------------------------------------
+
+# test point optional instantiation
+point = Point()
+assert point.x == 0, "Expected x to be 0, got {}".format(point.x)
+assert point.y == 0, "Expected y to be 0, got {}".format(point.y)
+assert point.toString() == "Point(0, 0)", "Expected 'Point(0, 0)', got {}".format(point.toString())
+
+point_custom = Point(10, 20)
+assert point_custom.x == 10, "Expected x to be 10, got {}".format(point_custom.x)
+assert point_custom.y == 20, "Expected y to be 20, got {}".format(point_custom.y)
+assert point_custom.toString() == "Point(10, 20)", "Expected 'Point(10, 20)', got {}".format(point_custom.toString())
+
+# test point optional equality
+point1 = Point(10, 20)
+point2 = Point(10, 20)
+point3 = Point(5, 15)
+
+assert point1.isEqual(point2), "Expected point1 to be equal to point2"
+assert not point1.isEqual(point3), "Expected point1 to not be equal to point3"
+
+# test circle optional instantiation
+circle_default = Circle()
+assert circle_default.center is None, "Expected center to be None, got {}".format(circle_default.center)
+assert circle_default.radius is None, "Expected radius to be None, got {}".format(circle_default.radius)
+assert circle_default.name is None, "Expected name to be None, got {}".format(circle_default.name)
+assert circle_default.toString() == "Circle(, , )", "Expected 'Circle(, , )', got {}".format(circle_default.toString())
+
+point = Point(5, 5)
+radius = 10
+name = "TestCircle"
+circle_custom = Circle(point, radius, name)
+assert circle_custom.center.isEqual(point), "Expected center to be {}, got {}".format(point, circle_custom.center)
+assert circle_custom.radius == radius, "Expected radius to be {}, got {}".format(radius, circle_custom.radius)
+assert circle_custom.name == name, "Expected name to be '{}', got {}".format(name, circle_custom.name)
+assert (
+    circle_custom.toString() == "Circle({}, {}, {})".format(point.toString(), radius, name)
+), "Expected 'Circle({}, {}, {})', got {}".format(point.toString(), radius, name, circle_custom.toString())
+
+# test circle optional equality
+point1 = Point(10, 10)
+point2 = Point(15, 15)
+
+circle1 = Circle(point1, 5, "CircleA")
+circle2 = Circle(point1, 5, "CircleA")
+circle3 = Circle(point2, 10, "CircleB")
+
+assert circle1.isEqual(circle2), "Expected circle1 to be equal to circle2"
+assert not circle1.isEqual(circle3), "Expected circle1 to not be equal to circle3"
+
+# test circle optional property assignment
+circle = Circle()
+
+point = Point(3, 4)
+radius = 20
+name = "UpdatedCircle"
+
+circle.center = point
+circle.radius = radius
+circle.name = name
+
+assert circle.center.isEqual(point), "Expected center to be {}, got {}".format(point, circle.center)
+assert circle.radius == radius, "Expected radius to be {}, got {}".format(radius, circle.radius)
+assert circle.name == name, "Expected name to be '{}', got '{}'".format(name, circle.name)
+
+assert (
+    circle.toString() == "Circle({}, {}, {})".format(point.toString(), radius, name)
+), "Expected 'Circle({}, {}, {})', got {}".format(point.toString(), radius, name, circle.toString())
+
+# test circle optional handling
+circle = Circle()
+
+point = Point(10, 10)
+radius = 15
+name = "TestCircle"
+
+circle.center = point
+circle.radius = radius
+circle.name = name
+
+assert circle.center.isEqual(point), "Expected center to be {}, got {}".format(point, circle.center)
+assert circle.radius == radius, "Expected radius to be {}, got {}".format(radius, circle.radius)
+assert circle.name == name, "Expected name to be '{}', got '{}'".format(name, circle.name)
+
+circle.center = None
+circle.radius = None
+circle.name = None
+
+assert circle.center is None, "Expected center to be None, got {}".format(circle.center)
+assert circle.radius is None, "Expected radius to be None, got {}".format(circle.radius)
+assert circle.name is None, "Expected name to be None, got {}".format(circle.name)
+
+# test custom optional initialization
+point = Point(1, 2)  # Assuming Point takes (x, y) arguments
+circle = Circle(Point(3, 4), 5, "CircleA")  # Circle takes (center Point, radius, name)
+
+obj = TestObjectCustom(point, circle)
+
+assert obj.getPoint().isEqual(point), "Expected point {}, got {}".format(point.toString(), obj.getPoint().toString())
+assert obj.getPointOpt().isEqual(point), "Expected point {}, got {}".format(point.toString(), obj.getPointOpt().toString())
+assert obj.getCircleOpt().isEqual(
+    circle
+), "Expected circle {}, got {}".format(circle.toString(), obj.getCircleOpt().toString())
+
+# test set and get custom optional
+point = Point(5, 6)
+circle = Circle(Point(7, 8), 10, "CircleB")
+
+obj = TestObjectCustom(point, circle)
+
+new_point = Point(10, 20)
+obj.setPoint(new_point)
+
+assert obj.getPoint().isEqual(new_point), "Expected point {}, got {}".format(new_point.toString(), obj.getPoint().toString())
+
+# test set and get custom optional (cleared point)
+point = Point(1, 2)
+circle = Circle(Point(3, 4), 5, "CircleA")
+
+obj = TestObjectCustom(point, circle)
+
+new_point = Point(15, 25)
+obj.setPointOpt(new_point)
+
+assert obj.getPointOpt().isEqual(
+    new_point
+), "Expected optional point {}, got {}".format(new_point.toString(), obj.getPointOpt().toString())
+
+obj.setPointOpt(None)
+
+assert obj.getPointOpt() is None, "Expected None, got a value"
+
+# test set and get custom optional (cleared circle)
+point = Point(1, 2)
+circle = Circle(Point(3, 4), 5, "CircleA")
+
+obj = TestObjectCustom(point, circle)
+
+new_circle = Circle(Point(6, 7), 15, "CircleB")
+obj.setCircleOpt(new_circle)
+
+assert obj.getCircleOpt().isEqual(
+    new_circle
+), "Expected optional circle {}, got {}".format(new_circle.toString(), obj.getCircleOpt().toString())
+
+obj.setCircleOpt(None)
+
+assert obj.getCircleOpt() is None, "Expected None, got a value"
+
+# test clear custom optional (clear point & circle)
+point = Point(5, 5)
+circle = Circle(Point(10, 10), 10, "TestCircle")
+
+obj = TestObjectCustom(point, circle)
+
+new_point = Point(8, 8)
+new_circle = Circle(Point(12, 12), 20, "NewCircle")
+
+obj.setPointOpt(new_point)
+obj.setCircleOpt(new_circle)
+
+assert obj.getPointOpt().isEqual(
+    new_point
+), "Expected optional point {}, got {}".format(new_point.toString(), obj.getPointOpt().toString())
+assert obj.getCircleOpt().isEqual(
+    new_circle
+), "Expected optional circle {}, got {}".format(new_circle.toString(), obj.getCircleOpt().toString())
+
+obj.setPointOpt(None)
+obj.setCircleOpt(None)
+
+assert obj.getPointOpt() is None, "Expected optional point to be None"
+assert obj.getCircleOpt() is None, "Expected optional circle to be None"
+
+
+# Directed Optionals
+# -----------------------------------------------------------------------------
+
+test_default_directed = TestObjectDirected()
+
+# CHECKME: add better description - test default directed doValueOptionalChanged with value
+result = test_default_directed.doValueOptionalChanged(42)
+assert result == "", "Expected empty string when value is provided."
+
+# CHECKME: add better description - test default directed doValueOptionalChanged with none
+result = test_default_directed.doValueOptionalChanged(None)
+assert result == "", "Expected empty string when None is passed."
+
+# CHECKME: add better description - test default directed doReferenceOptionalChanged with value
+result = test_default_directed.doReferenceOptionalChanged(99)
+assert result == "", "Expected empty string when reference value is provided."
+
+# CHECKME: add better description - test default directed doReferenceOptionalChanged with none
+result = test_default_directed.doReferenceOptionalChanged(None)
+assert result == "", "Expected empty string when None is passed as reference."
+
+# CHECKME: add better description - test default directed onClassReferenceOptionalChanged with value
+rect = Rect(5.0, 3.0)
+result = test_default_directed.onClassReferenceOptionalChanged(rect)
+assert result == "", "Expected empty string when a valid Rect object is provided."
+
+# CHECKME: add better description - test default directed onClassReferenceOptionalChanged with none
+result = test_default_directed.onClassReferenceOptionalChanged(None)
+assert result == "", "Expected empty string when None is passed as a class reference."
+
+
+# Derived directed Optionals
+# -----------------------------------------------------------------------------
+
+class TestObjectDerived(TestObjectDirected):
+
+    def onValueOptionalChanged(self, value):
+        return "None" if value is None else "value: {}".format(value)
+
+    def onReferenceOptionalChanged(self, reference):
+        return "None" if reference is None else "reference: {}".format(reference)
+
+    def onClassReferenceOptionalChanged(self, reference):
+        return "None" if reference is None else "class reference: {}".format(reference.toString())
+
+test_derived_directed = TestObjectDerived()
+
+# CHECKME: add better description - test derived directed doValueOptionalChanged with value
+result = test_derived_directed.doValueOptionalChanged(42)
+assert result == "value: 42", "Expected 'value: 42' when a valid value is provided."
+
+# CHECKME: add better description - test derived directed doValueOptionalChanged with none
+result = test_derived_directed.doValueOptionalChanged(None)
+assert result == "None", "Expected 'None' when None is passed."
+
+# CHECKME: add better description - test derived directed doReferenceOptionalChanged with value
+result = test_derived_directed.doReferenceOptionalChanged(99)
+assert result == "reference: 99", "Expected 'reference: 99' when reference value is provided."
+
+# CHECKME: add better description - test derived directed doReferenceOptionalChanged with none
+result = test_derived_directed.doReferenceOptionalChanged(None)
+assert result == "None", "Expected 'None' when None is passed as reference."
+
+# CHECKME: add better description - test derived directed doClassReferenceOptionalChanged with value
+rect = Rect(5.0, 3.0)
+result = test_derived_directed.doClassReferenceOptionalChanged(rect)
+assert (
+    result == "class reference: {}".format(rect.toString())
+), "Expected 'class reference: {}' when a valid Rect object is provided.".format(rect.toString())
+
+# CHECKME: add better description - test derived directed doClassReferenceOptionalChanged with none
+result = test_derived_directed.doClassReferenceOptionalChanged(None)
+assert result == "None", "Expected 'None' when None is passed as a class reference."

--- a/Lib/csharp/std_optional.i
+++ b/Lib/csharp/std_optional.i
@@ -1,3 +1,45 @@
+// Purpose: SWIG interface file for std::optional<> type.
+//
+// This file defines macros for handling optional types in SWIG.
+// The macros provided are %optional, %optional_string, and %optional_arithmetic.
+//
+// Usage:
+//
+// 1. %optional_arithmetic(TYPE, INTERNAL_NAME):
+//    This macro is used to bind arithmetic types (int, float, double, etc.) to C# nullable value type (represented as Nullable<T>).
+//    Example:
+//    %optional_arithmetic(double, OptDouble)
+//    This will generate code to handle std::optional<double>.
+//    An internal class name OptDouble will be created to bind the optional type from C++ to C# nullable value type.
+// 
+// 2. %optional_string():
+//    This macro is used specifically for std::optional<std::string>.
+//    Example:
+//    %optional_string()
+//    This will generate code to handle std::optional<std::string>.
+//
+// 3. %optional(TYPE):
+//    This macro is used to bind structs and classes to either C# nullable reference type (if SWIG_STD_OPTIONAL_USE_NULLABLE_REFERENCE_TYPES is defined) or C# non-nullable reference type.
+//    Example:
+//    %optional(MyStruct)
+//    This will generate code to handle std::optional<MyStruct>.
+//
+// The SWIG_STD_OPTIONAL_DEFAULT_TYPES macro is used to define a set of default types that are supported by SWIG when working with std::optional.
+// This macro ensures that common types such as int, double, and std::string are automatically recognized and handled by SWIG when generating bindings.
+//
+// The SWIG_STD_OPTIONAL_USE_NULLABLE_REFERENCE_TYPES macro definition is used to enable the use of nullable reference types in the generated SWIG bindings.
+// When this macro is defined, SWIG will generate code that treats std::optional types as C# nullable reference types, allowing the compiler to run null-state analysis (C# >= 8 required).
+// When this macro is defined, any module using this file should be declared with the #nullable enable directive.
+// Example:
+// %module(csbegin="#nullable enable\n") MyModule
+// 
+
+#if defined(SWIG_STD_OPTIONAL_USE_NULLABLE_REFERENCE_TYPES)
+%define SWIG_STD_OPTIONAL_NULLABLE_TYPE "?" %enddef
+#else
+%define SWIG_STD_OPTIONAL_NULLABLE_TYPE "" %enddef
+#endif
+
 %{
     #include <optional>
 %}
@@ -23,7 +65,7 @@ namespace std {
 
 %naturalvar std::optional< TYPE >;
 
-%typemap(cstype) std::optional< TYPE >, std::optional< TYPE > const & "$typemap(cstype, TYPE)"
+%typemap(cstype) std::optional< TYPE >, std::optional< TYPE > const & "$typemap(cstype, TYPE)"SWIG_STD_OPTIONAL_NULLABLE_TYPE
 
 
 // This typemap is used to convert C# nullable type to the handler passed to the
@@ -51,7 +93,7 @@ namespace std {
 
 
 // This code is used for the optional-valued properties in C#.
-%typemap(cstype) std::optional< TYPE > *, std::optional< TYPE > const * "$typemap(cstype, TYPE)"
+%typemap(cstype) std::optional< TYPE > *, std::optional< TYPE > const * "$typemap(cstype, TYPE)"SWIG_STD_OPTIONAL_NULLABLE_TYPE
 %typemap(csin) std::optional< TYPE > *, std::optional< TYPE > const * "$typemap(cstype, TYPE).getCPtr($csinput)"
 
 %typemap(csvarin, excode=SWIGEXCODE) std::optional< TYPE > *, std::optional< TYPE > const * %{
@@ -148,7 +190,7 @@ namespace std {
 // std::optional<std::string>
 %typemap(ctype) std::optional<std::string> "const char *"
 %typemap(imtype) std::optional<std::string> "string"
-%typemap(cstype) std::optional<std::string> "string"
+%typemap(cstype) std::optional<std::string> "string"SWIG_STD_OPTIONAL_NULLABLE_TYPE
 
 %typemap(csdirectorin) std::optional<std::string> "$iminput"
 %typemap(csdirectorout) std::optional<std::string> "$cscall"
@@ -173,7 +215,7 @@ namespace std {
 // std::optional<std::string> const &
 %typemap(ctype) std::optional<std::string> const & "const char *"
 %typemap(imtype) std::optional<std::string> const & "string"
-%typemap(cstype) std::optional<std::string> const & "string"
+%typemap(cstype) std::optional<std::string> const & "string"SWIG_STD_OPTIONAL_NULLABLE_TYPE
 
 %typemap(csdirectorin) std::optional<std::string> const & "$iminput"
 %typemap(csdirectorout) std::optional<std::string> const & "$cscall"
@@ -205,7 +247,7 @@ namespace std {
 // std::optional<std::string> * (used to map C# properties)
 %typemap(ctype) std::optional<std::string> * "const char *"
 %typemap(imtype) std::optional<std::string> * "string"
-%typemap(cstype) std::optional<std::string> * "string"
+%typemap(cstype) std::optional<std::string> * "string"SWIG_STD_OPTIONAL_NULLABLE_TYPE
 
 %typemap(csdirectorin) std::optional<std::string> * "$iminput"
 %typemap(csdirectorout) std::optional<std::string> * "$cscall"
@@ -236,8 +278,7 @@ namespace std {
 
 %enddef
 
-
-#if !defined(SWIG_NO_STD_OPTIONAL_DEFAULT_TYPES)
+#if defined(SWIG_STD_OPTIONAL_DEFAULT_TYPES)
   %optional_arithmetic(bool, OptBool)
   %optional_arithmetic(std::int8_t, OptSignedByte)
   %optional_arithmetic(std::int16_t, OptSignedShort)

--- a/Lib/csharp/std_optional.i
+++ b/Lib/csharp/std_optional.i
@@ -1,0 +1,256 @@
+%{
+    #include <optional>
+%}
+
+%include <stdint.i>
+%include <std_string.i>
+
+namespace std {
+  template<typename T> class optional {
+    public:
+        typedef T value_type;
+
+        optional();
+        optional(T value);
+        optional(const optional& other);
+
+        constexpr bool has_value() const noexcept;
+        constexpr const T& value() const&;
+  };
+}
+
+%define %optional(TYPE)
+
+%naturalvar std::optional< TYPE >;
+
+%typemap(cstype) std::optional< TYPE >, std::optional< TYPE > const & "$typemap(cstype, TYPE)"
+
+
+// This typemap is used to convert C# nullable type to the handler passed to the
+// intermediate native wrapper function.
+%typemap(csin) std::optional< TYPE >, std::optional< TYPE > const & "$typemap(cstype, TYPE).getCPtr($csinput)"
+
+// This is used for functions returning optional values.
+%typemap(csout, excode=SWIGEXCODE) std::optional< TYPE >, std::optional< TYPE > const & {
+    var instance = $imcall;
+    var ret = (instance != global::System.IntPtr.Zero) ? new $typemap(cstype, TYPE)(instance, $owner) : null;$excode
+    return ret;
+  }
+
+%typemap(in) std::optional< TYPE >, std::optional< TYPE > const & (std::optional< TYPE > var) %{
+    $1 = &var;
+    var = ($input == nullptr) ? std::nullopt : std::optional< TYPE > { *(TYPE*) $input };
+%}
+%typemap(out) std::optional< TYPE > const & %{ 
+    $result = $1->has_value() ? new TYPE { $1->value() } : nullptr;
+%}
+
+%typemap(out) std::optional< TYPE > %{ 
+    $result = $1.has_value() ? new TYPE { $1.value() } : nullptr;
+%}
+
+
+// This code is used for the optional-valued properties in C#.
+%typemap(cstype) std::optional< TYPE > *, std::optional< TYPE > const * "$typemap(cstype, TYPE)"
+%typemap(csin) std::optional< TYPE > *, std::optional< TYPE > const * "$typemap(cstype, TYPE).getCPtr($csinput)"
+
+%typemap(csvarin, excode=SWIGEXCODE) std::optional< TYPE > *, std::optional< TYPE > const * %{
+    set {
+      $imcall;$excode
+    }%}
+%typemap(csvarout, excode=SWIGEXCODE2) std::optional< TYPE > *, std::optional< TYPE > const * %{
+    get {
+        var instance = $imcall;
+        var ret = (instance != global::System.IntPtr.Zero) ? new $typemap(cstype, TYPE)(instance, $owner) : null;$excode
+        return ret;
+    }%}
+
+%typemap(in) std::optional< TYPE > * (std::optional< TYPE > var) %{
+    $1 = &var;
+    var = ($input == nullptr) ? std::nullopt : std::optional< TYPE > { *(TYPE*) $input };
+%}
+%typemap(out) std::optional< TYPE > * %{ 
+    $result = $1->has_value() ? new TYPE { $1->value() } : nullptr;
+%}
+
+
+%typemap(csdirectorin) std::optional< TYPE >, std::optional< TYPE > const & "($iminput != global::System.IntPtr.Zero) ? new $typemap(cstype, TYPE)($iminput, true) : null"
+
+
+%enddef
+
+
+// ----------------------------------------------------------------------------
+// optional arithmetic specialisation
+// ----------------------------------------------------------------------------
+%define %optional_arithmetic(TYPE, NAME)
+ 
+// The std::optional<> specializations themselves are only going to be used
+// inside our own code, the user will deal with either T? or T, depending on
+// whether T is a value or a reference type, so make them private to our own
+// assembly.
+%typemap(csclassmodifiers) std::optional< TYPE > "internal class"
+
+// Do this to use reference typemaps instead of the pointer ones used by
+// default for the member variables of this type.
+//
+// Notice that this must be done before %template below, SWIG must know about
+// all features attached to the type before dealing with it.
+%naturalvar std::optional< TYPE >;
+
+// Even although we're not going to really use them, we must still name the
+// exported template instantiation, otherwise SWIG would give it an
+// auto-generated name starting with SWIGTYPE which would be even uglier.
+%template("NAME") std::optional< TYPE >;
+
+
+// Define the type we want to use in C#.
+%typemap(cstype) std::optional< TYPE >, std::optional< TYPE > const & "$typemap(cstype, TYPE)?"
+
+// This typemap is used to convert C# nullable type to the handler passed to the
+// intermediate native wrapper function.
+%typemap(csin,
+         pre="    NAME opt_$csinput = $csinput.HasValue ? new NAME($csinput.Value) : new NAME();"
+         ) std::optional< TYPE >, std::optional< TYPE > const& "$csclassname.getCPtr(opt_$csinput)"
+
+// This is used for functions returning optional values.
+%typemap(csout, excode=SWIGEXCODE) std::optional< TYPE >, std::optional< TYPE > const & {
+    NAME ret = new NAME($imcall, $owner);$excode
+    return ret.has_value() ? ret.value() : ($typemap(cstype, TYPE)?)null;
+  }
+
+// This code is used for the optional-valued properties in C#.
+%typemap(csvarin, excode=SWIGEXCODE2) std::optional< TYPE >, std::optional< TYPE > const & %{
+    set {
+      NAME opt_value = value.HasValue ? new NAME(value.Value) : new NAME();
+      $imcall;$excode
+    }%}
+%typemap(csvarout, excode=SWIGEXCODE2) std::optional< TYPE >, std::optional< TYPE > const & %{
+    get {
+      NAME ret = new NAME($imcall, $owner);$excode
+      return ret.has_value() ? ret.value() : ($typemap(cstype, TYPE)?)null;
+    }%}
+
+%typemap(csdirectorin,
+         pre="    NAME opt_$iminput = ($iminput != global::System.IntPtr.Zero) ? new NAME($iminput, true) : new NAME();"
+         ) std::optional< TYPE >, std::optional< TYPE > const & "opt_$iminput.has_value() ? opt_$iminput.value() : ($typemap(cstype, TYPE)?)null"
+
+%enddef
+
+
+// ----------------------------------------------------------------------------
+// optional string specialisation
+// ----------------------------------------------------------------------------
+%define %optional_string()
+
+%naturalvar std::optional<std::string>;
+
+// std::optional<std::string>
+%typemap(ctype) std::optional<std::string> "const char *"
+%typemap(imtype) std::optional<std::string> "string"
+%typemap(cstype) std::optional<std::string> "string"
+
+%typemap(csdirectorin) std::optional<std::string> "$iminput"
+%typemap(csdirectorout) std::optional<std::string> "$cscall"
+
+%typemap(in) std::optional<std::string> (std::optional<std::string> var) %{
+    $1 = &var;
+    var = ($input == nullptr) ? std::nullopt : std::optional<std::string> { (char const*) $input };
+%}
+%typemap(out) std::optional<std::string> %{ 
+    $result = SWIG_csharp_string_callback($1.has_value() ? $1.value().c_str() : nullptr );
+%}
+
+%typemap(csin) std::optional<std::string> "$csinput"
+%typemap(csout, excode=SWIGEXCODE) std::optional<std::string> {
+    string ret = $imcall;$excode
+    return ret;
+  }
+
+%typemap(typecheck) std::optional<std::string> = char *;
+
+
+// std::optional<std::string> const &
+%typemap(ctype) std::optional<std::string> const & "const char *"
+%typemap(imtype) std::optional<std::string> const & "string"
+%typemap(cstype) std::optional<std::string> const & "string"
+
+%typemap(csdirectorin) std::optional<std::string> const & "$iminput"
+%typemap(csdirectorout) std::optional<std::string> const & "$cscall"
+
+%typemap(in) std::optional<std::string> const & (std::optional<std::string> var) %{
+    $1 = &var;
+    var = ($input == nullptr) ? std::nullopt : std::optional<std::string> { (char const*) $input };
+%}
+%typemap(out) std::optional<std::string> const & %{ 
+    $result = SWIG_csharp_string_callback($1->has_value() ? $1->value().c_str() : nullptr); 
+%}
+
+%typemap(directorin) std::optional<std::string> const & %{ 
+    $input = $1.has_value() ? $1.value().c_str() : nullptr;
+%}
+%typemap(directorout) std::optional<std::string> const & %{
+    #error not implemented
+%}
+
+%typemap(csin) std::optional<std::string> const & "$csinput"
+%typemap(csout, excode=SWIGEXCODE) std::optional<std::string> const & {
+    string ret = $imcall;$excode
+    return ret;
+  }
+
+%typemap(typecheck) std::optional<std::string> const & = char *;
+
+
+// std::optional<std::string> * (used to map C# properties)
+%typemap(ctype) std::optional<std::string> * "const char *"
+%typemap(imtype) std::optional<std::string> * "string"
+%typemap(cstype) std::optional<std::string> * "string"
+
+%typemap(csdirectorin) std::optional<std::string> * "$iminput"
+%typemap(csdirectorout) std::optional<std::string> * "$cscall"
+
+%typemap(in) std::optional<std::string> * (std::optional<std::string> var) %{
+    $1 = &var;
+    var = ($input == nullptr) ? std::nullopt : std::optional<std::string> { (char const*) $input };
+%}
+%typemap(out) std::optional<std::string> * %{ 
+    $result = SWIG_csharp_string_callback($1->has_value() ? $1->value().c_str() : nullptr); 
+%}
+
+%typemap(csvarin, excode=SWIGEXCODE2) std::optional<std::string> * %{
+    set {
+      $imcall;$excode
+    } %}
+%typemap(csvarout, excode=SWIGEXCODE2) std::optional<std::string> * %{
+    get {
+      string ret = $imcall;$excode
+      return ret;
+    } %}
+
+%typemap(csin) std::optional<std::string> * "$csinput"
+%typemap(csout, excode=SWIGEXCODE) std::optional<std::string> * {
+    string ret = $imcall;$excode
+    return ret;
+  }
+
+%enddef
+
+
+#if !defined(SWIG_NO_STD_OPTIONAL_DEFAULT_TYPES)
+  %optional_arithmetic(bool, OptBool)
+  %optional_arithmetic(std::int8_t, OptSignedByte)
+  %optional_arithmetic(std::int16_t, OptSignedShort)
+  %optional_arithmetic(std::int32_t, OptSignedInt)
+  %optional_arithmetic(std::uint8_t, OptUnsignedByte)
+  %optional_arithmetic(std::uint16_t, OptUnsignedShort)
+  %optional_arithmetic(std::uint32_t, OptUnsignedInt)
+
+  %optional_arithmetic(std::int64_t, OptSignedLong)
+  %optional_arithmetic(std::uint64_t, OptUnsignedLong)
+
+  %optional_arithmetic(float, OptFloat)
+  %optional_arithmetic(double, OptDouble)
+
+  %optional_string()
+#endif

--- a/Lib/python/std_optional.i
+++ b/Lib/python/std_optional.i
@@ -1,0 +1,164 @@
+// Purpose: SWIG interface file for std::optional<> type.
+//
+// This file defines macros for handling optional types in SWIG.
+//
+// Usage:
+//
+// %optional(TYPE):
+//    This macro is used to bind structs and classes to wrapped python interfaces returning None if the optional is empty.
+//    Example:
+//    %optional(MyStruct)
+//    This will generate code to handle std::optional<MyStruct>.
+//
+// The SWIG_STD_OPTIONAL_DEFAULT_TYPES macro is used to define a set of default types that are supported by SWIG when working with std::optional.
+// This macro ensures that common types such as int, double, and std::string are automatically recognized and handled by SWIG when generating bindings.
+// 
+
+%{
+    #include <optional>
+%}
+
+%include <stdint.i>
+%include <std_string.i>
+
+namespace std {
+  template<typename T> class optional {};
+}
+
+%define %optional(TYPE)
+
+%naturalvar std::optional< TYPE >;
+
+// CHECKME: when is this used
+%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER) std::optional< TYPE >, std::optional< TYPE > const & (std::optional< TYPE > tmp_ov) %{
+  if ($input == Py_None)
+    $1 = true;
+  else {
+    $typemap(typecheck, TYPE)
+  }
+%}
+
+%typemap(in,implicitconv=1) std::optional< TYPE > const, std::optional< TYPE > %{
+  if ($input == Py_None) {
+    $1 = std::nullopt;
+  } else {
+    $typemap(in, TYPE)
+  }
+%}
+
+%typemap(in,implicitconv=1) std::optional< TYPE > const & (std::optional< TYPE > val), std::optional< TYPE > & (std::optional< TYPE > val) %{
+  $1 = &val;
+  if ($input == Py_None) {
+    val = std::nullopt;
+  } else
+  {
+    TYPE $1; // shadow assignment
+    $typemap(in, TYPE)
+    val.emplace($1);
+  }
+%}
+
+%typemap(in,implicitconv=1) std::optional< TYPE > const * (std::optional< TYPE > val), std::optional< TYPE > * (std::optional< TYPE > val) %{
+  $1 = &val;
+  if ($input == Py_None) {
+    val = std::nullopt;
+  } else
+  {
+    TYPE $1; // shadow assignment
+    $typemap(in, TYPE)
+    val.emplace($1);
+  }
+%}
+
+%typemap(directorin,implicitconv=1) std::optional< TYPE > const, std::optional< TYPE > %{
+  if ( ($1).has_value() ) {
+    auto& tmp_ov = $1;
+    {
+      auto& $1 = tmp_ov.value(); // shadow assignment
+      $typemap(directorin, TYPE)
+    }
+  } else {
+    $input = Py_None;
+    Py_INCREF(Py_None);
+  }
+%}
+
+%typemap(directorin,implicitconv=1) std::optional< TYPE > const & (std::optional< TYPE > val), std::optional< TYPE > & (std::optional< TYPE > val) %{
+  if ( ($1).has_value() ) {
+    auto& tmp_ov = $1;
+    {
+      auto& $1 = tmp_ov.value(); // shadow assignment
+      $typemap(directorin, TYPE)
+    }
+  } else {
+    $input = Py_None;
+    Py_INCREF(Py_None);
+  }
+%}
+
+%typemap(out) std::optional< TYPE > const, std::optional< TYPE > %{
+  if ( $1.has_value() ) {
+    auto const& tmp_ov = *($1).operator&(); // shadow assignment
+    {
+      TYPE const& result = tmp_ov.value();
+      $typemap(out, TYPE)
+    }
+  } else {
+    $result = Py_None;
+    Py_INCREF(Py_None);
+  }
+%}
+
+
+%typemap(out) std::optional< TYPE > const &, std::optional< TYPE > & %{
+  if ( ($1)->has_value() )
+  {
+    auto const& tmp_ov = *$1; // shadow assignment
+    {
+      TYPE const& result = tmp_ov.value();
+      $typemap(out, TYPE)
+    }
+  }
+  else
+  {
+    $result = Py_None;
+    Py_INCREF(Py_None);
+  }
+%}
+
+%typemap(out) std::optional< TYPE > const *, std::optional< TYPE > * %{
+  if ( ($1)->has_value() )
+  {
+    auto const& tmp_ov = *$1; // shadow assignment
+    {
+      TYPE const& result = tmp_ov.value();
+      $typemap(out, TYPE)
+    }
+  }
+  else
+  {
+    $result = Py_None;
+    Py_INCREF(Py_None);
+  }
+%}
+
+%enddef
+
+
+#if defined(SWIG_STD_OPTIONAL_DEFAULT_TYPES)
+  %optional(bool)
+  %optional(std::int8_t)
+  %optional(std::int16_t)
+  %optional(std::int32_t)
+  %optional(std::uint8_t)
+  %optional(std::uint16_t)
+  %optional(std::uint32_t)
+
+  %optional(std::int64_t)
+  %optional(std::uint64_t)
+
+  %optional(float)
+  %optional(double)
+
+  %optional(std::string)
+#endif


### PR DESCRIPTION
Provide `std::optional` support for *python*.

Based on interface and test definitions of PR #3078 for C# bindings.
Can perhaps subsequently merged.