### PR TITLE
Refactor SWIG Code to Address SonarQube Rule cpp:S5827

### DIFF
--- a/Lib/java/std_vector.i
+++ b/Lib/java/std_vector.i
@@ -128,7 +128,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
       }
 
       void doAdd(jint index, const value_type& x) throw (std::out_of_range) {
-        jint size = static_cast<jint>(self->size());
+        auto size = static_cast<jint>(self->size());
         if (0 <= index && index <= size) {
           self->insert(self->begin() + index, x);
         } else {
@@ -137,7 +137,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
       }
 
       value_type doRemove(jint index) throw (std::out_of_range) {
-        jint size = static_cast<jint>(self->size());
+        auto size = static_cast<jint>(self->size());
         if (0 <= index && index < size) {
           CTYPE const old_value = (*self)[index];
           self->erase(self->begin() + index);
@@ -148,7 +148,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
       }
 
       CONST_REFERENCE doGet(jint index) throw (std::out_of_range) {
-        jint size = static_cast<jint>(self->size());
+        auto size = static_cast<jint>(self->size());
         if (index >= 0 && index < size)
           return (*self)[index];
         else
@@ -156,7 +156,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
       }
 
       value_type doSet(jint index, const value_type& val) throw (std::out_of_range) {
-        jint size = static_cast<jint>(self->size());
+        auto size = static_cast<jint>(self->size());
         if (index >= 0 && index < size) {
           CTYPE const old_value = (*self)[index];
           (*self)[index] = val;
@@ -167,7 +167,7 @@ SWIGINTERN jint SWIG_VectorSize(size_t size) {
       }
 
       void doRemoveRange(jint fromIndex, jint toIndex) throw (std::out_of_range) {
-        jint size = static_cast<jint>(self->size());
+        auto size = static_cast<jint>(self->size());
         if (0 <= fromIndex && fromIndex <= toIndex && toIndex <= size) {
           self->erase(self->begin() + fromIndex, self->begin() + toIndex);
         } else {


### PR DESCRIPTION
This PR refactors SWIG's C++ code to comply with SonarQube rule cpp:S5827, which recommends using auto to eliminate redundant type declarations. By applying this change, we improve code readability, maintainability, and reduce unnecessary verbosity while preserving functionality.