### PR TITLE
Fix crash when using directors in Python without limited API

### DIFF
--- a/Lib/python/director_py_mutex.swg
+++ b/Lib/python/director_py_mutex.swg
@@ -16,9 +16,9 @@ namespace Swig {
        PyThread_type_lock mutex_;
    public:
        Mutex() : mutex_(PyThread_allocate_lock()) {}
-       ~Mutex() { PyThread_release_lock(mutex_); }
+       ~Mutex() { PyThread_free_lock(mutex_); }
        void lock() { PyThread_acquire_lock(mutex_, WAIT_LOCK); }
-       void unlock() { PyThread_free_lock(mutex_); }
+       void unlock() { PyThread_release_lock(mutex_); }
    };
 }
 #endif


### PR DESCRIPTION
Call correct functions when unlocking/destroying a mutex implemented using Python API: they were accidentally exchanged in 21f1c923c (Make directors implementation for Python work with limited API, 2019-12-23) resulting in crashes when using directors and threads together.

Closes #2889.