### PR TITLE
Revert "Restore plain python-3.12 testing without -nogil"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -122,6 +122,7 @@ jobs:
         - SWIGLANG: python
           VER: '3.12'
           CSTD: gnu99
+          SWIG_FEATURES: -nogil  # Test that -nogil has no effect on non-free-threading Python
         - SWIGLANG: python
           VER: '3.13'
           CSTD: gnu99
@@ -129,11 +130,7 @@ jobs:
           VER: '3.13-dbg'
           CSTD: gnu99
         - SWIGLANG: python
-          VER: '3.13'
-          CSTD: gnu99
-          SWIG_FEATURES: -nogil  # Test that -nogil has no effect on non-free-threading Python
-        - SWIGLANG: python
-          VER: '3.13t'
+          VER: '3.13t' # no-gil testing
           CSTD: gnu99
           SWIG_FEATURES: -nogil
         - SWIGLANG: python


### PR DESCRIPTION
This reverts commit 0f58f9872d0bc63cd6833d5f6bb04a71bee1602e.

The reason for the original test was that the current implentation
```C
#ifdef SWIGPYTHON_NOGIL
#ifdef Py_GIL_DISABLED
    { Py_mod_gil, Py_MOD_GIL_NOT_USED },
#endif
#endif
```
works with Python versions older than 3.13, but
```C
#ifdef SWIGPYTHON_NOGIL
    { Py_mod_gil, Py_MOD_GIL_NOT_USED },
#endif
```
would work on Python 3.13 (GIL enabled) but crash on older versions. The test was verifying that we have the first implementation and not the second one.