### PR TITLE
Python: Thread-safe `SWIG_runtime_data_module`

### DIFF
--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -120,16 +120,10 @@ static PyObject *Swig_runtime_data_module_global = NULL;
 SWIGINTERN PyObject *
 SWIG_runtime_data_module() {
   if (!Swig_runtime_data_module_global) {
-#if PY_VERSION_HEX >= 0x030D00A0
-    /* On free-threaded Python, handle race condition with other SWIG-compiled
-       Python modules creating the same module at the same time.
-       Note that global variables are local to the current Python module,
-       so a mutex would not help!
-     */
-    PyImport_AddModule(SWIG_RUNTIME_MODULE);
-    /* Now we are guaranteed that a module is referenced by sys.modules,
-       but not necessarily the one returned by the previous function call.
-     */
+#if PY_VERSION_HEX >= 0x030D0000
+    /* free-threading note: the GIL is always enabled when this function is first called
+       by SWIG_init, so there's no risk of race conditions
+     */  
     Swig_runtime_data_module_global = PyImport_AddModuleRef(SWIG_RUNTIME_MODULE);
 #elif PY_VERSION_HEX >= 0x03000000
     Swig_runtime_data_module_global = PyImport_AddModule(SWIG_RUNTIME_MODULE);

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -120,14 +120,27 @@ static PyObject *Swig_runtime_data_module_global = NULL;
 SWIGINTERN PyObject *
 SWIG_runtime_data_module() {
   if (!Swig_runtime_data_module_global) {
-#if PY_VERSION_HEX >= 0x03000000
+#if PY_VERSION_HEX >= 0x030D00A0
+    /* On free-threaded Python, handle race condition with other SWIG-compiled
+       Python modules creating the same module at the same time.
+       Note that global variables are local to the current Python module,
+       so a mutex would not help!
+     */
+    PyImport_AddModule(SWIG_RUNTIME_MODULE);
+    /* Now we are guaranteed that a module is referenced by sys.modules,
+       but not necessarily the one returned by the previous function call.
+     */
+    Swig_runtime_data_module_global = PyImport_AddModuleRef(SWIG_RUNTIME_MODULE);
+#elif PY_VERSION_HEX >= 0x03000000
     Swig_runtime_data_module_global = PyImport_AddModule(SWIG_RUNTIME_MODULE);
+    SWIG_Py_XINCREF(Swig_runtime_data_module_global);
 #else
     static PyMethodDef swig_empty_runtime_method_table[] = { {NULL, NULL, 0, NULL} }; /* Sentinel */
     Swig_runtime_data_module_global = Py_InitModule(SWIG_RUNTIME_MODULE, swig_empty_runtime_method_table);
-#endif
     SWIG_Py_XINCREF(Swig_runtime_data_module_global);
+#endif
   }
+  assert(Swig_runtime_data_module_global);
   return Swig_runtime_data_module_global;
 }
 


### PR DESCRIPTION
[EDIT] `SWIG_runtime_data_module` is thread-safe as the first call to the function holds the GIL even in free-threaded python. This PR uses the new API when available (this is just cosmetic) and adds a comment explaining it.

Original OP below:

~On free-threaded Python, prevent a situation where a thread calls `import module1` and another calls `import module2`, where `module1` and `module2` are two separate SWIG-generated Python modules, and the two modules end up with two completely separate copies of the `swig_runtime_data5` module, only one of which is referenced by `sys.modules`.~

~`SWIG_runtime_data_module` creates the empty module `swig_runtime_data5` when the first SWIG-compiled module is imported. To my understanding, `PyImport_AddModuleRef` only prevents a segfault due to a pointer to a dereferenced PyObject. It does not prevent from ending up with two separate modules, only one of which is referenced by `sys.modules`.~

~There is no protection against race conditions caused by `reimport`. Unless a user deliberately runs `del sys.modules["swig_runtime_data5"]`, reimporting the actual user's SWIG modules (`module1` / `module2` in the above example) will just return a reference to the same `swig_runtime_data5` that had been created previously.~

~No unit tests for this as it would be quite hard to concoct one.~