### PR TITLE
Address s5416 SonarQube issue for carrays.i&javahead.swg files

### DIFF
--- a/Lib/carrays.i
+++ b/Lib/carrays.i
@@ -77,7 +77,7 @@ void NAME##_setitem(TYPE *ary, size_t index, TYPE value);
 
 %define %array_class(TYPE,NAME)
 %{
-typedef TYPE NAME;
+using NAME = TYPE;
 %}
 typedef struct {
   /* Put language specific enhancements here */

--- a/Lib/java/javahead.swg
+++ b/Lib/java/javahead.swg
@@ -37,7 +37,7 @@
 
 %insert(runtime) %{
 /* Support for throwing Java exceptions */
-typedef enum {
+enum SWIG_JavaExceptionCodes {
   SWIG_JavaOutOfMemoryError = 1,
   SWIG_JavaIOException,
   SWIG_JavaRuntimeException,
@@ -48,12 +48,12 @@ typedef enum {
   SWIG_JavaDirectorPureVirtual,
   SWIG_JavaUnknownError,
   SWIG_JavaIllegalStateException,
-} SWIG_JavaExceptionCodes;
+};
 
-typedef struct {
+struct SWIG_JavaExceptions_t {
   SWIG_JavaExceptionCodes code;
   const char *java_exception;
-} SWIG_JavaExceptions_t;
+};
 %}
 
 %insert(runtime) {


### PR DESCRIPTION
This PR introduces an improvement aimed at reducing SonarQube issues in SWIG. Our team has been maintaining local modifications to address static analysis findings, and we would like to contribute these changes upstream.
This pull request addresses SonarQube rule cpp:S5416: "using" should be preferred to "typedef" for type aliasing. 