### PR TITLE
update PCRE2 find module to be compatible with upstream CMake config script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,8 @@ endif ()
 
 option (WITH_PCRE "Enable PCRE" ON)
 if (WITH_PCRE)
-  find_package (PCRE2 REQUIRED)
+  find_package (PCRE2 10.39 REQUIRED COMPONENTS 8BIT)
   set (HAVE_PCRE 1)
-  include_directories (${PCRE2_INCLUDE_DIRS})
 endif()
 
 #if (WIN32)
@@ -148,7 +147,7 @@ add_executable (swig
   ${PROJECT_BINARY_DIR}/Source/CParse/parser.h
 )
 if (PCRE2_FOUND)
-  target_link_libraries (swig ${PCRE2_LIBRARIES})
+  target_link_libraries (swig PRIVATE PCRE2::8BIT)
 endif ()
 install (TARGETS swig DESTINATION bin)
 

--- a/Tools/cmake/FindPCRE2.cmake
+++ b/Tools/cmake/FindPCRE2.cmake
@@ -1,6 +1,10 @@
-# - Find PCRE2
-# Perl Compatible Regular Expressions
-# https://www.pcre.org/
+# FindPCRE2.cmake
+#
+# CMake find module for Perl Compatible Regular Expressions.
+#
+# In particular, it looks for the more recent PCRE2, not the EOL PCRE library.
+#
+# See https://www.pcre.org/ for more details.
 
 # This find module first tries to use the upstream PCRE2 CMake config script
 # that is bundled with more recent PCRE2 versions since 10.38.

--- a/Tools/cmake/FindPCRE2.cmake
+++ b/Tools/cmake/FindPCRE2.cmake
@@ -2,20 +2,116 @@
 # Perl Compatible Regular Expressions
 # https://www.pcre.org/
 
-# The following variables are set:
-# PCRE2_FOUND - System has the PCRE library
-# PCRE2_LIBRARIES - The PCRE library file
-# PCRE2_INCLUDE_DIRS - The folder with the PCRE headers
+# This find module first tries to use the upstream PCRE2 CMake config script
+# that is bundled with more recent PCRE2 versions since 10.38.
+#
+# If config search fails, the original find logic will be used, and if
+# successful will define the imported PCRE2::8BIT library target.
+#
+# On Windows, PCRE2_USE_STATIC_LIBS is implicitly set to ON if not defined.
+# Usually PCRE2 is built static on Windows to begin with so this is desired.
+#
+# When search succeeds, PCRE2_FOUND is true, and these variables are set:
+#
+#   PCRE2_LIBRARIES       PCRE2 library files
+#   PCRE2_INCLUDE_DIRS    PCRE2 include directories
 
-find_library(PCRE2_LIBRARY NAMES pcre2 pcre2-8)
+# if not defined, use PCRE2_USE_STATIC_LIBS=ON for Windows
+if(WIN32 AND NOT DEFINED PCRE2_USE_STATIC_LIBS)
+  set(PCRE2_USE_STATIC_LIBS ON)
+endif()
+if(WIN32)
+  if(PCRE2_USE_STATIC_LIBS)
+    message(STATUS "PCRE2 libs: Static")
+  else()
+    message(STATUS "PCRE2 libs: Shared")
+  endif()
+endif()
+# attempt to locate using upstream config script and return if found
+find_package(PCRE2 CONFIG)
+if(PCRE2_FOUND)
+  return()
+endif()
+
+# manual search. find header and attempt to get version
 find_path(PCRE2_INCLUDE_DIR pcre2.h)
