### PR TITLE
cmake - remove unused policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,6 @@ set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 
 project (swig)
 
-if (POLICY CMP0074)
-  cmake_policy (SET CMP0074 NEW)
-endif()
-
 file (STRINGS configure.ac line LIMIT_COUNT 1 REGEX "AC_INIT\\(.*\\)" )
 if (line MATCHES "AC_INIT\\(\\[(.*)\\],[ \t]*\\[(.*)\\],[ \t]*\\[(.*)\\]\\)" )
   set (SWIG_VERSION ${CMAKE_MATCH_2})


### PR DESCRIPTION
`CMP0074` was introduced in cmake 3.12 and since min cmake version is now 3.13, then setting this policy have no use anymore and can be safely removed.

https://github.com/swig/swig/blob/f38f249c9ca397a548b31440e540bf6b0d953abf/CMakeLists.txt#L1

Ref https://cmake.org/cmake/help/latest/policy/CMP0074.html