### PR TITLE
added support for Python free threading (aka no-gil)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,7 +134,7 @@ jobs:
           VER: '3.13'
           CSTD: gnu99
         - SWIGLANG: python
-          VER: '3.13-nogil'
+          VER: '3.13t'
           CSTD: gnu99
         - SWIGLANG: python
           PY2: 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -134,6 +134,9 @@ jobs:
           VER: '3.13'
           CSTD: gnu99
         - SWIGLANG: python
+          VER: '3.13-nogil'
+          CSTD: gnu99
+        - SWIGLANG: python
           PY2: 2
           SWIG_FEATURES: -builtin
         - SWIGLANG: python

--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ Examples/r/*/.RData
 Examples/test-suite/scilab/*/
 loader.sce
 
+/bin/

--- a/Examples/test-suite/python/langobj_runme.py
+++ b/Examples/test-suite/python/langobj_runme.py
@@ -3,6 +3,10 @@ from langobj import *
 
 
 x = 256*256+1
+
+# avoid immortal object in no-gil scenario
+x += 1
+
 rx = sys.getrefcount(x)
 v = identity(x)
 rv = sys.getrefcount(v)

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -103,7 +103,7 @@ SWIG_Python_str_FromChar(const char *c)
 #endif
 
 /* Increment and Decrement wrappers - for portability when using the stable abi and for performance otherwise */
-#if defined(Py_LIMITED_API) || defined(Py_GIL_DISABLED)
+#ifdef Py_LIMITED_API
 # define SWIG_Py_INCREF Py_IncRef
 # define SWIG_Py_XINCREF Py_IncRef
 # define SWIG_Py_DECREF Py_DecRef

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -75,7 +75,20 @@ SWIG_Python_str_FromChar(const char *c)
 #define Py_hash_t long
 #endif
 
-#ifdef Py_LIMITED_API
+#ifdef Py_GIL_DISABLED
+# undef PyTuple_GET_ITEM
+# undef PyTuple_SET_ITEM
+# undef PyTuple_GET_SIZE
+# undef PyCFunction_GET_FLAGS
+# undef PyCFunction_GET_FUNCTION
+# undef PyCFunction_GET_SELF
+# undef PyList_GET_ITEM
+# undef PyList_SET_ITEM
+# undef PySliceObject
+#endif
+
+
+#if defined(Py_LIMITED_API) || defined(Py_GIL_DISABLED)
 # define PyTuple_GET_ITEM PyTuple_GetItem
 /* Note that PyTuple_SetItem() has different semantics from PyTuple_SET_ITEM as it decref's the original tuple item, so in general they cannot be used
   interchangeably. However in SWIG-generated code PyTuple_SET_ITEM is only used with newly initialized tuples without any items and for them this does work. */
@@ -90,7 +103,7 @@ SWIG_Python_str_FromChar(const char *c)
 #endif
 
 /* Increment and Decrement wrappers - for portability when using the stable abi and for performance otherwise */
