### PR TITLE
Improve wchar_t handling

### DIFF
--- a/Lib/swig.swg
+++ b/Lib/swig.swg
@@ -714,3 +714,5 @@ template <typename T> T SwigValueInit() {
 #endif
 
 %insert("runtime") "swigcompat.swg"
+
+typedef __WCHAR_T__ wchar_t;

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -953,7 +953,7 @@ num_common:
         yylval.type = NewSwigType(T_CHAR);
         return (TYPE_CHAR);
       }
-      if (strcmp(yytext, "wchar_t") == 0) {
+      if (strcmp(yytext, "__WCHAR_T__") == 0) {
         yylval.type = NewSwigType(T_WCHAR);
         return (TYPE_WCHAR);
       }


### PR DESCRIPTION
SWIG previously always treated wchar_t as a keyword, which it is in C++ but not in C.  So for example `typedef unsigned short wchar_t;` was rejected with a parse error even in C mode.

Also MSVC seems to allow such a typedef even in C++ mode.

SWIG now has a` __WCHAR_T__` keyword, and we typedef wchar_t to that so the typedef above no longer causes a parse error (you will still get a warning).  This is done in both C and C++ mode, so C++ headers relying on MSVC's laxness can also now be parsed.

Fixes #3081