### PR TITLE
Fix redeclaration error in std_string_view.i for python

### DIFF
--- a/Lib/python/std_string_view.i
+++ b/Lib/python/std_string_view.i
@@ -29,23 +29,23 @@ namespace std {
     %}
 
     %typemap(in) string_view (PyObject *bytes = NULL) {
-        Py_ssize_t len;
+        Py_ssize_t $1_len;
 %#ifdef SWIG_PYTHON_STRICT_BYTE_CHAR
-        const char *p = PyBytes_AsString($input);
-        if (!p) SWIG_fail;
-        len = PyBytes_Size($input);
+        const char *$1_p = PyBytes_AsString($input);
+        if (!$1_p) SWIG_fail;
+        $1_len = PyBytes_Size($input);
 %#else
-        const char *p;
+        const char *$1_p;
         if (PyUnicode_Check($input)) {
-          p = SWIG_PyUnicode_AsUTF8AndSize($input, &len, &bytes);
-          if (!p) SWIG_fail;
+          $1_p = SWIG_PyUnicode_AsUTF8AndSize($input, &$1_len, &bytes);
+          if (!$1_p) SWIG_fail;
         } else {
-          p = PyBytes_AsString($input);
-          if (!p) SWIG_fail;
-          len = PyBytes_Size($input);
+          $1_p = PyBytes_AsString($input);
+          if (!$1_p) SWIG_fail;
+          $1_len = PyBytes_Size($input);
         }
 %#endif
-        $1 = std::string_view(p, len);
+        $1 = std::string_view($1_p, $1_len);
     }
 
     %typemap(freearg) string_view %{


### PR DESCRIPTION
When using multiple std::string_view as argument of a function, gcc complain that variable are redeclared. see error below:

```
libpctool_wrap.cxx: In function 'PyObject* _wrap_new_DeviceView(PyObject*, PyObject*)':
libpctool_wrap.cxx:4867:14: error: redeclaration of 'Py_ssize_t len'
 4867 |   Py_ssize_t len;
      |              ^~~
libpctool_wrap.cxx:4848:14: note: 'Py_ssize_t len' previously declared here
 4848 |   Py_ssize_t len;
      |              ^~~
libpctool_wrap.cxx:4873:15: error: redeclaration of 'const char* p'
 4873 |   const char *p;
      |               ^
libpctool_wrap.cxx:4854:15: note: 'const char* p' previously declared here
 4854 |   const char *p;
      |               ^
libpctool_wrap.cxx:4886:14: error: redeclaration of 'Py_ssize_t len'
 4886 |   Py_ssize_t len;
      |              ^~~
libpctool_wrap.cxx:4848:14: note: 'Py_ssize_t len' previously declared here
 4848 |   Py_ssize_t len;
      |              ^~~
libpctool_wrap.cxx:4892:15: error: redeclaration of 'const char* p'
 4892 |   const char *p;
      |               ^
libpctool_wrap.cxx:4854:15: note: 'const char* p' previously declared here
 4854 |   const char *p;
      |               ^
ninja: build stopped: subcommand failed.
```

This change use various names for each argument.