### PR TITLE
Python: Use multi-phase initialization

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -162,7 +162,7 @@ jobs:
           SWIG_FEATURES: -builtin -O
         - SWIGLANG: python
           VER: '3.8'
-          PY_ABI_VER: '3.4'
+          PY_ABI_VER: '3.5'
         - SWIGLANG: r
           os: ubuntu-24.04
         - SWIGLANG: ruby

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -4174,19 +4174,19 @@ This is enabled by defining <tt>Py_LIMITED_API</tt> during the compilation of th
 </p>
 
 <p>
-SWIG supports the stable ABI, but only version 3.4 of Python and later is supported.
-There are two recommended approaches for using SWIG and the stable ABI and both require setting the <tt>Py_LIMITED_API</tt> macro to be set to <tt>0x03040000</tt> as a minimum value (Python 3.4).
+SWIG supports the stable ABI, but only version 3.5 of Python and later is supported.
+There are two recommended approaches for using SWIG and the stable ABI and both require setting the <tt>Py_LIMITED_API</tt> macro to be set to <tt>0x03050000</tt> as a minimum value (Python 3.5).
 Either set this using <tt>%begin</tt> by adding the following into your interface file so that this macro appears at the beginning of the generated C/C++ code:
 </p>
 
 <div class="code"><pre>
 %begin %{
-#define Py_LIMITED_API 0x03040000
+#define Py_LIMITED_API 0x03050000
 %}
 </pre></div>
 
 <p>
-or simply define the macro using your C/C++ compiler's <tt>-D</tt> command line option, for example, <tt>-DPy_LIMITED_API=0x03040000</tt>.
+or simply define the macro using your C/C++ compiler's <tt>-D</tt> command line option, for example, <tt>-DPy_LIMITED_API=0x03050000</tt>.
 </p>
 
 <p>

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -193,6 +193,9 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
  *  Partial Init method
  * -----------------------------------------------------------------------------*/
 
