### PR TITLE
Use C++11 std::mutex with MSVC too

### DIFF
--- a/Lib/director_guard.swg
+++ b/Lib/director_guard.swg
@@ -22,7 +22,7 @@
 
 #ifdef SWIG_THREADS
 
-#if __cplusplus >= 201103L
+#if (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) >= 201103L
 /*
  * C++ 11 or above
  * std::mutex        https://en.cppreference.com/w/cpp/thread/mutex


### PR DESCRIPTION
Check for _MSVC_LANG in addition to checking for __cplusplus as MSVC compiler still doesn't define the latter by default, even if supports not just C++11 but even much later standards.

This notably avoids including <windows.h> from this file which wreaks havoc with the code after it due to the definitions of many common names as macros in it.

----

I know that you can force MSVC to define `__cplusplus` by using the corresponding non-default `/Z` switch but IMO it doesn't cost anything to also handle the case when this switch is not used gracefully instead of falling back to using Windows critical section which is less efficient (std::mutex uses SRW locks) and results in problems due to defining plenty of common symbols in `windows.h`.