### PR TITLE
Makefile.am: avoid double `bison` execution on parallel build

### DIFF
--- a/Source/Makefile.am
+++ b/Source/Makefile.am
@@ -99,7 +99,9 @@ eswig_SOURCES =	CParse/cscanner.c		\
 
 bin_PROGRAMS = eswig
 
-CParse/parser.c CParse/parser.h: CParse/parser.y
+# Use GNU make's grouped targets to avoid repeated bison execution for
+# each target.
+CParse/parser.c CParse/parser.h &: CParse/parser.y
 	$(BISON) $(AM_YFLAGS) $(YFLAGS) --output=CParse/parser.c $(srcdir)/CParse/parser.y
 
 # The executable is copied to the root directory for installation and running the test-suite.


### PR DESCRIPTION
Before the change `make -j16` ran `bison` twice on the same input:

    $ make -j16
    ...
    make[1]: Entering directory '/build/source/Source'
    bison -d -Wall -Werror  --output=CParse/parser.c ./CParse/parser.y
    gcc -g -O2 -Wall -W -I.   -c -o mdfour.o mdfour.c
    bison -d -Wall -Werror  --output=CParse/parser.c ./CParse/parser.y
    ...

Note how two parallel `bison` calls both generate the same files. It works most of the time, but is prone to generate unexpected output.

This happens because Makefile rules like:

    a b: c; COMMAND
    all: a b

will run COMMAND for each target (twice here: once for `a` and once for `b`),

The fix uses GNU make's Grouped Targets to use single command to produce
multiple targets.