+SWIGINTERN int SWIG_mod_exec(PyObject *module);
+
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -204,21 +207,40 @@ SWIGEXPORT
   void
 #endif
 SWIG_init(void) {
-  PyObject *m, *d, *md, *globals;
 
 #if PY_VERSION_HEX >= 0x03000000
+  static PyModuleDef_Slot SwigSlots[] = {
+    {Py_mod_exec, (void*)SWIG_mod_exec},
+    {0, NULL}
+  };
+
   static struct PyModuleDef SWIG_module = {
     PyModuleDef_HEAD_INIT,
     SWIG_name,
     NULL,
-    -1,
+    0,
     SwigMethods,
-    NULL,
+    SwigSlots,
     NULL,
     NULL,
     NULL
   };
+
+  return PyModuleDef_Init(&SWIG_module);
+#else
+  PyObject *m;
+  m = Py_InitModule(SWIG_name, SwigMethods);
+  if (m == NULL) return;
+  if (SWIG_mod_exec(m) != 0)
+  {
+    Py_DECREF(m);
+    return;
+  }
 #endif
+} /* SWIG_init */
+
+SWIGINTERN int SWIG_mod_exec(PyObject *m) {
+  PyObject *d, *md, *globals;
 
 #if defined(SWIGPYTHON_BUILTIN)
   static SwigPyClientData SwigPyObject_clientdata = {0, 0, 0, 0, 0, 0, 0};
@@ -272,11 +294,6 @@ SWIG_init(void) {
   /* Fix SwigMethods to carry the callback ptrs when needed */
   SWIG_Python_FixMethods(SwigMethods, swig_const_table, swig_types, swig_type_initial);
 
-#if PY_VERSION_HEX >= 0x03000000
-  m = PyModule_Create(&SWIG_module);
-#else
-  m = Py_InitModule(SWIG_name, SwigMethods);
-#endif
 #ifdef Py_GIL_DISABLED
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif	
@@ -297,11 +314,7 @@ SWIG_init(void) {
     SwigPyObject_clientdata.pytype = swigpyobject;
   } else if (swigpyobject->tp_basicsize != cd->pytype->tp_basicsize) {
     PyErr_SetString(PyExc_RuntimeError, "Import error: attempted to load two incompatible swig-generated modules.");
-# if PY_VERSION_HEX >= 0x03000000
-    return NULL;
-# else
-    return;
-# endif
+    return -1;
   }
 
   /* All objects have a 'this' attribute */

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -11,8 +11,8 @@
 # error "This version of SWIG only supports Python >= 2.7"
 #endif
 
-#if PY_VERSION_HEX >= 0x03000000 && PY_VERSION_HEX < 0x03030000
-# error "This version of SWIG only supports Python 3 >= 3.3"
+#if PY_VERSION_HEX >= 0x03000000 && PY_VERSION_HEX < 0x03050000
+# error "This version of SWIG only supports Python 3 >= 3.5"
 #endif
 
 /* Common SWIG API */

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -852,11 +852,7 @@ public:
 
     Dump(f_varlinks, f_init);
 
-    Printf(f_init, "#if PY_VERSION_HEX >= 0x03000000\n");
-    Printf(f_init, "  return m;\n");
-    Printf(f_init, "#else\n");
-    Printf(f_init, "  return;\n");
-    Printf(f_init, "#endif\n");
+    Printf(f_init, "  return 0;\n");
     Printf(f_init, "}\n");
 
     Printf(f_wrappers, "#ifdef __cplusplus\n");
@@ -3479,11 +3475,7 @@ public:
       Printf(f_init, "\t globals = SWIG_globals();\n");
       Printf(f_init, "\t if (!globals) {\n");
       Printf(f_init, "     PyErr_SetString(PyExc_TypeError, \"Failure to create SWIG globals.\");\n");
-      Printf(f_init, "#if PY_VERSION_HEX >= 0x03000000\n");
-      Printf(f_init, "\t   return NULL;\n");
-      Printf(f_init, "#else\n");
-      Printf(f_init, "\t   return;\n");
-      Printf(f_init, "#endif\n");
+      Printf(f_init, "\t   return -1;\n");
       Printf(f_init, "\t }\n");
       Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", globals);\n", global_name);
       if (builtin)
@@ -4012,11 +4004,7 @@ public:
 	Printv(f_init, "    builtin_bases[builtin_base_count++] = ((SwigPyClientData *) builtin_basetype->clientdata)->pytype;\n", NIL);
 	Printv(f_init, "  } else {\n", NIL);
 	Printf(f_init, "    PyErr_SetString(PyExc_TypeError, \"Could not create type '%s' as base '%s' has not been initialized.\\n\");\n", symname, bname);
-	Printv(f_init, "#if PY_VERSION_HEX >= 0x03000000\n", NIL);
-	Printv(f_init, "      return NULL;\n", NIL);
-	Printv(f_init, "#else\n", NIL);
-	Printv(f_init, "      return;\n", NIL);
-	Printv(f_init, "#endif\n", NIL);
+	Printv(f_init, "      return -1;\n", NIL);
 	Printv(f_init, "  }\n", NIL);
 	Delete(base_name);
 	Delete(base_mname);
@@ -4538,11 +4526,7 @@ public:
 
     Printf(f_init, "    builtin_pytype = %s_type_create(metatype, builtin_bases, d);\n", templ);
     Printf(f_init, "    if(!builtin_pytype) {\n", templ);
-    Printv(f_init, "#if PY_VERSION_HEX >= 0x03000000\n", NIL);
-    Printv(f_init, "      return NULL;\n", NIL);
-    Printv(f_init, "#else\n", NIL);
-    Printv(f_init, "      return;\n", NIL);
-    Printv(f_init, "#endif\n", NIL);
+    Printv(f_init, "      return -1;\n", NIL);
     Printv(f_init, "    }\n", NIL);
     Printf(f_init, "    SwigPyBuiltin_%s_clientdata.pytype = builtin_pytype;\n", mname);
     if (GetFlag(n, "feature:implicitconv")) {


### PR DESCRIPTION
Implements https://peps.python.org/pep-0489/
Bumps minimal python3 version from 3.4 to 3.5.
The idea is to move the initialization of the module in a new SWIG_mod_exec function.

Closes #3168

TODO: Figure out why it makes the swigvarlink warning reappear: DeprecationWarning: builtin type swigvarlink has no __module__ attribute make python_pybuffer.cpptest