### PR TITLE
Microsoft fix the STL library, issue #3008 is fixed

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,14 +55,10 @@ jobs:
         - SWIGLANG: java
           COMPILER: gcc
           VER: 11
-       # Next two are using old VC++ as the new visual c++ not handling containers of enums
-       # See https://github.com/swig/swig/issues/3008
         - SWIGLANG: python
           VER: '3.7'
-          os: 'windows-2019'
         - SWIGLANG: python
           VER: '3.12'
-          os: 'windows-2019'
        #  TODO require fixing of probing in configure.ac
        #- SWIGLANG: python
        #  INSTALL: 'true'


### PR DESCRIPTION
Microsoft fix the STL library in the new MSVC.
Github Windows 2022 uses MSVC 19.42.34436.

Fixing Issue #3008 