-#ifdef Py_LIMITED_API
+#if defined(Py_LIMITED_API) || defined(Py_GIL_DISABLED)
 # define SWIG_Py_INCREF Py_IncRef
 # define SWIG_Py_XINCREF Py_IncRef
 # define SWIG_Py_DECREF Py_DecRef

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -275,6 +275,9 @@ SWIG_init(void) {
   m = PyModule_Create(&SWIG_module);
 #else
   m = Py_InitModule(SWIG_name, SwigMethods);
+# ifdef Py_GIL_DISABLED
+	PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+# endif	
 #endif
 
   md = d = PyModule_GetDict(m);

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -275,10 +275,10 @@ SWIG_init(void) {
   m = PyModule_Create(&SWIG_module);
 #else
   m = Py_InitModule(SWIG_name, SwigMethods);
-# ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-# endif	
 #endif
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif	
 
   md = d = PyModule_GetDict(m);
   (void)md;

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -276,7 +276,7 @@ SWIG_init(void) {
 #else
   m = Py_InitModule(SWIG_name, SwigMethods);
 # ifdef Py_GIL_DISABLED
-	PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 # endif	
 #endif
 

--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -278,6 +278,7 @@ SWIG_TypeCheck(const char *c, swig_type_info *ty) {
       if (strcmp(iter->type->name, c) == 0) {
         if (iter == ty->cast)
           return iter;
+#ifndef Py_GIL_DISABLED
         /* Move iter to the top of the linked list */
         iter->prev->next = iter->next;
         if (iter->next)
@@ -286,6 +287,7 @@ SWIG_TypeCheck(const char *c, swig_type_info *ty) {
         iter->prev = 0;
         if (ty->cast) ty->cast->prev = iter;
         ty->cast = iter;
+#endif        
         return iter;
       }
       iter = iter->next;
@@ -305,6 +307,7 @@ SWIG_TypeCheckStruct(const swig_type_info *from, swig_type_info *ty) {
       if (iter->type == from) {
         if (iter == ty->cast)
           return iter;
+#ifndef Py_GIL_DISABLED
         /* Move iter to the top of the linked list */
         iter->prev->next = iter->next;
         if (iter->next)
@@ -313,6 +316,7 @@ SWIG_TypeCheckStruct(const swig_type_info *from, swig_type_info *ty) {
         iter->prev = 0;
         if (ty->cast) ty->cast->prev = iter;
         ty->cast = iter;
+#endif        
         return iter;
       }
       iter = iter->next;

--- a/Tools/CI-linux-install.sh
+++ b/Tools/CI-linux-install.sh
@@ -114,7 +114,11 @@ case "$SWIGLANG" in
 		if [[ "$VER" ]]; then
 			$RETRY sudo add-apt-repository -y ppa:deadsnakes/ppa
 			$RETRY sudo apt-get -qq update
-			$RETRY sudo apt-get -qq install python${VER}-dev
+			if [[ "$VER" != *"t" ]]; then
+				$RETRY sudo apt-get -qq install python${VER}-dev
+			else
+				$RETRY sudo apt-get -qq install python${VER::-1}-dev python${VER::-1}-nogil
+			fi
 			WITHLANG=$WITHLANG=$SWIGLANG$VER
 		elif [[ "$PY2" ]]; then
 			$RETRY sudo apt-get install -qq python-dev

--- a/configure.ac
+++ b/configure.ac
@@ -2075,6 +2075,13 @@ else
     if test -z "$PYVER"; then
       PYVER=0
     fi
+
+    AC_MSG_CHECKING([for $PYTHON3 GIL is disabled])
+    PYGIL=`($PYTHON3 -c "import sysconfig; print(not bool(sysconfig.get_config_var('Py_GIL_DISABLED')))") 2>/dev/null`
+    AC_MSG_RESULT($PYGIL)
+    if test x"$PYGIL" = x"False"; then
+      PYTHON3="$PYTHON3 -Xgil=0"
+    fi
   fi
 
   if test $PYVER -ge 3; then

--- a/configure.ac
+++ b/configure.ac
@@ -2076,11 +2076,11 @@ else
       PYVER=0
     fi
 
-    AC_MSG_CHECKING([for $PYTHON3 GIL is disabled])
+    AC_MSG_CHECKING([for $PYTHON3 GIL is enabled])
     PYGIL=`($PYTHON3 -c "import sysconfig; print(not bool(sysconfig.get_config_var('Py_GIL_DISABLED')))") 2>/dev/null`
     AC_MSG_RESULT($PYGIL)
     if test x"$PYGIL" = x"False"; then
-      PYTHON3="$PYTHON3 -Xgil=0"
+      PYTHON3="$PYTHON3 -X gil=0"
     fi
   fi
 


### PR DESCRIPTION
Python 3.13 now supports free threading (aka disabling the GIL). Some marcos are deemed unsafe for this use case and should be disabled. In addition a variant of [Thread Safety Bugfix #103](https://github.com/swig/swig/issues/103) needs to be put in place.
