### PR TITLE
Improve parsing multi-line expr via error recovery

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,13 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.4.0 (in progress)
 ===========================
 
+2025-02-28: olly
+	    #3127 Fix bad generated code in some cases when a constant
+	    expression is split over multiple lines and used as part of a type.
+	    This manifested in cases where SWIG's parser gets the expression
+	    text by skipping to the matching closing parenthesis and grabbing
+	    the skipped program text.
+
 2025-02-19: wsfulton
             Add support for $n special variable expansion in the names of typemap
             local variables, such as:

--- a/Examples/test-suite/cpp11_constexpr.i
+++ b/Examples/test-suite/cpp11_constexpr.i
@@ -74,4 +74,22 @@ struct A {
 };
 constexpr A a{42};
 constexpr int N = a.i;
+
+// Regression test for https://github.com/swig/swig/issues/3127 fixed in 4.4.0:
+#include <array>
+
+constexpr std::size_t __my_enum_size =
+   sizeof(
+    decltype(
+      42
+    )
+  ) ? 1 + static_cast<std::size_t>(
+    4
+  ) : alignof(
+    std::size_t
+  );
+
+std::array<bool, __my_enum_size> do_something() {
+  return std::array<bool, __my_enum_size>{true,true,true,true,true};
+}
 %}


### PR DESCRIPTION
Fix bad generated code in some cases when a constant expression is split over multiple lines and used as part of a type.  This manifested in cases where SWIG's parser handles the expression via parser error recovery.

Fixes #3127