### PR TITLE
Free-threading Python: revert special treatment for PyList_GET_ITEM etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,10 +209,9 @@ Examples/python/**/foo.py
 Examples/python/**/robin.py
 Examples/python/**/runme3.py
 Examples/python/**/spam.py
-Examples/python/doxygen/example.html
-Examples/python/external_runtime/swig_runtime.hxx
 Examples/python/import_packages/module_is_init/pkg1/__init__.py
 Examples/python/import_packages/namespace_pkg/path4.zip
+Examples/python/doxygen/example.html
 
 # R
 Examples/test-suite/r/*.R

--- a/.gitignore
+++ b/.gitignore
@@ -209,9 +209,10 @@ Examples/python/**/foo.py
 Examples/python/**/robin.py
 Examples/python/**/runme3.py
 Examples/python/**/spam.py
+Examples/python/doxygen/example.html
+Examples/python/external_runtime/swig_runtime.hxx
 Examples/python/import_packages/module_is_init/pkg1/__init__.py
 Examples/python/import_packages/namespace_pkg/path4.zip
-Examples/python/doxygen/example.html
 
 # R
 Examples/test-suite/r/*.R

--- a/Lib/python/pyhead.swg
+++ b/Lib/python/pyhead.swg
@@ -93,20 +93,7 @@ SWIG_Python_str_FromChar(const char *c)
 #define Py_hash_t long
 #endif
 
-#ifdef Py_GIL_DISABLED
-# undef PyTuple_GET_ITEM
-# undef PyTuple_SET_ITEM
-# undef PyTuple_GET_SIZE
-# undef PyCFunction_GET_FLAGS
-# undef PyCFunction_GET_FUNCTION
-# undef PyCFunction_GET_SELF
-# undef PyList_GET_ITEM
-# undef PyList_SET_ITEM
-# undef PySliceObject
-#endif
-
-
-#if defined(Py_LIMITED_API) || defined(Py_GIL_DISABLED)
+#if defined(Py_LIMITED_API)
 # define PyTuple_GET_ITEM PyTuple_GetItem
 /* Note that PyTuple_SetItem() has different semantics from PyTuple_SET_ITEM as it decref's the original tuple item, so in general they cannot be used
   interchangeably. However in SWIG-generated code PyTuple_SET_ITEM is only used with newly initialized tuples without any items and for them this does work. */


### PR DESCRIPTION
Partially revert #3137.
This change did nothing to improve thread safety.
e.g. to get an item from a list you can use:
- `PyList_GET_ITEM` - thread unsafe vs. list element swap due to borrowed references; thread unsafe against list shrinking; no bounds checking regardless of threading
- `PyList_GetItem` - thread unsafe vs. list element swap; unsure about thread safety vs. list shrinking; bounds checked. Slower than `PyList_GET_ITEM`.
- `PyList_GetItemRef`. Thread safe and bounds checked; slower than both of the above.

To clarify there is absolutely nothing wrong with using `PyList_GET_ITEM` or `PyList_GetItem` in free-threading Python, as long as you can guaranteed that either
- the list is private to the thread; or
- your code is protected by a [critical section](https://docs.python.org/3/c-api/init.html#python-critical-section-api) and is not going to be suspended within it; or
- your code is protected by a lock

CC @klausspanderen @ngoldbaum 