### PR TITLE
python -builtin: remove __dict__ docstring

### DIFF
--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3377,8 +3377,7 @@ public:
       }
       Setattr(h, "getter", "SwigPyObject_get___dict__");
       if (!Getattr(h, "doc")) {
-	Setattr(n, "doc:high:name", Getattr(n, "name"));
-	Setattr(h, "doc", cdocstring(n, AUTODOC_VAR));
+	Setattr(h, "doc", "");
       }
     }
 


### PR DESCRIPTION
The docstring from the previously documented atribute or method was being applied to the builtin `__dict__` member. This now has no docstring, like `this` and `thisown`.

(This trivially small change doesn't merit an entry in the change log.)