-
-set (PCRE2_LIBRARIES ${PCRE2_LIBRARY})
-set (PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
+if(PCRE2_INCLUDE_DIR)
+  # read major + minor versions
+  file(
+    STRINGS ${PCRE2_INCLUDE_DIR}/pcre2.h PCRE2_VERSION
+    REGEX "^#define[ ]+PCRE2_(MAJOR|MINOR)[ ]+[0-9]+")
+  # strip unnecessary components and build version
+  list(
+    TRANSFORM PCRE2_VERSION
+    REPLACE "^#define[ ]+PCRE2_(MAJOR|MINOR)[ ]+([0-9]+)" "\\2")
+  list(JOIN PCRE2_VERSION "." PCRE2_VERSION)
+endif()
+# find library. on Windows static name has the -static suffix
+# note: NO_CACHE used since PCRE2_LIBRARY has a different meaning on Windows
+if(WIN32 AND PCRE2_USE_STATIC_LIBS)
+  find_library(PCRE2_LIBRARY NAMES pcre2-8-static NO_CACHE)
+else()
+  find_library(PCRE2_LIBRARY NAMES pcre2 pcre2-8 NO_CACHE)
+endif()
+# if on Windows and PCRE2_USE_STATIC_LIBS is not ON, look for DLL as well
+if(WIN32 AND NOT PCRE2_USE_STATIC_LIBS)
+  find_file(PCRE2_LIBRARY_DLL NAMES pcre2-8.dll PATH_SUFFIXES bin)
+endif()
+# add PCRE2::8BIT target if library found
+if(PCRE2_LIBRARY)
+  # on Windows we explicitly distinguish static and shared because we know if
+  # we explicitly requested static or shared
+  if(WIN32)
+    if(PCRE2_USE_STATIC_LIBS)
+      add_library(PCRE2::8BIT STATIC IMPORTED)
+      set_target_properties(
+        PCRE2::8BIT PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "PCRE2_STATIC"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${PCRE2_LIBRARY}"
+      )
+    # still need DLL file for shared on Windows
+    elseif(PCRE2_LIBRARY_DLL)
+      add_library(PCRE2::8BIT SHARED IMPORTED)
+      set_target_properties(
+        PCRE2::8BIT PROPERTIES
+        IMPORTED_IMPLIB "${PCRE2_LIBRARY}"
+        IMPORTED_LOCATION "${PCRE2_LIBRARY_DLL}"
+      )
+    endif()
+  else()
+    add_library(PCRE2::8BIT UNKNOWN IMPORTED)
+    set_target_properties(
+      PCRE2::8BIT PROPERTIES
+      IMPORTED_LOCATION "${PCRE2_LIBRARY}"
+    )
+  endif()
+endif()
+# if PCRE2::8BIT target is created, set include directories + mark as found
+if(TARGET PCRE2::8BIT)
+  set_target_properties(
+    PCRE2::8BIT PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${PCRE2_INCLUDE_DIR}"
+  )
+  set(PCRE2_8BIT_FOUND ON)
+  # for compatibility
+  set(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
+  set(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
+endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCRE2 DEFAULT_MSG PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS)
 
-mark_as_advanced (
-  PCRE2_LIBRARY
-  PCRE2_INCLUDE_DIR)
+# build list of required variables (include DLL for shared on Windows)
+# note: PCRE2_LIBRARIES goes first so it shows in the message
+set(_required_vars PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS)
+if(WIN32 AND NOT PCRE2_USE_STATIC_LIBS)
+  list(APPEND _required_vars PCRE2_LIBRARY_DLL)
+endif()
+# check required vars
+find_package_handle_standard_args(PCRE2
+  REQUIRED_VARS ${_required_vars}
+  VERSION_VAR PCRE2_VERSION
+  HANDLE_COMPONENTS)
+# hide in CMake GUI unless showing advanced
+mark_as_advanced(${_required_vars})
+unset(_required_vars)


### PR DESCRIPTION
## Background

SWIG's CMake build config makes it much simpler to build SWIG on Windows assuming an existing Bison and PCRE2 installation. PCRE2 [10.38 and above](https://github.com/PCRE2Project/pcre2/commit/2410fbe3869cab403f02b94caa9ab37ee9f5854b) provides a CMake config script, although only after the 10.45 release did this config script become idiomatic, i.e. using the [CMake config helpers](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html). These allow `find_package` to be used in the "standard" way instead of using find-module logic as provided in `Tools/cmake/FindPCRE2.cmake`, e.g. with:

```cmake
if(WITH_PCRE)
  find_package(PCRE2 10.39 REQUIRED COMPONENTS 8BIT)
  set(HAVE_PCRE 1)
endif()
```

We can also link against the PCRE2 8-bit library target as follows when necessary:

```cmake
if(PCRE2_FOUND)
  target_link_libraries(swig PRIVATE PCRE2::8BIT)
endif()
```

The upstream PCRE2 config script will correctly handle defining `PCRE2_STATIC` during compilation.

## Changes

The changes are mostly to the `Tools/cmake/FindPCRE2.cmake` find module, which have the following logic:

1. Attempt to locate PCRE2 via CMake package config script if possible
2. If failed, use the existing find module logic while considering on Windows differences in static/shared PCRE2
   * For example, Windows PCRE2 static libraries have the name `pcre2-[bitness]-static`
   * [`PCRE2_USE_STATIC_LIBS`](https://github.com/PCRE2Project/pcre2/blob/bf50eeef64fc4f5ddfc93a041e2f4d7357f3c431/cmake/pcre2-config.cmake.in#L17) is respected and if not defined on Windows, implicitly set to `ON`
3. Additional enhancements to more closely mirror the upstream CMake config script's behavior
   * The `PCRE2::8BIT` [`IMPORTED`](https://cmake.org/cmake/help/latest/command/add_library.html#imported-libraries) library target is defined by `FindPCRE2.cmake` if necessary
   * The version (read from `pcre2.h`) and components passed to `find_package` are both checked

## Testing

Both Linux (WSL1 Ubuntu 22.04 with GCC 11.3) and Windows (64-bit hosted CL.exe 19.36.32535) configurations have been tested with PCRE versions 10.45 and 10.46 built from source with CMake package config scripts. On WSL1 Linux PCRE version 10.39 was tested, which does not have CMake support and so exercises the manual search logic in `FindPCRE2.cmake`.

SWIG was built on both Linux and Windows with specific PCRE2 installation roots controlled by `PCRE2_ROOT` appropriately, as well as using the system-installed PCRE 10.39 on WSL1 Linux. So a broad spectrum of use cases have been covered.

## Remarks

It would be great to have these patches merged into the mainline branch. I am also happy to update any relevant documentation pages so Windows users can have an easier build-from-source experience.