### PR TITLE
pyrun.swg: fix -Wparentheses warning

### DIFF
--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -742,7 +742,7 @@ SwigPyObject_richcompare(PyObject *v, PyObject *w, int op)
     /* Per https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
      * the first argument is guaranteed to be an instance of SwigPyObject, but the
      * second is not, so we typecheck that one. */
-    if (op != Py_EQ && op != Py_NE || !SwigPyObject_Check(w)) {
+    if ((op != Py_EQ && op != Py_NE) || !SwigPyObject_Check(w)) {
       SWIG_Py_INCREF(Py_NotImplemented);
       return Py_NotImplemented;
     }


### PR DESCRIPTION
Fixes gcc 14.3 warning
```
 extensions/gnm_wrap.cpp: In function 'PyObject* SwigPyObject_richcompare(PyObject*, PyObject*, int)':
extensions/gnm_wrap.cpp:2031:21: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
 2031 |     if (op != Py_EQ && op != Py_NE || !SwigPyObject_Check(w)) {
```