### PR TITLE
SWIG_Hash: Fix unaligned pointer dereference.

### DIFF
--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -276,7 +276,7 @@ SWIGRUNTIME unsigned int SWIG_Hash(const char *str, unsigned int len) {
   int rem = (int)len;
 
   while (rem >= (int)sizeof(unsigned int)) {
-    k = *(unsigned int *)data;
+    memcpy(&k, data, sizeof(unsigned int));
     k += i++;
     hash ^= k;
     hash *= 171717;


### PR DESCRIPTION
Casting an (unaligned) char* to a int* is not allowed by the C specs. Let's use the memcpy fallback instead. All compilers should be able to inline it anyways.

Fixes at least -fsanitize=undefined on my system:

_MyModule.cxx:496:7: runtime error: load of misaligned address 0x7f66e1f358e2 for type 'unsigned int', which requires 4 byte alignment
0x7f66e1f358e2: note: pointer points here
 73 20  2a 00 5f 70 5f 44 65 6c  61 79 65 64 43 68 61 6e  6e 65 6c 00 44 65 6c 61  79 65 64 43 68 61