### PR TITLE
CI: Drop continue-on-error for py3.14

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,11 +142,9 @@ jobs:
           VER: '3.14'
           PY_ABI_VER: '3.14'
           CSTD: gnu99
-          continue-on-error: true
         - SWIGLANG: python
           VER: '3.14'
           CSTD: gnu99
-          continue-on-error: true
         - SWIGLANG: python
           PY2: 2
           SWIG_FEATURES: -builtin


### PR DESCRIPTION
Python 3.14 has been released so this should not be needed anymore