### PR TITLE
Remove redundant casts to const char* after using GetStringUTFChars method

### DIFF
--- a/Lib/java/std_string.i
+++ b/Lib/java/std_string.i
@@ -31,7 +31,7 @@ class string;
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      return $null;
     } 
-    const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
+    const char *$1_pstr = jenv->GetStringUTFChars($input, 0); 
     if (!$1_pstr) return $null;
     $1.assign($1_pstr);
     jenv->ReleaseStringUTFChars($input, $1_pstr); %}
@@ -43,7 +43,7 @@ class string;
      }
      return $null;
    } 
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0); 
    if (!$1_pstr) return $null;
    $result.assign($1_pstr);
    jenv->ReleaseStringUTFChars($input, $1_pstr); %}
@@ -79,7 +79,7 @@ class string;
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      return $null;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0); 
    if (!$1_pstr) return $null;
    $*1_ltype $1_str($1_pstr);
    $1 = &$1_str;
@@ -90,7 +90,7 @@ class string;
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      return $null;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0); 
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0); 
    if (!$1_pstr) return $null;
    /* possible thread/reentrant code problem */
    static $*1_ltype $1_str;

--- a/Lib/java/std_string_view.i
+++ b/Lib/java/std_string_view.i
@@ -32,7 +32,7 @@ class string_view;
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      return $null;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0);
    if (!$1_pstr) return $null;
    $1 = std::string_view($1_pstr); %}
 
@@ -48,7 +48,7 @@ class string_view;
      }
      return $null;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0);
    if (!$1_pstr) return $null;
    /* possible thread/reentrant code problem */
    static std::string $1_str;
@@ -91,7 +91,7 @@ class string_view;
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      return $null;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0);
    if (!$1_pstr) return $null;
    $*1_ltype $1_str($1_pstr);
    $1 = &$1_str; %}
@@ -106,7 +106,7 @@ class string_view;
      SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
      return $null;
    }
-   const char *$1_pstr = (const char *)jenv->GetStringUTFChars($input, 0);
+   const char *$1_pstr = jenv->GetStringUTFChars($input, 0);
    if (!$1_pstr) return $null;
    /* possible thread/reentrant code problem */
    static std::string $1_str;


### PR DESCRIPTION
This PR introduces an improvement aimed at reducing SonarQube issues in SWIG. Our team has been maintaining local modifications to address static analysis findings, and we would like to contribute these changes upstream.

The signature of the function:
`const char * GetStringUTFChars(...); `
There is no reason of casting the return value to `const char *`