### PR TITLE
Use SWIG_NULLPTR instead of NULL for java director methods

### DIFF
--- a/Lib/java/cdata.i
+++ b/Lib/java/cdata.i
@@ -58,7 +58,7 @@ static jbyteArray SWIG_JavaArrayOutCDATA(JNIEnv *jenv, char *result, jsize sz) {
   if (!jresult) {
     return SWIG_NULLPTR;
   }
-  arr = JCALL2(GetByteArrayElements, jenv, jresult, 0);
+  arr = JCALL2(GetByteArrayElements, jenv, jresult, SWIG_NULLPTR);
   if (!arr) {
     return SWIG_NULLPTR;
   }

--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -666,13 +666,13 @@ template<typename T> class SwigValueWrapper {
     T *ptr;
     SwigSmartPointer(T *p) : ptr(p) { }
     ~SwigSmartPointer() { delete ptr; }
-    SwigSmartPointer& operator=(SwigSmartPointer& rhs) { T* oldptr = ptr; ptr = 0; delete oldptr; ptr = rhs.ptr; rhs.ptr = 0; return *this; }
-    void reset(T *p) { T* oldptr = ptr; ptr = 0; delete oldptr; ptr = p; }
+    SwigSmartPointer& operator=(SwigSmartPointer& rhs) { T* oldptr = ptr; ptr = SWIG_NULLPTR; delete oldptr; ptr = rhs.ptr; rhs.ptr = SWIG_NULLPTR; return *this; }
+    void reset(T *p) { T* oldptr = ptr; ptr = SWIG_NULLPTR; delete oldptr; ptr = p; }
   } pointer;
   SwigValueWrapper& operator=(const SwigValueWrapper<T>& rhs);
   SwigValueWrapper(const SwigValueWrapper<T>& rhs);
 public:
-  SwigValueWrapper() : pointer(0) { }
+  SwigValueWrapper() : pointer(SWIG_NULLPTR) { }
   SwigValueWrapper& operator=(const T& t) { SwigSmartPointer tmp(new T(t)); pointer = tmp; return *this; }
 #if __cplusplus >=201103L
   SwigValueWrapper& operator=(T&& t) { SwigSmartPointer tmp(new T(std::move(t))); pointer = tmp; return *this; }

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -3780,7 +3780,7 @@ public:
 
       Printf(f_runtime, "namespace Swig {\n");
       Printf(f_runtime, "  namespace {\n");
-      Printf(f_runtime, "    jclass jclass_%s = NULL;\n", imclass_name);
+      Printf(f_runtime, "    jclass jclass_%s = SWIG_NULLPTR;\n", imclass_name);
       Printf(f_runtime, "    jmethodID director_method_ids[%d];\n", n_methods);
       Printf(f_runtime, "  }\n");
       Printf(f_runtime, "}\n");
@@ -4182,7 +4182,7 @@ public:
 
       Wrapper_add_localv(w, "swigjnienv", "JNIEnvWrapper", "swigjnienv(this)", NIL, NIL);
       Wrapper_add_localv(w, jenvstr, "JNIEnv *", jenvstr, "= swigjnienv.getJNIEnv()", NIL);
-      Wrapper_add_localv(w, jobjstr, "jobject", jobjstr, "= (jobject) NULL", NIL);
+      Wrapper_add_localv(w, jobjstr, "jobject", jobjstr, "= (jobject) SWIG_NULLPTR", NIL);
       Delete(jenvstr);
       Delete(jobjstr);
 
@@ -4215,7 +4215,7 @@ public:
     if (!ignored_method) {
       Printf(w->code, "}\n");
       Printf(w->code, "swigjobj = swig_get_self(jenv);\n");
-      Printf(w->code, "if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {\n");
+      Printf(w->code, "if (swigjobj && jenv->IsSameObject(swigjobj, SWIG_NULLPTR) == JNI_FALSE) {\n");
     }
 
     /* Start the Java field descriptor for the intermediate class's upcall (insert jself object) */


### PR DESCRIPTION
We use SWIG as part of our system and rely on SonarQube for static code analysis. Replacing NULL with SWIG_NULLPTR eliminates the S4962 warnings, improving code quality and maintaining compliance with modern C++ best practices.