### PR TITLE
Correct docs for Python abi3 mode

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -4136,7 +4136,7 @@ or simply define the macro using your C/C++ compiler's <tt>-D</tt> command line 
 The default SWIG command line options generate code that enable the limited API/stable ABI.
 Some options, such as <tt>-builtin</tt>, <tt>-fastproxy</tt> (used by <tt>-O</tt>) do not use the limited API and hence when <tt>Py_LIMITED_API</tt> is defined there will be missing symbols during compilation.
 Compatibility of user's custom typemaps is of course dependent on the Python APIs used in the typemaps.
-Use of typemaps requires passing the <tt>-fastdispatch</tt> option to SWIG (which is typically otherwise enabled by the abi3-incompatible <tt>-O</tt>).
+If you disable <tt>-O</tt>, you could consider enabling <tt>-fastdispatch</tt> as this option is abi3 compatible.
 </p>
 
 <p>

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -4135,8 +4135,8 @@ or simply define the macro using your C/C++ compiler's <tt>-D</tt> command line 
 <p>
 The default SWIG command line options generate code that enable the limited API/stable ABI.
 Some options, such as <tt>-builtin</tt>, <tt>-fastproxy</tt> (used by <tt>-O</tt>) do not use the limited API and hence when <tt>Py_LIMITED_API</tt> is defined there will be missing symbols during compilation.
+Limited API is only guaranteed to work with the default code generation options.
 Compatibility of user's custom typemaps is of course dependent on the Python APIs used in the typemaps.
-If you disable <tt>-O</tt>, you could consider enabling <tt>-fastdispatch</tt> as this option is abi3 compatible.
 </p>
 
 <p>

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -4134,8 +4134,9 @@ or simply define the macro using your C/C++ compiler's <tt>-D</tt> command line 
 
 <p>
 The default SWIG command line options generate code that enable the limited API/stable ABI.
-Some options, such as <tt>-builtin</tt>, <tt>-fast</tt> (used by <tt>-O</tt>) do not use the limited API and hence when <tt>Py_LIMITED_API</tt> is defined there will be missing symbols during compilation.
+Some options, such as <tt>-builtin</tt>, <tt>-fastproxy</tt> (used by <tt>-O</tt>) do not use the limited API and hence when <tt>Py_LIMITED_API</tt> is defined there will be missing symbols during compilation.
 Compatibility of user's custom typemaps is of course dependent on the Python APIs used in the typemaps.
+Use of typemaps requires passing the <tt>-fastdispatch</tt> option to SWIG (which is typically otherwise enabled by the abi3-incompatible <tt>-O</tt>).
 </p>
 
 <p>


### PR DESCRIPTION
# Doc update

This PR updates the docs based on my experience working with the new `abi3` mode from https://github.com/swig/swig/pull/2727. It might also qualify as a bug report, which I can separate out (see below :point_down: ) but want to mention here to explain the necessity of the second point:

1. The `-fast*` option that is specifically problematic in `-O` is `-fastproxy` (I found this by trial-and-error so I might be wrong)
2. Instead of `-O` you should use `-fastdispatch` if you use typemaps (and it should be abi3-compatible, or at least is according to `abi3audit` for me!)

cc @wsfulton since I think you wrote those docs and worked on the abi3 stuff.

# Possible bug

Regarding the need for `-fastdispatch`, I use swig over in OpenMEEG with a some simple typemaps like:

https://github.com/openmeeg/openmeeg/blob/4cf760b23f88ddb0523b66235e01debe2795bd42/wrapping/python/openmeeg/_openmeeg.i#L357-L362

If I `swig` with `-O`, everything is fine. According to the docs, I can't do that now that I'm trying to use `abi3` (and I do see missing symbols during compilation as suggested!), so I removed that option. But when I did that, I started getting duck-typing errors in my tests, where I could no longer instantiate objects that I could before, almost as if the typemap didn't exist anymore:
```
FAILED ../venv/lib/python3.10/site-packages/openmeeg/tests/test_vector.py::test_vector - TypeError: Wrong number or type of arguments for overloaded function 'new_Vector'.
  Possible C/C++ prototypes are:
    OpenMEEG::Vector::Vector()
    OpenMEEG::Vector::Vector(OpenMEEG::Dimension const)
    OpenMEEG::Vector::Vector(OpenMEEG::Vector const &,OpenMEEG::DeepCopy const)
    OpenMEEG::Vector::Vector(OpenMEEG::Matrix const &)
    OpenMEEG::Vector::Vector(OpenMEEG::SymMatrix const &)
    OpenMEEG::Vector::Vector(PyObject *)
```
So then by trial and error I started putting back some `-O` options to see if anything fixed things for me, and it looks like the one that works is:
```
     -fastdispatch   - Enable fast dispatch mode to produce faster overload dispatcher code
```
You can see it working in the Linux run of the [CI job](https://github.com/openmeeg/openmeeg/actions/runs/12303396171/job/34338423522?pr=708) where [I set `-fastdispatch`](https://github.com/openmeeg/openmeeg/pull/708/commits/36630de943339185f0567066c288cef143af2817) but failing in the [CI job](https://github.com/openmeeg/openmeeg/actions/runs/12303318513/job/34338169903?pr=708#step:7:1222) where I [remove the switch](https://github.com/openmeeg/openmeeg/pull/708/commits/16e8b768bfa1399c74edaafbe3ef66da58947275).

It seems like a potential bug that this needs to be enabled for my type mapping to work. From this description it sounds like it will only affect the *speed* of produced code rather than typemap functionality.

If this is a bug that needs to be fixed in `swig`, I'm happy to open a new issue but I'd be way out of my depth to try to fix it.

If it's not a bug, then maybe an additional note to the `-fastdispatch` command line option either in the `swig -python --help` or `swig --help` would be warranted to make it clearer it's not just a speed switch but also affects functionality?

FYI this part is not `abi3`-specific -- this possibly errant typemap behavior based on the presence or absence of `-fastdispatch` happens either way.