### PR TITLE
Use clang-format on SWIG source

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,7 +66,7 @@ jobs:
           esac
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         show-progress: false
 
@@ -121,7 +121,7 @@ jobs:
       run: systeminfo | findstr /B /C:"OS Name" /B /C:"OS Version"
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         show-progress: false
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,9 +22,11 @@ permissions:
 
 jobs:
   # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
-  clang-format-oldest:
+  # The clang-format version used is slightly different for each OS workflow file
+  # This job gates the main build job so must succeed before the main build job is run
+  clang-format:
     runs-on: ubuntu-latest
-    name: clang-format 18
+    name: clang-format 18 # 18 is the oldest supported version
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -32,20 +34,6 @@ jobs:
           show-progress: false
       - name: Check with clang-format
         uses: RafikFarhad/clang-format-github-action@v4.1
-        with:
-          sources: "Source/*/*.c,Source/*/*.cxx,Source/*/*.h"
-          style: file
-
-  clang-format-newest:
-    runs-on: ubuntu-latest
-    name: clang-format 21
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.1
-        with:
-          show-progress: false
-      - name: Check with clang-format
-        uses: RafikFarhad/clang-format-github-action@v6.0.1
         with:
           sources: "Source/*/*.c,Source/*/*.cxx,Source/*/*.h"
           style: file
@@ -62,7 +50,7 @@ jobs:
     # can define the additional "desc" field with any additional information to include in the name.
     name: ${{ matrix.SWIGLANG || 'none' }}${{ matrix.PY2 }} ${{ matrix.ENGINE}} ${{ matrix.VER }} ${{ matrix.PY_ABI_VER && format('abi={0}', matrix.PY_ABI_VER) }} ${{ matrix.SWIG_FEATURES }} ${{ (matrix.compiler || 'gcc') }}${{ matrix.GCC }} ${{ matrix.CPPSTD }} ${{ matrix.CSTD }} ${{ matrix.desc }} ${{ matrix.continue-on-error && '(can fail)' }}
 
-    needs: [clang-format-oldest, clang-format-newest]
+    needs: [clang-format]
 
     strategy:
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,35 @@ permissions:
   contents: read
 
 jobs:
+  # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
+  clang-format-oldest:
+    runs-on: ubuntu-latest
+    name: clang-format 18
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          show-progress: false
+      - name: Check with clang-format
+        uses: RafikFarhad/clang-format-github-action@v4.1
+        with:
+          sources: "Source/*/*.c,Source/*/*.cxx,Source/*/*.h"
+          style: file
+
+  clang-format-newest:
+    runs-on: ubuntu-latest
+    name: clang-format 21
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+        with:
+          show-progress: false
+      - name: Check with clang-format
+        uses: RafikFarhad/clang-format-github-action@v6.0.1
+        with:
+          sources: "Source/*/*.c,Source/*/*.cxx,Source/*/*.h"
+          style: file
+
   build:
 
     # When continue-on-error is true for an individual build, that build can fail (it'll show red),
@@ -32,6 +61,8 @@ jobs:
     # By default, the name of the build is the language used and SWIG options, but matrix entries
     # can define the additional "desc" field with any additional information to include in the name.
     name: ${{ matrix.SWIGLANG || 'none' }}${{ matrix.PY2 }} ${{ matrix.ENGINE}} ${{ matrix.VER }} ${{ matrix.PY_ABI_VER && format('abi={0}', matrix.PY_ABI_VER) }} ${{ matrix.SWIG_FEATURES }} ${{ (matrix.compiler || 'gcc') }}${{ matrix.GCC }} ${{ matrix.CPPSTD }} ${{ matrix.CSTD }} ${{ matrix.desc }} ${{ matrix.continue-on-error && '(can fail)' }}
+
+    needs: [clang-format-oldest, clang-format-newest]
 
     strategy:
       matrix:
@@ -470,7 +501,7 @@ jobs:
           cat /etc/lsb-release
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         show-progress: false
         submodules: recursive

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,6 +25,23 @@ permissions:
   contents: read
 
 jobs:
+  # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
+  # The clang-format version used is slightly different for each OS workflow file
+  # This job gates the main build job so must succeed before the main build job is run
+  clang-format:
+    runs-on: ubuntu-latest
+    name: clang-format 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          show-progress: false
+      - name: Check with clang-format
+        uses: RafikFarhad/clang-format-github-action@v5.1
+        with:
+          sources: "Source/*/*.c,Source/*/*.cxx,Source/*/*.h"
+          style: file
+
   build:
 
     # When continue-on-error is true for an individual build,
@@ -45,6 +62,8 @@ jobs:
       ${{ matrix.CSTD }}
       ${{ matrix.os }}
       ${{ matrix.continue-on-error && '(can fail)' }}
+
+    needs: [clang-format]
 
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,23 @@ permissions:
   contents: read
 
 jobs:
+  # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
+  # The clang-format version used is slightly different for each OS workflow file
+  # This job gates the main build job so must succeed before the main build job is run
+  clang-format:
+    runs-on: ubuntu-latest
+    name: clang-format 21
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          show-progress: false
+      - name: Check with clang-format
+        uses: RafikFarhad/clang-format-github-action@v6.0.1
+        with:
+          sources: "Source/*/*.c,Source/*/*.cxx,Source/*/*.h"
+          style: file
+
   # This action build using MSYS2 environment
   # We use two compilers C/C++:
   # - Microsoft Visual Studio compiler.
@@ -37,7 +54,7 @@ jobs:
   #  and install only missed software.
   # We use different versions of installed languages by using
   #  proper envirounment.
-  win_ci:
+  build:
     # When continue-on-error is true for an individual build,
     # that build can fail (it'll show red),
     # but it won't fail the overall tests
@@ -55,6 +72,8 @@ jobs:
       ${{ matrix.CSTD }}
       ${{ matrix.os }}
       ${{ matrix.continue-on-error && '(can fail)' }}
+
+    needs: [clang-format]
 
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -136,7 +136,7 @@ jobs:
           systeminfo | findstr /B /C:"OS Name" /B /C:"OS Version"
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         show-progress: false
 

--- a/Doc/Manual/Extending.html
+++ b/Doc/Manual/Extending.html
@@ -3616,29 +3616,108 @@ Some topics that you'll want to be sure to address include:
 
 
 <p>
-The coding guidelines for the C/C++ source code are pretty much K&amp;R C style.
-The style can be inferred from the existing code base and is
-largely dictated by the <tt>indent</tt> code beautifier tool set to K&amp;R style.
-The code can be formatted using the make targets in the Source directory.
-Below is an example of how to format the emit.cxx file:
+The coding guidelines for the C/C++ source code are defined and implemented by the <tt>clang-format</tt> tool using
+the <tt>Source/.clang-format</tt> config file.
+Interested readers should take a look at the <a href="https://clang.llvm.org/docs/ClangFormat.html">ClangFormat documentation</a>.
+</p>
+
+<p>
+The <tt>clang-format</tt> tool is searched for during the configuration of SWIG and if found
+it will automatically be used to warn about code formatting discrepancies during the build.
+The tool is invoked immediately after compilation and linking of the SWIG executable.
+There are various make target which allow a developer to invoke <tt>clang-format</tt>
+to check the code format as well as reformat the code.
+These coding style guidelines are just for the SWIG source C and C++ code.
+</p>
+
+<p>
+How the tool is used during the development/building of SWIG depends on configure time options as follows:
+</p>
+
+<table BORDER summary="clang-format configure options">
+<tr>
+  <td><b>Configure options</b></td> <td><b>Description</b></td> <td><b>Recommended for</b></td>
+</tr>
+<tr>
+  <td>./configure</td> <td>Look for clang-format and only use if found (default)</td> <td>SWIG developers if clang-format is installed, everyone else if not installed</td>
+<tr>
+<tr>
+  <td>./configure --with-clang-format</td> <td>Look for clang-format and only use if found</td> <td>SWIG developers with a standard clang-format installation</td>
+<tr>
+</tr>
+<td>./configure --with-clang-format=&lt;path&gt;</td> <td>Use explicit/renamed clang-format binary</td> <td>SWIG developers with a non-standard clang-format installation</td>
+</tr>
+<tr>
+  <td>./configure --without-clang-format</td> <td>Don't use clang-format even if installed on system</td> <td>SWIG users, non-developers and system builders</td>
+</tr>
+</table>
+
+<p>
+The version of <tt>clang-format</tt> is checked at configure time.
+It is only enabled if the version is recent enough and this is clearly stated in the output of configure.
+Version 18 was the initial minimum version given it introduced support for the required
+<tt>Source/.clang-format-ignore</tt> file.
+</p>
+
+<p>
+If <tt>clang-format</tt> is found during configure time, the make targets listed below can be used:
+</p>
+
+<table BORDER summary="make targets for formatting">
+<tr>
+  <td><b>Make target</b></td> <td><b>Example usage</b></td> <td><b>Description</b></td>
+</tr>
+<tr>
+  <td>format-review</td> <td>make format-review</td> <td>For invoking clang-format to warn about source formatting discrepancies</td>
+<tr>
+<tr>
+  <td>format-check</td> <td>make format-check</td> <td>For invoking clang-format to error out when there are source formatting discrepancies</td>
+<tr>
+<tr>
+  <td>format-inplace</td> <td>make format-inplace</td> <td>For invoking clang-format to correct source formatting - overwrites source files in-place</td>
+<tr>
+<tr>
+  <td>format</td> <td>make format</td> <td>Identical to format-inplace target</td>
+<tr>
+<tr>
+  <td></td> <td>make</td> <td>Default make target for building the swig executable and then invoking the format-review target</td>
+<tr>
+</table>
+
+<p>
+The targets are available in both the root directory and the Source subdirectory.
+The <tt>CLANG_FORMAT_OPTIONS</tt> variable can be used to add options to the <tt>clang-format</tt> invocation (the variable is empty by default).
+For example, <tt>clang-format</tt> has a <tt>--verbose</tt> option to output the name of the file it is currently working on:
 </p>
 
 <blockquote>
 <pre>
-$ cd Source
-$ make beautify-file INDENTFILE=Modules/emit.cxx
+$ make format CLANG_FORMAT_OPTIONS=--verbose
 </pre>
 </blockquote>
 
 <p>
-The tool is far from perfect as it is more of a C beautify than a C++ beautifier; sometimes the output it
-generates need fixing up.
+As mentioned, if <tt>clang-format</tt> is configured to be used during configure time, the <tt>format-review</tt> target is always invoked after the SWIG executable has been built.
+This can be temporarily avoided without rerunning configure.
+Instead set the <tt>CLANG_FORMAT</tt> variable set to nothing (it normally holds the name of the <tt>clang-format</tt> executable):
+</p>
+
+<blockquote>
+<pre>
+$ make format CLANG_FORMAT=
+</pre>
+</blockquote>
+
+<p>
+Of particular note regarding the code style is only spaces are used and indentation is 2 spaces.
+The generated C/C++ code should also follow this whitespace style as close as possible.
 </p>
 
 <p>
-Of particular note regarding the code style is indentation is set to 2 spaces and a tab is used instead of 8 spaces.
-The generated C/C++ code should also follow this style as close as possible. However, tabs
-should be avoided as unlike the SWIG developers, users will never have consistent tab settings.
+<b>Compatibility Note:</b> The clang-formatting was introduced during the development of SWIG-4.5.0.
+Prior to that the GNU <tt>indent</tt> tool was recommended for formatting.
+The switch to <tt>clang-format</tt> was made in order to gain automated, consistent and working reformatting for C++ source code.
+The SWIG code base had to undergo some subtle formatting changes as a result.
 </p>
 
 

--- a/Doc/Manual/Extending.html
+++ b/Doc/Manual/Extending.html
@@ -3692,11 +3692,9 @@ The <tt>CLANG_FORMAT_OPTIONS</tt> variable can be used to add options to the cla
 For example, clang-format has a <tt>--verbose</tt> option to output the name of the file it is currently working on:
 </p>
 
-<blockquote>
-<pre>
+<div class="shell"><pre>
 $ make format CLANG_FORMAT_OPTIONS=--verbose
-</pre>
-</blockquote>
+</pre></div>
 
 <p>
 As mentioned, if clang-format is configured to be used during configure time, the <tt>format-review</tt> target is always invoked after the SWIG executable has been built.
@@ -3704,17 +3702,34 @@ This can be temporarily avoided without rerunning configure.
 Instead set the <tt>CLANG_FORMAT</tt> variable set to nothing (it normally holds the name of the clang-format executable):
 </p>
 
-<blockquote>
-<pre>
+<div class="shell"><pre>
 $ make format CLANG_FORMAT=
-</pre>
-</blockquote>
+</pre></div>
 
-<blockquote>
-<pre>
-$ make format CLANG_FORMAT=
-</pre>
-</blockquote>
+<p>
+Developers are also urged to use the SWIG pre-commit git hook script which is available in <tt>Tools/pre-commit</tt>.
+This is useful for preventing accidental commits with incorrectly formatted code.
+It invokes clang-format to validate the formatting is correct on all modified (both git staged and unstaged) files in the Source directory.
+Find the .git/hooks directory for the SWIG repository (usually in your git working directory) and copy it there, such as:
+</p>
+
+<div class="shell"><pre>
+$ cp Tools/pre-commit .git/hooks/
+</pre></div>
+
+<p>
+Modify the <tt>clang_format</tt> variable in the script if clang-format is not the name of the clang-format executable that is version 18 or later.
+Then when committing code, you'll see something like the following if the code is not formatted correctly:
+</p>
+
+<div class="shell"><pre>
+$ git commit .
+Running clang-format in git pre-commit hook to validate modified files...
+Source/Modules/java.cxx:26:30: error: code should be clang-formatted [-Wclang-format-violations]
+  const String *empty_string;
+                             ^
+Error: Fix formatting before committing, see Doc/Manual/Extending.html#Extending_coding_style_guidelines.
+</pre></div>
 
 <p>
 Of particular note regarding the code style is only spaces are used and indentation is 2 spaces.

--- a/Doc/Manual/Extending.html
+++ b/Doc/Manual/Extending.html
@@ -3616,18 +3616,19 @@ Some topics that you'll want to be sure to address include:
 
 
 <p>
-The coding guidelines for the C/C++ source code are defined and implemented by the <tt>clang-format</tt> tool using
+The coding guidelines for the C/C++ source code are defined and implemented by the clang-format tool using
 the <tt>Source/.clang-format</tt> config file.
-Interested readers should take a look at the <a href="https://clang.llvm.org/docs/ClangFormat.html">ClangFormat documentation</a>.
+Interested readers should take a look at the <a href="https://clang.llvm.org/docs/ClangFormat.html">ClangFormat documentation</a> for more details.
+SWIG developers are encouraged to use this ClangFormat documentation for setting up their chosen editor for integrating clang-format during editing and development.
 </p>
 
 <p>
-The <tt>clang-format</tt> tool is searched for during the configuration of SWIG and if found
+The clang-format tool is searched for during the configuration of SWIG and if found
 it will automatically be used to warn about code formatting discrepancies during the build.
-The tool is invoked immediately after compilation and linking of the SWIG executable.
-There are various make target which allow a developer to invoke <tt>clang-format</tt>
+The tool can be invoked during compilation and linking of the SWIG executable.
+There are various make target which allow a developer to invoke clang-format
 to check the code format as well as reformat the code.
-These coding style guidelines are just for the SWIG source C and C++ code.
+These coding style guidelines are just for the SWIG C and C++ source code including header files.
 </p>
 
 <p>
@@ -3648,19 +3649,20 @@ How the tool is used during the development/building of SWIG depends on configur
 <td>./configure --with-clang-format=&lt;path&gt;</td> <td>Use explicit/renamed clang-format binary</td> <td>SWIG developers with a non-standard clang-format installation</td>
 </tr>
 <tr>
-  <td>./configure --without-clang-format</td> <td>Don't use clang-format even if installed on system</td> <td>SWIG users, non-developers and system builders</td>
+  <td>./configure --without-clang-format</td> <td>Don't use clang-format even if installed on system</td> <td>SWIG users, system builders and other non-developers</td>
 </tr>
 </table>
 
 <p>
-The version of <tt>clang-format</tt> is checked at configure time.
-It is only enabled if the version is recent enough and this is clearly stated in the output of configure.
-Version 18 was the initial minimum version given it introduced support for the required
-<tt>Source/.clang-format-ignore</tt> file.
+The version of clang-format is inspected at configure time.
+It is only enabled if the version is recent enough and this is clearly shown in the output of configure.
+Version 18 is the minimum supported version and was carefully chosen when clang-format was first used for SWIG as this is the first version to support the
+<tt>Source/.clang-format-ignore</tt> file that SWIG requires.
+The ignore file helps the clang-format tooling format just the files in the source tree that should be formatted.
 </p>
 
 <p>
-If <tt>clang-format</tt> is found during configure time, the make targets listed below can be used:
+If clang-format is found during configure time, the make targets listed below can be used:
 </p>
 
 <table BORDER summary="make targets for formatting">
@@ -3680,14 +3682,14 @@ If <tt>clang-format</tt> is found during configure time, the make targets listed
   <td>format</td> <td>make format</td> <td>Identical to format-inplace target</td>
 <tr>
 <tr>
-  <td></td> <td>make</td> <td>Default make target for building the swig executable and then invoking the format-review target</td>
+  <td></td> <td>make</td> <td>Default make target for building the swig executable and invoking the format-review target</td>
 <tr>
 </table>
 
 <p>
 The targets are available in both the root directory and the Source subdirectory.
-The <tt>CLANG_FORMAT_OPTIONS</tt> variable can be used to add options to the <tt>clang-format</tt> invocation (the variable is empty by default).
-For example, <tt>clang-format</tt> has a <tt>--verbose</tt> option to output the name of the file it is currently working on:
+The <tt>CLANG_FORMAT_OPTIONS</tt> variable can be used to add options to the clang-format invocation (the variable is empty by default).
+For example, clang-format has a <tt>--verbose</tt> option to output the name of the file it is currently working on:
 </p>
 
 <blockquote>
@@ -3697,10 +3699,16 @@ $ make format CLANG_FORMAT_OPTIONS=--verbose
 </blockquote>
 
 <p>
-As mentioned, if <tt>clang-format</tt> is configured to be used during configure time, the <tt>format-review</tt> target is always invoked after the SWIG executable has been built.
+As mentioned, if clang-format is configured to be used during configure time, the <tt>format-review</tt> target is always invoked after the SWIG executable has been built.
 This can be temporarily avoided without rerunning configure.
-Instead set the <tt>CLANG_FORMAT</tt> variable set to nothing (it normally holds the name of the <tt>clang-format</tt> executable):
+Instead set the <tt>CLANG_FORMAT</tt> variable set to nothing (it normally holds the name of the clang-format executable):
 </p>
+
+<blockquote>
+<pre>
+$ make format CLANG_FORMAT=
+</pre>
+</blockquote>
 
 <blockquote>
 <pre>
@@ -3716,7 +3724,7 @@ The generated C/C++ code should also follow this whitespace style as close as po
 <p>
 <b>Compatibility Note:</b> The clang-formatting was introduced during the development of SWIG-4.5.0.
 Prior to that the GNU <tt>indent</tt> tool was recommended for formatting.
-The switch to <tt>clang-format</tt> was made in order to gain automated, consistent and working reformatting for C++ source code.
+The switch to clang-format was made in order to gain automated, consistent and working reformatting for C++ source code.
 The SWIG code base had to undergo some subtle formatting changes as a result.
 </p>
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -2,7 +2,7 @@
 # SWIG top level Makefile
 #######################################################################
 
-.PHONY: ccache source swig
+.PHONY: swig source format-review format-check format-inplace format ccache
 
 prefix      = @prefix@
 exec_prefix = @exec_prefix@
@@ -34,6 +34,17 @@ swig: libfiles source ccache
 
 source:
 	@$(MAKE) -C $(SOURCE)
+
+format-review:
+	@$(MAKE) -C $(SOURCE) format-review
+
+format-check:
+	@$(MAKE) -C $(SOURCE) format-check
+
+format-inplace:
+	@$(MAKE) -C $(SOURCE) format-inplace
+
+format: format-inplace
 
 ccache:
 	test -z "$(ENABLE_CCACHE)" || $(MAKE) -C $(CCACHE)

--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -1,0 +1,26 @@
+# This file format requires clang-format version 14 or later
+# SWIG requires clang-format version 18 or later for .clang-format-ignore support
+
+Language: Cpp
+BasedOnStyle: Google
+AlignArrayOfStructures: Left
+AlignTrailingComments: true
+AccessModifierOffset: -2
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: false
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 160
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+IndentCaseBlocks: true
+IndentCaseLabels: false
+IndentGotoLabels: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+PackConstructorInitializers: CurrentLine
+PointerAlignment: Right
+SortIncludes: Never

--- a/Source/.clang-format-ignore
+++ b/Source/.clang-format-ignore
@@ -1,0 +1,3 @@
+CParse/parser.c
+CParse/parser.h
+Include/swigconfig.h

--- a/Source/CParse/cparse.h
+++ b/Source/CParse/cparse.h
@@ -22,61 +22,63 @@ extern "C" {
 #endif
 
 /* cscanner.c */
-  extern String *cparse_file;
-  extern int cparse_line;
-  extern int cparse_cplusplus;
-  extern int cparse_cplusplusout;
-  extern int cparse_start_line;
-  extern String *cparse_unknown_directive;
-  extern int scan_doxygen_comments;
+extern String *cparse_file;
+extern int cparse_line;
+extern int cparse_cplusplus;
+extern int cparse_cplusplusout;
+extern int cparse_start_line;
+extern String *cparse_unknown_directive;
+extern int scan_doxygen_comments;
 
-  extern void Swig_cparse_cplusplus(int);
-  extern void Swig_cparse_cplusplusout(int);
-  extern void scanner_file(File *);
-  extern void scanner_next_token(int);
-  extern int skip_balanced(int startchar, int endchar);
-  extern String *get_raw_text_balanced(int startchar, int endchar);
-  extern void skip_decl(void);
-  extern void scanner_last_id(int);
-  extern void scanner_clear_rename(void);
-  extern void scanner_set_location(String *file, int line);
-  extern void scanner_set_main_input_file(String *file);
-  extern String *scanner_get_main_input_file(void);
-  extern void Swig_cparse_follow_locators(int);
-  extern void scanner_start_inline(String *, int);
-  extern String *scanner_ccode;
-  extern int yylex(void);
+extern void Swig_cparse_cplusplus(int);
+extern void Swig_cparse_cplusplusout(int);
+extern void scanner_file(File *);
+extern void scanner_next_token(int);
+extern int skip_balanced(int startchar, int endchar);
+extern String *get_raw_text_balanced(int startchar, int endchar);
+extern void skip_decl(void);
+extern void scanner_last_id(int);
+extern void scanner_clear_rename(void);
+extern void scanner_set_location(String *file, int line);
+extern void scanner_set_main_input_file(String *file);
+extern String *scanner_get_main_input_file(void);
+extern void Swig_cparse_follow_locators(int);
+extern void scanner_start_inline(String *, int);
+extern String *scanner_ccode;
+extern int yylex(void);
 
 /* parser.y */
-  extern SwigType *Swig_cparse_type(String *);
-  extern Node *Swig_cparse(File *);
-  extern Hash *Swig_cparse_features(void);
-  extern void SWIG_cparse_set_compact_default_args(int defargs);
-  extern int SWIG_cparse_template_reduce(int treduce);
+extern SwigType *Swig_cparse_type(String *);
+extern Node *Swig_cparse(File *);
+extern Hash *Swig_cparse_features(void);
+extern void SWIG_cparse_set_compact_default_args(int defargs);
+extern int SWIG_cparse_template_reduce(int treduce);
 
 /* util.c */
-  extern void Swig_cparse_replace_descriptor(String *s);
-  extern SwigType *Swig_cparse_smartptr(Node *n);
-  extern Parm *Swig_cparse_parm(String *s);
-  extern ParmList *Swig_cparse_parms(String *s, Node *file_line_node);
-  extern Node *Swig_cparse_new_node(const_String_or_char_ptr tag);
+extern void Swig_cparse_replace_descriptor(String *s);
+extern SwigType *Swig_cparse_smartptr(Node *n);
+extern Parm *Swig_cparse_parm(String *s);
+extern ParmList *Swig_cparse_parms(String *s, Node *file_line_node);
+extern Node *Swig_cparse_new_node(const_String_or_char_ptr tag);
 
 /* templ.c */
-  extern int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab *tscope);
-  extern Node *Swig_cparse_template_locate(String *name, ParmList *tparms, String *symname, Symtab *tscope);
-  extern void Swig_cparse_debug_templates(int);
-  extern ParmList *Swig_cparse_template_parms_expand(ParmList *instantiated_parameters, Node *primary, Node *templ);
-  extern ParmList *Swig_cparse_template_partialargs_expand(ParmList *partially_specialized_parms, Node *primary, ParmList *templateparms);
+extern int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab *tscope);
+extern Node *Swig_cparse_template_locate(String *name, ParmList *tparms, String *symname, Symtab *tscope);
+extern void Swig_cparse_debug_templates(int);
+extern ParmList *Swig_cparse_template_parms_expand(ParmList *instantiated_parameters, Node *primary, Node *templ);
+extern ParmList *Swig_cparse_template_partialargs_expand(ParmList *partially_specialized_parms, Node *primary, ParmList *templateparms);
 
 #ifdef __cplusplus
 }
 #endif
-#define SWIG_WARN_NODE_BEGIN(Node) \
- { \
-  String *wrnfilter = Node ? Getattr(Node,"feature:warnfilter") : 0; \
-  if (wrnfilter) Swig_warnfilter(wrnfilter,1)
-#define SWIG_WARN_NODE_END(Node) \
-  if (wrnfilter) Swig_warnfilter(wrnfilter,0); \
- }
+#define SWIG_WARN_NODE_BEGIN(Node)                                      \
+  {                                                                     \
+    String *wrnfilter = Node ? Getattr(Node, "feature:warnfilter") : 0; \
+    if (wrnfilter)                                                      \
+    Swig_warnfilter(wrnfilter, 1)
+#define SWIG_WARN_NODE_END(Node)   \
+  if (wrnfilter)                   \
+    Swig_warnfilter(wrnfilter, 0); \
+  }
 
 #endif

--- a/Source/CParse/cparse.h
+++ b/Source/CParse/cparse.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -31,9 +31,9 @@ String *scanner_ccode = 0;
 static String *main_input_file = 0;
 
 /* Error reporting/location information */
-int     cparse_line = 1;
+int cparse_line = 1;
 String *cparse_file = 0;
-int     cparse_start_line = 0;
+int cparse_start_line = 0;
 
 /* C++ mode */
 int cparse_cplusplus = 0;
@@ -59,42 +59,22 @@ static int rename_active = 0;
 int scan_doxygen_comments = 0;
 
 static int isStructuralDoxygen(String *s) {
-  static const char* const structuralTags[] = {
-    "addtogroup",
-    "callgraph",
-    "callergraph",
-    "category",
-    "def",
-    "defgroup",
-    "dir",
-    "example",
-    "file",
-    "headerfile",
-    "internal",
-    "mainpage",
-    "name",
-    "nosubgrouping",
-    "overload",
-    "package",
-    "page",
-    "protocol",
-    "relates",
-    "relatesalso",
-    "showinitializer",
-    "weakgroup",
+  static const char *const structuralTags[] = {
+    "addtogroup", "callgraph", "callergraph",   "category", "def",     "defgroup", "dir",      "example", "file",        "headerfile",      "internal",
+    "mainpage",   "name",      "nosubgrouping", "overload", "package", "page",     "protocol", "relates", "relatesalso", "showinitializer", "weakgroup",
   };
 
   unsigned n;
   char *slashPointer = Strchr(s, '\\');
-  char *atPointer = Strchr(s,'@');
+  char *atPointer = Strchr(s, '@');
   if (slashPointer == NULL && atPointer == NULL)
     return 0;
-  else if(slashPointer == NULL)
+  else if (slashPointer == NULL)
     slashPointer = atPointer;
 
   slashPointer++; /* skip backslash or at sign */
 
-  for (n = 0; n < sizeof(structuralTags)/sizeof(structuralTags[0]); n++) {
+  for (n = 0; n < sizeof(structuralTags) / sizeof(structuralTags[0]); n++) {
     const size_t len = strlen(structuralTags[n]);
     if (strncmp(slashPointer, structuralTags[n], len) == 0) {
       /* Take care to avoid false positives with prefixes of other tags. */
@@ -130,7 +110,7 @@ void Swig_cparse_cplusplusout(int v) {
 
 static void scanner_init(void) {
   scan = NewScanner();
-  Scanner_idstart(scan,"%");
+  Scanner_idstart(scan, "%");
   scan_init = 1;
   scanner_ccode = NewStringEmpty();
 }
@@ -140,10 +120,11 @@ static void scanner_init(void) {
  *
  * Start reading from new file
  * ------------------------------------------------------------------------- */
-void scanner_file(DOHFile * f) {
-  if (!scan_init) scanner_init();
+void scanner_file(DOHFile *f) {
+  if (!scan_init)
+    scanner_init();
   Scanner_clear(scan);
-  Scanner_push(scan,f);
+  Scanner_push(scan, f);
 }
 
 /* ----------------------------------------------------------------------------
@@ -156,10 +137,10 @@ void scanner_file(DOHFile * f) {
 void scanner_start_inline(String *text, int line) {
   String *stext = Copy(text);
 
-  Seek(stext,0,SEEK_SET);
-  Setfile(stext,cparse_file);
-  Setline(stext,line);
-  Scanner_push(scan,stext);
+  Seek(stext, 0, SEEK_SET);
+  Setfile(stext, cparse_file);
+  Setline(stext, line);
+  Scanner_push(scan, stext);
   Delete(stext);
 }
 
@@ -176,7 +157,7 @@ int skip_balanced(int startchar, int endchar) {
   int start_line = Scanner_line(scan);
   Clear(scanner_ccode);
 
-  if (Scanner_skip_balanced(scan,startchar,endchar) < 0) {
+  if (Scanner_skip_balanced(scan, startchar, endchar) < 0) {
     Swig_error(cparse_file, start_line, "Missing '%c'. Reached end of input.\n", endchar);
     return -1;
   }
@@ -226,7 +207,7 @@ void skip_decl(void) {
       return;
     }
     if (tok == SWIG_TOKEN_LBRACE) {
-      if (Scanner_skip_balanced(scan,'{','}') < 0) {
+      if (Scanner_skip_balanced(scan, '{', '}') < 0) {
         Swig_error(cparse_file, start_line, "Missing closing brace ('}'). Reached end of input.\n");
       }
       break;
@@ -258,7 +239,7 @@ static int yylook(void) {
     cparse_line = Scanner_line(scan);
     cparse_file = Scanner_file(scan);
 
-    switch(tok) {
+    switch (tok) {
     case SWIG_TOKEN_ID:
       return ID;
     case SWIG_TOKEN_LPAREN:
@@ -348,7 +329,7 @@ static int yylook(void) {
         } else if (nexttok == SWIG_TOKEN_NOT) {
           return DCNOT;
         } else {
-          Scanner_pushtoken(scan,nexttok,Scanner_text(scan));
+          Scanner_pushtoken(scan, nexttok, Scanner_text(scan));
           if (!last_id) {
             scanner_next_token(DCOLON);
             return NONID;
@@ -443,11 +424,7 @@ static int yylook(void) {
 
     case SWIG_TOKEN_COMMENT:
       {
-        typedef enum {
-          DOX_COMMENT_PRE = -1,
-          DOX_COMMENT_NONE,
-          DOX_COMMENT_POST
-        } comment_kind_t;
+        typedef enum { DOX_COMMENT_PRE = -1, DOX_COMMENT_NONE, DOX_COMMENT_POST } comment_kind_t;
         comment_kind_t existing_comment = DOX_COMMENT_NONE;
 
         /* Concatenate or skip all consecutive comments at once. */
@@ -455,7 +432,7 @@ static int yylook(void) {
           String *cmt = Scanner_text(scan);
           String *cmt_modified = 0;
           char *loc = Char(cmt);
-          if ((strncmp(loc, "/*@SWIG", 7) == 0) && (loc[Len(cmt)-3] == '@')) {
+          if ((strncmp(loc, "/*@SWIG", 7) == 0) && (loc[Len(cmt) - 3] == '@')) {
             Scanner_locator(scan, cmt);
           }
           if (scan_doxygen_comments) { /* else just skip this node, to avoid crashes in parser module*/
@@ -524,12 +501,12 @@ static int yylook(void) {
         Scanner_pushtoken(scan, tok, Scanner_text(scan));
 
         switch (existing_comment) {
-          case DOX_COMMENT_PRE:
-            return DOXYGENSTRING;
-          case DOX_COMMENT_NONE:
-            break;
-          case DOX_COMMENT_POST:
-            return DOXYGENPOSTSTRING;
+        case DOX_COMMENT_PRE:
+          return DOXYGENSTRING;
+        case DOX_COMMENT_NONE:
+          break;
+        case DOX_COMMENT_POST:
+          return DOXYGENPOSTSTRING;
         }
       }
       break;
@@ -545,7 +522,7 @@ static int yylook(void) {
 }
 
 void scanner_set_location(String *file, int line) {
-  Scanner_set_location(scan,file,line-1);
+  Scanner_set_location(scan, file, line - 1);
 }
 
 void scanner_last_id(int x) {
@@ -651,40 +628,44 @@ int yylex(void) {
     yylval.dtype = default_dtype;
     yylval.dtype.type = T_ULONGLONG;
     goto num_common;
-num_common: {
-    yylval.dtype.val = NewString(Scanner_text(scan));
-    const char *c = Char(yylval.dtype.val);
-    if (c[0] == '0') {
-      // Convert to base 10 using strtoull().
-      unsigned long long value;
-      char *e;
-      errno = 0;
-      if (c[1] == 'b' || c[1] == 'B') {
-        /* strtoull() doesn't handle binary literal prefixes so skip the prefix
-         * and specify base 2 explicitly. */
-        value = strtoull(c + 2, &e, 2);
+num_common:
+    {
+      yylval.dtype.val = NewString(Scanner_text(scan));
+      const char *c = Char(yylval.dtype.val);
+      if (c[0] == '0') {
+        // Convert to base 10 using strtoull().
+        unsigned long long value;
+        char *e;
+        errno = 0;
+        if (c[1] == 'b' || c[1] == 'B') {
+          /* strtoull() doesn't handle binary literal prefixes so skip the prefix
+           * and specify base 2 explicitly. */
+          value = strtoull(c + 2, &e, 2);
+        } else {
+          value = strtoull(c, &e, 0);
+        }
+        if (errno != ERANGE) {
+          while (*e && strchr("ULul", *e))
+            ++e;
+        }
+        if (errno != ERANGE && *e == '\0') {
+          yylval.dtype.numval = NewStringf("%llu", value);
+        } else {
+          // Our unsigned long long isn't wide enough or this isn't an integer.
+        }
       } else {
-        value = strtoull(c, &e, 0);
+        const char *e = c;
+        while (isdigit((unsigned char)*e))
+          ++e;
+        int len = (int)(e - c);
+        while (*e && strchr("ULul", *e))
+          ++e;
+        if (*e == '\0') {
+          yylval.dtype.numval = NewStringWithSize(c, len);
+        }
       }
-      if (errno != ERANGE) {
-        while (*e && strchr("ULul", *e)) ++e;
-      }
-      if (errno != ERANGE && *e == '\0') {
-        yylval.dtype.numval = NewStringf("%llu", value);
-      } else {
-        // Our unsigned long long isn't wide enough or this isn't an integer.
-      }
-    } else {
-      const char *e = c;
-      while (isdigit((unsigned char)*e)) ++e;
-      int len = (int)(e - c);
-      while (*e && strchr("ULul", *e)) ++e;
-      if (*e == '\0') {
-        yylval.dtype.numval = NewStringWithSize(c, len);
-      }
+      return (l);
     }
-    return (l);
-  }
   case NUM_BOOL:
     yylval.dtype = default_dtype;
     yylval.dtype.type = T_BOOL;
@@ -810,16 +791,16 @@ num_common: {
 
           if (Scanner_isoperator(nexttok)) {
             /* One of the standard C/C++ symbolic operators */
-            Append(s,Scanner_text(scan));
+            Append(s, Scanner_text(scan));
             yylval.str = s;
             return OPERATOR;
           } else if (nexttok == SWIG_TOKEN_LPAREN) {
             /* Function call operator.  The next token MUST be a RPAREN */
             nexttok = Scanner_token(scan);
             if (nexttok != SWIG_TOKEN_RPAREN) {
-              Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
+              Swig_error(Scanner_file(scan), Scanner_line(scan), "Syntax error. Bad operator name.\n");
             } else {
-              Append(s,"()");
+              Append(s, "()");
               yylval.str = s;
               return OPERATOR;
             }
@@ -827,15 +808,15 @@ num_common: {
             /* Array access operator.  The next token MUST be a RBRACKET */
             nexttok = Scanner_token(scan);
             if (nexttok != SWIG_TOKEN_RBRACKET) {
-              Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
+              Swig_error(Scanner_file(scan), Scanner_line(scan), "Syntax error. Bad operator name.\n");
             } else {
-              Append(s,"[]");
+              Append(s, "[]");
               yylval.str = s;
               return OPERATOR;
             }
           } else if (nexttok == SWIG_TOKEN_STRING) {
             /* Operator "" or user-defined string literal ""_suffix */
-            Append(s,"\"\"");
+            Append(s, "\"\"");
             yylval.str = s;
             return OPERATOR;
           } else if (nexttok == SWIG_TOKEN_ID) {
@@ -849,12 +830,12 @@ num_common: {
             int termtoken = 0;
             const char *termvalue = 0;
 
-            Append(s,Scanner_text(scan));
+            Append(s, Scanner_text(scan));
             while (1) {
 
               nexttok = Scanner_token(scan);
               if (nexttok <= 0) {
-                Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
+                Swig_error(Scanner_file(scan), Scanner_line(scan), "Syntax error. Bad operator name.\n");
               }
               if (nexttok == SWIG_TOKEN_LPAREN) {
                 termtoken = SWIG_TOKEN_LPAREN;
@@ -878,13 +859,13 @@ num_common: {
                 break;
               } else if (nexttok == SWIG_TOKEN_ID) {
                 if (needspace) {
-                  Append(s," ");
+                  Append(s, " ");
                 }
-                Append(s,Scanner_text(scan));
+                Append(s, Scanner_text(scan));
               } else if (nexttok == SWIG_TOKEN_ENDLINE) {
               } else if (nexttok == SWIG_TOKEN_COMMENT) {
               } else {
-                Append(s,Scanner_text(scan));
+                Append(s, Scanner_text(scan));
                 needspace = 0;
               }
             }
@@ -892,21 +873,18 @@ num_common: {
             if (!rename_active) {
               String *cs;
               char *t = Char(s) + 9;
-              if (!((strcmp(t, "new") == 0)
-                    || (strcmp(t, "delete") == 0)
-                    || (strcmp(t, "new[]") == 0)
-                    || (strcmp(t, "delete[]") == 0)
-                    )) {
+              if (!((strcmp(t, "new") == 0) || (strcmp(t, "delete") == 0) || (strcmp(t, "new[]") == 0) || (strcmp(t, "delete[]") == 0))) {
                 /*              retract(strlen(t)); */
 
                 /* The operator is a conversion operator.   In order to deal with this, we need to feed the
                    type information back into the parser.  For now this is a hack.  Needs to be cleaned up later. */
                 cs = NewString(t);
-                if (termtoken) Append(cs,termvalue);
-                Seek(cs,0,SEEK_SET);
-                Setline(cs,cparse_line);
-                Setfile(cs,cparse_file);
-                Scanner_push(scan,cs);
+                if (termtoken)
+                  Append(cs, termvalue);
+                Seek(cs, 0, SEEK_SET);
+                Setline(cs, cparse_line);
+                Setfile(cs, cparse_file);
+                Scanner_push(scan, cs);
                 Delete(cs);
                 return CONVERSIONOPERATOR;
               }
@@ -1083,10 +1061,10 @@ num_common: {
        */
       cparse_unknown_directive = NewString(yytext);
       stext = NewString(yytext + 1);
-      Seek(stext,0,SEEK_SET);
-      Setfile(stext,cparse_file);
-      Setline(stext,cparse_line);
-      Scanner_push(scan,stext);
+      Seek(stext, 0, SEEK_SET);
+      Setfile(stext, cparse_file);
+      Setline(stext, cparse_line);
+      Scanner_push(scan, stext);
       Delete(stext);
       return (MODULO);
     }

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -99,7 +99,7 @@ static int isStructuralDoxygen(String *s) {
     if (strncmp(slashPointer, structuralTags[n], len) == 0) {
       /* Take care to avoid false positives with prefixes of other tags. */
       if (slashPointer[len] == '\0' || isspace((int)slashPointer[len]))
-	return 1;
+        return 1;
     }
   }
 
@@ -221,13 +221,13 @@ void skip_decl(void) {
     tok = Scanner_token(scan);
     if (tok == 0) {
       if (!Swig_error_count()) {
-	Swig_error(cparse_file, start_line, "Missing semicolon (';'). Reached end of input.\n");
+        Swig_error(cparse_file, start_line, "Missing semicolon (';'). Reached end of input.\n");
       }
       return;
     }
     if (tok == SWIG_TOKEN_LBRACE) {
       if (Scanner_skip_balanced(scan,'{','}') < 0) {
-	Swig_error(cparse_file, start_line, "Missing closing brace ('}'). Reached end of input.\n");
+        Swig_error(cparse_file, start_line, "Missing closing brace ('}'). Reached end of input.\n");
       }
       break;
     }
@@ -274,10 +274,10 @@ static int yylook(void) {
     case SWIG_TOKEN_RBRACE:
       num_brace--;
       if (num_brace < 0) {
-	Swig_error(cparse_file, cparse_line, "Syntax error. Extraneous closing brace ('}')\n");
-	num_brace = 0;
+        Swig_error(cparse_file, cparse_line, "Syntax error. Extraneous closing brace ('}')\n");
+        num_brace = 0;
       } else {
-	return RBRACE;
+        return RBRACE;
       }
       break;
     case SWIG_TOKEN_LBRACE:
@@ -342,20 +342,20 @@ static int yylook(void) {
       
     case SWIG_TOKEN_DCOLON:
       {
-	int nexttok = Scanner_token(scan);
-	if (nexttok == SWIG_TOKEN_STAR) {
-	  return DSTAR;
-	} else if (nexttok == SWIG_TOKEN_NOT) {
-	  return DCNOT;
-	} else {
-	  Scanner_pushtoken(scan,nexttok,Scanner_text(scan));
-	  if (!last_id) {
-	    scanner_next_token(DCOLON);
-	    return NONID;
-	  } else {
-	    return DCOLON;
-	  }
-	}
+        int nexttok = Scanner_token(scan);
+        if (nexttok == SWIG_TOKEN_STAR) {
+          return DSTAR;
+        } else if (nexttok == SWIG_TOKEN_NOT) {
+          return DCNOT;
+        } else {
+          Scanner_pushtoken(scan,nexttok,Scanner_text(scan));
+          if (!last_id) {
+            scanner_next_token(DCOLON);
+            return NONID;
+          } else {
+            return DCOLON;
+          }
+        }
       }
       break;
       
@@ -389,14 +389,14 @@ static int yylook(void) {
     case SWIG_TOKEN_CHAR:
       yylval.str = NewString(Scanner_text(scan));
       if (Len(yylval.str) == 0) {
-	Swig_error(cparse_file, cparse_line, "Empty character constant\n");
+        Swig_error(cparse_file, cparse_line, "Empty character constant\n");
       }
       return CHARCONST;
 
     case SWIG_TOKEN_WCHAR:
       yylval.str = NewString(Scanner_text(scan));
       if (Len(yylval.str) == 0) {
-	Swig_error(cparse_file, cparse_line, "Empty character constant\n");
+        Swig_error(cparse_file, cparse_line, "Empty character constant\n");
       }
       return WCHARCONST;
 
@@ -443,94 +443,94 @@ static int yylook(void) {
       
     case SWIG_TOKEN_COMMENT:
       {
-	typedef enum {
-	  DOX_COMMENT_PRE = -1,
-	  DOX_COMMENT_NONE,
-	  DOX_COMMENT_POST
-	} comment_kind_t;
-	comment_kind_t existing_comment = DOX_COMMENT_NONE;
+        typedef enum {
+          DOX_COMMENT_PRE = -1,
+          DOX_COMMENT_NONE,
+          DOX_COMMENT_POST
+        } comment_kind_t;
+        comment_kind_t existing_comment = DOX_COMMENT_NONE;
 
-	/* Concatenate or skip all consecutive comments at once. */
-	do {
-	  String *cmt = Scanner_text(scan);
-	  String *cmt_modified = 0;
-	  char *loc = Char(cmt);
-	  if ((strncmp(loc, "/*@SWIG", 7) == 0) && (loc[Len(cmt)-3] == '@')) {
-	    Scanner_locator(scan, cmt);
-	  }
-	  if (scan_doxygen_comments) { /* else just skip this node, to avoid crashes in parser module*/
+        /* Concatenate or skip all consecutive comments at once. */
+        do {
+          String *cmt = Scanner_text(scan);
+          String *cmt_modified = 0;
+          char *loc = Char(cmt);
+          if ((strncmp(loc, "/*@SWIG", 7) == 0) && (loc[Len(cmt)-3] == '@')) {
+            Scanner_locator(scan, cmt);
+          }
+          if (scan_doxygen_comments) { /* else just skip this node, to avoid crashes in parser module*/
 
-	    int slashStyle = 0; /* Flag for "///" style doxygen comments */
-	    if (strncmp(loc, "///", 3) == 0) {
-	      slashStyle = 1;
-	      if (Len(cmt) == 3) {
-		/* Modify to make length=4 to ensure that the empty comment does
-		   get processed to preserve the newlines in the original comments. */
-		cmt_modified = NewStringf("%s ", cmt);
-		cmt = cmt_modified;
-		loc = Char(cmt);
-	      }
-	    }
-	    
-	    /* Check for all possible Doxygen comment start markers while ignoring
-	       comments starting with a row of asterisks or slashes just as
-	       Doxygen itself does.  Also skip empty comment (slash-star-star-slash), 
-	       which causes a crash due to begin > end. */
-	    if (Len(cmt) > 3 && loc[0] == '/' &&
-		((loc[1] == '/' && ((loc[2] == '/' && loc[3] != '/') || loc[2] == '!')) ||
-		 (loc[1] == '*' && ((loc[2] == '*' && loc[3] != '*' && loc[3] != '/') || loc[2] == '!')))) {
-	      comment_kind_t this_comment = loc[3] == '<' ? DOX_COMMENT_POST : DOX_COMMENT_PRE;
-	      if (existing_comment != DOX_COMMENT_NONE && this_comment != existing_comment) {
-		/* We can't concatenate together Doxygen pre- and post-comments. */
-		break;
-	      }
+            int slashStyle = 0; /* Flag for "///" style doxygen comments */
+            if (strncmp(loc, "///", 3) == 0) {
+              slashStyle = 1;
+              if (Len(cmt) == 3) {
+                /* Modify to make length=4 to ensure that the empty comment does
+                   get processed to preserve the newlines in the original comments. */
+                cmt_modified = NewStringf("%s ", cmt);
+                cmt = cmt_modified;
+                loc = Char(cmt);
+              }
+            }
+            
+            /* Check for all possible Doxygen comment start markers while ignoring
+               comments starting with a row of asterisks or slashes just as
+               Doxygen itself does.  Also skip empty comment (slash-star-star-slash), 
+               which causes a crash due to begin > end. */
+            if (Len(cmt) > 3 && loc[0] == '/' &&
+                ((loc[1] == '/' && ((loc[2] == '/' && loc[3] != '/') || loc[2] == '!')) ||
+                 (loc[1] == '*' && ((loc[2] == '*' && loc[3] != '*' && loc[3] != '/') || loc[2] == '!')))) {
+              comment_kind_t this_comment = loc[3] == '<' ? DOX_COMMENT_POST : DOX_COMMENT_PRE;
+              if (existing_comment != DOX_COMMENT_NONE && this_comment != existing_comment) {
+                /* We can't concatenate together Doxygen pre- and post-comments. */
+                break;
+              }
 
-	      if (this_comment == DOX_COMMENT_POST || !isStructuralDoxygen(loc)) {
-		String *str;
+              if (this_comment == DOX_COMMENT_POST || !isStructuralDoxygen(loc)) {
+                String *str;
 
-		int begin = this_comment == DOX_COMMENT_POST ? 4 : 3;
-		int end = Len(cmt);
-		if (loc[end - 1] == '/' && loc[end - 2] == '*') {
-		  end -= 2;
-		}
+                int begin = this_comment == DOX_COMMENT_POST ? 4 : 3;
+                int end = Len(cmt);
+                if (loc[end - 1] == '/' && loc[end - 2] == '*') {
+                  end -= 2;
+                }
 
-		str = NewStringWithSize(loc + begin, end - begin);
+                str = NewStringWithSize(loc + begin, end - begin);
 
-		if (existing_comment == DOX_COMMENT_NONE) {
-		  yylval.str = str;
-		  Setline(yylval.str, Scanner_start_line(scan));
-		  Setfile(yylval.str, Scanner_file(scan));
-		} else {
-		  if (slashStyle) {
-		    /* Add a newline to the end of each doxygen "///" comment,
-		       since they are processed individually, unlike the
-		       slash-star style, which gets processed as a block with
-		       newlines included. */
-		    Append(yylval.str, "\n");
-		  }
-		  Append(yylval.str, str);
-		}
+                if (existing_comment == DOX_COMMENT_NONE) {
+                  yylval.str = str;
+                  Setline(yylval.str, Scanner_start_line(scan));
+                  Setfile(yylval.str, Scanner_file(scan));
+                } else {
+                  if (slashStyle) {
+                    /* Add a newline to the end of each doxygen "///" comment,
+                       since they are processed individually, unlike the
+                       slash-star style, which gets processed as a block with
+                       newlines included. */
+                    Append(yylval.str, "\n");
+                  }
+                  Append(yylval.str, str);
+                }
 
-		existing_comment = this_comment;
-	      }
-	    }
-	  }
-	  do {
-	    tok = Scanner_token(scan);
-	  } while (tok == SWIG_TOKEN_ENDLINE);
-	  Delete(cmt_modified);
-	} while (tok == SWIG_TOKEN_COMMENT);
+                existing_comment = this_comment;
+              }
+            }
+          }
+          do {
+            tok = Scanner_token(scan);
+          } while (tok == SWIG_TOKEN_ENDLINE);
+          Delete(cmt_modified);
+        } while (tok == SWIG_TOKEN_COMMENT);
 
-	Scanner_pushtoken(scan, tok, Scanner_text(scan));
+        Scanner_pushtoken(scan, tok, Scanner_text(scan));
 
-	switch (existing_comment) {
-	  case DOX_COMMENT_PRE:
-	    return DOXYGENSTRING;
-	  case DOX_COMMENT_NONE:
-	    break;
-	  case DOX_COMMENT_POST:
-	    return DOXYGENPOSTSTRING;
-	}
+        switch (existing_comment) {
+          case DOX_COMMENT_PRE:
+            return DOXYGENSTRING;
+          case DOX_COMMENT_NONE:
+            break;
+          case DOX_COMMENT_POST:
+            return DOXYGENPOSTSTRING;
+        }
       }
       break;
     case SWIG_TOKEN_ENDLINE:
@@ -660,19 +660,19 @@ num_common: {
       char *e;
       errno = 0;
       if (c[1] == 'b' || c[1] == 'B') {
-	/* strtoull() doesn't handle binary literal prefixes so skip the prefix
-	 * and specify base 2 explicitly. */
-	value = strtoull(c + 2, &e, 2);
+        /* strtoull() doesn't handle binary literal prefixes so skip the prefix
+         * and specify base 2 explicitly. */
+        value = strtoull(c + 2, &e, 2);
       } else {
-	value = strtoull(c, &e, 0);
+        value = strtoull(c, &e, 0);
       }
       if (errno != ERANGE) {
-	while (*e && strchr("ULul", *e)) ++e;
+        while (*e && strchr("ULul", *e)) ++e;
       }
       if (errno != ERANGE && *e == '\0') {
-	yylval.dtype.numval = NewStringf("%llu", value);
+        yylval.dtype.numval = NewStringf("%llu", value);
       } else {
-	// Our unsigned long long isn't wide enough or this isn't an integer.
+        // Our unsigned long long isn't wide enough or this isn't an integer.
       }
     } else {
       const char *e = c;
@@ -698,95 +698,95 @@ num_common: {
       /* Look for keywords now */
 
       if (strcmp(yytext, "int") == 0) {
-	yylval.type = NewSwigType(T_INT);
-	return (TYPE_INT);
+        yylval.type = NewSwigType(T_INT);
+        return (TYPE_INT);
       }
       if (strcmp(yytext, "double") == 0) {
-	yylval.type = NewSwigType(T_DOUBLE);
-	return (TYPE_DOUBLE);
+        yylval.type = NewSwigType(T_DOUBLE);
+        return (TYPE_DOUBLE);
       }
       if (strcmp(yytext, "void") == 0) {
-	yylval.type = NewSwigType(T_VOID);
-	return (TYPE_VOID);
+        yylval.type = NewSwigType(T_VOID);
+        return (TYPE_VOID);
       }
       if (strcmp(yytext, "char") == 0) {
-	yylval.type = NewSwigType(T_CHAR);
-	return (TYPE_CHAR);
+        yylval.type = NewSwigType(T_CHAR);
+        return (TYPE_CHAR);
       }
       if (strcmp(yytext, "wchar_t") == 0) {
-	yylval.type = NewSwigType(T_WCHAR);
-	return (TYPE_WCHAR);
+        yylval.type = NewSwigType(T_WCHAR);
+        return (TYPE_WCHAR);
       }
       if (strcmp(yytext, "short") == 0) {
-	yylval.type = NewSwigType(T_SHORT);
-	return (TYPE_SHORT);
+        yylval.type = NewSwigType(T_SHORT);
+        return (TYPE_SHORT);
       }
       if (strcmp(yytext, "long") == 0) {
-	yylval.type = NewSwigType(T_LONG);
-	return (TYPE_LONG);
+        yylval.type = NewSwigType(T_LONG);
+        return (TYPE_LONG);
       }
       if (strcmp(yytext, "float") == 0) {
-	yylval.type = NewSwigType(T_FLOAT);
-	return (TYPE_FLOAT);
+        yylval.type = NewSwigType(T_FLOAT);
+        return (TYPE_FLOAT);
       }
       if (strcmp(yytext, "signed") == 0) {
-	yylval.type = NewSwigType(T_INT);
-	return (TYPE_SIGNED);
+        yylval.type = NewSwigType(T_INT);
+        return (TYPE_SIGNED);
       }
       if (strcmp(yytext, "unsigned") == 0) {
-	yylval.type = NewSwigType(T_UINT);
-	return (TYPE_UNSIGNED);
+        yylval.type = NewSwigType(T_UINT);
+        return (TYPE_UNSIGNED);
       }
       if (strcmp(yytext, "bool") == 0) {
-	yylval.type = NewSwigType(T_BOOL);
-	return (TYPE_BOOL);
+        yylval.type = NewSwigType(T_BOOL);
+        return (TYPE_BOOL);
       }
 
       /* Non ISO (Windows) C extensions */
       if (strcmp(yytext, "__int8") == 0) {
-	yylval.type = NewString(yytext);
-	return (TYPE_NON_ISO_INT8);
+        yylval.type = NewString(yytext);
+        return (TYPE_NON_ISO_INT8);
       }
       if (strcmp(yytext, "__int16") == 0) {
-	yylval.type = NewString(yytext);
-	return (TYPE_NON_ISO_INT16);
+        yylval.type = NewString(yytext);
+        return (TYPE_NON_ISO_INT16);
       }
       if (strcmp(yytext, "__int32") == 0) {
-	yylval.type = NewString(yytext);
-	return (TYPE_NON_ISO_INT32);
+        yylval.type = NewString(yytext);
+        return (TYPE_NON_ISO_INT32);
       }
       if (strcmp(yytext, "__int64") == 0) {
-	yylval.type = NewString(yytext);
-	return (TYPE_NON_ISO_INT64);
+        yylval.type = NewString(yytext);
+        return (TYPE_NON_ISO_INT64);
       }
 
       /* C++ keywords */
       if (cparse_cplusplus) {
-	if (strcmp(yytext, "class") == 0)
-	  return (CLASS);
-	if (strcmp(yytext, "private") == 0)
-	  return (PRIVATE);
-	if (strcmp(yytext, "public") == 0)
-	  return (PUBLIC);
-	if (strcmp(yytext, "protected") == 0)
-	  return (PROTECTED);
-	if (strcmp(yytext, "friend") == 0)
-	  return (FRIEND);
-	if (strcmp(yytext, "constexpr") == 0)
-	  return (CONSTEXPR);
-	if (strcmp(yytext, "thread_local") == 0)
-	  return (THREAD_LOCAL);
-	if (strcmp(yytext, "decltype") == 0)
-	  return (DECLTYPE);
-	if (strcmp(yytext, "virtual") == 0)
-	  return (VIRTUAL);
-	if (strcmp(yytext, "static_assert") == 0)
-	  return (STATIC_ASSERT);
-	if (strcmp(yytext, "operator") == 0) {
-	  int nexttok;
-	  String *s = NewString("operator ");
+        if (strcmp(yytext, "class") == 0)
+          return (CLASS);
+        if (strcmp(yytext, "private") == 0)
+          return (PRIVATE);
+        if (strcmp(yytext, "public") == 0)
+          return (PUBLIC);
+        if (strcmp(yytext, "protected") == 0)
+          return (PROTECTED);
+        if (strcmp(yytext, "friend") == 0)
+          return (FRIEND);
+        if (strcmp(yytext, "constexpr") == 0)
+          return (CONSTEXPR);
+        if (strcmp(yytext, "thread_local") == 0)
+          return (THREAD_LOCAL);
+        if (strcmp(yytext, "decltype") == 0)
+          return (DECLTYPE);
+        if (strcmp(yytext, "virtual") == 0)
+          return (VIRTUAL);
+        if (strcmp(yytext, "static_assert") == 0)
+          return (STATIC_ASSERT);
+        if (strcmp(yytext, "operator") == 0) {
+          int nexttok;
+          String *s = NewString("operator ");
 
-	  /* If we have an operator, we have to collect the operator symbol and attach it to
+          /* If we have an operator, we have to collect the operator symbol and attach it to
              the operator identifier.   To do this, we need to scan ahead by several tokens.
              Cases include:
 
@@ -797,69 +797,69 @@ num_common: {
 
              (2) If the next token is (, we look for ).  This is operator ().
              (3) If the next token is [, we look for ].  This is operator [].
-	     (4) If the next token is an identifier.  The operator is possibly a conversion operator.
+             (4) If the next token is an identifier.  The operator is possibly a conversion operator.
                       (a) Must check for special case new[] and delete[]
 
              Error handling is somewhat tricky here.  We'll try to back out gracefully if we can.
  
-	  */
+          */
 
-	  do {
-	    nexttok = Scanner_token(scan);
-	  } while (nexttok == SWIG_TOKEN_ENDLINE || nexttok == SWIG_TOKEN_COMMENT);
+          do {
+            nexttok = Scanner_token(scan);
+          } while (nexttok == SWIG_TOKEN_ENDLINE || nexttok == SWIG_TOKEN_COMMENT);
 
-	  if (Scanner_isoperator(nexttok)) {
-	    /* One of the standard C/C++ symbolic operators */
-	    Append(s,Scanner_text(scan));
-	    yylval.str = s;
-	    return OPERATOR;
-	  } else if (nexttok == SWIG_TOKEN_LPAREN) {
-	    /* Function call operator.  The next token MUST be a RPAREN */
-	    nexttok = Scanner_token(scan);
-	    if (nexttok != SWIG_TOKEN_RPAREN) {
-	      Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
-	    } else {
-	      Append(s,"()");
-	      yylval.str = s;
-	      return OPERATOR;
-	    }
-	  } else if (nexttok == SWIG_TOKEN_LBRACKET) {
-	    /* Array access operator.  The next token MUST be a RBRACKET */
-	    nexttok = Scanner_token(scan);
-	    if (nexttok != SWIG_TOKEN_RBRACKET) {
-	      Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");	      
-	    } else {
-	      Append(s,"[]");
-	      yylval.str = s;
-	      return OPERATOR;
-	    }
-	  } else if (nexttok == SWIG_TOKEN_STRING) {
-	    /* Operator "" or user-defined string literal ""_suffix */
-	    Append(s,"\"\"");
-	    yylval.str = s;
-	    return OPERATOR;
-	  } else if (nexttok == SWIG_TOKEN_ID) {
-	    /* We have an identifier.  It could be "new" or "delete",
-	     * potentially followed by "[]", or it could be a conversion
-	     * operator (it can't be "and_eq" or similar as those are returned
-	     * as SWIG_TOKEN_ANDEQUAL, etc by Scanner_token()).  To deal with
-	     * this we read tokens until we encounter a suitable terminating
-	     * token.  Some care is needed for formatting. */
-	    int needspace = 1;
-	    int termtoken = 0;
-	    const char *termvalue = 0;
+          if (Scanner_isoperator(nexttok)) {
+            /* One of the standard C/C++ symbolic operators */
+            Append(s,Scanner_text(scan));
+            yylval.str = s;
+            return OPERATOR;
+          } else if (nexttok == SWIG_TOKEN_LPAREN) {
+            /* Function call operator.  The next token MUST be a RPAREN */
+            nexttok = Scanner_token(scan);
+            if (nexttok != SWIG_TOKEN_RPAREN) {
+              Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
+            } else {
+              Append(s,"()");
+              yylval.str = s;
+              return OPERATOR;
+            }
+          } else if (nexttok == SWIG_TOKEN_LBRACKET) {
+            /* Array access operator.  The next token MUST be a RBRACKET */
+            nexttok = Scanner_token(scan);
+            if (nexttok != SWIG_TOKEN_RBRACKET) {
+              Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");	      
+            } else {
+              Append(s,"[]");
+              yylval.str = s;
+              return OPERATOR;
+            }
+          } else if (nexttok == SWIG_TOKEN_STRING) {
+            /* Operator "" or user-defined string literal ""_suffix */
+            Append(s,"\"\"");
+            yylval.str = s;
+            return OPERATOR;
+          } else if (nexttok == SWIG_TOKEN_ID) {
+            /* We have an identifier.  It could be "new" or "delete",
+             * potentially followed by "[]", or it could be a conversion
+             * operator (it can't be "and_eq" or similar as those are returned
+             * as SWIG_TOKEN_ANDEQUAL, etc by Scanner_token()).  To deal with
+             * this we read tokens until we encounter a suitable terminating
+             * token.  Some care is needed for formatting. */
+            int needspace = 1;
+            int termtoken = 0;
+            const char *termvalue = 0;
 
-	    Append(s,Scanner_text(scan));
-	    while (1) {
+            Append(s,Scanner_text(scan));
+            while (1) {
 
-	      nexttok = Scanner_token(scan);
-	      if (nexttok <= 0) {
-		Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");	      
-	      }
-	      if (nexttok == SWIG_TOKEN_LPAREN) {
-		termtoken = SWIG_TOKEN_LPAREN;
-		termvalue = "(";
-		break;
+              nexttok = Scanner_token(scan);
+              if (nexttok <= 0) {
+                Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");	      
+              }
+              if (nexttok == SWIG_TOKEN_LPAREN) {
+                termtoken = SWIG_TOKEN_LPAREN;
+                termvalue = "(";
+                break;
               } else if (nexttok == SWIG_TOKEN_CODEBLOCK) {
                 termtoken = SWIG_TOKEN_CODEBLOCK;
                 termvalue = Char(Scanner_text(scan));
@@ -869,208 +869,208 @@ num_common: {
                 termvalue = "{";
                 break;
               } else if (nexttok == SWIG_TOKEN_SEMI) {
-		termtoken = SWIG_TOKEN_SEMI;
-		termvalue = ";";
-		break;
+                termtoken = SWIG_TOKEN_SEMI;
+                termvalue = ";";
+                break;
               } else if (nexttok == SWIG_TOKEN_STRING) {
-		termtoken = SWIG_TOKEN_STRING;
+                termtoken = SWIG_TOKEN_STRING;
                 termvalue = Swig_copy_string(Char(Scanner_text(scan)));
-		break;
-	      } else if (nexttok == SWIG_TOKEN_ID) {
-		if (needspace) {
-		  Append(s," ");
-		}
-		Append(s,Scanner_text(scan));
-	      } else if (nexttok == SWIG_TOKEN_ENDLINE) {
-	      } else if (nexttok == SWIG_TOKEN_COMMENT) {
-	      } else {
-		Append(s,Scanner_text(scan));
-		needspace = 0;
-	      }
-	    }
-	    yylval.str = s;
-	    if (!rename_active) {
-	      String *cs;
-	      char *t = Char(s) + 9;
-	      if (!((strcmp(t, "new") == 0)
-		    || (strcmp(t, "delete") == 0)
-		    || (strcmp(t, "new[]") == 0)
-		    || (strcmp(t, "delete[]") == 0)
-		    )) {
-		/*              retract(strlen(t)); */
+                break;
+              } else if (nexttok == SWIG_TOKEN_ID) {
+                if (needspace) {
+                  Append(s," ");
+                }
+                Append(s,Scanner_text(scan));
+              } else if (nexttok == SWIG_TOKEN_ENDLINE) {
+              } else if (nexttok == SWIG_TOKEN_COMMENT) {
+              } else {
+                Append(s,Scanner_text(scan));
+                needspace = 0;
+              }
+            }
+            yylval.str = s;
+            if (!rename_active) {
+              String *cs;
+              char *t = Char(s) + 9;
+              if (!((strcmp(t, "new") == 0)
+                    || (strcmp(t, "delete") == 0)
+                    || (strcmp(t, "new[]") == 0)
+                    || (strcmp(t, "delete[]") == 0)
+                    )) {
+                /*              retract(strlen(t)); */
 
-		/* The operator is a conversion operator.   In order to deal with this, we need to feed the
+                /* The operator is a conversion operator.   In order to deal with this, we need to feed the
                    type information back into the parser.  For now this is a hack.  Needs to be cleaned up later. */
-		cs = NewString(t);
-		if (termtoken) Append(cs,termvalue);
-		Seek(cs,0,SEEK_SET);
-		Setline(cs,cparse_line);
-		Setfile(cs,cparse_file);
-		Scanner_push(scan,cs);
-		Delete(cs);
-		return CONVERSIONOPERATOR;
-	      }
-	    }
-	    if (termtoken)
+                cs = NewString(t);
+                if (termtoken) Append(cs,termvalue);
+                Seek(cs,0,SEEK_SET);
+                Setline(cs,cparse_line);
+                Setfile(cs,cparse_file);
+                Scanner_push(scan,cs);
+                Delete(cs);
+                return CONVERSIONOPERATOR;
+              }
+            }
+            if (termtoken)
               Scanner_pushtoken(scan, termtoken, termvalue);
-	    return (OPERATOR);
-	  }
-	}
-	if (strcmp(yytext, "throw") == 0)
-	  return (THROW);
-	if (strcmp(yytext, "noexcept") == 0)
-	  return (NOEXCEPT);
-	if (strcmp(yytext, "try") == 0)
-	  return (yylex());
-	if (strcmp(yytext, "catch") == 0)
-	  return (CATCH);
-	if (strcmp(yytext, "inline") == 0)
-	  return (yylex());
-	if (strcmp(yytext, "mutable") == 0)
-	  return (yylex());
-	if (strcmp(yytext, "explicit") == 0)
-	  return (EXPLICIT);
-	if (strcmp(yytext, "auto") == 0)
-	  return (AUTO);
-	if (strcmp(yytext, "export") == 0)
-	  return (yylex());
-	if (strcmp(yytext, "typename") == 0)
-	  return (TYPENAME);
-	if (strcmp(yytext, "template") == 0) {
-	  yylval.intvalue = cparse_line;
-	  return (TEMPLATE);
-	}
-	if (strcmp(yytext, "delete") == 0)
-	  return (DELETE_KW);
-	if (strcmp(yytext, "default") == 0)
-	  return (DEFAULT);
-	if (strcmp(yytext, "using") == 0)
-	  return (USING);
-	if (strcmp(yytext, "namespace") == 0)
-	  return (NAMESPACE);
-	if (strcmp(yytext, "alignof") == 0)
-	  return (ALIGNOF);
-	if (strcmp(yytext, "override") == 0) {
-	  last_id = 1;
-	  return (OVERRIDE);
-	}
-	if (strcmp(yytext, "final") == 0) {
-	  last_id = 1;
-	  return (FINAL);
-	}
+            return (OPERATOR);
+          }
+        }
+        if (strcmp(yytext, "throw") == 0)
+          return (THROW);
+        if (strcmp(yytext, "noexcept") == 0)
+          return (NOEXCEPT);
+        if (strcmp(yytext, "try") == 0)
+          return (yylex());
+        if (strcmp(yytext, "catch") == 0)
+          return (CATCH);
+        if (strcmp(yytext, "inline") == 0)
+          return (yylex());
+        if (strcmp(yytext, "mutable") == 0)
+          return (yylex());
+        if (strcmp(yytext, "explicit") == 0)
+          return (EXPLICIT);
+        if (strcmp(yytext, "auto") == 0)
+          return (AUTO);
+        if (strcmp(yytext, "export") == 0)
+          return (yylex());
+        if (strcmp(yytext, "typename") == 0)
+          return (TYPENAME);
+        if (strcmp(yytext, "template") == 0) {
+          yylval.intvalue = cparse_line;
+          return (TEMPLATE);
+        }
+        if (strcmp(yytext, "delete") == 0)
+          return (DELETE_KW);
+        if (strcmp(yytext, "default") == 0)
+          return (DEFAULT);
+        if (strcmp(yytext, "using") == 0)
+          return (USING);
+        if (strcmp(yytext, "namespace") == 0)
+          return (NAMESPACE);
+        if (strcmp(yytext, "alignof") == 0)
+          return (ALIGNOF);
+        if (strcmp(yytext, "override") == 0) {
+          last_id = 1;
+          return (OVERRIDE);
+        }
+        if (strcmp(yytext, "final") == 0) {
+          last_id = 1;
+          return (FINAL);
+        }
       } else {
-	if (strcmp(yytext, "class") == 0) {
-	  Swig_warning(WARN_PARSE_CLASS_KEYWORD, cparse_file, cparse_line, "class keyword used, but not in C++ mode.\n");
-	}
-	if (strcmp(yytext, "_Bool") == 0) {
-	  /* C99 boolean type. */
-	  yylval.type = NewSwigType(T_BOOL);
-	  return (TYPE_BOOL);
-	}
-	if (strcmp(yytext, "_Complex") == 0) {
-	  yylval.type = NewSwigType(T_COMPLEX);
-	  return (TYPE_COMPLEX);
-	}
-	if (strcmp(yytext, "restrict") == 0)
-	  return (yylex());
+        if (strcmp(yytext, "class") == 0) {
+          Swig_warning(WARN_PARSE_CLASS_KEYWORD, cparse_file, cparse_line, "class keyword used, but not in C++ mode.\n");
+        }
+        if (strcmp(yytext, "_Bool") == 0) {
+          /* C99 boolean type. */
+          yylval.type = NewSwigType(T_BOOL);
+          return (TYPE_BOOL);
+        }
+        if (strcmp(yytext, "_Complex") == 0) {
+          yylval.type = NewSwigType(T_COMPLEX);
+          return (TYPE_COMPLEX);
+        }
+        if (strcmp(yytext, "restrict") == 0)
+          return (yylex());
       }
 
       /* Misc keywords */
 
       if (strcmp(yytext, "extern") == 0)
-	return (EXTERN);
+        return (EXTERN);
       if (strcmp(yytext, "const") == 0)
-	return (CONST_QUAL);
+        return (CONST_QUAL);
       if (strcmp(yytext, "static") == 0)
-	return (STATIC);
+        return (STATIC);
       if (strcmp(yytext, "struct") == 0)
-	return (STRUCT);
+        return (STRUCT);
       if (strcmp(yytext, "union") == 0)
-	return (UNION);
+        return (UNION);
       if (strcmp(yytext, "enum") == 0)
-	return (ENUM);
+        return (ENUM);
       if (strcmp(yytext, "sizeof") == 0)
-	return (SIZEOF);
+        return (SIZEOF);
 
       if (strcmp(yytext, "typedef") == 0) {
-	return (TYPEDEF);
+        return (TYPEDEF);
       }
 
       /* Ignored keywords */
 
       if (strcmp(yytext, "volatile") == 0)
-	return (VOLATILE);
+        return (VOLATILE);
       if (strcmp(yytext, "register") == 0)
-	return (REGISTER);
+        return (REGISTER);
       if (strcmp(yytext, "inline") == 0)
-	return (yylex());
+        return (yylex());
 
     } else {
       /* SWIG directives */
       String *stext = 0;
       if (strcmp(yytext, "%module") == 0)
-	return (MODULE);
+        return (MODULE);
       if (strcmp(yytext, "%insert") == 0)
-	return (INSERT);
+        return (INSERT);
       if (strcmp(yytext, "%rename") == 0) {
-	rename_active = 1;
-	return (RENAME);
+        rename_active = 1;
+        return (RENAME);
       }
       if (strcmp(yytext, "%namewarn") == 0) {
-	rename_active = 1;
-	return (NAMEWARN);
+        rename_active = 1;
+        return (NAMEWARN);
       }
       if (strcmp(yytext, "%includefile") == 0)
-	return (INCLUDE);
+        return (INCLUDE);
       if (strcmp(yytext, "%beginfile") == 0)
-	return (BEGINFILE);
+        return (BEGINFILE);
       if (strcmp(yytext, "%endoffile") == 0)
-	return (ENDOFFILE);
+        return (ENDOFFILE);
       if (strcmp(yytext, "%constant") == 0)
-	return (CONSTANT);
+        return (CONSTANT);
       if (strcmp(yytext, "%typedef") == 0) {
-	Swig_warning(WARN_DEPRECATED_TYPEDEF, cparse_file, cparse_line, "%%typedef directive is deprecated, use plain typedef instead\n");
-	return (TYPEDEF);
+        Swig_warning(WARN_DEPRECATED_TYPEDEF, cparse_file, cparse_line, "%%typedef directive is deprecated, use plain typedef instead\n");
+        return (TYPEDEF);
       }
       if (strcmp(yytext, "%native") == 0)
-	return (NATIVE);
+        return (NATIVE);
       if (strcmp(yytext, "%pragma") == 0)
-	return (PRAGMA);
+        return (PRAGMA);
       if (strcmp(yytext, "%extend") == 0)
-	return (EXTEND);
+        return (EXTEND);
       if (strcmp(yytext, "%fragment") == 0)
-	return (FRAGMENT);
+        return (FRAGMENT);
       if (strcmp(yytext, "%inline") == 0)
-	return (INLINE);
+        return (INLINE);
       if (strcmp(yytext, "%typemap") == 0)
-	return (TYPEMAP);
+        return (TYPEMAP);
       if (strcmp(yytext, "%feature") == 0) {
         /* The rename_active indicates we don't need the information of the 
          * following function's return type. This applied for %rename, so do
          * %feature. 
          */
         rename_active = 1;
-	return (FEATURE);
+        return (FEATURE);
       }
       if (strcmp(yytext, "%importfile") == 0)
-	return (IMPORT);
+        return (IMPORT);
       if (strcmp(yytext, "%echo") == 0)
-	return (ECHO);
+        return (ECHO);
       if (strcmp(yytext, "%apply") == 0)
-	return (APPLY);
+        return (APPLY);
       if (strcmp(yytext, "%clear") == 0)
-	return (CLEAR);
+        return (CLEAR);
       if (strcmp(yytext, "%types") == 0)
-	return (TYPES);
+        return (TYPES);
       if (strcmp(yytext, "%parms") == 0)
-	return (PARMS);
+        return (PARMS);
       if (strcmp(yytext, "%varargs") == 0)
-	return (VARARGS);
+        return (VARARGS);
       if (strcmp(yytext, "%template") == 0) {
-	return (SWIGTEMPLATE);
+        return (SWIGTEMPLATE);
       }
       if (strcmp(yytext, "%warn") == 0)
-	return (WARN);
+        return (WARN);
 
       /* Note down the apparently unknown directive for error reporting - if
        * we end up reporting a generic syntax error we'll instead report an

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -261,9 +261,9 @@ static int yylook(void) {
     switch(tok) {
     case SWIG_TOKEN_ID:
       return ID;
-    case SWIG_TOKEN_LPAREN: 
+    case SWIG_TOKEN_LPAREN:
       return LPAREN;
-    case SWIG_TOKEN_RPAREN: 
+    case SWIG_TOKEN_RPAREN:
       return RPAREN;
     case SWIG_TOKEN_SEMI:
       return SEMI;
@@ -339,7 +339,7 @@ static int yylook(void) {
       return DSTAR;
     case SWIG_TOKEN_LTEQUALGT:
       return LESSEQUALGREATER;
-      
+
     case SWIG_TOKEN_DCOLON:
       {
         int nexttok = Scanner_token(scan);
@@ -358,7 +358,7 @@ static int yylook(void) {
         }
       }
       break;
-      
+
     case SWIG_TOKEN_ELLIPSIS:
       return ELLIPSIS;
 
@@ -377,7 +377,7 @@ static int yylook(void) {
       return RBRACKET;
 
       /* Look for multi-character sequences */
-      
+
     case SWIG_TOKEN_STRING:
       yylval.str = NewString(Scanner_text(scan));
       return STRING;
@@ -385,7 +385,7 @@ static int yylook(void) {
     case SWIG_TOKEN_WSTRING:
       yylval.str = NewString(Scanner_text(scan));
       return WSTRING;
-      
+
     case SWIG_TOKEN_CHAR:
       yylval.str = NewString(Scanner_text(scan));
       if (Len(yylval.str) == 0) {
@@ -401,46 +401,46 @@ static int yylook(void) {
       return WCHARCONST;
 
       /* Numbers */
-      
+
     case SWIG_TOKEN_INT:
       return NUM_INT;
-      
+
     case SWIG_TOKEN_UINT:
       return NUM_UNSIGNED;
-      
+
     case SWIG_TOKEN_LONG:
       return NUM_LONG;
-      
+
     case SWIG_TOKEN_ULONG:
       return NUM_ULONG;
-      
+
     case SWIG_TOKEN_LONGLONG:
       return NUM_LONGLONG;
-      
+
     case SWIG_TOKEN_ULONGLONG:
       return NUM_ULONGLONG;
-      
+
     case SWIG_TOKEN_DOUBLE:
       return NUM_DOUBLE;
 
     case SWIG_TOKEN_FLOAT:
       return NUM_FLOAT;
-      
+
     case SWIG_TOKEN_LONGDOUBLE:
       return NUM_LONGDOUBLE;
 
     case SWIG_TOKEN_BOOL:
       return NUM_BOOL;
-      
+
     case SWIG_TOKEN_POUND:
       Scanner_skip_line(scan);
       yylval.id = Swig_copy_string(Char(Scanner_text(scan)));
       return POUND;
-      
+
     case SWIG_TOKEN_CODEBLOCK:
       yylval.str = NewString(Scanner_text(scan));
       return HBLOCK;
-      
+
     case SWIG_TOKEN_COMMENT:
       {
         typedef enum {
@@ -471,10 +471,10 @@ static int yylook(void) {
                 loc = Char(cmt);
               }
             }
-            
+
             /* Check for all possible Doxygen comment start markers while ignoring
                comments starting with a row of asterisks or slashes just as
-               Doxygen itself does.  Also skip empty comment (slash-star-star-slash), 
+               Doxygen itself does.  Also skip empty comment (slash-star-star-slash),
                which causes a crash due to begin > end. */
             if (Len(cmt) > 3 && loc[0] == '/' &&
                 ((loc[1] == '/' && ((loc[2] == '/' && loc[3] != '/') || loc[2] == '!')) ||
@@ -801,7 +801,7 @@ num_common: {
                       (a) Must check for special case new[] and delete[]
 
              Error handling is somewhat tricky here.  We'll try to back out gracefully if we can.
- 
+
           */
 
           do {
@@ -827,7 +827,7 @@ num_common: {
             /* Array access operator.  The next token MUST be a RBRACKET */
             nexttok = Scanner_token(scan);
             if (nexttok != SWIG_TOKEN_RBRACKET) {
-              Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");	      
+              Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
             } else {
               Append(s,"[]");
               yylval.str = s;
@@ -854,7 +854,7 @@ num_common: {
 
               nexttok = Scanner_token(scan);
               if (nexttok <= 0) {
-                Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");	      
+                Swig_error(Scanner_file(scan),Scanner_line(scan),"Syntax error. Bad operator name.\n");
               }
               if (nexttok == SWIG_TOKEN_LPAREN) {
                 termtoken = SWIG_TOKEN_LPAREN;
@@ -1045,9 +1045,9 @@ num_common: {
       if (strcmp(yytext, "%typemap") == 0)
         return (TYPEMAP);
       if (strcmp(yytext, "%feature") == 0) {
-        /* The rename_active indicates we don't need the information of the 
+        /* The rename_active indicates we don't need the information of the
          * following function's return type. This applied for %rename, so do
-         * %feature. 
+         * %feature.
          */
         rename_active = 1;
         return (FEATURE);

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -8,7 +8,7 @@
  *
  * templ.c
  *
- * Expands a template into a specialized version.   
+ * Expands a template into a specialized version.
  * ----------------------------------------------------------------------------- */
 
 #include "swig.h"
@@ -941,7 +941,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
     }
 
     /* Search for partial specializations.
-     * Example: template<typename T> class name<T *> { ... } 
+     * Example: template<typename T> class name<T *> { ... }
 
      * There are 3 types of template arguments:
      * (1) Template type arguments
@@ -1049,7 +1049,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
         for (col = 0; col < parms_len; col++) {
           int *priorities_col = priorities_matrix + col;
           int maxpriority = -1;
-          /* 
+          /*
              Printf(stdout, "max_possible_partials: %d col:%d\n", max_possible_partials, col);
              Printf(stdout, "        ");
              */
@@ -1215,7 +1215,7 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
       firstn = Swig_symbol_clookup_local(name, 0);
       n = firstn;
       /* First look for all overloaded functions (non-variadic) template matches.
-       * Looking for all template parameter matches only (not function parameter matches) 
+       * Looking for all template parameter matches only (not function parameter matches)
        * as %template instantiation uses template parameters without any function parameters. */
       while (n) {
         if (Strcmp(nodeType(n), "template") == 0) {

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -936,7 +936,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
         Swig_error(cparse_file, cparse_line, "'%s' is not defined as a template. (%s)\n", name, nodeType(n));
         Delete(tname);
         Delete(parms);
-        return 0;	  /* Found a match, but it's not a template of any kind. */
+        return 0;         /* Found a match, but it's not a template of any kind. */
       }
     }
 

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -83,12 +83,12 @@ static void expand_variadic_parms(Node *n, const char *attribute, Parm *unexpand
       Parm *ep = expanded;
       int i = 0;
       while (ep) {
-	SwigType *newtype = Copy(type);
-	SwigType_del_variadic(newtype);
-	Replaceid(newtype, unexpanded_name, Getattr(ep, "type"));
-	Setattr(ep, "type", newtype);
-	Setattr(ep, "name", name ? NewStringf("%s%d", name, ++i) : 0);
-	ep = nextSibling(ep);
+        SwigType *newtype = Copy(type);
+        SwigType_del_variadic(newtype);
+        Replaceid(newtype, unexpanded_name, Getattr(ep, "type"));
+        Setattr(ep, "type", newtype);
+        Setattr(ep, "name", name ? NewStringf("%s%d", name, ++i) : 0);
+        ep = nextSibling(ep);
       }
       expanded = ParmList_replace_last(p, expanded);
       Setattr(n, attribute, expanded);
@@ -163,15 +163,15 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
       /* conversion operator "name" and "sym:name" attributes are unusual as they contain c++ types, so treat as code for patching */
       Append(cpatchlist, Getattr(n, "name"));
       if (Getattr(n, "sym:name")) {
-	Append(cpatchlist, Getattr(n, "sym:name"));
+        Append(cpatchlist, Getattr(n, "sym:name"));
       }
     }
     if (Strstr(Getattr(n, "storage"), "friend")) {
       String *symname = Getattr(n, "sym:name");
       if (symname) {
-	String *stripped_name = SwigType_templateprefix(symname);
-	Setattr(n, "sym:name", stripped_name);
-	Delete(stripped_name);
+        String *stripped_name = SwigType_templateprefix(symname);
+        Setattr(n, "sym:name", stripped_name);
+        Delete(stripped_name);
       }
       Append(typelist, Getattr(n, "name"));
     }
@@ -184,43 +184,43 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
     {
       int b = 0;
       for (b = 0; b < 3; ++b) {
-	List *bases = Getattr(n, baselists[b]);
-	if (bases) {
-	  int i;
-	  int ilen = Len(bases);
-	  for (i = 0; i < ilen; i++) {
-	    String *name = Copy(Getitem(bases, i));
-	    if (SwigType_isvariadic(name)) {
-	      Parm *parm = NewParmWithoutFileLineInfo(name, 0);
-	      Node *temp_parm_node = NewHash();
-	      Setattr(temp_parm_node, "variadicbaseparms", parm);
-	      assert(i == ilen - 1);
-	      Delitem(bases, i);
-	      expand_variadic_parms(temp_parm_node, "variadicbaseparms", unexpanded_variadic_parm, expanded_variadic_parms);
-	      {
-		Parm *vp = Getattr(temp_parm_node, "variadicbaseparms");
-		while (vp) {
-		  String *name = Copy(Getattr(vp, "type"));
-		  Append(bases, name);
-		  Append(typelist, name);
-		  vp = nextSibling(vp);
-		}
-	      }
-	      Delete(temp_parm_node);
-	    } else {
-	      Setitem(bases, i, name);
-	      Append(typelist, name);
-	    }
-	  }
-	}
+        List *bases = Getattr(n, baselists[b]);
+        if (bases) {
+          int i;
+          int ilen = Len(bases);
+          for (i = 0; i < ilen; i++) {
+            String *name = Copy(Getitem(bases, i));
+            if (SwigType_isvariadic(name)) {
+              Parm *parm = NewParmWithoutFileLineInfo(name, 0);
+              Node *temp_parm_node = NewHash();
+              Setattr(temp_parm_node, "variadicbaseparms", parm);
+              assert(i == ilen - 1);
+              Delitem(bases, i);
+              expand_variadic_parms(temp_parm_node, "variadicbaseparms", unexpanded_variadic_parm, expanded_variadic_parms);
+              {
+                Parm *vp = Getattr(temp_parm_node, "variadicbaseparms");
+                while (vp) {
+                  String *name = Copy(Getattr(vp, "type"));
+                  Append(bases, name);
+                  Append(typelist, name);
+                  vp = nextSibling(vp);
+                }
+              }
+              Delete(temp_parm_node);
+            } else {
+              Setitem(bases, i, name);
+              Append(typelist, name);
+            }
+          }
+        }
       }
     }
     /* Patch children */
     {
       Node *cn = firstChild(n);
       while (cn) {
-	cparse_template_expand(templnode, cn, tname, rname, templateargs, patchlist, typelist, cpatchlist, unexpanded_variadic_parm, expanded_variadic_parms);
-	cn = nextSibling(cn);
+        cparse_template_expand(templnode, cn, tname, rname, templateargs, patchlist, typelist, cpatchlist, unexpanded_variadic_parm, expanded_variadic_parms);
+        cn = nextSibling(cn);
       }
     }
   } else if (Equal(nodeType, "classforward")) {
@@ -230,24 +230,24 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
       String *symname = Getattr(n, "sym:name");
       String *name;
       if (symname) {
-	String *stripped_name = SwigType_templateprefix(symname);
-	if (Strstr(tname, stripped_name)) {
-	  Replaceid(symname, stripped_name, tname);
-	}
-	Delete(stripped_name);
+        String *stripped_name = SwigType_templateprefix(symname);
+        if (Strstr(tname, stripped_name)) {
+          Replaceid(symname, stripped_name, tname);
+        }
+        Delete(stripped_name);
       }
       name = Getattr(n, "sym:name");
       if (name) {
-	if (strchr(Char(name), '<')) {
-	  Clear(name);
-	  Append(name, rname);
-	} else {
-	  String *tmp = Copy(name);
-	  Replace(tmp, tname, rname, DOH_REPLACE_ANY);
-	  Clear(name);
-	  Append(name, tmp);
-	  Delete(tmp);
-	}
+        if (strchr(Char(name), '<')) {
+          Clear(name);
+          Append(name, rname);
+        } else {
+          String *tmp = Copy(name);
+          Replace(tmp, tname, rname, DOH_REPLACE_ANY);
+          Clear(name);
+          Append(name, tmp);
+          Delete(tmp);
+        }
       }
     }
     Append(cpatchlist, Getattr(n, "code"));
@@ -261,7 +261,7 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
     if (parent == templnode || (parentNode(parent) == templnode && Equal(nodeType(parent), "extend"))) {
       String *symname = Getattr(n, "sym:name");
       if (symname)
-	Replace(symname, tname, rname, DOH_REPLACE_ANY);
+        Replace(symname, tname, rname, DOH_REPLACE_ANY);
       Append(cpatchlist, Getattr(n, "code"));
     }
   } else if (Equal(nodeType, "using")) {
@@ -275,32 +275,32 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
       String *symname;
       String *stripped_name = SwigType_templateprefix(name);
       if (Strstr(tname, stripped_name)) {
-	Replaceid(name, stripped_name, tname);
+        Replaceid(name, stripped_name, tname);
       }
       Delete(stripped_name);
       symname = Getattr(n, "sym:name");
       if (symname) {
-	stripped_name = SwigType_templateprefix(symname);
-	if (Strstr(tname, stripped_name)) {
-	  Replaceid(symname, stripped_name, tname);
-	}
-	Delete(stripped_name);
+        stripped_name = SwigType_templateprefix(symname);
+        if (Strstr(tname, stripped_name)) {
+          Replaceid(symname, stripped_name, tname);
+        }
+        Delete(stripped_name);
       }
       if (strchr(Char(name), '<')) {
-	Append(patchlist, Getattr(n, "name"));
+        Append(patchlist, Getattr(n, "name"));
       }
       name = Getattr(n, "sym:name");
       if (name) {
-	if (strchr(Char(name), '<')) {
-	  Clear(name);
-	  Append(name, rname);
-	} else {
-	  String *tmp = Copy(name);
-	  Replace(tmp, tname, rname, DOH_REPLACE_ANY);
-	  Clear(name);
-	  Append(name, tmp);
-	  Delete(tmp);
-	}
+        if (strchr(Char(name), '<')) {
+          Clear(name);
+          Append(name, rname);
+        } else {
+          String *tmp = Copy(name);
+          Replace(tmp, tname, rname, DOH_REPLACE_ANY);
+          Clear(name);
+          Append(name, tmp);
+          Delete(tmp);
+        }
       }
     }
 
@@ -396,8 +396,8 @@ static void cparse_postprocess_expanded_template(Node *n) {
       /* A function node */
       SwigType *t = Getattr(n, "type");
       if (t) {
-	String *name = Getattr(n, "name");
-	cparse_fix_function_decl(name, d, t);
+        String *name = Getattr(n, "name");
+        cparse_fix_function_decl(name, d, t);
       }
     }
   } else {
@@ -437,7 +437,7 @@ static Parm *partial_arg(const SwigType *type, const SwigType *partialtype) {
     String *prefix = NewStringWithSize(cp, prefix_length);
     while (++suffix) {
       if (!isdigit((int)*suffix))
-	break;
+        break;
     }
     parmname = NewStringWithSize(c, (int)(suffix - c)); /* $1, $2 etc */
     suffix_length = (int)strlen(suffix);
@@ -489,24 +489,24 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
       ptype = Getattr(p, "type");
       tptype = Getattr(tp, "type");
       if (ptype && tptype) {
-	SwigType *ty = Swig_symbol_typedef_reduce(tptype, tscope);
-	Parm *partial_parm = partial_arg(ty, ptype);
-	String *partial_name = Getattr(partial_parm, "name");
-	partial_type = Copy(Getattr(partial_parm, "type"));
-	/*      Printf(stdout,"partial '%s' '%s'  ---> '%s'\n", tptype, ptype, partial_type); */
-	if (partial_name && strchr(Char(partial_name), '$') == Char(partial_name)) {
-	  int index = atoi(Char(partial_name) + 1) - 1;
-	  Parm *parm;
-	  assert(index >= 0);
-	  parm = ParmList_nth_parm(templateparms, index);
-	  assert(parm);
-	  if (parm) {
-	    Setattr(parm, "type", partial_type);
-	  }
-	}
-	Delete(partial_parm);
-	Delete(partial_type);
-	Delete(ty);
+        SwigType *ty = Swig_symbol_typedef_reduce(tptype, tscope);
+        Parm *partial_parm = partial_arg(ty, ptype);
+        String *partial_name = Getattr(partial_parm, "name");
+        partial_type = Copy(Getattr(partial_parm, "type"));
+        /*      Printf(stdout,"partial '%s' '%s'  ---> '%s'\n", tptype, ptype, partial_type); */
+        if (partial_name && strchr(Char(partial_name), '$') == Char(partial_name)) {
+          int index = atoi(Char(partial_name) + 1) - 1;
+          Parm *parm;
+          assert(index >= 0);
+          parm = ParmList_nth_parm(templateparms, index);
+          assert(parm);
+          if (parm) {
+            Setattr(parm, "type", partial_type);
+          }
+        }
+        Delete(partial_parm);
+        Delete(partial_type);
+        Delete(ty);
       }
       p = nextSibling(p);
       tp = nextSibling(tp);
@@ -536,7 +536,7 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
       String *nodeType = nodeType(n);
       name_with_templateargs = NewStringf("%s%s", name, templateargs);
       if (!(Equal(nodeType, "constructor") || Equal(nodeType, "destructor"))) {
-	Setattr(n, "name", name_with_templateargs);
+        Setattr(n, "name", name_with_templateargs);
       }
     }
   }
@@ -550,92 +550,92 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
       Symtab *tsdecl = Getattr(n, "sym:symtab");
       String *tsname = Getattr(n, "sym:name");
       while (tp) {
-	String *name, *value, *valuestr, *tmp, *tmpr;
-	int sz, i;
-	String *dvalue = 0;
-	String *qvalue = 0;
+        String *name, *value, *valuestr, *tmp, *tmpr;
+        int sz, i;
+        String *dvalue = 0;
+        String *qvalue = 0;
 
-	name = Getattr(tp, "name");
-	value = Getattr(tp, "value");
+        name = Getattr(tp, "name");
+        value = Getattr(tp, "value");
 
-	if (name) {
-	  if (!value)
-	    value = Getattr(tp, "type");
-	  qvalue = Swig_symbol_typedef_reduce(value, tsdecl);
-	  dvalue = Swig_symbol_type_qualify(qvalue, tsdecl);
-	  if (SwigType_istemplate(dvalue)) {
-	    String *ty = Swig_symbol_template_deftype(dvalue, tscope);
-	    Delete(dvalue);
-	    dvalue = ty;
-	  }
+        if (name) {
+          if (!value)
+            value = Getattr(tp, "type");
+          qvalue = Swig_symbol_typedef_reduce(value, tsdecl);
+          dvalue = Swig_symbol_type_qualify(qvalue, tsdecl);
+          if (SwigType_istemplate(dvalue)) {
+            String *ty = Swig_symbol_template_deftype(dvalue, tscope);
+            Delete(dvalue);
+            dvalue = ty;
+          }
 
-	  assert(dvalue);
-	  valuestr = SwigType_str(dvalue, 0);
-	  sz = Len(patchlist);
-	  for (i = 0; i < sz; i++) {
-	    /* Patch String or SwigType with SwigType, eg T => int in Foo<(T)>, or TT => Hello<(int)> in X<(TT)>::meth */
-	    String *s = Getitem(patchlist, i);
-	    Replace(s, name, dvalue, DOH_REPLACE_ID);
-	    /* Try treat the string as a proper SwigType thought it's usually a string containing an unparsed
-	     * C type.  The proper fix would be to parse the String to convert it to a SwigType say using
-	     * Swig_cparse_type, but we'd need a re-entrant parser for that. This hack usually works for simple types.
-	     */
-	    SwigType_typename_replace(s, tbase, name_with_templateargs);
-	  }
+          assert(dvalue);
+          valuestr = SwigType_str(dvalue, 0);
+          sz = Len(patchlist);
+          for (i = 0; i < sz; i++) {
+            /* Patch String or SwigType with SwigType, eg T => int in Foo<(T)>, or TT => Hello<(int)> in X<(TT)>::meth */
+            String *s = Getitem(patchlist, i);
+            Replace(s, name, dvalue, DOH_REPLACE_ID);
+            /* Try treat the string as a proper SwigType thought it's usually a string containing an unparsed
+             * C type.  The proper fix would be to parse the String to convert it to a SwigType say using
+             * Swig_cparse_type, but we'd need a re-entrant parser for that. This hack usually works for simple types.
+             */
+            SwigType_typename_replace(s, tbase, name_with_templateargs);
+          }
 
-	  sz = Len(typelist);
-	  for (i = 0; i < sz; i++) {
-	    SwigType *s = Getitem(typelist, i);
-	    Node *tynode;
-	    String *tyname;
+          sz = Len(typelist);
+          for (i = 0; i < sz; i++) {
+            SwigType *s = Getitem(typelist, i);
+            Node *tynode;
+            String *tyname;
 
-	    SwigType_variadic_replace(s, unexpanded_variadic_parm, expanded_variadic_parms);
+            SwigType_variadic_replace(s, unexpanded_variadic_parm, expanded_variadic_parms);
 
-	    /*
-	      The approach of 'trivially' replacing template arguments is kind of fragile.
-	      In particular if types with similar name in different namespaces appear.
-	      We will not replace template args if a type/class exists with the same
-	      name which is not a template.
-	    */
-	    tynode = Swig_symbol_clookup(s, 0);
-	    tyname  = tynode ? Getattr(tynode, "sym:name") : 0;
-	    /*
-	    Printf(stdout, "  replacing %s with %s to %s or %s to %s\n", s, name, dvalue, tbase, name_with_templateargs);
-	    Printf(stdout, "    %d %s to %s\n", tp == unexpanded_variadic_parm, name, ParmList_str_defaultargs(expanded_variadic_parms));
-	    */
-	    if (!tyname || !tsname || !Equal(tyname, tsname) || Getattr(tynode, "templatetype")) {
-	      SwigType_typename_replace(s, name, dvalue);
-	      SwigType_typename_replace(s, tbase, name_with_templateargs);
-	    }
-	  }
+            /*
+              The approach of 'trivially' replacing template arguments is kind of fragile.
+              In particular if types with similar name in different namespaces appear.
+              We will not replace template args if a type/class exists with the same
+              name which is not a template.
+            */
+            tynode = Swig_symbol_clookup(s, 0);
+            tyname  = tynode ? Getattr(tynode, "sym:name") : 0;
+            /*
+            Printf(stdout, "  replacing %s with %s to %s or %s to %s\n", s, name, dvalue, tbase, name_with_templateargs);
+            Printf(stdout, "    %d %s to %s\n", tp == unexpanded_variadic_parm, name, ParmList_str_defaultargs(expanded_variadic_parms));
+            */
+            if (!tyname || !tsname || !Equal(tyname, tsname) || Getattr(tynode, "templatetype")) {
+              SwigType_typename_replace(s, name, dvalue);
+              SwigType_typename_replace(s, tbase, name_with_templateargs);
+            }
+          }
 
-	  tmp = NewStringf("#%s", name);
-	  tmpr = NewStringf("\"%s\"", valuestr);
+          tmp = NewStringf("#%s", name);
+          tmpr = NewStringf("\"%s\"", valuestr);
 
-	  sz = Len(cpatchlist);
-	  for (i = 0; i < sz; i++) {
-	    /* Patch String with C++ String type, eg T => int in Foo< T >, or TT => Hello< int > in X< TT >::meth */
-	    String *s = Getitem(cpatchlist, i);
-	    /* Stringising that ought to be done in the preprocessor really, eg #T => "int" */
-	    Replace(s, tmp, tmpr, DOH_REPLACE_ID);
-	    Replace(s, name, valuestr, DOH_REPLACE_ID);
-	  }
-	  Delete(tmp);
-	  Delete(tmpr);
-	  Delete(valuestr);
-	  Delete(dvalue);
-	  Delete(qvalue);
-	}
-	tp = nextSibling(tp);
+          sz = Len(cpatchlist);
+          for (i = 0; i < sz; i++) {
+            /* Patch String with C++ String type, eg T => int in Foo< T >, or TT => Hello< int > in X< TT >::meth */
+            String *s = Getitem(cpatchlist, i);
+            /* Stringising that ought to be done in the preprocessor really, eg #T => "int" */
+            Replace(s, tmp, tmpr, DOH_REPLACE_ID);
+            Replace(s, name, valuestr, DOH_REPLACE_ID);
+          }
+          Delete(tmp);
+          Delete(tmpr);
+          Delete(valuestr);
+          Delete(dvalue);
+          Delete(qvalue);
+        }
+        tp = nextSibling(tp);
       }
     } else {
       /* No template parameters at all.  This could be a specialization */
       int i, sz;
       sz = Len(typelist);
       for (i = 0; i < sz; i++) {
-	String *s = Getitem(typelist, i);
-	SwigType_variadic_replace(s, unexpanded_variadic_parm, expanded_variadic_parms);
-	SwigType_typename_replace(s, tbase, name_with_templateargs);
+        String *s = Getitem(typelist, i);
+        SwigType_variadic_replace(s, unexpanded_variadic_parm, expanded_variadic_parms);
+        SwigType_typename_replace(s, tbase, name_with_templateargs);
       }
     }
   }
@@ -647,10 +647,10 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
     if (bases) {
       Iterator b;
       for (b = First(bases); b.item; b = Next(b)) {
-	String *qn = Swig_symbol_type_qualify(b.item, tscope);
-	Clear(b.item);
-	Append(b.item, qn);
-	Delete(qn);
+        String *qn = Swig_symbol_type_qualify(b.item, tscope);
+        Clear(b.item);
+        Append(b.item, qn);
+        Delete(qn);
       }
     }
   }
@@ -681,7 +681,7 @@ static int is_exact_partial_type(const SwigType *type) {
     const char *suffix = c + 1;
     while (++suffix) {
       if (!isdigit((int)*suffix))
-	break;
+        break;
     }
     is_exact = (*suffix == 0);
   }
@@ -716,88 +716,88 @@ static EMatch does_parm_match(SwigType *type, SwigType *partial_parm_type, Symta
   } else if (match == PartiallySpecializedNoMatch) {
     if ((pp_len > 0 && Strncmp(ty, pp_prefix, pp_len) == 0)) {
       /*
-	 Type starts with pp_prefix, so it is a partial specialization type match, for example,
-	 all of the following could match the type in the %template:
-	   template <typename T> struct XX {};
-	   template <typename T> struct XX<T &> {};         // r.$1
-	   template <typename T> struct XX<T const&> {};    // r.q(const).$1
-	   template <typename T> struct XX<T *const&> {};   // r.q(const).p.$1
-	   %template(XXX) XX<int *const&>;                  // r.q(const).p.int
-	 where type="r.q(const).p.int" will match either of pp_prefix="r.", pp_prefix="r.q(const)." pp_prefix="r.q(const).p."
+         Type starts with pp_prefix, so it is a partial specialization type match, for example,
+         all of the following could match the type in the %template:
+           template <typename T> struct XX {};
+           template <typename T> struct XX<T &> {};         // r.$1
+           template <typename T> struct XX<T const&> {};    // r.q(const).$1
+           template <typename T> struct XX<T *const&> {};   // r.q(const).p.$1
+           %template(XXX) XX<int *const&>;                  // r.q(const).p.int
+         where type="r.q(const).p.int" will match either of pp_prefix="r.", pp_prefix="r.q(const)." pp_prefix="r.q(const).p."
       */
       match = PartiallySpecializedMatch;
       *specialization_priority = pp_len;
     } else if (pp_len == 0 && is_exact_partial_type(partial_parm_type)) {
       /*
-	 Type without a prefix match, as in $1 for int
-	   template <typename T, typename U> struct XX {};
-	   template <typename T, typename U> struct XX<T, U &> {};  // $1,r.$2
-	   %template(XXX) XX<int, double&>;                         // int,r.double
+         Type without a prefix match, as in $1 for int
+           template <typename T, typename U> struct XX {};
+           template <typename T, typename U> struct XX<T, U &> {};  // $1,r.$2
+           %template(XXX) XX<int, double&>;                         // int,r.double
        */
       match = PartiallySpecializedMatch;
       *specialization_priority = pp_len;
     } else {
       /*
-	Check for template types that are templates such as
-	  template<typename V> struct Vect {};
-	  template<typename T> class XX {};
-	  template<class TT> class XX<Vect<TT>> {};
-	  %template(XXVectInt) XX<Vect<int>>;
-	matches type="Vect<(int)>" and partial_parm_type="Vect<($1)>"
+        Check for template types that are templates such as
+          template<typename V> struct Vect {};
+          template<typename T> class XX {};
+          template<class TT> class XX<Vect<TT>> {};
+          %template(XXVectInt) XX<Vect<int>>;
+        matches type="Vect<(int)>" and partial_parm_type="Vect<($1)>"
        */
       if (SwigType_istemplate(partial_parm_type) && SwigType_istemplate(ty)) {
 
-	SwigType *qt = Swig_symbol_typedef_reduce(ty, tscope);
-	String *tsuffix = SwigType_templatesuffix(qt);
+        SwigType *qt = Swig_symbol_typedef_reduce(ty, tscope);
+        String *tsuffix = SwigType_templatesuffix(qt);
 
-	SwigType *pp_qt = Swig_symbol_typedef_reduce(partial_parm_type, tscope);
-	String *pp_tsuffix = SwigType_templatesuffix(pp_qt);
+        SwigType *pp_qt = Swig_symbol_typedef_reduce(partial_parm_type, tscope);
+        String *pp_tsuffix = SwigType_templatesuffix(pp_qt);
 
-	if (Equal(tsuffix, pp_tsuffix) && Len(tsuffix) == 0) {
-	  String *tprefix = SwigType_templateprefix(qt);
-	  String *qprefix = SwigType_typedef_qualified(tprefix);
+        if (Equal(tsuffix, pp_tsuffix) && Len(tsuffix) == 0) {
+          String *tprefix = SwigType_templateprefix(qt);
+          String *qprefix = SwigType_typedef_qualified(tprefix);
 
-	  String *pp_tprefix = SwigType_templateprefix(pp_qt);
-	  String *pp_qprefix = SwigType_typedef_qualified(pp_tprefix);
+          String *pp_tprefix = SwigType_templateprefix(pp_qt);
+          String *pp_qprefix = SwigType_typedef_qualified(pp_tprefix);
 
-	  if (Equal(qprefix, pp_qprefix)) {
-	    String *templateargs = SwigType_templateargs(qt);
-	    List *parms = SwigType_parmlist(templateargs);
-	    Iterator pi = First(parms);
-	    Parm *p = pi.item;
+          if (Equal(qprefix, pp_qprefix)) {
+            String *templateargs = SwigType_templateargs(qt);
+            List *parms = SwigType_parmlist(templateargs);
+            Iterator pi = First(parms);
+            Parm *p = pi.item;
 
-	    String *pp_templateargs = SwigType_templateargs(pp_qt);
-	    List *pp_parms = SwigType_parmlist(pp_templateargs);
-	    Iterator pp_pi = First(pp_parms);
-	    Parm *pp = pp_pi.item;
+            String *pp_templateargs = SwigType_templateargs(pp_qt);
+            List *pp_parms = SwigType_parmlist(pp_templateargs);
+            Iterator pp_pi = First(pp_parms);
+            Parm *pp = pp_pi.item;
 
-	    if (p && pp) {
-	      /* Implementation is limited to matching single parameter templates only for now */
-	      int priority;
-	      match = does_parm_match(p, pp, tscope, &priority);
-	      if (match <= PartiallySpecializedNoMatch) {
-		*specialization_priority = priority;
-	      } else {
-		*specialization_priority = priority + TEMPLATE_MATCH_PRIORITY;
-	      }
-	    }
+            if (p && pp) {
+              /* Implementation is limited to matching single parameter templates only for now */
+              int priority;
+              match = does_parm_match(p, pp, tscope, &priority);
+              if (match <= PartiallySpecializedNoMatch) {
+                *specialization_priority = priority;
+              } else {
+                *specialization_priority = priority + TEMPLATE_MATCH_PRIORITY;
+              }
+            }
 
-	    Delete(pp_parms);
-	    Delete(pp_templateargs);
-	    Delete(parms);
-	    Delete(templateargs);
-	  }
+            Delete(pp_parms);
+            Delete(pp_templateargs);
+            Delete(parms);
+            Delete(templateargs);
+          }
 
-	  Delete(pp_qprefix);
-	  Delete(pp_tprefix);
-	  Delete(qprefix);
-	  Delete(tprefix);
-	}
+          Delete(pp_qprefix);
+          Delete(pp_tprefix);
+          Delete(qprefix);
+          Delete(tprefix);
+        }
 
-	Delete(pp_tsuffix);
-	Delete(pp_qt);
-	Delete(tsuffix);
-	Delete(qt);
+        Delete(pp_tsuffix);
+        Delete(pp_qt);
+        Delete(tsuffix);
+        Delete(qt);
       }
     }
   }
@@ -864,9 +864,9 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
     while (p) {
       SwigType *ty = Getattr(p, "type");
       if (ty) {
-	SwigType *nt = Swig_symbol_type_qualify(ty, tscope);
-	Setattr(p, "type", nt);
-	Delete(nt);
+        SwigType *nt = Swig_symbol_type_qualify(ty, tscope);
+        Setattr(p, "type", nt);
+        Delete(nt);
       }
       p = nextSibling(p);
     }
@@ -875,68 +875,68 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
     /* Search for an explicit (exact) specialization. Example: template<> class name<int> { ... } */
     {
       if (template_debug) {
-	Printf(stdout, "    searching for : '%s' (explicit specialization)\n", tname);
+        Printf(stdout, "    searching for : '%s' (explicit specialization)\n", tname);
       }
       n = Swig_symbol_clookup_local(tname, primary_scope);
       if (!n) {
-	SwigType *rname = Swig_symbol_typedef_reduce(tname, tscope);
-	if (!Equal(rname, tname)) {
-	  if (template_debug) {
-	    Printf(stdout, "    searching for : '%s' (explicit specialization with typedef reduction)\n", rname);
-	  }
-	  n = Swig_symbol_clookup_local(rname, primary_scope);
-	}
-	Delete(rname);
+        SwigType *rname = Swig_symbol_typedef_reduce(tname, tscope);
+        if (!Equal(rname, tname)) {
+          if (template_debug) {
+            Printf(stdout, "    searching for : '%s' (explicit specialization with typedef reduction)\n", rname);
+          }
+          n = Swig_symbol_clookup_local(rname, primary_scope);
+        }
+        Delete(rname);
       }
       if (n) {
-	Node *tn;
-	String *nodeType = nodeType(n);
-	if (Equal(nodeType, "template")) {
-	  if (template_debug) {
-	    Printf(stdout, "    explicit specialization found: '%s'\n", Getattr(n, "name"));
-	  }
-	  goto success;
-	}
-	tn = Getattr(n, "template");
-	if (tn) {
-	  /* Previously wrapped by a template instantiation */
-	  Node *previous_named_instantiation = GetFlag(n, "hidden") ? Getattr(n, "csym:nextSibling") : n; /* "hidden" is set when "sym:name" is a __dummy_ name */
-	  if (!symname) {
-	    /* Quietly ignore empty template instantiations if there is a previous (empty or non-empty) template instantiation */
-	    if (template_debug) {
-	      if (previous_named_instantiation)
-		Printf(stdout, "    previous instantiation with name '%s' found: '%s' - duplicate empty template instantiation ignored\n", Getattr(previous_named_instantiation, "sym:name"), Getattr(n, "name"));
-	      else
-		Printf(stdout, "    previous empty template instantiation found: '%s' - duplicate empty template instantiation ignored\n", Getattr(n, "name"));
-	    }
-	    return 0;
-	  }
-	  /* Accept a second instantiation only if previous template instantiation is empty */
-	  if (previous_named_instantiation) {
-	    String *previous_name = Getattr(previous_named_instantiation, "name");
-	    String *previous_symname = Getattr(previous_named_instantiation, "sym:name");
-	    String *unprocessed_tname = Copy(name);
-	    SwigType_add_template(unprocessed_tname, instantiated_parms);
+        Node *tn;
+        String *nodeType = nodeType(n);
+        if (Equal(nodeType, "template")) {
+          if (template_debug) {
+            Printf(stdout, "    explicit specialization found: '%s'\n", Getattr(n, "name"));
+          }
+          goto success;
+        }
+        tn = Getattr(n, "template");
+        if (tn) {
+          /* Previously wrapped by a template instantiation */
+          Node *previous_named_instantiation = GetFlag(n, "hidden") ? Getattr(n, "csym:nextSibling") : n; /* "hidden" is set when "sym:name" is a __dummy_ name */
+          if (!symname) {
+            /* Quietly ignore empty template instantiations if there is a previous (empty or non-empty) template instantiation */
+            if (template_debug) {
+              if (previous_named_instantiation)
+                Printf(stdout, "    previous instantiation with name '%s' found: '%s' - duplicate empty template instantiation ignored\n", Getattr(previous_named_instantiation, "sym:name"), Getattr(n, "name"));
+              else
+                Printf(stdout, "    previous empty template instantiation found: '%s' - duplicate empty template instantiation ignored\n", Getattr(n, "name"));
+            }
+            return 0;
+          }
+          /* Accept a second instantiation only if previous template instantiation is empty */
+          if (previous_named_instantiation) {
+            String *previous_name = Getattr(previous_named_instantiation, "name");
+            String *previous_symname = Getattr(previous_named_instantiation, "sym:name");
+            String *unprocessed_tname = Copy(name);
+            SwigType_add_template(unprocessed_tname, instantiated_parms);
 
-	    if (template_debug)
-	      Printf(stdout, "    previous instantiation with name '%s' found: '%s' - duplicate instantiation ignored\n", previous_symname, Getattr(n, "name"));
-	    SWIG_WARN_NODE_BEGIN(n);
-	    Swig_warning(WARN_TYPE_REDEFINED, cparse_file, cparse_line, "Duplicate template instantiation of '%s' with name '%s' ignored,\n", SwigType_namestr(unprocessed_tname), symname);
-	    Swig_warning(WARN_TYPE_REDEFINED, Getfile(n), Getline(n), "previous instantiation of '%s' with name '%s'.\n", SwigType_namestr(previous_name), previous_symname);
-	    SWIG_WARN_NODE_END(n);
+            if (template_debug)
+              Printf(stdout, "    previous instantiation with name '%s' found: '%s' - duplicate instantiation ignored\n", previous_symname, Getattr(n, "name"));
+            SWIG_WARN_NODE_BEGIN(n);
+            Swig_warning(WARN_TYPE_REDEFINED, cparse_file, cparse_line, "Duplicate template instantiation of '%s' with name '%s' ignored,\n", SwigType_namestr(unprocessed_tname), symname);
+            Swig_warning(WARN_TYPE_REDEFINED, Getfile(n), Getline(n), "previous instantiation of '%s' with name '%s'.\n", SwigType_namestr(previous_name), previous_symname);
+            SWIG_WARN_NODE_END(n);
 
-	    Delete(unprocessed_tname);
-	    return 0;
-	  }
-	  if (template_debug)
-	    Printf(stdout, "    previous empty template instantiation found: '%s' - using as duplicate instantiation overrides empty template instantiation\n", Getattr(n, "name"));
-	  n = tn;
-	  goto success;
-	}
-	Swig_error(cparse_file, cparse_line, "'%s' is not defined as a template. (%s)\n", name, nodeType(n));
-	Delete(tname);
-	Delete(parms);
-	return 0;	  /* Found a match, but it's not a template of any kind. */
+            Delete(unprocessed_tname);
+            return 0;
+          }
+          if (template_debug)
+            Printf(stdout, "    previous empty template instantiation found: '%s' - using as duplicate instantiation overrides empty template instantiation\n", Getattr(n, "name"));
+          n = tn;
+          goto success;
+        }
+        Swig_error(cparse_file, cparse_line, "'%s' is not defined as a template. (%s)\n", name, nodeType(n));
+        Delete(tname);
+        Delete(parms);
+        return 0;	  /* Found a match, but it's not a template of any kind. */
       }
     }
 
@@ -957,45 +957,45 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
 
       partials = Getattr(templ, "partials"); /* note that these partial specializations do not include explicit specializations */
       if (partials) {
-	Iterator pi;
-	int parms_len = ParmList_len(parms); /* max parameters including defaulted parameters from primary template (ie max parameters) */
-	int *priorities_row;
-	max_possible_partials = Len(partials);
-	priorities_matrix = (int *)Malloc(sizeof(int) * max_possible_partials * parms_len); /* slightly wasteful allocation for max possible matches */
-	priorities_row = priorities_matrix;
-	for (pi = First(partials); pi.item; pi = Next(pi)) {
-	  Parm *p = parms;
-	  int i = 1;
-	  Parm *partialparms = Getattr(pi.item, "partialparms");
-	  Parm *pp = partialparms;
-	  String *templcsymname = Getattr(pi.item, "templcsymname");
-	  if (template_debug) {
-	    Printf(stdout, "    checking match: '%s' (partial specialization)\n", templcsymname);
-	  }
-	  if (ParmList_len(partialparms) == parms_len) {
-	    int all_parameters_match = 1;
-	    while (p && pp) {
-	      SwigType *t;
-	      t = Getattr(p, "type");
-	      if (!t)
-		t = Getattr(p, "value");
-	      if (t) {
-		EMatch match = does_parm_match(t, Getattr(pp, "type"), tscope, priorities_row + i - 1);
-		if (match < (int)PartiallySpecializedMatch) {
-		  all_parameters_match = 0;
-		  break;
-		}
-	      }
-	      i++;
-	      p = nextSibling(p);
-	      pp = nextSibling(pp);
-	    }
-	    if (all_parameters_match) {
-	      Append(possiblepartials, pi.item);
-	      priorities_row += parms_len;
-	    }
-	  }
-	}
+        Iterator pi;
+        int parms_len = ParmList_len(parms); /* max parameters including defaulted parameters from primary template (ie max parameters) */
+        int *priorities_row;
+        max_possible_partials = Len(partials);
+        priorities_matrix = (int *)Malloc(sizeof(int) * max_possible_partials * parms_len); /* slightly wasteful allocation for max possible matches */
+        priorities_row = priorities_matrix;
+        for (pi = First(partials); pi.item; pi = Next(pi)) {
+          Parm *p = parms;
+          int i = 1;
+          Parm *partialparms = Getattr(pi.item, "partialparms");
+          Parm *pp = partialparms;
+          String *templcsymname = Getattr(pi.item, "templcsymname");
+          if (template_debug) {
+            Printf(stdout, "    checking match: '%s' (partial specialization)\n", templcsymname);
+          }
+          if (ParmList_len(partialparms) == parms_len) {
+            int all_parameters_match = 1;
+            while (p && pp) {
+              SwigType *t;
+              t = Getattr(p, "type");
+              if (!t)
+                t = Getattr(p, "value");
+              if (t) {
+                EMatch match = does_parm_match(t, Getattr(pp, "type"), tscope, priorities_row + i - 1);
+                if (match < (int)PartiallySpecializedMatch) {
+                  all_parameters_match = 0;
+                  break;
+                }
+              }
+              i++;
+              p = nextSibling(p);
+              pp = nextSibling(pp);
+            }
+            if (all_parameters_match) {
+              Append(possiblepartials, pi.item);
+              priorities_row += parms_len;
+            }
+          }
+        }
       }
     }
 
@@ -1003,14 +1003,14 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
     if (template_debug) {
       int i;
       if (posslen == 0)
-	Printf(stdout, "    matched partials: NONE\n");
+        Printf(stdout, "    matched partials: NONE\n");
       else if (posslen == 1)
-	Printf(stdout, "    chosen partial: '%s'\n", Getattr(Getitem(possiblepartials, 0), "templcsymname"));
+        Printf(stdout, "    chosen partial: '%s'\n", Getattr(Getitem(possiblepartials, 0), "templcsymname"));
       else {
-	Printf(stdout, "    possibly matched partials:\n");
-	for (i = 0; i < posslen; i++) {
-	  Printf(stdout, "      '%s'\n", Getattr(Getitem(possiblepartials, i), "templcsymname"));
-	}
+        Printf(stdout, "    possibly matched partials:\n");
+        for (i = 0; i < posslen; i++) {
+          Printf(stdout, "      '%s'\n", Getattr(Getitem(possiblepartials, i), "templcsymname"));
+        }
       }
     }
 
@@ -1030,80 +1030,80 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
        *
        */
       if (template_debug) {
-	int row, col;
-	int parms_len = ParmList_len(parms);
-	Printf(stdout, "      parameter priorities matrix (%d parms):\n", parms_len);
-	for (row = 0; row < posslen; row++) {
-	  int *priorities_row = priorities_matrix + row*parms_len;
-	  Printf(stdout, "        ");
-	  for (col = 0; col < parms_len; col++) {
-	    Printf(stdout, "%5d ", priorities_row[col]);
-	  }
-	  Printf(stdout, "\n");
-	}
+        int row, col;
+        int parms_len = ParmList_len(parms);
+        Printf(stdout, "      parameter priorities matrix (%d parms):\n", parms_len);
+        for (row = 0; row < posslen; row++) {
+          int *priorities_row = priorities_matrix + row*parms_len;
+          Printf(stdout, "        ");
+          for (col = 0; col < parms_len; col++) {
+            Printf(stdout, "%5d ", priorities_row[col]);
+          }
+          Printf(stdout, "\n");
+        }
       }
       {
-	int row, col;
-	int parms_len = ParmList_len(parms);
-	/* Printf(stdout, "      parameter priorities inverse matrix (%d parms):\n", parms_len); */
-	for (col = 0; col < parms_len; col++) {
-	  int *priorities_col = priorities_matrix + col;
-	  int maxpriority = -1;
-	  /* 
-	     Printf(stdout, "max_possible_partials: %d col:%d\n", max_possible_partials, col);
-	     Printf(stdout, "        ");
-	     */
-	  /* determine the highest rank for this nth parameter */
-	  for (row = 0; row < posslen; row++) {
-	    int *element_ptr = priorities_col + row*parms_len;
-	    int priority = *element_ptr;
-	    if (priority > maxpriority)
-	      maxpriority = priority;
-	    /* Printf(stdout, "%5d ", priority); */
-	  }
-	  /* Printf(stdout, "\n"); */
-	  /* flag all the parameters which equal the highest rank */
-	  for (row = 0; row < posslen; row++) {
-	    int *element_ptr = priorities_col + row*parms_len;
-	    int priority = *element_ptr;
-	    *element_ptr = (priority >= maxpriority) ? 1 : 0;
-	  }
-	}
+        int row, col;
+        int parms_len = ParmList_len(parms);
+        /* Printf(stdout, "      parameter priorities inverse matrix (%d parms):\n", parms_len); */
+        for (col = 0; col < parms_len; col++) {
+          int *priorities_col = priorities_matrix + col;
+          int maxpriority = -1;
+          /* 
+             Printf(stdout, "max_possible_partials: %d col:%d\n", max_possible_partials, col);
+             Printf(stdout, "        ");
+             */
+          /* determine the highest rank for this nth parameter */
+          for (row = 0; row < posslen; row++) {
+            int *element_ptr = priorities_col + row*parms_len;
+            int priority = *element_ptr;
+            if (priority > maxpriority)
+              maxpriority = priority;
+            /* Printf(stdout, "%5d ", priority); */
+          }
+          /* Printf(stdout, "\n"); */
+          /* flag all the parameters which equal the highest rank */
+          for (row = 0; row < posslen; row++) {
+            int *element_ptr = priorities_col + row*parms_len;
+            int priority = *element_ptr;
+            *element_ptr = (priority >= maxpriority) ? 1 : 0;
+          }
+        }
       }
       {
-	int row, col;
-	int parms_len = ParmList_len(parms);
-	Iterator pi = First(possiblepartials);
-	Node *chosenpartials = NewList();
-	if (template_debug)
-	  Printf(stdout, "      priority flags matrix:\n");
-	for (row = 0; row < posslen; row++) {
-	  int *priorities_row = priorities_matrix + row*parms_len;
-	  int highest_count = 0; /* count of highest priority parameters */
-	  for (col = 0; col < parms_len; col++) {
-	    highest_count += priorities_row[col];
-	  }
-	  if (template_debug) {
-	    Printf(stdout, "        ");
-	    for (col = 0; col < parms_len; col++) {
-	      Printf(stdout, "%5d ", priorities_row[col]);
-	    }
-	    Printf(stdout, "\n");
-	  }
-	  if (highest_count == parms_len) {
-	    Append(chosenpartials, pi.item);
-	  }
-	  pi = Next(pi);
-	}
-	if (Len(chosenpartials) > 0) {
-	  /* one or more best match found */
-	  Delete(possiblepartials);
-	  possiblepartials = chosenpartials;
-	  posslen = Len(possiblepartials);
-	} else {
-	  /* no best match found */
-	  Delete(chosenpartials);
-	}
+        int row, col;
+        int parms_len = ParmList_len(parms);
+        Iterator pi = First(possiblepartials);
+        Node *chosenpartials = NewList();
+        if (template_debug)
+          Printf(stdout, "      priority flags matrix:\n");
+        for (row = 0; row < posslen; row++) {
+          int *priorities_row = priorities_matrix + row*parms_len;
+          int highest_count = 0; /* count of highest priority parameters */
+          for (col = 0; col < parms_len; col++) {
+            highest_count += priorities_row[col];
+          }
+          if (template_debug) {
+            Printf(stdout, "        ");
+            for (col = 0; col < parms_len; col++) {
+              Printf(stdout, "%5d ", priorities_row[col]);
+            }
+            Printf(stdout, "\n");
+          }
+          if (highest_count == parms_len) {
+            Append(chosenpartials, pi.item);
+          }
+          pi = Next(pi);
+        }
+        if (Len(chosenpartials) > 0) {
+          /* one or more best match found */
+          Delete(possiblepartials);
+          possiblepartials = chosenpartials;
+          posslen = Len(possiblepartials);
+        } else {
+          /* no best match found */
+          Delete(chosenpartials);
+        }
       }
     }
 
@@ -1111,23 +1111,23 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
       String *s = Getattr(Getitem(possiblepartials, 0), "templcsymname");
       n = Swig_symbol_clookup_local(s, primary_scope);
       if (posslen > 1) {
-	int i;
-	if (n) {
-	  Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, cparse_file, cparse_line, "Instantiation of template '%s' is ambiguous,\n", SwigType_namestr(tname));
-	  Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, Getfile(n), Getline(n), "  instantiation '%s' used,\n", SwigType_namestr(Getattr(n, "name")));
-	}
-	for (i = 1; i < posslen; i++) {
-	  String *templcsymname = Getattr(Getitem(possiblepartials, i), "templcsymname");
-	  Node *ignored_node = Swig_symbol_clookup_local(templcsymname, primary_scope);
-	  assert(ignored_node);
-	  Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, Getfile(ignored_node), Getline(ignored_node), "  instantiation '%s' ignored.\n", SwigType_namestr(Getattr(ignored_node, "name")));
-	}
+        int i;
+        if (n) {
+          Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, cparse_file, cparse_line, "Instantiation of template '%s' is ambiguous,\n", SwigType_namestr(tname));
+          Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, Getfile(n), Getline(n), "  instantiation '%s' used,\n", SwigType_namestr(Getattr(n, "name")));
+        }
+        for (i = 1; i < posslen; i++) {
+          String *templcsymname = Getattr(Getitem(possiblepartials, i), "templcsymname");
+          Node *ignored_node = Swig_symbol_clookup_local(templcsymname, primary_scope);
+          assert(ignored_node);
+          Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, Getfile(ignored_node), Getline(ignored_node), "  instantiation '%s' ignored.\n", SwigType_namestr(Getattr(ignored_node, "name")));
+        }
       }
     }
 
     if (!n) {
       if (template_debug) {
-	Printf(stdout, "    chosen primary template: '%s'\n", Getattr(templ, "name"));
+        Printf(stdout, "    chosen primary template: '%s'\n", Getattr(templ, "name"));
       }
       n = templ;
     }
@@ -1189,16 +1189,16 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
       int variadic = ParmList_variadic_parm(tparmsfound) != 0;
       match = n;
       if (!specialized) {
-	if (!variadic && (ParmList_len(instantiated_parms) > ParmList_len(tparmsfound))) {
-	  Swig_error(cparse_file, cparse_line, "Too many template parameters. Maximum of %d.\n", ParmList_len(tparmsfound));
-	  match = 0;
-	} else if (ParmList_len(instantiated_parms) < ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)) { /* Variadic parameter is optional */
-	  Swig_error(cparse_file, cparse_line, "Not enough template parameters specified. Minimum of %d required.\n", (ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)) );
-	  match = 0;
-	}
+        if (!variadic && (ParmList_len(instantiated_parms) > ParmList_len(tparmsfound))) {
+          Swig_error(cparse_file, cparse_line, "Too many template parameters. Maximum of %d.\n", ParmList_len(tparmsfound));
+          match = 0;
+        } else if (ParmList_len(instantiated_parms) < ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)) { /* Variadic parameter is optional */
+          Swig_error(cparse_file, cparse_line, "Not enough template parameters specified. Minimum of %d required.\n", (ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)) );
+          match = 0;
+        }
       }
       if (match)
-	SetFlag(n, "instantiate");
+        SetFlag(n, "instantiate");
     } else {
       Node *firstn = 0;
       /* If not a class template we must have a function template.
@@ -1209,7 +1209,7 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
          function template with different numbers of template parameters. */
 
       if (template_debug) {
-	Printf(stdout, "    Not a class template, seeking all appropriate primary function templates\n");
+        Printf(stdout, "    Not a class template, seeking all appropriate primary function templates\n");
       }
 
       firstn = Swig_symbol_clookup_local(name, 0);
@@ -1218,49 +1218,49 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
        * Looking for all template parameter matches only (not function parameter matches) 
        * as %template instantiation uses template parameters without any function parameters. */
       while (n) {
-	if (Strcmp(nodeType(n), "template") == 0) {
-	  Parm *tparmsfound = Getattr(n, "templateparms");
-	  if (!ParmList_variadic_parm(tparmsfound)) {
-	    if (ParmList_len(instantiated_parms) == ParmList_len(tparmsfound)) {
-	      /* successful match */
-	      if (template_debug) {
-		Printf(stdout, "    found: template <%s> '%s' (%s)\n", ParmList_str_defaultargs(Getattr(n, "templateparms")), name, ParmList_str_defaultargs(Getattr(n, "parms")));
-	      }
-	      SetFlag(n, "instantiate");
-	      if (!match)
-		match = n; /* first match */
-	    }
-	  }
-	}
-	/* repeat to find all matches with correct number of templated parameters */
-	n = Getattr(n, "sym:nextSibling");
+        if (Strcmp(nodeType(n), "template") == 0) {
+          Parm *tparmsfound = Getattr(n, "templateparms");
+          if (!ParmList_variadic_parm(tparmsfound)) {
+            if (ParmList_len(instantiated_parms) == ParmList_len(tparmsfound)) {
+              /* successful match */
+              if (template_debug) {
+                Printf(stdout, "    found: template <%s> '%s' (%s)\n", ParmList_str_defaultargs(Getattr(n, "templateparms")), name, ParmList_str_defaultargs(Getattr(n, "parms")));
+              }
+              SetFlag(n, "instantiate");
+              if (!match)
+                match = n; /* first match */
+            }
+          }
+        }
+        /* repeat to find all matches with correct number of templated parameters */
+        n = Getattr(n, "sym:nextSibling");
       }
 
       /* Only consider variadic templates if there are no non-variadic template matches */
       if (!match) {
-	n = firstn;
-	while (n) {
-	  if (Strcmp(nodeType(n), "template") == 0) {
-	    Parm *tparmsfound = Getattr(n, "templateparms");
-	    if (ParmList_variadic_parm(tparmsfound)) {
-	      if (ParmList_len(instantiated_parms) >= ParmList_len(tparmsfound) - 1) {
-		/* successful variadic match */
-		if (template_debug) {
-		  Printf(stdout, "    found: template <%s> '%s' (%s)\n", ParmList_str_defaultargs(Getattr(n, "templateparms")), name, ParmList_str_defaultargs(Getattr(n, "parms")));
-		}
-		SetFlag(n, "instantiate");
-		if (!match)
-		  match = n; /* first match */
-	      }
-	    }
-	  }
-	  /* repeat to find all matches with correct number of templated parameters */
-	  n = Getattr(n, "sym:nextSibling");
-	}
+        n = firstn;
+        while (n) {
+          if (Strcmp(nodeType(n), "template") == 0) {
+            Parm *tparmsfound = Getattr(n, "templateparms");
+            if (ParmList_variadic_parm(tparmsfound)) {
+              if (ParmList_len(instantiated_parms) >= ParmList_len(tparmsfound) - 1) {
+                /* successful variadic match */
+                if (template_debug) {
+                  Printf(stdout, "    found: template <%s> '%s' (%s)\n", ParmList_str_defaultargs(Getattr(n, "templateparms")), name, ParmList_str_defaultargs(Getattr(n, "parms")));
+                }
+                SetFlag(n, "instantiate");
+                if (!match)
+                  match = n; /* first match */
+              }
+            }
+          }
+          /* repeat to find all matches with correct number of templated parameters */
+          n = Getattr(n, "sym:nextSibling");
+        }
       }
 
       if (!match) {
-	Swig_error(cparse_file, cparse_line, "No matching function template '%s' found.\n", name);
+        Swig_error(cparse_file, cparse_line, "No matching function template '%s' found.\n", name);
       }
     }
   }
@@ -1345,9 +1345,9 @@ static void expand_defaults(ParmList *expanded_templateparms) {
       String *name = Getattr(p, "name");
       String *value = Getattr(p, "value");
       if (!value)
-	value = Getattr(p, "type");
+        value = Getattr(p, "type");
       if (name)
-	Replaceid(tv, name, value);
+        Replaceid(tv, name, value);
       p = nextSibling(p);
     }
     tp = nextSibling(tp);
@@ -1376,10 +1376,10 @@ ParmList *Swig_cparse_template_parms_expand(ParmList *instantiated_parms, Node *
     if (!variadic) {
       ParmList *defaults_start = ParmList_nth_parm(templateparms, ParmList_len(instantiated_parms));
       if (defaults_start) {
-	ParmList *defaults = CopyParmList(defaults_start);
-	use_mark_defaults(defaults);
-	expanded_templateparms = ParmList_join(expanded_templateparms, defaults);
-	expand_defaults(expanded_templateparms);
+        ParmList *defaults = CopyParmList(defaults_start);
+        use_mark_defaults(defaults);
+        expanded_templateparms = ParmList_join(expanded_templateparms, defaults);
+        expand_defaults(expanded_templateparms);
       }
     }
   } else {
@@ -1414,10 +1414,10 @@ ParmList *Swig_cparse_template_partialargs_expand(ParmList *partially_specialize
     if (!variadic) {
       ParmList *defaults_start = ParmList_nth_parm(templateparms, ParmList_len(partially_specialized_parms));
       if (defaults_start) {
-	ParmList *defaults = CopyParmList(defaults_start);
-	use_mark_specialized_defaults(defaults);
-	expanded_templateparms = ParmList_join(expanded_templateparms, defaults);
-	expand_defaults(expanded_templateparms);
+        ParmList *defaults = CopyParmList(defaults_start);
+        use_mark_specialized_defaults(defaults);
+        expanded_templateparms = ParmList_join(expanded_templateparms, defaults);
+        expand_defaults(expanded_templateparms);
       }
     }
   } else {

--- a/Source/CParse/templ.c
+++ b/Source/CParse/templ.c
@@ -17,7 +17,6 @@
 
 static int template_debug = 0;
 
-
 const char *baselists[3];
 
 void SwigType_template_init(void) {
@@ -103,7 +102,8 @@ static void expand_variadic_parms(Node *n, const char *attribute, Parm *unexpand
  * and typelist for later template parameter substitutions.
  * ----------------------------------------------------------------------------- */
 
-static void expand_parms(Node *n, const char *attribute, Parm *unexpanded_variadic_parm, ParmList *expanded_variadic_parms, List *patchlist, List *typelist, int is_pattern) {
+static void expand_parms(Node *n, const char *attribute, Parm *unexpanded_variadic_parm, ParmList *expanded_variadic_parms, List *patchlist, List *typelist,
+                         int is_pattern) {
   ParmList *p;
   expand_variadic_parms(n, attribute, unexpanded_variadic_parm, expanded_variadic_parms);
   p = Getattr(n, attribute);
@@ -118,7 +118,8 @@ static void expand_parms(Node *n, const char *attribute, Parm *unexpanded_variad
  * template parameters
  * ----------------------------------------------------------------------------- */
 
-static void cparse_template_expand(Node *templnode, Node *n, String *tname, String *rname, String *templateargs, List *patchlist, List *typelist, List *cpatchlist, Parm *unexpanded_variadic_parm, ParmList *expanded_variadic_parms) {
+static void cparse_template_expand(Node *templnode, Node *n, String *tname, String *rname, String *templateargs, List *patchlist, List *typelist,
+                                   List *cpatchlist, Parm *unexpanded_variadic_parm, ParmList *expanded_variadic_parms) {
   static int expanded = 0;
   String *nodeType;
   if (!n)
@@ -257,7 +258,7 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
   } else if (Equal(nodeType, "destructor")) {
     /* We only need to patch the dtor of the template itself, not the destructors of any nested classes, so check that the parent of this node is the root
      * template node, with the special exception for %extend which adds its methods under an intermediate node. */
-    Node* parent = parentNode(n);
+    Node *parent = parentNode(n);
     if (parent == templnode || (parentNode(parent) == templnode && Equal(nodeType(parent), "extend"))) {
       String *symname = Getattr(n, "sym:name");
       if (symname)
@@ -306,7 +307,6 @@ static void cparse_template_expand(Node *templnode, Node *n, String *tname, Stri
 
     if (Getattr(n, "namespace")) {
       /* Namespace link.   This is nasty.  Is other namespace defined? */
-
     }
   } else {
     /* Look for obvious parameters */
@@ -441,7 +441,7 @@ static Parm *partial_arg(const SwigType *type, const SwigType *partialtype) {
     }
     parmname = NewStringWithSize(c, (int)(suffix - c)); /* $1, $2 etc */
     suffix_length = (int)strlen(suffix);
-    assert(Strstr(type, prefix) == Char(type)); /* check that the start of both types match */
+    assert(Strstr(type, prefix) == Char(type));                            /* check that the start of both types match */
     assert(strcmp(Char(type) + type_length - suffix_length, suffix) == 0); /* check that the end of both types match */
     parmtype = NewStringWithSize(Char(type) + prefix_length, type_length - suffix_length - prefix_length);
     Delete(prefix);
@@ -598,7 +598,7 @@ int Swig_cparse_template_expand(Node *n, String *rname, ParmList *tparms, Symtab
               name which is not a template.
             */
             tynode = Swig_symbol_clookup(s, 0);
-            tyname  = tynode ? Getattr(tynode, "sym:name") : 0;
+            tyname = tynode ? Getattr(tynode, "sym:name") : 0;
             /*
             Printf(stdout, "  replacing %s with %s to %s or %s to %s\n", s, name, dvalue, tbase, name_with_templateargs);
             Printf(stdout, "    %d %s to %s\n", tp == unexpanded_variadic_parm, name, ParmList_str_defaultargs(expanded_variadic_parms));
@@ -703,7 +703,8 @@ static int is_exact_partial_type(const SwigType *type) {
 
 static EMatch does_parm_match(SwigType *type, SwigType *partial_parm_type, Symtab *tscope, int *specialization_priority) {
   static const int EXACT_MATCH_PRIORITY = 99999; /* a number bigger than the length of any conceivable type */
-  static const int TEMPLATE_MATCH_PRIORITY = 1000; /* a priority added for each nested template, assumes max length of any prefix, such as r.q(const). , is less than this number */
+  static const int TEMPLATE_MATCH_PRIORITY =
+    1000; /* a priority added for each nested template, assumes max length of any prefix, such as r.q(const). , is less than this number */
   SwigType *ty = Swig_symbol_typedef_reduce(type, tscope);
   SwigType *pp_prefix = SwigType_prefix(partial_parm_type);
   int pp_len = Len(pp_prefix);
@@ -844,7 +845,8 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
   templ = Swig_symbol_clookup(name, 0);
 
   if (templ) {
-    /* TODO: check that this is not a specialization (might be a user error specializing a template before a primary template), but note https://stackoverflow.com/questions/9757642/wrapping-specialised-c-template-class-with-swig */
+    /* TODO: check that this is not a specialization (might be a user error specializing a template before a primary template), but note
+     * https://stackoverflow.com/questions/9757642/wrapping-specialised-c-template-class-with-swig */
     if (template_debug) {
       Printf(stdout, "    found primary template <%s> '%s'\n", ParmList_str_defaultargs(Getattr(templ, "templateparms")), Getattr(templ, "name"));
     }
@@ -900,12 +902,16 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
         tn = Getattr(n, "template");
         if (tn) {
           /* Previously wrapped by a template instantiation */
-          Node *previous_named_instantiation = GetFlag(n, "hidden") ? Getattr(n, "csym:nextSibling") : n; /* "hidden" is set when "sym:name" is a __dummy_ name */
+          Node *previous_named_instantiation =
+            GetFlag(n, "hidden") ? Getattr(n, "csym:nextSibling") : n; /* "hidden" is set when "sym:name" is a __dummy_ name */
           if (!symname) {
             /* Quietly ignore empty template instantiations if there is a previous (empty or non-empty) template instantiation */
             if (template_debug) {
               if (previous_named_instantiation)
-                Printf(stdout, "    previous instantiation with name '%s' found: '%s' - duplicate empty template instantiation ignored\n", Getattr(previous_named_instantiation, "sym:name"), Getattr(n, "name"));
+                Printf(stdout,
+                       "    previous instantiation with name '%s' found: '%s' - duplicate empty template instantiation ignored\n",
+                       Getattr(previous_named_instantiation, "sym:name"),
+                       Getattr(n, "name"));
               else
                 Printf(stdout, "    previous empty template instantiation found: '%s' - duplicate empty template instantiation ignored\n", Getattr(n, "name"));
             }
@@ -921,22 +927,34 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
             if (template_debug)
               Printf(stdout, "    previous instantiation with name '%s' found: '%s' - duplicate instantiation ignored\n", previous_symname, Getattr(n, "name"));
             SWIG_WARN_NODE_BEGIN(n);
-            Swig_warning(WARN_TYPE_REDEFINED, cparse_file, cparse_line, "Duplicate template instantiation of '%s' with name '%s' ignored,\n", SwigType_namestr(unprocessed_tname), symname);
-            Swig_warning(WARN_TYPE_REDEFINED, Getfile(n), Getline(n), "previous instantiation of '%s' with name '%s'.\n", SwigType_namestr(previous_name), previous_symname);
+            Swig_warning(WARN_TYPE_REDEFINED,
+                         cparse_file,
+                         cparse_line,
+                         "Duplicate template instantiation of '%s' with name '%s' ignored,\n",
+                         SwigType_namestr(unprocessed_tname),
+                         symname);
+            Swig_warning(WARN_TYPE_REDEFINED,
+                         Getfile(n),
+                         Getline(n),
+                         "previous instantiation of '%s' with name '%s'.\n",
+                         SwigType_namestr(previous_name),
+                         previous_symname);
             SWIG_WARN_NODE_END(n);
 
             Delete(unprocessed_tname);
             return 0;
           }
           if (template_debug)
-            Printf(stdout, "    previous empty template instantiation found: '%s' - using as duplicate instantiation overrides empty template instantiation\n", Getattr(n, "name"));
+            Printf(stdout,
+                   "    previous empty template instantiation found: '%s' - using as duplicate instantiation overrides empty template instantiation\n",
+                   Getattr(n, "name"));
           n = tn;
           goto success;
         }
         Swig_error(cparse_file, cparse_line, "'%s' is not defined as a template. (%s)\n", name, nodeType(n));
         Delete(tname);
         Delete(parms);
-        return 0;         /* Found a match, but it's not a template of any kind. */
+        return 0; /* Found a match, but it's not a template of any kind. */
       }
     }
 
@@ -1034,7 +1052,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
         int parms_len = ParmList_len(parms);
         Printf(stdout, "      parameter priorities matrix (%d parms):\n", parms_len);
         for (row = 0; row < posslen; row++) {
-          int *priorities_row = priorities_matrix + row*parms_len;
+          int *priorities_row = priorities_matrix + row * parms_len;
           Printf(stdout, "        ");
           for (col = 0; col < parms_len; col++) {
             Printf(stdout, "%5d ", priorities_row[col]);
@@ -1055,7 +1073,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
              */
           /* determine the highest rank for this nth parameter */
           for (row = 0; row < posslen; row++) {
-            int *element_ptr = priorities_col + row*parms_len;
+            int *element_ptr = priorities_col + row * parms_len;
             int priority = *element_ptr;
             if (priority > maxpriority)
               maxpriority = priority;
@@ -1064,7 +1082,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
           /* Printf(stdout, "\n"); */
           /* flag all the parameters which equal the highest rank */
           for (row = 0; row < posslen; row++) {
-            int *element_ptr = priorities_col + row*parms_len;
+            int *element_ptr = priorities_col + row * parms_len;
             int priority = *element_ptr;
             *element_ptr = (priority >= maxpriority) ? 1 : 0;
           }
@@ -1078,7 +1096,7 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
         if (template_debug)
           Printf(stdout, "      priority flags matrix:\n");
         for (row = 0; row < posslen; row++) {
-          int *priorities_row = priorities_matrix + row*parms_len;
+          int *priorities_row = priorities_matrix + row * parms_len;
           int highest_count = 0; /* count of highest priority parameters */
           for (col = 0; col < parms_len; col++) {
             highest_count += priorities_row[col];
@@ -1120,7 +1138,11 @@ static Node *template_locate(String *name, Parm *instantiated_parms, String *sym
           String *templcsymname = Getattr(Getitem(possiblepartials, i), "templcsymname");
           Node *ignored_node = Swig_symbol_clookup_local(templcsymname, primary_scope);
           assert(ignored_node);
-          Swig_warning(WARN_PARSE_TEMPLATE_AMBIG, Getfile(ignored_node), Getline(ignored_node), "  instantiation '%s' ignored.\n", SwigType_namestr(Getattr(ignored_node, "name")));
+          Swig_warning(WARN_PARSE_TEMPLATE_AMBIG,
+                       Getfile(ignored_node),
+                       Getline(ignored_node),
+                       "  instantiation '%s' ignored.\n",
+                       SwigType_namestr(Getattr(ignored_node, "name")));
         }
       }
     }
@@ -1163,7 +1185,6 @@ success:
   return n;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_cparse_template_locate()
  *
@@ -1193,7 +1214,10 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
           Swig_error(cparse_file, cparse_line, "Too many template parameters. Maximum of %d.\n", ParmList_len(tparmsfound));
           match = 0;
         } else if (ParmList_len(instantiated_parms) < ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)) { /* Variadic parameter is optional */
-          Swig_error(cparse_file, cparse_line, "Not enough template parameters specified. Minimum of %d required.\n", (ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)) );
+          Swig_error(cparse_file,
+                     cparse_line,
+                     "Not enough template parameters specified. Minimum of %d required.\n",
+                     (ParmList_numrequired(tparmsfound) - (variadic ? 1 : 0)));
           match = 0;
         }
       }
@@ -1224,7 +1248,11 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
             if (ParmList_len(instantiated_parms) == ParmList_len(tparmsfound)) {
               /* successful match */
               if (template_debug) {
-                Printf(stdout, "    found: template <%s> '%s' (%s)\n", ParmList_str_defaultargs(Getattr(n, "templateparms")), name, ParmList_str_defaultargs(Getattr(n, "parms")));
+                Printf(stdout,
+                       "    found: template <%s> '%s' (%s)\n",
+                       ParmList_str_defaultargs(Getattr(n, "templateparms")),
+                       name,
+                       ParmList_str_defaultargs(Getattr(n, "parms")));
               }
               SetFlag(n, "instantiate");
               if (!match)
@@ -1246,7 +1274,11 @@ Node *Swig_cparse_template_locate(String *name, Parm *instantiated_parms, String
               if (ParmList_len(instantiated_parms) >= ParmList_len(tparmsfound) - 1) {
                 /* successful variadic match */
                 if (template_debug) {
-                  Printf(stdout, "    found: template <%s> '%s' (%s)\n", ParmList_str_defaultargs(Getattr(n, "templateparms")), name, ParmList_str_defaultargs(Getattr(n, "parms")));
+                  Printf(stdout,
+                         "    found: template <%s> '%s' (%s)\n",
+                         ParmList_str_defaultargs(Getattr(n, "templateparms")),
+                         name,
+                         ParmList_str_defaultargs(Getattr(n, "parms")));
                 }
                 SetFlag(n, "instantiate");
                 if (!match)
@@ -1341,7 +1373,7 @@ static void expand_defaults(ParmList *expanded_templateparms) {
     String *tv = Getattr(tp, "value");
     if (!tv)
       tv = Getattr(tp, "type");
-    while(p) {
+    while (p) {
       String *name = Getattr(p, "name");
       String *value = Getattr(p, "value");
       if (!value)

--- a/Source/CParse/util.c
+++ b/Source/CParse/util.c
@@ -32,12 +32,12 @@ void Swig_cparse_replace_descriptor(String *s) {
     int level = 0;
     while (*c) {
       if (*c == '(')
-	level++;
+        level++;
       if (*c == ')') {
-	level--;
-	if (level == 0) {
-	  break;
-	}
+        level--;
+        if (level == 0) {
+          break;
+        }
       }
       *d = *c;
       d++;
@@ -83,10 +83,10 @@ SwigType *Swig_cparse_smartptr(Node *n) {
     if (smartptr) {
       SwigType *cpt = Swig_cparse_type(smartptr);
       if (cpt) {
-	smart = SwigType_typedef_resolve_all(cpt);
-	Delete(cpt);
+        smart = SwigType_typedef_resolve_all(cpt);
+        Delete(cpt);
       } else {
-	Swig_error(Getfile(n), Getline(n), "Invalid type (%s) in 'smartptr' feature for class %s.\n", smartptr, SwigType_namestr(Getattr(n, "name")));
+        Swig_error(Getfile(n), Getline(n), "Invalid type (%s) in 'smartptr' feature for class %s.\n", smartptr, SwigType_namestr(Getattr(n, "name")));
       }
     }
     return smart;

--- a/Source/CParse/util.c
+++ b/Source/CParse/util.c
@@ -78,18 +78,18 @@ void Swig_cparse_replace_descriptor(String *s) {
  * ----------------------------------------------------------------------------- */
 
 SwigType *Swig_cparse_smartptr(Node *n) {
-    SwigType *smart = 0;
-    String *smartptr = Getattr(n, "feature:smartptr");
-    if (smartptr) {
-      SwigType *cpt = Swig_cparse_type(smartptr);
-      if (cpt) {
-        smart = SwigType_typedef_resolve_all(cpt);
-        Delete(cpt);
-      } else {
-        Swig_error(Getfile(n), Getline(n), "Invalid type (%s) in 'smartptr' feature for class %s.\n", smartptr, SwigType_namestr(Getattr(n, "name")));
-      }
+  SwigType *smart = 0;
+  String *smartptr = Getattr(n, "feature:smartptr");
+  if (smartptr) {
+    SwigType *cpt = Swig_cparse_type(smartptr);
+    if (cpt) {
+      smart = SwigType_typedef_resolve_all(cpt);
+      Delete(cpt);
+    } else {
+      Swig_error(Getfile(n), Getline(n), "Invalid type (%s) in 'smartptr' feature for class %s.\n", smartptr, SwigType_namestr(Getattr(n, "name")));
     }
-    return smart;
+  }
+  return smart;
 }
 
 /* -----------------------------------------------------------------------------
@@ -100,8 +100,8 @@ SwigType *Swig_cparse_smartptr(Node *n) {
 
 Node *Swig_cparse_new_node(const_String_or_char_ptr tag) {
   Node *n = NewHash();
-  set_nodeType(n,tag);
-  Setfile(n,cparse_file);
-  Setline(n,cparse_line);
+  set_nodeType(n, tag);
+  Setfile(n, cparse_file);
+  Setline(n, cparse_line);
   return n;
 }

--- a/Source/CParse/util.c
+++ b/Source/CParse/util.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/DOH/base.c
+++ b/Source/DOH/base.c
@@ -19,7 +19,7 @@
  * ----------------------------------------------------------------------------- */
 
 void DohDelete(DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
 
   if (!obj)
@@ -35,7 +35,7 @@ void DohDelete(DOH *obj) {
   if (b->refcount <= 0) {
     objinfo = b->type;
     if (objinfo->doh_del) {
-      (objinfo->doh_del) (b);
+      (objinfo->doh_del)(b);
     } else {
       if (b->data)
         DohFree(b->data);
@@ -49,7 +49,7 @@ void DohDelete(DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 DOH *DohCopy(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
 
   if (!obj)
@@ -60,11 +60,11 @@ DOH *DohCopy(const DOH *obj) {
   }
   objinfo = b->type;
   if (objinfo->doh_copy) {
-    DohBase *bc = (DohBase *) (objinfo->doh_copy) (b);
+    DohBase *bc = (DohBase *)(objinfo->doh_copy)(b);
     if ((bc) && b->meta) {
       bc->meta = Copy(b->meta);
     }
-    return (DOH *) bc;
+    return (DOH *)bc;
   }
   return 0;
 }
@@ -78,10 +78,10 @@ void DohIncref(DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 void DohClear(DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_clear)
-    (objinfo->doh_clear) (b);
+    (objinfo->doh_clear)(b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -90,14 +90,14 @@ void DohClear(DOH *obj) {
 
 DOH *DohStr(const DOH *obj) {
   char buffer[512];
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(b)) {
     objinfo = b->type;
     if (objinfo->doh_str) {
-      return (objinfo->doh_str) (b);
+      return (objinfo->doh_str)(b);
     }
-    sprintf(buffer, "<Object '%s' at %p>", objinfo->objname, (void *) b);
+    sprintf(buffer, "<Object '%s' at %p>", objinfo->objname, (void *)b);
     return NewString(buffer);
   } else {
     return NewString(obj);
@@ -109,10 +109,10 @@ DOH *DohStr(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 int DohDump(const DOH *obj, DOH *out) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_dump) {
-    return (objinfo->doh_dump) (b, out);
+    return (objinfo->doh_dump)(b, out);
   }
   return 0;
 }
@@ -121,18 +121,18 @@ int DohDump(const DOH *obj, DOH *out) {
  * DohLen() - Defaults to strlen() if not a DOH object
  * ----------------------------------------------------------------------------- */
 int DohLen(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (!b)
     return 0;
   if (DohCheck(b)) {
     objinfo = b->type;
     if (objinfo->doh_len) {
-      return (objinfo->doh_len) (b);
+      return (objinfo->doh_len)(b);
     }
     return 0;
   } else {
-    return (int)strlen((char *) obj);
+    return (int)strlen((char *)obj);
   }
 }
 
@@ -141,14 +141,14 @@ int DohLen(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 int DohHashval(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   /* obj is already checked and/or converted into DohBase* */
   /*  if (DohCheck(b)) */
   {
     objinfo = b->type;
     if (objinfo->doh_hashval) {
-      return (objinfo->doh_hashval) (b);
+      return (objinfo->doh_hashval)(b);
     }
   }
   return 0;
@@ -159,16 +159,16 @@ int DohHashval(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 void *DohData(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(obj)) {
     objinfo = b->type;
     if (objinfo->doh_data) {
-      return (objinfo->doh_data) (b);
+      return (objinfo->doh_data)(b);
     }
     return 0;
   }
-  return (void *) obj;
+  return (void *)obj;
 }
 
 /* -----------------------------------------------------------------------------
@@ -177,9 +177,8 @@ void *DohData(const DOH *obj) {
 
 static void *RawData(DohBase *b) {
   DohObjInfo *objinfo = b->type;
-  return (objinfo->doh_data) ? (objinfo->doh_data) (b) : 0;
+  return (objinfo->doh_data) ? (objinfo->doh_data)(b) : 0;
 }
-
 
 /* -----------------------------------------------------------------------------
  * DohCmp()
@@ -189,8 +188,8 @@ int DohCmp(const DOH *obj1, const DOH *obj2) {
   DohBase *b1, *b2;
   DohObjInfo *b1info, *b2info;
   int c1, c2;
-  b1 = (DohBase *) obj1;
-  b2 = (DohBase *) obj2;
+  b1 = (DohBase *)obj1;
+  b2 = (DohBase *)obj2;
   c1 = DohCheck(b1);
   c2 = DohCheck(b2);
   /* most of the times, obj2 is a plain c string */
@@ -201,12 +200,12 @@ int DohCmp(const DOH *obj1, const DOH *obj2) {
       return 1;
     if (!b1 && b2)
       return -1;
-    return strcmp((char *) (c1 ? RawData(b1) : (void *) obj1), (char *) (c2 ? RawData(b2) : (void *) obj2));
+    return strcmp((char *)(c1 ? RawData(b1) : (void *)obj1), (char *)(c2 ? RawData(b2) : (void *)obj2));
   }
   b1info = b1->type;
   b2info = b2->type;
   if ((b1info == b2info) && (b1info->doh_cmp))
-    return (b1info->doh_cmp) (b1, b2);
+    return (b1info->doh_cmp)(b1, b2);
   /* finally compare pointers */
   return b1 < b2 ? -1 : b1 == b2 ? 0 : 1;
 }
@@ -216,8 +215,8 @@ int DohCmp(const DOH *obj1, const DOH *obj2) {
  * ----------------------------------------------------------------------------- */
 
 int DohEqual(const DOH *obj1, const DOH *obj2) {
-  DohBase *b1 = (DohBase *) obj1;
-  DohBase *b2 = (DohBase *) obj2;
+  DohBase *b1 = (DohBase *)obj1;
+  DohBase *b2 = (DohBase *)obj2;
   if (!b1) {
     return !b2;
   } else if (!b2) {
@@ -230,22 +229,22 @@ int DohEqual(const DOH *obj1, const DOH *obj2) {
       if (DohCheck(b2)) {
         b2info = b2->type;
       } else {
-        int len = (b1info->doh_len) (b1);
-        char *cobj = (char *) obj2;
-        return len == (int) strlen(cobj) ? (memcmp(RawData(b1), cobj, len) == 0) : 0;
+        int len = (b1info->doh_len)(b1);
+        char *cobj = (char *)obj2;
+        return len == (int)strlen(cobj) ? (memcmp(RawData(b1), cobj, len) == 0) : 0;
       }
     } else if (DohCheck(b2)) {
-      int len = (b2->type->doh_len) (b2);
-      char *cobj = (char *) obj1;
-      return len == (int) strlen(cobj) ? (memcmp(RawData(b2), cobj, len) == 0) : 0;
+      int len = (b2->type->doh_len)(b2);
+      char *cobj = (char *)obj1;
+      return len == (int)strlen(cobj) ? (memcmp(RawData(b2), cobj, len) == 0) : 0;
     } else {
-      return strcmp((char *) obj1, (char *) obj2) == 0;
+      return strcmp((char *)obj1, (char *)obj2) == 0;
     }
 
     if (!b1info) {
       return obj1 == obj2;
     } else if (b1info == b2info) {
-      return b1info->doh_equal ? (b1info->doh_equal) (b1, b2) : (b1info->doh_cmp ? (b1info->doh_cmp) (b1, b2) == 0 : (b1 == b2));
+      return b1info->doh_equal ? (b1info->doh_equal)(b1, b2) : (b1info->doh_cmp ? (b1info->doh_cmp)(b1, b2) == 0 : (b1 == b2));
     } else {
       return 0;
     }
@@ -261,11 +260,11 @@ DohIterator DohFirst(DOH *obj) {
   DohBase *b;
   DohObjInfo *binfo;
 
-  b = (DohBase *) obj;
+  b = (DohBase *)obj;
   if (DohCheck(b)) {
     binfo = b->type;
     if (binfo->doh_first) {
-      return (binfo->doh_first) (b);
+      return (binfo->doh_first)(b);
     }
   }
   iter.object = 0;
@@ -287,10 +286,10 @@ DohIterator DohNext(DohIterator iter) {
     DohBase *b;
     DohObjInfo *binfo;
 
-    b = (DohBase *) iter.object;
+    b = (DohBase *)iter.object;
     binfo = b->type;
     if (binfo->doh_next) {
-      return (binfo->doh_next) (iter);
+      return (binfo->doh_next)(iter);
     }
   }
   niter = iter;
@@ -301,7 +300,7 @@ DohIterator DohNext(DohIterator iter) {
  * DohIsMapping()
  * ----------------------------------------------------------------------------- */
 int DohIsMapping(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (!DohCheck(b))
     return 0;
@@ -317,10 +316,10 @@ int DohIsMapping(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 DOH *DohGetattr(DOH *obj, const DOH *name) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_hash && objinfo->doh_hash->doh_getattr) {
-    DOH *r = (objinfo->doh_hash->doh_getattr) (b, (DOH *) name);
+    DOH *r = (objinfo->doh_hash->doh_getattr)(b, (DOH *)name);
     return (r == DohNone) ? 0 : r;
   }
   return 0;
@@ -331,10 +330,10 @@ DOH *DohGetattr(DOH *obj, const DOH *name) {
  * ----------------------------------------------------------------------------- */
 
 int DohSetattr(DOH *obj, const DOH *name, const DOH *value) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_hash && objinfo->doh_hash->doh_setattr) {
-    return (objinfo->doh_hash->doh_setattr) (b, (DOH *) name, (DOH *) value);
+    return (objinfo->doh_hash->doh_setattr)(b, (DOH *)name, (DOH *)value);
   }
   return 0;
 }
@@ -344,10 +343,10 @@ int DohSetattr(DOH *obj, const DOH *name, const DOH *value) {
  * ----------------------------------------------------------------------------- */
 
 int DohDelattr(DOH *obj, const DOH *name) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_hash && objinfo->doh_hash->doh_delattr) {
-    return (objinfo->doh_hash->doh_delattr) (b, (DOH *) name);
+    return (objinfo->doh_hash->doh_delattr)(b, (DOH *)name);
   }
   return 0;
 }
@@ -357,9 +356,10 @@ int DohDelattr(DOH *obj, const DOH *name) {
  * ----------------------------------------------------------------------------- */
 
 int DohCheckattr(DOH *obj, const DOH *name, const DOH *value) {
-  DOH *attr = Getattr(obj,name);
-  if (!attr) return 0;
-  return DohEqual(attr,value);
+  DOH *attr = Getattr(obj, name);
+  if (!attr)
+    return 0;
+  return DohEqual(attr, value);
 }
 
 /* -----------------------------------------------------------------------------
@@ -367,10 +367,10 @@ int DohCheckattr(DOH *obj, const DOH *name, const DOH *value) {
  * ----------------------------------------------------------------------------- */
 
 DOH *DohKeys(DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo && objinfo->doh_hash->doh_keys) {
-    return (objinfo->doh_hash->doh_keys) (b);
+    return (objinfo->doh_hash->doh_keys)(b);
   }
   return 0;
 }
@@ -379,7 +379,7 @@ DOH *DohKeys(DOH *obj) {
  * DohSortedKeys()
  * ----------------------------------------------------------------------------- */
 
-DOH *DohSortedKeys(DOH *obj, int (*cmp) (const DOH *, const DOH *)) {
+DOH *DohSortedKeys(DOH *obj, int (*cmp)(const DOH *, const DOH *)) {
   DOHList *keys = DohKeys(obj);
   if (keys) {
     DohSortList(keys, cmp);
@@ -393,11 +393,11 @@ DOH *DohSortedKeys(DOH *obj, int (*cmp) (const DOH *, const DOH *)) {
 
 int DohGetInt(DOH *obj, const DOH *name) {
   DOH *val;
-  val = Getattr(obj, (DOH *) name);
+  val = Getattr(obj, (DOH *)name);
   if (!val)
     return 0;
   if (DohIsString(val)) {
-    return atoi((char *) Data(val));
+    return atoi((char *)Data(val));
   }
   return 0;
 }
@@ -408,11 +408,11 @@ int DohGetInt(DOH *obj, const DOH *name) {
 
 double DohGetDouble(DOH *obj, const DOH *name) {
   DOH *val;
-  val = Getattr(obj, (DOH *) name);
+  val = Getattr(obj, (DOH *)name);
   if (!val)
     return 0;
   if (DohIsString(val)) {
-    return atof((char *) Data(val));
+    return atof((char *)Data(val));
   }
   return 0;
 }
@@ -423,11 +423,11 @@ double DohGetDouble(DOH *obj, const DOH *name) {
 
 char *DohGetChar(DOH *obj, const DOH *name) {
   DOH *val;
-  val = Getattr(obj, (DOH *) name);
+  val = Getattr(obj, (DOH *)name);
   if (!val)
     return 0;
   if (DohIsString(val)) {
-    return (char *) Data(val);
+    return (char *)Data(val);
   }
   return 0;
 }
@@ -442,9 +442,8 @@ char *DohGetChar(DOH *obj, const DOH *name) {
  * DohGetFlagAttr() returns the flag value if is set, NULL otherwise
  * ----------------------------------------------------------------------------- */
 
-
 DOH *DohGetFlagAttr(DOH *obj, const DOH *name) {
-  DOH *val = Getattr(obj, (DOH *) name);
+  DOH *val = Getattr(obj, (DOH *)name);
   if (!val) {
     return NULL;
   } else {
@@ -459,17 +458,16 @@ int DohGetFlag(DOH *obj, const DOH *name) {
   return DohGetFlagAttr(obj, name) ? 1 : 0;
 }
 
-
 /* -----------------------------------------------------------------------------
  * DohGetVoid()
  * ----------------------------------------------------------------------------- */
 
 void *DohGetVoid(DOH *obj, const DOH *name) {
   DOH *val;
-  val = Getattr(obj, (DOH *) name);
+  val = Getattr(obj, (DOH *)name);
   if (!val)
     return 0;
-  return (void *) Data(val);
+  return (void *)Data(val);
 }
 
 /* -----------------------------------------------------------------------------
@@ -480,7 +478,7 @@ void DohSetInt(DOH *obj, const DOH *name, int value) {
   DOH *temp;
   temp = NewStringEmpty();
   Printf(temp, "%d", value);
-  Setattr(obj, (DOH *) name, temp);
+  Setattr(obj, (DOH *)name, temp);
 }
 
 /* -----------------------------------------------------------------------------
@@ -491,7 +489,7 @@ void DohSetDouble(DOH *obj, const DOH *name, double value) {
   DOH *temp;
   temp = NewStringEmpty();
   Printf(temp, "%0.17f", value);
-  Setattr(obj, (DOH *) name, temp);
+  Setattr(obj, (DOH *)name, temp);
 }
 
 /* -----------------------------------------------------------------------------
@@ -499,7 +497,7 @@ void DohSetDouble(DOH *obj, const DOH *name, double value) {
  * ----------------------------------------------------------------------------- */
 
 void DohSetChar(DOH *obj, const DOH *name, char *value) {
-  Setattr(obj, (DOH *) name, NewString(value));
+  Setattr(obj, (DOH *)name, NewString(value));
 }
 
 /* -----------------------------------------------------------------------------
@@ -507,11 +505,11 @@ void DohSetChar(DOH *obj, const DOH *name, char *value) {
  * ----------------------------------------------------------------------------- */
 
 void DohSetFlagAttr(DOH *obj, const DOH *name, const DOH *attr) {
-  Setattr(obj, (DOH *) name, attr ? attr : NewString("0"));
+  Setattr(obj, (DOH *)name, attr ? attr : NewString("0"));
 }
 
 void DohSetFlag(DOH *obj, const DOH *name) {
-  Setattr(obj, (DOH *) name, NewString("1"));
+  Setattr(obj, (DOH *)name, NewString("1"));
 }
 
 /* -----------------------------------------------------------------------------
@@ -519,7 +517,7 @@ void DohSetFlag(DOH *obj, const DOH *name) {
  * ----------------------------------------------------------------------------- */
 
 void DohSetVoid(DOH *obj, const DOH *name, void *value) {
-  Setattr(obj, (DOH *) name, NewVoid(value, 0));
+  Setattr(obj, (DOH *)name, NewVoid(value, 0));
 }
 
 /* -----------------------------------------------------------------------------
@@ -527,7 +525,7 @@ void DohSetVoid(DOH *obj, const DOH *name, void *value) {
  * ----------------------------------------------------------------------------- */
 
 int DohIsSequence(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (!DohCheck(b))
     return 0;
@@ -543,10 +541,10 @@ int DohIsSequence(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 DOH *DohGetitem(DOH *obj, int index) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_list && objinfo->doh_list->doh_getitem) {
-    return (objinfo->doh_list->doh_getitem) (b, index);
+    return (objinfo->doh_list->doh_getitem)(b, index);
   }
   return 0;
 }
@@ -556,10 +554,10 @@ DOH *DohGetitem(DOH *obj, int index) {
  * ----------------------------------------------------------------------------- */
 
 int DohSetitem(DOH *obj, int index, const DOH *value) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_list && objinfo->doh_list->doh_setitem) {
-    return (objinfo->doh_list->doh_setitem) (b, index, (DOH *) value);
+    return (objinfo->doh_list->doh_setitem)(b, index, (DOH *)value);
   }
   return -1;
 }
@@ -569,10 +567,10 @@ int DohSetitem(DOH *obj, int index, const DOH *value) {
  * ----------------------------------------------------------------------------- */
 
 int DohDelitem(DOH *obj, int index) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_list && objinfo->doh_list->doh_delitem) {
-    return (objinfo->doh_list->doh_delitem) (b, index);
+    return (objinfo->doh_list->doh_delitem)(b, index);
   }
   return -1;
 }
@@ -582,24 +580,23 @@ int DohDelitem(DOH *obj, int index) {
  * ----------------------------------------------------------------------------- */
 
 int DohInsertitem(DOH *obj, int index, const DOH *value) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_list && objinfo->doh_list->doh_insitem) {
-    return (objinfo->doh_list->doh_insitem) (b, index, (DOH *) value);
+    return (objinfo->doh_list->doh_insitem)(b, index, (DOH *)value);
   }
   return -1;
 }
-
 
 /* -----------------------------------------------------------------------------
  * DohDelslice()
  * ----------------------------------------------------------------------------- */
 
 int DohDelslice(DOH *obj, int sindex, int eindex) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo = b->type;
   if (objinfo->doh_list && objinfo->doh_list->doh_delslice) {
-    return (objinfo->doh_list->doh_delslice) (b, sindex, eindex);
+    return (objinfo->doh_list->doh_delslice)(b, sindex, eindex);
   }
   return -1;
 }
@@ -609,7 +606,7 @@ int DohDelslice(DOH *obj, int sindex, int eindex) {
  * ----------------------------------------------------------------------------- */
 
 int DohIsFile(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (!DohCheck(b))
     return 0;
@@ -625,17 +622,17 @@ int DohIsFile(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 int DohRead(DOH *obj, void *buffer, int length) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(obj)) {
     objinfo = b->type;
     if ((objinfo->doh_file) && (objinfo->doh_file->doh_read)) {
-      return (objinfo->doh_file->doh_read) (b, buffer, length);
+      return (objinfo->doh_file->doh_read)(b, buffer, length);
     }
     return -1;
   }
   /* Hmmm.  Not a file.  Maybe it's a real FILE */
-  return (int)fread(buffer, 1, length, (FILE *) b);
+  return (int)fread(buffer, 1, length, (FILE *)b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -643,17 +640,17 @@ int DohRead(DOH *obj, void *buffer, int length) {
  * ----------------------------------------------------------------------------- */
 
 int DohWrite(DOH *obj, const void *buffer, int length) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(obj)) {
     objinfo = b->type;
     if ((objinfo->doh_file) && (objinfo->doh_file->doh_write)) {
-      return (objinfo->doh_file->doh_write) (b, buffer, length);
+      return (objinfo->doh_file->doh_write)(b, buffer, length);
     }
     return -1;
   }
   /* Hmmm.  Not a file.  Maybe it's a real FILE */
-  return (int)fwrite(buffer, 1, length, (FILE *) b);
+  return (int)fwrite(buffer, 1, length, (FILE *)b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -661,16 +658,16 @@ int DohWrite(DOH *obj, const void *buffer, int length) {
  * ----------------------------------------------------------------------------- */
 
 int DohSeek(DOH *obj, long offset, int whence) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(obj)) {
     objinfo = b->type;
     if ((objinfo->doh_file) && (objinfo->doh_file->doh_seek)) {
-      return (objinfo->doh_file->doh_seek) (b, offset, whence);
+      return (objinfo->doh_file->doh_seek)(b, offset, whence);
     }
     return -1;
   }
-  return fseek((FILE *) b, offset, whence);
+  return fseek((FILE *)b, offset, whence);
 }
 
 /* -----------------------------------------------------------------------------
@@ -678,16 +675,16 @@ int DohSeek(DOH *obj, long offset, int whence) {
  * ----------------------------------------------------------------------------- */
 
 long DohTell(DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(obj)) {
     objinfo = b->type;
     if ((objinfo->doh_file) && (objinfo->doh_file->doh_tell)) {
-      return (objinfo->doh_file->doh_tell) (b);
+      return (objinfo->doh_file->doh_tell)(b);
     }
     return -1;
   }
-  return ftell((FILE *) b);
+  return ftell((FILE *)b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -696,21 +693,21 @@ long DohTell(DOH *obj) {
 
 int DohGetc(DOH *obj) {
   static DOH *lastdoh = 0;
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (obj == lastdoh) {
     objinfo = b->type;
-    return (objinfo->doh_file->doh_getc) (b);
+    return (objinfo->doh_file->doh_getc)(b);
   }
   if (DohCheck(obj)) {
     objinfo = b->type;
     if (objinfo->doh_file->doh_getc) {
       lastdoh = obj;
-      return (objinfo->doh_file->doh_getc) (b);
+      return (objinfo->doh_file->doh_getc)(b);
     }
     return EOF;
   }
-  return fgetc((FILE *) b);
+  return fgetc((FILE *)b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -719,22 +716,22 @@ int DohGetc(DOH *obj) {
 
 int DohPutc(int ch, DOH *obj) {
   static DOH *lastdoh = 0;
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
 
   if (obj == lastdoh) {
     objinfo = b->type;
-    return (objinfo->doh_file->doh_putc) (b, ch);
+    return (objinfo->doh_file->doh_putc)(b, ch);
   }
   if (DohCheck(obj)) {
     objinfo = b->type;
     if (objinfo->doh_file->doh_putc) {
       lastdoh = obj;
-      return (objinfo->doh_file->doh_putc) (b, ch);
+      return (objinfo->doh_file->doh_putc)(b, ch);
     }
     return EOF;
   }
-  return fputc(ch, (FILE *) b);
+  return fputc(ch, (FILE *)b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -742,16 +739,16 @@ int DohPutc(int ch, DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 int DohUngetc(int ch, DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (DohCheck(obj)) {
     objinfo = b->type;
     if (objinfo->doh_file->doh_ungetc) {
-      return (objinfo->doh_file->doh_ungetc) (b, ch);
+      return (objinfo->doh_file->doh_ungetc)(b, ch);
     }
     return EOF;
   }
-  return ungetc(ch, (FILE *) b);
+  return ungetc(ch, (FILE *)b);
 }
 
 /* -----------------------------------------------------------------------------
@@ -759,7 +756,7 @@ int DohUngetc(int ch, DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 int DohIsString(const DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   DohObjInfo *objinfo;
   if (!DohCheck(b))
     return 0;
@@ -775,7 +772,7 @@ int DohIsString(const DOH *obj) {
  * ----------------------------------------------------------------------------- */
 
 int DohReplace(DOH *src, const DOH *token, const DOH *rep, int flags) {
-  DohBase *b = (DohBase *) src;
+  DohBase *b = (DohBase *)src;
   DohObjInfo *objinfo;
   if (!token)
     return 0;
@@ -784,7 +781,7 @@ int DohReplace(DOH *src, const DOH *token, const DOH *rep, int flags) {
   if (DohIsString(src)) {
     objinfo = b->type;
     if (objinfo->doh_string->doh_replace) {
-      return (objinfo->doh_string->doh_replace) (b, (DOH *) token, (DOH *) rep, flags);
+      return (objinfo->doh_string->doh_replace)(b, (DOH *)token, (DOH *)rep, flags);
     }
   }
   return 0;
@@ -795,12 +792,12 @@ int DohReplace(DOH *src, const DOH *token, const DOH *rep, int flags) {
  * ----------------------------------------------------------------------------- */
 
 void DohChop(DOH *src) {
-  DohBase *b = (DohBase *) src;
+  DohBase *b = (DohBase *)src;
   DohObjInfo *objinfo;
   if (DohIsString(src)) {
     objinfo = b->type;
     if (objinfo->doh_string->doh_chop) {
-      (objinfo->doh_string->doh_chop) (b);
+      (objinfo->doh_string->doh_chop)(b);
     }
   }
 }
@@ -809,26 +806,26 @@ void DohChop(DOH *src) {
  * DohSetFile()
  * ----------------------------------------------------------------------------- */
 void DohSetfile(DOH *ho, DOH *file) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   DohObjInfo *objinfo;
   if (!h)
     return;
   objinfo = h->type;
   if (objinfo->doh_setfile)
-    (objinfo->doh_setfile) (h, file);
+    (objinfo->doh_setfile)(h, file);
 }
 
 /* -----------------------------------------------------------------------------
  * DohGetFile()
  * ----------------------------------------------------------------------------- */
 DOH *DohGetfile(const DOH *ho) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   DohObjInfo *objinfo;
   if (!h)
     return 0;
   objinfo = h->type;
   if (objinfo->doh_getfile)
-    return (objinfo->doh_getfile) (h);
+    return (objinfo->doh_getfile)(h);
   return 0;
 }
 
@@ -836,26 +833,26 @@ DOH *DohGetfile(const DOH *ho) {
  * DohSetLine()
  * ----------------------------------------------------------------------------- */
 void DohSetline(DOH *ho, int l) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   DohObjInfo *objinfo;
   if (!h)
     return;
   objinfo = h->type;
   if (objinfo->doh_setline)
-    (objinfo->doh_setline) (h, l);
+    (objinfo->doh_setline)(h, l);
 }
 
 /* -----------------------------------------------------------------------------
  * DohGetLine()
  * ----------------------------------------------------------------------------- */
 int DohGetline(const DOH *ho) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   DohObjInfo *objinfo;
   if (!h)
     return 0;
   objinfo = h->type;
   if (objinfo->doh_getline)
-    return (objinfo->doh_getline) (h);
+    return (objinfo->doh_getline)(h);
   return 0;
 }
 
@@ -864,7 +861,7 @@ int DohGetline(const DOH *ho) {
  * ----------------------------------------------------------------------------- */
 
 DOH *DohGetmeta(DOH *ho, const DOH *name) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   if (!DohCheck(ho))
     return 0;
   if (!h->meta)
@@ -877,7 +874,7 @@ DOH *DohGetmeta(DOH *ho, const DOH *name) {
  * ----------------------------------------------------------------------------- */
 
 int DohSetmeta(DOH *ho, const DOH *name, const DOH *value) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   if (!DohCheck(ho))
     return 0;
   if (!h->meta)
@@ -890,7 +887,7 @@ int DohSetmeta(DOH *ho, const DOH *name, const DOH *value) {
  * ----------------------------------------------------------------------------- */
 
 int DohDelmeta(DOH *ho, const DOH *name) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   if (!DohCheck(ho))
     return 0;
   if (!h->meta)
@@ -903,12 +900,12 @@ int DohDelmeta(DOH *ho, const DOH *name) {
  * ----------------------------------------------------------------------------- */
 
 void DohSetmark(DOH *ho, int x) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   h->flag_usermark = x;
 }
 
 int DohGetmark(DOH *ho) {
-  DohBase *h = (DohBase *) ho;
+  DohBase *h = (DohBase *)ho;
   return h->flag_usermark;
 }
 
@@ -933,6 +930,6 @@ DOH *DohCall(DOH *func, DOH *args) {
 
   if (!builtin.p)
     return 0;
-  result = (*builtin.func) (args);
+  result = (*builtin.func)(args);
   return result;
 }

--- a/Source/DOH/base.c
+++ b/Source/DOH/base.c
@@ -1,12 +1,12 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
  * included with the SWIG source code as distributed by the SWIG developers
  * and at https://www.swig.org/legal.html.
  *
- * base.c 
+ * base.c
  *
  *     This file contains the function entry points for dispatching methods on
  *     DOH objects.  A number of small utility functions are also included.
@@ -437,7 +437,7 @@ char *DohGetChar(DOH *obj, const DOH *name) {
  * A flag is unset if the attribute (name) does not exist on the node (obj),
  * or it is set to "0". If the attribute is set to any other value,
  * the flag is set.
- * 
+ *
  * DohGetFlag()     returns if the flag is set or not
  * DohGetFlagAttr() returns the flag value if is set, NULL otherwise
  * ----------------------------------------------------------------------------- */
@@ -921,7 +921,7 @@ int DohGetmark(DOH *ho) {
  *       "builtin"    -  Pointer to built-in function (if any)
  *
  * (Additional attributes may be added later)
- * 
+ *
  * Returns a DOH object with result on success. Returns NULL on error
  * ----------------------------------------------------------------------------- */
 

--- a/Source/DOH/base.c
+++ b/Source/DOH/base.c
@@ -38,7 +38,7 @@ void DohDelete(DOH *obj) {
       (objinfo->doh_del) (b);
     } else {
       if (b->data)
-	DohFree(b->data);
+        DohFree(b->data);
     }
     DohObjFree(b);
   }
@@ -228,11 +228,11 @@ int DohEqual(const DOH *obj1, const DOH *obj2) {
     if (DohCheck(b1)) {
       b1info = b1->type;
       if (DohCheck(b2)) {
-	b2info = b2->type;
+        b2info = b2->type;
       } else {
-	int len = (b1info->doh_len) (b1);
-	char *cobj = (char *) obj2;
-	return len == (int) strlen(cobj) ? (memcmp(RawData(b1), cobj, len) == 0) : 0;
+        int len = (b1info->doh_len) (b1);
+        char *cobj = (char *) obj2;
+        return len == (int) strlen(cobj) ? (memcmp(RawData(b1), cobj, len) == 0) : 0;
       }
     } else if (DohCheck(b2)) {
       int len = (b2->type->doh_len) (b2);

--- a/Source/DOH/doh.h
+++ b/Source/DOH/doh.h
@@ -35,99 +35,99 @@
 
 /* Namespace control.  These macros define all of the public API names in DOH */
 
-#define DohCheck           DOH_NAMESPACE(Check)
-#define DohIntern          DOH_NAMESPACE(Intern)
-#define DohDelete          DOH_NAMESPACE(Delete)
-#define DohCopy            DOH_NAMESPACE(Copy)
-#define DohClear           DOH_NAMESPACE(Clear)
-#define DohStr             DOH_NAMESPACE(Str)
-#define DohData            DOH_NAMESPACE(Data)
-#define DohDump            DOH_NAMESPACE(Dump)
-#define DohLen             DOH_NAMESPACE(Len)
-#define DohHashval         DOH_NAMESPACE(Hashval)
-#define DohCmp             DOH_NAMESPACE(Cmp)
-#define DohEqual           DOH_NAMESPACE(Equal)
-#define DohIncref          DOH_NAMESPACE(Incref)
-#define DohCheckattr       DOH_NAMESPACE(Checkattr)
-#define DohSetattr         DOH_NAMESPACE(Setattr)
-#define DohDelattr         DOH_NAMESPACE(Delattr)
-#define DohKeys            DOH_NAMESPACE(Keys)
-#define DohSortedKeys      DOH_NAMESPACE(SortedKeys)
-#define DohGetInt          DOH_NAMESPACE(GetInt)
-#define DohGetDouble       DOH_NAMESPACE(GetDouble)
-#define DohGetChar         DOH_NAMESPACE(GetChar)
-#define DohSetChar         DOH_NAMESPACE(SetChar)
-#define DohSetInt          DOH_NAMESPACE(SetInt)
-#define DohSetDouble       DOH_NAMESPACE(SetDouble)
-#define DohSetVoid         DOH_NAMESPACE(SetVoid)
-#define DohGetVoid         DOH_NAMESPACE(GetVoid)
-#define DohGetitem         DOH_NAMESPACE(Getitem)
-#define DohSetitem         DOH_NAMESPACE(Setitem)
-#define DohDelitem         DOH_NAMESPACE(Delitem)
-#define DohInsertitem      DOH_NAMESPACE(Insertitem)
-#define DohDelslice        DOH_NAMESPACE(Delslice)
-#define DohWrite           DOH_NAMESPACE(Write)
-#define DohRead            DOH_NAMESPACE(Read)
-#define DohSeek            DOH_NAMESPACE(Seek)
-#define DohTell            DOH_NAMESPACE(Tell)
-#define DohGetc            DOH_NAMESPACE(Getc)
-#define DohPutc            DOH_NAMESPACE(Putc)
-#define DohUngetc          DOH_NAMESPACE(Ungetc)
-#define DohGetline         DOH_NAMESPACE(Getline)
-#define DohSetline         DOH_NAMESPACE(Setline)
-#define DohGetfile         DOH_NAMESPACE(Getfile)
-#define DohSetfile         DOH_NAMESPACE(Setfile)
-#define DohReplace         DOH_NAMESPACE(Replace)
-#define DohChop            DOH_NAMESPACE(Chop)
-#define DohGetmeta         DOH_NAMESPACE(Getmeta)
-#define DohSetmeta         DOH_NAMESPACE(Setmeta)
-#define DohDelmeta         DOH_NAMESPACE(Delmeta)
-#define DohEncoding        DOH_NAMESPACE(Encoding)
-#define DohPrintf          DOH_NAMESPACE(Printf)
-#define DohvPrintf         DOH_NAMESPACE(vPrintf)
-#define DohPrintv          DOH_NAMESPACE(Printv)
-#define DohReadline        DOH_NAMESPACE(Readline)
-#define DohIsMapping       DOH_NAMESPACE(IsMapping)
-#define DohIsSequence      DOH_NAMESPACE(IsSequence)
-#define DohIsString        DOH_NAMESPACE(IsString)
-#define DohIsFile          DOH_NAMESPACE(IsFile)
-#define DohNewString       DOH_NAMESPACE(NewString)
-#define DohNewStringEmpty  DOH_NAMESPACE(NewStringEmpty)
-#define DohNewStringWithSize  DOH_NAMESPACE(NewStringWithSize)
-#define DohNewStringf      DOH_NAMESPACE(NewStringf)
-#define DohStrcmp          DOH_NAMESPACE(Strcmp)
-#define DohStrncmp         DOH_NAMESPACE(Strncmp)
-#define DohStrstr          DOH_NAMESPACE(Strstr)
-#define DohStrchr          DOH_NAMESPACE(Strchr)
-#define DohNewFile         DOH_NAMESPACE(NewFile)
-#define DohNewFileFromFile DOH_NAMESPACE(NewFileFromFile)
-#define DohNewFileFromFd   DOH_NAMESPACE(NewFileFromFd)
-#define DohFileErrorDisplay   DOH_NAMESPACE(FileErrorDisplay)
-#define DohCopyto          DOH_NAMESPACE(Copyto)
-#define DohNewList         DOH_NAMESPACE(NewList)
-#define DohNewHash         DOH_NAMESPACE(NewHash)
-#define DohNewVoid         DOH_NAMESPACE(NewVoid)
-#define DohSplit           DOH_NAMESPACE(Split)
-#define DohSplitLines      DOH_NAMESPACE(SplitLines)
-#define DohNone            DOH_NAMESPACE(None)
-#define DohCall            DOH_NAMESPACE(Call)
-#define DohObjMalloc       DOH_NAMESPACE(ObjMalloc)
-#define DohObjFree         DOH_NAMESPACE(ObjFree)
-#define DohMemoryDebug     DOH_NAMESPACE(MemoryDebug)
-#define DohStringType      DOH_NAMESPACE(StringType)
-#define DohListType        DOH_NAMESPACE(ListType)
-#define DohHashType        DOH_NAMESPACE(HashType)
-#define DohFileType        DOH_NAMESPACE(FileType)
-#define DohVoidType        DOH_NAMESPACE(VoidType)
-#define DohIterator        DOH_NAMESPACE(Iterator)
-#define DohFirst           DOH_NAMESPACE(First)
-#define DohNext            DOH_NAMESPACE(Next)
-#define DohMalloc          DOH_NAMESPACE(Malloc)
-#define DohRealloc         DOH_NAMESPACE(Realloc)
-#define DohCalloc          DOH_NAMESPACE(Calloc)
-#define DohFree            DOH_NAMESPACE(Free)
-#define DohSetExitHandler  DOH_NAMESPACE(SetExitHandler)
-#define DohExit            DOH_NAMESPACE(Exit)
+#define DohCheck             DOH_NAMESPACE(Check)
+#define DohIntern            DOH_NAMESPACE(Intern)
+#define DohDelete            DOH_NAMESPACE(Delete)
+#define DohCopy              DOH_NAMESPACE(Copy)
+#define DohClear             DOH_NAMESPACE(Clear)
+#define DohStr               DOH_NAMESPACE(Str)
+#define DohData              DOH_NAMESPACE(Data)
+#define DohDump              DOH_NAMESPACE(Dump)
+#define DohLen               DOH_NAMESPACE(Len)
+#define DohHashval           DOH_NAMESPACE(Hashval)
+#define DohCmp               DOH_NAMESPACE(Cmp)
+#define DohEqual             DOH_NAMESPACE(Equal)
+#define DohIncref            DOH_NAMESPACE(Incref)
+#define DohCheckattr         DOH_NAMESPACE(Checkattr)
+#define DohSetattr           DOH_NAMESPACE(Setattr)
+#define DohDelattr           DOH_NAMESPACE(Delattr)
+#define DohKeys              DOH_NAMESPACE(Keys)
+#define DohSortedKeys        DOH_NAMESPACE(SortedKeys)
+#define DohGetInt            DOH_NAMESPACE(GetInt)
+#define DohGetDouble         DOH_NAMESPACE(GetDouble)
+#define DohGetChar           DOH_NAMESPACE(GetChar)
+#define DohSetChar           DOH_NAMESPACE(SetChar)
+#define DohSetInt            DOH_NAMESPACE(SetInt)
+#define DohSetDouble         DOH_NAMESPACE(SetDouble)
+#define DohSetVoid           DOH_NAMESPACE(SetVoid)
+#define DohGetVoid           DOH_NAMESPACE(GetVoid)
+#define DohGetitem           DOH_NAMESPACE(Getitem)
+#define DohSetitem           DOH_NAMESPACE(Setitem)
+#define DohDelitem           DOH_NAMESPACE(Delitem)
+#define DohInsertitem        DOH_NAMESPACE(Insertitem)
+#define DohDelslice          DOH_NAMESPACE(Delslice)
+#define DohWrite             DOH_NAMESPACE(Write)
+#define DohRead              DOH_NAMESPACE(Read)
+#define DohSeek              DOH_NAMESPACE(Seek)
+#define DohTell              DOH_NAMESPACE(Tell)
+#define DohGetc              DOH_NAMESPACE(Getc)
+#define DohPutc              DOH_NAMESPACE(Putc)
+#define DohUngetc            DOH_NAMESPACE(Ungetc)
+#define DohGetline           DOH_NAMESPACE(Getline)
+#define DohSetline           DOH_NAMESPACE(Setline)
+#define DohGetfile           DOH_NAMESPACE(Getfile)
+#define DohSetfile           DOH_NAMESPACE(Setfile)
+#define DohReplace           DOH_NAMESPACE(Replace)
+#define DohChop              DOH_NAMESPACE(Chop)
+#define DohGetmeta           DOH_NAMESPACE(Getmeta)
+#define DohSetmeta           DOH_NAMESPACE(Setmeta)
+#define DohDelmeta           DOH_NAMESPACE(Delmeta)
+#define DohEncoding          DOH_NAMESPACE(Encoding)
+#define DohPrintf            DOH_NAMESPACE(Printf)
+#define DohvPrintf           DOH_NAMESPACE(vPrintf)
+#define DohPrintv            DOH_NAMESPACE(Printv)
+#define DohReadline          DOH_NAMESPACE(Readline)
+#define DohIsMapping         DOH_NAMESPACE(IsMapping)
+#define DohIsSequence        DOH_NAMESPACE(IsSequence)
+#define DohIsString          DOH_NAMESPACE(IsString)
+#define DohIsFile            DOH_NAMESPACE(IsFile)
+#define DohNewString         DOH_NAMESPACE(NewString)
+#define DohNewStringEmpty    DOH_NAMESPACE(NewStringEmpty)
+#define DohNewStringWithSize DOH_NAMESPACE(NewStringWithSize)
+#define DohNewStringf        DOH_NAMESPACE(NewStringf)
+#define DohStrcmp            DOH_NAMESPACE(Strcmp)
+#define DohStrncmp           DOH_NAMESPACE(Strncmp)
+#define DohStrstr            DOH_NAMESPACE(Strstr)
+#define DohStrchr            DOH_NAMESPACE(Strchr)
+#define DohNewFile           DOH_NAMESPACE(NewFile)
+#define DohNewFileFromFile   DOH_NAMESPACE(NewFileFromFile)
+#define DohNewFileFromFd     DOH_NAMESPACE(NewFileFromFd)
+#define DohFileErrorDisplay  DOH_NAMESPACE(FileErrorDisplay)
+#define DohCopyto            DOH_NAMESPACE(Copyto)
+#define DohNewList           DOH_NAMESPACE(NewList)
+#define DohNewHash           DOH_NAMESPACE(NewHash)
+#define DohNewVoid           DOH_NAMESPACE(NewVoid)
+#define DohSplit             DOH_NAMESPACE(Split)
+#define DohSplitLines        DOH_NAMESPACE(SplitLines)
+#define DohNone              DOH_NAMESPACE(None)
+#define DohCall              DOH_NAMESPACE(Call)
+#define DohObjMalloc         DOH_NAMESPACE(ObjMalloc)
+#define DohObjFree           DOH_NAMESPACE(ObjFree)
+#define DohMemoryDebug       DOH_NAMESPACE(MemoryDebug)
+#define DohStringType        DOH_NAMESPACE(StringType)
+#define DohListType          DOH_NAMESPACE(ListType)
+#define DohHashType          DOH_NAMESPACE(HashType)
+#define DohFileType          DOH_NAMESPACE(FileType)
+#define DohVoidType          DOH_NAMESPACE(VoidType)
+#define DohIterator          DOH_NAMESPACE(Iterator)
+#define DohFirst             DOH_NAMESPACE(First)
+#define DohNext              DOH_NAMESPACE(Next)
+#define DohMalloc            DOH_NAMESPACE(Malloc)
+#define DohRealloc           DOH_NAMESPACE(Realloc)
+#define DohCalloc            DOH_NAMESPACE(Calloc)
+#define DohFree              DOH_NAMESPACE(Free)
+#define DohSetExitHandler    DOH_NAMESPACE(SetExitHandler)
+#define DohExit              DOH_NAMESPACE(Exit)
 #endif
 
 #define DOH_MAJOR_VERSION 0
@@ -141,30 +141,30 @@ typedef void DOH;
  * names are used.
  */
 
-#define DOHString          DOH
-#define DOHList            DOH
-#define DOHHash            DOH
-#define DOHFile            DOH
-#define DOHVoid            DOH
-#define DOHString_or_char  DOH
-#define DOHObj_or_char     DOH
+#define DOHString         DOH
+#define DOHList           DOH
+#define DOHHash           DOH
+#define DOHFile           DOH
+#define DOHVoid           DOH
+#define DOHString_or_char DOH
+#define DOHObj_or_char    DOH
 
-typedef const DOHString_or_char * const_String_or_char_ptr;
-typedef const DOHString_or_char * DOHconst_String_or_char_ptr;
+typedef const DOHString_or_char *const_String_or_char_ptr;
+typedef const DOHString_or_char *DOHconst_String_or_char_ptr;
 
-#define DOH_BEGIN          -1
-#define DOH_END            -2
-#define DOH_CUR            -3
-#define DOH_CURRENT        -3
+#define DOH_BEGIN   -1
+#define DOH_END     -2
+#define DOH_CUR     -3
+#define DOH_CURRENT -3
 
 /* Iterator objects */
 
 typedef struct {
-  void *key;                    /* Current key (if any)       */
-  void *item;                   /* Current item               */
-  void *object;                 /* Object being iterated over */
-  void *_current;               /* Internal use */
-  int _index;                   /* Internal use */
+  void *key;      /* Current key (if any)       */
+  void *item;     /* Current item               */
+  void *object;   /* Object being iterated over */
+  void *_current; /* Internal use */
+  int _index;     /* Internal use */
 } DohIterator;
 
 /* Memory management */
@@ -178,17 +178,17 @@ extern void *DohCalloc(size_t n, size_t size);
 #define DohFree free
 #endif
 
-extern int DohCheck(const DOH *ptr);    /* Check if a DOH object */
-extern void DohIntern(DOH *);   /* Intern an object      */
+extern int DohCheck(const DOH *ptr); /* Check if a DOH object */
+extern void DohIntern(DOH *);        /* Intern an object      */
 
 /* Basic object methods.  Common to most objects */
 
-extern void DohDelete(DOH *obj);        /* Delete an object      */
+extern void DohDelete(DOH *obj); /* Delete an object      */
 extern DOH *DohCopy(const DOH *obj);
 extern void DohClear(DOH *obj);
 extern DOHString *DohStr(const DOH *obj);
 extern void *DohData(const DOH *obj);
-extern int DohDump(const DOH *obj, DOHFile * out);
+extern int DohDump(const DOH *obj, DOHFile *out);
 extern int DohLen(const DOH *obj);
 extern int DohHashval(const DOH *obj);
 extern int DohCmp(const DOH *obj1, const DOH *obj2);
@@ -198,11 +198,11 @@ extern void DohIncref(DOH *obj);
 /* Mapping methods */
 
 extern DOH *DohGetattr(DOH *obj, const DOHString_or_char *name);
-extern int DohSetattr(DOH *obj, const DOHString_or_char *name, const DOHObj_or_char * value);
+extern int DohSetattr(DOH *obj, const DOHString_or_char *name, const DOHObj_or_char *value);
 extern int DohDelattr(DOH *obj, const DOHString_or_char *name);
 extern int DohCheckattr(DOH *obj, const DOHString_or_char *name, const DOHString_or_char *value);
 extern DOH *DohKeys(DOH *obj);
-extern DOH *DohSortedKeys(DOH *obj, int (*cmp) (const DOH *, const DOH *));
+extern DOH *DohSortedKeys(DOH *obj, int (*cmp)(const DOH *, const DOH *));
 extern int DohGetInt(DOH *obj, const DOHString_or_char *name);
 extern void DohSetInt(DOH *obj, const DOHString_or_char *name, int);
 extern double DohGetDouble(DOH *obj, const DOHString_or_char *name);
@@ -219,22 +219,20 @@ extern void DohSetVoid(DOH *obj, const DOHString_or_char *name, void *value);
 /* Sequence methods */
 
 extern DOH *DohGetitem(DOH *obj, int index);
-extern int DohSetitem(DOH *obj, int index, const DOHObj_or_char * value);
+extern int DohSetitem(DOH *obj, int index, const DOHObj_or_char *value);
 extern int DohDelitem(DOH *obj, int index);
-extern int DohInsertitem(DOH *obj, int index, const DOHObj_or_char * value);
+extern int DohInsertitem(DOH *obj, int index, const DOHObj_or_char *value);
 extern int DohDelslice(DOH *obj, int sindex, int eindex);
 
 /* File methods */
 
-extern int DohWrite(DOHFile * obj, const void *buffer, int length);
-extern int DohRead(DOHFile * obj, void *buffer, int length);
-extern int DohSeek(DOHFile * obj, long offset, int whence);
-extern long DohTell(DOHFile * obj);
-extern int DohGetc(DOHFile * obj);
-extern int DohPutc(int ch, DOHFile * obj);
-extern int DohUngetc(int ch, DOHFile * obj);
-
-
+extern int DohWrite(DOHFile *obj, const void *buffer, int length);
+extern int DohRead(DOHFile *obj, void *buffer, int length);
+extern int DohSeek(DOHFile *obj, long offset, int whence);
+extern long DohTell(DOHFile *obj);
+extern int DohGetc(DOHFile *obj);
+extern int DohPutc(int ch, DOHFile *obj);
+extern int DohUngetc(int ch, DOHFile *obj);
 
 /* Iterators */
 extern DohIterator DohFirst(DOH *obj);
@@ -247,25 +245,25 @@ extern void DohSetline(DOH *obj, int line);
 extern DOH *DohGetfile(const DOH *obj);
 extern void DohSetfile(DOH *obj, DOH *file);
 
-  /* String Methods */
+/* String Methods */
 
-extern int DohReplace(DOHString * src, const DOHString_or_char *token, const DOHString_or_char *rep, int flags);
-extern void DohChop(DOHString * src);
+extern int DohReplace(DOHString *src, const DOHString_or_char *token, const DOHString_or_char *rep, int flags);
+extern void DohChop(DOHString *src);
 
 /* Meta-variables */
 extern DOH *DohGetmeta(DOH *, const DOH *);
 extern int DohSetmeta(DOH *, const DOH *, const DOH *value);
 extern int DohDelmeta(DOH *, const DOH *);
 
-  /* Utility functions */
+/* Utility functions */
 
-extern void DohEncoding(const char *name, DOH *(*fn) (DOH *s));
-extern int DohPrintf(DOHFile * obj, const char *format, ...);
-extern int DohvPrintf(DOHFile * obj, const char *format, va_list ap);
-extern int DohPrintv(DOHFile * obj, ...);
-extern DOH *DohReadline(DOHFile * in);
+extern void DohEncoding(const char *name, DOH *(*fn)(DOH *s));
+extern int DohPrintf(DOHFile *obj, const char *format, ...);
+extern int DohvPrintf(DOHFile *obj, const char *format, va_list ap);
+extern int DohPrintv(DOHFile *obj, ...);
+extern DOH *DohReadline(DOHFile *in);
 
-  /* Miscellaneous */
+/* Miscellaneous */
 
 extern int DohIsMapping(const DOH *obj);
 extern int DohIsSequence(const DOH *obj);
@@ -311,17 +309,17 @@ extern char *DohStrchr(const DOHString_or_char *s1, int ch);
 
 /* String replacement flags */
 
-#define   DOH_REPLACE_ANY         0x01
-#define   DOH_REPLACE_NOQUOTE     0x02
-#define   DOH_REPLACE_NOCOMMENT   0x04
-#define   DOH_REPLACE_ID          0x08
-#define   DOH_REPLACE_FIRST       0x10
-#define   DOH_REPLACE_ID_BEGIN    0x20
-#define   DOH_REPLACE_ID_END      0x40
-#define   DOH_REPLACE_NUMBER_END  0x80
+#define DOH_REPLACE_ANY        0x01
+#define DOH_REPLACE_NOQUOTE    0x02
+#define DOH_REPLACE_NOCOMMENT  0x04
+#define DOH_REPLACE_ID         0x08
+#define DOH_REPLACE_FIRST      0x10
+#define DOH_REPLACE_ID_BEGIN   0x20
+#define DOH_REPLACE_ID_END     0x40
+#define DOH_REPLACE_NUMBER_END 0x80
 
-#define Replaceall(s,t,r)  DohReplace(s,t,r,DOH_REPLACE_ANY)
-#define Replaceid(s,t,r)   DohReplace(s,t,r,DOH_REPLACE_ID)
+#define Replaceall(s, t, r)    DohReplace(s, t, r, DOH_REPLACE_ANY)
+#define Replaceid(s, t, r)     DohReplace(s, t, r, DOH_REPLACE_ID)
 
 /* -----------------------------------------------------------------------------
  * Files
@@ -330,17 +328,16 @@ extern char *DohStrchr(const DOHString_or_char *s1, int ch);
 extern DOHFile *DohNewFile(DOHString *filename, const char *mode, DOHList *outfiles);
 extern DOHFile *DohNewFileFromFile(FILE *f);
 extern DOHFile *DohNewFileFromFd(int fd);
-extern void DohFileErrorDisplay(DOHString * filename);
-extern int DohCopyto(DOHFile * input, DOHFile * output);
+extern void DohFileErrorDisplay(DOHString *filename);
+extern int DohCopyto(DOHFile *input, DOHFile *output);
 extern void DohCloseAllOpenFiles(void);
-
 
 /* -----------------------------------------------------------------------------
  * List
  * ----------------------------------------------------------------------------- */
 
 extern DOHList *DohNewList(void);
-extern void DohSortList(DOH *lo, int (*cmp) (const DOH *, const DOH *));
+extern void DohSortList(DOH *lo, int (*cmp)(const DOH *, const DOH *));
 
 /* -----------------------------------------------------------------------------
  * Hash
@@ -352,14 +349,14 @@ extern DOHHash *DohNewHash(void);
  * Void
  * ----------------------------------------------------------------------------- */
 
-extern DOHVoid *DohNewVoid(void *ptr, void (*del) (void *));
-extern DOHList *DohSplit(DOHFile * input, char ch, int nsplits);
-extern DOHList *DohSplitLines(DOHFile * input);
+extern DOHVoid *DohNewVoid(void *ptr, void (*del)(void *));
+extern DOHList *DohSplit(DOHFile *input, char ch, int nsplits);
+extern DOHList *DohSplitLines(DOHFile *input);
 extern DOH *DohNone;
 
 /* Helper union for converting between function and object pointers. */
 typedef union DohFuncPtr {
-  void* p;
+  void *p;
   DOH *(*func)(DOH *);
 } DohFuncPtr_t;
 
@@ -369,41 +366,41 @@ extern void DohMemoryDebug(void);
 /* Macros to invoke the above functions.  Includes the location of
    the caller to simplify debugging if something goes wrong */
 
-#define Delete             DohDelete
-#define Copy               DohCopy
-#define Clear              DohClear
-#define Str                DohStr
-#define Dump               DohDump
-#define Getattr            DohGetattr
-#define Setattr            DohSetattr
-#define Delattr            DohDelattr
-#define Checkattr          DohCheckattr
-#define Hashval            DohHashval
-#define Getitem            DohGetitem
-#define Setitem            DohSetitem
-#define Delitem            DohDelitem
-#define Insert             DohInsertitem
-#define Delslice           DohDelslice
-#define Append(s,x)        DohInsertitem(s,DOH_END,x)
-#define Push(s,x)          DohInsertitem(s,DOH_BEGIN,x)
-#define Len                DohLen
-#define Data               DohData
-#define Char(X)            ((char *) Data(X))
-#define Cmp                DohCmp
-#define Equal              DohEqual
-#define Setline            DohSetline
-#define Getline            DohGetline
-#define Setfile            DohSetfile
-#define Getfile            DohGetfile
-#define Write              DohWrite
-#define Read               DohRead
-#define Seek               DohSeek
-#define Tell               DohTell
-#define Printf             DohPrintf
-#define Printv             DohPrintv
-#define Getc               DohGetc
-#define Putc               DohPutc
-#define Ungetc             DohUngetc
+#define Delete            DohDelete
+#define Copy              DohCopy
+#define Clear             DohClear
+#define Str               DohStr
+#define Dump              DohDump
+#define Getattr           DohGetattr
+#define Setattr           DohSetattr
+#define Delattr           DohDelattr
+#define Checkattr         DohCheckattr
+#define Hashval           DohHashval
+#define Getitem           DohGetitem
+#define Setitem           DohSetitem
+#define Delitem           DohDelitem
+#define Insert            DohInsertitem
+#define Delslice          DohDelslice
+#define Append(s, x)      DohInsertitem(s, DOH_END, x)
+#define Push(s, x)        DohInsertitem(s, DOH_BEGIN, x)
+#define Len               DohLen
+#define Data              DohData
+#define Char(X)           ((char *)Data(X))
+#define Cmp               DohCmp
+#define Equal             DohEqual
+#define Setline           DohSetline
+#define Getline           DohGetline
+#define Setfile           DohSetfile
+#define Getfile           DohGetfile
+#define Write             DohWrite
+#define Read              DohRead
+#define Seek              DohSeek
+#define Tell              DohTell
+#define Printf            DohPrintf
+#define Printv            DohPrintv
+#define Getc              DohGetc
+#define Putc              DohPutc
+#define Ungetc            DohUngetc
 
 /* #define StringPutc         DohStringPutc */
 /* #define StringGetc         DohStringGetc */
@@ -413,95 +410,95 @@ extern void DohMemoryDebug(void);
 /* #define StringChar         DohStringChar */
 /* #define StringEqual        DohStringEqual */
 
-#define vPrintf            DohvPrintf
-#define GetInt             DohGetInt
-#define GetDouble          DohGetDouble
-#define GetChar            DohGetChar
-#define GetVoid            DohGetVoid
-#define GetFlagAttr        DohGetFlagAttr
-#define GetFlag            DohGetFlag
-#define SetInt             DohSetInt
-#define SetDouble          DohSetDouble
-#define SetChar            DohSetattr
-#define SetVoid            DohSetVoid
-#define SetFlagAttr        DohSetFlagAttr
-#define SetFlag            DohSetFlag
-#define UnsetFlag(o,n)     DohSetFlagAttr(o,n,NULL)
-#define ClearFlag(o,n)     DohSetFlagAttr(o,n,"")
-#define Readline           DohReadline
-#define Replace            DohReplace
-#define Chop               DohChop
-#define Getmeta            DohGetmeta
-#define Setmeta            DohSetmeta
-#define Delmeta            DohDelmeta
-#define NewString          DohNewString
-#define NewStringEmpty     DohNewStringEmpty
-#define NewStringWithSize  DohNewStringWithSize
-#define NewStringf         DohNewStringf
-#define NewHash            DohNewHash
-#define NewList            DohNewList
-#define NewFile            DohNewFile
-#define NewFileFromFile    DohNewFileFromFile
-#define NewFileFromFd      DohNewFileFromFd
-#define FileErrorDisplay   DohFileErrorDisplay
-#define NewVoid            DohNewVoid
-#define Keys               DohKeys
-#define SortedKeys         DohSortedKeys
-#define Strcmp             DohStrcmp
-#define Strncmp            DohStrncmp
-#define Strstr             DohStrstr
-#define Strchr             DohStrchr
-#define Copyto             DohCopyto
-#define CloseAllOpenFiles  DohCloseAllOpenFiles
-#define Split              DohSplit
-#define SplitLines         DohSplitLines
-#define Setmark            DohSetmark
-#define Getmark            DohGetmark
-#define SetMaxHashExpand   DohSetMaxHashExpand
-#define GetMaxHashExpand   DohGetMaxHashExpand
-#define None               DohNone
-#define Call               DohCall
-#define First              DohFirst
-#define Next               DohNext
-#define Iterator           DohIterator
-#define SortList           DohSortList
-#define Malloc             DohMalloc
-#define Realloc            DohRealloc
-#define Calloc             DohCalloc
-#define Free               DohFree
-#define SetExitHandler     DohSetExitHandler
-#define Exit               DohExit
+#define vPrintf           DohvPrintf
+#define GetInt            DohGetInt
+#define GetDouble         DohGetDouble
+#define GetChar           DohGetChar
+#define GetVoid           DohGetVoid
+#define GetFlagAttr       DohGetFlagAttr
+#define GetFlag           DohGetFlag
+#define SetInt            DohSetInt
+#define SetDouble         DohSetDouble
+#define SetChar           DohSetattr
+#define SetVoid           DohSetVoid
+#define SetFlagAttr       DohSetFlagAttr
+#define SetFlag           DohSetFlag
+#define UnsetFlag(o, n)   DohSetFlagAttr(o, n, NULL)
+#define ClearFlag(o, n)   DohSetFlagAttr(o, n, "")
+#define Readline          DohReadline
+#define Replace           DohReplace
+#define Chop              DohChop
+#define Getmeta           DohGetmeta
+#define Setmeta           DohSetmeta
+#define Delmeta           DohDelmeta
+#define NewString         DohNewString
+#define NewStringEmpty    DohNewStringEmpty
+#define NewStringWithSize DohNewStringWithSize
+#define NewStringf        DohNewStringf
+#define NewHash           DohNewHash
+#define NewList           DohNewList
+#define NewFile           DohNewFile
+#define NewFileFromFile   DohNewFileFromFile
+#define NewFileFromFd     DohNewFileFromFd
+#define FileErrorDisplay  DohFileErrorDisplay
+#define NewVoid           DohNewVoid
+#define Keys              DohKeys
+#define SortedKeys        DohSortedKeys
+#define Strcmp            DohStrcmp
+#define Strncmp           DohStrncmp
+#define Strstr            DohStrstr
+#define Strchr            DohStrchr
+#define Copyto            DohCopyto
+#define CloseAllOpenFiles DohCloseAllOpenFiles
+#define Split             DohSplit
+#define SplitLines        DohSplitLines
+#define Setmark           DohSetmark
+#define Getmark           DohGetmark
+#define SetMaxHashExpand  DohSetMaxHashExpand
+#define GetMaxHashExpand  DohGetMaxHashExpand
+#define None              DohNone
+#define Call              DohCall
+#define First             DohFirst
+#define Next              DohNext
+#define Iterator          DohIterator
+#define SortList          DohSortList
+#define Malloc            DohMalloc
+#define Realloc           DohRealloc
+#define Calloc            DohCalloc
+#define Free              DohFree
+#define SetExitHandler    DohSetExitHandler
+#define Exit              DohExit
 #endif
 
 #ifdef NIL
 #undef NIL
 #endif
 
-#define NIL  (char *) NULL
+#define NIL                  (char *)NULL
 
 /* Defines to allow use of poisoned identifiers.
  *
  * For DOH-internal use only!
  */
-#define doh_internal_calloc calloc
-#define doh_internal_exit exit
+#define doh_internal_calloc  calloc
+#define doh_internal_exit    exit
 /* doh_internal_free not needed as Free() is a macro defined above. */
-#define doh_internal_malloc malloc
+#define doh_internal_malloc  malloc
 #define doh_internal_realloc realloc
 
 #if defined __GNUC__ && defined DOH_POISON
 /* Use Malloc(), Realloc(), Calloc(), and Free() instead (which will exit with
  * an error rather than return NULL).
  */
-# ifndef DOH_NO_POISON_MALLOC_FREE
+#ifndef DOH_NO_POISON_MALLOC_FREE
 /* This works around bison's template checking if malloc and free are defined,
  * which triggers GCC's poison checks.
  */
-#  pragma GCC poison malloc free
-# endif
-# pragma GCC poison realloc calloc
+#pragma GCC poison malloc free
+#endif
+#pragma GCC poison realloc calloc
 /* Use Exit() instead (which will remove output files on error). */
-# pragma GCC poison abort exit
+#pragma GCC poison abort exit
 #endif
 
-#endif                          /* SWIG_DOH_H */
+#endif /* SWIG_DOH_H */

--- a/Source/DOH/doh.h
+++ b/Source/DOH/doh.h
@@ -160,11 +160,11 @@ typedef const DOHString_or_char * DOHconst_String_or_char_ptr;
 /* Iterator objects */
 
 typedef struct {
-  void *key;			/* Current key (if any)       */
-  void *item;			/* Current item               */
-  void *object;			/* Object being iterated over */
-  void *_current;		/* Internal use */
-  int _index;			/* Internal use */
+  void *key;                    /* Current key (if any)       */
+  void *item;                   /* Current item               */
+  void *object;                 /* Object being iterated over */
+  void *_current;               /* Internal use */
+  int _index;                   /* Internal use */
 } DohIterator;
 
 /* Memory management */
@@ -178,12 +178,12 @@ extern void *DohCalloc(size_t n, size_t size);
 #define DohFree free
 #endif
 
-extern int DohCheck(const DOH *ptr);	/* Check if a DOH object */
-extern void DohIntern(DOH *);	/* Intern an object      */
+extern int DohCheck(const DOH *ptr);    /* Check if a DOH object */
+extern void DohIntern(DOH *);   /* Intern an object      */
 
 /* Basic object methods.  Common to most objects */
 
-extern void DohDelete(DOH *obj);	/* Delete an object      */
+extern void DohDelete(DOH *obj);        /* Delete an object      */
 extern DOH *DohCopy(const DOH *obj);
 extern void DohClear(DOH *obj);
 extern DOHString *DohStr(const DOH *obj);
@@ -504,4 +504,4 @@ extern void DohMemoryDebug(void);
 # pragma GCC poison abort exit
 #endif
 
-#endif				/* SWIG_DOH_H */
+#endif                          /* SWIG_DOH_H */

--- a/Source/DOH/doh.h
+++ b/Source/DOH/doh.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/DOH/dohint.h
+++ b/Source/DOH/dohint.h
@@ -25,30 +25,30 @@
 
 /* Hash objects */
 typedef struct {
-  DOH *(*doh_getattr) (DOH *obj, DOH *name);	/* Get attribute */
-  int (*doh_setattr) (DOH *obj, DOH *name, DOH *value);	/* Set attribute */
-  int (*doh_delattr) (DOH *obj, DOH *name);	/* Del attribute */
-  DOH *(*doh_keys) (DOH *obj);	/* All keys as a list */
+  DOH *(*doh_getattr) (DOH *obj, DOH *name);    /* Get attribute */
+  int (*doh_setattr) (DOH *obj, DOH *name, DOH *value); /* Set attribute */
+  int (*doh_delattr) (DOH *obj, DOH *name);     /* Del attribute */
+  DOH *(*doh_keys) (DOH *obj);  /* All keys as a list */
 } DohHashMethods;
 
 /* List objects */
 typedef struct {
-  DOH *(*doh_getitem) (DOH *obj, int index);	/* Get item      */
-  int (*doh_setitem) (DOH *obj, int index, DOH *value);	/* Set item      */
-  int (*doh_delitem) (DOH *obj, int index);	/* Delete item   */
-  int (*doh_insitem) (DOH *obj, int index, DOH *value);	/* Insert item   */
-  int (*doh_delslice) (DOH *obj, int sindex, int eindex);	/* Delete slice  */
+  DOH *(*doh_getitem) (DOH *obj, int index);    /* Get item      */
+  int (*doh_setitem) (DOH *obj, int index, DOH *value); /* Set item      */
+  int (*doh_delitem) (DOH *obj, int index);     /* Delete item   */
+  int (*doh_insitem) (DOH *obj, int index, DOH *value); /* Insert item   */
+  int (*doh_delslice) (DOH *obj, int sindex, int eindex);       /* Delete slice  */
 } DohListMethods;
 
 /* File methods */
 typedef struct {
-  int (*doh_read) (DOH *obj, void *buffer, int nbytes);	/* Read bytes */
-  int (*doh_write) (DOH *obj, const void *buffer, int nbytes);	/* Write bytes */
-  int (*doh_putc) (DOH *obj, int ch);	/* Put character */
-  int (*doh_getc) (DOH *obj);	/* Get character */
-  int (*doh_ungetc) (DOH *obj, int ch);	/* Unget character */
-  int (*doh_seek) (DOH *obj, long offset, int whence);	/* Seek */
-  long (*doh_tell) (DOH *obj);	/* Tell */
+  int (*doh_read) (DOH *obj, void *buffer, int nbytes); /* Read bytes */
+  int (*doh_write) (DOH *obj, const void *buffer, int nbytes);  /* Write bytes */
+  int (*doh_putc) (DOH *obj, int ch);   /* Put character */
+  int (*doh_getc) (DOH *obj);   /* Get character */
+  int (*doh_ungetc) (DOH *obj, int ch); /* Unget character */
+  int (*doh_seek) (DOH *obj, long offset, int whence);  /* Seek */
+  long (*doh_tell) (DOH *obj);  /* Tell */
 } DohFileMethods;
 
 /* String methods */
@@ -62,17 +62,17 @@ typedef struct {
  * ----------------------------------------------------------------------------- */
 
 typedef struct DohObjInfo {
-  const char *objname;		/* Object name        */
+  const char *objname;          /* Object name        */
 
   /* Basic object methods */
-  void (*doh_del) (DOH *obj);	/* Delete object      */
-  DOH *(*doh_copy) (DOH *obj);	/* Copy and object    */
-  void (*doh_clear) (DOH *obj);	/* Clear an object    */
+  void (*doh_del) (DOH *obj);   /* Delete object      */
+  DOH *(*doh_copy) (DOH *obj);  /* Copy and object    */
+  void (*doh_clear) (DOH *obj); /* Clear an object    */
 
   /* I/O methods */
-  DOH *(*doh_str) (DOH *obj);	/* Make a full string */
-  void *(*doh_data) (DOH *obj);	/* Return raw data    */
-  int (*doh_dump) (DOH *obj, DOH *out);	/* Serialize on out   */
+  DOH *(*doh_str) (DOH *obj);   /* Make a full string */
+  void *(*doh_data) (DOH *obj); /* Return raw data    */
+  int (*doh_dump) (DOH *obj, DOH *out); /* Serialize on out   */
 
   /* Length and hash values */
   int (*doh_len) (DOH *obj);
@@ -94,23 +94,23 @@ typedef struct DohObjInfo {
   void (*doh_setline) (DOH *obj, int line);
   int (*doh_getline) (DOH *obj);
 
-  DohHashMethods *doh_hash;	/* Hash methods       */
-  DohListMethods *doh_list;	/* List methods       */
-  DohFileMethods *doh_file;	/* File methods       */
-  DohStringMethods *doh_string;	/* String methods     */
-  void *doh_reserved;		/* Reserved           */
-  void *clientdata;		/* User data          */
+  DohHashMethods *doh_hash;     /* Hash methods       */
+  DohListMethods *doh_list;     /* List methods       */
+  DohFileMethods *doh_file;     /* File methods       */
+  DohStringMethods *doh_string; /* String methods     */
+  void *doh_reserved;           /* Reserved           */
+  void *clientdata;             /* User data          */
 } DohObjInfo;
 
 typedef struct {
-  void *data;			/* Data pointer */
+  void *data;                   /* Data pointer */
   DohObjInfo *type;
-  void *meta;			/* Meta data */
-  unsigned int flag_intern:1;	/* Interned object */
-  unsigned int flag_marked:1;	/* Mark flag. Used to avoid recursive loops in places */
-  unsigned int flag_user:1;	/* User flag */
-  unsigned int flag_usermark:1;	/* User marked */
-  unsigned int refcount:28;	/* Reference count (max 256 million) */
+  void *meta;                   /* Meta data */
+  unsigned int flag_intern:1;   /* Interned object */
+  unsigned int flag_marked:1;   /* Mark flag. Used to avoid recursive loops in places */
+  unsigned int flag_user:1;     /* User flag */
+  unsigned int flag_usermark:1; /* User marked */
+  unsigned int refcount:28;     /* Reference count (max 256 million) */
 } DohBase;
 
 /* Macros for decrefing and increfing (safe for null objects). */
@@ -125,7 +125,7 @@ typedef struct {
 #define ObjGetMark(a)     ((DohBase *)a)->flag_marked
 #define ObjType(a)        ((DohBase *)a)->type
 
-extern DOH *DohObjMalloc(DohObjInfo *type, void *data);	/* Allocate a DOH object */
-extern void DohObjFree(DOH *ptr);	/* Free a DOH object     */
+extern DOH *DohObjMalloc(DohObjInfo *type, void *data); /* Allocate a DOH object */
+extern void DohObjFree(DOH *ptr);       /* Free a DOH object     */
 
-#endif				/* SWIG_DOHINT_H */
+#endif                          /* SWIG_DOHINT_H */

--- a/Source/DOH/dohint.h
+++ b/Source/DOH/dohint.h
@@ -25,36 +25,36 @@
 
 /* Hash objects */
 typedef struct {
-  DOH *(*doh_getattr) (DOH *obj, DOH *name);    /* Get attribute */
-  int (*doh_setattr) (DOH *obj, DOH *name, DOH *value); /* Set attribute */
-  int (*doh_delattr) (DOH *obj, DOH *name);     /* Del attribute */
-  DOH *(*doh_keys) (DOH *obj);  /* All keys as a list */
+  DOH *(*doh_getattr)(DOH *obj, DOH *name);            /* Get attribute */
+  int (*doh_setattr)(DOH *obj, DOH *name, DOH *value); /* Set attribute */
+  int (*doh_delattr)(DOH *obj, DOH *name);             /* Del attribute */
+  DOH *(*doh_keys)(DOH *obj);                          /* All keys as a list */
 } DohHashMethods;
 
 /* List objects */
 typedef struct {
-  DOH *(*doh_getitem) (DOH *obj, int index);    /* Get item      */
-  int (*doh_setitem) (DOH *obj, int index, DOH *value); /* Set item      */
-  int (*doh_delitem) (DOH *obj, int index);     /* Delete item   */
-  int (*doh_insitem) (DOH *obj, int index, DOH *value); /* Insert item   */
-  int (*doh_delslice) (DOH *obj, int sindex, int eindex);       /* Delete slice  */
+  DOH *(*doh_getitem)(DOH *obj, int index);              /* Get item      */
+  int (*doh_setitem)(DOH *obj, int index, DOH *value);   /* Set item      */
+  int (*doh_delitem)(DOH *obj, int index);               /* Delete item   */
+  int (*doh_insitem)(DOH *obj, int index, DOH *value);   /* Insert item   */
+  int (*doh_delslice)(DOH *obj, int sindex, int eindex); /* Delete slice  */
 } DohListMethods;
 
 /* File methods */
 typedef struct {
-  int (*doh_read) (DOH *obj, void *buffer, int nbytes); /* Read bytes */
-  int (*doh_write) (DOH *obj, const void *buffer, int nbytes);  /* Write bytes */
-  int (*doh_putc) (DOH *obj, int ch);   /* Put character */
-  int (*doh_getc) (DOH *obj);   /* Get character */
-  int (*doh_ungetc) (DOH *obj, int ch); /* Unget character */
-  int (*doh_seek) (DOH *obj, long offset, int whence);  /* Seek */
-  long (*doh_tell) (DOH *obj);  /* Tell */
+  int (*doh_read)(DOH *obj, void *buffer, int nbytes);        /* Read bytes */
+  int (*doh_write)(DOH *obj, const void *buffer, int nbytes); /* Write bytes */
+  int (*doh_putc)(DOH *obj, int ch);                          /* Put character */
+  int (*doh_getc)(DOH *obj);                                  /* Get character */
+  int (*doh_ungetc)(DOH *obj, int ch);                        /* Unget character */
+  int (*doh_seek)(DOH *obj, long offset, int whence);         /* Seek */
+  long (*doh_tell)(DOH *obj);                                 /* Tell */
 } DohFileMethods;
 
 /* String methods */
 typedef struct {
-  int (*doh_replace) (DOH *obj, const DOHString_or_char *old, const DOHString_or_char *rep, int flags);
-  void (*doh_chop) (DOH *obj);
+  int (*doh_replace)(DOH *obj, const DOHString_or_char *old, const DOHString_or_char *rep, int flags);
+  void (*doh_chop)(DOH *obj);
 } DohStringMethods;
 
 /* -----------------------------------------------------------------------------
@@ -62,37 +62,37 @@ typedef struct {
  * ----------------------------------------------------------------------------- */
 
 typedef struct DohObjInfo {
-  const char *objname;          /* Object name        */
+  const char *objname; /* Object name        */
 
   /* Basic object methods */
-  void (*doh_del) (DOH *obj);   /* Delete object      */
-  DOH *(*doh_copy) (DOH *obj);  /* Copy and object    */
-  void (*doh_clear) (DOH *obj); /* Clear an object    */
+  void (*doh_del)(DOH *obj);   /* Delete object      */
+  DOH *(*doh_copy)(DOH *obj);  /* Copy and object    */
+  void (*doh_clear)(DOH *obj); /* Clear an object    */
 
   /* I/O methods */
-  DOH *(*doh_str) (DOH *obj);   /* Make a full string */
-  void *(*doh_data) (DOH *obj); /* Return raw data    */
-  int (*doh_dump) (DOH *obj, DOH *out); /* Serialize on out   */
+  DOH *(*doh_str)(DOH *obj);           /* Make a full string */
+  void *(*doh_data)(DOH *obj);         /* Return raw data    */
+  int (*doh_dump)(DOH *obj, DOH *out); /* Serialize on out   */
 
   /* Length and hash values */
-  int (*doh_len) (DOH *obj);
-  int (*doh_hashval) (DOH *obj);
+  int (*doh_len)(DOH *obj);
+  int (*doh_hashval)(DOH *obj);
 
   /* Compare */
-  int (*doh_cmp) (DOH *obj1, DOH *obj2);
+  int (*doh_cmp)(DOH *obj1, DOH *obj2);
 
   /* Equal */
-  int (*doh_equal) (DOH *obj1, DOH *obj2);
+  int (*doh_equal)(DOH *obj1, DOH *obj2);
 
   /* Iterators */
-  DohIterator (*doh_first) (DOH *obj);
-  DohIterator (*doh_next) (DohIterator);
+  DohIterator (*doh_first)(DOH *obj);
+  DohIterator (*doh_next)(DohIterator);
 
   /* Positional */
-  void (*doh_setfile) (DOH *obj, DOHString_or_char *file);
-  DOH *(*doh_getfile) (DOH *obj);
-  void (*doh_setline) (DOH *obj, int line);
-  int (*doh_getline) (DOH *obj);
+  void (*doh_setfile)(DOH *obj, DOHString_or_char *file);
+  DOH *(*doh_getfile)(DOH *obj);
+  void (*doh_setline)(DOH *obj, int line);
+  int (*doh_getline)(DOH *obj);
 
   DohHashMethods *doh_hash;     /* Hash methods       */
   DohListMethods *doh_list;     /* List methods       */
@@ -103,29 +103,33 @@ typedef struct DohObjInfo {
 } DohObjInfo;
 
 typedef struct {
-  void *data;                   /* Data pointer */
+  void *data; /* Data pointer */
   DohObjInfo *type;
-  void *meta;                   /* Meta data */
-  unsigned int flag_intern:1;   /* Interned object */
-  unsigned int flag_marked:1;   /* Mark flag. Used to avoid recursive loops in places */
-  unsigned int flag_user:1;     /* User flag */
-  unsigned int flag_usermark:1; /* User marked */
-  unsigned int refcount:28;     /* Reference count (max 256 million) */
+  void *meta;                     /* Meta data */
+  unsigned int flag_intern : 1;   /* Interned object */
+  unsigned int flag_marked : 1;   /* Mark flag. Used to avoid recursive loops in places */
+  unsigned int flag_user : 1;     /* User flag */
+  unsigned int flag_usermark : 1; /* User marked */
+  unsigned int refcount : 28;     /* Reference count (max 256 million) */
 } DohBase;
 
 /* Macros for decrefing and increfing (safe for null objects). */
 
-#define Decref(a)         if (a) ((DohBase *) a)->refcount--
-#define Incref(a)         if (a) ((DohBase *) a)->refcount++
-#define Refcount(a)       ((DohBase *) a)->refcount
+#define Decref(a) \
+  if (a)          \
+  ((DohBase *)a)->refcount--
+#define Incref(a) \
+  if (a)          \
+  ((DohBase *)a)->refcount++
+#define Refcount(a)      ((DohBase *)a)->refcount
 
 /* Macros for manipulating objects in a safe manner */
-#define ObjData(a)        ((DohBase *)a)->data
-#define ObjSetMark(a,x)   ((DohBase *)a)->flag_marked = x
-#define ObjGetMark(a)     ((DohBase *)a)->flag_marked
-#define ObjType(a)        ((DohBase *)a)->type
+#define ObjData(a)       ((DohBase *)a)->data
+#define ObjSetMark(a, x) ((DohBase *)a)->flag_marked = x
+#define ObjGetMark(a)    ((DohBase *)a)->flag_marked
+#define ObjType(a)       ((DohBase *)a)->type
 
 extern DOH *DohObjMalloc(DohObjInfo *type, void *data); /* Allocate a DOH object */
-extern void DohObjFree(DOH *ptr);       /* Free a DOH object     */
+extern void DohObjFree(DOH *ptr);                       /* Free a DOH object     */
 
-#endif                          /* SWIG_DOHINT_H */
+#endif /* SWIG_DOHINT_H */

--- a/Source/DOH/dohint.h
+++ b/Source/DOH/dohint.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/DOH/file.c
+++ b/Source/DOH/file.c
@@ -99,7 +99,7 @@ void DohCloseAllOpenFiles(void) {
  * ----------------------------------------------------------------------------- */
 
 static void DelFile(DOH *fo) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->closeondel) {
     if (f->filep) {
       fclose(f->filep);
@@ -109,7 +109,7 @@ static void DelFile(DOH *fo) {
       close(f->fd);
     }
 #endif
-  open_files_list_remove(f);
+    open_files_list_remove(f);
   }
   DohFree(f);
 }
@@ -119,7 +119,7 @@ static void DelFile(DOH *fo) {
  * ----------------------------------------------------------------------------- */
 
 static int File_read(DOH *fo, void *buffer, int len) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
 
   if (f->filep) {
     return (int)fread(buffer, 1, len, f->filep);
@@ -136,9 +136,9 @@ static int File_read(DOH *fo, void *buffer, int len) {
  * ----------------------------------------------------------------------------- */
 
 static int File_write(DOH *fo, const void *buffer, int len) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->filep) {
-    int ret = (int) fwrite(buffer, 1, len, f->filep);
+    int ret = (int)fwrite(buffer, 1, len, f->filep);
     int err = (ret != len) ? ferror(f->filep) : 0;
     return err ? -1 : ret;
   } else if (f->fd) {
@@ -154,7 +154,7 @@ static int File_write(DOH *fo, const void *buffer, int len) {
  * ----------------------------------------------------------------------------- */
 
 static int File_seek(DOH *fo, long offset, int whence) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->filep) {
     return fseek(f->filep, offset, whence);
   } else if (f->fd) {
@@ -170,7 +170,7 @@ static int File_seek(DOH *fo, long offset, int whence) {
  * ----------------------------------------------------------------------------- */
 
 static long File_tell(DOH *fo) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->filep) {
     return ftell(f->filep);
   } else if (f->fd) {
@@ -186,13 +186,13 @@ static long File_tell(DOH *fo) {
  * ----------------------------------------------------------------------------- */
 
 static int File_putc(DOH *fo, int ch) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->filep) {
     return fputc(ch, f->filep);
   } else if (f->fd) {
 #ifdef DOH_INTFILE
     char c;
-    c = (char) ch;
+    c = (char)ch;
     return write(f->fd, &c, 1);
 #endif
   }
@@ -204,7 +204,7 @@ static int File_putc(DOH *fo, int ch) {
  * ----------------------------------------------------------------------------- */
 
 static int File_getc(DOH *fo) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->filep) {
     return fgetc(f->filep);
   } else if (f->fd) {
@@ -225,7 +225,7 @@ static int File_getc(DOH *fo) {
  * ----------------------------------------------------------------------------- */
 
 static int File_ungetc(DOH *fo, int ch) {
-  DohFile *f = (DohFile *) ObjData(fo);
+  DohFile *f = (DohFile *)ObjData(fo);
   if (f->filep) {
     return ungetc(ch, f->filep);
   } else if (f->fd) {
@@ -247,29 +247,29 @@ static DohFileMethods FileFileMethods = {
 };
 
 static DohObjInfo DohFileType = {
-  "DohFile",                    /* objname      */
-  DelFile,                      /* doh_del      */
-  0,                            /* doh_copy     */
-  0,                            /* doh_clear    */
-  0,                            /* doh_str      */
-  0,                            /* doh_data     */
-  0,                            /* doh_dump     */
-  0,                            /* doh_len      */
-  0,                            /* doh_hash     */
-  0,                            /* doh_cmp      */
-  0,                            /* doh_equal    */
-  0,                            /* doh_first    */
-  0,                            /* doh_next     */
-  0,                            /* doh_setfile  */
-  0,                            /* doh_getfile  */
-  0,                            /* doh_setline  */
-  0,                            /* doh_getline  */
-  0,                            /* doh_mapping  */
-  0,                            /* doh_sequence */
-  &FileFileMethods,             /* doh_file     */
-  0,                            /* doh_string   */
-  0,                            /* doh_reserved */
-  0,                            /* clientdata */
+  "DohFile",        /* objname      */
+  DelFile,          /* doh_del      */
+  0,                /* doh_copy     */
+  0,                /* doh_clear    */
+  0,                /* doh_str      */
+  0,                /* doh_data     */
+  0,                /* doh_dump     */
+  0,                /* doh_len      */
+  0,                /* doh_hash     */
+  0,                /* doh_cmp      */
+  0,                /* doh_equal    */
+  0,                /* doh_first    */
+  0,                /* doh_next     */
+  0,                /* doh_setfile  */
+  0,                /* doh_getfile  */
+  0,                /* doh_setline  */
+  0,                /* doh_getline  */
+  0,                /* doh_mapping  */
+  0,                /* doh_sequence */
+  &FileFileMethods, /* doh_file     */
+  0,                /* doh_string   */
+  0,                /* doh_reserved */
+  0,                /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------
@@ -290,7 +290,7 @@ DOH *DohNewFile(DOHString *filename, const char *mode, DOHList *newfiles) {
   if (!file)
     return 0;
 
-  f = (DohFile *) DohMalloc(sizeof(DohFile));
+  f = (DohFile *)DohMalloc(sizeof(DohFile));
   if (newfiles)
     Append(newfiles, filename);
   f->filep = file;
@@ -309,7 +309,7 @@ DOH *DohNewFile(DOHString *filename, const char *mode, DOHList *newfiles) {
 
 DOH *DohNewFileFromFile(FILE *file) {
   DohFile *f;
-  f = (DohFile *) DohMalloc(sizeof(DohFile));
+  f = (DohFile *)DohMalloc(sizeof(DohFile));
   f->filep = file;
   f->fd = 0;
   f->closeondel = 0;
@@ -324,7 +324,7 @@ DOH *DohNewFileFromFile(FILE *file) {
 
 DOH *DohNewFileFromFd(int fd) {
   DohFile *f;
-  f = (DohFile *) DohMalloc(sizeof(DohFile));
+  f = (DohFile *)DohMalloc(sizeof(DohFile));
   f->filep = 0;
   f->fd = fd;
   f->closeondel = 0;
@@ -337,6 +337,6 @@ DOH *DohNewFileFromFd(int fd) {
  * Display cause of one of the NewFile functions failing.
  * ----------------------------------------------------------------------------- */
 
-void DohFileErrorDisplay(DOHString * filename) {
+void DohFileErrorDisplay(DOHString *filename) {
   Printf(stderr, "Unable to open file %s: %s\n", filename, strerror(errno));
 }

--- a/Source/DOH/file.c
+++ b/Source/DOH/file.c
@@ -84,8 +84,8 @@ void DohCloseAllOpenFiles(void) {
     (void)check;
     if (f->closeondel) {
       if (f->filep) {
-	check = fclose(f->filep);
-	assert(check == 0);
+        check = fclose(f->filep);
+        assert(check == 0);
       }
       f->closeondel = 0;
       f->filep = 0;

--- a/Source/DOH/file.c
+++ b/Source/DOH/file.c
@@ -247,29 +247,29 @@ static DohFileMethods FileFileMethods = {
 };
 
 static DohObjInfo DohFileType = {
-  "DohFile",			/* objname      */
-  DelFile,			/* doh_del      */
-  0,				/* doh_copy     */
-  0,				/* doh_clear    */
-  0,				/* doh_str      */
-  0,				/* doh_data     */
-  0,				/* doh_dump     */
-  0,				/* doh_len      */
-  0,				/* doh_hash     */
-  0,				/* doh_cmp      */
-  0,				/* doh_equal    */
-  0,				/* doh_first    */
-  0,				/* doh_next     */
-  0,				/* doh_setfile  */
-  0,				/* doh_getfile  */
-  0,				/* doh_setline  */
-  0,				/* doh_getline  */
-  0,				/* doh_mapping  */
-  0,				/* doh_sequence */
-  &FileFileMethods,		/* doh_file     */
-  0,				/* doh_string   */
-  0,				/* doh_reserved */
-  0,				/* clientdata */
+  "DohFile",                    /* objname      */
+  DelFile,                      /* doh_del      */
+  0,                            /* doh_copy     */
+  0,                            /* doh_clear    */
+  0,                            /* doh_str      */
+  0,                            /* doh_data     */
+  0,                            /* doh_dump     */
+  0,                            /* doh_len      */
+  0,                            /* doh_hash     */
+  0,                            /* doh_cmp      */
+  0,                            /* doh_equal    */
+  0,                            /* doh_first    */
+  0,                            /* doh_next     */
+  0,                            /* doh_setfile  */
+  0,                            /* doh_getfile  */
+  0,                            /* doh_setline  */
+  0,                            /* doh_getline  */
+  0,                            /* doh_mapping  */
+  0,                            /* doh_sequence */
+  &FileFileMethods,             /* doh_file     */
+  0,                            /* doh_string   */
+  0,                            /* doh_reserved */
+  0,                            /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------

--- a/Source/DOH/file.c
+++ b/Source/DOH/file.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -8,7 +8,7 @@
  *
  * file.c
  *
- *     This file implements a file-like object that can be built around an 
+ *     This file implements a file-like object that can be built around an
  *     ordinary FILE * or integer file descriptor.
  * ----------------------------------------------------------------------------- */
 

--- a/Source/DOH/fio.c
+++ b/Source/DOH/fio.c
@@ -14,9 +14,9 @@
 
 #include "dohint.h"
 
-#define OBUFLEN  512
+#define OBUFLEN 512
 
-static DOH *encodings = 0;      /* Encoding hash */
+static DOH *encodings = 0; /* Encoding hash */
 
 /* -----------------------------------------------------------------------------
  * Writen()
@@ -27,7 +27,7 @@ static DOH *encodings = 0;      /* Encoding hash */
 
 static int Writen(DOH *out, void *buffer, int len) {
   int nw = len, ret;
-  char *cb = (char *) buffer;
+  char *cb = (char *)buffer;
   while (nw) {
     ret = Write(out, cb, nw);
     if (ret < 0)
@@ -45,14 +45,14 @@ static int Writen(DOH *out, void *buffer, int len) {
  * two file-like objects and operate as a filter.
  * ----------------------------------------------------------------------------- */
 
-void DohEncoding(const char *name, DOH *(*fn) (DOH *s)) {
+void DohEncoding(const char *name, DOH *(*fn)(DOH *s)) {
   DohFuncPtr_t fp;
 
   if (!encodings)
     encodings = NewHash();
 
   fp.func = fn;
-  Setattr(encodings, (void *) name, NewVoid(fp.p, 0));
+  Setattr(encodings, (void *)name, NewVoid(fp.p, 0));
 }
 
 /* internal function for processing an encoding */
@@ -65,8 +65,8 @@ static DOH *encode(char *name, DOH *s) {
   if (cfmt) {
     tmp = NewString(cfmt + 1);
     Append(tmp, s);
-    Setfile(tmp, Getfile((DOH *) s));
-    Setline(tmp, Getline((DOH *) s));
+    Setfile(tmp, Getfile((DOH *)s));
+    Setline(tmp, Getline((DOH *)s));
     *cfmt = '\0';
   }
   if (!encodings || !(handle = Getattr(encodings, name))) {
@@ -78,7 +78,7 @@ static DOH *encode(char *name, DOH *s) {
   Seek(s, 0, SEEK_SET);
 
   fp.p = Data(handle);
-  ns = (*fp.func) (s);
+  ns = (*fp.func)(s);
   assert(pos != -1);
   (void)Seek(s, pos, SEEK_SET);
   if (tmp)
@@ -125,7 +125,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
 
   while (*p) {
     switch (state) {
-    case 0:                     /* Ordinary text */
+    case 0: /* Ordinary text */
       if (*p != '%') {
         Putc(*p, so);
         nbytes++;
@@ -138,8 +138,8 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
         state = 10;
       }
       break;
-    case 10:                    /* Look for a width and precision */
-      if (isdigit((int) *p) && (*p != '0')) {
+    case 10: /* Look for a width and precision */
+      if (isdigit((int)*p) && (*p != '0')) {
         w = temp;
         *(w++) = *p;
         *(fmt++) = *p;
@@ -170,8 +170,8 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
       }
       break;
 
-    case 20:                    /* Hmmm. At the start of a width field */
-      if (isdigit((int) *p)) {
+    case 20: /* Hmmm. At the start of a width field */
+      if (isdigit((int)*p)) {
         *(w++) = *p;
         *(fmt++) = *p;
       } else if (strchr(fmt_codes, *p)) {
@@ -195,7 +195,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
       }
       break;
 
-    case 30:                    /* Parsed a width from an argument.  Look for a . */
+    case 30: /* Parsed a width from an argument.  Look for a . */
       if (*p == '.') {
         w = temp;
         *(fmt++) = *p;
@@ -213,7 +213,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
 
     case 40:
       /* Start of precision expected */
-      if (isdigit((int) *p) && (*p != '0')) {
+      if (isdigit((int)*p) && (*p != '0')) {
         *(fmt++) = *p;
         *(w++) = *p;
         state = 41;
@@ -234,7 +234,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
       }
       break;
     case 41:
-      if (isdigit((int) *p)) {
+      if (isdigit((int)*p)) {
         *(fmt++) = *p;
         *(w++) = *p;
       } else if (strchr(fmt_codes, *p)) {
@@ -310,7 +310,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
           if ((maxwidth + 1) < OBUFLEN) {
             stemp = obuffer;
           } else {
-            stemp = (char *) DohMalloc(maxwidth + 1);
+            stemp = (char *)DohMalloc(maxwidth + 1);
           }
           if (enc) {
             nbytes += sprintf(stemp, newformat, Data(enc));
@@ -319,7 +319,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
           }
           if (Writen(so, stemp, (int)strlen(stemp)) < 0)
             return -1;
-          if ((DOH *) Sval != doh) {
+          if ((DOH *)Sval != doh) {
             Delete(Sval);
           }
           if (enc)
@@ -332,7 +332,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
           }
         } else {
           if (!doh)
-            doh = (char *) "";
+            doh = (char *)"";
 
           if (strlen(encoder)) {
             DOH *s = NewString(doh);
@@ -343,13 +343,13 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
           } else {
             enc = 0;
           }
-          maxwidth = maxwidth + (int)strlen(newformat) + (int)strlen((char *) doh);
+          maxwidth = maxwidth + (int)strlen(newformat) + (int)strlen((char *)doh);
           *(fmt++) = 's';
           *fmt = 0;
           if ((maxwidth + 1) < OBUFLEN) {
             stemp = obuffer;
           } else {
-            stemp = (char *) DohMalloc(maxwidth + 1);
+            stemp = (char *)DohMalloc(maxwidth + 1);
           }
           nbytes += sprintf(stemp, newformat, doh);
           if (Writen(so, stemp, (int)strlen(stemp)) < 0)
@@ -371,7 +371,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
         if (maxwidth < OBUFLEN)
           stemp = obuffer;
         else
-          stemp = (char *) DohMalloc(maxwidth + 1);
+          stemp = (char *)DohMalloc(maxwidth + 1);
         switch (*p) {
         case 'd':
         case 'i':
@@ -390,25 +390,28 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
             break;
           }
           /* FALLTHRU */
-        case 'c': {
-          int ivalue = va_arg(ap, int);
-          nbytes += sprintf(stemp, newformat, ivalue);
-          break;
-        }
+        case 'c':
+          {
+            int ivalue = va_arg(ap, int);
+            nbytes += sprintf(stemp, newformat, ivalue);
+            break;
+          }
         case 'f':
         case 'g':
         case 'e':
         case 'E':
-        case 'G': {
-          double dvalue = va_arg(ap, double);
-          nbytes += sprintf(stemp, newformat, dvalue);
-          break;
-        }
-        case 'p': {
-          void *pvalue = va_arg(ap, void *);
-          nbytes += sprintf(stemp, newformat, pvalue);
-          break;
-        }
+        case 'G':
+          {
+            double dvalue = va_arg(ap, double);
+            nbytes += sprintf(stemp, newformat, dvalue);
+            break;
+          }
+        case 'p':
+          {
+            void *pvalue = va_arg(ap, void *);
+            nbytes += sprintf(stemp, newformat, pvalue);
+            break;
+          }
         default:
           break;
         }
@@ -454,7 +457,7 @@ int DohPrintf(DOH *obj, const char *format, ...) {
  * Print a null-terminated variable length list of DOH objects
  * ----------------------------------------------------------------------------- */
 
-int DohPrintv(DOHFile * f, ...) {
+int DohPrintv(DOHFile *f, ...) {
   va_list ap;
   int ret = 0;
   DOH *obj;
@@ -466,7 +469,7 @@ int DohPrintv(DOHFile * f, ...) {
     if (DohCheck(obj)) {
       ret += DohDump(obj, f);
     } else {
-      ret += DohWrite(f, obj, (int)strlen((char *) obj));
+      ret += DohWrite(f, obj, (int)strlen((char *)obj));
     }
   }
   va_end(ap);
@@ -509,7 +512,6 @@ int DohCopyto(DOH *in, DOH *out) {
   }
   return nbytes;
 }
-
 
 /* -----------------------------------------------------------------------------
  * DohSplit()
@@ -579,7 +581,6 @@ DOH *DohSplitLines(DOH *in) {
   }
   return list;
 }
-
 
 /* -----------------------------------------------------------------------------
  * DohReadline()

--- a/Source/DOH/fio.c
+++ b/Source/DOH/fio.c
@@ -127,295 +127,295 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
     switch (state) {
     case 0:			/* Ordinary text */
       if (*p != '%') {
-	Putc(*p, so);
-	nbytes++;
+        Putc(*p, so);
+        nbytes++;
       } else {
-	fmt = newformat;
-	widthval = 0;
-	precval = 0;
-	*(fmt++) = *p;
-	encoder[0] = 0;
-	state = 10;
+        fmt = newformat;
+        widthval = 0;
+        precval = 0;
+        *(fmt++) = *p;
+        encoder[0] = 0;
+        state = 10;
       }
       break;
     case 10:			/* Look for a width and precision */
       if (isdigit((int) *p) && (*p != '0')) {
-	w = temp;
-	*(w++) = *p;
-	*(fmt++) = *p;
-	state = 20;
+        w = temp;
+        *(w++) = *p;
+        *(fmt++) = *p;
+        state = 20;
       } else if (strchr(fmt_codes, *p)) {
-	/* Got one of the formatting codes */
-	p--;
-	state = 100;
+        /* Got one of the formatting codes */
+        p--;
+        state = 100;
       } else if (*p == '*') {
-	/* Width field is specified in the format list */
-	widthval = va_arg(ap, int);
-	sprintf(temp, "%d", widthval);
-	for (w = temp; *w; w++) {
-	  *(fmt++) = *w;
-	}
-	state = 30;
+        /* Width field is specified in the format list */
+        widthval = va_arg(ap, int);
+        sprintf(temp, "%d", widthval);
+        for (w = temp; *w; w++) {
+          *(fmt++) = *w;
+        }
+        state = 30;
       } else if (*p == '%') {
-	Putc(*p, so);
-	fmt = newformat;
-	nbytes++;
-	state = 0;
+        Putc(*p, so);
+        fmt = newformat;
+        nbytes++;
+        state = 0;
       } else if (*p == '(') {
-	++plevel;
-	ec = encoder;
-	state = 60;
+        ++plevel;
+        ec = encoder;
+        state = 60;
       } else {
-	*(fmt++) = *p;
+        *(fmt++) = *p;
       }
       break;
 
     case 20:			/* Hmmm. At the start of a width field */
       if (isdigit((int) *p)) {
-	*(w++) = *p;
-	*(fmt++) = *p;
+        *(w++) = *p;
+        *(fmt++) = *p;
       } else if (strchr(fmt_codes, *p)) {
-	/* Got one of the formatting codes */
-	/* Figure out width */
-	*w = 0;
-	widthval = atoi(temp);
-	p--;
-	state = 100;
+        /* Got one of the formatting codes */
+        /* Figure out width */
+        *w = 0;
+        widthval = atoi(temp);
+        p--;
+        state = 100;
       } else if (*p == '.') {
-	*w = 0;
-	widthval = atoi(temp);
-	w = temp;
-	*(fmt++) = *p;
-	state = 40;
+        *w = 0;
+        widthval = atoi(temp);
+        w = temp;
+        *(fmt++) = *p;
+        state = 40;
       } else {
-	/* ??? */
-	*w = 0;
-	widthval = atoi(temp);
-	state = 50;
+        /* ??? */
+        *w = 0;
+        widthval = atoi(temp);
+        state = 50;
       }
       break;
 
     case 30:			/* Parsed a width from an argument.  Look for a . */
       if (*p == '.') {
-	w = temp;
-	*(fmt++) = *p;
-	state = 40;
+        w = temp;
+        *(fmt++) = *p;
+        state = 40;
       } else if (strchr(fmt_codes, *p)) {
-	/* Got one of the formatting codes */
-	/* Figure out width */
-	p--;
-	state = 100;
+        /* Got one of the formatting codes */
+        /* Figure out width */
+        p--;
+        state = 100;
       } else {
-	/* hmmm. Something else. */
-	state = 50;
+        /* hmmm. Something else. */
+        state = 50;
       }
       break;
 
     case 40:
       /* Start of precision expected */
       if (isdigit((int) *p) && (*p != '0')) {
-	*(fmt++) = *p;
-	*(w++) = *p;
-	state = 41;
+        *(fmt++) = *p;
+        *(w++) = *p;
+        state = 41;
       } else if (*p == '*') {
-	/* Precision field is specified in the format list */
-	precval = va_arg(ap, int);
-	sprintf(temp, "%d", precval);
-	for (w = temp; *w; w++) {
-	  *(fmt++) = *w;
-	}
-	state = 50;
+        /* Precision field is specified in the format list */
+        precval = va_arg(ap, int);
+        sprintf(temp, "%d", precval);
+        for (w = temp; *w; w++) {
+          *(fmt++) = *w;
+        }
+        state = 50;
       } else if (strchr(fmt_codes, *p)) {
-	p--;
-	state = 100;
+        p--;
+        state = 100;
       } else {
-	*(fmt++) = *p;
-	state = 50;
+        *(fmt++) = *p;
+        state = 50;
       }
       break;
     case 41:
       if (isdigit((int) *p)) {
-	*(fmt++) = *p;
-	*(w++) = *p;
+        *(fmt++) = *p;
+        *(w++) = *p;
       } else if (strchr(fmt_codes, *p)) {
-	/* Got one of the formatting codes */
-	/* Figure out width */
-	*w = 0;
-	precval = atoi(temp);
-	p--;
-	state = 100;
+        /* Got one of the formatting codes */
+        /* Figure out width */
+        *w = 0;
+        precval = atoi(temp);
+        p--;
+        state = 100;
       } else {
-	*w = 0;
-	precval = atoi(temp);
-	*(fmt++) = *p;
-	state = 50;
+        *w = 0;
+        precval = atoi(temp);
+        *(fmt++) = *p;
+        state = 50;
       }
       break;
       /* Hang out, wait for format specifier */
     case 50:
       if (strchr(fmt_codes, *p)) {
-	p--;
-	state = 100;
+        p--;
+        state = 100;
       } else {
-	*(fmt++) = *p;
+        *(fmt++) = *p;
       }
       break;
 
       /* Got an encoding header */
     case 60:
       if (*p == '(') {
-	++plevel;
-	*ec = *p;
-	ec++;
+        ++plevel;
+        *ec = *p;
+        ec++;
       } else if (*p == ')') {
-	--plevel;
-	if (plevel <= 0) {
-	  *ec = 0;
-	  state = 10;
-	} else {
-	  *ec = *p;
-	  ec++;
-	}
+        --plevel;
+        if (plevel <= 0) {
+          *ec = 0;
+          state = 10;
+        } else {
+          *ec = *p;
+          ec++;
+        }
       } else {
-	*ec = *p;
-	ec++;
+        *ec = *p;
+        ec++;
       }
       break;
     case 100:
       /* Got a formatting code */
       if (widthval < precval)
-	maxwidth = precval;
+        maxwidth = precval;
       else
-	maxwidth = widthval;
+        maxwidth = widthval;
       if ((*p == 's') || (*p == 'S')) {	/* Null-Terminated string */
-	DOH *doh;
-	DOH *Sval;
-	DOH *enc = 0;
-	doh = va_arg(ap, DOH *);
-	if (DohCheck(doh)) {
-	  /* Is a DOH object. */
-	  if (DohIsString(doh)) {
-	    Sval = doh;
-	  } else {
-	    Sval = Str(doh);
-	  }
-	  if (strlen(encoder)) {
-	    enc = encode(encoder, Sval);
-	    maxwidth = maxwidth + (int)strlen(newformat) + Len(enc);
-	  } else {
-	    maxwidth = maxwidth + (int)strlen(newformat) + Len(Sval);
-	  }
-	  *(fmt++) = 's';
-	  *fmt = 0;
-	  if ((maxwidth + 1) < OBUFLEN) {
-	    stemp = obuffer;
-	  } else {
-	    stemp = (char *) DohMalloc(maxwidth + 1);
-	  }
-	  if (enc) {
-	    nbytes += sprintf(stemp, newformat, Data(enc));
-	  } else {
-	    nbytes += sprintf(stemp, newformat, Data(Sval));
-	  }
-	  if (Writen(so, stemp, (int)strlen(stemp)) < 0)
-	    return -1;
-	  if ((DOH *) Sval != doh) {
-	    Delete(Sval);
-	  }
-	  if (enc)
-	    Delete(enc);
-	  if (*p == 'S') {
-	    Delete(doh);
-	  }
-	  if (stemp != obuffer) {
-	    DohFree(stemp);
-	  }
-	} else {
-	  if (!doh)
-	    doh = (char *) "";
+        DOH *doh;
+        DOH *Sval;
+        DOH *enc = 0;
+        doh = va_arg(ap, DOH *);
+        if (DohCheck(doh)) {
+          /* Is a DOH object. */
+          if (DohIsString(doh)) {
+            Sval = doh;
+          } else {
+            Sval = Str(doh);
+          }
+          if (strlen(encoder)) {
+            enc = encode(encoder, Sval);
+            maxwidth = maxwidth + (int)strlen(newformat) + Len(enc);
+          } else {
+            maxwidth = maxwidth + (int)strlen(newformat) + Len(Sval);
+          }
+          *(fmt++) = 's';
+          *fmt = 0;
+          if ((maxwidth + 1) < OBUFLEN) {
+            stemp = obuffer;
+          } else {
+            stemp = (char *) DohMalloc(maxwidth + 1);
+          }
+          if (enc) {
+            nbytes += sprintf(stemp, newformat, Data(enc));
+          } else {
+            nbytes += sprintf(stemp, newformat, Data(Sval));
+          }
+          if (Writen(so, stemp, (int)strlen(stemp)) < 0)
+            return -1;
+          if ((DOH *) Sval != doh) {
+            Delete(Sval);
+          }
+          if (enc)
+            Delete(enc);
+          if (*p == 'S') {
+            Delete(doh);
+          }
+          if (stemp != obuffer) {
+            DohFree(stemp);
+          }
+        } else {
+          if (!doh)
+            doh = (char *) "";
 
-	  if (strlen(encoder)) {
-	    DOH *s = NewString(doh);
-	    Seek(s, 0, SEEK_SET);
-	    enc = encode(encoder, s);
-	    Delete(s);
-	    doh = Char(enc);
-	  } else {
-	    enc = 0;
-	  }
-	  maxwidth = maxwidth + (int)strlen(newformat) + (int)strlen((char *) doh);
-	  *(fmt++) = 's';
-	  *fmt = 0;
-	  if ((maxwidth + 1) < OBUFLEN) {
-	    stemp = obuffer;
-	  } else {
-	    stemp = (char *) DohMalloc(maxwidth + 1);
-	  }
-	  nbytes += sprintf(stemp, newformat, doh);
-	  if (Writen(so, stemp, (int)strlen(stemp)) < 0)
-	    return -1;
-	  if (stemp != obuffer) {
-	    DohFree(stemp);
-	  }
-	  if (enc)
-	    Delete(enc);
-	}
+          if (strlen(encoder)) {
+            DOH *s = NewString(doh);
+            Seek(s, 0, SEEK_SET);
+            enc = encode(encoder, s);
+            Delete(s);
+            doh = Char(enc);
+          } else {
+            enc = 0;
+          }
+          maxwidth = maxwidth + (int)strlen(newformat) + (int)strlen((char *) doh);
+          *(fmt++) = 's';
+          *fmt = 0;
+          if ((maxwidth + 1) < OBUFLEN) {
+            stemp = obuffer;
+          } else {
+            stemp = (char *) DohMalloc(maxwidth + 1);
+          }
+          nbytes += sprintf(stemp, newformat, doh);
+          if (Writen(so, stemp, (int)strlen(stemp)) < 0)
+            return -1;
+          if (stemp != obuffer) {
+            DohFree(stemp);
+          }
+          if (enc)
+            Delete(enc);
+        }
       } else {
-	*(fmt++) = *p;
-	*fmt = 0;
-	maxwidth = maxwidth + (int)strlen(newformat) + 64;
+        *(fmt++) = *p;
+        *fmt = 0;
+        maxwidth = maxwidth + (int)strlen(newformat) + 64;
 
-	/* Only allocate a buffer if it is too big to fit.  Shouldn't have to do
-	   this very often */
+        /* Only allocate a buffer if it is too big to fit.  Shouldn't have to do
+           this very often */
 
-	if (maxwidth < OBUFLEN)
-	  stemp = obuffer;
-	else
-	  stemp = (char *) DohMalloc(maxwidth + 1);
-	switch (*p) {
-	case 'd':
-	case 'i':
-	case 'o':
-	case 'u':
-	case 'x':
-	case 'X':
-	  if (p[-1] == 'l') {
-	    if (p[-2] == 'l') {
-	      long long llvalue = va_arg(ap, long long);
-	      nbytes += sprintf(stemp, newformat, llvalue);
-	      break;
-	    }
-	    long lvalue = va_arg(ap, long);
-	    nbytes += sprintf(stemp, newformat, lvalue);
-	    break;
-	  }
-	  /* FALLTHRU */
-	case 'c': {
-	  int ivalue = va_arg(ap, int);
-	  nbytes += sprintf(stemp, newformat, ivalue);
-	  break;
-	}
-	case 'f':
-	case 'g':
-	case 'e':
-	case 'E':
-	case 'G': {
-	  double dvalue = va_arg(ap, double);
-	  nbytes += sprintf(stemp, newformat, dvalue);
-	  break;
-	}
-	case 'p': {
-	  void *pvalue = va_arg(ap, void *);
-	  nbytes += sprintf(stemp, newformat, pvalue);
-	  break;
-	}
-	default:
-	  break;
-	}
-	if (Writen(so, stemp, (int)strlen(stemp)) < 0)
-	  return -1;
-	if (stemp != obuffer)
-	  DohFree(stemp);
+        if (maxwidth < OBUFLEN)
+          stemp = obuffer;
+        else
+          stemp = (char *) DohMalloc(maxwidth + 1);
+        switch (*p) {
+        case 'd':
+        case 'i':
+        case 'o':
+        case 'u':
+        case 'x':
+        case 'X':
+          if (p[-1] == 'l') {
+            if (p[-2] == 'l') {
+              long long llvalue = va_arg(ap, long long);
+              nbytes += sprintf(stemp, newformat, llvalue);
+              break;
+            }
+            long lvalue = va_arg(ap, long);
+            nbytes += sprintf(stemp, newformat, lvalue);
+            break;
+          }
+          /* FALLTHRU */
+        case 'c': {
+          int ivalue = va_arg(ap, int);
+          nbytes += sprintf(stemp, newformat, ivalue);
+          break;
+        }
+        case 'f':
+        case 'g':
+        case 'e':
+        case 'E':
+        case 'G': {
+          double dvalue = va_arg(ap, double);
+          nbytes += sprintf(stemp, newformat, dvalue);
+          break;
+        }
+        case 'p': {
+          void *pvalue = va_arg(ap, void *);
+          nbytes += sprintf(stemp, newformat, pvalue);
+          break;
+        }
+        default:
+          break;
+        }
+        if (Writen(so, stemp, (int)strlen(stemp)) < 0)
+          return -1;
+        if (stemp != obuffer)
+          DohFree(stemp);
       }
       state = 0;
       break;
@@ -494,13 +494,13 @@ int DohCopyto(DOH *in, DOH *out) {
       nwrite = ret;
       cw = buffer;
       while (nwrite) {
-	wret = Write(out, cw, nwrite);
-	if (wret < 0) {
-	  nbytes = -1;
-	  break;
-	}
-	nwrite = nwrite - wret;
-	cw += wret;
+        wret = Write(out, cw, nwrite);
+        if (wret < 0) {
+          nbytes = -1;
+          break;
+        }
+        nwrite = nwrite - wret;
+        cw += wret;
       }
       nbytes += ret;
     } else {
@@ -537,10 +537,10 @@ DOH *DohSplit(DOH *in, char ch, int nsplits) {
     if (c != EOF) {
       Putc(c, str);
       while (1) {
-	c = Getc(in);
-	if ((c == EOF) || ((c == ch) && (nsplits != 0)))
-	  break;
-	Putc(c, str);
+        c = Getc(in);
+        if ((c == EOF) || ((c == ch) && (nsplits != 0)))
+          break;
+        Putc(c, str);
       }
       nsplits--;
     }
@@ -594,8 +594,8 @@ DOH *DohReadline(DOH *in) {
   while (1) {
     if (Read(in, &c, 1) < 0) {
       if (n == 0) {
-	Delete(s);
-	s = 0;
+        Delete(s);
+        s = 0;
       }
       break;
     }

--- a/Source/DOH/fio.c
+++ b/Source/DOH/fio.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -450,7 +450,7 @@ int DohPrintf(DOH *obj, const char *format, ...) {
 
 /* -----------------------------------------------------------------------------
  * DohPrintv()
- * 
+ *
  * Print a null-terminated variable length list of DOH objects
  * ----------------------------------------------------------------------------- */
 
@@ -473,7 +473,7 @@ int DohPrintv(DOHFile * f, ...) {
   return ret;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * DohCopyto()
  *
  * Copies all of the input from an input stream to an output stream. Returns the

--- a/Source/DOH/fio.c
+++ b/Source/DOH/fio.c
@@ -16,7 +16,7 @@
 
 #define OBUFLEN  512
 
-static DOH *encodings = 0;	/* Encoding hash */
+static DOH *encodings = 0;      /* Encoding hash */
 
 /* -----------------------------------------------------------------------------
  * Writen()
@@ -125,7 +125,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
 
   while (*p) {
     switch (state) {
-    case 0:			/* Ordinary text */
+    case 0:                     /* Ordinary text */
       if (*p != '%') {
         Putc(*p, so);
         nbytes++;
@@ -138,7 +138,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
         state = 10;
       }
       break;
-    case 10:			/* Look for a width and precision */
+    case 10:                    /* Look for a width and precision */
       if (isdigit((int) *p) && (*p != '0')) {
         w = temp;
         *(w++) = *p;
@@ -170,7 +170,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
       }
       break;
 
-    case 20:			/* Hmmm. At the start of a width field */
+    case 20:                    /* Hmmm. At the start of a width field */
       if (isdigit((int) *p)) {
         *(w++) = *p;
         *(fmt++) = *p;
@@ -195,7 +195,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
       }
       break;
 
-    case 30:			/* Parsed a width from an argument.  Look for a . */
+    case 30:                    /* Parsed a width from an argument.  Look for a . */
       if (*p == '.') {
         w = temp;
         *(fmt++) = *p;
@@ -287,7 +287,7 @@ int DohvPrintf(DOH *so, const char *format, va_list ap) {
         maxwidth = precval;
       else
         maxwidth = widthval;
-      if ((*p == 's') || (*p == 'S')) {	/* Null-Terminated string */
+      if ((*p == 's') || (*p == 'S')) { /* Null-Terminated string */
         DOH *doh;
         DOH *Sval;
         DOH *enc = 0;

--- a/Source/DOH/hash.c
+++ b/Source/DOH/hash.c
@@ -44,7 +44,7 @@ static int max_expand = 1;
 
 /* Find or create a key in the interned key table */
 static DOH *find_key(DOH *doh_c) {
-  char *c = (char *) doh_c;
+  char *c = (char *)doh_c;
   KeyValue *r, *s;
   int d = 0;
   /* OK, sure, we use a binary tree for maintaining interned
@@ -63,8 +63,8 @@ static DOH *find_key(DOH *doh_c) {
       r = r->right;
   }
   /*  fprintf(stderr,"Interning '%s'\n", c); */
-  r = (KeyValue *) DohMalloc(sizeof(KeyValue));
-  r->cstr = (char *) DohMalloc(strlen(c) + 1);
+  r = (KeyValue *)DohMalloc(sizeof(KeyValue));
+  r->cstr = (char *)DohMalloc(strlen(c) + 1);
   strcpy(r->cstr, c);
   r->sstr = NewString(c);
   DohIntern(r->sstr);
@@ -81,11 +81,11 @@ static DOH *find_key(DOH *doh_c) {
   return r->sstr;
 }
 
-#define HASH_INIT_SIZE   7
+#define HASH_INIT_SIZE 7
 
 /* Create a new hash node */
 static HashNode *NewNode(DOH *k, void *obj) {
-  HashNode *hn = (HashNode *) DohMalloc(sizeof(HashNode));
+  HashNode *hn = (HashNode *)DohMalloc(sizeof(HashNode));
   hn->key = k;
   Incref(hn->key);
   hn->object = obj;
@@ -108,7 +108,7 @@ static void DelNode(HashNode *hn) {
  * ----------------------------------------------------------------------------- */
 
 static void DelHash(DOH *ho) {
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   HashNode *n, *next;
   int i;
 
@@ -134,7 +134,7 @@ static void DelHash(DOH *ho) {
  * ----------------------------------------------------------------------------- */
 
 static void Hash_clear(DOH *ho) {
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   HashNode *n, *next;
   int i;
 
@@ -174,7 +174,7 @@ static void resize(Hash *h) {
     p = p + 2;
   }
 
-  table = (HashNode **) DohCalloc(newsize, sizeof(HashNode *));
+  table = (HashNode **)DohCalloc(newsize, sizeof(HashNode *));
 
   /* Walk down the old set of nodes and re-place */
   h->hashsize = newsize;
@@ -202,7 +202,7 @@ static void resize(Hash *h) {
 static int Hash_setattr(DOH *ho, DOH *k, DOH *obj) {
   int hv;
   HashNode *n, *prev;
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
 
   if (!obj) {
     return DohDelattr(ho, k);
@@ -210,7 +210,7 @@ static int Hash_setattr(DOH *ho, DOH *k, DOH *obj) {
   if (!DohCheck(k))
     k = find_key(k);
   if (!DohCheck(obj)) {
-    obj = NewString((char *) obj);
+    obj = NewString((char *)obj);
     Decref(obj);
   }
   hv = (Hashval(k)) % h->hashsize;
@@ -226,7 +226,7 @@ static int Hash_setattr(DOH *ho, DOH *k, DOH *obj) {
       Delete(n->object);
       n->object = obj;
       Incref(obj);
-      return 1;                 /* Return 1 to indicate a replacement */
+      return 1; /* Return 1 to indicate a replacement */
     } else {
       prev = n;
       n = n->next;
@@ -248,28 +248,29 @@ static int Hash_setattr(DOH *ho, DOH *k, DOH *obj) {
  *
  * Get an attribute from the hash table. Returns 0 if it doesn't exist.
  * ----------------------------------------------------------------------------- */
-typedef int (*binop) (DOH *obj1, DOH *obj2);
-
+typedef int (*binop)(DOH *obj1, DOH *obj2);
 
 static DOH *Hash_getattr(DOH *h, DOH *k) {
   DOH *obj = 0;
-  Hash *ho = (Hash *) ObjData(h);
+  Hash *ho = (Hash *)ObjData(h);
   DOH *ko = DohCheck(k) ? k : find_key(k);
   int hv = Hashval(ko) % ho->hashsize;
-  DohObjInfo *k_type = ((DohBase*)ko)->type;
+  DohObjInfo *k_type = ((DohBase *)ko)->type;
   HashNode *n = ho->hashtable[hv];
   if (k_type->doh_equal) {
     binop equal = k_type->doh_equal;
     while (n) {
       DohBase *nk = (DohBase *)n->key;
-      if ((k_type == nk->type) && equal(ko, nk)) obj = n->object;
+      if ((k_type == nk->type) && equal(ko, nk))
+        obj = n->object;
       n = n->next;
     }
   } else {
     binop cmp = k_type->doh_cmp;
     while (n) {
       DohBase *nk = (DohBase *)n->key;
-      if ((k_type == nk->type) && (cmp(ko, nk) == 0)) obj = n->object;
+      if ((k_type == nk->type) && (cmp(ko, nk) == 0))
+        obj = n->object;
       n = n->next;
     }
   }
@@ -285,7 +286,7 @@ static DOH *Hash_getattr(DOH *h, DOH *k) {
 static int Hash_delattr(DOH *ho, DOH *k) {
   HashNode *n, *prev;
   int hv;
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
 
   if (!DohCheck(k))
     k = find_key(k);
@@ -313,12 +314,12 @@ static int Hash_delattr(DOH *ho, DOH *k) {
 
 static DohIterator Hash_firstiter(DOH *ho) {
   DohIterator iter;
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   iter.object = ho;
   iter._current = 0;
   iter.item = 0;
   iter.key = 0;
-  iter._index = 0;              /* Index in hash table */
+  iter._index = 0; /* Index in hash table */
   while ((iter._index < h->hashsize) && !h->hashtable[iter._index])
     iter._index++;
 
@@ -326,17 +327,17 @@ static DohIterator Hash_firstiter(DOH *ho) {
     return iter;
   }
   iter._current = h->hashtable[iter._index];
-  iter.item = ((HashNode *) iter._current)->object;
-  iter.key = ((HashNode *) iter._current)->key;
+  iter.item = ((HashNode *)iter._current)->object;
+  iter.key = ((HashNode *)iter._current)->key;
 
   /* Actually save the next slot in the hash.  This makes it possible to
      delete the item being iterated over without trashing the universe */
-  iter._current = ((HashNode *) iter._current)->next;
+  iter._current = ((HashNode *)iter._current)->next;
   return iter;
 }
 
 static DohIterator Hash_nextiter(DohIterator iter) {
-  Hash *h = (Hash *) ObjData(iter.object);
+  Hash *h = (Hash *)ObjData(iter.object);
   if (!iter._current) {
     iter._index++;
     while ((iter._index < h->hashsize) && !h->hashtable[iter._index]) {
@@ -350,11 +351,11 @@ static DohIterator Hash_nextiter(DohIterator iter) {
     }
     iter._current = h->hashtable[iter._index];
   }
-  iter.key = ((HashNode *) iter._current)->key;
-  iter.item = ((HashNode *) iter._current)->object;
+  iter.key = ((HashNode *)iter._current)->key;
+  iter.item = ((HashNode *)iter._current)->object;
 
   /* Store the next node to iterator on */
-  iter._current = ((HashNode *) iter._current)->next;
+  iter._current = ((HashNode *)iter._current)->next;
   return iter;
 }
 
@@ -407,7 +408,7 @@ static DOH *Hash_str(DOH *ho) {
   DOH *s;
   static int expanded = 0;
   static const char *tab = "  ";
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
 
   s = NewStringEmpty();
   if (ObjGetMark(ho)) {
@@ -454,7 +455,7 @@ static DOH *Hash_str(DOH *ho) {
  * ----------------------------------------------------------------------------- */
 
 static int Hash_len(DOH *ho) {
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   return h->nitems;
 }
 
@@ -470,10 +471,10 @@ static DOH *CopyHash(DOH *ho) {
   DOH *nho;
 
   int i;
-  h = (Hash *) ObjData(ho);
-  nh = (Hash *) DohMalloc(sizeof(Hash));
+  h = (Hash *)ObjData(ho);
+  nh = (Hash *)DohMalloc(sizeof(Hash));
   nh->hashsize = h->hashsize;
-  nh->hashtable = (HashNode **) DohMalloc(nh->hashsize * sizeof(HashNode *));
+  nh->hashtable = (HashNode **)DohMalloc(nh->hashsize * sizeof(HashNode *));
   for (i = 0; i < nh->hashsize; i++) {
     nh->hashtable[i] = 0;
   }
@@ -494,11 +495,9 @@ static DOH *CopyHash(DOH *ho) {
   return nho;
 }
 
-
-
 static void Hash_setfile(DOH *ho, DOH *file) {
   DOH *fo;
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
 
   if (!DohCheck(file)) {
     fo = NewString(file);
@@ -511,17 +510,17 @@ static void Hash_setfile(DOH *ho, DOH *file) {
 }
 
 static DOH *Hash_getfile(DOH *ho) {
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   return h->file;
 }
 
 static void Hash_setline(DOH *ho, int line) {
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   h->line = line;
 }
 
 static int Hash_getline(DOH *ho) {
-  Hash *h = (Hash *) ObjData(ho);
+  Hash *h = (Hash *)ObjData(ho);
   return h->line;
 }
 
@@ -537,29 +536,29 @@ static DohHashMethods HashHashMethods = {
 };
 
 DohObjInfo DohHashType = {
-  "Hash",                       /* objname */
-  DelHash,                      /* doh_del */
-  CopyHash,                     /* doh_copy */
-  Hash_clear,                   /* doh_clear */
-  Hash_str,                     /* doh_str */
-  0,                            /* doh_data */
-  0,                            /* doh_dump */
-  Hash_len,                     /* doh_len */
-  0,                            /* doh_hash    */
-  0,                            /* doh_cmp */
-  0,                            /* doh_equal    */
-  Hash_firstiter,               /* doh_first    */
-  Hash_nextiter,                /* doh_next     */
-  Hash_setfile,                 /* doh_setfile */
-  Hash_getfile,                 /* doh_getfile */
-  Hash_setline,                 /* doh_setline */
-  Hash_getline,                 /* doh_getline */
-  &HashHashMethods,             /* doh_mapping */
-  0,                            /* doh_sequence */
-  0,                            /* doh_file */
-  0,                            /* doh_string */
-  0,                            /* doh_reserved */
-  0,                            /* clientdata */
+  "Hash",           /* objname */
+  DelHash,          /* doh_del */
+  CopyHash,         /* doh_copy */
+  Hash_clear,       /* doh_clear */
+  Hash_str,         /* doh_str */
+  0,                /* doh_data */
+  0,                /* doh_dump */
+  Hash_len,         /* doh_len */
+  0,                /* doh_hash    */
+  0,                /* doh_cmp */
+  0,                /* doh_equal    */
+  Hash_firstiter,   /* doh_first    */
+  Hash_nextiter,    /* doh_next     */
+  Hash_setfile,     /* doh_setfile */
+  Hash_getfile,     /* doh_getfile */
+  Hash_setline,     /* doh_setline */
+  Hash_getline,     /* doh_getline */
+  &HashHashMethods, /* doh_mapping */
+  0,                /* doh_sequence */
+  0,                /* doh_file */
+  0,                /* doh_string */
+  0,                /* doh_reserved */
+  0,                /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------
@@ -571,9 +570,9 @@ DohObjInfo DohHashType = {
 DOH *DohNewHash(void) {
   Hash *h;
   int i;
-  h = (Hash *) DohMalloc(sizeof(Hash));
+  h = (Hash *)DohMalloc(sizeof(Hash));
   h->hashsize = HASH_INIT_SIZE;
-  h->hashtable = (HashNode **) DohMalloc(h->hashsize * sizeof(HashNode *));
+  h->hashtable = (HashNode **)DohMalloc(h->hashsize * sizeof(HashNode *));
   for (i = 0; i < h->hashsize; i++) {
     h->hashtable[i] = 0;
   }

--- a/Source/DOH/hash.c
+++ b/Source/DOH/hash.c
@@ -220,8 +220,8 @@ static int Hash_setattr(DOH *ho, DOH *k, DOH *obj) {
     if (Cmp(n->key, k) == 0) {
       /* Node already exists.  Just replace its contents */
       if (n->object == obj) {
-	/* Whoa. Same object.  Do nothing */
-	return 1;
+        /* Whoa. Same object.  Do nothing */
+        return 1;
       }
       Delete(n->object);
       n->object = obj;
@@ -297,9 +297,9 @@ static int Hash_delattr(DOH *ho, DOH *k) {
       /* Found it, kill it */
 
       if (prev) {
-	prev->next = n->next;
+        prev->next = n->next;
       } else {
-	h->hashtable[hv] = n->next;
+        h->hashtable[hv] = n->next;
       }
       DelNode(n);
       h->nitems--;
@@ -420,8 +420,8 @@ static DOH *Hash_str(DOH *ho) {
     for (i = 0; i < h->hashsize; i++) {
       n = h->hashtable[i];
       while (n) {
-	Putc('.', s);
-	n = n->next;
+        Putc('.', s);
+        n = n->next;
       }
     }
     Putc('}', s);
@@ -433,7 +433,7 @@ static DOH *Hash_str(DOH *ho) {
     n = h->hashtable[i];
     while (n) {
       for (j = 0; j < expanded + 1; j++)
-	Printf(s, tab);
+        Printf(s, tab);
       expanded += 1;
       Printf(s, "'%s' : %s, \n", n->key, n->object);
       expanded -= 1;

--- a/Source/DOH/hash.c
+++ b/Source/DOH/hash.c
@@ -226,7 +226,7 @@ static int Hash_setattr(DOH *ho, DOH *k, DOH *obj) {
       Delete(n->object);
       n->object = obj;
       Incref(obj);
-      return 1;			/* Return 1 to indicate a replacement */
+      return 1;                 /* Return 1 to indicate a replacement */
     } else {
       prev = n;
       n = n->next;
@@ -318,7 +318,7 @@ static DohIterator Hash_firstiter(DOH *ho) {
   iter._current = 0;
   iter.item = 0;
   iter.key = 0;
-  iter._index = 0;		/* Index in hash table */
+  iter._index = 0;              /* Index in hash table */
   while ((iter._index < h->hashsize) && !h->hashtable[iter._index])
     iter._index++;
 
@@ -537,29 +537,29 @@ static DohHashMethods HashHashMethods = {
 };
 
 DohObjInfo DohHashType = {
-  "Hash",			/* objname */
-  DelHash,			/* doh_del */
-  CopyHash,			/* doh_copy */
-  Hash_clear,			/* doh_clear */
-  Hash_str,			/* doh_str */
-  0,				/* doh_data */
-  0,				/* doh_dump */
-  Hash_len,			/* doh_len */
-  0,				/* doh_hash    */
-  0,				/* doh_cmp */
-  0,				/* doh_equal    */
-  Hash_firstiter,		/* doh_first    */
-  Hash_nextiter,		/* doh_next     */
-  Hash_setfile,			/* doh_setfile */
-  Hash_getfile,			/* doh_getfile */
-  Hash_setline,			/* doh_setline */
-  Hash_getline,			/* doh_getline */
-  &HashHashMethods,		/* doh_mapping */
-  0,				/* doh_sequence */
-  0,				/* doh_file */
-  0,				/* doh_string */
-  0,				/* doh_reserved */
-  0,				/* clientdata */
+  "Hash",                       /* objname */
+  DelHash,                      /* doh_del */
+  CopyHash,                     /* doh_copy */
+  Hash_clear,                   /* doh_clear */
+  Hash_str,                     /* doh_str */
+  0,                            /* doh_data */
+  0,                            /* doh_dump */
+  Hash_len,                     /* doh_len */
+  0,                            /* doh_hash    */
+  0,                            /* doh_cmp */
+  0,                            /* doh_equal    */
+  Hash_firstiter,               /* doh_first    */
+  Hash_nextiter,                /* doh_next     */
+  Hash_setfile,                 /* doh_setfile */
+  Hash_getfile,                 /* doh_getfile */
+  Hash_setline,                 /* doh_setline */
+  Hash_getline,                 /* doh_getline */
+  &HashHashMethods,             /* doh_mapping */
+  0,                            /* doh_sequence */
+  0,                            /* doh_file */
+  0,                            /* doh_string */
+  0,                            /* doh_reserved */
+  0,                            /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------

--- a/Source/DOH/hash.c
+++ b/Source/DOH/hash.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/DOH/list.c
+++ b/Source/DOH/list.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -171,7 +171,7 @@ static DOH *List_get(DOH *lo, int n) {
 /* -----------------------------------------------------------------------------
  * List_set()
  *
- * Set the nth item in the list replacing any previous item. 
+ * Set the nth item in the list replacing any previous item.
  * ----------------------------------------------------------------------------- */
 
 static int List_set(DOH *lo, int n, DOH *val) {
@@ -213,7 +213,7 @@ static DohIterator List_first(DOH *lo) {
 
 /* -----------------------------------------------------------------------------
  * List_next()
- * 
+ *
  * Return the next item in the list.
  * ----------------------------------------------------------------------------- */
 

--- a/Source/DOH/list.c
+++ b/Source/DOH/list.c
@@ -14,8 +14,8 @@
 #include "dohint.h"
 
 typedef struct List {
-  int maxitems;                 /* Max size  */
-  int nitems;                   /* Num items */
+  int maxitems; /* Max size  */
+  int nitems;   /* Num items */
   DOH *file;
   int line;
   DOH **items;
@@ -24,9 +24,8 @@ typedef struct List {
 extern DohObjInfo DohListType;
 
 /* Doubles amount of memory in a list */
-static
-void more(List *l) {
-  l->items = (void **) DohRealloc(l->items, l->maxitems * 2 * sizeof(void *));
+static void more(List *l) {
+  l->items = (void **)DohRealloc(l->items, l->maxitems * 2 * sizeof(void *));
   l->maxitems *= 2;
 }
 
@@ -38,11 +37,11 @@ void more(List *l) {
 static DOH *CopyList(DOH *lo) {
   List *l, *nl;
   int i;
-  l = (List *) ObjData(lo);
-  nl = (List *) DohMalloc(sizeof(List));
+  l = (List *)ObjData(lo);
+  nl = (List *)DohMalloc(sizeof(List));
   nl->nitems = l->nitems;
   nl->maxitems = l->maxitems;
-  nl->items = (void **) DohMalloc(l->maxitems * sizeof(void *));
+  nl->items = (void **)DohMalloc(l->maxitems * sizeof(void *));
   for (i = 0; i < l->nitems; i++) {
     nl->items[i] = l->items[i];
     Incref(nl->items[i]);
@@ -61,7 +60,7 @@ static DOH *CopyList(DOH *lo) {
  * ----------------------------------------------------------------------------- */
 
 static void DelList(DOH *lo) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   int i;
   for (i = 0; i < l->nitems; i++)
     Delete(l->items[i]);
@@ -77,7 +76,7 @@ static void DelList(DOH *lo) {
  * ----------------------------------------------------------------------------- */
 
 static void List_clear(DOH *lo) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   int i;
   for (i = 0; i < l->nitems; i++) {
     Delete(l->items[i]);
@@ -93,7 +92,7 @@ static void List_clear(DOH *lo) {
  * ----------------------------------------------------------------------------- */
 
 static int List_insert(DOH *lo, int pos, DOH *item) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   int i;
 
   if (!item)
@@ -126,7 +125,7 @@ static int List_insert(DOH *lo, int pos, DOH *item) {
  * ----------------------------------------------------------------------------- */
 
 static int List_remove(DOH *lo, int pos) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   int i;
   if (pos == DOH_END)
     pos = l->nitems - 1;
@@ -148,7 +147,7 @@ static int List_remove(DOH *lo, int pos) {
  * ----------------------------------------------------------------------------- */
 
 static int List_len(DOH *lo) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   return l->nitems;
 }
 
@@ -159,7 +158,7 @@ static int List_len(DOH *lo) {
  * ----------------------------------------------------------------------------- */
 
 static DOH *List_get(DOH *lo, int n) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   if (n == DOH_END)
     n = l->nitems - 1;
   if (n == DOH_BEGIN)
@@ -175,7 +174,7 @@ static DOH *List_get(DOH *lo, int n) {
  * ----------------------------------------------------------------------------- */
 
 static int List_set(DOH *lo, int n, DOH *val) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   if (!val)
     return -1;
   assert(!((n < 0) || (n >= l->nitems)));
@@ -198,7 +197,7 @@ static int List_set(DOH *lo, int n, DOH *val) {
 
 static DohIterator List_first(DOH *lo) {
   DohIterator iter;
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   iter.object = lo;
   iter._index = 0;
   iter._current = 0;
@@ -218,7 +217,7 @@ static DohIterator List_first(DOH *lo) {
  * ----------------------------------------------------------------------------- */
 
 static DohIterator List_next(DohIterator iter) {
-  List *l = (List *) ObjData(iter.object);
+  List *l = (List *)ObjData(iter.object);
   iter._index = iter._index + 1;
   if (iter._index >= l->nitems) {
     iter.item = 0;
@@ -237,7 +236,7 @@ static DohIterator List_next(DohIterator iter) {
 static DOH *List_str(DOH *lo) {
   DOH *s;
   int i;
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   s = NewStringEmpty();
   if (ObjGetMark(lo)) {
     Printf(s, "List(%p)", lo);
@@ -264,7 +263,7 @@ static DOH *List_str(DOH *lo) {
 static int List_dump(DOH *lo, DOH *out) {
   int nsent = 0;
   int i, ret;
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   for (i = 0; i < l->nitems; i++) {
     ret = Dump(l->items[i], out);
     if (ret < 0)
@@ -276,7 +275,7 @@ static int List_dump(DOH *lo, DOH *out) {
 
 static void List_setfile(DOH *lo, DOH *file) {
   DOH *fo;
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
 
   if (!DohCheck(file)) {
     fo = NewString(file);
@@ -289,17 +288,17 @@ static void List_setfile(DOH *lo, DOH *file) {
 }
 
 static DOH *List_getfile(DOH *lo) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   return l->file;
 }
 
 static void List_setline(DOH *lo, int line) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   l->line = line;
 }
 
 static int List_getline(DOH *lo) {
-  List *l = (List *) ObjData(lo);
+  List *l = (List *)ObjData(lo);
   return l->line;
 }
 
@@ -312,29 +311,29 @@ static DohListMethods ListListMethods = {
 };
 
 DohObjInfo DohListType = {
-  "List",                       /* objname */
-  DelList,                      /* doh_del */
-  CopyList,                     /* doh_copy */
-  List_clear,                   /* doh_clear */
-  List_str,                     /* doh_str */
-  0,                            /* doh_data */
-  List_dump,                    /* doh_dump */
-  List_len,                     /* doh_len */
-  0,                            /* doh_hash    */
-  0,                            /* doh_cmp */
-  0,                            /* doh_equal    */
-  List_first,                   /* doh_first    */
-  List_next,                    /* doh_next     */
-  List_setfile,                 /* doh_setfile */
-  List_getfile,                 /* doh_getfile */
-  List_setline,                 /* doh_setline */
-  List_getline,                 /* doh_getline */
-  0,                            /* doh_mapping */
-  &ListListMethods,             /* doh_sequence */
-  0,                            /* doh_file */
-  0,                            /* doh_string */
-  0,                            /* doh_reserved */
-  0,                            /* clientdata */
+  "List",           /* objname */
+  DelList,          /* doh_del */
+  CopyList,         /* doh_copy */
+  List_clear,       /* doh_clear */
+  List_str,         /* doh_str */
+  0,                /* doh_data */
+  List_dump,        /* doh_dump */
+  List_len,         /* doh_len */
+  0,                /* doh_hash    */
+  0,                /* doh_cmp */
+  0,                /* doh_equal    */
+  List_first,       /* doh_first    */
+  List_next,        /* doh_next     */
+  List_setfile,     /* doh_setfile */
+  List_getfile,     /* doh_getfile */
+  List_setline,     /* doh_setline */
+  List_getline,     /* doh_getline */
+  0,                /* doh_mapping */
+  &ListListMethods, /* doh_sequence */
+  0,                /* doh_file */
+  0,                /* doh_string */
+  0,                /* doh_reserved */
+  0,                /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------
@@ -346,23 +345,23 @@ DohObjInfo DohListType = {
 #define MAXLISTITEMS 8
 
 DOH *DohNewList(void) {
-  List *l = (List *) DohMalloc(sizeof(List));
+  List *l = (List *)DohMalloc(sizeof(List));
   l->nitems = 0;
   l->maxitems = MAXLISTITEMS;
-  l->items = (void **) DohCalloc(l->maxitems, sizeof(void *));
+  l->items = (void **)DohCalloc(l->maxitems, sizeof(void *));
   l->file = 0;
   l->line = 0;
   return DohObjMalloc(&DohListType, l);
 }
 
-static int (*List_sort_compare_func) (const DOH *, const DOH *);
+static int (*List_sort_compare_func)(const DOH *, const DOH *);
 static int List_qsort_compare(const void *a, const void *b) {
-  return List_sort_compare_func(*((DOH **) a), *((DOH **) b));
+  return List_sort_compare_func(*((DOH **)a), *((DOH **)b));
 }
 
 /* Sort a list */
-void DohSortList(DOH *lo, int (*cmp) (const DOH *, const DOH *)) {
-  List *l = (List *) ObjData(lo);
+void DohSortList(DOH *lo, int (*cmp)(const DOH *, const DOH *)) {
+  List *l = (List *)ObjData(lo);
   if (cmp) {
     List_sort_compare_func = cmp;
   } else {

--- a/Source/DOH/list.c
+++ b/Source/DOH/list.c
@@ -14,8 +14,8 @@
 #include "dohint.h"
 
 typedef struct List {
-  int maxitems;			/* Max size  */
-  int nitems;			/* Num items */
+  int maxitems;                 /* Max size  */
+  int nitems;                   /* Num items */
   DOH *file;
   int line;
   DOH **items;
@@ -312,29 +312,29 @@ static DohListMethods ListListMethods = {
 };
 
 DohObjInfo DohListType = {
-  "List",			/* objname */
-  DelList,			/* doh_del */
-  CopyList,			/* doh_copy */
-  List_clear,			/* doh_clear */
-  List_str,			/* doh_str */
-  0,				/* doh_data */
-  List_dump,			/* doh_dump */
-  List_len,			/* doh_len */
-  0,				/* doh_hash    */
-  0,				/* doh_cmp */
-  0,				/* doh_equal    */
-  List_first,			/* doh_first    */
-  List_next,			/* doh_next     */
-  List_setfile,			/* doh_setfile */
-  List_getfile,			/* doh_getfile */
-  List_setline,			/* doh_setline */
-  List_getline,			/* doh_getline */
-  0,				/* doh_mapping */
-  &ListListMethods,		/* doh_sequence */
-  0,				/* doh_file */
-  0,				/* doh_string */
-  0,				/* doh_reserved */
-  0,				/* clientdata */
+  "List",                       /* objname */
+  DelList,                      /* doh_del */
+  CopyList,                     /* doh_copy */
+  List_clear,                   /* doh_clear */
+  List_str,                     /* doh_str */
+  0,                            /* doh_data */
+  List_dump,                    /* doh_dump */
+  List_len,                     /* doh_len */
+  0,                            /* doh_hash    */
+  0,                            /* doh_cmp */
+  0,                            /* doh_equal    */
+  List_first,                   /* doh_first    */
+  List_next,                    /* doh_next     */
+  List_setfile,                 /* doh_setfile */
+  List_getfile,                 /* doh_getfile */
+  List_setline,                 /* doh_setline */
+  List_getline,                 /* doh_getline */
+  0,                            /* doh_mapping */
+  &ListListMethods,             /* doh_sequence */
+  0,                            /* doh_file */
+  0,                            /* doh_string */
+  0,                            /* doh_reserved */
+  0,                            /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------

--- a/Source/DOH/memory.c
+++ b/Source/DOH/memory.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 
 #ifndef DOH_POOL_SIZE
-#define DOH_POOL_SIZE         4194304
+#define DOH_POOL_SIZE 4194304
 #endif
 
 /* Checks stale DOH object use - will use a lot more memory as pool memory is not re-used. */
@@ -28,19 +28,19 @@
 
 static int PoolSize = DOH_POOL_SIZE;
 
-DOH *DohNone = 0;               /* The DOH None object */
+DOH *DohNone = 0; /* The DOH None object */
 
 typedef struct pool {
-  DohBase *ptr;                 /* Start of pool */
-  int len;                      /* Length of pool */
-  int blen;                     /* Byte length of pool */
-  int current;                  /* Current position for next allocation */
-  char *pbeg;                   /* Beg of pool */
-  char *pend;                   /* End of pool */
-  struct pool *next;            /* Next pool */
+  DohBase *ptr;      /* Start of pool */
+  int len;           /* Length of pool */
+  int blen;          /* Byte length of pool */
+  int current;       /* Current position for next allocation */
+  char *pbeg;        /* Beg of pool */
+  char *pend;        /* End of pool */
+  struct pool *next; /* Next pool */
 } Pool;
 
-static DohBase *FreeList = 0;   /* List of free objects */
+static DohBase *FreeList = 0; /* List of free objects */
 static Pool *Pools = 0;
 static int pools_initialized = 0;
 
@@ -50,12 +50,12 @@ static int pools_initialized = 0;
 
 static void CreatePool(void) {
   Pool *p = 0;
-  p = (Pool *) DohMalloc(sizeof(Pool));
-  p->ptr = (DohBase *) DohCalloc(PoolSize, sizeof(DohBase));
+  p = (Pool *)DohMalloc(sizeof(Pool));
+  p->ptr = (DohBase *)DohCalloc(PoolSize, sizeof(DohBase));
   p->len = PoolSize;
   p->blen = PoolSize * sizeof(DohBase);
   p->current = 0;
-  p->pbeg = ((char *) p->ptr);
+  p->pbeg = ((char *)p->ptr);
   p->pend = p->pbeg + p->blen;
   p->next = Pools;
   Pools = p;
@@ -68,9 +68,9 @@ static void CreatePool(void) {
 static void InitPools(void) {
   if (pools_initialized)
     return;
-  CreatePool();                 /* Create initial pool */
+  CreatePool(); /* Create initial pool */
   pools_initialized = 1;
-  DohNone = NewVoid(0, 0);      /* Create the None object */
+  DohNone = NewVoid(0, 0); /* Create the None object */
   DohIntern(DohNone);
 }
 
@@ -82,11 +82,11 @@ static void InitPools(void) {
 
 int DohCheck(const DOH *ptr) {
   Pool *p = Pools;
-  char *cptr = (char *) ptr;
+  char *cptr = (char *)ptr;
   while (p) {
     if ((cptr >= p->pbeg) && (cptr < p->pend)) {
 #ifdef DOH_DEBUG_MEMORY_POOLS
-      DohBase *b = (DohBase *) ptr;
+      DohBase *b = (DohBase *)ptr;
       int DOH_object_already_deleted = b->type == 0;
       assert(!DOH_object_already_deleted);
 #endif
@@ -105,7 +105,7 @@ int DohCheck(const DOH *ptr) {
  * ----------------------------------------------------------------------------- */
 
 void DohIntern(DOH *obj) {
-  DohBase *b = (DohBase *) obj;
+  DohBase *b = (DohBase *)obj;
   b->flag_intern = 1;
 }
 
@@ -122,7 +122,7 @@ DOH *DohObjMalloc(DohObjInfo *type, void *data) {
 #ifndef DOH_DEBUG_MEMORY_POOLS
   if (FreeList) {
     obj = FreeList;
-    FreeList = (DohBase *) obj->data;
+    FreeList = (DohBase *)obj->data;
   } else {
 #endif
     while (Pools->current == Pools->len) {
@@ -141,7 +141,7 @@ DOH *DohObjMalloc(DohObjInfo *type, void *data) {
   obj->flag_marked = 0;
   obj->flag_user = 0;
   obj->flag_usermark = 0;
-  return (DOH *) obj;
+  return (DOH *)obj;
 }
 
 /* ----------------------------------------------------------------------
@@ -150,11 +150,11 @@ DOH *DohObjMalloc(DohObjInfo *type, void *data) {
 
 void DohObjFree(DOH *ptr) {
   DohBase *b, *meta;
-  b = (DohBase *) ptr;
+  b = (DohBase *)ptr;
   if (b->flag_intern)
     return;
-  meta = (DohBase *) b->meta;
-  b->data = (void *) FreeList;
+  meta = (DohBase *)b->meta;
+  b->data = (void *)FreeList;
   b->meta = 0;
   b->type = 0;
   b->refcount = 0;
@@ -205,7 +205,7 @@ void DohMemoryDebug(void) {
           numhash++;
       }
     }
-    printf("    Pool %8p: size = %10d. used = %10d. free = %10d\n", (void *) p, p->len, nused, nfree);
+    printf("    Pool %8p: size = %10d. used = %10d. free = %10d\n", (void *)p, p->len, nused, nfree);
     totsize += p->len;
     totused += nused;
     totfree += nfree;
@@ -232,7 +232,6 @@ void DohMemoryDebug(void) {
     p = p->next;
   }
 #endif
-
 }
 
 /* Function to call instead of exit(). */
@@ -267,18 +266,21 @@ static void allocation_failed(size_t n, size_t size) {
 
 void *DohMalloc(size_t size) {
   void *p = doh_internal_malloc(size);
-  if (!p) allocation_failed(1, size);
+  if (!p)
+    allocation_failed(1, size);
   return p;
 }
 
 void *DohRealloc(void *ptr, size_t size) {
   void *p = doh_internal_realloc(ptr, size);
-  if (!p) allocation_failed(1, size);
+  if (!p)
+    allocation_failed(1, size);
   return p;
 }
 
 void *DohCalloc(size_t n, size_t size) {
   void *p = doh_internal_calloc(n, size);
-  if (!p) allocation_failed(n, size);
+  if (!p)
+    allocation_failed(n, size);
   return p;
 }

--- a/Source/DOH/memory.c
+++ b/Source/DOH/memory.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -45,7 +45,7 @@ static Pool *Pools = 0;
 static int pools_initialized = 0;
 
 /* ----------------------------------------------------------------------
- * CreatePool() - Create a new memory pool 
+ * CreatePool() - Create a new memory pool
  * ---------------------------------------------------------------------- */
 
 static void CreatePool(void) {

--- a/Source/DOH/memory.c
+++ b/Source/DOH/memory.c
@@ -28,19 +28,19 @@
 
 static int PoolSize = DOH_POOL_SIZE;
 
-DOH *DohNone = 0;		/* The DOH None object */
+DOH *DohNone = 0;               /* The DOH None object */
 
 typedef struct pool {
-  DohBase *ptr;			/* Start of pool */
-  int len;			/* Length of pool */
-  int blen;			/* Byte length of pool */
-  int current;			/* Current position for next allocation */
-  char *pbeg;			/* Beg of pool */
-  char *pend;			/* End of pool */
-  struct pool *next;		/* Next pool */
+  DohBase *ptr;                 /* Start of pool */
+  int len;                      /* Length of pool */
+  int blen;                     /* Byte length of pool */
+  int current;                  /* Current position for next allocation */
+  char *pbeg;                   /* Beg of pool */
+  char *pend;                   /* End of pool */
+  struct pool *next;            /* Next pool */
 } Pool;
 
-static DohBase *FreeList = 0;	/* List of free objects */
+static DohBase *FreeList = 0;   /* List of free objects */
 static Pool *Pools = 0;
 static int pools_initialized = 0;
 
@@ -68,9 +68,9 @@ static void CreatePool(void) {
 static void InitPools(void) {
   if (pools_initialized)
     return;
-  CreatePool();			/* Create initial pool */
+  CreatePool();                 /* Create initial pool */
   pools_initialized = 1;
-  DohNone = NewVoid(0, 0);	/* Create the None object */
+  DohNone = NewVoid(0, 0);      /* Create the None object */
   DohIntern(DohNone);
 }
 

--- a/Source/DOH/memory.c
+++ b/Source/DOH/memory.c
@@ -194,15 +194,15 @@ void DohMemoryDebug(void) {
     int nused = 0, nfree = 0;
     for (i = 0; i < p->len; i++) {
       if (p->ptr[i].refcount <= 0)
-	nfree++;
+        nfree++;
       else {
-	nused++;
-	if (p->ptr[i].type == &DohStringType)
-	  numstring++;
-	else if (p->ptr[i].type == &DohListType)
-	  numlist++;
-	else if (p->ptr[i].type == &DohHashType)
-	  numhash++;
+        nused++;
+        if (p->ptr[i].type == &DohStringType)
+          numstring++;
+        else if (p->ptr[i].type == &DohListType)
+          numlist++;
+        else if (p->ptr[i].type == &DohHashType)
+          numhash++;
       }
     }
     printf("    Pool %8p: size = %10d. used = %10d. free = %10d\n", (void *) p, p->len, nused, nfree);
@@ -224,9 +224,9 @@ void DohMemoryDebug(void) {
     int i;
     for (i = 0; i < p->len; i++) {
       if (p->ptr[i].refcount > 0) {
-	if (p->ptr[i].type == &DohStringType) {
-	  Printf(stdout, "%s\n", p->ptr + i);
-	}
+        if (p->ptr[i].type == &DohStringType) {
+          Printf(stdout, "%s\n", p->ptr + i);
+        }
       }
     }
     p = p->next;

--- a/Source/DOH/string.c
+++ b/Source/DOH/string.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -685,7 +685,7 @@ static char *match_number_end(char *base, char *s, char *token, int tokenlen) {
 /* -----------------------------------------------------------------------------
  * replace_simple()
  *
- * Replaces count non-overlapping occurrences of token with rep in a string.   
+ * Replaces count non-overlapping occurrences of token with rep in a string.
  * ----------------------------------------------------------------------------- */
 
 static int replace_simple(String *str, char *token, char *rep, int flags, int count, char *(*match) (char *, char *, char *, int)) {

--- a/Source/DOH/string.c
+++ b/Source/DOH/string.c
@@ -19,11 +19,11 @@ extern DohObjInfo DohStringType;
 typedef struct String {
   DOH *file;
   int line;
-  int maxsize;                  /* Max size allocated */
-  int len;                      /* Current length     */
-  int hashkey;                  /* Hash key value     */
-  int sp;                       /* Current position   */
-  char *str;                    /* String data        */
+  int maxsize; /* Max size allocated */
+  int len;     /* Current length     */
+  int hashkey; /* Hash key value     */
+  int sp;      /* Current position   */
+  char *str;   /* String data        */
 } String;
 
 /* -----------------------------------------------------------------------------
@@ -31,9 +31,9 @@ typedef struct String {
  * ----------------------------------------------------------------------------- */
 
 static void *String_data(DOH *so) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   s->str[s->len] = 0;
-  return (void *) s->str;
+  return (void *)s->str;
 }
 
 /* static char *String_char(DOH *so) {
@@ -48,7 +48,7 @@ static void *String_data(DOH *so) {
 static int String_dump(DOH *so, DOH *out) {
   int nsent;
   int ret;
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   nsent = 0;
   while (nsent < s->len) {
     ret = Write(out, s->str + nsent, (s->len - nsent));
@@ -65,15 +65,15 @@ static int String_dump(DOH *so, DOH *out) {
 
 static DOH *CopyString(DOH *so) {
   String *str;
-  String *s = (String *) ObjData(so);
-  str = (String *) DohMalloc(sizeof(String));
+  String *s = (String *)ObjData(so);
+  str = (String *)DohMalloc(sizeof(String));
   str->hashkey = s->hashkey;
   str->sp = s->sp;
   str->line = s->line;
   str->file = s->file;
   if (str->file)
     Incref(str->file);
-  str->str = (char *) DohMalloc(s->len + 1);
+  str->str = (char *)DohMalloc(s->len + 1);
   memcpy(str->str, s->str, s->len);
   str->maxsize = s->len;
   str->len = s->len;
@@ -87,7 +87,7 @@ static DOH *CopyString(DOH *so) {
  * ----------------------------------------------------------------------------- */
 
 static void DelString(DOH *so) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   DohFree(s->str);
   DohFree(s);
 }
@@ -97,10 +97,9 @@ static void DelString(DOH *so) {
  * ----------------------------------------------------------------------------- */
 
 static int String_len(DOH *so) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   return s->len;
 }
-
 
 /* -----------------------------------------------------------------------------
  * String_cmp() - Compare two strings
@@ -110,8 +109,8 @@ static int String_cmp(DOH *so1, DOH *so2) {
   String *s1, *s2;
   char *c1, *c2;
   int maxlen, i;
-  s1 = (String *) ObjData(so1);
-  s2 = (String *) ObjData(so2);
+  s1 = (String *)ObjData(so1);
+  s2 = (String *)ObjData(so2);
   maxlen = s1->len;
   if (s2->len < maxlen)
     maxlen = s2->len;
@@ -139,8 +138,8 @@ static int String_cmp(DOH *so1, DOH *so2) {
  * ----------------------------------------------------------------------------- */
 
 static int String_equal(DOH *so1, DOH *so2) {
-  String *s1 = (String *) ObjData(so1);
-  String *s2 = (String *) ObjData(so2);
+  String *s1 = (String *)ObjData(so1);
+  String *s2 = (String *)ObjData(so2);
   int len = s1->len;
   if (len != s2->len) {
     return 0;
@@ -176,7 +175,7 @@ static int String_equal(DOH *so1, DOH *so2) {
  * ----------------------------------------------------------------------------- */
 
 static int String_hash(DOH *so) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   if (s->hashkey >= 0) {
     return s->hashkey;
   } else {
@@ -215,16 +214,16 @@ static int String_hash(DOH *so) {
 static void DohString_append(DOH *so, const DOHString_or_char *str) {
   int oldlen, newlen, newmaxsize, l, sp;
   char *tc;
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   char *newstr = 0;
 
   if (DohCheck(str)) {
-    String *ss = (String *) ObjData(str);
-    newstr = (char *) String_data((DOH *) str);
+    String *ss = (String *)ObjData(str);
+    newstr = (char *)String_data((DOH *)str);
     l = ss->len;
   } else {
-    newstr = (char *) (str);
-    l = (int) strlen(newstr);
+    newstr = (char *)(str);
+    l = (int)strlen(newstr);
   }
   if (!newstr)
     return;
@@ -236,7 +235,7 @@ static void DohString_append(DOH *so, const DOHString_or_char *str) {
     newmaxsize = 2 * s->maxsize;
     if (newlen >= newmaxsize - 1)
       newmaxsize = newlen + 1;
-    s->str = (char *) DohRealloc(s->str, newmaxsize);
+    s->str = (char *)DohRealloc(s->str, newmaxsize);
     s->maxsize = newmaxsize;
   }
   tc = s->str;
@@ -254,7 +253,6 @@ static void DohString_append(DOH *so, const DOHString_or_char *str) {
   s->len += l;
 }
 
-
 /* -----------------------------------------------------------------------------
  * String_clear() - Clear string contents
  *
@@ -262,7 +260,7 @@ static void DohString_append(DOH *so, const DOHString_or_char *str) {
  * ----------------------------------------------------------------------------- */
 
 static void String_clear(DOH *so) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   s->hashkey = -1;
   s->len = 0;
   *(s->str) = 0;
@@ -283,16 +281,15 @@ static int String_insert(DOH *so, int pos, DOH *str) {
     return 0;
   }
 
-
-  s = (String *) ObjData(so);
+  s = (String *)ObjData(so);
   s->hashkey = -1;
   if (DohCheck(str)) {
-    String *ss = (String *) ObjData(str);
-    data = (char *) String_data(str);
+    String *ss = (String *)ObjData(str);
+    data = (char *)String_data(str);
     len = ss->len;
   } else {
-    data = (char *) (str);
-    len = (int) strlen(data);
+    data = (char *)(str);
+    len = (int)strlen(data);
   }
 
   if (pos < 0)
@@ -303,7 +300,7 @@ static int String_insert(DOH *so, int pos, DOH *str) {
   /* See if there is room to insert the new data */
   while (s->maxsize <= s->len + len) {
     int newsize = 2 * s->maxsize;
-    s->str = (char *) DohRealloc(s->str, newsize);
+    s->str = (char *)DohRealloc(s->str, newsize);
     s->maxsize = newsize;
   }
   memmove(s->str + pos + len, s->str + pos, (s->len - pos));
@@ -327,7 +324,7 @@ static int String_insert(DOH *so, int pos, DOH *str) {
  * ----------------------------------------------------------------------------- */
 
 static int String_delitem(DOH *so, int pos) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   s->hashkey = -1;
   if (pos == DOH_END)
     pos = s->len - 1;
@@ -353,7 +350,7 @@ static int String_delitem(DOH *so, int pos) {
  * ----------------------------------------------------------------------------- */
 
 static int String_delslice(DOH *so, int sindex, int eindex) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   int size;
   if (s->len == 0)
     return 0;
@@ -391,7 +388,7 @@ static int String_delslice(DOH *so, int sindex, int eindex) {
  * ----------------------------------------------------------------------------- */
 
 static DOH *String_str(DOH *so) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   s->str[s->len] = 0;
   return NewString(s->str);
 }
@@ -403,13 +400,13 @@ static DOH *String_str(DOH *so) {
 static int String_read(DOH *so, void *buffer, int len) {
   int reallen, retlen;
   char *cb;
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   if ((s->sp + len) > s->len)
     reallen = (s->len - s->sp);
   else
     reallen = len;
 
-  cb = (char *) buffer;
+  cb = (char *)buffer;
   retlen = reallen;
 
   if (reallen > 0) {
@@ -424,13 +421,13 @@ static int String_read(DOH *so, void *buffer, int len) {
  * ----------------------------------------------------------------------------- */
 static int String_write(DOH *so, const void *buffer, int len) {
   int newlen;
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   s->hashkey = -1;
   if (s->sp > s->len)
     s->sp = s->len;
   newlen = s->sp + len + 1;
   if (newlen > s->maxsize) {
-    s->str = (char *) DohRealloc(s->str, newlen);
+    s->str = (char *)DohRealloc(s->str, newlen);
     s->maxsize = newlen;
     s->len = s->sp + len;
   }
@@ -448,7 +445,7 @@ static int String_write(DOH *so, const void *buffer, int len) {
 
 static int String_seek(DOH *so, long offset, int whence) {
   int pos, nsp, inc;
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   if (whence == SEEK_SET)
     pos = 0;
   else if (whence == SEEK_CUR)
@@ -504,8 +501,8 @@ static int String_seek(DOH *so, long offset, int whence) {
  * ----------------------------------------------------------------------------- */
 
 static long String_tell(DOH *so) {
-  String *s = (String *) ObjData(so);
-  return (long) (s->sp);
+  String *s = (String *)ObjData(so);
+  return (long)(s->sp);
 }
 
 /* -----------------------------------------------------------------------------
@@ -513,7 +510,7 @@ static long String_tell(DOH *so) {
  * ----------------------------------------------------------------------------- */
 
 static int String_putc(DOH *so, int ch) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   int len = s->len;
   int sp = s->sp;
   s->hashkey = -1;
@@ -522,16 +519,16 @@ static int String_putc(DOH *so, int ch) {
     char *tc = s->str;
     if (len > (maxsize - 2)) {
       maxsize *= 2;
-      tc = (char *) DohRealloc(tc, maxsize);
-      s->maxsize = (int) maxsize;
+      tc = (char *)DohRealloc(tc, maxsize);
+      s->maxsize = (int)maxsize;
       s->str = tc;
     }
     tc += sp;
-    *tc = (char) ch;
+    *tc = (char)ch;
     *(++tc) = 0;
     s->len = s->sp = sp + 1;
   } else {
-    s->str[s->sp++] = (char) ch;
+    s->str[s->sp++] = (char)ch;
   }
   if (ch == '\n')
     s->line++;
@@ -544,11 +541,11 @@ static int String_putc(DOH *so, int ch) {
 
 static int String_getc(DOH *so) {
   int c;
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   if (s->sp >= s->len)
     c = EOF;
   else
-    c = (int)(unsigned char) s->str[s->sp++];
+    c = (int)(unsigned char)s->str[s->sp++];
   if (c == '\n')
     s->line++;
   return c;
@@ -559,7 +556,7 @@ static int String_getc(DOH *so) {
  * ----------------------------------------------------------------------------- */
 
 static int String_ungetc(DOH *so, int ch) {
-  String *s = (String *) ObjData(so);
+  String *s = (String *)ObjData(so);
   if (ch == EOF)
     return ch;
   if (s->sp <= 0)
@@ -608,8 +605,8 @@ static char *end_comment(char *s) {
 }
 
 static char *match_simple(char *base, char *s, char *token, int tokenlen) {
-  (void) base;
-  (void) tokenlen;
+  (void)base;
+  (void)tokenlen;
   return strstr(s, token);
 }
 
@@ -618,12 +615,12 @@ static char *match_identifier(char *base, char *s, char *token, int tokenlen) {
     s = strstr(s, token);
     if (!s)
       return 0;
-    if ((s > base) && (isalnum((int) *(s - 1)) || (*(s - 1) == '_'))) {
+    if ((s > base) && (isalnum((int)*(s - 1)) || (*(s - 1) == '_'))) {
       /* We could advance by tokenlen if strstr(s, token) matches can't overlap. */
       ++s;
       continue;
     }
-    if (isalnum((int) *(s + tokenlen)) || (*(s + tokenlen) == '_')) {
+    if (isalnum((int)*(s + tokenlen)) || (*(s + tokenlen) == '_')) {
       /* We could advance by tokenlen if strstr(s, token) matches can't overlap. */
       ++s;
       continue;
@@ -633,14 +630,13 @@ static char *match_identifier(char *base, char *s, char *token, int tokenlen) {
   return 0;
 }
 
-
 static char *match_identifier_begin(char *base, char *s, char *token, int tokenlen) {
   (void)tokenlen;
   while (s) {
     s = strstr(s, token);
     if (!s)
       return 0;
-    if ((s > base) && (isalnum((int) *(s - 1)) || (*(s - 1) == '_'))) {
+    if ((s > base) && (isalnum((int)*(s - 1)) || (*(s - 1) == '_'))) {
       /* We could advance by tokenlen if strstr(s, token) matches can't overlap. */
       ++s;
       continue;
@@ -651,12 +647,12 @@ static char *match_identifier_begin(char *base, char *s, char *token, int tokenl
 }
 
 static char *match_identifier_end(char *base, char *s, char *token, int tokenlen) {
-  (void) base;
+  (void)base;
   while (s) {
     s = strstr(s, token);
     if (!s)
       return 0;
-    if (isalnum((int) *(s + tokenlen)) || (*(s + tokenlen) == '_')) {
+    if (isalnum((int)*(s + tokenlen)) || (*(s + tokenlen) == '_')) {
       /* We could advance by tokenlen if strstr(s, token) matches can't overlap. */
       ++s;
       continue;
@@ -667,12 +663,12 @@ static char *match_identifier_end(char *base, char *s, char *token, int tokenlen
 }
 
 static char *match_number_end(char *base, char *s, char *token, int tokenlen) {
-  (void) base;
+  (void)base;
   while (s) {
     s = strstr(s, token);
     if (!s)
       return 0;
-    if (isdigit((int) *(s + tokenlen))) {
+    if (isdigit((int)*(s + tokenlen))) {
       /* We could advance by tokenlen if strstr(s, token) matches can't overlap. */
       ++s;
       continue;
@@ -688,9 +684,9 @@ static char *match_number_end(char *base, char *s, char *token, int tokenlen) {
  * Replaces count non-overlapping occurrences of token with rep in a string.
  * ----------------------------------------------------------------------------- */
 
-static int replace_simple(String *str, char *token, char *rep, int flags, int count, char *(*match) (char *, char *, char *, int)) {
-  int tokenlen;                 /* Length of the token */
-  int replen;                   /* Length of the replacement */
+static int replace_simple(String *str, char *token, char *rep, int flags, int count, char *(*match)(char *, char *, char *, int)) {
+  int tokenlen; /* Length of the token */
+  int replen;   /* Length of the replacement */
   int delta, expand = 0;
   int ic;
   int rcount = 0;
@@ -707,10 +703,10 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
 
   base = str->str;
   tokenlen = (int)strlen(token);
-  s = (*match) (base, base, token, tokenlen);
+  s = (*match)(base, base, token, tokenlen);
 
   if (!s)
-    return 0;                   /* No matches.  Who cares */
+    return 0; /* No matches.  Who cares */
 
   str->hashkey = -1;
 
@@ -726,7 +722,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
   if (noquote) {
     q = strpbrk(base, "\"\'");
     if (!q) {
-      noquote = 0;              /* Well, no quotes to worry about. Oh well */
+      noquote = 0; /* Well, no quotes to worry about. Oh well */
     } else {
       while (q && (q < s)) {
         /* First match was found inside a quote.  Try to find another match */
@@ -736,13 +732,13 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
         }
         if (q2 > s) {
           /* Find next match */
-          s = (*match) (base, q2 + 1, token, tokenlen);
+          s = (*match)(base, q2 + 1, token, tokenlen);
         }
         if (!s)
-          return 0;             /* Oh well, no matches */
+          return 0; /* Oh well, no matches */
         q = strpbrk(q2 + 1, "\"\'");
         if (!q)
-          noquote = 0;          /* No more quotes */
+          noquote = 0; /* No more quotes */
       }
     }
   }
@@ -751,7 +747,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
   if (nocomment) {
     q = strstr(base, "/*");
     if (!q) {
-      nocomment = 0;            /* Well, no comments to worry about. Oh well */
+      nocomment = 0; /* Well, no comments to worry about. Oh well */
     } else {
       while (q && (q < s)) {
         /* First match was found inside a comment.  Try to find another match */
@@ -761,13 +757,13 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
         }
         if (q2 > s) {
           /* Find next match */
-          s = (*match) (base, q2 + 1, token, tokenlen);
+          s = (*match)(base, q2 + 1, token, tokenlen);
         }
         if (!s)
-          return 0;             /* Oh well, no matches */
+          return 0; /* Oh well, no matches */
         q = strstr(q2 + 1, "/*");
         if (!q)
-          nocomment = 0;                /* No more comments */
+          nocomment = 0; /* No more comments */
       }
     }
   }
@@ -781,7 +777,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     /* String is either shrinking or staying the same size */
     /* In this case, we do the replacement in place without memory reallocation */
     ic = count;
-    t = s;                      /* Target of memory copies */
+    t = s; /* Target of memory copies */
     while (ic && s) {
       if (replen) {
         memcpy(t, rep, replen);
@@ -793,7 +789,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       s += tokenlen;
       if (ic == 1)
         break;
-      c = (*match) (base, s, token, tokenlen);
+      c = (*match)(base, s, token, tokenlen);
 
       if (noquote) {
         q = strpbrk(s, "\"\'");
@@ -808,12 +804,12 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             }
             if (q2 > c)
-              c = (*match) (base, q2 + 1, token, tokenlen);
+              c = (*match)(base, q2 + 1, token, tokenlen);
             if (!c)
               break;
             q = strpbrk(q2 + 1, "\"\'");
             if (!q)
-              noquote = 0;      /* No more quotes */
+              noquote = 0; /* No more quotes */
           }
         }
       }
@@ -830,12 +826,12 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             }
             if (q2 > c)
-              c = (*match) (base, q2 + 1, token, tokenlen);
+              c = (*match)(base, q2 + 1, token, tokenlen);
             if (!c)
               break;
             q = strstr(q2 + 1, "/*");
             if (!q)
-              nocomment = 0;    /* No more comments */
+              nocomment = 0; /* No more comments */
           }
         }
       }
@@ -860,7 +856,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     str->len += expand;
     str->str[str->len] = 0;
     if (str->sp >= str->len)
-      str->sp += expand;        /* Fix the end of file pointer */
+      str->sp += expand; /* Fix the end of file pointer */
     return rcount;
   }
   /* The string is expanding as a result of the replacement */
@@ -872,7 +868,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     rcount++;
     ic = count - 1;
     s += tokenlen;
-    while (ic && (c = (*match) (base, s, token, tokenlen))) {
+    while (ic && (c = (*match)(base, s, token, tokenlen))) {
       if (noquote) {
         q = strpbrk(s, "\"\'");
         if (!q) {
@@ -886,7 +882,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             }
             if (q2 > c) {
-              c = (*match) (base, q2 + 1, token, tokenlen);
+              c = (*match)(base, q2 + 1, token, tokenlen);
               if (!c)
                 break;
             }
@@ -909,7 +905,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             }
             if (q2 > c) {
-              c = (*match) (base, q2 + 1, token, tokenlen);
+              c = (*match)(base, q2 + 1, token, tokenlen);
               if (!c)
                 break;
             }
@@ -928,12 +924,12 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       }
     }
 
-    expand = delta * rcount;    /* Total amount of expansion for the replacement */
+    expand = delta * rcount; /* Total amount of expansion for the replacement */
     newsize = str->maxsize;
     while ((str->len + expand) >= newsize)
       newsize *= 2;
 
-    ns = (char *) DohMalloc(newsize);
+    ns = (char *)DohMalloc(newsize);
     t = ns;
     s = first;
 
@@ -946,7 +942,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       memcpy(t, rep, replen);
       t += replen;
       s += tokenlen;
-      c = (*match) (base, s, token, tokenlen);
+      c = (*match)(base, s, token, tokenlen);
       if (noquote) {
         q = strpbrk(s, "\"\'");
         if (!q) {
@@ -960,13 +956,13 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             }
             if (q2 > c) {
-              c = (*match) (base, q2 + 1, token, tokenlen);
+              c = (*match)(base, q2 + 1, token, tokenlen);
               if (!c)
                 break;
             }
             q = strpbrk(q2 + 1, "\"\'");
             if (!q)
-              noquote = 0;      /* No more quotes */
+              noquote = 0; /* No more quotes */
           }
         }
       }
@@ -983,13 +979,13 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             }
             if (q2 > c) {
-              c = (*match) (base, q2 + 1, token, tokenlen);
+              c = (*match)(base, q2 + 1, token, tokenlen);
               if (!c)
                 break;
             }
             q = strstr(q2 + 1, "/*");
             if (!q)
-              nocomment = 0;    /* No more comments */
+              nocomment = 0; /* No more comments */
           }
         }
       }
@@ -1019,7 +1015,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
 
 static int String_replace(DOH *stro, const DOHString_or_char *token, const DOHString_or_char *rep, int flags) {
   int count = -1;
-  String *str = (String *) ObjData(stro);
+  String *str = (String *)ObjData(stro);
 
   if (flags & DOH_REPLACE_FIRST)
     count = 1;
@@ -1043,10 +1039,10 @@ static int String_replace(DOH *stro, const DOHString_or_char *token, const DOHSt
 
 static void String_chop(DOH *so) {
   char *c;
-  String *str = (String *) ObjData(so);
+  String *str = (String *)ObjData(so);
   /* Replace trailing whitespace */
   c = str->str + str->len - 1;
-  while ((str->len > 0) && (isspace((int) *c))) {
+  while ((str->len > 0) && (isspace((int)*c))) {
     if (str->sp >= str->len) {
       str->sp--;
       if (*c == '\n')
@@ -1062,7 +1058,7 @@ static void String_chop(DOH *so) {
 
 static void String_setfile(DOH *so, DOH *file) {
   DOH *fo;
-  String *str = (String *) ObjData(so);
+  String *str = (String *)ObjData(so);
 
   if (!DohCheck(file)) {
     fo = NewString(file);
@@ -1075,26 +1071,26 @@ static void String_setfile(DOH *so, DOH *file) {
 }
 
 static DOH *String_getfile(DOH *so) {
-  String *str = (String *) ObjData(so);
+  String *str = (String *)ObjData(so);
   return str->file;
 }
 
 static void String_setline(DOH *so, int line) {
-  String *str = (String *) ObjData(so);
+  String *str = (String *)ObjData(so);
   str->line = line;
 }
 
 static int String_getline(DOH *so) {
-  String *str = (String *) ObjData(so);
+  String *str = (String *)ObjData(so);
   return str->line;
 }
 
 static DohListMethods StringListMethods = {
-  0,                            /* doh_getitem */
-  0,                            /* doh_setitem */
-  String_delitem,               /* doh_delitem */
-  String_insert,                /* doh_insitem */
-  String_delslice,              /* doh_delslice */
+  0,               /* doh_getitem */
+  0,               /* doh_setitem */
+  String_delitem,  /* doh_delitem */
+  String_insert,   /* doh_insitem */
+  String_delslice, /* doh_delslice */
 };
 
 static DohFileMethods StringFileMethods = {
@@ -1113,33 +1109,32 @@ static DohStringMethods StringStringMethods = {
 };
 
 DohObjInfo DohStringType = {
-  "String",                     /* objname */
-  DelString,                    /* doh_del */
-  CopyString,                   /* doh_copy */
-  String_clear,                 /* doh_clear */
-  String_str,                   /* doh_str */
-  String_data,                  /* doh_data */
-  String_dump,                  /* doh_dump */
-  String_len,                   /* doh_len */
-  String_hash,                  /* doh_hash    */
-  String_cmp,                   /* doh_cmp */
-  String_equal,                 /* doh_equal */
-  0,                            /* doh_first    */
-  0,                            /* doh_next     */
-  String_setfile,               /* doh_setfile */
-  String_getfile,               /* doh_getfile */
-  String_setline,               /* doh_setline */
-  String_getline,               /* doh_getline */
-  0,                            /* doh_mapping */
-  &StringListMethods,           /* doh_sequence */
-  &StringFileMethods,           /* doh_file */
-  &StringStringMethods,         /* doh_string */
-  0,                            /* doh_reserved */
-  0,                            /* clientdata */
+  "String",             /* objname */
+  DelString,            /* doh_del */
+  CopyString,           /* doh_copy */
+  String_clear,         /* doh_clear */
+  String_str,           /* doh_str */
+  String_data,          /* doh_data */
+  String_dump,          /* doh_dump */
+  String_len,           /* doh_len */
+  String_hash,          /* doh_hash    */
+  String_cmp,           /* doh_cmp */
+  String_equal,         /* doh_equal */
+  0,                    /* doh_first    */
+  0,                    /* doh_next     */
+  String_setfile,       /* doh_setfile */
+  String_getfile,       /* doh_getfile */
+  String_setline,       /* doh_setline */
+  String_getline,       /* doh_getline */
+  0,                    /* doh_mapping */
+  &StringListMethods,   /* doh_sequence */
+  &StringFileMethods,   /* doh_file */
+  &StringStringMethods, /* doh_string */
+  0,                    /* doh_reserved */
+  0,                    /* clientdata */
 };
 
-
-#define INIT_MAXSIZE  16
+#define INIT_MAXSIZE 16
 
 /* -----------------------------------------------------------------------------
  * NewString() - Create a new string
@@ -1151,16 +1146,16 @@ DOHString *DohNewString(const DOHString_or_char *so) {
   char *s;
   int hashkey = -1;
   if (DohCheck(so)) {
-    str = (String *) ObjData(so);
-    s = (char *) String_data((String *) so);
+    str = (String *)ObjData(so);
+    s = (char *)String_data((String *)so);
     l = s ? str->len : 0;
     hashkey = str->hashkey;
   } else {
-    s = (char *) so;
-    l = s ? (int) strlen(s) : 0;
+    s = (char *)so;
+    l = s ? (int)strlen(s) : 0;
   }
 
-  str = (String *) DohMalloc(sizeof(String));
+  str = (String *)DohMalloc(sizeof(String));
   str->hashkey = hashkey;
   str->sp = 0;
   str->line = 0;
@@ -1170,7 +1165,7 @@ DOHString *DohNewString(const DOHString_or_char *so) {
     if ((l + 1) > max)
       max = l + 1;
   }
-  str->str = (char *) DohMalloc(max);
+  str->str = (char *)DohMalloc(max);
   str->maxsize = max;
   if (s) {
     strcpy(str->str, s);
@@ -1183,19 +1178,18 @@ DOHString *DohNewString(const DOHString_or_char *so) {
   return DohObjMalloc(&DohStringType, str);
 }
 
-
 /* -----------------------------------------------------------------------------
  * NewStringEmpty() - Create a new string
  * ----------------------------------------------------------------------------- */
 
 DOHString *DohNewStringEmpty(void) {
   int max = INIT_MAXSIZE;
-  String *str = (String *) DohMalloc(sizeof(String));
+  String *str = (String *)DohMalloc(sizeof(String));
   str->hashkey = 0;
   str->sp = 0;
   str->line = 0;
   str->file = 0;
-  str->str = (char *) DohMalloc(max);
+  str->str = (char *)DohMalloc(max);
   str->maxsize = max;
   str->str[0] = 0;
   str->len = 0;
@@ -1211,23 +1205,23 @@ DOHString *DohNewStringWithSize(const DOHString_or_char *so, int len) {
   String *str;
   char *s;
   if (DohCheck(so)) {
-    s = (char *) String_data((String *) so);
+    s = (char *)String_data((String *)so);
   } else {
-    s = (char *) so;
+    s = (char *)so;
   }
 
-  str = (String *) DohMalloc(sizeof(String));
+  str = (String *)DohMalloc(sizeof(String));
   str->hashkey = -1;
   str->sp = 0;
   str->line = 0;
   str->file = 0;
   max = INIT_MAXSIZE;
   if (s) {
-    l = (int) len;
+    l = (int)len;
     if ((l + 1) > max)
       max = l + 1;
   }
-  str->str = (char *) DohMalloc(max);
+  str->str = (char *)DohMalloc(max);
   str->maxsize = max;
   if (s) {
     memcpy(str->str, s, len);
@@ -1254,7 +1248,7 @@ DOHString *DohNewStringf(const DOHString_or_char *fmt, ...) {
   r = NewStringEmpty();
   DohvPrintf(r, Char(fmt), ap);
   va_end(ap);
-  return (DOHString *) r;
+  return (DOHString *)r;
 }
 
 /* -----------------------------------------------------------------------------

--- a/Source/DOH/string.c
+++ b/Source/DOH/string.c
@@ -19,11 +19,11 @@ extern DohObjInfo DohStringType;
 typedef struct String {
   DOH *file;
   int line;
-  int maxsize;			/* Max size allocated */
-  int len;			/* Current length     */
-  int hashkey;			/* Hash key value     */
-  int sp;			/* Current position   */
-  char *str;			/* String data        */
+  int maxsize;                  /* Max size allocated */
+  int len;                      /* Current length     */
+  int hashkey;                  /* Hash key value     */
+  int sp;                       /* Current position   */
+  char *str;                    /* String data        */
 } String;
 
 /* -----------------------------------------------------------------------------
@@ -689,8 +689,8 @@ static char *match_number_end(char *base, char *s, char *token, int tokenlen) {
  * ----------------------------------------------------------------------------- */
 
 static int replace_simple(String *str, char *token, char *rep, int flags, int count, char *(*match) (char *, char *, char *, int)) {
-  int tokenlen;			/* Length of the token */
-  int replen;			/* Length of the replacement */
+  int tokenlen;                 /* Length of the token */
+  int replen;                   /* Length of the replacement */
   int delta, expand = 0;
   int ic;
   int rcount = 0;
@@ -710,7 +710,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
   s = (*match) (base, base, token, tokenlen);
 
   if (!s)
-    return 0;			/* No matches.  Who cares */
+    return 0;                   /* No matches.  Who cares */
 
   str->hashkey = -1;
 
@@ -726,7 +726,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
   if (noquote) {
     q = strpbrk(base, "\"\'");
     if (!q) {
-      noquote = 0;		/* Well, no quotes to worry about. Oh well */
+      noquote = 0;              /* Well, no quotes to worry about. Oh well */
     } else {
       while (q && (q < s)) {
         /* First match was found inside a quote.  Try to find another match */
@@ -739,10 +739,10 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
           s = (*match) (base, q2 + 1, token, tokenlen);
         }
         if (!s)
-          return 0;		/* Oh well, no matches */
+          return 0;             /* Oh well, no matches */
         q = strpbrk(q2 + 1, "\"\'");
         if (!q)
-          noquote = 0;		/* No more quotes */
+          noquote = 0;          /* No more quotes */
       }
     }
   }
@@ -751,7 +751,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
   if (nocomment) {
     q = strstr(base, "/*");
     if (!q) {
-      nocomment = 0;		/* Well, no comments to worry about. Oh well */
+      nocomment = 0;            /* Well, no comments to worry about. Oh well */
     } else {
       while (q && (q < s)) {
         /* First match was found inside a comment.  Try to find another match */
@@ -764,10 +764,10 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
           s = (*match) (base, q2 + 1, token, tokenlen);
         }
         if (!s)
-          return 0;		/* Oh well, no matches */
+          return 0;             /* Oh well, no matches */
         q = strstr(q2 + 1, "/*");
         if (!q)
-          nocomment = 0;		/* No more comments */
+          nocomment = 0;                /* No more comments */
       }
     }
   }
@@ -781,7 +781,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     /* String is either shrinking or staying the same size */
     /* In this case, we do the replacement in place without memory reallocation */
     ic = count;
-    t = s;			/* Target of memory copies */
+    t = s;                      /* Target of memory copies */
     while (ic && s) {
       if (replen) {
         memcpy(t, rep, replen);
@@ -813,7 +813,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             q = strpbrk(q2 + 1, "\"\'");
             if (!q)
-              noquote = 0;	/* No more quotes */
+              noquote = 0;      /* No more quotes */
           }
         }
       }
@@ -835,7 +835,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
               break;
             q = strstr(q2 + 1, "/*");
             if (!q)
-              nocomment = 0;	/* No more comments */
+              nocomment = 0;    /* No more comments */
           }
         }
       }
@@ -860,7 +860,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     str->len += expand;
     str->str[str->len] = 0;
     if (str->sp >= str->len)
-      str->sp += expand;	/* Fix the end of file pointer */
+      str->sp += expand;        /* Fix the end of file pointer */
     return rcount;
   }
   /* The string is expanding as a result of the replacement */
@@ -928,7 +928,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       }
     }
 
-    expand = delta * rcount;	/* Total amount of expansion for the replacement */
+    expand = delta * rcount;    /* Total amount of expansion for the replacement */
     newsize = str->maxsize;
     while ((str->len + expand) >= newsize)
       newsize *= 2;
@@ -966,7 +966,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
             }
             q = strpbrk(q2 + 1, "\"\'");
             if (!q)
-              noquote = 0;	/* No more quotes */
+              noquote = 0;      /* No more quotes */
           }
         }
       }
@@ -989,7 +989,7 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
             }
             q = strstr(q2 + 1, "/*");
             if (!q)
-              nocomment = 0;	/* No more comments */
+              nocomment = 0;    /* No more comments */
           }
         }
       }
@@ -1090,11 +1090,11 @@ static int String_getline(DOH *so) {
 }
 
 static DohListMethods StringListMethods = {
-  0,				/* doh_getitem */
-  0,				/* doh_setitem */
-  String_delitem,		/* doh_delitem */
-  String_insert,		/* doh_insitem */
-  String_delslice,		/* doh_delslice */
+  0,                            /* doh_getitem */
+  0,                            /* doh_setitem */
+  String_delitem,               /* doh_delitem */
+  String_insert,                /* doh_insitem */
+  String_delslice,              /* doh_delslice */
 };
 
 static DohFileMethods StringFileMethods = {
@@ -1113,29 +1113,29 @@ static DohStringMethods StringStringMethods = {
 };
 
 DohObjInfo DohStringType = {
-  "String",			/* objname */
-  DelString,			/* doh_del */
-  CopyString,			/* doh_copy */
-  String_clear,			/* doh_clear */
-  String_str,			/* doh_str */
-  String_data,			/* doh_data */
-  String_dump,			/* doh_dump */
-  String_len,	    	        /* doh_len */
-  String_hash,			/* doh_hash    */
-  String_cmp,			/* doh_cmp */
-  String_equal,	    	        /* doh_equal */
-  0,				/* doh_first    */
-  0,				/* doh_next     */
-  String_setfile,		/* doh_setfile */
-  String_getfile,		/* doh_getfile */
-  String_setline,		/* doh_setline */
-  String_getline,		/* doh_getline */
-  0,				/* doh_mapping */
-  &StringListMethods,		/* doh_sequence */
-  &StringFileMethods,		/* doh_file */
-  &StringStringMethods,		/* doh_string */
-  0,				/* doh_reserved */
-  0,				/* clientdata */
+  "String",                     /* objname */
+  DelString,                    /* doh_del */
+  CopyString,                   /* doh_copy */
+  String_clear,                 /* doh_clear */
+  String_str,                   /* doh_str */
+  String_data,                  /* doh_data */
+  String_dump,                  /* doh_dump */
+  String_len,                   /* doh_len */
+  String_hash,                  /* doh_hash    */
+  String_cmp,                   /* doh_cmp */
+  String_equal,                 /* doh_equal */
+  0,                            /* doh_first    */
+  0,                            /* doh_next     */
+  String_setfile,               /* doh_setfile */
+  String_getfile,               /* doh_getfile */
+  String_setline,               /* doh_setline */
+  String_getline,               /* doh_getline */
+  0,                            /* doh_mapping */
+  &StringListMethods,           /* doh_sequence */
+  &StringFileMethods,           /* doh_file */
+  &StringStringMethods,         /* doh_string */
+  0,                            /* doh_reserved */
+  0,                            /* clientdata */
 };
 
 

--- a/Source/DOH/string.c
+++ b/Source/DOH/string.c
@@ -152,17 +152,17 @@ static int String_equal(DOH *so1, DOH *so2) {
     int i = mlen;
     for (; i; --i) {
       if (*(c1++) != *(c2++))
-	return 0;
+        return 0;
       if (*(c1++) != *(c2++))
-	return 0;
+        return 0;
       if (*(c1++) != *(c2++))
-	return 0;
+        return 0;
       if (*(c1++) != *(c2++))
-	return 0;
+        return 0;
     }
     for (i = len - (mlen << 2); i; --i) {
       if (*(c1++) != *(c2++))
-	return 0;
+        return 0;
     }
     return 1;
 #else
@@ -247,7 +247,7 @@ static void DohString_append(DOH *so, const DOHString_or_char *str) {
     tc += sp;
     for (; i; --i) {
       if (*(tc++) == '\n')
-	s->line++;
+        s->line++;
     }
     s->sp = oldlen + l;
   }
@@ -313,7 +313,7 @@ static int String_insert(DOH *so, int pos, DOH *str) {
 
     for (i = 0; i < len; i++) {
       if (data[i] == '\n')
-	s->line++;
+        s->line++;
     }
     s->sp += len;
   }
@@ -376,7 +376,7 @@ static int String_delslice(DOH *so, int sindex, int eindex) {
     }
     for (i = sindex; i < end; i++) {
       if (s->str[i] == '\n')
-	s->line--;
+        s->line--;
     }
     assert(s->sp >= 0);
   }
@@ -475,7 +475,7 @@ static int String_seek(DOH *so, long offset, int whence) {
     while (sp != nsp) {
       int prev = sp + inc;
       if (prev >= 0 && prev <= len && tc[prev] == '\n')
-	s->line += inc;
+        s->line += inc;
       sp += inc;
     }
 #else
@@ -483,13 +483,13 @@ static int String_seek(DOH *so, long offset, int whence) {
     char *tc = s->str;
     if (inc > 0) {
       while (sp != nsp) {
-	if (tc[++sp] == '\n')
-	  ++s->line;
+        if (tc[++sp] == '\n')
+          ++s->line;
       }
     } else {
       while (sp != nsp) {
-	if (tc[--sp] == '\n')
-	  --s->line;
+        if (tc[--sp] == '\n')
+          --s->line;
       }
     }
 #endif
@@ -583,8 +583,8 @@ static char *end_quote(char *s) {
     if (nl && (nl < q)) {
       /* A new line appears before the end of the string */
       if (*(nl - 1) == '\\') {
-	s = nl + 1;
-	continue;
+        s = nl + 1;
+        continue;
       }
       /* String was terminated by a newline.  Wing it */
       return qs;
@@ -729,20 +729,20 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       noquote = 0;		/* Well, no quotes to worry about. Oh well */
     } else {
       while (q && (q < s)) {
-	/* First match was found inside a quote.  Try to find another match */
-	q2 = end_quote(q);
-	if (!q2) {
-	  return 0;
-	}
-	if (q2 > s) {
-	  /* Find next match */
-	  s = (*match) (base, q2 + 1, token, tokenlen);
-	}
-	if (!s)
-	  return 0;		/* Oh well, no matches */
-	q = strpbrk(q2 + 1, "\"\'");
-	if (!q)
-	  noquote = 0;		/* No more quotes */
+        /* First match was found inside a quote.  Try to find another match */
+        q2 = end_quote(q);
+        if (!q2) {
+          return 0;
+        }
+        if (q2 > s) {
+          /* Find next match */
+          s = (*match) (base, q2 + 1, token, tokenlen);
+        }
+        if (!s)
+          return 0;		/* Oh well, no matches */
+        q = strpbrk(q2 + 1, "\"\'");
+        if (!q)
+          noquote = 0;		/* No more quotes */
       }
     }
   }
@@ -754,20 +754,20 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       nocomment = 0;		/* Well, no comments to worry about. Oh well */
     } else {
       while (q && (q < s)) {
-	/* First match was found inside a comment.  Try to find another match */
-	q2 = end_comment(q);
-	if (!q2) {
-	  return 0;
-	}
-	if (q2 > s) {
-	  /* Find next match */
-	  s = (*match) (base, q2 + 1, token, tokenlen);
-	}
-	if (!s)
-	  return 0;		/* Oh well, no matches */
-	q = strstr(q2 + 1, "/*");
-	if (!q)
-	  nocomment = 0;		/* No more comments */
+        /* First match was found inside a comment.  Try to find another match */
+        q2 = end_comment(q);
+        if (!q2) {
+          return 0;
+        }
+        if (q2 > s) {
+          /* Find next match */
+          s = (*match) (base, q2 + 1, token, tokenlen);
+        }
+        if (!s)
+          return 0;		/* Oh well, no matches */
+        q = strstr(q2 + 1, "/*");
+        if (!q)
+          nocomment = 0;		/* No more comments */
       }
     }
   }
@@ -784,72 +784,72 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     t = s;			/* Target of memory copies */
     while (ic && s) {
       if (replen) {
-	memcpy(t, rep, replen);
-	t += replen;
+        memcpy(t, rep, replen);
+        t += replen;
       }
       rcount++;
       expand += delta;
       /* Find the next location */
       s += tokenlen;
       if (ic == 1)
-	break;
+        break;
       c = (*match) (base, s, token, tokenlen);
 
       if (noquote) {
-	q = strpbrk(s, "\"\'");
-	if (!q) {
-	  noquote = 0;
-	} else {
-	  while (q && (q < c)) {
-	    /* First match was found inside a quote.  Try to find another match */
-	    q2 = end_quote(q);
-	    if (!q2) {
-	      c = 0;
-	      break;
-	    }
-	    if (q2 > c)
-	      c = (*match) (base, q2 + 1, token, tokenlen);
-	    if (!c)
-	      break;
-	    q = strpbrk(q2 + 1, "\"\'");
-	    if (!q)
-	      noquote = 0;	/* No more quotes */
-	  }
-	}
+        q = strpbrk(s, "\"\'");
+        if (!q) {
+          noquote = 0;
+        } else {
+          while (q && (q < c)) {
+            /* First match was found inside a quote.  Try to find another match */
+            q2 = end_quote(q);
+            if (!q2) {
+              c = 0;
+              break;
+            }
+            if (q2 > c)
+              c = (*match) (base, q2 + 1, token, tokenlen);
+            if (!c)
+              break;
+            q = strpbrk(q2 + 1, "\"\'");
+            if (!q)
+              noquote = 0;	/* No more quotes */
+          }
+        }
       }
       if (nocomment) {
-	q = strstr(s, "/*");
-	if (!q) {
-	  nocomment = 0;
-	} else {
-	  while (q && (q < c)) {
-	    /* First match was found inside a comment.  Try to find another match */
-	    q2 = end_comment(q);
-	    if (!q2) {
-	      c = 0;
-	      break;
-	    }
-	    if (q2 > c)
-	      c = (*match) (base, q2 + 1, token, tokenlen);
-	    if (!c)
-	      break;
-	    q = strstr(q2 + 1, "/*");
-	    if (!q)
-	      nocomment = 0;	/* No more comments */
-	  }
-	}
+        q = strstr(s, "/*");
+        if (!q) {
+          nocomment = 0;
+        } else {
+          while (q && (q < c)) {
+            /* First match was found inside a comment.  Try to find another match */
+            q2 = end_comment(q);
+            if (!q2) {
+              c = 0;
+              break;
+            }
+            if (q2 > c)
+              c = (*match) (base, q2 + 1, token, tokenlen);
+            if (!c)
+              break;
+            q = strstr(q2 + 1, "/*");
+            if (!q)
+              nocomment = 0;	/* No more comments */
+          }
+        }
       }
       if (delta) {
-	if (c) {
-	  memmove(t, s, c - s);
-	  t += (c - s);
-	} else {
-	  memmove(t, s, (str->str + str->len) - s + 1);
-	}
+        if (c) {
+          memmove(t, s, c - s);
+          t += (c - s);
+        } else {
+          memmove(t, s, (str->str + str->len) - s + 1);
+        }
       } else {
-	if (c) {
-	  t += (c - s);
-	}
+        if (c) {
+          t += (c - s);
+        }
       }
       s = c;
       ic--;
@@ -874,57 +874,57 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
     s += tokenlen;
     while (ic && (c = (*match) (base, s, token, tokenlen))) {
       if (noquote) {
-	q = strpbrk(s, "\"\'");
-	if (!q) {
-	  break;
-	} else {
-	  while (q && (q < c)) {
-	    /* First match was found inside a quote.  Try to find another match */
-	    q2 = end_quote(q);
-	    if (!q2) {
-	      c = 0;
-	      break;
-	    }
-	    if (q2 > c) {
-	      c = (*match) (base, q2 + 1, token, tokenlen);
-	      if (!c)
-		break;
-	    }
-	    q = strpbrk(q2 + 1, "\"\'");
-	    if (!q)
-	      noquote = 0;
-	  }
-	}
+        q = strpbrk(s, "\"\'");
+        if (!q) {
+          break;
+        } else {
+          while (q && (q < c)) {
+            /* First match was found inside a quote.  Try to find another match */
+            q2 = end_quote(q);
+            if (!q2) {
+              c = 0;
+              break;
+            }
+            if (q2 > c) {
+              c = (*match) (base, q2 + 1, token, tokenlen);
+              if (!c)
+                break;
+            }
+            q = strpbrk(q2 + 1, "\"\'");
+            if (!q)
+              noquote = 0;
+          }
+        }
       }
       if (nocomment) {
-	q = strstr(s, "/*");
-	if (!q) {
-	  break;
-	} else {
-	  while (q && (q < c)) {
-	    /* First match was found inside a comment.  Try to find another match */
-	    q2 = end_comment(q);
-	    if (!q2) {
-	      c = 0;
-	      break;
-	    }
-	    if (q2 > c) {
-	      c = (*match) (base, q2 + 1, token, tokenlen);
-	      if (!c)
-		break;
-	    }
-	    q = strstr(q2 + 1, "/*");
-	    if (!q)
-	      nocomment = 0;
-	  }
-	}
+        q = strstr(s, "/*");
+        if (!q) {
+          break;
+        } else {
+          while (q && (q < c)) {
+            /* First match was found inside a comment.  Try to find another match */
+            q2 = end_comment(q);
+            if (!q2) {
+              c = 0;
+              break;
+            }
+            if (q2 > c) {
+              c = (*match) (base, q2 + 1, token, tokenlen);
+              if (!c)
+                break;
+            }
+            q = strstr(q2 + 1, "/*");
+            if (!q)
+              nocomment = 0;
+          }
+        }
       }
       if (c) {
-	rcount++;
-	ic--;
-	s = c + tokenlen;
+        rcount++;
+        ic--;
+        s = c + tokenlen;
       } else {
-	break;
+        break;
       }
     }
 
@@ -948,56 +948,56 @@ static int replace_simple(String *str, char *token, char *rep, int flags, int co
       s += tokenlen;
       c = (*match) (base, s, token, tokenlen);
       if (noquote) {
-	q = strpbrk(s, "\"\'");
-	if (!q) {
-	  noquote = 0;
-	} else {
-	  while (q && (q < c)) {
-	    /* First match was found inside a quote.  Try to find another match */
-	    q2 = end_quote(q);
-	    if (!q2) {
-	      c = 0;
-	      break;
-	    }
-	    if (q2 > c) {
-	      c = (*match) (base, q2 + 1, token, tokenlen);
-	      if (!c)
-		break;
-	    }
-	    q = strpbrk(q2 + 1, "\"\'");
-	    if (!q)
-	      noquote = 0;	/* No more quotes */
-	  }
-	}
+        q = strpbrk(s, "\"\'");
+        if (!q) {
+          noquote = 0;
+        } else {
+          while (q && (q < c)) {
+            /* First match was found inside a quote.  Try to find another match */
+            q2 = end_quote(q);
+            if (!q2) {
+              c = 0;
+              break;
+            }
+            if (q2 > c) {
+              c = (*match) (base, q2 + 1, token, tokenlen);
+              if (!c)
+                break;
+            }
+            q = strpbrk(q2 + 1, "\"\'");
+            if (!q)
+              noquote = 0;	/* No more quotes */
+          }
+        }
       }
       if (nocomment) {
-	q = strstr(s, "/*");
-	if (!q) {
-	  nocomment = 0;
-	} else {
-	  while (q && (q < c)) {
-	    /* First match was found inside a comment.  Try to find another match */
-	    q2 = end_comment(q);
-	    if (!q2) {
-	      c = 0;
-	      break;
-	    }
-	    if (q2 > c) {
-	      c = (*match) (base, q2 + 1, token, tokenlen);
-	      if (!c)
-		break;
-	    }
-	    q = strstr(q2 + 1, "/*");
-	    if (!q)
-	      nocomment = 0;	/* No more comments */
-	  }
-	}
+        q = strstr(s, "/*");
+        if (!q) {
+          nocomment = 0;
+        } else {
+          while (q && (q < c)) {
+            /* First match was found inside a comment.  Try to find another match */
+            q2 = end_comment(q);
+            if (!q2) {
+              c = 0;
+              break;
+            }
+            if (q2 > c) {
+              c = (*match) (base, q2 + 1, token, tokenlen);
+              if (!c)
+                break;
+            }
+            q = strstr(q2 + 1, "/*");
+            if (!q)
+              nocomment = 0;	/* No more comments */
+          }
+        }
       }
       if (i < (rcount - 1)) {
-	memcpy(t, s, c - s);
-	t += (c - s);
+        memcpy(t, s, c - s);
+        t += (c - s);
       } else {
-	memcpy(t, s, (str->str + str->len) - s + 1);
+        memcpy(t, s, (str->str + str->len) - s + 1);
       }
       s = c;
     }
@@ -1050,7 +1050,7 @@ static void String_chop(DOH *so) {
     if (str->sp >= str->len) {
       str->sp--;
       if (*c == '\n')
-	str->line--;
+        str->line--;
     }
     str->len--;
     c--;

--- a/Source/DOH/void.c
+++ b/Source/DOH/void.c
@@ -16,7 +16,7 @@
 
 typedef struct {
   void *ptr;
-  void (*del) (void *);
+  void (*del)(void *);
 } VoidObj;
 
 /* -----------------------------------------------------------------------------
@@ -26,9 +26,9 @@ typedef struct {
  * ----------------------------------------------------------------------------- */
 
 static void Void_delete(DOH *vo) {
-  VoidObj *v = (VoidObj *) ObjData(vo);
+  VoidObj *v = (VoidObj *)ObjData(vo);
   if (v->del)
-    (*v->del) (v->ptr);
+    (*v->del)(v->ptr);
   DohFree(v);
 }
 
@@ -40,7 +40,7 @@ static void Void_delete(DOH *vo) {
  * ----------------------------------------------------------------------------- */
 
 static DOH *Void_copy(DOH *vo) {
-  VoidObj *v = (VoidObj *) ObjData(vo);
+  VoidObj *v = (VoidObj *)ObjData(vo);
   return NewVoid(v->ptr, 0);
 }
 
@@ -51,34 +51,34 @@ static DOH *Void_copy(DOH *vo) {
  * ----------------------------------------------------------------------------- */
 
 static void *Void_data(DOH *vo) {
-  VoidObj *v = (VoidObj *) ObjData(vo);
+  VoidObj *v = (VoidObj *)ObjData(vo);
   return v->ptr;
 }
 
 static DohObjInfo DohVoidType = {
-  "VoidObj",                    /* objname */
-  Void_delete,                  /* doh_del */
-  Void_copy,                    /* doh_copy */
-  0,                            /* doh_clear */
-  0,                            /* doh_str */
-  Void_data,                    /* doh_data */
-  0,                            /* doh_dump */
-  0,                            /* doh_len */
-  0,                            /* doh_hash    */
-  0,                            /* doh_cmp */
-  0,                            /* doh_equal    */
-  0,                            /* doh_first    */
-  0,                            /* doh_next     */
-  0,                            /* doh_setfile */
-  0,                            /* doh_getfile */
-  0,                            /* doh_setline */
-  0,                            /* doh_getline */
-  0,                            /* doh_mapping */
-  0,                            /* doh_sequence */
-  0,                            /* doh_file  */
-  0,                            /* doh_string */
-  0,                            /* doh_reserved */
-  0,                            /* clientdata */
+  "VoidObj",   /* objname */
+  Void_delete, /* doh_del */
+  Void_copy,   /* doh_copy */
+  0,           /* doh_clear */
+  0,           /* doh_str */
+  Void_data,   /* doh_data */
+  0,           /* doh_dump */
+  0,           /* doh_len */
+  0,           /* doh_hash    */
+  0,           /* doh_cmp */
+  0,           /* doh_equal    */
+  0,           /* doh_first    */
+  0,           /* doh_next     */
+  0,           /* doh_setfile */
+  0,           /* doh_getfile */
+  0,           /* doh_setline */
+  0,           /* doh_getline */
+  0,           /* doh_mapping */
+  0,           /* doh_sequence */
+  0,           /* doh_file  */
+  0,           /* doh_string */
+  0,           /* doh_reserved */
+  0,           /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------
@@ -87,9 +87,9 @@ static DohObjInfo DohVoidType = {
  * Creates a new Void object given a void * and an optional destructor function.
  * ----------------------------------------------------------------------------- */
 
-DOH *DohNewVoid(void *obj, void (*del) (void *)) {
+DOH *DohNewVoid(void *obj, void (*del)(void *)) {
   VoidObj *v;
-  v = (VoidObj *) DohMalloc(sizeof(VoidObj));
+  v = (VoidObj *)DohMalloc(sizeof(VoidObj));
   v->ptr = obj;
   v->del = del;
   return DohObjMalloc(&DohVoidType, v);

--- a/Source/DOH/void.c
+++ b/Source/DOH/void.c
@@ -56,29 +56,29 @@ static void *Void_data(DOH *vo) {
 }
 
 static DohObjInfo DohVoidType = {
-  "VoidObj",			/* objname */
-  Void_delete,			/* doh_del */
-  Void_copy,			/* doh_copy */
-  0,				/* doh_clear */
-  0,				/* doh_str */
-  Void_data,			/* doh_data */
-  0,				/* doh_dump */
-  0,				/* doh_len */
-  0,				/* doh_hash    */
-  0,				/* doh_cmp */
-  0,				/* doh_equal    */
-  0,				/* doh_first    */
-  0,				/* doh_next     */
-  0,				/* doh_setfile */
-  0,				/* doh_getfile */
-  0,				/* doh_setline */
-  0,				/* doh_getline */
-  0,				/* doh_mapping */
-  0,				/* doh_sequence */
-  0,				/* doh_file  */
-  0,				/* doh_string */
-  0,				/* doh_reserved */
-  0,				/* clientdata */
+  "VoidObj",                    /* objname */
+  Void_delete,                  /* doh_del */
+  Void_copy,                    /* doh_copy */
+  0,                            /* doh_clear */
+  0,                            /* doh_str */
+  Void_data,                    /* doh_data */
+  0,                            /* doh_dump */
+  0,                            /* doh_len */
+  0,                            /* doh_hash    */
+  0,                            /* doh_cmp */
+  0,                            /* doh_equal    */
+  0,                            /* doh_first    */
+  0,                            /* doh_next     */
+  0,                            /* doh_setfile */
+  0,                            /* doh_getfile */
+  0,                            /* doh_setline */
+  0,                            /* doh_getline */
+  0,                            /* doh_mapping */
+  0,                            /* doh_sequence */
+  0,                            /* doh_file  */
+  0,                            /* doh_string */
+  0,                            /* doh_reserved */
+  0,                            /* clientdata */
 };
 
 /* -----------------------------------------------------------------------------

--- a/Source/DOH/void.c
+++ b/Source/DOH/void.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Doxygen/csharpdoc.cxx
+++ b/Source/Doxygen/csharpdoc.cxx
@@ -87,7 +87,7 @@ public:
     if (m_output->length() > lenIndentLevel) {
       const size_t start = m_output->length() - lenIndentLevel;
       if (m_output->compare(start, string::npos, Level()) == 0)
-	m_output->erase(start);
+        m_output->erase(start);
     }
   }
 
@@ -178,11 +178,11 @@ static string padCodeAndVerbatimBlocks(const string &docString) {
       lastLineWasNonBlank = false;
     } else {
       if (lastLineWasNonBlank &&
-	  (line.compare(pos, 13, ".. code-block") == 0 ||
-	   line.compare(pos, 7, ".. math") == 0 ||
-	   line.compare(pos, 3, ">>>") == 0)) {
-	// Must separate code or math blocks from the previous line
-	result += '\n';
+          (line.compare(pos, 13, ".. code-block") == 0 ||
+           line.compare(pos, 7, ".. math") == 0 ||
+           line.compare(pos, 3, ">>>") == 0)) {
+        // Must separate code or math blocks from the previous line
+        result += '\n';
       }
       lastLineWasNonBlank = true;
     }
@@ -411,7 +411,7 @@ std::string CSharpDocConverter::getParamValue(std::string param) {
     if (pname && Char(pname) == param) {
       String *pval = Getattr(p, "value");
       if (pval)
-	value = Char(pval);
+        value = Char(pval);
       break;
     }
   }
@@ -602,12 +602,12 @@ void CSharpDocConverter::handleMath(DoxygenEntity &tag, std::string &translatedC
   if (start != std::string::npos) {
     for (size_t n = start; n <= end; n++) {
       if (formula[n] == '\n') {
-	// New lines must be suppressed in inline maths and indented in the block ones.
-	if (!inlineFormula)
-	  translatedComment += formulaNL;
+        // New lines must be suppressed in inline maths and indented in the block ones.
+        if (!inlineFormula)
+          translatedComment += formulaNL;
       } else {
-	// Just copy everything else.
-	translatedComment += formula[n];
+        // Just copy everything else.
+        translatedComment += formula[n];
       }
     }
   }
@@ -895,7 +895,7 @@ void CSharpDocConverter::handleDoxyHtmlTag_tr(DoxygenEntity &tag, std::string &t
     if (nlPos != string::npos) {
       size_t startOfTableLinePos = translatedComment.find_first_not_of(" \t", nlPos + 1);
       if (startOfTableLinePos != string::npos) {
-	m_tableLineLen = translatedComment.size() - startOfTableLinePos;
+        m_tableLineLen = translatedComment.size() - startOfTableLinePos;
       }
     }
   } else {
@@ -907,7 +907,7 @@ void CSharpDocConverter::handleDoxyHtmlTag_tr(DoxygenEntity &tag, std::string &t
       translatedComment += string(m_tableLineLen, '-') + '\n';
 
       if (nlPos != string::npos) {
-	translatedComment += string (numLeadingSpaces, ' ');
+        translatedComment += string (numLeadingSpaces, ' ');
       }
       m_prevRowIsTH = false;
     }

--- a/Source/Doxygen/csharpdoc.cxx
+++ b/Source/Doxygen/csharpdoc.cxx
@@ -33,8 +33,9 @@ public:
   static const char *Level() {
     return "    ";
   }
-  // Default ctor doesn't do anything and prevents the dtor from doing anything// too and should only be used when the guard needs to be initialized// conditionally as Init() can then be called after checking some condition.// Otherwise, prefer to use the non default ctor below.
-      IndentGuard() {
+  // Default ctor doesn't do anything and prevents the dtor from doing anything// too and should only be used when the guard needs to be initialized//
+  // conditionally as Init() can then be called after checking some condition.// Otherwise, prefer to use the non default ctor below.
+  IndentGuard() {
     m_initialized = false;
   }
 
@@ -177,10 +178,7 @@ static string padCodeAndVerbatimBlocks(const string &docString) {
     if (pos == string::npos) {
       lastLineWasNonBlank = false;
     } else {
-      if (lastLineWasNonBlank &&
-          (line.compare(pos, 13, ".. code-block") == 0 ||
-           line.compare(pos, 7, ".. math") == 0 ||
-           line.compare(pos, 3, ">>>") == 0)) {
+      if (lastLineWasNonBlank && (line.compare(pos, 13, ".. code-block") == 0 || line.compare(pos, 7, ".. math") == 0 || line.compare(pos, 3, ">>>") == 0)) {
         // Must separate code or math blocks from the previous line
         result += '\n';
       }
@@ -201,9 +199,8 @@ CSharpDocConverter::TagHandlersMap::mapped_type CSharpDocConverter::make_handler
 }
 
 void CSharpDocConverter::fillStaticTables() {
-  if (tagHandlers.size()) // fill only once
+  if (tagHandlers.size())  // fill only once
     return;
-
 
   tagHandlers["a"] = make_handler(&CSharpDocConverter::handleTagWrap, "*");
   tagHandlers["b"] = make_handler(&CSharpDocConverter::handleTagWrap, "**");
@@ -361,8 +358,7 @@ void CSharpDocConverter::fillStaticTables() {
   tagHandlers["&rarr"] = make_handler(&CSharpDocConverter::handleHtmlEntity, "-->");
 }
 
-CSharpDocConverter::CSharpDocConverter(int flags):
-DoxygenTranslator(flags), m_tableLineLen(0), m_prevRowIsTH(false) {
+CSharpDocConverter::CSharpDocConverter(int flags) : DoxygenTranslator(flags), m_tableLineLen(0), m_prevRowIsTH(false) {
   fillStaticTables();
 }
 
@@ -442,7 +438,7 @@ bool CSharpDocConverter::paramExists(std::string param) {
     /* doesn't seem to work always: in some cases (especially for 'self' parameters)
      * tmap:in is present, but tmap:in:next is not and so this code skips all the parameters
      */
-    //p = Getattr(p, "tmap:in") ? Getattr(p, "tmap:in:next") : nextSibling(p);
+    // p = Getattr(p, "tmap:in") ? Getattr(p, "tmap:in:next") : nextSibling(p);
     p = nextSibling(p);
   }
 
@@ -473,7 +469,7 @@ void CSharpDocConverter::translateEntity(DoxygenEntity &doxyEntity, std::string 
   std::map<std::string, std::pair<tagHandler, std::string> >::iterator it;
   it = tagHandlers.find(getBaseCommand(doxyEntity.typeOfEntity));
   if (it != tagHandlers.end())
-    (this->*(it->second.first)) (doxyEntity, translatedComment, it->second.second);
+    (this->*(it->second.first))(doxyEntity, translatedComment, it->second.second);
 }
 
 void CSharpDocConverter::handleIgnore(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
@@ -497,7 +493,6 @@ void CSharpDocConverter::handleSummary(DoxygenEntity &tag, std::string &translat
 
   translatedComment += summary;
 
-
   translatedComment += "</summary>";
   translatedComment += "\n";
 }
@@ -511,7 +506,6 @@ void CSharpDocConverter::handleLine(DoxygenEntity &tag, std::string &translatedC
   }
   translatedComment += "</" + tagName + ">";
 }
-
 
 void CSharpDocConverter::handleNotHandled(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
 
@@ -533,7 +527,6 @@ void CSharpDocConverter::handleAddList(DoxygenEntity &tag, std::string &translat
   translatedComment += listItem;
   translatedComment += "\n";
 }
-
 
 void CSharpDocConverter::handleParagraph(DoxygenEntity &tag, std::string &translatedComment, const std::string &tagName) {
   translatedComment += "<";
@@ -560,7 +553,7 @@ void CSharpDocConverter::handleVerbatimBlock(DoxygenEntity &tag, std::string &tr
   eraseLeadingNewLine(verb);
 
   // Remove the last newline to prevent doubling the newline already present after \endverbatim
-  trimWhitespace(verb); // Needed to catch trailing newline below
+  trimWhitespace(verb);  // Needed to catch trailing newline below
   eraseTrailingSpaceNewLines(verb);
   escapeSpecificCharacters(verb);
 
@@ -777,7 +770,6 @@ void CSharpDocConverter::handleTagParam(DoxygenEntity &tag, std::string &transla
   translatedComment += "</param> \n";
 }
 
-
 void CSharpDocConverter::handleTagReturn(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
   IndentGuard indent(translatedComment, m_indent);
 
@@ -786,7 +778,6 @@ void CSharpDocConverter::handleTagReturn(DoxygenEntity &tag, std::string &transl
   eraseTrailingSpaceNewLines(translatedComment);
   translatedComment += "</returns> \n";
 }
-
 
 void CSharpDocConverter::handleTagException(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
   IndentGuard indent(translatedComment, m_indent);
@@ -806,7 +797,6 @@ void CSharpDocConverter::handleTagException(DoxygenEntity &tag, std::string &tra
 
   translatedComment += "</exception> \n";
 }
-
 
 void CSharpDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
 
@@ -828,9 +818,8 @@ void CSharpDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translate
   translatedComment += "\\ref " + anchorText;
 }
 
-
 void CSharpDocConverter::handleTagWrap(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg) {
-  if (tag.entityList.size()) { // do not include empty tags
+  if (tag.entityList.size()) {  // do not include empty tags
     std::string tagData = translateSubtree(tag);
     // wrap the thing, ignoring whitespace
     size_t wsPos = tagData.find_last_not_of("\n\t ");
@@ -907,7 +896,7 @@ void CSharpDocConverter::handleDoxyHtmlTag_tr(DoxygenEntity &tag, std::string &t
       translatedComment += string(m_tableLineLen, '-') + '\n';
 
       if (nlPos != string::npos) {
-        translatedComment += string (numLeadingSpaces, ' ');
+        translatedComment += string(numLeadingSpaces, ' ');
       }
       m_prevRowIsTH = false;
     }

--- a/Source/Doxygen/csharpdoc.h
+++ b/Source/Doxygen/csharpdoc.h
@@ -172,7 +172,7 @@ protected:
   void handleTagReturn(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
 
   /*
-   * Writes text for \ref tag. 
+   * Writes text for \ref tag.
    */
   void handleTagRef(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
 

--- a/Source/Doxygen/csharpdoc.h
+++ b/Source/Doxygen/csharpdoc.h
@@ -20,8 +20,8 @@
 #include "doxyentity.h"
 #include "doxytranslator.h"
 
-#define DOC_STRING_LENGTH         64 // characters per line allowed
-#define DOC_PARAM_STRING_LENGTH   30 // characters reserved for param name / type
+#define DOC_STRING_LENGTH       64  // characters per line allowed
+#define DOC_PARAM_STRING_LENGTH 30  // characters reserved for param name / type
 
 class CSharpDocConverter : public DoxygenTranslator {
 public:
@@ -30,7 +30,6 @@ public:
   String *makeDocumentation(Node *node);
 
 protected:
-
   size_t m_tableLineLen;
   bool m_prevRowIsTH;
   std::string m_url;
@@ -52,7 +51,7 @@ protected:
    * Typedef for the function that handles one tag
    * arg - some string argument to easily pass it through lookup table
    */
-  typedef void (CSharpDocConverter::*tagHandler) (DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
+  typedef void (CSharpDocConverter::*tagHandler)(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
 
   /*
    * Wrap the command data with the some string
@@ -82,12 +81,12 @@ protected:
 
   /**
    *  Print the content without any tag
-  */
+   */
   void handleNotHandled(DoxygenEntity &tag, std::string &translatedComment, const std::string &tagName);
 
   /**
    *  Print the content as an item of a list
-  */
+   */
   void handleAddList(DoxygenEntity &tag, std::string &translatedComment, const std::string &tagName);
 
   /*
@@ -95,7 +94,7 @@ protected:
    */
   void handleParagraph(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg = std::string());
 
-/*
+  /*
    * Ignore the tag
    */
   void handleIgnore(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg = std::string());
@@ -206,7 +205,6 @@ protected:
   /* Handles HTML entities recognized by Doxygen, like &lt;, &copy;, ... */
   void handleHtmlEntity(DoxygenEntity &, std::string &translatedComment, const std::string &arg);
 
-
   /*
    * Simple helper function that calculates correct parameter type
    * of the node stored in 'currentNode'
@@ -227,9 +225,8 @@ private:
   std::string m_indent;
 
   // this contains the handler pointer and one string argument
-  typedef std::map<std::string, std::pair<tagHandler, std::string> >TagHandlersMap;
+  typedef std::map<std::string, std::pair<tagHandler, std::string> > TagHandlersMap;
   static TagHandlersMap tagHandlers;
-
 
   // Helper functions for fillStaticTables(): make a new tag handler object.
   TagHandlersMap::mapped_type make_handler(tagHandler handler);

--- a/Source/Doxygen/doxycommands.h
+++ b/Source/Doxygen/doxycommands.h
@@ -29,101 +29,115 @@ const char *CMD_END_LATEX_1 = "f$";
 const char *CMD_END_LATEX_2 = "f}";
 const char *CMD_END_LATEX_3 = "f]";
 
-const char *sectionIndicators[] = {
-  "attention", "author", "authors", "brief", "bug", "cond", "date",
-  "deprecated", "details", "else", "elseif", "endcond", "endif",
-  "exception", "if", "ifnot", "invariant", "note", "par", "param",
-  "tparam", "post", "pre", "remarks", "remark", "result", "return",
-  "returns", "retval", "sa", "see", "since", "test", "throw", "throws",
-  "todo", "version", "warning", "xrefitem"
-};
+const char *sectionIndicators[] = {"attention", "author",  "authors", "brief",     "bug",    "cond",   "date",      "deprecated", "details", "else",
+                                   "elseif",    "endcond", "endif",   "exception", "if",     "ifnot",  "invariant", "note",       "par",     "param",
+                                   "tparam",    "post",    "pre",     "remarks",   "remark", "result", "return",    "returns",    "retval",  "sa",
+                                   "see",       "since",   "test",    "throw",     "throws", "todo",   "version",   "warning",    "xrefitem"};
 
 const int sectionIndicatorsSize = sizeof(sectionIndicators) / sizeof(*sectionIndicators);
 
 /* All of the doxygen commands divided up by how they are parsed */
 const char *simpleCommands[] = {
   // the first line are escaped chars, except \~, which is a language ID command.
-  "n", "$", "@", "\\", "&", "~", "<", ">", "#", "%", "\"", ".", "::",
+  "n",
+  "$",
+  "@",
+  "\\",
+  "&",
+  "~",
+  "<",
+  ">",
+  "#",
+  "%",
+  "\"",
+  ".",
+  "::",
   // Member groups, which we currently ignore.
-  "{", "}",
+  "{",
+  "}",
   "endcond",
-  "callgraph", "callergraph", "showinitializer", "hideinitializer", "internal",
-  "nosubgrouping", "public", "publicsection", "private", "privatesection",
-  "protected", "protectedsection", "tableofcontents"
-};
+  "callgraph",
+  "callergraph",
+  "showinitializer",
+  "hideinitializer",
+  "internal",
+  "nosubgrouping",
+  "public",
+  "publicsection",
+  "private",
+  "privatesection",
+  "protected",
+  "protectedsection",
+  "tableofcontents"};
 
 const int simpleCommandsSize = sizeof(simpleCommands) / sizeof(*simpleCommands);
 
-const char *commandWords[] = {
-  "a", "b", "c", "e", "em", "p", "def", "enum", "package", "relates",
-  "namespace", "relatesalso", "anchor", "dontinclude", "include",
-  "includelineno", "copydoc", "copybrief", "copydetails", "verbinclude",
-  "htmlinclude", "extends", "implements", "memberof", "related", "relatedalso",
-  "cite"
-};
+const char *commandWords[] = {"a",           "b",           "c",           "e",       "em",          "p",        "def",           "enum",        "package",
+                              "relates",     "namespace",   "relatesalso", "anchor",  "dontinclude", "include",  "includelineno", "copydoc",     "copybrief",
+                              "copydetails", "verbinclude", "htmlinclude", "extends", "implements",  "memberof", "related",       "relatedalso", "cite"};
 
 const int commandWordsSize = sizeof(commandWords) / sizeof(*commandWords);
 
-const char *commandLines[] = {
-  "addindex", "fn", "name", "line", "var", "skipline", "typedef", "skip",
-  "until", "property"
-};
+const char *commandLines[] = {"addindex", "fn", "name", "line", "var", "skipline", "typedef", "skip", "until", "property"};
 
 const int commandLinesSize = sizeof(commandLines) / sizeof(*commandLines);
 
 const char *commandParagraph[] = {
-  "partofdescription", "result", "return", "returns", "remarks", "remark",
-  "since", "test", "sa", "see", "pre", "post", "details", "invariant",
-  "deprecated", "date", "note", "warning", "version", "todo", "bug",
-  "attention", "brief", "author", "authors", "copyright", "short"
-};
+  "partofdescription", "result",    "return",     "returns", "remarks", "remark",  "since",   "test", "sa",  "see",       "pre",   "post",
+  "details",           "invariant", "deprecated", "date",    "note",    "warning", "version", "todo", "bug", "attention", "brief", "author",
+  "authors",           "copyright", "short"};
 
 const int commandParagraphSize = sizeof(commandParagraph) / sizeof(*commandParagraph);
 
-const char *commandEndCommands[] = {
-  CMD_HTML_ONLY, "latexonly", "manonly", "xmlonly", "link", "rtfonly"
-};
+const char *commandEndCommands[] = {CMD_HTML_ONLY, "latexonly", "manonly", "xmlonly", "link", "rtfonly"};
 
 const int commandEndCommandsSize = sizeof(commandEndCommands) / sizeof(*commandEndCommands);
 
-const char *commandWordParagraphs[] = {
-  "param", "tparam", "throw", "throws", "retval", "exception", "example"
-};
+const char *commandWordParagraphs[] = {"param", "tparam", "throw", "throws", "retval", "exception", "example"};
 
 const int commandWordParagraphsSize = sizeof(commandWordParagraphs) / sizeof(*commandWordParagraphs);
 
-const char *commandWordLines[] = {
-  "page", "subsection", "subsubsection", "section", "paragraph", "defgroup",
-  "snippet", "mainpage"
-};
+const char *commandWordLines[] = {"page", "subsection", "subsubsection", "section", "paragraph", "defgroup", "snippet", "mainpage"};
 
 const int commandWordLinesSize = sizeof(commandWordLines) / sizeof(*commandWordLines);
 
-const char *commandWordOWordOWords[] = {
-  "category", "class", "protocol", "interface", "struct", "union"
-};
+const char *commandWordOWordOWords[] = {"category", "class", "protocol", "interface", "struct", "union"};
 
 const int commandWordOWordOWordsSize = sizeof(commandWordOWordOWords) / sizeof(*commandWordOWordOWords);
 
-const char *commandOWords[] = {
-  "dir", "file", "cond"
-};
+const char *commandOWords[] = {"dir", "file", "cond"};
 
 const int commandOWordsSize = sizeof(commandOWords) / sizeof(*commandOWords);
 
-const char *commandErrorThrowings[] = {
-  "annotatedclassstd::list", "classhierarchy", "define", "functionindex", "header",
-  "headerfilestd::list", "inherit", "l", "postheader", "endcode", "enddot", "endmsc", "endhtmlonly",
-  "endlatexonly", "endmanonly", "endlink", "endverbatim", "endxmlonly", "f]", "f}", "endif", "else",
-  "endrtfonly"
-};
+const char *commandErrorThrowings[] = {"annotatedclassstd::list",
+                                       "classhierarchy",
+                                       "define",
+                                       "functionindex",
+                                       "header",
+                                       "headerfilestd::list",
+                                       "inherit",
+                                       "l",
+                                       "postheader",
+                                       "endcode",
+                                       "enddot",
+                                       "endmsc",
+                                       "endhtmlonly",
+                                       "endlatexonly",
+                                       "endmanonly",
+                                       "endlink",
+                                       "endverbatim",
+                                       "endxmlonly",
+                                       "f]",
+                                       "f}",
+                                       "endif",
+                                       "else",
+                                       "endrtfonly"};
 
 const int commandErrorThrowingsSize = sizeof(commandErrorThrowings) / sizeof(*commandErrorThrowings);
 
-const char *commandUniques[] = {
-  "xrefitem", "arg", "ingroup", "par", "headerfile", "overload", "weakgroup", "ref", "subpage", "dotfile", "image", "addtogroup", "li",
-  "if", "ifnot", "elseif", "else", "mscfile", "code", CMD_VERBATIM, "f{", "f[", "f$", "dot", "msc"
-};
+const char *commandUniques[] = {"xrefitem", "arg",        "ingroup",    "par", "headerfile", "overload", "weakgroup", "ref",  "subpage",
+                                "dotfile",  "image",      "addtogroup", "li",  "if",         "ifnot",    "elseif",    "else", "mscfile",
+                                "code",     CMD_VERBATIM, "f{",         "f[",  "f$",         "dot",      "msc"};
 
 const int commandUniquesSize = sizeof(commandUniques) / sizeof(*commandUniques);
 
@@ -132,41 +146,39 @@ const int commandUniquesSize = sizeof(commandUniques) / sizeof(*commandUniques);
 // output. So <varName> appears as &lt;varName&gt; in HTML output. The same
 // behavior must be repeated by SWIG. See Doxygen doc for the list of commands.
 // '<' is prepended to distinguish HTML tags from Doxygen commands.
-const char *commandHtml[] = {
-  "<a", "<b", "<blockquote", "<body", "<br", "<center", "<caption", "<code", "<dd", "<dfn",
-  "<div", "<dl", "<dt", "<em", "<form", "<hr", "<h1", "<h2", "<h3", "<i", "<input", "<img",
-  "<li", "<meta", "<multicol", "<ol", "<p", "<pre", "<small", "<span", "<strong",
-  "<sub", "<sup", "<table", "<td", "<th", "<tr", "<tt", "<kbd", "<ul", "<var"
-};
+const char *commandHtml[] = {"<a",     "<b",    "<blockquote", "<body", "<br", "<center", "<caption", "<code", "<dd",     "<dfn",   "<div",
+                             "<dl",    "<dt",   "<em",         "<form", "<hr", "<h1",     "<h2",      "<h3",   "<i",      "<input", "<img",
+                             "<li",    "<meta", "<multicol",   "<ol",   "<p",  "<pre",    "<small",   "<span", "<strong", "<sub",   "<sup",
+                             "<table", "<td",   "<th",         "<tr",   "<tt", "<kbd",    "<ul",      "<var"};
 
 const int commandHtmlSize = sizeof(commandHtml) / sizeof(*commandHtml);
 
 // Only entities which are translatable to plain text are used here. Others
 // are copied unchanged to output.
 const char *commandHtmlEntities[] = {
-  "&copy",                  // (C)
-  "&trade",                 // (TM)
-  "&reg",                   // (R)
-  "&lt",                    // less-than symbol
-  "&gt",                    // greater-than symbol
-  "&amp",                   // ampersand
-  "&apos",                  // single quotation mark (straight)
-  "&quot",                  // double quotation mark (straight)
-  "&lsquo",                 // left single quotation mark
-  "&rsquo",                 // right single quotation mark
-  "&ldquo",                 // left double quotation mark
-  "&rdquo",                 // right double quotation mark
-  "&ndash",                 // n-dash (for numeric ranges, e.g. 2–8)
-  "&mdash",                 // --
-  "&nbsp",                  //
-  "&times",                 // x
-  "&minus",                 // -
-  "&sdot",                  // .
-  "&sim",                   // ~
-  "&le",                    // <=
-  "&ge",                    // >=
-  "&larr",                  // <--
-  "&rarr"                   // -->
+  "&copy",   // (C)
+  "&trade",  // (TM)
+  "&reg",    // (R)
+  "&lt",     // less-than symbol
+  "&gt",     // greater-than symbol
+  "&amp",    // ampersand
+  "&apos",   // single quotation mark (straight)
+  "&quot",   // double quotation mark (straight)
+  "&lsquo",  // left single quotation mark
+  "&rsquo",  // right single quotation mark
+  "&ldquo",  // left double quotation mark
+  "&rdquo",  // right double quotation mark
+  "&ndash",  // n-dash (for numeric ranges, e.g. 2–8)
+  "&mdash",  // --
+  "&nbsp",   //
+  "&times",  // x
+  "&minus",  // -
+  "&sdot",   // .
+  "&sim",    // ~
+  "&le",     // <=
+  "&ge",     // >=
+  "&larr",   // <--
+  "&rarr"    // -->
 };
 
 const int commandHtmlEntitiesSize = sizeof(commandHtmlEntities) / sizeof(*commandHtmlEntities);

--- a/Source/Doxygen/doxyentity.cxx
+++ b/Source/Doxygen/doxyentity.cxx
@@ -16,9 +16,8 @@
 
 using std::cout;
 
-DoxygenEntity::DoxygenEntity(const std::string &typeEnt):typeOfEntity(typeEnt), isLeaf(true) {
+DoxygenEntity::DoxygenEntity(const std::string &typeEnt) : typeOfEntity(typeEnt), isLeaf(true) {
 }
-
 
 /* Basic node for commands that have
  * only 1 item after them
@@ -28,13 +27,11 @@ DoxygenEntity::DoxygenEntity(const std::string &typeEnt):typeOfEntity(typeEnt), 
 DoxygenEntity::DoxygenEntity(const std::string &typeEnt, const std::string &param1) : typeOfEntity(typeEnt), data(param1), isLeaf(true) {
 }
 
-
 /* Nonterminal node
  * contains
  */
 DoxygenEntity::DoxygenEntity(const std::string &typeEnt, const DoxygenEntityList &entList) : typeOfEntity(typeEnt), isLeaf(false), entityList(entList) {
 }
-
 
 void DoxygenEntity::printEntity(int level) const {
 

--- a/Source/Doxygen/doxyentity.h
+++ b/Source/Doxygen/doxyentity.h
@@ -17,13 +17,11 @@
 #include <string>
 #include <list>
 
-
 class DoxygenEntity;
 
 typedef std::list<DoxygenEntity> DoxygenEntityList;
 typedef DoxygenEntityList::iterator DoxygenEntityListIt;
 typedef DoxygenEntityList::const_iterator DoxygenEntityListCIt;
-
 
 /*
  * Structure to represent a doxygen comment entry

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -317,8 +317,8 @@ DoxygenParser::TokenListCIt DoxygenParser::getEndOfParagraph(const TokenList &to
     // could contain empty lines that would appear to be paragraph
     // ends:
     if (endOfParagraph->m_tokenType == COMMAND &&
-	(endOfParagraph->m_tokenString == "code" ||
-	 endOfParagraph->m_tokenString == "verbatim")) {
+        (endOfParagraph->m_tokenString == "code" ||
+         endOfParagraph->m_tokenString == "verbatim")) {
       const string theCommand = endOfParagraph->m_tokenString;
       endOfParagraph = getEndCommand("end" + theCommand, tokList);
       endOfParagraph++; // Move after the end command

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -49,7 +49,7 @@ static size_t getEndOfWordCommand(const std::string &line, size_t pos) {
   size_t endOfWordPos = line.find_first_not_of(DOXYGEN_WORD_CHARS, pos);
   if (line.substr(pos, 6) == "param[")
     // include ",", which can appear in param[in,out]
-    endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS)+ ",", pos);  
+    endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS)+ ",", pos);
   else if (line.substr(pos, 5) == "code{")
     // include ".", which can appear in e.g. code{.py}
     endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS)+ ".", pos);
@@ -1220,7 +1220,7 @@ void DoxygenParser::processWordCommands(size_t &pos, const std::string &line) {
       endOfWordPos = line.find_first_not_of(" \t", endOfWordPos);
     }
   }
-  
+
   pos = endOfWordPos;
 }
 

--- a/Source/Doxygen/doxyparser.cxx
+++ b/Source/Doxygen/doxyparser.cxx
@@ -17,26 +17,29 @@
 #include <iostream>
 #include <vector>
 
-using std::string;
 using std::cout;
 using std::endl;
+using std::string;
 
 // This constant defines the (only) characters valid inside a Doxygen "word".
 // It includes some unusual ones because of the commands such as \f[, \f{, \f],
 // \f} and \f$.
-static const char *DOXYGEN_WORD_CHARS = "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "0123456789" "$[]{}";
+static const char *DOXYGEN_WORD_CHARS = "abcdefghijklmnopqrstuvwxyz"
+                                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                        "0123456789"
+                                        "$[]{}";
 
 // Define static class members
 DoxygenParser::DoxyCommandsMap DoxygenParser::doxygenCommands;
 std::set<std::string> DoxygenParser::doxygenSectionIndicators;
 
-const int TOKENSPERLINE = 8; //change this to change the printing behaviour of the token list
+const int TOKENSPERLINE = 8;  // change this to change the printing behaviour of the token list
 const std::string END_HTML_TAG_MARK("/");
 
 std::string getBaseCommand(const std::string &cmd) {
-  if (cmd.substr(0,5) == "param")
+  if (cmd.substr(0, 5) == "param")
     return "param";
-  else if (cmd.substr(0,4) == "code")
+  else if (cmd.substr(0, 4) == "code")
     return "code";
   else
     return cmd;
@@ -49,13 +52,12 @@ static size_t getEndOfWordCommand(const std::string &line, size_t pos) {
   size_t endOfWordPos = line.find_first_not_of(DOXYGEN_WORD_CHARS, pos);
   if (line.substr(pos, 6) == "param[")
     // include ",", which can appear in param[in,out]
-    endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS)+ ",", pos);
+    endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS) + ",", pos);
   else if (line.substr(pos, 5) == "code{")
     // include ".", which can appear in e.g. code{.py}
-    endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS)+ ".", pos);
+    endOfWordPos = line.find_first_not_of(string(DOXYGEN_WORD_CHARS) + ".", pos);
   return endOfWordPos;
 }
-
 
 DoxygenParser::DoxygenParser(bool noisy) : noisy(noisy) {
   fillTables();
@@ -156,8 +158,11 @@ DoxygenParser::DoxyCommandEnum DoxygenParser::commandBelongs(const std::string &
     // one given to it by SWIG itself), we may use the value in the future, but
     // for now we only use the attributes.
     if (Strcmp(ignore, "1") != 0) {
-      Swig_warning(WARN_PP_UNEXPECTED_TOKENS, m_fileName.c_str(), m_fileLineNo,
-                   "Feature \"doxygen:ignore\" value ignored for Doxygen command \"%s\".\n", theCommand.c_str());
+      Swig_warning(WARN_PP_UNEXPECTED_TOKENS,
+                   m_fileName.c_str(),
+                   m_fileLineNo,
+                   "Feature \"doxygen:ignore\" value ignored for Doxygen command \"%s\".\n",
+                   theCommand.c_str());
     }
     // Also ensure that the matching end command, if any, will be recognized.
     const string endCommand = getIgnoreFeatureEndCommand(theCommand);
@@ -194,8 +199,7 @@ void DoxygenParser::skipWhitespaceTokens() {
     return;
   }
 
-  while (m_tokenListIt != m_tokenList.end()
-         && (m_tokenListIt->m_tokenType == END_LINE || trim(m_tokenListIt->m_tokenString).empty())) {
+  while (m_tokenListIt != m_tokenList.end() && (m_tokenListIt->m_tokenType == END_LINE || trim(m_tokenListIt->m_tokenString).empty())) {
 
     m_tokenListIt++;
   }
@@ -220,8 +224,7 @@ std::string DoxygenParser::getNextWord() {
      return "";
      }
    */
-  while (m_tokenListIt != m_tokenList.end()
-         && (m_tokenListIt->m_tokenType == PLAINSTRING)) {
+  while (m_tokenListIt != m_tokenList.end() && (m_tokenListIt->m_tokenType == PLAINSTRING)) {
     // handle quoted strings as words
     string token = m_tokenListIt->m_tokenString;
     if (token == "\"") {
@@ -230,7 +233,7 @@ std::string DoxygenParser::getNextWord() {
       m_tokenListIt++;
       while (true) {
         string nextWord = getNextToken();
-        if (nextWord.empty()) { // maybe report unterminated string error
+        if (nextWord.empty()) {  // maybe report unterminated string error
           return word;
         }
         word += nextWord;
@@ -275,7 +278,7 @@ std::string DoxygenParser::getStringTilCommand(const TokenList &tokList) {
   while (m_tokenListIt->m_tokenType == PLAINSTRING) {
     const Token &currentToken = *m_tokenListIt++;
     if (currentToken.m_tokenType == PLAINSTRING) {
-      description = description + currentToken.m_tokenString; // + " ";
+      description = description + currentToken.m_tokenString;  // + " ";
     }
   }
   return description;
@@ -316,20 +319,17 @@ DoxygenParser::TokenListCIt DoxygenParser::getEndOfParagraph(const TokenList &to
     // go all the way to the end of that command, since the content
     // could contain empty lines that would appear to be paragraph
     // ends:
-    if (endOfParagraph->m_tokenType == COMMAND &&
-        (endOfParagraph->m_tokenString == "code" ||
-         endOfParagraph->m_tokenString == "verbatim")) {
+    if (endOfParagraph->m_tokenType == COMMAND && (endOfParagraph->m_tokenString == "code" || endOfParagraph->m_tokenString == "verbatim")) {
       const string theCommand = endOfParagraph->m_tokenString;
       endOfParagraph = getEndCommand("end" + theCommand, tokList);
-      endOfParagraph++; // Move after the end command
+      endOfParagraph++;  // Move after the end command
       return endOfParagraph;
     }
     if (endOfParagraph->m_tokenType == END_LINE) {
       endOfParagraph++;
-      if (endOfParagraph != tokList.end()
-          && endOfParagraph->m_tokenType == END_LINE) {
+      if (endOfParagraph != tokList.end() && endOfParagraph->m_tokenType == END_LINE) {
         endOfParagraph++;
-        //cout << "ENCOUNTERED END OF PARA" << endl;
+        // cout << "ENCOUNTERED END OF PARA" << endl;
         return endOfParagraph;
       }
 
@@ -386,13 +386,12 @@ DoxygenParser::TokenListCIt DoxygenParser::getEndCommand(const std::string &theC
       }
     }
   }
-  //End command not found
+  // End command not found
   return tokList.end();
 }
 
 void DoxygenParser::skipEndOfLine() {
-  if (m_tokenListIt != m_tokenList.end()
-      && m_tokenListIt->m_tokenType == END_LINE) {
+  if (m_tokenListIt != m_tokenList.end() && m_tokenListIt->m_tokenType == END_LINE) {
     m_tokenListIt++;
   }
 }
@@ -487,7 +486,7 @@ void DoxygenParser::addCommandWordLine(const std::string &theCommand, const Toke
   aNewList = parse(endOfLine, tokList);
   aNewList.push_front(DoxygenEntity("plainstd::string", name));
   doxyList.push_back(DoxygenEntity(theCommand, aNewList));
-  //else cout << "No line followed " << theCommand <<  " command. Not added" << endl;
+  // else cout << "No line followed " << theCommand <<  " command. Not added" << endl;
 }
 
 void DoxygenParser::addCommandWordOWordOWord(const std::string &theCommand, const TokenList &, DoxygenEntityList &doxyList) {
@@ -689,8 +688,8 @@ void DoxygenParser::addCommandUnique(const std::string &theCommand, const TokenL
   // \f{ ... \f}
   // \f{env}{ ... \f}
   // \f$ ... \f$
-  else if (getBaseCommand(theCommand) == "code" || theCommand == "verbatim"
-           || theCommand == "dot" || theCommand == "msc" || theCommand == "f[" || theCommand == "f{" || theCommand == "f$") {
+  else if (getBaseCommand(theCommand) == "code" || theCommand == "verbatim" || theCommand == "dot" || theCommand == "msc" || theCommand == "f[" ||
+           theCommand == "f{" || theCommand == "f$") {
     if (!endCommands.size()) {
       // fill in static table of end commands
       endCommands["f["] = "f]";
@@ -760,7 +759,8 @@ void DoxygenParser::addCommandUnique(const std::string &theCommand, const TokenL
       cout << "Parsing " << theCommand << endl;
     std::string name = getNextWord();
     if (name.empty()) {
-      printListError(WARN_DOXYGEN_COMMAND_ERROR, "Error parsing Doxygen command " + theCommand + ": There should be at least one word following the command. Command ignored.");
+      printListError(WARN_DOXYGEN_COMMAND_ERROR,
+                     "Error parsing Doxygen command " + theCommand + ": There should be at least one word following the command. Command ignored.");
       return;
     }
     DoxygenEntityList aNewList;
@@ -778,7 +778,7 @@ void DoxygenParser::addCommandUnique(const std::string &theCommand, const TokenL
       cout << "Parsing " << theCommand << endl;
 
     std::string cond;
-    bool skipEndif = false; // if true then we skip endif after parsing block of code
+    bool skipEndif = false;  // if true then we skip endif after parsing block of code
     bool needsCond = (theCommand == "if" || theCommand == "ifnot" || theCommand == "elseif");
     if (needsCond) {
       cond = getNextWord();
@@ -798,11 +798,11 @@ void DoxygenParser::addCommandUnique(const std::string &theCommand, const TokenL
           nestedCounter++;
         else if (it->m_tokenString == "endif")
           nestedCounter--;
-        if (nestedCounter == 1 && (it->m_tokenString == "else" || it->m_tokenString == "elseif")) { // else found
+        if (nestedCounter == 1 && (it->m_tokenString == "else" || it->m_tokenString == "elseif")) {  // else found
           endCommand = it;
           break;
         }
-        if (nestedCounter == 0) { // endif found
+        if (nestedCounter == 0) {  // endif found
           endCommand = it;
           skipEndif = true;
           break;
@@ -825,7 +825,7 @@ void DoxygenParser::addCommandUnique(const std::string &theCommand, const TokenL
   }
 }
 
-void DoxygenParser::aliasCommand(const std::string &theCommand, const TokenList &/* tokList */ , DoxygenEntityList &doxyList) {
+void DoxygenParser::aliasCommand(const std::string &theCommand, const TokenList & /* tokList */, DoxygenEntityList &doxyList) {
   String *const alias = Getattr(m_node, ("feature:doxygen:alias:" + theCommand).c_str());
   if (!alias)
     return;
@@ -1114,13 +1114,14 @@ bool DoxygenParser::addDoxyCommand(DoxygenParser::TokenList &tokList, const std:
  * \htmlonly, \f$, \f[, and \f{.
  */
 size_t DoxygenParser::processVerbatimText(size_t pos, const std::string &line) {
-  if (line[pos] == '\\' || line[pos] == '@') { // check for end commands
+  if (line[pos] == '\\' || line[pos] == '@') {  // check for end commands
 
     pos++;
     size_t endOfWordPos = line.find_first_not_of(DOXYGEN_WORD_CHARS, pos);
     string cmd = line.substr(pos, endOfWordPos - pos);
 
-    if (cmd == CMD_END_HTML_ONLY || cmd == CMD_END_VERBATIM || cmd == CMD_END_LATEX_1 || cmd == CMD_END_LATEX_2 || cmd == CMD_END_LATEX_3 || cmd == CMD_END_CODE) {
+    if (cmd == CMD_END_HTML_ONLY || cmd == CMD_END_VERBATIM || cmd == CMD_END_LATEX_1 || cmd == CMD_END_LATEX_2 || cmd == CMD_END_LATEX_3 ||
+        cmd == CMD_END_CODE) {
 
       m_isVerbatimText = false;
       addDoxyCommand(m_tokenList, cmd);
@@ -1205,9 +1206,11 @@ void DoxygenParser::processWordCommands(size_t &pos, const std::string &line) {
     // and it won't hurt anything for block \code (TODO: are the other
     // commands also compatible with skip leading space?  If so, just
     // do it every time.)
-    if (getBaseCommand(cmd) == CMD_CODE) skipLeadingSpace = true;
-    else skipLeadingSpace = false;
-  } else if (cmd.substr(0,3) == "end") {
+    if (getBaseCommand(cmd) == CMD_CODE)
+      skipLeadingSpace = true;
+    else
+      skipLeadingSpace = false;
+  } else if (cmd.substr(0, 3) == "end") {
     // If processing an "end" command such as "endlink", don't skip
     // the space before the next string
     skipLeadingSpace = false;
@@ -1269,7 +1272,7 @@ void DoxygenParser::processHtmlTags(size_t &pos, const std::string &line) {
     }
 
     if (pos < line.size()) {
-      pos++; // skip '>'
+      pos++;  // skip '>'
     }
   } else {
     // the command is not HTML supported by Doxygen, < and > will be
@@ -1288,7 +1291,7 @@ void DoxygenParser::processHtmlEntities(size_t &pos, const std::string &line) {
       // if entity is not recognized by Doxygen (not in the list of
       // commands) nothing is added (here and in Doxygen).
       addDoxyCommand(m_tokenList, line.substr(pos, endOfWordPos - pos));
-      endOfWordPos++; // skip ';'
+      endOfWordPos++;  // skip ';'
     } else {
       // it is not an entity - add entity for ampersand and the rest of string
       addDoxyCommand(m_tokenList, "&amp");
@@ -1312,7 +1315,7 @@ size_t DoxygenParser::processNormalComment(size_t pos, const std::string &line) 
     processWordCommands(pos, line);
     break;
 
-  case ' ': // whitespace
+  case ' ':  // whitespace
   case '\t':
     {
       // whitespaces are stored as plain strings
@@ -1325,7 +1328,7 @@ size_t DoxygenParser::processNormalComment(size_t pos, const std::string &line) 
   case '<':
     processHtmlTags(pos, line);
     break;
-  case '>': // this char is detected here only when it is not part of HTML tag
+  case '>':  // this char is detected here only when it is not part of HTML tag
     addDoxyCommand(m_tokenList, "&gt");
     pos++;
     break;
@@ -1366,7 +1369,7 @@ void DoxygenParser::tokenizeDoxygenComment(const std::string &doxygenComment, co
     string lastLine = lines[lines.size() - 1];
 
     if (trim(lastLine).empty()) {
-      lines.pop_back(); // remove trailing empty line
+      lines.pop_back();  // remove trailing empty line
     }
   }
 
@@ -1393,7 +1396,7 @@ void DoxygenParser::tokenizeDoxygenComment(const std::string &doxygenComment, co
     // ' *    comment' gets translated to ' *    comment', not ' * comment'
     // This is important to keep formatting for comments translated to Python.
     if (isStartOfCommentLineCharFound && line[pos] == ' ') {
-      pos++; // points to char after ' * '
+      pos++;  // points to char after ' * '
       if (pos == line.size()) {
         m_tokenList.push_back(Token(END_LINE, "\n"));
         continue;
@@ -1433,8 +1436,7 @@ void DoxygenParser::tokenizeDoxygenComment(const std::string &doxygenComment, co
         string punctuations(".,:");
         size_t textSize = text.size();
 
-        if (!text.empty()
-            && punctuations.find(text[text.size() - 1]) != string::npos &&
+        if (!text.empty() && punctuations.find(text[text.size() - 1]) != string::npos &&
             // but do not break ellipsis (...)
             !(textSize > 1 && text[textSize - 2] == '.')) {
           m_tokenList.push_back(Token(PLAINSTRING, text.substr(0, text.size() - 1)));
@@ -1462,7 +1464,7 @@ void DoxygenParser::tokenizeDoxygenComment(const std::string &doxygenComment, co
         }
       }
     }
-    m_tokenList.push_back(Token(END_LINE, "\n")); // add when pos == npos - end of line
+    m_tokenList.push_back(Token(END_LINE, "\n"));  // add when pos == npos - end of line
   }
 
   m_tokenListIt = m_tokenList.begin();

--- a/Source/Doxygen/doxyparser.h
+++ b/Source/Doxygen/doxyparser.h
@@ -25,10 +25,8 @@
 // include options, e.g. param[in] -> param
 std::string getBaseCommand(const std::string &cmd);
 
-
 class DoxygenParser {
 private:
-
   enum DoxyCommandEnum {
     NONE = -1,
     SIMPLECOMMAND,
@@ -51,7 +49,6 @@ private:
     PLAINSTRING,
     COMMAND
   };
-
 
   /** This class contains parts of Doxygen comment as a token. */
   class Token {
@@ -78,7 +75,6 @@ private:
     }
   };
 
-
   typedef std::vector<Token> TokenList;
   typedef TokenList::const_iterator TokenListCIt;
   typedef TokenList::iterator TokenListIt;
@@ -96,7 +92,7 @@ private:
   static DoxyCommandsMap doxygenCommands;
   static std::set<std::string> doxygenSectionIndicators;
 
-  bool m_isVerbatimText; // used to handle \htmlonly and \verbatim commands
+  bool m_isVerbatimText;  // used to handle \htmlonly and \verbatim commands
   bool m_isInQuotedString;
 
   Node *m_node;
@@ -192,7 +188,7 @@ private:
    * Returns a properly formatted std::string
    * up til the command specified is encountered
    */
-  //TODO check that this behaves properly for formulas
+  // TODO check that this behaves properly for formulas
   std::string getStringTilEndCommand(const std::string &theCommand, const TokenList &tokList);
 
   /*
@@ -352,7 +348,6 @@ private:
   void processWordCommands(size_t &pos, const std::string &line);
   void processHtmlTags(size_t &pos, const std::string &line);
   void processHtmlEntities(size_t &pos, const std::string &line);
-
 
   /** Processes comment outside \htmlonly and \verbatim commands. */
   size_t processNormalComment(size_t pos, const std::string &line);

--- a/Source/Doxygen/doxyparser.h
+++ b/Source/Doxygen/doxyparser.h
@@ -61,7 +61,7 @@ private:
 
     Token(DoxyCommandEnum tType, std::string tString) : m_tokenType(tType), m_tokenString(tString) {
     }
-    
+
     std::string toString() const {
       switch (m_tokenType) {
       case END_LINE:
@@ -124,7 +124,7 @@ private:
    */
   std::string stringToLower(const std::string &stringToConvert);
 
-  /* 
+  /*
    * isSectionIndicator returns a boolean if the command is a section indicator
    * This is a helper method for finding the end of a paragraph
    * by Doxygen's terms
@@ -176,7 +176,7 @@ private:
    */
   std::string getNextWordInComment();
 
-  /* 
+  /*
    * Returns the location of the end of the line as
    * an iterator.
    */
@@ -245,7 +245,7 @@ private:
    * CommandWord
    * Format: @command <word>
    * Commands with a single WORD after then such as @b
-   * "a", "b", "c", "e", "em", "p", "def", "enum", "example", "package", 
+   * "a", "b", "c", "e", "em", "p", "def", "enum", "example", "package",
    * "relates", "namespace", "relatesalso","anchor", "dontinclude", "include",
    * "includelineno"
    */
@@ -332,7 +332,7 @@ private:
    */
   void ignoreCommand(const std::string &theCommand, const TokenList &tokList, DoxygenEntityList &doxyList);
 
-  /* 
+  /*
    * The actual "meat" of the doxygen parser. Calls the correct addCommand...()
    * function.
    */

--- a/Source/Doxygen/doxytranslator.cxx
+++ b/Source/Doxygen/doxytranslator.cxx
@@ -14,18 +14,15 @@
 
 #include "doxytranslator.h"
 
-DoxygenTranslator::DoxygenTranslator(int flags) : m_flags(flags), parser((flags &debug_parser) != 0) {
+DoxygenTranslator::DoxygenTranslator(int flags) : m_flags(flags), parser((flags & debug_parser) != 0) {
 }
-
 
 DoxygenTranslator::~DoxygenTranslator() {
 }
 
-
 bool DoxygenTranslator::hasDocumentation(Node *node) {
   return getDoxygenComment(node) != NULL;
 }
-
 
 String *DoxygenTranslator::getDoxygenComment(Node *node) {
   return Getattr(node, "doxygen");
@@ -43,7 +40,7 @@ void DoxygenTranslator::extraIndentation(String *comment, const_String_or_char_p
     Replaceall(comment, "\n", replace);
     if (trailing_newline) {
       len = Len(comment);
-      Delslice(comment, len - 2, len); // Remove added trailing spaces on last line
+      Delslice(comment, len - 2, len);  // Remove added trailing spaces on last line
     }
     Delete(replace);
   }
@@ -59,7 +56,6 @@ String *DoxygenTranslator::getDocumentation(Node *node, const_String_or_char_ptr
   extraIndentation(documentation, indentationString);
   return documentation;
 }
-
 
 void DoxygenTranslator::printTree(const DoxygenEntityList &entityList) {
 

--- a/Source/Doxygen/doxytranslator.h
+++ b/Source/Doxygen/doxytranslator.h
@@ -21,7 +21,6 @@
 #include <list>
 #include <string>
 
-
 /*
  * This is a base class for translator classes. It defines the basic interface
  * for translators, which convert Doxygen comments into alternative formats for

--- a/Source/Doxygen/doxytranslator.h
+++ b/Source/Doxygen/doxytranslator.h
@@ -53,7 +53,7 @@ public:
   virtual ~DoxygenTranslator();
 
   /*
-   * Return the documentation for a given node formatted for the correct 
+   * Return the documentation for a given node formatted for the correct
    * documentation system.
    */
   String *getDocumentation(Node *node, const_String_or_char_ptr indentationString);

--- a/Source/Doxygen/javadoc.cxx
+++ b/Source/Doxygen/javadoc.cxx
@@ -15,19 +15,19 @@
 #include <vector>
 #include <list>
 #include "swigmod.h"
-#define APPROX_LINE_LENGTH 64   // characters per line allowed
-#define TAB_SIZE 8              // current tab size in spaces
-//TODO {@link} {@linkplain} {@docRoot}, and other useful doxy commands that are not a javadoc tag
+#define APPROX_LINE_LENGTH 64  // characters per line allowed
+#define TAB_SIZE           8   // current tab size in spaces
+// TODO {@link} {@linkplain} {@docRoot}, and other useful doxy commands that are not a javadoc tag
 
 // define static tables, they are filled in JavaDocConverter's constructor
 std::map<std::string, std::pair<JavaDocConverter::tagHandler, std::string> > JavaDocConverter::tagHandlers;
 
-using std::string;
 using std::list;
+using std::string;
 using std::vector;
 
 void JavaDocConverter::fillStaticTables() {
-  if (tagHandlers.size()) // fill only once
+  if (tagHandlers.size())  // fill only once
     return;
 
   /*
@@ -114,8 +114,8 @@ void JavaDocConverter::fillStaticTables() {
   tagHandlers["result"] = make_pair(&JavaDocConverter::handleTagSame, "return");
   tagHandlers["return"] = make_pair(&JavaDocConverter::handleTagSame, "");
   tagHandlers["returns"] = make_pair(&JavaDocConverter::handleTagSame, "return");
-  //tagHandlers["see"] = make_pair(&JavaDocConverter::handleTagSame, "");
-  //tagHandlers["sa"] = make_pair(&JavaDocConverter::handleTagSame, "see");
+  // tagHandlers["see"] = make_pair(&JavaDocConverter::handleTagSame, "");
+  // tagHandlers["sa"] = make_pair(&JavaDocConverter::handleTagSame, "see");
   tagHandlers["since"] = make_pair(&JavaDocConverter::handleTagSame, "");
   tagHandlers["throws"] = make_pair(&JavaDocConverter::handleTagSame, "");
   tagHandlers["throw"] = make_pair(&JavaDocConverter::handleTagSame, "throws");
@@ -139,7 +139,8 @@ void JavaDocConverter::fillStaticTables() {
   tagHandlers["note"] = make_pair(&JavaDocConverter::handleTagMessage, "Note: ");
   tagHandlers["overload"] = make_pair(&JavaDocConverter::handleTagMessage,
                                       "This is an overloaded member function, provided for"
-                                      " convenience. It differs from the above function only in what" " argument(s) it accepts.");
+                                      " convenience. It differs from the above function only in what"
+                                      " argument(s) it accepts.");
   tagHandlers["par"] = make_pair(&JavaDocConverter::handleTagPar, "");
   tagHandlers["remark"] = make_pair(&JavaDocConverter::handleTagMessage, "Remarks: ");
   tagHandlers["remarks"] = make_pair(&JavaDocConverter::handleTagMessage, "Remarks: ");
@@ -227,8 +228,7 @@ void JavaDocConverter::fillStaticTables() {
   tagHandlers["&rarr"] = make_pair(&JavaDocConverter::handleHtmlEntity, "&rarr");
 }
 
-JavaDocConverter::JavaDocConverter(int flags) :
-  DoxygenTranslator(flags) {
+JavaDocConverter::JavaDocConverter(int flags) : DoxygenTranslator(flags) {
   fillStaticTables();
 }
 
@@ -242,7 +242,7 @@ JavaDocConverter::JavaDocConverter(int flags) :
  */
 std::string JavaDocConverter::formatCommand(std::string unformattedLine, int indent) {
   std::string formattedLines;
-  return unformattedLine; // currently disabled
+  return unformattedLine;  // currently disabled
   std::string::size_type lastPosition = 0;
   std::string::size_type i = 0;
   int isFirstLine = 1;
@@ -260,12 +260,12 @@ std::string JavaDocConverter::formatCommand(std::string unformattedLine, int ind
       if (!isFirstLine)
         for (int j = 0; j < indent; j++) {
           formattedLines.append("\t");
-      } else {
+        }
+      else {
         isFirstLine = 0;
       }
       formattedLines.append(unformattedLine.substr(lastPosition, i - lastPosition + 1));
       formattedLines.append("\n *");
-
     }
   }
   if (lastPosition < unformattedLine.length()) {
@@ -303,7 +303,7 @@ bool JavaDocConverter::paramExists(std::string param) {
     /* doesn't seem to work always: in some cases (especially for 'self' parameters)
      * tmap:in is present, but tmap:in:next is not and so this code skips all the parameters
      */
-    //p = Getattr(p, "tmap:in") ? Getattr(p, "tmap:in:next") : nextSibling(p);
+    // p = Getattr(p, "tmap:in") ? Getattr(p, "tmap:in:next") : nextSibling(p);
     p = nextSibling(p);
   }
 
@@ -345,14 +345,12 @@ void JavaDocConverter::translateEntity(DoxygenEntity &tag, std::string &translat
   }
 }
 
-
 void JavaDocConverter::handleTagAnchor(DoxygenEntity &tag, std::string &translatedComment, std::string &) {
   translatedComment += "<a id=\"" + translateSubtree(tag) + "\"></a>";
 }
 
-
 void JavaDocConverter::handleTagHtml(DoxygenEntity &tag, std::string &translatedComment, std::string &arg) {
-  if (tag.entityList.size()) { // do not include empty tags
+  if (tag.entityList.size()) {  // do not include empty tags
     std::string tagData = translateSubtree(tag);
     // wrap the thing, ignoring whitespace
     size_t wsPos = tagData.find_last_not_of("\n\t ");
@@ -488,7 +486,6 @@ void JavaDocConverter::handleTagPar(DoxygenEntity &tag, std::string &translatedC
   translatedComment += "</p>";
 }
 
-
 void JavaDocConverter::handleTagParam(DoxygenEntity &tag, std::string &translatedComment, std::string &) {
   std::string dummy;
 
@@ -502,7 +499,6 @@ void JavaDocConverter::handleTagParam(DoxygenEntity &tag, std::string &translate
   tag.entityList.pop_front();
   handleParagraph(tag, translatedComment, dummy);
 }
-
 
 void JavaDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translatedComment, std::string &) {
   std::string dummy;
@@ -521,7 +517,6 @@ void JavaDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translatedC
   translatedComment += "<a href=\"#" + anchor + "\">" + anchorText + "</a>";
 }
 
-
 string JavaDocConverter::convertLink(string linkObject) {
   if (GetFlag(currentNode, "feature:doxygen:nolinktranslate"))
     return linkObject;
@@ -531,8 +526,7 @@ string JavaDocConverter::convertLink(string linkObject) {
   if (lbracePos == string::npos || rbracePos == string::npos || lbracePos >= rbracePos)
     return "";
 
-  string paramsStr = linkObject.substr(lbracePos + 1,
-                                       rbracePos - lbracePos - 1);
+  string paramsStr = linkObject.substr(lbracePos + 1, rbracePos - lbracePos - 1);
   // strip the params, to fill them later
   string additionalObject = linkObject.substr(rbracePos + 1, string::npos);
   linkObject = linkObject.substr(0, lbracePos);
@@ -597,7 +591,7 @@ string JavaDocConverter::convertLink(string linkObject) {
     Swig_typemap_attach_parms("jstype", dummyParam, NULL);
     Language::instance()->replaceSpecialVariables(0, Getattr(dummyParam, "tmap:jstype"), dummyParam);
 
-    //Swig_print(dummyParam, 1);
+    // Swig_print(dummyParam, 1);
     linkObject += Char(Getattr(dummyParam, "tmap:jstype"));
     if (i != params.size() - 1)
       linkObject += ",";
@@ -704,8 +698,7 @@ int JavaDocConverter::shiftEndlinesUpTree(DoxygenEntity &root, int level) {
   }
 
   int removedCount = 0;
-  while (!root.entityList.empty()
-         && root.entityList.rbegin()->typeOfEntity == "plainstd::endl") {
+  while (!root.entityList.empty() && root.entityList.rbegin()->typeOfEntity == "plainstd::endl") {
     root.entityList.pop_back();
     removedCount++;
   }
@@ -760,7 +753,7 @@ std::string JavaDocConverter::indentAndInsertAsterisks(const string &doc) {
       if (translatedStr[nonspaceIdx] != '\n') {
         // add '* ' to each line without it
         translatedStr = translatedStr.substr(0, nonspaceIdx) + "* " + translatedStr.substr(nonspaceIdx);
-        //printf(translatedStr.c_str());
+        // printf(translatedStr.c_str());
       } else {
         // we found empty line, replace it with indented '*'
         translatedStr = translatedStr.substr(0, idx + 1) + indentStr + "* " + translatedStr.substr(nonspaceIdx);
@@ -821,14 +814,12 @@ String *JavaDocConverter::makeDocumentation(Node *node) {
   shiftEndlinesUpTree(root);
 
   // strip line endings at the beginning
-  while (!root.entityList.empty()
-         && root.entityList.begin()->typeOfEntity == "plainstd::endl") {
+  while (!root.entityList.empty() && root.entityList.begin()->typeOfEntity == "plainstd::endl") {
     root.entityList.pop_front();
   }
 
   // and at the end
-  while (!root.entityList.empty()
-         && root.entityList.rbegin()->typeOfEntity == "plainstd::endl") {
+  while (!root.entityList.empty() && root.entityList.rbegin()->typeOfEntity == "plainstd::endl") {
     root.entityList.pop_back();
   }
 

--- a/Source/Doxygen/javadoc.cxx
+++ b/Source/Doxygen/javadoc.cxx
@@ -774,7 +774,7 @@ std::string JavaDocConverter::indentAndInsertAsterisks(const string &doc) {
   if (nonspaceEndIdx != string::npos) {
     if (translatedStr[nonspaceEndIdx] != '\n') {
       if (!singleLineComment)
-	translatedStr += '\n';
+        translatedStr += '\n';
     } else {
       // remove trailing spaces
       translatedStr = translatedStr.substr(0, nonspaceEndIdx + 1);

--- a/Source/Doxygen/javadoc.cxx
+++ b/Source/Doxygen/javadoc.cxx
@@ -509,7 +509,7 @@ void JavaDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translatedC
   if (!tag.entityList.size())
     return;
 
-  // we translate to link, although \page is not supported in Java, but 
+  // we translate to link, although \page is not supported in Java, but
   // reader at least knows what to look at. Also for \anchor tag on the same
   // page this link works.
   string anchor = tag.entityList.begin()->data;

--- a/Source/Doxygen/javadoc.h
+++ b/Source/Doxygen/javadoc.h
@@ -138,7 +138,7 @@ protected:
   void handleTagParam(DoxygenEntity &tag, std::string &translatedComment, std::string &arg);
 
   /*
-   * Writes link for \ref tag. 
+   * Writes link for \ref tag.
    */
   void handleTagRef(DoxygenEntity &tag, std::string &translatedComment, std::string &);
 

--- a/Source/Doxygen/javadoc.h
+++ b/Source/Doxygen/javadoc.h
@@ -56,7 +56,7 @@ protected:
    * Typedef for the function that handles one tag
    * arg - some string argument to easily pass it through lookup table
    */
-  typedef void (JavaDocConverter::*tagHandler) (DoxygenEntity &tag, std::string &translatedComment, std::string &arg);
+  typedef void (JavaDocConverter::*tagHandler)(DoxygenEntity &tag, std::string &translatedComment, std::string &arg);
 
   /**
    * Copies verbatim args of the tag to output, used for commands like \f$, ...

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -34,8 +34,9 @@ public:
   static const char *Level() {
     return "    ";
   }
-  // Default ctor doesn't do anything and prevents the dtor from doing anything// too and should only be used when the guard needs to be initialized// conditionally as Init() can then be called after checking some condition.// Otherwise, prefer to use the non default ctor below.
-      IndentGuard() {
+  // Default ctor doesn't do anything and prevents the dtor from doing anything// too and should only be used when the guard needs to be initialized//
+  // conditionally as Init() can then be called after checking some condition.// Otherwise, prefer to use the non default ctor below.
+  IndentGuard() {
     m_initialized = false;
   }
 
@@ -172,10 +173,7 @@ static string padCodeAndVerbatimBlocks(const string &docString) {
     if (pos == string::npos) {
       lastLineWasNonBlank = false;
     } else {
-      if (lastLineWasNonBlank &&
-          (line.compare(pos, 13, ".. code-block") == 0 ||
-           line.compare(pos, 7, ".. math") == 0 ||
-           line.compare(pos, 3, ">>>") == 0)) {
+      if (lastLineWasNonBlank && (line.compare(pos, 13, ".. code-block") == 0 || line.compare(pos, 7, ".. math") == 0 || line.compare(pos, 3, ">>>") == 0)) {
         // Must separate code or math blocks from the previous line
         result += '\n';
       }
@@ -194,11 +192,10 @@ static std::string getCommandOption(const std::string &command, char openChar, c
   opt_begin = command.find(openChar);
   opt_end = command.find(closeChar);
   if (opt_begin != string::npos && opt_end != string::npos)
-    option = command.substr(opt_begin+1, opt_end-opt_begin-1);
+    option = command.substr(opt_begin + 1, opt_end - opt_begin - 1);
 
   return option;
 }
-
 
 /* static */
 PyDocConverter::TagHandlersMap::mapped_type PyDocConverter::make_handler(tagHandler handler) {
@@ -211,7 +208,7 @@ PyDocConverter::TagHandlersMap::mapped_type PyDocConverter::make_handler(tagHand
 }
 
 void PyDocConverter::fillStaticTables() {
-  if (tagHandlers.size()) // fill only once
+  if (tagHandlers.size())  // fill only once
     return;
 
   // table of section titles, they are printed only once
@@ -225,8 +222,8 @@ void PyDocConverter::fillStaticTables() {
   sectionTitles["remark"] = "Remarks: ";
   sectionTitles["remarks"] = "Remarks: ";
   sectionTitles["warning"] = "Warning: ";
-//  sectionTitles["sa"] = "See also: ";
-//  sectionTitles["see"] = "See also: ";
+  //  sectionTitles["sa"] = "See also: ";
+  //  sectionTitles["see"] = "See also: ";
   sectionTitles["since"] = "Since: ";
   sectionTitles["todo"] = "TODO: ";
   sectionTitles["version"] = "Version: ";
@@ -296,7 +293,8 @@ void PyDocConverter::fillStaticTables() {
   tagHandlers["li"] = make_handler(&PyDocConverter::handleTagMessage, "* ");
   tagHandlers["overload"] = make_handler(&PyDocConverter::handleTagMessage,
                                          "This is an overloaded member function, provided for"
-                                         " convenience.\nIt differs from the above function only in what" " argument(s) it accepts.");
+                                         " convenience.\nIt differs from the above function only in what"
+                                         " argument(s) it accepts.");
   tagHandlers["par"] = make_handler(&PyDocConverter::handleTagPar);
   tagHandlers["param"] = tagHandlers["tparam"] = make_handler(&PyDocConverter::handleTagParam);
   tagHandlers["ref"] = make_handler(&PyDocConverter::handleTagRef);
@@ -388,8 +386,7 @@ void PyDocConverter::fillStaticTables() {
   tagHandlers["&rarr"] = make_handler(&PyDocConverter::handleHtmlEntity, "-->");
 }
 
-PyDocConverter::PyDocConverter(int flags):
-DoxygenTranslator(flags), m_tableLineLen(0), m_prevRowIsTH(false) {
+PyDocConverter::PyDocConverter(int flags) : DoxygenTranslator(flags), m_tableLineLen(0), m_prevRowIsTH(false) {
   fillStaticTables();
 }
 
@@ -490,7 +487,7 @@ void PyDocConverter::translateEntity(DoxygenEntity &doxyEntity, std::string &tra
   std::map<std::string, std::pair<tagHandler, std::string> >::iterator it;
   it = tagHandlers.find(getBaseCommand(doxyEntity.typeOfEntity));
   if (it != tagHandlers.end())
-    (this->*(it->second.first)) (doxyEntity, translatedComment, it->second.second);
+    (this->*(it->second.first))(doxyEntity, translatedComment, it->second.second);
 }
 
 void PyDocConverter::handleParagraph(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
@@ -503,7 +500,7 @@ void PyDocConverter::handleVerbatimBlock(DoxygenEntity &tag, std::string &transl
   eraseLeadingNewLine(verb);
 
   // Remove the last newline to prevent doubling the newline already present after \endverbatim
-  trimWhitespace(verb); // Needed to catch trailing newline below
+  trimWhitespace(verb);  // Needed to catch trailing newline below
   eraseTrailingNewLine(verb);
   translatedComment += verb;
 }
@@ -599,11 +596,11 @@ void PyDocConverter::handleCode(DoxygenEntity &tag, std::string &translatedComme
   size_t startPos;
   // ">>>" would normally appear at the beginning, but doxygen comment
   // style may have space in front, so skip leading whitespace
-  if ((startPos=code.find_first_not_of(" \t")) != string::npos && code.substr(startPos,3) == ">>>")
+  if ((startPos = code.find_first_not_of(" \t")) != string::npos && code.substr(startPos, 3) == ">>>")
     isDocTestBlock = true;
 
   string codeIndent;
-  if (! isDocTestBlock) {
+  if (!isDocTestBlock) {
     // Use the current indent for the code-block line itself.
     translatedComment += indent.getFirstLineIndent();
     translatedComment += ".. code-block:: " + codeLanguage + "\n\n";
@@ -703,7 +700,8 @@ void PyDocConverter::handleTagParam(DoxygenEntity &tag, std::string &translatedC
 
   // Get command option, e.g. "in", "out", or "in,out"
   string commandOpt = getCommandOption(tag.typeOfEntity, '[', ']');
-  if (commandOpt == "in,out") commandOpt = "in/out";
+  if (commandOpt == "in,out")
+    commandOpt = "in/out";
 
   // If provided, append the parameter direction to the type
   // information via a suffix:
@@ -727,7 +725,6 @@ void PyDocConverter::handleTagParam(DoxygenEntity &tag, std::string &translatedC
   handleParagraph(tag, translatedComment);
 }
 
-
 void PyDocConverter::handleTagReturn(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
   IndentGuard indent(translatedComment, m_indent);
 
@@ -743,14 +740,12 @@ void PyDocConverter::handleTagReturn(DoxygenEntity &tag, std::string &translated
   handleParagraph(tag, translatedComment);
 }
 
-
 void PyDocConverter::handleTagException(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
   IndentGuard indent(translatedComment, m_indent);
 
   translatedComment += ":raises: ";
   handleParagraph(tag, translatedComment);
 }
-
 
 void PyDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translatedComment, const std::string &) {
   if (!tag.entityList.size())
@@ -765,9 +760,8 @@ void PyDocConverter::handleTagRef(DoxygenEntity &tag, std::string &translatedCom
   translatedComment += "'" + anchorText + "'";
 }
 
-
 void PyDocConverter::handleTagWrap(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg) {
-  if (tag.entityList.size()) { // do not include empty tags
+  if (tag.entityList.size()) {  // do not include empty tags
     std::string tagData = translateSubtree(tag);
     // wrap the thing, ignoring whitespace
     size_t wsPos = tagData.find_last_not_of("\n\t ");
@@ -936,7 +930,7 @@ String *PyDocConverter::makeDocumentation(Node *n) {
     if (allDocumentation.size() > 1) {
       string indentStr;
       if (minIndent != static_cast<size_t>(-1))
-       indentStr.assign(minIndent, ' ');
+        indentStr.assign(minIndent, ' ');
 
       std::ostringstream concatDocString;
       for (size_t realOverloadCount = 0; realOverloadCount < allDocumentation.size(); realOverloadCount++) {
@@ -990,4 +984,3 @@ String *PyDocConverter::makeDocumentation(Node *n) {
 
   return NewString(pyDocString.c_str());
 }
-

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -74,7 +74,7 @@ public:
   string getFirstLineIndent() const {
     return string(m_firstLineIndent, ' ');
   }
- 
+
   ~IndentGuard() {
     if (!m_initialized)
       return;
@@ -161,7 +161,7 @@ static string padCodeAndVerbatimBlocks(const string &docString) {
 
   // Initialize to false because there is no previous line yet
   bool lastLineWasNonBlank = false;
-  
+
   for (string line; std::getline(iss, line); result += line) {
     if (!result.empty()) {
       // Terminate the previous line
@@ -710,12 +710,12 @@ void PyDocConverter::handleTagParam(DoxygenEntity &tag, std::string &translatedC
   std::string suffix;
   if (commandOpt.size() > 0)
     suffix = ", " + commandOpt;
-  
+
   // If the parameter has a default value, flag it as optional in the
   // generated type definition.  Particularly helpful when the python
   // call is generated with *args, **kwargs.
   if (paramValue.size() > 0)
-    suffix += ", optional";  
+    suffix += ", optional";
 
   if (!paramType.empty()) {
     translatedComment += ":type " + paramName + ": " + paramType + suffix + "\n";

--- a/Source/Doxygen/pydoc.cxx
+++ b/Source/Doxygen/pydoc.cxx
@@ -173,11 +173,11 @@ static string padCodeAndVerbatimBlocks(const string &docString) {
       lastLineWasNonBlank = false;
     } else {
       if (lastLineWasNonBlank &&
-	  (line.compare(pos, 13, ".. code-block") == 0 ||
-	   line.compare(pos, 7, ".. math") == 0 ||
-	   line.compare(pos, 3, ">>>") == 0)) {
-	// Must separate code or math blocks from the previous line
-	result += '\n';
+          (line.compare(pos, 13, ".. code-block") == 0 ||
+           line.compare(pos, 7, ".. math") == 0 ||
+           line.compare(pos, 3, ">>>") == 0)) {
+        // Must separate code or math blocks from the previous line
+        result += '\n';
       }
       lastLineWasNonBlank = true;
     }
@@ -452,7 +452,7 @@ std::string PyDocConverter::getParamValue(std::string param) {
     if (pname && Char(pname) == param) {
       String *pval = Getattr(p, "value");
       if (pval)
-	value = Char(pval);
+        value = Char(pval);
       break;
     }
   }

--- a/Source/Doxygen/pydoc.h
+++ b/Source/Doxygen/pydoc.h
@@ -20,8 +20,8 @@
 #include "doxyentity.h"
 #include "doxytranslator.h"
 
-#define DOC_STRING_LENGTH         64 // characters per line allowed
-#define DOC_PARAM_STRING_LENGTH   30 // characters reserved for param name / type
+#define DOC_STRING_LENGTH       64  // characters per line allowed
+#define DOC_PARAM_STRING_LENGTH 30  // characters reserved for param name / type
 
 class PyDocConverter : public DoxygenTranslator {
 public:
@@ -29,7 +29,6 @@ public:
   String *makeDocumentation(Node *node);
 
 protected:
-
   size_t m_tableLineLen;
   bool m_prevRowIsTH;
   std::string m_url;
@@ -51,7 +50,7 @@ protected:
    * Typedef for the function that handles one tag
    * arg - some string argument to easily pass it through lookup table
    */
-  typedef void (PyDocConverter::*tagHandler) (DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
+  typedef void (PyDocConverter::*tagHandler)(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
 
   /*
    * Wrap the command data with the some string
@@ -170,7 +169,6 @@ protected:
   /* Handles HTML entities recognized by Doxygen, like &lt;, &copy;, ... */
   void handleHtmlEntity(DoxygenEntity &, std::string &translatedComment, const std::string &arg);
 
-
   /*
    * Simple helper function that calculates correct parameter type
    * of the node stored in 'currentNode'
@@ -190,9 +188,8 @@ private:
   // Extra indent for the current paragraph, must be output after each new line.
   std::string m_indent;
 
-
   // this contains the handler pointer and one string argument
-  typedef std::map<std::string, std::pair<tagHandler, std::string> >TagHandlersMap;
+  typedef std::map<std::string, std::pair<tagHandler, std::string> > TagHandlersMap;
   static TagHandlersMap tagHandlers;
 
   // this contains the sections titles, like 'Arguments:' or 'Notes:', that are printed only once

--- a/Source/Doxygen/pydoc.h
+++ b/Source/Doxygen/pydoc.h
@@ -136,7 +136,7 @@ protected:
   void handleTagReturn(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
 
   /*
-   * Writes text for \ref tag. 
+   * Writes text for \ref tag.
    */
   void handleTagRef(DoxygenEntity &tag, std::string &translatedComment, const std::string &arg);
 

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -108,54 +108,54 @@
 #define WARN_CPP14_AUTO               345
 #define WARN_CPP11_AUTO               346
 
-#define WARN_IGNORE_OPERATOR_NEW        350	/* new */
-#define WARN_IGNORE_OPERATOR_DELETE     351	/* delete */
-#define WARN_IGNORE_OPERATOR_PLUS       352	/* + */
-#define WARN_IGNORE_OPERATOR_MINUS      353	/* - */
-#define WARN_IGNORE_OPERATOR_MUL        354	/* * */
-#define WARN_IGNORE_OPERATOR_DIV        355	/* / */
-#define WARN_IGNORE_OPERATOR_MOD        356	/* % */
-#define WARN_IGNORE_OPERATOR_XOR        357	/* ^ */
-#define WARN_IGNORE_OPERATOR_AND        358	/* & */
-#define WARN_IGNORE_OPERATOR_OR         359	/* | */
-#define WARN_IGNORE_OPERATOR_NOT        360	/* ~ */
-#define WARN_IGNORE_OPERATOR_LNOT       361	/* ! */
-#define WARN_IGNORE_OPERATOR_EQ         362	/* = */
-#define WARN_IGNORE_OPERATOR_LT         363	/* < */
-#define WARN_IGNORE_OPERATOR_GT         364	/* > */
-#define WARN_IGNORE_OPERATOR_PLUSEQ     365	/* += */
-#define WARN_IGNORE_OPERATOR_MINUSEQ    366	/* -= */
-#define WARN_IGNORE_OPERATOR_MULEQ      367	/* *= */
-#define WARN_IGNORE_OPERATOR_DIVEQ      368	/* /= */
-#define WARN_IGNORE_OPERATOR_MODEQ      369	/* %= */
-#define WARN_IGNORE_OPERATOR_XOREQ      370	/* ^= */
-#define WARN_IGNORE_OPERATOR_ANDEQ      371	/* &= */
-#define WARN_IGNORE_OPERATOR_OREQ       372	/* |= */
-#define WARN_IGNORE_OPERATOR_LSHIFT     373	/* << */
-#define WARN_IGNORE_OPERATOR_RSHIFT     374	/* >> */
-#define WARN_IGNORE_OPERATOR_LSHIFTEQ   375	/* <<= */
-#define WARN_IGNORE_OPERATOR_RSHIFTEQ   376	/* >>= */
-#define WARN_IGNORE_OPERATOR_EQUALTO    377	/* == */
-#define WARN_IGNORE_OPERATOR_NOTEQUAL   378	/* != */
-#define WARN_IGNORE_OPERATOR_LTEQUAL    379	/* <= */
-#define WARN_IGNORE_OPERATOR_GTEQUAL    380	/* >= */
-#define WARN_IGNORE_OPERATOR_LAND       381	/* && */
-#define WARN_IGNORE_OPERATOR_LOR        382	/* || */
-#define WARN_IGNORE_OPERATOR_PLUSPLUS   383	/* ++ */
-#define WARN_IGNORE_OPERATOR_MINUSMINUS 384	/* -- */
-#define WARN_IGNORE_OPERATOR_COMMA      385	/* , */
-#define WARN_IGNORE_OPERATOR_ARROWSTAR  386	/* ->* */
-#define WARN_IGNORE_OPERATOR_ARROW      387	/* -> */
-#define WARN_IGNORE_OPERATOR_CALL       388	/* () */
-#define WARN_IGNORE_OPERATOR_INDEX      389	/* [] */
-#define WARN_IGNORE_OPERATOR_UPLUS      390	/* + */
-#define WARN_IGNORE_OPERATOR_UMINUS     391	/* - */
-#define WARN_IGNORE_OPERATOR_UMUL       392	/* * */
-#define WARN_IGNORE_OPERATOR_UAND       393	/* & */
-#define WARN_IGNORE_OPERATOR_NEWARR     394	/* new [] */
-#define WARN_IGNORE_OPERATOR_DELARR     395	/* delete [] */
-#define WARN_IGNORE_OPERATOR_REF        396	/* operator *() */
-#define WARN_IGNORE_OPERATOR_LTEQUALGT  397	/* <=> */
+#define WARN_IGNORE_OPERATOR_NEW        350     /* new */
+#define WARN_IGNORE_OPERATOR_DELETE     351     /* delete */
+#define WARN_IGNORE_OPERATOR_PLUS       352     /* + */
+#define WARN_IGNORE_OPERATOR_MINUS      353     /* - */
+#define WARN_IGNORE_OPERATOR_MUL        354     /* * */
+#define WARN_IGNORE_OPERATOR_DIV        355     /* / */
+#define WARN_IGNORE_OPERATOR_MOD        356     /* % */
+#define WARN_IGNORE_OPERATOR_XOR        357     /* ^ */
+#define WARN_IGNORE_OPERATOR_AND        358     /* & */
+#define WARN_IGNORE_OPERATOR_OR         359     /* | */
+#define WARN_IGNORE_OPERATOR_NOT        360     /* ~ */
+#define WARN_IGNORE_OPERATOR_LNOT       361     /* ! */
+#define WARN_IGNORE_OPERATOR_EQ         362     /* = */
+#define WARN_IGNORE_OPERATOR_LT         363     /* < */
+#define WARN_IGNORE_OPERATOR_GT         364     /* > */
+#define WARN_IGNORE_OPERATOR_PLUSEQ     365     /* += */
+#define WARN_IGNORE_OPERATOR_MINUSEQ    366     /* -= */
+#define WARN_IGNORE_OPERATOR_MULEQ      367     /* *= */
+#define WARN_IGNORE_OPERATOR_DIVEQ      368     /* /= */
+#define WARN_IGNORE_OPERATOR_MODEQ      369     /* %= */
+#define WARN_IGNORE_OPERATOR_XOREQ      370     /* ^= */
+#define WARN_IGNORE_OPERATOR_ANDEQ      371     /* &= */
+#define WARN_IGNORE_OPERATOR_OREQ       372     /* |= */
+#define WARN_IGNORE_OPERATOR_LSHIFT     373     /* << */
+#define WARN_IGNORE_OPERATOR_RSHIFT     374     /* >> */
+#define WARN_IGNORE_OPERATOR_LSHIFTEQ   375     /* <<= */
+#define WARN_IGNORE_OPERATOR_RSHIFTEQ   376     /* >>= */
+#define WARN_IGNORE_OPERATOR_EQUALTO    377     /* == */
+#define WARN_IGNORE_OPERATOR_NOTEQUAL   378     /* != */
+#define WARN_IGNORE_OPERATOR_LTEQUAL    379     /* <= */
+#define WARN_IGNORE_OPERATOR_GTEQUAL    380     /* >= */
+#define WARN_IGNORE_OPERATOR_LAND       381     /* && */
+#define WARN_IGNORE_OPERATOR_LOR        382     /* || */
+#define WARN_IGNORE_OPERATOR_PLUSPLUS   383     /* ++ */
+#define WARN_IGNORE_OPERATOR_MINUSMINUS 384     /* -- */
+#define WARN_IGNORE_OPERATOR_COMMA      385     /* , */
+#define WARN_IGNORE_OPERATOR_ARROWSTAR  386     /* ->* */
+#define WARN_IGNORE_OPERATOR_ARROW      387     /* -> */
+#define WARN_IGNORE_OPERATOR_CALL       388     /* () */
+#define WARN_IGNORE_OPERATOR_INDEX      389     /* [] */
+#define WARN_IGNORE_OPERATOR_UPLUS      390     /* + */
+#define WARN_IGNORE_OPERATOR_UMINUS     391     /* - */
+#define WARN_IGNORE_OPERATOR_UMUL       392     /* * */
+#define WARN_IGNORE_OPERATOR_UAND       393     /* & */
+#define WARN_IGNORE_OPERATOR_NEWARR     394     /* new [] */
+#define WARN_IGNORE_OPERATOR_DELARR     395     /* delete [] */
+#define WARN_IGNORE_OPERATOR_REF        396     /* operator *() */
+#define WARN_IGNORE_OPERATOR_LTEQUALGT  397     /* <=> */
 
 /* please leave 350-399 free for WARN_IGNORE_OPERATOR_* */
 
@@ -185,7 +185,7 @@
 #define WARN_TYPEMAP_TYPECHECK        467
 #define WARN_TYPEMAP_THROW            468
 #define WARN_TYPEMAP_DIRECTORIN_UNDEF  469
-#define WARN_TYPEMAP_THREAD_UNSAFE     470	/* mostly used in directorout typemaps */
+#define WARN_TYPEMAP_THREAD_UNSAFE     470      /* mostly used in directorout typemaps */
 #define WARN_TYPEMAP_DIRECTOROUT_UNDEF 471
 #define WARN_TYPEMAP_TYPECHECK_UNDEF   472
 #define WARN_TYPEMAP_DIRECTOROUT_PTR   473

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -25,7 +25,7 @@
 #ifndef SWIG_SWIGWARN_H
 #define SWIG_SWIGWARN_H
 
-#define WARN_NONE                     0
+#define WARN_NONE                                    0
 
 /* -- Deprecated features -- */
 
@@ -55,187 +55,187 @@
 /* Unused since 4.1.0: #define WARN_DEPRECATED_TYPEMAP_LANG  124 */
 /* Unused since 4.2.0: #define WARN_DEPRECATED_INPUT_FILE    125 */
 /* Unused since 4.3.0: #define WARN_DEPRECATED_NESTED_WORKAROUND 126 */
-#define WARN_DEPRECATED_TYPEDEF 127
+#define WARN_DEPRECATED_TYPEDEF                      127
 
 /* -- Preprocessor -- */
 
-#define WARN_PP_MISSING_FILE          201
-#define WARN_PP_EVALUATION            202
-#define WARN_PP_INCLUDEALL_IMPORTALL  203
-#define WARN_PP_CPP_WARNING           204
-#define WARN_PP_CPP_ERROR             205
-#define WARN_PP_UNEXPECTED_TOKENS     206
+#define WARN_PP_MISSING_FILE                         201
+#define WARN_PP_EVALUATION                           202
+#define WARN_PP_INCLUDEALL_IMPORTALL                 203
+#define WARN_PP_CPP_WARNING                          204
+#define WARN_PP_CPP_ERROR                            205
+#define WARN_PP_UNEXPECTED_TOKENS                    206
 
 /* -- C/C++ Parser -- */
 
-#define WARN_PARSE_CLASS_KEYWORD      301
-#define WARN_PARSE_REDEFINED          302
-#define WARN_PARSE_EXTEND_UNDEF       303
-#define WARN_PARSE_UNSUPPORTED_VALUE  304
-#define WARN_PARSE_BAD_VALUE          305
+#define WARN_PARSE_CLASS_KEYWORD                     301
+#define WARN_PARSE_REDEFINED                         302
+#define WARN_PARSE_EXTEND_UNDEF                      303
+#define WARN_PARSE_UNSUPPORTED_VALUE                 304
+#define WARN_PARSE_BAD_VALUE                         305
 /* Unused since 1.3.32: #define WARN_PARSE_PRIVATE            306 */
 /* Unused since 4.2.0: #define WARN_PARSE_BAD_DEFAULT        307 */
-#define WARN_PARSE_NAMESPACE_ALIAS    308
-#define WARN_PARSE_PRIVATE_INHERIT    309
+#define WARN_PARSE_NAMESPACE_ALIAS                   308
+#define WARN_PARSE_PRIVATE_INHERIT                   309
 /* Unused since 1.3.18: #define WARN_PARSE_TEMPLATE_REPEAT    310 */
 /* Unused since 1.3.18: #define WARN_PARSE_TEMPLATE_PARTIAL   311 */
-#define WARN_PARSE_UNNAMED_NESTED_CLASS 312
-#define WARN_PARSE_UNDEFINED_EXTERN   313
-#define WARN_PARSE_KEYWORD            314
-#define WARN_PARSE_USING_UNDEF        315
+#define WARN_PARSE_UNNAMED_NESTED_CLASS              312
+#define WARN_PARSE_UNDEFINED_EXTERN                  313
+#define WARN_PARSE_KEYWORD                           314
+#define WARN_PARSE_USING_UNDEF                       315
 /* Unused since 1.3.18: #define WARN_PARSE_MODULE_REPEAT      316 */
-#define WARN_PARSE_TEMPLATE_SP_UNDEF  317
-#define WARN_PARSE_TEMPLATE_AMBIG     318
-#define WARN_PARSE_NO_ACCESS          319
-#define WARN_PARSE_EXPLICIT_TEMPLATE  320
-#define WARN_PARSE_BUILTIN_NAME       321
-#define WARN_PARSE_REDUNDANT          322
-#define WARN_PARSE_REC_INHERITANCE    323
-#define WARN_PARSE_NESTED_TEMPLATE    324
-#define WARN_PARSE_NAMED_NESTED_CLASS 325
-#define WARN_PARSE_EXTEND_NAME        326
-#define WARN_PARSE_EXTERN_TEMPLATE    327
-#define WARN_PARSE_ASSIGNED_VALUE     328
-#define WARN_PARSE_USING_CONSTRUCTOR  329
-#define WARN_PARSE_TEMPLATE_FORWARD   330
-#define WARN_PARSE_TEMPLATE_NESTED    331
+#define WARN_PARSE_TEMPLATE_SP_UNDEF                 317
+#define WARN_PARSE_TEMPLATE_AMBIG                    318
+#define WARN_PARSE_NO_ACCESS                         319
+#define WARN_PARSE_EXPLICIT_TEMPLATE                 320
+#define WARN_PARSE_BUILTIN_NAME                      321
+#define WARN_PARSE_REDUNDANT                         322
+#define WARN_PARSE_REC_INHERITANCE                   323
+#define WARN_PARSE_NESTED_TEMPLATE                   324
+#define WARN_PARSE_NAMED_NESTED_CLASS                325
+#define WARN_PARSE_EXTEND_NAME                       326
+#define WARN_PARSE_EXTERN_TEMPLATE                   327
+#define WARN_PARSE_ASSIGNED_VALUE                    328
+#define WARN_PARSE_USING_CONSTRUCTOR                 329
+#define WARN_PARSE_TEMPLATE_FORWARD                  330
+#define WARN_PARSE_TEMPLATE_NESTED                   331
 
-#define WARN_CPP11_LAMBDA             340
+#define WARN_CPP11_LAMBDA                            340
 /* Unused since 3.0.11: #define WARN_CPP11_ALIAS_DECLARATION  341 */
 /* Unused since 3.0.11: #define WARN_CPP11_ALIAS_TEMPLATE     342 */
 /* Unused since 4.2.0: #define WARN_CPP11_VARIADIC_TEMPLATE  343 */
-#define WARN_CPP11_DECLTYPE           344
-#define WARN_CPP14_AUTO               345
-#define WARN_CPP11_AUTO               346
+#define WARN_CPP11_DECLTYPE                          344
+#define WARN_CPP14_AUTO                              345
+#define WARN_CPP11_AUTO                              346
 
-#define WARN_IGNORE_OPERATOR_NEW        350     /* new */
-#define WARN_IGNORE_OPERATOR_DELETE     351     /* delete */
-#define WARN_IGNORE_OPERATOR_PLUS       352     /* + */
-#define WARN_IGNORE_OPERATOR_MINUS      353     /* - */
-#define WARN_IGNORE_OPERATOR_MUL        354     /* * */
-#define WARN_IGNORE_OPERATOR_DIV        355     /* / */
-#define WARN_IGNORE_OPERATOR_MOD        356     /* % */
-#define WARN_IGNORE_OPERATOR_XOR        357     /* ^ */
-#define WARN_IGNORE_OPERATOR_AND        358     /* & */
-#define WARN_IGNORE_OPERATOR_OR         359     /* | */
-#define WARN_IGNORE_OPERATOR_NOT        360     /* ~ */
-#define WARN_IGNORE_OPERATOR_LNOT       361     /* ! */
-#define WARN_IGNORE_OPERATOR_EQ         362     /* = */
-#define WARN_IGNORE_OPERATOR_LT         363     /* < */
-#define WARN_IGNORE_OPERATOR_GT         364     /* > */
-#define WARN_IGNORE_OPERATOR_PLUSEQ     365     /* += */
-#define WARN_IGNORE_OPERATOR_MINUSEQ    366     /* -= */
-#define WARN_IGNORE_OPERATOR_MULEQ      367     /* *= */
-#define WARN_IGNORE_OPERATOR_DIVEQ      368     /* /= */
-#define WARN_IGNORE_OPERATOR_MODEQ      369     /* %= */
-#define WARN_IGNORE_OPERATOR_XOREQ      370     /* ^= */
-#define WARN_IGNORE_OPERATOR_ANDEQ      371     /* &= */
-#define WARN_IGNORE_OPERATOR_OREQ       372     /* |= */
-#define WARN_IGNORE_OPERATOR_LSHIFT     373     /* << */
-#define WARN_IGNORE_OPERATOR_RSHIFT     374     /* >> */
-#define WARN_IGNORE_OPERATOR_LSHIFTEQ   375     /* <<= */
-#define WARN_IGNORE_OPERATOR_RSHIFTEQ   376     /* >>= */
-#define WARN_IGNORE_OPERATOR_EQUALTO    377     /* == */
-#define WARN_IGNORE_OPERATOR_NOTEQUAL   378     /* != */
-#define WARN_IGNORE_OPERATOR_LTEQUAL    379     /* <= */
-#define WARN_IGNORE_OPERATOR_GTEQUAL    380     /* >= */
-#define WARN_IGNORE_OPERATOR_LAND       381     /* && */
-#define WARN_IGNORE_OPERATOR_LOR        382     /* || */
-#define WARN_IGNORE_OPERATOR_PLUSPLUS   383     /* ++ */
-#define WARN_IGNORE_OPERATOR_MINUSMINUS 384     /* -- */
-#define WARN_IGNORE_OPERATOR_COMMA      385     /* , */
-#define WARN_IGNORE_OPERATOR_ARROWSTAR  386     /* ->* */
-#define WARN_IGNORE_OPERATOR_ARROW      387     /* -> */
-#define WARN_IGNORE_OPERATOR_CALL       388     /* () */
-#define WARN_IGNORE_OPERATOR_INDEX      389     /* [] */
-#define WARN_IGNORE_OPERATOR_UPLUS      390     /* + */
-#define WARN_IGNORE_OPERATOR_UMINUS     391     /* - */
-#define WARN_IGNORE_OPERATOR_UMUL       392     /* * */
-#define WARN_IGNORE_OPERATOR_UAND       393     /* & */
-#define WARN_IGNORE_OPERATOR_NEWARR     394     /* new [] */
-#define WARN_IGNORE_OPERATOR_DELARR     395     /* delete [] */
-#define WARN_IGNORE_OPERATOR_REF        396     /* operator *() */
-#define WARN_IGNORE_OPERATOR_LTEQUALGT  397     /* <=> */
+#define WARN_IGNORE_OPERATOR_NEW                     350 /* new */
+#define WARN_IGNORE_OPERATOR_DELETE                  351 /* delete */
+#define WARN_IGNORE_OPERATOR_PLUS                    352 /* + */
+#define WARN_IGNORE_OPERATOR_MINUS                   353 /* - */
+#define WARN_IGNORE_OPERATOR_MUL                     354 /* * */
+#define WARN_IGNORE_OPERATOR_DIV                     355 /* / */
+#define WARN_IGNORE_OPERATOR_MOD                     356 /* % */
+#define WARN_IGNORE_OPERATOR_XOR                     357 /* ^ */
+#define WARN_IGNORE_OPERATOR_AND                     358 /* & */
+#define WARN_IGNORE_OPERATOR_OR                      359 /* | */
+#define WARN_IGNORE_OPERATOR_NOT                     360 /* ~ */
+#define WARN_IGNORE_OPERATOR_LNOT                    361 /* ! */
+#define WARN_IGNORE_OPERATOR_EQ                      362 /* = */
+#define WARN_IGNORE_OPERATOR_LT                      363 /* < */
+#define WARN_IGNORE_OPERATOR_GT                      364 /* > */
+#define WARN_IGNORE_OPERATOR_PLUSEQ                  365 /* += */
+#define WARN_IGNORE_OPERATOR_MINUSEQ                 366 /* -= */
+#define WARN_IGNORE_OPERATOR_MULEQ                   367 /* *= */
+#define WARN_IGNORE_OPERATOR_DIVEQ                   368 /* /= */
+#define WARN_IGNORE_OPERATOR_MODEQ                   369 /* %= */
+#define WARN_IGNORE_OPERATOR_XOREQ                   370 /* ^= */
+#define WARN_IGNORE_OPERATOR_ANDEQ                   371 /* &= */
+#define WARN_IGNORE_OPERATOR_OREQ                    372 /* |= */
+#define WARN_IGNORE_OPERATOR_LSHIFT                  373 /* << */
+#define WARN_IGNORE_OPERATOR_RSHIFT                  374 /* >> */
+#define WARN_IGNORE_OPERATOR_LSHIFTEQ                375 /* <<= */
+#define WARN_IGNORE_OPERATOR_RSHIFTEQ                376 /* >>= */
+#define WARN_IGNORE_OPERATOR_EQUALTO                 377 /* == */
+#define WARN_IGNORE_OPERATOR_NOTEQUAL                378 /* != */
+#define WARN_IGNORE_OPERATOR_LTEQUAL                 379 /* <= */
+#define WARN_IGNORE_OPERATOR_GTEQUAL                 380 /* >= */
+#define WARN_IGNORE_OPERATOR_LAND                    381 /* && */
+#define WARN_IGNORE_OPERATOR_LOR                     382 /* || */
+#define WARN_IGNORE_OPERATOR_PLUSPLUS                383 /* ++ */
+#define WARN_IGNORE_OPERATOR_MINUSMINUS              384 /* -- */
+#define WARN_IGNORE_OPERATOR_COMMA                   385 /* , */
+#define WARN_IGNORE_OPERATOR_ARROWSTAR               386 /* ->* */
+#define WARN_IGNORE_OPERATOR_ARROW                   387 /* -> */
+#define WARN_IGNORE_OPERATOR_CALL                    388 /* () */
+#define WARN_IGNORE_OPERATOR_INDEX                   389 /* [] */
+#define WARN_IGNORE_OPERATOR_UPLUS                   390 /* + */
+#define WARN_IGNORE_OPERATOR_UMINUS                  391 /* - */
+#define WARN_IGNORE_OPERATOR_UMUL                    392 /* * */
+#define WARN_IGNORE_OPERATOR_UAND                    393 /* & */
+#define WARN_IGNORE_OPERATOR_NEWARR                  394 /* new [] */
+#define WARN_IGNORE_OPERATOR_DELARR                  395 /* delete [] */
+#define WARN_IGNORE_OPERATOR_REF                     396 /* operator *() */
+#define WARN_IGNORE_OPERATOR_LTEQUALGT               397 /* <=> */
 
 /* please leave 350-399 free for WARN_IGNORE_OPERATOR_* */
 
 /* -- Type system and typemaps -- */
 
-#define WARN_TYPE_UNDEFINED_CLASS     401
-#define WARN_TYPE_INCOMPLETE          402
-#define WARN_TYPE_ABSTRACT            403
-#define WARN_TYPE_REDEFINED           404
-#define WARN_TYPE_RVALUE_REF_QUALIFIER_IGNORED 405
-#define WARN_TYPE_NSPACE_SETTING      406
+#define WARN_TYPE_UNDEFINED_CLASS                    401
+#define WARN_TYPE_INCOMPLETE                         402
+#define WARN_TYPE_ABSTRACT                           403
+#define WARN_TYPE_REDEFINED                          404
+#define WARN_TYPE_RVALUE_REF_QUALIFIER_IGNORED       405
+#define WARN_TYPE_NSPACE_SETTING                     406
 
 /* Unused since 4.1.0: #define WARN_TYPEMAP_SOURCETARGET     450 */
-#define WARN_TYPEMAP_CHARLEAK         451
+#define WARN_TYPEMAP_CHARLEAK                        451
 /* Unused since 1.3.32: #define WARN_TYPEMAP_SWIGTYPE         452 */
-#define WARN_TYPEMAP_APPLY_UNDEF      453
-#define WARN_TYPEMAP_SWIGTYPELEAK     454
-#define WARN_TYPEMAP_WCHARLEAK        455
+#define WARN_TYPEMAP_APPLY_UNDEF                     453
+#define WARN_TYPEMAP_SWIGTYPELEAK                    454
+#define WARN_TYPEMAP_WCHARLEAK                       455
 
-#define WARN_TYPEMAP_IN_UNDEF         460
-#define WARN_TYPEMAP_OUT_UNDEF        461
-#define WARN_TYPEMAP_VARIN_UNDEF      462
-#define WARN_TYPEMAP_VAROUT_UNDEF     463
-#define WARN_TYPEMAP_CONST_UNDEF      464
-#define WARN_TYPEMAP_UNDEF            465
-#define WARN_TYPEMAP_VAR_UNDEF        466
-#define WARN_TYPEMAP_TYPECHECK        467
-#define WARN_TYPEMAP_THROW            468
-#define WARN_TYPEMAP_DIRECTORIN_UNDEF  469
-#define WARN_TYPEMAP_THREAD_UNSAFE     470      /* mostly used in directorout typemaps */
-#define WARN_TYPEMAP_DIRECTOROUT_UNDEF 471
-#define WARN_TYPEMAP_TYPECHECK_UNDEF   472
-#define WARN_TYPEMAP_DIRECTOROUT_PTR   473
-#define WARN_TYPEMAP_OUT_OPTIMAL_IGNORED  474
-#define WARN_TYPEMAP_OUT_OPTIMAL_MULTIPLE 475
-#define WARN_TYPEMAP_INITIALIZER_LIST  476
-#define WARN_TYPEMAP_DIRECTORTHROWS_UNDEF 477
+#define WARN_TYPEMAP_IN_UNDEF                        460
+#define WARN_TYPEMAP_OUT_UNDEF                       461
+#define WARN_TYPEMAP_VARIN_UNDEF                     462
+#define WARN_TYPEMAP_VAROUT_UNDEF                    463
+#define WARN_TYPEMAP_CONST_UNDEF                     464
+#define WARN_TYPEMAP_UNDEF                           465
+#define WARN_TYPEMAP_VAR_UNDEF                       466
+#define WARN_TYPEMAP_TYPECHECK                       467
+#define WARN_TYPEMAP_THROW                           468
+#define WARN_TYPEMAP_DIRECTORIN_UNDEF                469
+#define WARN_TYPEMAP_THREAD_UNSAFE                   470 /* mostly used in directorout typemaps */
+#define WARN_TYPEMAP_DIRECTOROUT_UNDEF               471
+#define WARN_TYPEMAP_TYPECHECK_UNDEF                 472
+#define WARN_TYPEMAP_DIRECTOROUT_PTR                 473
+#define WARN_TYPEMAP_OUT_OPTIMAL_IGNORED             474
+#define WARN_TYPEMAP_OUT_OPTIMAL_MULTIPLE            475
+#define WARN_TYPEMAP_INITIALIZER_LIST                476
+#define WARN_TYPEMAP_DIRECTORTHROWS_UNDEF            477
 
 /* -- Fragments -- */
-#define WARN_FRAGMENT_NOT_FOUND       490
+#define WARN_FRAGMENT_NOT_FOUND                      490
 
 /* -- General code generation -- */
 
-#define WARN_LANG_OVERLOAD_DECL       501
-#define WARN_LANG_OVERLOAD_CONSTRUCT  502
-#define WARN_LANG_IDENTIFIER          503
-#define WARN_LANG_RETURN_TYPE         504
-#define WARN_LANG_VARARGS             505
-#define WARN_LANG_VARARGS_KEYWORD     506
-#define WARN_LANG_NATIVE_UNIMPL       507
-#define WARN_LANG_DEREF_SHADOW        508
-#define WARN_LANG_OVERLOAD_SHADOW     509
-#define WARN_LANG_FRIEND_IGNORE       510 /* No longer issued */
-#define WARN_LANG_OVERLOAD_KEYWORD    511
-#define WARN_LANG_OVERLOAD_CONST      512
-#define WARN_LANG_CLASS_UNNAMED       513
-#define WARN_LANG_DIRECTOR_VDESTRUCT  514
-#define WARN_LANG_DISCARD_CONST       515
-#define WARN_LANG_OVERLOAD_IGNORED    516
-#define WARN_LANG_DIRECTOR_ABSTRACT   517
-#define WARN_LANG_PORTABILITY_FILENAME 518
-#define WARN_LANG_TEMPLATE_METHOD_IGNORE 519
-#define WARN_LANG_SMARTPTR_MISSING    520
-#define WARN_LANG_ILLEGAL_DESTRUCTOR  521
-#define WARN_LANG_EXTEND_CONSTRUCTOR  522
-#define WARN_LANG_EXTEND_DESTRUCTOR   523
-#define WARN_LANG_EXPERIMENTAL        524
-#define WARN_LANG_DIRECTOR_FINAL      525
-#define WARN_LANG_USING_NAME_DIFFERENT 526
-#define WARN_LANG_DEPRECATED          527
+#define WARN_LANG_OVERLOAD_DECL                      501
+#define WARN_LANG_OVERLOAD_CONSTRUCT                 502
+#define WARN_LANG_IDENTIFIER                         503
+#define WARN_LANG_RETURN_TYPE                        504
+#define WARN_LANG_VARARGS                            505
+#define WARN_LANG_VARARGS_KEYWORD                    506
+#define WARN_LANG_NATIVE_UNIMPL                      507
+#define WARN_LANG_DEREF_SHADOW                       508
+#define WARN_LANG_OVERLOAD_SHADOW                    509
+#define WARN_LANG_FRIEND_IGNORE                      510 /* No longer issued */
+#define WARN_LANG_OVERLOAD_KEYWORD                   511
+#define WARN_LANG_OVERLOAD_CONST                     512
+#define WARN_LANG_CLASS_UNNAMED                      513
+#define WARN_LANG_DIRECTOR_VDESTRUCT                 514
+#define WARN_LANG_DISCARD_CONST                      515
+#define WARN_LANG_OVERLOAD_IGNORED                   516
+#define WARN_LANG_DIRECTOR_ABSTRACT                  517
+#define WARN_LANG_PORTABILITY_FILENAME               518
+#define WARN_LANG_TEMPLATE_METHOD_IGNORE             519
+#define WARN_LANG_SMARTPTR_MISSING                   520
+#define WARN_LANG_ILLEGAL_DESTRUCTOR                 521
+#define WARN_LANG_EXTEND_CONSTRUCTOR                 522
+#define WARN_LANG_EXTEND_DESTRUCTOR                  523
+#define WARN_LANG_EXPERIMENTAL                       524
+#define WARN_LANG_DIRECTOR_FINAL                     525
+#define WARN_LANG_USING_NAME_DIFFERENT               526
+#define WARN_LANG_DEPRECATED                         527
 
 /* -- Doxygen comments -- */
 
-#define WARN_DOXYGEN_UNKNOWN_COMMAND          560
-#define WARN_DOXYGEN_UNEXPECTED_END_OF_COMMENT  561
-#define WARN_DOXYGEN_COMMAND_EXPECTED         562
-#define WARN_DOXYGEN_HTML_ERROR               563
-#define WARN_DOXYGEN_COMMAND_ERROR            564
-#define WARN_DOXYGEN_UNKNOWN_CHARACTER        565
-#define WARN_DOXYGEN_UNEXPECTED_ITERATOR_VALUE  566
+#define WARN_DOXYGEN_UNKNOWN_COMMAND                 560
+#define WARN_DOXYGEN_UNEXPECTED_END_OF_COMMENT       561
+#define WARN_DOXYGEN_COMMAND_EXPECTED                562
+#define WARN_DOXYGEN_HTML_ERROR                      563
+#define WARN_DOXYGEN_COMMAND_ERROR                   564
+#define WARN_DOXYGEN_UNKNOWN_CHARACTER               565
+#define WARN_DOXYGEN_UNEXPECTED_ITERATOR_VALUE       566
 
 /* -- Reserved (600-699) -- */
 
@@ -244,97 +244,97 @@
 /* Feel free to claim any number in this space that's not currently being used. Just make sure you
    add an entry here */
 
-#define WARN_D_TYPEMAP_CTYPE_UNDEF            700
-#define WARN_D_TYPEMAP_IMTYPE_UNDEF           701
-#define WARN_D_TYPEMAP_DTYPE_UNDEF            702
-#define WARN_D_MULTIPLE_INHERITANCE           703
-#define WARN_D_TYPEMAP_CLASSMOD_UNDEF         704
-#define WARN_D_TYPEMAP_DBODY_UNDEF            705
-#define WARN_D_TYPEMAP_DOUT_UNDEF             706
-#define WARN_D_TYPEMAP_DIN_UNDEF              707
-#define WARN_D_TYPEMAP_DDIRECTORIN_UNDEF      708
-#define WARN_D_TYPEMAP_DCONSTRUCTOR_UNDEF     709
-#define WARN_D_EXCODE_MISSING                 710
-#define WARN_D_CANTHROW_MISSING               711
-#define WARN_D_NO_DIRECTORCONNECT_ATTR        712
-#define WARN_D_NAME_COLLISION                 713
+#define WARN_D_TYPEMAP_CTYPE_UNDEF                   700
+#define WARN_D_TYPEMAP_IMTYPE_UNDEF                  701
+#define WARN_D_TYPEMAP_DTYPE_UNDEF                   702
+#define WARN_D_MULTIPLE_INHERITANCE                  703
+#define WARN_D_TYPEMAP_CLASSMOD_UNDEF                704
+#define WARN_D_TYPEMAP_DBODY_UNDEF                   705
+#define WARN_D_TYPEMAP_DOUT_UNDEF                    706
+#define WARN_D_TYPEMAP_DIN_UNDEF                     707
+#define WARN_D_TYPEMAP_DDIRECTORIN_UNDEF             708
+#define WARN_D_TYPEMAP_DCONSTRUCTOR_UNDEF            709
+#define WARN_D_EXCODE_MISSING                        710
+#define WARN_D_CANTHROW_MISSING                      711
+#define WARN_D_NO_DIRECTORCONNECT_ATTR               712
+#define WARN_D_NAME_COLLISION                        713
 
 /* please leave 700-719 free for D */
 
-#define WARN_SCILAB_TRUNCATED_NAME            720
+#define WARN_SCILAB_TRUNCATED_NAME                   720
 
 /* please leave 720-739 free for Scilab */
 
-#define WARN_PYTHON_INDENT_MISMATCH           740
+#define WARN_PYTHON_INDENT_MISMATCH                  740
 
 /* please leave 740-749 free for Python */
 
 /* Unused since 4.2.0: #define WARN_R_MISSING_RTYPECHECK_TYPEMAP     750 */
-#define WARN_R_TYPEMAP_RTYPECHECK_UNDEF       751
+#define WARN_R_TYPEMAP_RTYPECHECK_UNDEF              751
 
 /* please leave 750-759 free for R */
 
-#define WARN_C_TYPEMAP_CTYPE_UNDEF            760
-#define WARN_C_UNSUPPORTTED                   761
+#define WARN_C_TYPEMAP_CTYPE_UNDEF                   760
+#define WARN_C_UNSUPPORTTED                          761
 
 /* please leave 760-779 free for C */
 
-#define WARN_RUBY_WRONG_NAME                  801
-#define WARN_RUBY_MULTIPLE_INHERITANCE        802
+#define WARN_RUBY_WRONG_NAME                         801
+#define WARN_RUBY_MULTIPLE_INHERITANCE               802
 
 /* please leave 800-809 free for Ruby */
 
-#define WARN_JAVA_TYPEMAP_JNI_UNDEF           810
-#define WARN_JAVA_TYPEMAP_JTYPE_UNDEF         811
-#define WARN_JAVA_TYPEMAP_JSTYPE_UNDEF        812
-#define WARN_JAVA_MULTIPLE_INHERITANCE        813
-#define WARN_JAVA_TYPEMAP_GETCPTR_UNDEF       814
-#define WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF      815
-#define WARN_JAVA_TYPEMAP_JAVABODY_UNDEF      816
-#define WARN_JAVA_TYPEMAP_JAVAOUT_UNDEF       817
-#define WARN_JAVA_TYPEMAP_JAVAIN_UNDEF        818
-#define WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF    819
-#define WARN_JAVA_TYPEMAP_JAVADIRECTOROUT_UNDEF   820
-#define WARN_JAVA_TYPEMAP_INTERFACECODE_UNDEF 821
-#define WARN_JAVA_COVARIANT_RET               822
-#define WARN_JAVA_TYPEMAP_JAVACONSTRUCT_UNDEF 823
-#define WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC   824
-#define WARN_JAVA_NO_DIRECTORCONNECT_ATTR     825
-#define WARN_JAVA_NSPACE_WITHOUT_PACKAGE      826
-#define WARN_JAVA_TYPEMAP_INTERFACEMODIFIERS_UNDEF 827
+#define WARN_JAVA_TYPEMAP_JNI_UNDEF                  810
+#define WARN_JAVA_TYPEMAP_JTYPE_UNDEF                811
+#define WARN_JAVA_TYPEMAP_JSTYPE_UNDEF               812
+#define WARN_JAVA_MULTIPLE_INHERITANCE               813
+#define WARN_JAVA_TYPEMAP_GETCPTR_UNDEF              814
+#define WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF             815
+#define WARN_JAVA_TYPEMAP_JAVABODY_UNDEF             816
+#define WARN_JAVA_TYPEMAP_JAVAOUT_UNDEF              817
+#define WARN_JAVA_TYPEMAP_JAVAIN_UNDEF               818
+#define WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF       819
+#define WARN_JAVA_TYPEMAP_JAVADIRECTOROUT_UNDEF      820
+#define WARN_JAVA_TYPEMAP_INTERFACECODE_UNDEF        821
+#define WARN_JAVA_COVARIANT_RET                      822
+#define WARN_JAVA_TYPEMAP_JAVACONSTRUCT_UNDEF        823
+#define WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC          824
+#define WARN_JAVA_NO_DIRECTORCONNECT_ATTR            825
+#define WARN_JAVA_NSPACE_WITHOUT_PACKAGE             826
+#define WARN_JAVA_TYPEMAP_INTERFACEMODIFIERS_UNDEF   827
 
 /* please leave 810-829 free for Java */
 
-#define WARN_CSHARP_TYPEMAP_CTYPE_UNDEF       830
-#define WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF      831
-#define WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF     832
-#define WARN_CSHARP_MULTIPLE_INHERITANCE      833
-#define WARN_CSHARP_TYPEMAP_GETCPTR_UNDEF     834
-#define WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF    835
-#define WARN_CSHARP_TYPEMAP_CSBODY_UNDEF      836
-#define WARN_CSHARP_TYPEMAP_CSOUT_UNDEF       837
-#define WARN_CSHARP_TYPEMAP_CSIN_UNDEF        838
-#define WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF    839
-#define WARN_CSHARP_TYPEMAP_CSDIRECTOROUT_UNDEF   840
-#define WARN_CSHARP_TYPEMAP_INTERFACECODE_UNDEF   841
-#define WARN_CSHARP_COVARIANT_RET             842
-#define WARN_CSHARP_TYPEMAP_CSCONSTRUCT_UNDEF 843
-#define WARN_CSHARP_EXCODE                    844
-#define WARN_CSHARP_CANTHROW                  845
-#define WARN_CSHARP_NO_DIRECTORCONNECT_ATTR   846
+#define WARN_CSHARP_TYPEMAP_CTYPE_UNDEF              830
+#define WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF             831
+#define WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF            832
+#define WARN_CSHARP_MULTIPLE_INHERITANCE             833
+#define WARN_CSHARP_TYPEMAP_GETCPTR_UNDEF            834
+#define WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF           835
+#define WARN_CSHARP_TYPEMAP_CSBODY_UNDEF             836
+#define WARN_CSHARP_TYPEMAP_CSOUT_UNDEF              837
+#define WARN_CSHARP_TYPEMAP_CSIN_UNDEF               838
+#define WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF       839
+#define WARN_CSHARP_TYPEMAP_CSDIRECTOROUT_UNDEF      840
+#define WARN_CSHARP_TYPEMAP_INTERFACECODE_UNDEF      841
+#define WARN_CSHARP_COVARIANT_RET                    842
+#define WARN_CSHARP_TYPEMAP_CSCONSTRUCT_UNDEF        843
+#define WARN_CSHARP_EXCODE                           844
+#define WARN_CSHARP_CANTHROW                         845
+#define WARN_CSHARP_NO_DIRECTORCONNECT_ATTR          846
 #define WARN_CSHARP_TYPEMAP_INTERFACEMODIFIERS_UNDEF 847
 
 /* please leave 830-849 free for C# */
 
 /* 850-860 were used by Modula 3 (removed in SWIG 4.1.0) - avoid reusing for now */
 
-#define WARN_PHP_MULTIPLE_INHERITANCE         870
-#define WARN_PHP_UNKNOWN_PRAGMA               871
+#define WARN_PHP_MULTIPLE_INHERITANCE                870
+#define WARN_PHP_UNKNOWN_PRAGMA                      871
 /* Unused since 4.1.0: define WARN_PHP_PUBLIC_BASE                  872 */
 
 /* please leave 870-889 free for PHP */
 
-#define WARN_GO_NAME_CONFLICT                 890
+#define WARN_GO_NAME_CONFLICT                        890
 
 /* please leave 890-899 free for Go */
 

--- a/Source/Makefile.am
+++ b/Source/Makefile.am
@@ -48,7 +48,7 @@ eswig_SOURCES =	CParse/cscanner.c		\
 		Doxygen/pydoc.h			\
 		Modules/allocate.cxx		\
 		Modules/contract.cxx		\
-		Modules/c.cxx		\
+		Modules/c.cxx			\
 		Modules/csharp.cxx		\
 		Modules/d.cxx			\
 		Modules/directors.cxx		\
@@ -128,15 +128,15 @@ distclean-local:
 
 # For warning about source formatting discrepancies
 format-review:
-	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) --dry-run $(eswig_SOURCES)
+	(cd $(srcdir) && $(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) --dry-run */*.c */*.cxx */*.h)
 
 # For erroring out about source formatting discrepancies
 format-check:
-	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) --dry-run --Werror $(eswig_SOURCES)
+	(cd $(srcdir) && $(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) --dry-run --Werror  */*.c */*.cxx */*.h)
 
 # For correcting source formatting - overwrites source files in-place
 format-inplace:
-	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) -i $(eswig_SOURCES)
+	(cd $(srcdir) && $(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) -i  */*.c */*.cxx */*.h)
 
 format: format-inplace
 

--- a/Source/Makefile.am
+++ b/Source/Makefile.am
@@ -110,6 +110,11 @@ CParse/parser.c CParse/parser.h &: CParse/parser.y
 all-local: eswig@EXEEXT@
 	cp -f $(top_builddir)/Source/eswig@EXEEXT@ $(top_builddir)/swig@EXEEXT@
 
+# Add clang-format checking (warnings) to dependencies building the executable
+ ifneq (,$(CLANG_FORMAT)) # Note space before ifneq/endif trick to prevent automake evaluating and removing this block during configure time
+all-local: format-review
+ endif
+
 clean-local:
 	rm -f $(top_builddir)/swig@EXEEXT@
 	rm -f core @EXTRA_CLEAN@
@@ -118,36 +123,21 @@ distclean-local:
 	rm -f $(top_builddir)/Source/Include/swigconfig.h
 	rm -f $(top_builddir)/Source/Include/stamp-h1
 
-# Beautify the code.
-# Note that this works well on C code, but does some odd joining of lines for C++ code.
-# Compiling with -DNDEBUG and no optimisations will allow one to do a binary diff of the
-# swig executable as a way of checking before and after the 'beautifying'.
-# Single files can be beautified with the beautify-file target, eg: 'make beautify-file INDENTFILE=chosenfile.c'
+# Beautify / check source code format with clang-format.
+# Note files in .clang-format-ignore will be skipped even if passed to clang-format (clang-format-18 and later).
 
-SWIGTYPEDEFS=-T bool -T File -T DohObjInfo -T Parm -T Language -T List -T TargetLanguageModule -T Typetab -T ModuleFactory -T ErrorMessageFormat -T Symtab -T Hash -T Scanner -T String -T DohBase -T Node -T String_or_char -T SwigType -T Dispatcher -T Wrapper -T DohStringMethods -T DohFileMethods -T DohListMethods -T DohHashMethods -T DOH -T DohIterator -T ParmList -T FILE -T HashNode -T DOHObj_or_char -T DOHFile -T DOHString -T DOHString_or_char -T UpcallData -T DoxygenEntity -T string
-INDENTBAKSDIR=../IndentBaks
+# For warning about source formatting discrepancies
+format-review:
+	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) --dry-run $(eswig_SOURCES)
 
-beautify:
-	rm -rf $(INDENTBAKSDIR)
-	mkdir $(INDENTBAKSDIR)
-	mkdir $(INDENTBAKSDIR)/CParse
-	mkdir $(INDENTBAKSDIR)/DOH
-	mkdir $(INDENTBAKSDIR)/Modules
-	mkdir $(INDENTBAKSDIR)/Preprocessor
-	mkdir $(INDENTBAKSDIR)/Swig
-	mkdir $(INDENTBAKSDIR)/Include
-	(csources=`find . -name "*.c"` && \
-	hsources=`find . -name "*.h"` && \
-	cxxsources=`find . -name "*.cxx"` && \
-	for file in $$csources $$hsources $$cxxsources; do \
-	  $(MAKE) beautify-file INDENTFILE=$$file; \
-	done; )
+# For erroring out about source formatting discrepancies
+format-check:
+	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) --dry-run --Werror $(eswig_SOURCES)
 
-beautify-file:
-	test -e $(INDENTBAKSDIR) || (echo $(INDENTBAKSDIR) directory does not exist && exit 1;)
-	test -n "$(INDENTFILE)" || (echo INDENTFILE not defined && exit 1;)
-	test -e $(INDENTFILE) || (echo File does not exist: $(INDENTFILE) && exit 1;)
-	cp $(INDENTFILE) $(INDENTBAKSDIR)/$(INDENTFILE);
-	indent -kr --honour-newlines --line-length160 --indent-level2 --braces-on-func-def-line --leave-optional-blank-lines $(SWIGTYPEDEFS) $(INDENTFILE) -o $(INDENTFILE).tmp;
-	cat $(INDENTFILE).tmp | sed -e 's/const const /const /' > $(INDENTFILE);
-	rm $(INDENTFILE).tmp;
+# For correcting source formatting - overwrites source files in-place
+format-inplace:
+	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTIONS) -i $(eswig_SOURCES)
+
+format: format-inplace
+
+CLANG_FORMAT_OPTIONS=

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -36,7 +36,7 @@ void Wrapper_virtual_elimination_mode_set(int flag) {
   virtual_elimination_mode = flag;
 }
 
-/* Helper function to assist with abstract class checking.  
+/* Helper function to assist with abstract class checking.
    This is a major hack. Sorry.  */
 
 extern "C" {
@@ -508,10 +508,10 @@ class Allocate:public Dispatcher {
 
   void process_exceptions(Node *n) {
     ParmList *catchlist = 0;
-    /* 
+    /*
        the "catchlist" attribute is used to emit the block
 
-       try {$action;} 
+       try {$action;}
        catch <list of catches>;
 
        in emit.cxx
@@ -635,7 +635,7 @@ class Allocate:public Dispatcher {
 
   void add_member_for_using_declaration(Node *c, Node *n, int &ccount, Node *&unodes, Node *&last_unodes) {
     if (GetFlag(c, "fvirtual:ignore")) {
-      // This node was ignored by fvirtual. Thus, it has feature:ignore set. 
+      // This node was ignored by fvirtual. Thus, it has feature:ignore set.
       // However, we may have new sibling overrides that will make us want to keep it.
       // Hence, temporarily unset the feature:ignore flag.
       UnsetFlag(c, "feature:ignore");
@@ -1099,7 +1099,7 @@ Allocate():
 #endif
 
                 if (firstoverloaded == n) {
-                  // This 'using' node we are cutting out was the first node in the overloaded list. 
+                  // This 'using' node we are cutting out was the first node in the overloaded list.
                   // Change the first node in the list
                   Delattr(firstoverloaded, "sym:overloaded");
                   firstoverloaded = fc ? fc : ns;

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -47,20 +47,20 @@ extern "C" {
        return 0;
     while (n) {
       if (Strcmp(nodeType(n), "cdecl") == 0) {
-	decl = Getattr(n, "decl");
-	if (SwigType_isfunction(decl)) {
-	  SwigType *decl1 = SwigType_typedef_resolve_all(decl);
-	  SwigType *decl2 = SwigType_pop_function(decl1);
-	  if (Strcmp(decl2, search_decl) == 0) {
-	    if (!GetFlag(n, "abstract")) {
-	      Delete(decl1);
-	      Delete(decl2);
-	      return n;
-	    }
-	  }
-	  Delete(decl1);
-	  Delete(decl2);
-	}
+        decl = Getattr(n, "decl");
+        if (SwigType_isfunction(decl)) {
+          SwigType *decl1 = SwigType_typedef_resolve_all(decl);
+          SwigType *decl2 = SwigType_pop_function(decl1);
+          if (Strcmp(decl2, search_decl) == 0) {
+            if (!GetFlag(n, "abstract")) {
+              Delete(decl1);
+              Delete(decl2);
+              return n;
+            }
+          }
+          Delete(decl1);
+          Delete(decl2);
+        }
       }
       n = Getattr(n, "csym:nextSibling");
     }
@@ -93,34 +93,34 @@ class Allocate:public Dispatcher {
       Node *b = Getitem(bases, i);
       Node *base = firstChild(b);
       while (base) {
-	if (Strcmp(nodeType(base), "extend") == 0) {
-	  // Loop through all the %extend methods
-	  Node *extend = firstChild(base);
-	  while (extend) {
-	    if (function_is_defined_in_bases_seek(n, b, extend, this_decl, name, this_type, resolved_decl)) {
-	      Delete(resolved_decl);
-	      return 1;
-	    }
-	    extend = nextSibling(extend);
-	  }
-	} else if (Strcmp(nodeType(base), "using") == 0) {
-	  // Loop through all the using declaration methods
-	  Node *usingdecl = firstChild(base);
-	  while (usingdecl) {
-	    if (function_is_defined_in_bases_seek(n, b, usingdecl, this_decl, name, this_type, resolved_decl)) {
-	      Delete(resolved_decl);
-	      return 1;
-	    }
-	    usingdecl = nextSibling(usingdecl);
-	  }
-	} else {
-	  // normal methods
-	  if (function_is_defined_in_bases_seek(n, b, base, this_decl, name, this_type, resolved_decl)) {
-	    Delete(resolved_decl);
-	    return 1;
-	  }
-	}
-	base = nextSibling(base);
+        if (Strcmp(nodeType(base), "extend") == 0) {
+          // Loop through all the %extend methods
+          Node *extend = firstChild(base);
+          while (extend) {
+            if (function_is_defined_in_bases_seek(n, b, extend, this_decl, name, this_type, resolved_decl)) {
+              Delete(resolved_decl);
+              return 1;
+            }
+            extend = nextSibling(extend);
+          }
+        } else if (Strcmp(nodeType(base), "using") == 0) {
+          // Loop through all the using declaration methods
+          Node *usingdecl = firstChild(base);
+          while (usingdecl) {
+            if (function_is_defined_in_bases_seek(n, b, usingdecl, this_decl, name, this_type, resolved_decl)) {
+              Delete(resolved_decl);
+              return 1;
+            }
+            usingdecl = nextSibling(usingdecl);
+          }
+        } else {
+          // normal methods
+          if (function_is_defined_in_bases_seek(n, b, base, this_decl, name, this_type, resolved_decl)) {
+            Delete(resolved_decl);
+            return 1;
+          }
+        }
+        base = nextSibling(base);
       }
     }
     Delete(resolved_decl);
@@ -128,7 +128,7 @@ class Allocate:public Dispatcher {
     for (int j = 0; j < Len(bases); j++) {
       Node *b = Getitem(bases, j);
       if (function_is_defined_in_bases(n, Getattr(b, "allbases")))
-	return 1;
+        return 1;
     }
     return 0;
   }
@@ -140,117 +140,117 @@ class Allocate:public Dispatcher {
     SwigType *base_type = Getattr(base, "type");
     if (base_decl && base_type) {
       if (checkAttribute(base, "name", name) && !GetFlag(b, "feature:ignore") /* whole class is ignored */ ) {
-	if (SwigType_isfunction(resolved_decl) && SwigType_isfunction(base_decl)) {
-	  // We have found a method that has the same name as one in a base class
-	  bool covariant_returntype = false;
-	  bool returntype_match = Strcmp(base_type, this_type) == 0 ? true : false;
-	  bool decl_match = Strcmp(base_decl, this_decl) == 0 ? true : false;
-	  if (returntype_match && decl_match) {
-	    // Exact match - we have found a method with identical signature
-	    // No typedef resolution was done, but skipping it speeds things up slightly
-	  } else {
-	    // Either we have:
-	    //  1) matching methods but are one of them uses a different typedef (return type or parameter) to the one in base class' method
-	    //  2) matching polymorphic methods with covariant return type
-	    //  3) a non-matching method (ie an overloaded method of some sort)
-	    //  4) a matching method which is not polymorphic, ie it hides the base class' method
+        if (SwigType_isfunction(resolved_decl) && SwigType_isfunction(base_decl)) {
+          // We have found a method that has the same name as one in a base class
+          bool covariant_returntype = false;
+          bool returntype_match = Strcmp(base_type, this_type) == 0 ? true : false;
+          bool decl_match = Strcmp(base_decl, this_decl) == 0 ? true : false;
+          if (returntype_match && decl_match) {
+            // Exact match - we have found a method with identical signature
+            // No typedef resolution was done, but skipping it speeds things up slightly
+          } else {
+            // Either we have:
+            //  1) matching methods but are one of them uses a different typedef (return type or parameter) to the one in base class' method
+            //  2) matching polymorphic methods with covariant return type
+            //  3) a non-matching method (ie an overloaded method of some sort)
+            //  4) a matching method which is not polymorphic, ie it hides the base class' method
 
-	    // Check if fully resolved return types match (including
-	    // covariant return types)
-	    if (!returntype_match) {
-	      String *this_returntype = function_return_type(n);
-	      String *base_returntype = function_return_type(base);
-	      returntype_match = Strcmp(this_returntype, base_returntype) == 0 ? true : false;
-	      if (!returntype_match) {
-		covariant_returntype = SwigType_issubtype(this_returntype, base_returntype) ? true : false;
-		returntype_match = covariant_returntype;
-	      }
-	      Delete(this_returntype);
-	      Delete(base_returntype);
-	    }
-	    // The return types must match at this point, for the whole method to match
-	    if (returntype_match && !decl_match) {
-	      // Now need to check the parameter list
-	      // First do an inexpensive parameter count
-	      ParmList *this_parms = Getattr(n, "parms");
-	      ParmList *base_parms = Getattr(base, "parms");
-	      if (ParmList_len(this_parms) == ParmList_len(base_parms)) {
-		// Number of parameters are the same, now check that all the parameters match
-		SwigType *base_fn = NewString("");
-		SwigType *this_fn = NewString("");
-		SwigType_add_function(base_fn, base_parms);
-		SwigType_add_function(this_fn, this_parms);
-		base_fn = SwigType_typedef_resolve_all(base_fn);
-		this_fn = SwigType_typedef_resolve_all(this_fn);
-		if (Strcmp(base_fn, this_fn) == 0) {
-		  // Finally check that the qualifiers match
-		  int base_qualifier = SwigType_isqualifier(resolved_decl);
-		  int this_qualifier = SwigType_isqualifier(base_decl);
-		  if (base_qualifier == this_qualifier) {
-		    decl_match = true;
-		  }
-		}
-		Delete(base_fn);
-		Delete(this_fn);
-	      }
-	    }
-	  }
-	  //Printf(stderr,"look %s %s %d %d\n",base_decl, this_decl, returntype_match, decl_match);
+            // Check if fully resolved return types match (including
+            // covariant return types)
+            if (!returntype_match) {
+              String *this_returntype = function_return_type(n);
+              String *base_returntype = function_return_type(base);
+              returntype_match = Strcmp(this_returntype, base_returntype) == 0 ? true : false;
+              if (!returntype_match) {
+                covariant_returntype = SwigType_issubtype(this_returntype, base_returntype) ? true : false;
+                returntype_match = covariant_returntype;
+              }
+              Delete(this_returntype);
+              Delete(base_returntype);
+            }
+            // The return types must match at this point, for the whole method to match
+            if (returntype_match && !decl_match) {
+              // Now need to check the parameter list
+              // First do an inexpensive parameter count
+              ParmList *this_parms = Getattr(n, "parms");
+              ParmList *base_parms = Getattr(base, "parms");
+              if (ParmList_len(this_parms) == ParmList_len(base_parms)) {
+                // Number of parameters are the same, now check that all the parameters match
+                SwigType *base_fn = NewString("");
+                SwigType *this_fn = NewString("");
+                SwigType_add_function(base_fn, base_parms);
+                SwigType_add_function(this_fn, this_parms);
+                base_fn = SwigType_typedef_resolve_all(base_fn);
+                this_fn = SwigType_typedef_resolve_all(this_fn);
+                if (Strcmp(base_fn, this_fn) == 0) {
+                  // Finally check that the qualifiers match
+                  int base_qualifier = SwigType_isqualifier(resolved_decl);
+                  int this_qualifier = SwigType_isqualifier(base_decl);
+                  if (base_qualifier == this_qualifier) {
+                    decl_match = true;
+                  }
+                }
+                Delete(base_fn);
+                Delete(this_fn);
+              }
+            }
+          }
+          //Printf(stderr,"look %s %s %d %d\n",base_decl, this_decl, returntype_match, decl_match);
 
-	  if (decl_match && returntype_match) {
-	    // Found an identical method in the base class
-	    bool this_wrapping_protected_members = is_member_director(n) ? true : false;	// This should really check for dirprot rather than just being a director method
-	    bool base_wrapping_protected_members = is_member_director(base) ? true : false;	// This should really check for dirprot rather than just being a director method
-	    bool both_have_public_access = is_public(n) && is_public(base);
-	    bool both_have_protected_access = (is_protected(n) && this_wrapping_protected_members) && (is_protected(base) && base_wrapping_protected_members);
-	    bool both_have_private_access = is_private(n) && is_private(base);
-	    if (checkAttribute(base, "storage", "virtual")) {
-	      // Found a polymorphic method.
-	      // Mark the polymorphic method, in case the virtual keyword was not used.
-	      Setattr(n, "storage", "virtual");
-	      if (!GetFlag(b, "feature:interface")) { // interface implementation neither hides nor overrides
-		if (both_have_public_access || both_have_protected_access) {
-		  if (!is_non_public_base(inclass, b))
-		    Setattr(n, "override", base);	// Note C# definition of override, ie access must be the same
-		}
-		else if (!both_have_private_access) {
-		  // Different access
-		  if (this_wrapping_protected_members || base_wrapping_protected_members)
-		    if (!is_non_public_base(inclass, b))
-		      Setattr(n, "hides", base);	// Note C# definition of hiding, ie hidden if access is different
-		}
-	      }
-	      // Try and find the most base's covariant return type
-	      SwigType *most_base_covariant_type = Getattr(base, "covariant");
-	      if (!most_base_covariant_type && covariant_returntype)
-		most_base_covariant_type = function_return_type(base, false);
+          if (decl_match && returntype_match) {
+            // Found an identical method in the base class
+            bool this_wrapping_protected_members = is_member_director(n) ? true : false;	// This should really check for dirprot rather than just being a director method
+            bool base_wrapping_protected_members = is_member_director(base) ? true : false;	// This should really check for dirprot rather than just being a director method
+            bool both_have_public_access = is_public(n) && is_public(base);
+            bool both_have_protected_access = (is_protected(n) && this_wrapping_protected_members) && (is_protected(base) && base_wrapping_protected_members);
+            bool both_have_private_access = is_private(n) && is_private(base);
+            if (checkAttribute(base, "storage", "virtual")) {
+              // Found a polymorphic method.
+              // Mark the polymorphic method, in case the virtual keyword was not used.
+              Setattr(n, "storage", "virtual");
+              if (!GetFlag(b, "feature:interface")) { // interface implementation neither hides nor overrides
+                if (both_have_public_access || both_have_protected_access) {
+                  if (!is_non_public_base(inclass, b))
+                    Setattr(n, "override", base);	// Note C# definition of override, ie access must be the same
+                }
+                else if (!both_have_private_access) {
+                  // Different access
+                  if (this_wrapping_protected_members || base_wrapping_protected_members)
+                    if (!is_non_public_base(inclass, b))
+                      Setattr(n, "hides", base);	// Note C# definition of hiding, ie hidden if access is different
+                }
+              }
+              // Try and find the most base's covariant return type
+              SwigType *most_base_covariant_type = Getattr(base, "covariant");
+              if (!most_base_covariant_type && covariant_returntype)
+                most_base_covariant_type = function_return_type(base, false);
 
-	      if (!most_base_covariant_type) {
-		// Eliminate the derived virtual method.
-		if (virtual_elimination_mode && !is_member_director(n))
-		  if (both_have_public_access)
-		    if (!is_non_public_base(inclass, b))
-		      if (!Swig_symbol_isoverloaded(n)) {
-			// Don't eliminate if an overloaded method as this hides the method
-			// in the scripting languages: the dispatch function will hide the base method if ignored.
-			SetFlag(n, "feature:ignore");
-			SetFlag(n, "fvirtual:ignore");
-		      }
-	      } else {
-		// Some languages need to know about covariant return types
-		Setattr(n, "covariant", most_base_covariant_type);
-	      }
+              if (!most_base_covariant_type) {
+                // Eliminate the derived virtual method.
+                if (virtual_elimination_mode && !is_member_director(n))
+                  if (both_have_public_access)
+                    if (!is_non_public_base(inclass, b))
+                      if (!Swig_symbol_isoverloaded(n)) {
+                        // Don't eliminate if an overloaded method as this hides the method
+                        // in the scripting languages: the dispatch function will hide the base method if ignored.
+                        SetFlag(n, "feature:ignore");
+                        SetFlag(n, "fvirtual:ignore");
+                      }
+              } else {
+                // Some languages need to know about covariant return types
+                Setattr(n, "covariant", most_base_covariant_type);
+              }
 
-	    } else {
-	      // Found an identical method in the base class, but it is not polymorphic.
-	      if (both_have_public_access || both_have_protected_access)
-		if (!is_non_public_base(inclass, b))
-		  Setattr(n, "hides", base);
-	    }
-	    if (both_have_public_access || both_have_protected_access)
-	      return 1;
-	  }
-	}
+            } else {
+              // Found an identical method in the base class, but it is not polymorphic.
+              if (both_have_public_access || both_have_protected_access)
+                if (!is_non_public_base(inclass, b))
+                  Setattr(n, "hides", base);
+            }
+            if (both_have_public_access || both_have_protected_access)
+              return 1;
+          }
+        }
       }
     }
     return 0;
@@ -263,17 +263,17 @@ class Allocate:public Dispatcher {
     Node *bases = Getattr(n, "privatebases");
     if (bases) {
       for (int i = 0; i < Len(bases); i++) {
-	Node *base = Getitem(bases, i);
-	if (base == b)
-	  non_public_base = true;
+        Node *base = Getitem(bases, i);
+        if (base == b)
+          non_public_base = true;
       }
     }
     bases = Getattr(n, "protectedbases");
     if (bases) {
       for (int i = 0; i < Len(bases); i++) {
-	Node *base = Getitem(bases, i);
-	if (base == b)
-	  non_public_base = true;
+        Node *base = Getitem(bases, i);
+        if (base == b)
+          non_public_base = true;
       }
     }
     return non_public_base;
@@ -310,10 +310,10 @@ class Allocate:public Dispatcher {
     {
       int old_mode = virtual_elimination_mode;
       if (is_member_director(classnode, member))
-	virtual_elimination_mode = 0;
+        virtual_elimination_mode = 0;
 
       if (function_is_defined_in_bases(member, bases)) {
-	defined = 1;
+        defined = 1;
       }
 
       virtual_elimination_mode = old_mode;
@@ -344,44 +344,44 @@ class Allocate:public Dispatcher {
       int dabstract = 0;
       int len = Len(abstracts);
       for (int i = 0; i < len; i++) {
-	Node *nn = Getitem(abstracts, i);
-	String *name = Getattr(nn, "name");
-	if (!name)
-	  continue;
-	if (Strchr(name, '~'))
-	  continue;		/* Don't care about destructors */
-	String *base_decl = Getattr(nn, "decl");
-	if (base_decl)
-	  base_decl = SwigType_typedef_resolve_all(base_decl);
-	if (SwigType_isfunction(base_decl))
-	  search_decl = SwigType_pop_function(base_decl);
-	Node *dn = Swig_symbol_clookup_local_check(name, 0, check_implemented);
-	Delete(search_decl);
-	Delete(base_decl);
+        Node *nn = Getitem(abstracts, i);
+        String *name = Getattr(nn, "name");
+        if (!name)
+          continue;
+        if (Strchr(name, '~'))
+          continue;		/* Don't care about destructors */
+        String *base_decl = Getattr(nn, "decl");
+        if (base_decl)
+          base_decl = SwigType_typedef_resolve_all(base_decl);
+        if (SwigType_isfunction(base_decl))
+          search_decl = SwigType_pop_function(base_decl);
+        Node *dn = Swig_symbol_clookup_local_check(name, 0, check_implemented);
+        Delete(search_decl);
+        Delete(base_decl);
 
-	if (!dn) {
-	  List *nabstracts = Getattr(n, "abstracts");
-	  if (!nabstracts) {
-	    nabstracts = NewList();
-	    Setattr(n, "abstracts", nabstracts);
-	    Delete(nabstracts);
-	  }
-	  Append(nabstracts, nn);
-	  if (!Getattr(n, "abstracts:firstnode")) {
-	    Setattr(n, "abstracts:firstnode", nn);
-	  }
-	  dabstract = base != n;
-	}
+        if (!dn) {
+          List *nabstracts = Getattr(n, "abstracts");
+          if (!nabstracts) {
+            nabstracts = NewList();
+            Setattr(n, "abstracts", nabstracts);
+            Delete(nabstracts);
+          }
+          Append(nabstracts, nn);
+          if (!Getattr(n, "abstracts:firstnode")) {
+            Setattr(n, "abstracts:firstnode", nn);
+          }
+          dabstract = base != n;
+        }
       }
       if (dabstract)
-	return 1;
+        return 1;
     }
     List *bases = Getattr(base, "allbases");
     if (!bases)
       return 0;
     for (int i = 0; i < Len(bases); i++) {
       if (is_abstract_inherit(n, Getitem(bases, i))) {
-	return 1;
+        return 1;
       }
     }
     return 0;
@@ -399,68 +399,68 @@ class Allocate:public Dispatcher {
 
     while (c) {
       if (Getattr(c, "error") || GetFlag(c, "feature:ignore")) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
       if (!isconst && (Strcmp(nodeType(c), "extend") == 0)) {
-	methods = smart_pointer_methods(c, methods, isconst, Getattr(cls, "name"));
+        methods = smart_pointer_methods(c, methods, isconst, Getattr(cls, "name"));
       } else if (Strcmp(nodeType(c), "cdecl") == 0) {
-	if (!GetFlag(c, "feature:ignore")) {
-	  String *storage = Getattr(c, "storage");
-	  if (!((Cmp(storage, "typedef") == 0))
-	      && !Strstr(storage, "friend")) {
-	    String *name = Getattr(c, "name");
-	    String *symname = Getattr(c, "sym:name");
-	    Node *e = Swig_symbol_clookup_local(name, 0);
-	    if (e && is_public(e) && !GetFlag(e, "feature:ignore") && (Cmp(symname, Getattr(e, "sym:name")) == 0)) {
-	      Swig_warning(WARN_LANG_DEREF_SHADOW, Getfile(e), Getline(e), "Declaration of '%s' shadows declaration accessible via operator->(),\n", name);
-	      Swig_warning(WARN_LANG_DEREF_SHADOW, Getfile(c), Getline(c), "previous declaration of '%s'.\n", name);
-	    } else {
-	      /* Make sure node with same name doesn't already exist */
-	      int k;
-	      int match = 0;
-	      for (k = 0; k < Len(methods); k++) {
-		e = Getitem(methods, k);
-		if (Cmp(symname, Getattr(e, "sym:name")) == 0) {
-		  match = 1;
-		  break;
-		}
-		if (!Getattr(e, "sym:name") && (Cmp(name, Getattr(e, "name")) == 0)) {
-		  match = 1;
-		  break;
-		}
-	      }
-	      if (!match) {
-		Node *cc = c;
-		while (cc) {
-		  Node *cp = cc;
-		  if (classname) {
-		    Setattr(cp, "extendsmartclassname", classname);
-		  }
-		  Setattr(cp, "allocate:smartpointeraccess", "1");
-		  /* If constant, we have to be careful */
-		  if (isconst) {
-		    SwigType *decl = Getattr(cp, "decl");
-		    if (decl) {
-		      if (SwigType_isfunction(decl)) {	/* If method, we only add if it's a const method */
-			if (SwigType_isconst(decl)) {
-			  Append(methods, cp);
-			}
-		      } else {
-			Append(methods, cp);
-		      }
-		    } else {
-		      Append(methods, cp);
-		    }
-		  } else {
-		    Append(methods, cp);
-		  }
-		  cc = Getattr(cc, "sym:nextSibling");
-		}
-	      }
-	    }
-	  }
-	}
+        if (!GetFlag(c, "feature:ignore")) {
+          String *storage = Getattr(c, "storage");
+          if (!((Cmp(storage, "typedef") == 0))
+              && !Strstr(storage, "friend")) {
+            String *name = Getattr(c, "name");
+            String *symname = Getattr(c, "sym:name");
+            Node *e = Swig_symbol_clookup_local(name, 0);
+            if (e && is_public(e) && !GetFlag(e, "feature:ignore") && (Cmp(symname, Getattr(e, "sym:name")) == 0)) {
+              Swig_warning(WARN_LANG_DEREF_SHADOW, Getfile(e), Getline(e), "Declaration of '%s' shadows declaration accessible via operator->(),\n", name);
+              Swig_warning(WARN_LANG_DEREF_SHADOW, Getfile(c), Getline(c), "previous declaration of '%s'.\n", name);
+            } else {
+              /* Make sure node with same name doesn't already exist */
+              int k;
+              int match = 0;
+              for (k = 0; k < Len(methods); k++) {
+                e = Getitem(methods, k);
+                if (Cmp(symname, Getattr(e, "sym:name")) == 0) {
+                  match = 1;
+                  break;
+                }
+                if (!Getattr(e, "sym:name") && (Cmp(name, Getattr(e, "name")) == 0)) {
+                  match = 1;
+                  break;
+                }
+              }
+              if (!match) {
+                Node *cc = c;
+                while (cc) {
+                  Node *cp = cc;
+                  if (classname) {
+                    Setattr(cp, "extendsmartclassname", classname);
+                  }
+                  Setattr(cp, "allocate:smartpointeraccess", "1");
+                  /* If constant, we have to be careful */
+                  if (isconst) {
+                    SwigType *decl = Getattr(cp, "decl");
+                    if (decl) {
+                      if (SwigType_isfunction(decl)) {	/* If method, we only add if it's a const method */
+                        if (SwigType_isconst(decl)) {
+                          Append(methods, cp);
+                        }
+                      } else {
+                        Append(methods, cp);
+                      }
+                    } else {
+                      Append(methods, cp);
+                    }
+                  } else {
+                    Append(methods, cp);
+                  }
+                  cc = Getattr(cc, "sym:nextSibling");
+                }
+              }
+            }
+          }
+        }
       }
 
       c = nextSibling(c);
@@ -470,18 +470,18 @@ class Allocate:public Dispatcher {
       Node *bases = Getattr(cls, "bases");
       int k;
       for (k = 0; k < Len(bases); k++) {
-	smart_pointer_methods(Getitem(bases, k), methods, isconst);
+        smart_pointer_methods(Getitem(bases, k), methods, isconst);
       }
     }
     /* Remove protected/private members */
     {
       for (int i = 0; i < Len(methods);) {
-	Node *n = Getitem(methods, i);
-	if (!is_public(n)) {
-	  Delitem(methods, i);
-	  continue;
-	}
-	i++;
+        Node *n = Getitem(methods, i);
+        if (!is_public(n)) {
+          Delitem(methods, i);
+          continue;
+        }
+        i++;
       }
     }
     return methods;
@@ -492,13 +492,13 @@ class Allocate:public Dispatcher {
       SwigType *ty = Getattr(p, "type");
       SwigType *t = SwigType_typedef_resolve_all(ty);
       if (SwigType_isreference(t) || SwigType_ispointer(t) || SwigType_isarray(t)) {
-	Delete(SwigType_pop(t));
+        Delete(SwigType_pop(t));
       }
       Node *c = Swig_symbol_clookup(t, 0);
       if (c) {
-	if (!GetFlag(c, "feature:exceptionclass")) {
-	  SetFlag(c, "feature:exceptionclass");
-	}
+        if (!GetFlag(c, "feature:exceptionclass")) {
+          SetFlag(c, "feature:exceptionclass");
+        }
       }
       p = nextSibling(p);
       Delete(t);
@@ -523,16 +523,16 @@ class Allocate:public Dispatcher {
     if (scatchlist) {
       catchlist = Swig_cparse_parms(scatchlist, n);
       if (catchlist) {
-	Setattr(n, "catchlist", catchlist);
-	mark_exception_classes(catchlist);
-	Delete(catchlist);
+        Setattr(n, "catchlist", catchlist);
+        mark_exception_classes(catchlist);
+        Delete(catchlist);
       }
     }
     ParmList *throws = Getattr(n, "throws");
     if (throws) {
       /* if there is no explicit catchlist, we catch everything in the throws list */
       if (!catchlist) {
-	Setattr(n, "catchlist", throws);
+        Setattr(n, "catchlist", throws);
       }
       mark_exception_classes(throws);
     }
@@ -555,8 +555,8 @@ class Allocate:public Dispatcher {
     while (over) {
       String *odecl = Getattr(over, "decl");
       if (Cmp(decl, odecl) == 0) {
-	match = 1;
-	break;
+        match = 1;
+        break;
       }
       over = Getattr(over, "sym:nextSibling");
     }
@@ -603,21 +603,21 @@ class Allocate:public Dispatcher {
       Setattr(nn, "parms", parms);
       Delete(parms);
       if (Getattr(n, "feature:extend")) {
-	String *ucode = is_void ? NewStringf("{ self->%s(", Getattr(n, "uname")) : NewStringf("{ return self->%s(", Getattr(n, "uname"));
+        String *ucode = is_void ? NewStringf("{ self->%s(", Getattr(n, "uname")) : NewStringf("{ return self->%s(", Getattr(n, "uname"));
 
-	for (ParmList *p = parms; p;) {
-	  Append(ucode, Getattr(p, "name"));
-	  p = nextSibling(p);
-	  if (p)
-	    Append(ucode, ",");
-	}
-	Append(ucode, "); }");
-	Setattr(nn, "code", ucode);
-	Delete(ucode);
+        for (ParmList *p = parms; p;) {
+          Append(ucode, Getattr(p, "name"));
+          p = nextSibling(p);
+          if (p)
+            Append(ucode, ",");
+        }
+        Append(ucode, "); }");
+        Setattr(nn, "code", ucode);
+        Delete(ucode);
       }
       ParmList *throw_parm_list = Getattr(c, "throws");
       if (throw_parm_list)
-	Setattr(nn, "throws", CopyParmList(throw_parm_list));
+        Setattr(nn, "throws", CopyParmList(throw_parm_list));
     } else {
       Delete(nn);
       nn = 0;
@@ -642,35 +642,35 @@ class Allocate:public Dispatcher {
     }
 
     if (!(Swig_storage_isstatic(c)
-	  || checkAttribute(c, "storage", "typedef")
-	  || Strstr(Getattr(c, "storage"), "friend")
-	  || (Getattr(c, "feature:extend") && !Getattr(c, "code"))
-	  || GetFlag(c, "feature:ignore"))) {
+          || checkAttribute(c, "storage", "typedef")
+          || Strstr(Getattr(c, "storage"), "friend")
+          || (Getattr(c, "feature:extend") && !Getattr(c, "code"))
+          || GetFlag(c, "feature:ignore"))) {
 
       String *symname = Getattr(n, "sym:name");
       String *csymname = Getattr(c, "sym:name");
       Node *parent = parentNode(n);
       bool using_inherited_constructor_symname_okay = Equal(nodeType(c), "constructor") && Equal(symname, Getattr(parent, "sym:name"));
       if (!csymname || Equal(csymname, symname) || using_inherited_constructor_symname_okay) {
-	Node *nn = clone_member_for_using_declaration(c, n);
-	if (nn) {
-	  ccount++;
-	  if (!last_unodes) {
-	    last_unodes = nn;
-	    unodes = nn;
-	  } else {
-	    Setattr(nn, "previousSibling", last_unodes);
-	    Setattr(last_unodes, "nextSibling", nn);
-	    Setattr(nn, "sym:previousSibling", last_unodes);
-	    Setattr(last_unodes, "sym:nextSibling", nn);
-	    Setattr(nn, "sym:overloaded", unodes);
-	    Setattr(unodes, "sym:overloaded", unodes);
-	    last_unodes = nn;
-	  }
-	}
+        Node *nn = clone_member_for_using_declaration(c, n);
+        if (nn) {
+          ccount++;
+          if (!last_unodes) {
+            last_unodes = nn;
+            unodes = nn;
+          } else {
+            Setattr(nn, "previousSibling", last_unodes);
+            Setattr(last_unodes, "nextSibling", nn);
+            Setattr(nn, "sym:previousSibling", last_unodes);
+            Setattr(last_unodes, "sym:nextSibling", nn);
+            Setattr(nn, "sym:overloaded", unodes);
+            Setattr(unodes, "sym:overloaded", unodes);
+            last_unodes = nn;
+          }
+        }
       } else {
-	Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(n), Getline(n), "Using declaration %s, with name '%s', is not actually using\n", SwigType_namestr(Getattr(n, "uname")), symname);
-	Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(c), Getline(c), "the method from %s, with name '%s', as the names are different.\n", Swig_name_decl(c), csymname);
+        Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(n), Getline(n), "Using declaration %s, with name '%s', is not actually using\n", SwigType_namestr(Getattr(n, "uname")), symname);
+        Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(c), Getline(c), "the method from %s, with name '%s', as the names are different.\n", Swig_name_decl(c), csymname);
       }
     }
     if (GetFlag(c, "fvirtual:ignore")) {
@@ -683,11 +683,11 @@ class Allocate:public Dispatcher {
     if (SwigType_type(type) == T_USER) {
       Node *cn = Swig_symbol_clookup(type, 0);
       if (cn) {
-	if ((Strcmp(nodeType(cn), "class") == 0)) {
-	  if (Getattr(cn, "allocate:noassign")) {
-	    assignable = false;
-	  }
-	}
+        if ((Strcmp(nodeType(cn), "class") == 0)) {
+          if (Getattr(cn, "allocate:noassign")) {
+            assignable = false;
+          }
+        }
       }
     } else if (SwigType_isarray(type)) {
       SwigType *array_type = SwigType_array_type(type);
@@ -775,10 +775,10 @@ Allocate():
     {
       List *bases = Getattr(n, "bases");
       if (bases) {
-	for (int i = 0; i < Len(bases); i++) {
-	  Node *b = Getitem(bases, i);
-	  classDeclaration(b);
-	}
+        for (int i = 0; i < Len(bases); i++) {
+          Node *b = Getitem(bases, i);
+          classDeclaration(b);
+        }
       }
     }
     inclass = n;
@@ -796,20 +796,20 @@ Allocate():
        a base class */
     if (!Getattr(n, "abstracts") && is_abstract_inherit(n)) {
       if (((Getattr(n, "allocate:public_constructor") || (!GetFlag(n, "feature:nodefault") && !Getattr(n, "allocate:has_constructor"))))) {
-	if (!GetFlag(n, "feature:notabstract")) {
-	  Node *na = Getattr(n, "abstracts:firstnode");
-	  if (na) {
-	    Swig_warning(WARN_TYPE_ABSTRACT, Getfile(n), Getline(n),
-			 "Class '%s' might be abstract, " "no constructors generated,\n", SwigType_namestr(Getattr(n, "name")));
-	    Swig_warning(WARN_TYPE_ABSTRACT, Getfile(na), Getline(na), "Method %s might not be implemented.\n", Swig_name_decl(na));
-	    if (!Getattr(n, "abstracts")) {
-	      List *abstracts = NewList();
-	      Append(abstracts, na);
-	      Setattr(n, "abstracts", abstracts);
-	      Delete(abstracts);
-	    }
-	  }
-	}
+        if (!GetFlag(n, "feature:notabstract")) {
+          Node *na = Getattr(n, "abstracts:firstnode");
+          if (na) {
+            Swig_warning(WARN_TYPE_ABSTRACT, Getfile(n), Getline(n),
+                         "Class '%s' might be abstract, " "no constructors generated,\n", SwigType_namestr(Getattr(n, "name")));
+            Swig_warning(WARN_TYPE_ABSTRACT, Getfile(na), Getline(na), "Method %s might not be implemented.\n", Swig_name_decl(na));
+            if (!Getattr(n, "abstracts")) {
+              List *abstracts = NewList();
+              Append(abstracts, na);
+              Setattr(n, "abstracts", abstracts);
+              Delete(abstracts);
+            }
+          }
+        }
       }
     }
 
@@ -817,67 +817,67 @@ Allocate():
       /* No constructor is defined.  We need to check a few things */
       /* If class is abstract.  No default constructor. Sorry */
       if (Getattr(n, "abstracts")) {
-	Delattr(n, "allocate:default_constructor");
+        Delattr(n, "allocate:default_constructor");
       }
       if (!Getattr(n, "allocate:default_constructor")) {
-	// No default constructor if either the default constructor or copy constructor is declared as deleted
-	if (!GetFlag(n, "allocate:deleted_default_constructor") && !GetFlag(n, "allocate:deleted_copy_constructor")) {
-	  /* Check base classes */
-	  List *bases = Getattr(n, "allbases");
-	  int allows_default = 1;
+        // No default constructor if either the default constructor or copy constructor is declared as deleted
+        if (!GetFlag(n, "allocate:deleted_default_constructor") && !GetFlag(n, "allocate:deleted_copy_constructor")) {
+          /* Check base classes */
+          List *bases = Getattr(n, "allbases");
+          int allows_default = 1;
 
-	  for (int i = 0; i < Len(bases); i++) {
-	    Node *n = Getitem(bases, i);
-	    /* If base class does not allow default constructor, we don't allow it either */
-	    if (!Getattr(n, "allocate:default_constructor") && (!Getattr(n, "allocate:default_base_constructor"))) {
-	      allows_default = 0;
-	    }
-	    /* not constructible if base destructor is deleted */
-	    if (Getattr(n, "allocate:deleted_default_destructor")) {
-	      allows_default = 0;
-	    }
-	  }
-	  if (allows_default) {
-	    Setattr(n, "allocate:default_constructor", "1");
-	  }
-	}
+          for (int i = 0; i < Len(bases); i++) {
+            Node *n = Getitem(bases, i);
+            /* If base class does not allow default constructor, we don't allow it either */
+            if (!Getattr(n, "allocate:default_constructor") && (!Getattr(n, "allocate:default_base_constructor"))) {
+              allows_default = 0;
+            }
+            /* not constructible if base destructor is deleted */
+            if (Getattr(n, "allocate:deleted_default_destructor")) {
+              allows_default = 0;
+            }
+          }
+          if (allows_default) {
+            Setattr(n, "allocate:default_constructor", "1");
+          }
+        }
       }
     }
 
     if (!Getattr(n, "allocate:has_copy_constructor")) {
       if (Getattr(n, "abstracts")) {
-	Delattr(n, "allocate:copy_constructor");
-	Delattr(n, "allocate:copy_constructor_non_const");
+        Delattr(n, "allocate:copy_constructor");
+        Delattr(n, "allocate:copy_constructor_non_const");
       }
       if (!Getattr(n, "allocate:copy_constructor")) {
-	// No copy constructor if the copy constructor is declared as deleted
-	if (!GetFlag(n, "allocate:deleted_copy_constructor")) {
-	  /* Check base classes */
-	  List *bases = Getattr(n, "allbases");
-	  int allows_copy = 1;
-	  int must_be_copy_non_const = 0;
+        // No copy constructor if the copy constructor is declared as deleted
+        if (!GetFlag(n, "allocate:deleted_copy_constructor")) {
+          /* Check base classes */
+          List *bases = Getattr(n, "allbases");
+          int allows_copy = 1;
+          int must_be_copy_non_const = 0;
 
-	  for (int i = 0; i < Len(bases); i++) {
-	    Node *n = Getitem(bases, i);
-	    /* If base class does not allow copy constructor, we don't allow it either */
-	    if (!Getattr(n, "allocate:copy_constructor") && (!Getattr(n, "allocate:copy_base_constructor"))) {
-	      allows_copy = 0;
-	    }
-	    /* not constructible if base destructor is deleted */
-	    if (Getattr(n, "allocate:deleted_default_destructor")) {
-	      allows_copy = 0;
-	    }
-	    if (Getattr(n, "allocate:copy_constructor_non_const") || (Getattr(n, "allocate:copy_base_constructor_non_const"))) {
-	      must_be_copy_non_const = 1;
-	    }
-	  }
-	  if (allows_copy) {
-	    Setattr(n, "allocate:copy_constructor", "1");
-	  }
-	  if (must_be_copy_non_const) {
-	    Setattr(n, "allocate:copy_constructor_non_const", "1");
-	  }
-	}
+          for (int i = 0; i < Len(bases); i++) {
+            Node *n = Getitem(bases, i);
+            /* If base class does not allow copy constructor, we don't allow it either */
+            if (!Getattr(n, "allocate:copy_constructor") && (!Getattr(n, "allocate:copy_base_constructor"))) {
+              allows_copy = 0;
+            }
+            /* not constructible if base destructor is deleted */
+            if (Getattr(n, "allocate:deleted_default_destructor")) {
+              allows_copy = 0;
+            }
+            if (Getattr(n, "allocate:copy_constructor_non_const") || (Getattr(n, "allocate:copy_base_constructor_non_const"))) {
+              must_be_copy_non_const = 1;
+            }
+          }
+          if (allows_copy) {
+            Setattr(n, "allocate:copy_constructor", "1");
+          }
+          if (must_be_copy_non_const) {
+            Setattr(n, "allocate:copy_constructor_non_const", "1");
+          }
+        }
       }
     }
 
@@ -885,20 +885,20 @@ Allocate():
       /* No destructor was defined */
       /* No destructor if the destructor is declared as deleted */
       if (!GetFlag(n, "allocate:deleted_default_destructor")) {
-	/* Check base classes */
-	List *bases = Getattr(n, "allbases");
-	int allows_destruct = 1;
+        /* Check base classes */
+        List *bases = Getattr(n, "allbases");
+        int allows_destruct = 1;
 
-	for (int i = 0; i < Len(bases); i++) {
-	  Node *n = Getitem(bases, i);
-	  /* If base class does not allow default destructor, we don't allow it either */
-	  if (!Getattr(n, "allocate:default_destructor") && (!Getattr(n, "allocate:default_base_destructor"))) {
-	    allows_destruct = 0;
-	  }
-	}
-	if (allows_destruct) {
-	  Setattr(n, "allocate:default_destructor", "1");
-	}
+        for (int i = 0; i < Len(bases); i++) {
+          Node *n = Getitem(bases, i);
+          /* If base class does not allow default destructor, we don't allow it either */
+          if (!Getattr(n, "allocate:default_destructor") && (!Getattr(n, "allocate:default_base_destructor"))) {
+            allows_destruct = 0;
+          }
+        }
+        if (allows_destruct) {
+          Setattr(n, "allocate:default_destructor", "1");
+        }
       }
     }
 
@@ -908,18 +908,18 @@ Allocate():
       int allows_assign = 1;
 
       for (int i = 0; i < Len(bases); i++) {
-	Node *n = Getitem(bases, i);
-	/* If base class does not allow assignment, we don't allow it either */
-	if (Getattr(n, "allocate:noassign")) {
-	  allows_assign = 0;
-	}
+        Node *n = Getitem(bases, i);
+        /* If base class does not allow assignment, we don't allow it either */
+        if (Getattr(n, "allocate:noassign")) {
+          allows_assign = 0;
+        }
       }
       /* If any member variables are non assignable, this class is also non assignable by default */
       if (GetFlag(n, "allocate:has_nonassignable")) {
-	allows_assign = 0;
+        allows_assign = 0;
       }
       if (!allows_assign) {
-	Setattr(n, "allocate:noassign", "1");
+        Setattr(n, "allocate:noassign", "1");
       }
     }
 
@@ -929,14 +929,14 @@ Allocate():
       int allows_new = 1;
 
       for (int i = 0; i < Len(bases); i++) {
-	Node *n = Getitem(bases, i);
-	/* If base class does not allow new operator, we don't allow it either */
-	if (Getattr(n, "allocate:has_new")) {
-	  allows_new = !Getattr(n, "allocate:nonew");
-	}
+        Node *n = Getitem(bases, i);
+        /* If base class does not allow new operator, we don't allow it either */
+        if (Getattr(n, "allocate:has_new")) {
+          allows_new = !Getattr(n, "allocate:nonew");
+        }
       }
       if (!allows_new) {
-	Setattr(n, "allocate:nonew", "1");
+        Setattr(n, "allocate:nonew", "1");
       }
     }
 
@@ -944,16 +944,16 @@ Allocate():
     if (!Getattr(n, "allocate:smartpointer")) {
       Node *sp = Swig_symbol_clookup("operator ->", 0);
       if (sp) {
-	/* Look for parent */
-	Node *p = parentNode(sp);
-	if (Strcmp(nodeType(p), "extend") == 0) {
-	  p = parentNode(p);
-	}
-	if (Strcmp(nodeType(p), "class") == 0) {
-	  if (GetFlag(p, "feature:ignore")) {
-	    Setattr(n, "allocate:smartpointer", Getattr(p, "allocate:smartpointer"));
-	  }
-	}
+        /* Look for parent */
+        Node *p = parentNode(sp);
+        if (Strcmp(nodeType(p), "extend") == 0) {
+          p = parentNode(p);
+        }
+        if (Strcmp(nodeType(p), "class") == 0) {
+          if (GetFlag(p, "feature:ignore")) {
+            Setattr(n, "allocate:smartpointer", Getattr(p, "allocate:smartpointer"));
+          }
+        }
       }
     }
 
@@ -967,31 +967,31 @@ Allocate():
     if (!ImportMode && !GetFlag(n, "feature:ignore")) {
       int dir = 0;
       if (Swig_directors_enabled()) {
-	int ndir = GetFlag(n, "feature:director");
-	int nndir = GetFlag(n, "feature:nodirector");
-	/* 'nodirector' has precedence over 'director' */
-	dir = (ndir || nndir) ? (ndir && !nndir) : 0;
+        int ndir = GetFlag(n, "feature:director");
+        int nndir = GetFlag(n, "feature:nodirector");
+        /* 'nodirector' has precedence over 'director' */
+        dir = (ndir || nndir) ? (ndir && !nndir) : 0;
       }
       int abstract = !dir && abstractClassTest(n);
       int odefault = !GetFlag(n, "feature:nodefault");
 
       /* default constructor */
       if (!abstract && !GetFlag(n, "feature:nodefaultctor") && odefault) {
-	if (!Getattr(n, "allocate:has_constructor") && Getattr(n, "allocate:default_constructor")) {
-	  addDefaultConstructor(n);
-	}
+        if (!Getattr(n, "allocate:has_constructor") && Getattr(n, "allocate:default_constructor")) {
+          addDefaultConstructor(n);
+        }
       }
       /* copy constructor */
       if (CPlusPlus && !abstract && GetFlag(n, "feature:copyctor")) {
-	if (!Getattr(n, "allocate:has_copy_constructor") && Getattr(n, "allocate:copy_constructor")) {
-	  addCopyConstructor(n);
-	}
+        if (!Getattr(n, "allocate:has_copy_constructor") && Getattr(n, "allocate:copy_constructor")) {
+          addCopyConstructor(n);
+        }
       }
       /* default destructor */
       if (!GetFlag(n, "feature:nodefaultdtor") && odefault) {
-	if (!Getattr(n, "allocate:has_destructor") && Getattr(n, "allocate:default_destructor")) {
-	  addDestructor(n);
-	}
+        if (!Getattr(n, "allocate:has_destructor") && Getattr(n, "allocate:default_destructor")) {
+          addDestructor(n);
+        }
       }
     }
 
@@ -1013,158 +1013,158 @@ Allocate():
       /* using id */
       Symtab *stab = Getattr(n, "sym:symtab");
       if (stab) {
-	String *uname = Getattr(n, "uname");
-	ns = Swig_symbol_clookup(uname, stab);
-	if (!ns && SwigType_istemplate(uname)) {
-	  String *tmp = Swig_symbol_template_deftype(uname, 0);
-	  if (!Equal(tmp, uname)) {
-	    ns = Swig_symbol_clookup(tmp, stab);
-	  }
-	  Delete(tmp);
-	}
+        String *uname = Getattr(n, "uname");
+        ns = Swig_symbol_clookup(uname, stab);
+        if (!ns && SwigType_istemplate(uname)) {
+          String *tmp = Swig_symbol_template_deftype(uname, 0);
+          if (!Equal(tmp, uname)) {
+            ns = Swig_symbol_clookup(tmp, stab);
+          }
+          Delete(tmp);
+        }
       } else {
-	ns = 0;
+        ns = 0;
       }
       if (!ns) {
-	if (is_public(n)) {
-	  Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(n), Getline(n), "Nothing known about '%s'.\n", SwigType_namestr(Getattr(n, "uname")));
-	}
+        if (is_public(n)) {
+          Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(n), Getline(n), "Nothing known about '%s'.\n", SwigType_namestr(Getattr(n, "uname")));
+        }
       } else if (Equal(nodeType(ns), "constructor") && !GetFlag(n, "usingctor")) {
-	Swig_warning(WARN_PARSE_USING_CONSTRUCTOR, Getfile(n), Getline(n), "Using declaration '%s' for inheriting constructors uses base '%s' which is not an immediate base of '%s'.\n", SwigType_namestr(Getattr(n, "uname")), SwigType_namestr(Getattr(ns, "name")), SwigType_namestr(Getattr(parentNode(n), "name")));
+        Swig_warning(WARN_PARSE_USING_CONSTRUCTOR, Getfile(n), Getline(n), "Using declaration '%s' for inheriting constructors uses base '%s' which is not an immediate base of '%s'.\n", SwigType_namestr(Getattr(n, "uname")), SwigType_namestr(Getattr(ns, "name")), SwigType_namestr(Getattr(parentNode(n), "name")));
       } else {
-	if (inclass && Getattr(n, "sym:name")) {
-	  {
-	    String *ntype = nodeType(ns);
-	    if (Equal(ntype, "cdecl") || Equal(ntype, "constructor") || Equal(ntype, "template") || Equal(ntype, "using")) {
-	      /* Add a new class member to the parse tree (copy it from the base class member pointed to by the using declaration in node n) */
-	      Node *c = ns;
-	      Node *unodes = 0, *last_unodes = 0;
-	      int ccount = 0;
+        if (inclass && Getattr(n, "sym:name")) {
+          {
+            String *ntype = nodeType(ns);
+            if (Equal(ntype, "cdecl") || Equal(ntype, "constructor") || Equal(ntype, "template") || Equal(ntype, "using")) {
+              /* Add a new class member to the parse tree (copy it from the base class member pointed to by the using declaration in node n) */
+              Node *c = ns;
+              Node *unodes = 0, *last_unodes = 0;
+              int ccount = 0;
 
-	      while (c) {
-		String *cnodetype = nodeType(c);
-		if (Equal(cnodetype, "cdecl")) {
-		  add_member_for_using_declaration(c, n, ccount, unodes, last_unodes);
-		} else if (Equal(cnodetype, "constructor")) {
-		  add_member_for_using_declaration(c, n, ccount, unodes, last_unodes);
-		} else if (Equal(cnodetype, "template")) {
-		  // A templated member (in a non-template class or in a template class that where the member has a separate template declaration)
-		  // Find the template instantiations in the using declaration (base class)
-		  for (Node *member = ns; member; member = nextSibling(member)) {
-		    /* Constructors have already been handled, only add member functions
-		     * This adds an implicit template instantiation and is a bit unusual as SWIG requires explicit %template for other template instantiations.
-		     * However, of note, is that there is no valid C++ syntax for a template instantiation to introduce a name via a using declaration...
-		     *
-		     *   struct Base { template <typename T> void template_method(T, T) {} };
-		     *   struct Derived : Base { using Base::template_method; };
-		     *   %template()   Base::template_method<int>;              // SWIG template instantiation
-		     *   template void Base::template_method<int>(int, int);    // C++ template instantiation
-		     *   template void Derived::template_method<int>(int, int); // Not valid C++
-		    */
-		    if (Getattr(member, "template") == ns && checkAttribute(ns, "templatetype", "cdecl")) {
-		      if (!GetFlag(member, "feature:ignore") && !Getattr(member, "error")) {
-			add_member_for_using_declaration(member, n, ccount, unodes, last_unodes);
-		      }
-		    }
-		  }
-		} else if (Equal(cnodetype, "using")) {
-		  for (Node *member = firstChild(c); member; member = nextSibling(member)) {
-		    add_member_for_using_declaration(member, n, ccount, unodes, last_unodes);
-		  }
-		}
-		c = Getattr(c, "csym:nextSibling");
-	      }
-	      if (unodes) {
-		set_firstChild(n, unodes);
-		if (ccount > 1) {
-		  if (!Getattr(n, "sym:overloaded")) {
-		    Setattr(n, "sym:overloaded", n);
-		    Setattr(n, "sym:overname", "_SWIG_0");
-		  }
-		}
-	      }
+              while (c) {
+                String *cnodetype = nodeType(c);
+                if (Equal(cnodetype, "cdecl")) {
+                  add_member_for_using_declaration(c, n, ccount, unodes, last_unodes);
+                } else if (Equal(cnodetype, "constructor")) {
+                  add_member_for_using_declaration(c, n, ccount, unodes, last_unodes);
+                } else if (Equal(cnodetype, "template")) {
+                  // A templated member (in a non-template class or in a template class that where the member has a separate template declaration)
+                  // Find the template instantiations in the using declaration (base class)
+                  for (Node *member = ns; member; member = nextSibling(member)) {
+                    /* Constructors have already been handled, only add member functions
+                     * This adds an implicit template instantiation and is a bit unusual as SWIG requires explicit %template for other template instantiations.
+                     * However, of note, is that there is no valid C++ syntax for a template instantiation to introduce a name via a using declaration...
+                     *
+                     *   struct Base { template <typename T> void template_method(T, T) {} };
+                     *   struct Derived : Base { using Base::template_method; };
+                     *   %template()   Base::template_method<int>;              // SWIG template instantiation
+                     *   template void Base::template_method<int>(int, int);    // C++ template instantiation
+                     *   template void Derived::template_method<int>(int, int); // Not valid C++
+                    */
+                    if (Getattr(member, "template") == ns && checkAttribute(ns, "templatetype", "cdecl")) {
+                      if (!GetFlag(member, "feature:ignore") && !Getattr(member, "error")) {
+                        add_member_for_using_declaration(member, n, ccount, unodes, last_unodes);
+                      }
+                    }
+                  }
+                } else if (Equal(cnodetype, "using")) {
+                  for (Node *member = firstChild(c); member; member = nextSibling(member)) {
+                    add_member_for_using_declaration(member, n, ccount, unodes, last_unodes);
+                  }
+                }
+                c = Getattr(c, "csym:nextSibling");
+              }
+              if (unodes) {
+                set_firstChild(n, unodes);
+                if (ccount > 1) {
+                  if (!Getattr(n, "sym:overloaded")) {
+                    Setattr(n, "sym:overloaded", n);
+                    Setattr(n, "sym:overname", "_SWIG_0");
+                  }
+                }
+              }
 
-	      /* Hack the parse tree symbol table for overloaded methods. Replace the "using" node with the
-	       * list of overloaded methods we have just added in as child nodes to the "using" node.
-	       * The node will still exist, it is just the symbol table linked list of overloaded methods
-	       * which is hacked. */
-	      if (Getattr(n, "sym:overloaded")) {
-		int cnt = 0;
-		Node *ps = Getattr(n, "sym:previousSibling");
-		Node *ns = Getattr(n, "sym:nextSibling");
-		Node *fc = firstChild(n);
-		Node *firstoverloaded = Getattr(n, "sym:overloaded");
+              /* Hack the parse tree symbol table for overloaded methods. Replace the "using" node with the
+               * list of overloaded methods we have just added in as child nodes to the "using" node.
+               * The node will still exist, it is just the symbol table linked list of overloaded methods
+               * which is hacked. */
+              if (Getattr(n, "sym:overloaded")) {
+                int cnt = 0;
+                Node *ps = Getattr(n, "sym:previousSibling");
+                Node *ns = Getattr(n, "sym:nextSibling");
+                Node *fc = firstChild(n);
+                Node *firstoverloaded = Getattr(n, "sym:overloaded");
 #ifdef DEBUG_OVERLOADED
-		show_overloaded(firstoverloaded);
+                show_overloaded(firstoverloaded);
 #endif
 
-		if (firstoverloaded == n) {
-		  // This 'using' node we are cutting out was the first node in the overloaded list. 
-		  // Change the first node in the list
-		  Delattr(firstoverloaded, "sym:overloaded");
-		  firstoverloaded = fc ? fc : ns;
+                if (firstoverloaded == n) {
+                  // This 'using' node we are cutting out was the first node in the overloaded list. 
+                  // Change the first node in the list
+                  Delattr(firstoverloaded, "sym:overloaded");
+                  firstoverloaded = fc ? fc : ns;
 
-		  // Correct all the sibling overloaded methods (before adding in new methods)
-		  Node *nnn = ns;
-		  while (nnn) {
-		    Setattr(nnn, "sym:overloaded", firstoverloaded);
-		    nnn = Getattr(nnn, "sym:nextSibling");
-		  }
-		}
+                  // Correct all the sibling overloaded methods (before adding in new methods)
+                  Node *nnn = ns;
+                  while (nnn) {
+                    Setattr(nnn, "sym:overloaded", firstoverloaded);
+                    nnn = Getattr(nnn, "sym:nextSibling");
+                  }
+                }
 
-		if (!fc) {
-		  // Remove from overloaded list ('using' node does not actually end up adding in any methods)
-		  if (ps) {
-		    Setattr(ps, "sym:nextSibling", ns);
-		  }
-		  if (ns) {
-		    Setattr(ns, "sym:previousSibling", ps);
-		  }
-		} else {
-		  // The 'using' node results in methods being added in - slot in these methods here
-		  Node *pp = fc;
-		  while (pp) {
-		    Node *ppn = Getattr(pp, "sym:nextSibling");
-		    Setattr(pp, "sym:overloaded", firstoverloaded);
-		    Setattr(pp, "sym:overname", NewStringf("%s_%d", Getattr(n, "sym:overname"), cnt++));
-		    if (ppn)
-		      pp = ppn;
-		    else
-		      break;
-		  }
-		  if (ps) {
-		    Setattr(ps, "sym:nextSibling", fc);
-		    Setattr(fc, "sym:previousSibling", ps);
-		  }
-		  if (ns) {
-		    Setattr(ns, "sym:previousSibling", pp);
-		    Setattr(pp, "sym:nextSibling", ns);
-		  }
-		}
-		Delattr(n, "sym:previousSibling");
-		Delattr(n, "sym:nextSibling");
-		Delattr(n, "sym:overloaded");
-		Delattr(n, "sym:overname");
-		clean_overloaded(firstoverloaded);
+                if (!fc) {
+                  // Remove from overloaded list ('using' node does not actually end up adding in any methods)
+                  if (ps) {
+                    Setattr(ps, "sym:nextSibling", ns);
+                  }
+                  if (ns) {
+                    Setattr(ns, "sym:previousSibling", ps);
+                  }
+                } else {
+                  // The 'using' node results in methods being added in - slot in these methods here
+                  Node *pp = fc;
+                  while (pp) {
+                    Node *ppn = Getattr(pp, "sym:nextSibling");
+                    Setattr(pp, "sym:overloaded", firstoverloaded);
+                    Setattr(pp, "sym:overname", NewStringf("%s_%d", Getattr(n, "sym:overname"), cnt++));
+                    if (ppn)
+                      pp = ppn;
+                    else
+                      break;
+                  }
+                  if (ps) {
+                    Setattr(ps, "sym:nextSibling", fc);
+                    Setattr(fc, "sym:previousSibling", ps);
+                  }
+                  if (ns) {
+                    Setattr(ns, "sym:previousSibling", pp);
+                    Setattr(pp, "sym:nextSibling", ns);
+                  }
+                }
+                Delattr(n, "sym:previousSibling");
+                Delattr(n, "sym:nextSibling");
+                Delattr(n, "sym:overloaded");
+                Delattr(n, "sym:overname");
+                clean_overloaded(firstoverloaded);
 #ifdef DEBUG_OVERLOADED
-		show_overloaded(firstoverloaded);
+                show_overloaded(firstoverloaded);
 #endif
-	      }
-	    }
-	  }
-	}
+              }
+            }
+          }
+        }
       }
 
       Node *c = 0;
       for (c = firstChild(n); c; c = nextSibling(c)) {
-	if (Equal(nodeType(c), "cdecl")) {
-	  process_exceptions(c);
+        if (Equal(nodeType(c), "cdecl")) {
+          process_exceptions(c);
 
-	  if (inclass)
-	    class_member_is_defined_in_bases(c, inclass);
-	} else if (Equal(nodeType(c), "constructor")) {
-	  constructorDeclaration(c);
-	}
+          if (inclass)
+            class_member_is_defined_in_bases(c, inclass);
+        } else if (Equal(nodeType(c), "constructor")) {
+          constructorDeclaration(c);
+        }
       }
     }
 
@@ -1184,104 +1184,104 @@ Allocate():
 
       int is_static = Swig_storage_isstatic(n);
       if (is_static) {
-	Setattr(n, "cplus:staticbase", inclass);
+        Setattr(n, "cplus:staticbase", inclass);
       }
 
       if (Cmp(Getattr(n, "kind"), "variable") == 0) {
         /* Check member variable to determine whether assignment is valid */
-	bool is_reference;
-	bool is_const;
-	bool assignable = is_assignable(n, is_reference, is_const);
-	if (!assignable || is_const) {
-	  SetFlag(n, "feature:immutable");
-	}
-	if (!is_static) {
-	  if (!assignable || is_reference || is_const)
-	    SetFlag(inclass, "allocate:has_nonassignable"); // The class has a variable that cannot be assigned to
-	}
+        bool is_reference;
+        bool is_const;
+        bool assignable = is_assignable(n, is_reference, is_const);
+        if (!assignable || is_const) {
+          SetFlag(n, "feature:immutable");
+        }
+        if (!is_static) {
+          if (!assignable || is_reference || is_const)
+            SetFlag(inclass, "allocate:has_nonassignable"); // The class has a variable that cannot be assigned to
+        }
       }
 
       String *name = Getattr(n, "name");
       if (cplus_mode != PUBLIC) {
-	if (Strcmp(name, "operator =") == 0) {
-	  /* Look for a private assignment operator */
-	  if (!GetFlag(n, "deleted"))
-	    Setattr(inclass, "allocate:has_assign", "1");
-	  Setattr(inclass, "allocate:noassign", "1");
-	} else if (Strcmp(name, "operator new") == 0) {
-	  /* Look for a private new operator */
-	  if (!GetFlag(n, "deleted"))
-	    Setattr(inclass, "allocate:has_new", "1");
-	  Setattr(inclass, "allocate:nonew", "1");
-	}
+        if (Strcmp(name, "operator =") == 0) {
+          /* Look for a private assignment operator */
+          if (!GetFlag(n, "deleted"))
+            Setattr(inclass, "allocate:has_assign", "1");
+          Setattr(inclass, "allocate:noassign", "1");
+        } else if (Strcmp(name, "operator new") == 0) {
+          /* Look for a private new operator */
+          if (!GetFlag(n, "deleted"))
+            Setattr(inclass, "allocate:has_new", "1");
+          Setattr(inclass, "allocate:nonew", "1");
+        }
       } else {
-	if (Strcmp(name, "operator =") == 0) {
-	  if (!GetFlag(n, "deleted"))
-	    Setattr(inclass, "allocate:has_assign", "1");
-	  else
-	    Setattr(inclass, "allocate:noassign", "1");
-	} else if (Strcmp(name, "operator new") == 0) {
-	  if (!GetFlag(n, "deleted"))
-	    Setattr(inclass, "allocate:has_new", "1");
-	  else
-	    Setattr(inclass, "allocate:nonew", "1");
-	}
-	/* Look for smart pointer operator */
-	if ((Strcmp(name, "operator ->") == 0) && (!GetFlag(n, "feature:ignore"))) {
-	  /* Look for version with no parameters */
-	  Node *sn = n;
-	  while (sn) {
-	    if (!Getattr(sn, "parms")) {
-	      SwigType *type = SwigType_typedef_resolve_all(Getattr(sn, "type"));
-	      SwigType_push(type, Getattr(sn, "decl"));
-	      Delete(SwigType_pop_function(type));
-	      SwigType *base = SwigType_base(type);
-	      Node *sc = Swig_symbol_clookup(base, 0);
-	      if ((sc) && (Strcmp(nodeType(sc), "class") == 0)) {
-		if (SwigType_check_decl(type, "p.")) {
-		  /* Need to check if type is a const pointer */
-		  int isconst = 0;
-		  Delete(SwigType_pop(type));
-		  if (SwigType_isconst(type)) {
-		    isconst = !Getattr(inclass, "allocate:smartpointermutable");
-		    Setattr(inclass, "allocate:smartpointerconst", "1");
-		  }
-		  else {
-		    Setattr(inclass, "allocate:smartpointermutable", "1");
-		  }
-		  List *methods = smart_pointer_methods(sc, 0, isconst);
-		  Setattr(inclass, "allocate:smartpointer", methods);
-		  Setattr(inclass, "allocate:smartpointerpointeeclassname", Getattr(sc, "name"));
-		} else {
-		  /* Hmmm.  The return value is not a pointer.  If the type is a value
-		     or reference.  We're going to chase it to see if another operator->()
-		     can be found */
-		  if ((SwigType_check_decl(type, "")) || (SwigType_check_decl(type, "r."))) {
-		    Node *nn = Swig_symbol_clookup("operator ->", Getattr(sc, "symtab"));
-		    if (nn) {
-		      Delete(base);
-		      Delete(type);
-		      sn = nn;
-		      continue;
-		    }
-		  }
-		}
-	      }
-	      Delete(base);
-	      Delete(type);
-	      break;
-	    }
-	  }
-	}
+        if (Strcmp(name, "operator =") == 0) {
+          if (!GetFlag(n, "deleted"))
+            Setattr(inclass, "allocate:has_assign", "1");
+          else
+            Setattr(inclass, "allocate:noassign", "1");
+        } else if (Strcmp(name, "operator new") == 0) {
+          if (!GetFlag(n, "deleted"))
+            Setattr(inclass, "allocate:has_new", "1");
+          else
+            Setattr(inclass, "allocate:nonew", "1");
+        }
+        /* Look for smart pointer operator */
+        if ((Strcmp(name, "operator ->") == 0) && (!GetFlag(n, "feature:ignore"))) {
+          /* Look for version with no parameters */
+          Node *sn = n;
+          while (sn) {
+            if (!Getattr(sn, "parms")) {
+              SwigType *type = SwigType_typedef_resolve_all(Getattr(sn, "type"));
+              SwigType_push(type, Getattr(sn, "decl"));
+              Delete(SwigType_pop_function(type));
+              SwigType *base = SwigType_base(type);
+              Node *sc = Swig_symbol_clookup(base, 0);
+              if ((sc) && (Strcmp(nodeType(sc), "class") == 0)) {
+                if (SwigType_check_decl(type, "p.")) {
+                  /* Need to check if type is a const pointer */
+                  int isconst = 0;
+                  Delete(SwigType_pop(type));
+                  if (SwigType_isconst(type)) {
+                    isconst = !Getattr(inclass, "allocate:smartpointermutable");
+                    Setattr(inclass, "allocate:smartpointerconst", "1");
+                  }
+                  else {
+                    Setattr(inclass, "allocate:smartpointermutable", "1");
+                  }
+                  List *methods = smart_pointer_methods(sc, 0, isconst);
+                  Setattr(inclass, "allocate:smartpointer", methods);
+                  Setattr(inclass, "allocate:smartpointerpointeeclassname", Getattr(sc, "name"));
+                } else {
+                  /* Hmmm.  The return value is not a pointer.  If the type is a value
+                     or reference.  We're going to chase it to see if another operator->()
+                     can be found */
+                  if ((SwigType_check_decl(type, "")) || (SwigType_check_decl(type, "r."))) {
+                    Node *nn = Swig_symbol_clookup("operator ->", Getattr(sc, "symtab"));
+                    if (nn) {
+                      Delete(base);
+                      Delete(type);
+                      sn = nn;
+                      continue;
+                    }
+                  }
+                }
+              }
+              Delete(base);
+              Delete(type);
+              break;
+            }
+          }
+        }
       }
     } else {
       if (Cmp(Getattr(n, "kind"), "variable") == 0) {
-	bool is_reference;
-	bool is_const;
-	bool assignable = is_assignable(n, is_reference, is_const);
-	if (!assignable || is_const) {
-	  SetFlag(n, "feature:immutable");
-	}
+        bool is_reference;
+        bool is_const;
+        bool assignable = is_assignable(n, is_reference, is_const);
+        if (!assignable || is_const) {
+          SetFlag(n, "feature:immutable");
+        }
       }
     }
     return SWIG_OK;
@@ -1308,27 +1308,27 @@ Allocate():
 
     if (!deleted_constructor) {
       if (!extendmode) {
-	if (default_constructor) {
-	  /* Class does define a default constructor */
-	  /* However, we had better see where it is defined */
-	  if (access_mode == PUBLIC) {
-	    Setattr(inclass, "allocate:default_constructor", "1");
-	  } else if (access_mode == PROTECTED) {
-	    Setattr(inclass, "allocate:default_base_constructor", "1");
-	  }
-	}
-	/* Class defines some kind of constructor. May or may not be public */
-	Setattr(inclass, "allocate:has_constructor", "1");
-	if (access_mode == PUBLIC) {
-	  Setattr(inclass, "allocate:public_constructor", "1");
-	}
+        if (default_constructor) {
+          /* Class does define a default constructor */
+          /* However, we had better see where it is defined */
+          if (access_mode == PUBLIC) {
+            Setattr(inclass, "allocate:default_constructor", "1");
+          } else if (access_mode == PROTECTED) {
+            Setattr(inclass, "allocate:default_base_constructor", "1");
+          }
+        }
+        /* Class defines some kind of constructor. May or may not be public */
+        Setattr(inclass, "allocate:has_constructor", "1");
+        if (access_mode == PUBLIC) {
+          Setattr(inclass, "allocate:public_constructor", "1");
+        }
       } else {
-	Setattr(inclass, "allocate:has_constructor", "1");
-	Setattr(inclass, "allocate:public_constructor", "1");
+        Setattr(inclass, "allocate:has_constructor", "1");
+        Setattr(inclass, "allocate:public_constructor", "1");
       }
     } else {
       if (default_constructor && !extendmode)
-	SetFlag(inclass, "allocate:deleted_default_constructor");
+        SetFlag(inclass, "allocate:deleted_default_constructor");
     }
 
     /* See if this is a copy constructor */
@@ -1341,57 +1341,57 @@ Allocate():
       String *cc = SwigType_typedef_resolve_all(tn);
       SwigType *rt = SwigType_typedef_resolve_all(Getattr(parms, "type"));
       if (SwigType_istemplate(type)) {
-	String *tmp = Swig_symbol_template_deftype(cc, 0);
-	Delete(cc);
-	cc = tmp;
-	tmp = Swig_symbol_template_deftype(rt, 0);
-	Delete(rt);
-	rt = tmp;
+        String *tmp = Swig_symbol_template_deftype(cc, 0);
+        Delete(cc);
+        cc = tmp;
+        tmp = Swig_symbol_template_deftype(rt, 0);
+        Delete(rt);
+        rt = tmp;
       }
       if (Strcmp(cc, rt) == 0) {
-	copy_constructor = 1;
+        copy_constructor = 1;
       } else {
-	Delete(cc);
-	cc = NewStringf("r.%s", Getattr(inclass, "name"));
-	if (Strcmp(cc, Getattr(parms, "type")) == 0) {
-	  copy_constructor = 1;
-	  copy_constructor_non_const = 1;
-	} else {
-	  Delete(cc);
-	  cc = NewStringf("p.%s", Getattr(inclass, "name"));
-	  String *ty = SwigType_strip_qualifiers(Getattr(parms, "type"));
-	  if (Strcmp(cc, ty) == 0) {
-	    copy_constructor = 1;
-	  }
-	  Delete(ty);
-	}
+        Delete(cc);
+        cc = NewStringf("r.%s", Getattr(inclass, "name"));
+        if (Strcmp(cc, Getattr(parms, "type")) == 0) {
+          copy_constructor = 1;
+          copy_constructor_non_const = 1;
+        } else {
+          Delete(cc);
+          cc = NewStringf("p.%s", Getattr(inclass, "name"));
+          String *ty = SwigType_strip_qualifiers(Getattr(parms, "type"));
+          if (Strcmp(cc, ty) == 0) {
+            copy_constructor = 1;
+          }
+          Delete(ty);
+        }
       }
       Delete(cc);
       Delete(rt);
       Delete(tn);
 
       if (copy_constructor) {
-	if (!deleted_constructor) {
-	  Setattr(n, "copy_constructor", "1");
-	  Setattr(inclass, "allocate:has_copy_constructor", "1");
-	  if (access_mode == PUBLIC) {
-	    Setattr(inclass, "allocate:copy_constructor", "1");
-	  } else if (access_mode == PROTECTED) {
-	    Setattr(inclass, "allocate:copy_base_constructor", "1");
-	  }
-	  if (copy_constructor_non_const) {
-	    Setattr(n, "copy_constructor_non_const", "1");
-	    Setattr(inclass, "allocate:has_copy_constructor_non_const", "1");
-	    if (access_mode == PUBLIC) {
-	      Setattr(inclass, "allocate:copy_constructor_non_const", "1");
-	    } else if (access_mode == PROTECTED) {
-	      Setattr(inclass, "allocate:copy_base_constructor_non_const", "1");
-	    }
-	  }
-	} else {
-	  if (!extendmode)
-	    SetFlag(inclass, "allocate:deleted_copy_constructor");
-	}
+        if (!deleted_constructor) {
+          Setattr(n, "copy_constructor", "1");
+          Setattr(inclass, "allocate:has_copy_constructor", "1");
+          if (access_mode == PUBLIC) {
+            Setattr(inclass, "allocate:copy_constructor", "1");
+          } else if (access_mode == PROTECTED) {
+            Setattr(inclass, "allocate:copy_base_constructor", "1");
+          }
+          if (copy_constructor_non_const) {
+            Setattr(n, "copy_constructor_non_const", "1");
+            Setattr(inclass, "allocate:has_copy_constructor_non_const", "1");
+            if (access_mode == PUBLIC) {
+              Setattr(inclass, "allocate:copy_constructor_non_const", "1");
+            } else if (access_mode == PROTECTED) {
+              Setattr(inclass, "allocate:copy_base_constructor_non_const", "1");
+            }
+          }
+        } else {
+          if (!extendmode)
+            SetFlag(inclass, "allocate:deleted_copy_constructor");
+        }
       }
     }
     return SWIG_OK;
@@ -1404,21 +1404,21 @@ Allocate():
 
     if (!GetFlag(n, "deleted")) {
       if (!extendmode) {
-	Setattr(inclass, "allocate:has_destructor", "1");
-	if (cplus_mode == PUBLIC) {
-	  Setattr(inclass, "allocate:default_destructor", "1");
-	} else if (cplus_mode == PROTECTED) {
-	  Setattr(inclass, "allocate:default_base_destructor", "1");
-	} else if (cplus_mode == PRIVATE) {
-	  Setattr(inclass, "allocate:private_destructor", "1");
-	}
+        Setattr(inclass, "allocate:has_destructor", "1");
+        if (cplus_mode == PUBLIC) {
+          Setattr(inclass, "allocate:default_destructor", "1");
+        } else if (cplus_mode == PROTECTED) {
+          Setattr(inclass, "allocate:default_base_destructor", "1");
+        } else if (cplus_mode == PRIVATE) {
+          Setattr(inclass, "allocate:private_destructor", "1");
+        }
       } else {
-	Setattr(inclass, "allocate:has_destructor", "1");
-	Setattr(inclass, "allocate:default_destructor", "1");
+        Setattr(inclass, "allocate:has_destructor", "1");
+        Setattr(inclass, "allocate:default_destructor", "1");
       }
     } else {
       if (!extendmode)
-	SetFlag(inclass, "allocate:deleted_default_destructor");
+        SetFlag(inclass, "allocate:deleted_default_destructor");
     }
 
     return SWIG_OK;
@@ -1447,14 +1447,14 @@ static void addCopyConstructor(Node *n) {
     Node *c;
     for (c = firstChild(n); c; c = nextSibling(c)) {
       if (Equal(nodeType(c), "constructor")) {
-	String *csname = Getattr(c, "sym:name");
-	String *clast = Swig_scopename_last(Getattr(c, "name"));
-	if (Equal(csname, clast)) {
-	  oldname = csname;
-	  Delete(clast);
-	  break;
-	}
-	Delete(clast);
+        String *csname = Getattr(c, "sym:name");
+        String *clast = Swig_scopename_last(Getattr(c, "name"));
+        if (Equal(csname, clast)) {
+          oldname = csname;
+          Delete(clast);
+          break;
+        }
+        Delete(clast);
       }
     }
   }
@@ -1575,14 +1575,14 @@ static void addDestructor(Node *n) {
       // For example: typedef struct X {} XX; %extend X { ~XX() {...} }
       // Don't add another destructor if a nonstandard one has been declared
       if (!nonstandard_destructor) {
-	Node *access = NewHash();
-	set_nodeType(access, "access");
-	Setattr(access, "kind", "public");
-	appendChild(n, access);
-	appendChild(n, cn);
-	Setattr(n, "has_destructor", "1");
-	Setattr(n, "allocate:has_destructor", "1");
-	Delete(access);
+        Node *access = NewHash();
+        set_nodeType(access, "access");
+        Setattr(access, "kind", "public");
+        appendChild(n, access);
+        appendChild(n, cn);
+        Setattr(n, "has_destructor", "1");
+        Setattr(n, "allocate:has_destructor", "1");
+        Delete(access);
       }
     }
     Delete(possible_nonstandard_symname);

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -29,7 +29,7 @@
 #include "swigmod.h"
 #include "cparse.h"
 
-static int virtual_elimination_mode = 0;        /* set to 0 on default */
+static int virtual_elimination_mode = 0; /* set to 0 on default */
 
 /* Set virtual_elimination_mode */
 void Wrapper_virtual_elimination_mode_set(int flag) {
@@ -40,35 +40,35 @@ void Wrapper_virtual_elimination_mode_set(int flag) {
    This is a major hack. Sorry.  */
 
 extern "C" {
-  static String *search_decl = 0;       /* Declarator being searched */
-  static Node *check_implemented(Node *n) {
-    String *decl;
-    if (!n)
-       return 0;
-    while (n) {
-      if (Strcmp(nodeType(n), "cdecl") == 0) {
-        decl = Getattr(n, "decl");
-        if (SwigType_isfunction(decl)) {
-          SwigType *decl1 = SwigType_typedef_resolve_all(decl);
-          SwigType *decl2 = SwigType_pop_function(decl1);
-          if (Strcmp(decl2, search_decl) == 0) {
-            if (!GetFlag(n, "abstract")) {
-              Delete(decl1);
-              Delete(decl2);
-              return n;
-            }
-          }
-          Delete(decl1);
-          Delete(decl2);
-        }
-      }
-      n = Getattr(n, "csym:nextSibling");
-    }
+static String *search_decl = 0; /* Declarator being searched */
+static Node *check_implemented(Node *n) {
+  String *decl;
+  if (!n)
     return 0;
+  while (n) {
+    if (Strcmp(nodeType(n), "cdecl") == 0) {
+      decl = Getattr(n, "decl");
+      if (SwigType_isfunction(decl)) {
+        SwigType *decl1 = SwigType_typedef_resolve_all(decl);
+        SwigType *decl2 = SwigType_pop_function(decl1);
+        if (Strcmp(decl2, search_decl) == 0) {
+          if (!GetFlag(n, "abstract")) {
+            Delete(decl1);
+            Delete(decl2);
+            return n;
+          }
+        }
+        Delete(decl1);
+        Delete(decl2);
+      }
+    }
+    n = Getattr(n, "csym:nextSibling");
   }
+  return 0;
+}
 }
 
-class Allocate:public Dispatcher {
+class Allocate : public Dispatcher {
   Node *inclass;
   int extendmode;
 
@@ -82,7 +82,7 @@ class Allocate:public Dispatcher {
 
     String *this_decl = Getattr(n, "decl");
     if (!this_decl)
-       return 0;
+      return 0;
 
     String *name = Getattr(n, "name");
     String *this_type = Getattr(n, "type");
@@ -139,7 +139,7 @@ class Allocate:public Dispatcher {
     String *base_decl = Getattr(base, "decl");
     SwigType *base_type = Getattr(base, "type");
     if (base_decl && base_type) {
-      if (checkAttribute(base, "name", name) && !GetFlag(b, "feature:ignore") /* whole class is ignored */ ) {
+      if (checkAttribute(base, "name", name) && !GetFlag(b, "feature:ignore") /* whole class is ignored */) {
         if (SwigType_isfunction(resolved_decl) && SwigType_isfunction(base_decl)) {
           // We have found a method that has the same name as one in a base class
           bool covariant_returntype = false;
@@ -195,12 +195,14 @@ class Allocate:public Dispatcher {
               }
             }
           }
-          //Printf(stderr,"look %s %s %d %d\n",base_decl, this_decl, returntype_match, decl_match);
+          // Printf(stderr,"look %s %s %d %d\n",base_decl, this_decl, returntype_match, decl_match);
 
           if (decl_match && returntype_match) {
             // Found an identical method in the base class
-            bool this_wrapping_protected_members = is_member_director(n) ? true : false;        // This should really check for dirprot rather than just being a director method
-            bool base_wrapping_protected_members = is_member_director(base) ? true : false;     // This should really check for dirprot rather than just being a director method
+            bool this_wrapping_protected_members =
+              is_member_director(n) ? true : false;  // This should really check for dirprot rather than just being a director method
+            bool base_wrapping_protected_members =
+              is_member_director(base) ? true : false;  // This should really check for dirprot rather than just being a director method
             bool both_have_public_access = is_public(n) && is_public(base);
             bool both_have_protected_access = (is_protected(n) && this_wrapping_protected_members) && (is_protected(base) && base_wrapping_protected_members);
             bool both_have_private_access = is_private(n) && is_private(base);
@@ -208,16 +210,15 @@ class Allocate:public Dispatcher {
               // Found a polymorphic method.
               // Mark the polymorphic method, in case the virtual keyword was not used.
               Setattr(n, "storage", "virtual");
-              if (!GetFlag(b, "feature:interface")) { // interface implementation neither hides nor overrides
+              if (!GetFlag(b, "feature:interface")) {  // interface implementation neither hides nor overrides
                 if (both_have_public_access || both_have_protected_access) {
                   if (!is_non_public_base(inclass, b))
-                    Setattr(n, "override", base);       // Note C# definition of override, ie access must be the same
-                }
-                else if (!both_have_private_access) {
+                    Setattr(n, "override", base);  // Note C# definition of override, ie access must be the same
+                } else if (!both_have_private_access) {
                   // Different access
                   if (this_wrapping_protected_members || base_wrapping_protected_members)
                     if (!is_non_public_base(inclass, b))
-                      Setattr(n, "hides", base);        // Note C# definition of hiding, ie hidden if access is different
+                      Setattr(n, "hides", base);  // Note C# definition of hiding, ie hidden if access is different
                 }
               }
               // Try and find the most base's covariant return type
@@ -300,7 +301,7 @@ class Allocate:public Dispatcher {
 
   /* Checks if a class member is the same as inherited from the class bases */
   int class_member_is_defined_in_bases(Node *member, Node *classnode) {
-    Node *bases;                /* bases is the closest ancestors of classnode */
+    Node *bases; /* bases is the closest ancestors of classnode */
     int defined = 0;
 
     bases = Getattr(classnode, "allbases");
@@ -333,7 +334,7 @@ class Allocate:public Dispatcher {
       return 0;
     if (!base) {
       /* Root node */
-      Symtab *stab = Getattr(n, "symtab");      /* Get symbol table for node */
+      Symtab *stab = Getattr(n, "symtab"); /* Get symbol table for node */
       Symtab *oldtab = Swig_symbol_setscope(stab);
       int ret = is_abstract_inherit(n, n, 1);
       Swig_symbol_setscope(oldtab);
@@ -349,7 +350,7 @@ class Allocate:public Dispatcher {
         if (!name)
           continue;
         if (Strchr(name, '~'))
-          continue;             /* Don't care about destructors */
+          continue; /* Don't care about destructors */
         String *base_decl = Getattr(nn, "decl");
         if (base_decl)
           base_decl = SwigType_typedef_resolve_all(base_decl);
@@ -387,7 +388,6 @@ class Allocate:public Dispatcher {
     return 0;
   }
 
-
   /* Grab methods used by smart pointers */
 
   List *smart_pointer_methods(Node *cls, List *methods, int isconst, String *classname = 0) {
@@ -407,8 +407,7 @@ class Allocate:public Dispatcher {
       } else if (Strcmp(nodeType(c), "cdecl") == 0) {
         if (!GetFlag(c, "feature:ignore")) {
           String *storage = Getattr(c, "storage");
-          if (!((Cmp(storage, "typedef") == 0))
-              && !Strstr(storage, "friend")) {
+          if (!((Cmp(storage, "typedef") == 0)) && !Strstr(storage, "friend")) {
             String *name = Getattr(c, "name");
             String *symname = Getattr(c, "sym:name");
             Node *e = Swig_symbol_clookup_local(name, 0);
@@ -442,7 +441,7 @@ class Allocate:public Dispatcher {
                   if (isconst) {
                     SwigType *decl = Getattr(cp, "decl");
                     if (decl) {
-                      if (SwigType_isfunction(decl)) {  /* If method, we only add if it's a const method */
+                      if (SwigType_isfunction(decl)) { /* If method, we only add if it's a const method */
                         if (SwigType_isconst(decl)) {
                           Append(methods, cp);
                         }
@@ -505,7 +504,6 @@ class Allocate:public Dispatcher {
     }
   }
 
-
   void process_exceptions(Node *n) {
     ParmList *catchlist = 0;
     /*
@@ -538,12 +536,12 @@ class Allocate:public Dispatcher {
     }
   }
 
-/* -----------------------------------------------------------------------------
- * clone_member_for_using_declaration()
- *
- * Create a new member (constructor or method) by copying it from member c, ready
- * for adding as a child to the using declaration node n.
- * ----------------------------------------------------------------------------- */
+  /* -----------------------------------------------------------------------------
+   * clone_member_for_using_declaration()
+   *
+   * Create a new member (constructor or method) by copying it from member c, ready
+   * for adding as a child to the using declaration node n.
+   * ----------------------------------------------------------------------------- */
 
   Node *clone_member_for_using_declaration(Node *c, Node *n) {
     Node *parent = parentNode(n);
@@ -625,13 +623,13 @@ class Allocate:public Dispatcher {
     return nn;
   }
 
-/* -----------------------------------------------------------------------------
- * add_member_for_using_declaration()
- *
- * Add a new member (constructor or method) by copying it from member c.
- * Add it into the linked list of members under the using declaration n (ccount,
- * unodes and last_unodes are used for this).
- * ----------------------------------------------------------------------------- */
+  /* -----------------------------------------------------------------------------
+   * add_member_for_using_declaration()
+   *
+   * Add a new member (constructor or method) by copying it from member c.
+   * Add it into the linked list of members under the using declaration n (ccount,
+   * unodes and last_unodes are used for this).
+   * ----------------------------------------------------------------------------- */
 
   void add_member_for_using_declaration(Node *c, Node *n, int &ccount, Node *&unodes, Node *&last_unodes) {
     if (GetFlag(c, "fvirtual:ignore")) {
@@ -641,11 +639,8 @@ class Allocate:public Dispatcher {
       UnsetFlag(c, "feature:ignore");
     }
 
-    if (!(Swig_storage_isstatic(c)
-          || checkAttribute(c, "storage", "typedef")
-          || Strstr(Getattr(c, "storage"), "friend")
-          || (Getattr(c, "feature:extend") && !Getattr(c, "code"))
-          || GetFlag(c, "feature:ignore"))) {
+    if (!(Swig_storage_isstatic(c) || checkAttribute(c, "storage", "typedef") || Strstr(Getattr(c, "storage"), "friend") ||
+          (Getattr(c, "feature:extend") && !Getattr(c, "code")) || GetFlag(c, "feature:ignore"))) {
 
       String *symname = Getattr(n, "sym:name");
       String *csymname = Getattr(c, "sym:name");
@@ -669,8 +664,18 @@ class Allocate:public Dispatcher {
           }
         }
       } else {
-        Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(n), Getline(n), "Using declaration %s, with name '%s', is not actually using\n", SwigType_namestr(Getattr(n, "uname")), symname);
-        Swig_warning(WARN_LANG_USING_NAME_DIFFERENT, Getfile(c), Getline(c), "the method from %s, with name '%s', as the names are different.\n", Swig_name_decl(c), csymname);
+        Swig_warning(WARN_LANG_USING_NAME_DIFFERENT,
+                     Getfile(n),
+                     Getline(n),
+                     "Using declaration %s, with name '%s', is not actually using\n",
+                     SwigType_namestr(Getattr(n, "uname")),
+                     symname);
+        Swig_warning(WARN_LANG_USING_NAME_DIFFERENT,
+                     Getfile(c),
+                     Getline(c),
+                     "the method from %s, with name '%s', as the names are different.\n",
+                     Swig_name_decl(c),
+                     csymname);
       }
     }
     if (GetFlag(c, "fvirtual:ignore")) {
@@ -720,8 +725,7 @@ class Allocate:public Dispatcher {
   }
 
 public:
-Allocate():
-  inclass(NULL), extendmode(0) {
+  Allocate() : inclass(NULL), extendmode(0) {
   }
 
   virtual int top(Node *n) {
@@ -754,7 +758,7 @@ Allocate():
   virtual int classDeclaration(Node *n) {
     Symtab *symtab = Swig_symbol_current();
     Swig_symbol_setscope(Getattr(n, "symtab"));
-    save_value<Node*> oldInclass(inclass);
+    save_value<Node *> oldInclass(inclass);
     save_value<AccessMode> oldAcessMode(cplus_mode);
     save_value<int> oldExtendMode(extendmode);
     if (Getattr(n, "template"))
@@ -799,8 +803,12 @@ Allocate():
         if (!GetFlag(n, "feature:notabstract")) {
           Node *na = Getattr(n, "abstracts:firstnode");
           if (na) {
-            Swig_warning(WARN_TYPE_ABSTRACT, Getfile(n), Getline(n),
-                         "Class '%s' might be abstract, " "no constructors generated,\n", SwigType_namestr(Getattr(n, "name")));
+            Swig_warning(WARN_TYPE_ABSTRACT,
+                         Getfile(n),
+                         Getline(n),
+                         "Class '%s' might be abstract, "
+                         "no constructors generated,\n",
+                         SwigType_namestr(Getattr(n, "name")));
             Swig_warning(WARN_TYPE_ABSTRACT, Getfile(na), Getline(na), "Method %s might not be implemented.\n", Swig_name_decl(na));
             if (!Getattr(n, "abstracts")) {
               List *abstracts = NewList();
@@ -1030,7 +1038,13 @@ Allocate():
           Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(n), Getline(n), "Nothing known about '%s'.\n", SwigType_namestr(Getattr(n, "uname")));
         }
       } else if (Equal(nodeType(ns), "constructor") && !GetFlag(n, "usingctor")) {
-        Swig_warning(WARN_PARSE_USING_CONSTRUCTOR, Getfile(n), Getline(n), "Using declaration '%s' for inheriting constructors uses base '%s' which is not an immediate base of '%s'.\n", SwigType_namestr(Getattr(n, "uname")), SwigType_namestr(Getattr(ns, "name")), SwigType_namestr(Getattr(parentNode(n), "name")));
+        Swig_warning(WARN_PARSE_USING_CONSTRUCTOR,
+                     Getfile(n),
+                     Getline(n),
+                     "Using declaration '%s' for inheriting constructors uses base '%s' which is not an immediate base of '%s'.\n",
+                     SwigType_namestr(Getattr(n, "uname")),
+                     SwigType_namestr(Getattr(ns, "name")),
+                     SwigType_namestr(Getattr(parentNode(n), "name")));
       } else {
         if (inclass && Getattr(n, "sym:name")) {
           {
@@ -1060,7 +1074,7 @@ Allocate():
                      *   %template()   Base::template_method<int>;              // SWIG template instantiation
                      *   template void Base::template_method<int>(int, int);    // C++ template instantiation
                      *   template void Derived::template_method<int>(int, int); // Not valid C++
-                    */
+                     */
                     if (Getattr(member, "template") == ns && checkAttribute(ns, "templatetype", "cdecl")) {
                       if (!GetFlag(member, "feature:ignore") && !Getattr(member, "error")) {
                         add_member_for_using_declaration(member, n, ccount, unodes, last_unodes);
@@ -1197,7 +1211,7 @@ Allocate():
         }
         if (!is_static) {
           if (!assignable || is_reference || is_const)
-            SetFlag(inclass, "allocate:has_nonassignable"); // The class has a variable that cannot be assigned to
+            SetFlag(inclass, "allocate:has_nonassignable");  // The class has a variable that cannot be assigned to
         }
       }
 
@@ -1245,8 +1259,7 @@ Allocate():
                   if (SwigType_isconst(type)) {
                     isconst = !Getattr(inclass, "allocate:smartpointermutable");
                     Setattr(inclass, "allocate:smartpointerconst", "1");
-                  }
-                  else {
+                  } else {
                     Setattr(inclass, "allocate:smartpointermutable", "1");
                   }
                   List *methods = smart_pointer_methods(sc, 0, isconst);
@@ -1398,7 +1411,7 @@ Allocate():
   }
 
   virtual int destructorDeclaration(Node *n) {
-    (void) n;
+    (void)n;
     if (!inclass)
       return SWIG_OK;
 
@@ -1424,176 +1437,175 @@ Allocate():
     return SWIG_OK;
   }
 
-static void addCopyConstructor(Node *n) {
-  Node *cn = NewHash();
-  set_nodeType(cn, "constructor");
-  Setattr(cn, "access", "public");
-  Setfile(cn, Getfile(n));
-  Setline(cn, Getline(n));
+  static void addCopyConstructor(Node *n) {
+    Node *cn = NewHash();
+    set_nodeType(cn, "constructor");
+    Setattr(cn, "access", "public");
+    Setfile(cn, Getfile(n));
+    Setline(cn, Getline(n));
 
-  int copy_constructor_non_const = GetFlag(n, "allocate:copy_constructor_non_const");
-  String *cname = Getattr(n, "name");
-  SwigType *type = Copy(cname);
-  String *lastname = Swig_scopename_last(cname);
-  String *name = SwigType_templateprefix(lastname);
-  String *cc = NewStringf(copy_constructor_non_const ? "r.%s" : "r.q(const).%s", type);
-  String *decl = NewStringf("f(%s).", cc);
-  String *oldname = Getattr(n, "sym:name");
+    int copy_constructor_non_const = GetFlag(n, "allocate:copy_constructor_non_const");
+    String *cname = Getattr(n, "name");
+    SwigType *type = Copy(cname);
+    String *lastname = Swig_scopename_last(cname);
+    String *name = SwigType_templateprefix(lastname);
+    String *cc = NewStringf(copy_constructor_non_const ? "r.%s" : "r.q(const).%s", type);
+    String *decl = NewStringf("f(%s).", cc);
+    String *oldname = Getattr(n, "sym:name");
 
-  if (Getattr(n, "allocate:has_constructor")) {
-    // to work properly with '%rename Class', we must look
-    // for any other constructor in the class, which has not been
-    // renamed, and use its name as oldname.
-    Node *c;
-    for (c = firstChild(n); c; c = nextSibling(c)) {
-      if (Equal(nodeType(c), "constructor")) {
-        String *csname = Getattr(c, "sym:name");
-        String *clast = Swig_scopename_last(Getattr(c, "name"));
-        if (Equal(csname, clast)) {
-          oldname = csname;
+    if (Getattr(n, "allocate:has_constructor")) {
+      // to work properly with '%rename Class', we must look
+      // for any other constructor in the class, which has not been
+      // renamed, and use its name as oldname.
+      Node *c;
+      for (c = firstChild(n); c; c = nextSibling(c)) {
+        if (Equal(nodeType(c), "constructor")) {
+          String *csname = Getattr(c, "sym:name");
+          String *clast = Swig_scopename_last(Getattr(c, "name"));
+          if (Equal(csname, clast)) {
+            oldname = csname;
+            Delete(clast);
+            break;
+          }
           Delete(clast);
-          break;
         }
-        Delete(clast);
       }
     }
-  }
 
-  String *symname = Swig_name_make(cn, cname, name, decl, oldname);
-  if (Strcmp(symname, "$ignore") != 0) {
-    Parm *p = NewParm(cc, "other", n);
+    String *symname = Swig_name_make(cn, cname, name, decl, oldname);
+    if (Strcmp(symname, "$ignore") != 0) {
+      Parm *p = NewParm(cc, "other", n);
 
-    Setattr(cn, "name", name);
-    Setattr(cn, "sym:name", symname);
-    SetFlag(cn, "feature:new");
-    Setattr(cn, "decl", decl);
-    Setattr(cn, "ismember", "1");
-    Setattr(cn, "parentNode", n);
-    Setattr(cn, "parms", p);
-    Setattr(cn, "copy_constructor", "1");
+      Setattr(cn, "name", name);
+      Setattr(cn, "sym:name", symname);
+      SetFlag(cn, "feature:new");
+      Setattr(cn, "decl", decl);
+      Setattr(cn, "ismember", "1");
+      Setattr(cn, "parentNode", n);
+      Setattr(cn, "parms", p);
+      Setattr(cn, "copy_constructor", "1");
 
-    Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
-    Node *on = Swig_symbol_add(symname, cn);
-    Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
-    Swig_symbol_setscope(oldscope);
+      Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
+      Node *on = Swig_symbol_add(symname, cn);
+      Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
+      Swig_symbol_setscope(oldscope);
 
-    if (on == cn) {
-      Node *access = NewHash();
-      set_nodeType(access, "access");
-      Setattr(access, "kind", "public");
-      appendChild(n, access);
-      appendChild(n, cn);
-      Setattr(n, "has_copy_constructor", "1");
-      Setattr(n, "copy_constructor_decl", decl);
-      Setattr(n, "allocate:copy_constructor", "1");
-      Delete(access);
-    }
-  }
-  Delete(cn);
-  Delete(lastname);
-  Delete(name);
-  Delete(decl);
-  Delete(symname);
-}
-
-static void addDefaultConstructor(Node *n) {
-  Node *cn = NewHash();
-  set_nodeType(cn, "constructor");
-  Setattr(cn, "access", "public");
-  Setfile(cn, Getfile(n));
-  Setline(cn, Getline(n));
-
-  String *cname = Getattr(n, "name");
-  String *lastname = Swig_scopename_last(cname);
-  String *name = SwigType_templateprefix(lastname);
-  String *decl = NewString("f().");
-  String *oldname = Getattr(n, "sym:name");
-  String *symname = Swig_name_make(cn, cname, name, decl, oldname);
-
-  if (Strcmp(symname, "$ignore") != 0) {
-    Setattr(cn, "name", name);
-    Setattr(cn, "sym:name", symname);
-    SetFlag(cn, "feature:new");
-    Setattr(cn, "decl", decl);
-    Setattr(cn, "ismember", "1");
-    Setattr(cn, "parentNode", n);
-    Setattr(cn, "default_constructor", "1");
-
-    Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
-    Node *on = Swig_symbol_add(symname, cn);
-    Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
-    Swig_symbol_setscope(oldscope);
-
-    if (on == cn) {
-      Node *access = NewHash();
-      set_nodeType(access, "access");
-      Setattr(access, "kind", "public");
-      appendChild(n, access);
-      appendChild(n, cn);
-      Setattr(n, "has_default_constructor", "1");
-      Setattr(n, "allocate:default_constructor", "1");
-      Delete(access);
-    }
-  }
-  Delete(cn);
-  Delete(lastname);
-  Delete(name);
-  Delete(decl);
-  Delete(symname);
-}
-
-static void addDestructor(Node *n) {
-  Node *cn = NewHash();
-  set_nodeType(cn, "destructor");
-  Setattr(cn, "access", "public");
-  Setfile(cn, Getfile(n));
-  Setline(cn, Getline(n));
-
-  String *cname = Getattr(n, "name");
-  String *lastname = Swig_scopename_last(cname);
-  String *name = SwigType_templateprefix(lastname);
-  Insert(name, 0, "~");
-  String *decl = NewString("f().");
-  String *symname = Swig_name_make(cn, cname, name, decl, 0);
-  if (Strcmp(symname, "$ignore") != 0) {
-    String *possible_nonstandard_symname = NewStringf("~%s", Getattr(n, "sym:name"));
-
-    Setattr(cn, "name", name);
-    Setattr(cn, "sym:name", symname);
-    Setattr(cn, "decl", "f().");
-    Setattr(cn, "ismember", "1");
-    Setattr(cn, "parentNode", n);
-
-    Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
-    Node *nonstandard_destructor = Equal(possible_nonstandard_symname, symname) ? 0 : Swig_symbol_clookup(possible_nonstandard_symname, 0);
-    Node *on = Swig_symbol_add(symname, cn);
-    Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
-    Swig_symbol_setscope(oldscope);
-
-    if (on == cn) {
-      // SWIG accepts a non-standard named destructor in %extend that uses a typedef for the destructor name
-      // For example: typedef struct X {} XX; %extend X { ~XX() {...} }
-      // Don't add another destructor if a nonstandard one has been declared
-      if (!nonstandard_destructor) {
+      if (on == cn) {
         Node *access = NewHash();
         set_nodeType(access, "access");
         Setattr(access, "kind", "public");
         appendChild(n, access);
         appendChild(n, cn);
-        Setattr(n, "has_destructor", "1");
-        Setattr(n, "allocate:has_destructor", "1");
+        Setattr(n, "has_copy_constructor", "1");
+        Setattr(n, "copy_constructor_decl", decl);
+        Setattr(n, "allocate:copy_constructor", "1");
         Delete(access);
       }
     }
-    Delete(possible_nonstandard_symname);
+    Delete(cn);
+    Delete(lastname);
+    Delete(name);
+    Delete(decl);
+    Delete(symname);
   }
-  Delete(cn);
-  Delete(lastname);
-  Delete(name);
-  Delete(decl);
-  Delete(symname);
-}
 
+  static void addDefaultConstructor(Node *n) {
+    Node *cn = NewHash();
+    set_nodeType(cn, "constructor");
+    Setattr(cn, "access", "public");
+    Setfile(cn, Getfile(n));
+    Setline(cn, Getline(n));
+
+    String *cname = Getattr(n, "name");
+    String *lastname = Swig_scopename_last(cname);
+    String *name = SwigType_templateprefix(lastname);
+    String *decl = NewString("f().");
+    String *oldname = Getattr(n, "sym:name");
+    String *symname = Swig_name_make(cn, cname, name, decl, oldname);
+
+    if (Strcmp(symname, "$ignore") != 0) {
+      Setattr(cn, "name", name);
+      Setattr(cn, "sym:name", symname);
+      SetFlag(cn, "feature:new");
+      Setattr(cn, "decl", decl);
+      Setattr(cn, "ismember", "1");
+      Setattr(cn, "parentNode", n);
+      Setattr(cn, "default_constructor", "1");
+
+      Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
+      Node *on = Swig_symbol_add(symname, cn);
+      Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
+      Swig_symbol_setscope(oldscope);
+
+      if (on == cn) {
+        Node *access = NewHash();
+        set_nodeType(access, "access");
+        Setattr(access, "kind", "public");
+        appendChild(n, access);
+        appendChild(n, cn);
+        Setattr(n, "has_default_constructor", "1");
+        Setattr(n, "allocate:default_constructor", "1");
+        Delete(access);
+      }
+    }
+    Delete(cn);
+    Delete(lastname);
+    Delete(name);
+    Delete(decl);
+    Delete(symname);
+  }
+
+  static void addDestructor(Node *n) {
+    Node *cn = NewHash();
+    set_nodeType(cn, "destructor");
+    Setattr(cn, "access", "public");
+    Setfile(cn, Getfile(n));
+    Setline(cn, Getline(n));
+
+    String *cname = Getattr(n, "name");
+    String *lastname = Swig_scopename_last(cname);
+    String *name = SwigType_templateprefix(lastname);
+    Insert(name, 0, "~");
+    String *decl = NewString("f().");
+    String *symname = Swig_name_make(cn, cname, name, decl, 0);
+    if (Strcmp(symname, "$ignore") != 0) {
+      String *possible_nonstandard_symname = NewStringf("~%s", Getattr(n, "sym:name"));
+
+      Setattr(cn, "name", name);
+      Setattr(cn, "sym:name", symname);
+      Setattr(cn, "decl", "f().");
+      Setattr(cn, "ismember", "1");
+      Setattr(cn, "parentNode", n);
+
+      Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
+      Node *nonstandard_destructor = Equal(possible_nonstandard_symname, symname) ? 0 : Swig_symbol_clookup(possible_nonstandard_symname, 0);
+      Node *on = Swig_symbol_add(symname, cn);
+      Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
+      Swig_symbol_setscope(oldscope);
+
+      if (on == cn) {
+        // SWIG accepts a non-standard named destructor in %extend that uses a typedef for the destructor name
+        // For example: typedef struct X {} XX; %extend X { ~XX() {...} }
+        // Don't add another destructor if a nonstandard one has been declared
+        if (!nonstandard_destructor) {
+          Node *access = NewHash();
+          set_nodeType(access, "access");
+          Setattr(access, "kind", "public");
+          appendChild(n, access);
+          appendChild(n, cn);
+          Setattr(n, "has_destructor", "1");
+          Setattr(n, "allocate:has_destructor", "1");
+          Delete(access);
+        }
+      }
+      Delete(possible_nonstandard_symname);
+    }
+    Delete(cn);
+    Delete(lastname);
+    Delete(name);
+    Delete(decl);
+    Delete(symname);
+  }
 };
 
 void Swig_default_allocators(Node *n) {

--- a/Source/Modules/allocate.cxx
+++ b/Source/Modules/allocate.cxx
@@ -29,7 +29,7 @@
 #include "swigmod.h"
 #include "cparse.h"
 
-static int virtual_elimination_mode = 0;	/* set to 0 on default */
+static int virtual_elimination_mode = 0;        /* set to 0 on default */
 
 /* Set virtual_elimination_mode */
 void Wrapper_virtual_elimination_mode_set(int flag) {
@@ -40,7 +40,7 @@ void Wrapper_virtual_elimination_mode_set(int flag) {
    This is a major hack. Sorry.  */
 
 extern "C" {
-  static String *search_decl = 0;	/* Declarator being searched */
+  static String *search_decl = 0;       /* Declarator being searched */
   static Node *check_implemented(Node *n) {
     String *decl;
     if (!n)
@@ -199,8 +199,8 @@ class Allocate:public Dispatcher {
 
           if (decl_match && returntype_match) {
             // Found an identical method in the base class
-            bool this_wrapping_protected_members = is_member_director(n) ? true : false;	// This should really check for dirprot rather than just being a director method
-            bool base_wrapping_protected_members = is_member_director(base) ? true : false;	// This should really check for dirprot rather than just being a director method
+            bool this_wrapping_protected_members = is_member_director(n) ? true : false;        // This should really check for dirprot rather than just being a director method
+            bool base_wrapping_protected_members = is_member_director(base) ? true : false;     // This should really check for dirprot rather than just being a director method
             bool both_have_public_access = is_public(n) && is_public(base);
             bool both_have_protected_access = (is_protected(n) && this_wrapping_protected_members) && (is_protected(base) && base_wrapping_protected_members);
             bool both_have_private_access = is_private(n) && is_private(base);
@@ -211,13 +211,13 @@ class Allocate:public Dispatcher {
               if (!GetFlag(b, "feature:interface")) { // interface implementation neither hides nor overrides
                 if (both_have_public_access || both_have_protected_access) {
                   if (!is_non_public_base(inclass, b))
-                    Setattr(n, "override", base);	// Note C# definition of override, ie access must be the same
+                    Setattr(n, "override", base);       // Note C# definition of override, ie access must be the same
                 }
                 else if (!both_have_private_access) {
                   // Different access
                   if (this_wrapping_protected_members || base_wrapping_protected_members)
                     if (!is_non_public_base(inclass, b))
-                      Setattr(n, "hides", base);	// Note C# definition of hiding, ie hidden if access is different
+                      Setattr(n, "hides", base);        // Note C# definition of hiding, ie hidden if access is different
                 }
               }
               // Try and find the most base's covariant return type
@@ -300,7 +300,7 @@ class Allocate:public Dispatcher {
 
   /* Checks if a class member is the same as inherited from the class bases */
   int class_member_is_defined_in_bases(Node *member, Node *classnode) {
-    Node *bases;		/* bases is the closest ancestors of classnode */
+    Node *bases;                /* bases is the closest ancestors of classnode */
     int defined = 0;
 
     bases = Getattr(classnode, "allbases");
@@ -333,7 +333,7 @@ class Allocate:public Dispatcher {
       return 0;
     if (!base) {
       /* Root node */
-      Symtab *stab = Getattr(n, "symtab");	/* Get symbol table for node */
+      Symtab *stab = Getattr(n, "symtab");      /* Get symbol table for node */
       Symtab *oldtab = Swig_symbol_setscope(stab);
       int ret = is_abstract_inherit(n, n, 1);
       Swig_symbol_setscope(oldtab);
@@ -349,7 +349,7 @@ class Allocate:public Dispatcher {
         if (!name)
           continue;
         if (Strchr(name, '~'))
-          continue;		/* Don't care about destructors */
+          continue;             /* Don't care about destructors */
         String *base_decl = Getattr(nn, "decl");
         if (base_decl)
           base_decl = SwigType_typedef_resolve_all(base_decl);
@@ -442,7 +442,7 @@ class Allocate:public Dispatcher {
                   if (isconst) {
                     SwigType *decl = Getattr(cp, "decl");
                     if (decl) {
-                      if (SwigType_isfunction(decl)) {	/* If method, we only add if it's a const method */
+                      if (SwigType_isfunction(decl)) {  /* If method, we only add if it's a const method */
                         if (SwigType_isconst(decl)) {
                           Append(methods, cp);
                         }

--- a/Source/Modules/c.cxx
+++ b/Source/Modules/c.cxx
@@ -3099,7 +3099,7 @@ public:
     Printv(sect_wrappers_decl, "#define ", name, " ", value, "\n", NIL);
     return SWIG_OK;
   }
-};				/* class C */
+};                              /* class C */
 
 /* -----------------------------------------------------------------------------
  * swig_c()    - Instantiate module

--- a/Source/Modules/c.cxx
+++ b/Source/Modules/c.cxx
@@ -232,11 +232,11 @@ Node* find_first_named_import(Node* parent) {
     if (Cmp(nodeType(n), "import") == 0) {
       // We've almost succeeded, but there are sometimes some weird unnamed import modules that don't really count for our purposes, so skip them.
       if (Getattr(n, "module"))
-	return n;
+        return n;
     } else if (Cmp(nodeType(n), "include") == 0) {
       // Recurse into this node as included files may contain imports too.
       if (Node* const import = find_first_named_import(n))
-	return import;
+        return import;
     } else {
       // We consider that import nodes can only occur in the global scope, some don't bother recursing here. If this turns out to be false, we'd just need to
       // start doing it.
@@ -310,9 +310,9 @@ public:
     // function twice. Note that just "auto" is enough because C functions can't return references, but we need "auto&&" for C++ result which can be anything
     // (defined by the user in their typemaps).
     scoped_dohptr code(NewStringf(
-	"\n"
-	"%sauto swig_cres = %s;\n",
-	cindent, value_.get()
+        "\n"
+        "%sauto swig_cres = %s;\n",
+        cindent, value_.get()
       ));
 
     // We support 2 cases: either typemap is a statement, or multiple statements, containing assignment to $result, in which case this assignment must occur at
@@ -436,14 +436,14 @@ struct cxx_wrappers
     switch (support) {
       case exceptions_support_enabled:
       case exceptions_support_imported:
-	except_check_start = "swig_check(";
-	except_check_end = ")";
-	break;
+        except_check_start = "swig_check(";
+        except_check_end = ")";
+        break;
 
       case exceptions_support_disabled:
-	except_check_start =
-	except_check_end = "";
-	break;
+        except_check_start =
+        except_check_end = "";
+        break;
     }
   }
 
@@ -475,11 +475,11 @@ struct cxx_wrappers
     }
 
     if (!type) {
-	Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, Getfile(n), Getline(n),
-	  "No ctype typemap defined for the return type \"%s\" of %s\n",
-	  SwigType_str(func_type, NULL),
-	  Getattr(n, "sym:name")
-	);
+        Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, Getfile(n), Getline(n),
+          "No ctype typemap defined for the return type \"%s\" of %s\n",
+          SwigType_str(func_type, NULL),
+          Getattr(n, "sym:name")
+        );
       return false;
     }
 
@@ -488,7 +488,7 @@ struct cxx_wrappers
 
     if (use_cxxout) {
       if (String* out_tm = Swig_typemap_lookup("cxxout", n, "", NULL))
-	rtype_desc.apply_out_typemap(out_tm);
+        rtype_desc.apply_out_typemap(out_tm);
     }
 
     return true;
@@ -508,9 +508,9 @@ struct cxx_wrappers
 
     if (!type) {
       Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, Getfile(p), Getline(p),
-	"No ctype typemap defined for the parameter \"%s\" of %s\n",
-	Getattr(p, "name"),
-	Getattr(n, "sym:name")
+        "No ctype typemap defined for the parameter \"%s\" of %s\n",
+        Getattr(p, "name"),
+        Getattr(n, "sym:name")
       );
       return false;
     }
@@ -520,7 +520,7 @@ struct cxx_wrappers
 
     if (use_cxxin) {
       if (String* in_tm = Getattr(p, "tmap:cxxin"))
-	ptype_desc.apply_in_typemap(Copy(in_tm));
+        ptype_desc.apply_in_typemap(Copy(in_tm));
     }
 
     return true;
@@ -539,12 +539,12 @@ struct cxx_wrappers
 
     if (SwigType *type = Getattr(parm, "type")) {
       if (ptype_desc_)
-	ptype_desc_->set_type(type);
+        ptype_desc_->set_type(type);
       if (rtype_desc_)
-	rtype_desc_->set_type(type);
+        rtype_desc_->set_type(type);
 
       if (!do_resolve_type(node_func_, type, tm, ptype_desc_, rtype_desc_))
-	return false;
+        return false;
     }
 
     return true;
@@ -601,26 +601,26 @@ private:
 
     for (int i = 0; i < Type_Max; ++i) {
       if (Strstr(s, typemaps[i])) {
-	typeKind = static_cast<TypeKind>(i);
-	break;
+        typeKind = static_cast<TypeKind>(i);
+        break;
       }
     }
 
     if (typeKind == Type_Max) {
       if (Strstr(s, "resolved_type")) {
-	Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number,
-	  "Unsupported typemap \"%s\" used for type \"%s\" of \"%s\"\n",
-	  s, type, Getattr(n, "name")
-	);
+        Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number,
+          "Unsupported typemap \"%s\" used for type \"%s\" of \"%s\"\n",
+          s, type, Getattr(n, "name")
+        );
 
-	return false;
+        return false;
       }
 
       // Nothing else needed.
       if (rtype_desc)
-	rtype_desc->set_type(s);
+        rtype_desc->set_type(s);
       if (ptype_desc)
-	ptype_desc->set_type(s);
+        ptype_desc->set_type(s);
 
       return true;
     }
@@ -638,183 +638,183 @@ private:
     if (SwigType_isenum(base_resolved_type)) {
       String* enumname = NULL;
       if (Node* const enum_node = Language::instance()->enumLookup(base_resolved_type)) {
-	// This is the name of the enum in C wrappers, it should be already set by getEnumName().
-	enumname = Getattr(enum_node, "enumname");
+        // This is the name of the enum in C wrappers, it should be already set by getEnumName().
+        enumname = Getattr(enum_node, "enumname");
 
-	if (enumname) {
-	  String* const enum_symname = Getattr(enum_node, "sym:name");
+        if (enumname) {
+          String* const enum_symname = Getattr(enum_node, "sym:name");
 
-	  if (Checkattr(enum_node, "ismember", "1")) {
-	    Node* const parent_class = parentNode(enum_node);
-	    typestr = NewStringf("%s::%s", Getattr(parent_class, "sym:name"), enum_symname);
-	  } else {
-	    typestr = Copy(enum_symname);
-	  }
-	}
+          if (Checkattr(enum_node, "ismember", "1")) {
+            Node* const parent_class = parentNode(enum_node);
+            typestr = NewStringf("%s::%s", Getattr(parent_class, "sym:name"), enum_symname);
+          } else {
+            typestr = Copy(enum_symname);
+          }
+        }
       }
 
       if (!enumname) {
-	// Unknown enums are mapped to int and no casts are necessary in this case.
-	typestr = NewString("int");
+        // Unknown enums are mapped to int and no casts are necessary in this case.
+        typestr = NewString("int");
       }
 
       if (SwigType_ispointer(type))
-	Append(typestr, " *");
+        Append(typestr, " *");
       else if (SwigType_isreference(type))
-	Append(typestr, " &");
+        Append(typestr, " &");
 
       if (enumname) {
-	switch (typeKind) {
-	  case Type_Ptr:
-	    if (rtype_desc) {
-	      rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
-	    }
+        switch (typeKind) {
+          case Type_Ptr:
+            if (rtype_desc) {
+              rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
+            }
 
-	    if (ptype_desc) {
-	      ptype_desc->apply_in_typemap(NewStringf("(%s*)$1", enumname));
-	    }
-	    break;
+            if (ptype_desc) {
+              ptype_desc->apply_in_typemap(NewStringf("(%s*)$1", enumname));
+            }
+            break;
 
-	  case Type_Ref:
-	    if (rtype_desc) {
-	      rtype_desc->apply_out_typemap(NewStringf("(%s)(*($cresult))", typestr.get()));
-	    }
+          case Type_Ref:
+            if (rtype_desc) {
+              rtype_desc->apply_out_typemap(NewStringf("(%s)(*($cresult))", typestr.get()));
+            }
 
-	    if (ptype_desc) {
-	      ptype_desc->apply_in_typemap(NewStringf("(%s*)&($1)", enumname));
-	    }
-	    break;
+            if (ptype_desc) {
+              ptype_desc->apply_in_typemap(NewStringf("(%s*)&($1)", enumname));
+            }
+            break;
 
-	  case Type_Enm:
-	    if (rtype_desc) {
-	      rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
-	    }
+          case Type_Enm:
+            if (rtype_desc) {
+              rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
+            }
 
-	    if (ptype_desc) {
-	      ptype_desc->apply_in_typemap(NewStringf("(%s)$1", enumname));
-	    }
-	    break;
+            if (ptype_desc) {
+              ptype_desc->apply_in_typemap(NewStringf("(%s)$1", enumname));
+            }
+            break;
 
-	  case Type_Obj:
-	  case Type_Max:
-	    // Unreachable, but keep here to avoid -Wswitch warnings.
-	    assert(0);
-	}
+          case Type_Obj:
+          case Type_Max:
+            // Unreachable, but keep here to avoid -Wswitch warnings.
+            assert(0);
+        }
       } else {
-	// This is the only thing we need to do even when we don't have the enum name.
-	if (typeKind == Type_Ref && ptype_desc)
-	  ptype_desc->apply_in_typemap(NewString("&($1)"));
+        // This is the only thing we need to do even when we don't have the enum name.
+        if (typeKind == Type_Ref && ptype_desc)
+          ptype_desc->apply_in_typemap(NewString("&($1)"));
       }
     } else {
       String* classname;
       if (Node* const class_node = Language::instance()->classLookup(type)) {
-	// Deal with some special cases:
-	switch (typeKind) {
-	  case Type_Ptr:
-	    // If this is a pointer passed by const reference, we return just the pointer directly because we don't have any pointer-valued variable to give out
-	    // a reference to.
-	    if (strncmp(Char(resolved_type), "r.q(const).", 11) == 0) {
-	      scoped_dohptr deref_type(Copy(resolved_type));
-	      Delslice(deref_type, 0, 11);
-	      typestr = SwigType_str(deref_type, 0);
-	    }
-	    break;
+        // Deal with some special cases:
+        switch (typeKind) {
+          case Type_Ptr:
+            // If this is a pointer passed by const reference, we return just the pointer directly because we don't have any pointer-valued variable to give out
+            // a reference to.
+            if (strncmp(Char(resolved_type), "r.q(const).", 11) == 0) {
+              scoped_dohptr deref_type(Copy(resolved_type));
+              Delslice(deref_type, 0, 11);
+              typestr = SwigType_str(deref_type, 0);
+            }
+            break;
 
-	  case Type_Obj:
-	    // Const objects are just objects for our purposes here, remove the const from them to avoid having "const const" in the output.
-	    if (SwigType_isconst(resolved_type))
-	      SwigType_del_qualifier(resolved_type);
-	    break;
+          case Type_Obj:
+            // Const objects are just objects for our purposes here, remove the const from them to avoid having "const const" in the output.
+            if (SwigType_isconst(resolved_type))
+              SwigType_del_qualifier(resolved_type);
+            break;
 
-	  case Type_Ref:
-	  case Type_Enm:
-	  case Type_Max:
-	    // Nothing special to do.
-	    break;
-	}
+          case Type_Ref:
+          case Type_Enm:
+          case Type_Max:
+            // Nothing special to do.
+            break;
+        }
 
-	if (!typestr)
-	  typestr = SwigType_str(resolved_type, 0);
+        if (!typestr)
+          typestr = SwigType_str(resolved_type, 0);
 
-	classname = Getattr(class_node, "sym:name");
+        classname = Getattr(class_node, "sym:name");
 
-	// We don't use namespaces, but the type may contain them, so get rid of them by replacing the base type name, which is fully qualified, with just the
-	// class name, which is not.
-	scoped_dohptr basetype(SwigType_base(resolved_type));
-	scoped_dohptr basetypestr(SwigType_str(basetype, 0));
-	if (Cmp(basetypestr, classname) != 0) {
-	  Replaceall(typestr, basetypestr, classname);
-	}
+        // We don't use namespaces, but the type may contain them, so get rid of them by replacing the base type name, which is fully qualified, with just the
+        // class name, which is not.
+        scoped_dohptr basetype(SwigType_base(resolved_type));
+        scoped_dohptr basetypestr(SwigType_str(basetype, 0));
+        if (Cmp(basetypestr, classname) != 0) {
+          Replaceall(typestr, basetypestr, classname);
+        }
       } else {
-	classname = NULL;
+        classname = NULL;
       }
 
       if (!classname) {
-	Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number,
-	  "Unsupported C++ wrapper function %s type \"%s\"\n",
-	  ptype_desc ? "parameter" : "return", SwigType_str(type, 0)
-	);
-	return false;
+        Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number,
+          "Unsupported C++ wrapper function %s type \"%s\"\n",
+          ptype_desc ? "parameter" : "return", SwigType_str(type, 0)
+        );
+        return false;
       }
 
       const char* const owns = GetFlag(n, "feature:new") ? "true" : "false";
       switch (typeKind) {
-	case Type_Ptr:
-	  if (ptype_desc) {
-	    ptype_desc->apply_in_typemap(NewString("$1->swig_self()"));
-	  }
+        case Type_Ptr:
+          if (ptype_desc) {
+            ptype_desc->apply_in_typemap(NewString("$1->swig_self()"));
+          }
 
-	  if (rtype_desc) {
-	    rtype_desc->apply_out_typemap(NewStringf(
-		"$cresult ? new %s($cresult, %s) : nullptr;",
-		classname, owns
-	      ));
-	  }
-	  break;
+          if (rtype_desc) {
+            rtype_desc->apply_out_typemap(NewStringf(
+                "$cresult ? new %s($cresult, %s) : nullptr;",
+                classname, owns
+              ));
+          }
+          break;
 
-	case Type_Ref:
-	  if (rtype_desc) {
-	    // We can't return a reference, as this requires an existing object and we don't have any, so we have to return an object instead, and this object
-	    // must be constructed using the special ctor not taking the pointer ownership.
-	    typestr = Copy(classname);
+        case Type_Ref:
+          if (rtype_desc) {
+            // We can't return a reference, as this requires an existing object and we don't have any, so we have to return an object instead, and this object
+            // must be constructed using the special ctor not taking the pointer ownership.
+            typestr = Copy(classname);
 
-	    rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, false}", classname));
-	  }
+            rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, false}", classname));
+          }
 
-	  if (ptype_desc) {
-	    ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
-	  }
-	  break;
+          if (ptype_desc) {
+            ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
+          }
+          break;
 
-	case Type_Obj:
-	  if (rtype_desc) {
-	    // The pointer returned by C function wrapping a function returning an object should never be null unless an exception happened, so we don't test
-	    // for it here, unlike in Type_Ptr case.
-	    //
-	    // Also, normally all returned objects should be owned by their wrappers, but there is a special case of objects not being returned by value: this
-	    // seems not to make sense, but can actually happen when typemaps map references or pointers to objects, like they do for e.g. shared_ptr<>.
-	    //
-	    // Note that we must use the type of the function, retrieved from its node, here and not the type passed to us which is the result of typemap
-	    // expansion and so may not be a reference any more.
-	    rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, %s}",
-		typestr.get(),
-		SwigType_isreference(Getattr(n, "type")) ? owns : "true"
-	      ));
-	  }
+        case Type_Obj:
+          if (rtype_desc) {
+            // The pointer returned by C function wrapping a function returning an object should never be null unless an exception happened, so we don't test
+            // for it here, unlike in Type_Ptr case.
+            //
+            // Also, normally all returned objects should be owned by their wrappers, but there is a special case of objects not being returned by value: this
+            // seems not to make sense, but can actually happen when typemaps map references or pointers to objects, like they do for e.g. shared_ptr<>.
+            //
+            // Note that we must use the type of the function, retrieved from its node, here and not the type passed to us which is the result of typemap
+            // expansion and so may not be a reference any more.
+            rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, %s}",
+                typestr.get(),
+                SwigType_isreference(Getattr(n, "type")) ? owns : "true"
+              ));
+          }
 
-	  if (ptype_desc) {
-	    // It doesn't seem like it can ever be useful to pass an object by value to a wrapper function and it can fail if it doesn't have a copy ctor (see
-	    // code related to has_copy_ctor_ in our dtor above), so always pass it by const reference instead.
-	    Append(typestr, " const&");
+          if (ptype_desc) {
+            // It doesn't seem like it can ever be useful to pass an object by value to a wrapper function and it can fail if it doesn't have a copy ctor (see
+            // code related to has_copy_ctor_ in our dtor above), so always pass it by const reference instead.
+            Append(typestr, " const&");
 
-	    ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
-	  }
-	  break;
+            ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
+          }
+          break;
 
-	case Type_Enm:
-	case Type_Max:
-	  // Unreachable, but keep here to avoid -Wswitch warnings.
-	  assert(0);
+        case Type_Enm:
+        case Type_Max:
+          // Unreachable, but keep here to avoid -Wswitch warnings.
+          assert(0);
       }
     }
 
@@ -862,7 +862,7 @@ public:
     if (Getattr(n, "sym:overloaded")) {
       Swig_overload_check(n);
       if (Getattr(n, "overload:ignore"))
-	return;
+        return;
     }
 
     if (!cxx_wrappers_.lookup_cxx_ret_type(rtype_desc, n))
@@ -875,41 +875,41 @@ public:
       // We want to use readable parameter names in our wrappers instead of the autogenerated arg$N if possible, so do it, and do it before calling
       // Swig_typemap_attach_parms(), as this uses the parameter names for typemap expansion.
       for (Parm* p2 = p; p2; p2 = nextSibling(p2)) {
-	String* name = Getattr(p, "name");
-	if (!name) {
-	  // Can't do anything for unnamed parameters.
-	  continue;
-	}
+        String* name = Getattr(p, "name");
+        if (!name) {
+          // Can't do anything for unnamed parameters.
+          continue;
+        }
 
-	// Static variables use fully qualified names, so we need to strip the scope from them.
-	scoped_dohptr name_ptr;
-	if (Strstr(name, "::")) {
-	  name_ptr = Swig_scopename_last(name);
-	  name = name_ptr.get();
-	}
+        // Static variables use fully qualified names, so we need to strip the scope from them.
+        scoped_dohptr name_ptr;
+        if (Strstr(name, "::")) {
+          name_ptr = Swig_scopename_last(name);
+          name = name_ptr.get();
+        }
 
-	Setattr(p, "lname", name);
+        Setattr(p, "lname", name);
       }
 
       Swig_typemap_attach_parms("cxxin", p, NULL);
 
       for (; p; p = Getattr(p, "tmap:in:next")) {
-	if (Checkattr(p, "tmap:in:numinputs", "0"))
-	  continue;
+        if (Checkattr(p, "tmap:in:numinputs", "0"))
+          continue;
 
-	String* const name = Getattr(p, "lname");
+        String* const name = Getattr(p, "lname");
 
-	cxx_ptype_desc ptype_desc;
-	if (!cxx_wrappers_.lookup_cxx_parm_type(ptype_desc, n, p))
-	  return;
+        cxx_ptype_desc ptype_desc;
+        if (!cxx_wrappers_.lookup_cxx_parm_type(ptype_desc, n, p))
+          return;
 
-	if (Len(parms_cxx))
-	  Append(parms_cxx, ", ");
-	Printv(parms_cxx, ptype_desc.type(), " ", name, NIL);
+        if (Len(parms_cxx))
+          Append(parms_cxx, ", ");
+        Printv(parms_cxx, ptype_desc.type(), " ", name, NIL);
 
-	if (Len(parms_call))
-	  Append(parms_call, ", ");
-	Append(parms_call, ptype_desc.get_param_code(name));
+        if (Len(parms_call))
+          Append(parms_call, ", ");
+        Append(parms_call, ptype_desc.get_param_code(name));
       }
     }
 
@@ -917,8 +917,8 @@ public:
     // Avoid checking for exceptions unnecessarily. Note that this is more than an optimization: we'd get into infinite recursion if we checked for exceptions
     // thrown by members of SWIG_CException itself if we didn't do it.
     if (cxx_wrappers_.is_exception_support_enabled() &&
-	  !Checkattr(n, "noexcept", "true") &&
-	    (!Checkattr(n, "throw", "1") || Getattr(n, "throws"))) {
+          !Checkattr(n, "noexcept", "true") &&
+            (!Checkattr(n, "throw", "1") || Getattr(n, "throws"))) {
       except_check_start = cxx_wrappers_.except_check_start;
       except_check_end = cxx_wrappers_.except_check_end;
     }
@@ -939,17 +939,17 @@ public:
 
     if (rtype_desc.is_void()) {
       Printv(cxx_wrappers_.sect_impls,
-	" ", wname, "(", wparms, "); ",
-	NIL
+        " ", wname, "(", wparms, "); ",
+        NIL
       );
 
       if (*except_check_start != '\0') {
-	Printv(cxx_wrappers_.sect_impls,
-	  except_check_start,
-	  except_check_end,
-	  "; ",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_impls,
+          except_check_start,
+          except_check_end,
+          "; ",
+          NIL
+        );
       }
     } else {
       rtype_desc.set_return_value(NewStringf("%s%s(%s)%s", except_check_start, wname, wparms, except_check_end));
@@ -1050,8 +1050,8 @@ public:
     scoped_dohptr base_classes(NewStringEmpty());
     if (uses_multiple_inheritance(n, &first_base_)) {
       Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-	"Multiple inheritance not supported yet, skipping C++ wrapper generation for %s\n",
-	classname
+        "Multiple inheritance not supported yet, skipping C++ wrapper generation for %s\n",
+        classname
       );
 
       // Return before initializing class_node_, so that the dtor won't output anything neither.
@@ -1128,13 +1128,13 @@ public:
     if (p && is_member && !is_ctor && !is_static) {
       // We should have "this" as the first parameter and we need to just skip it, as we handle it specially in C++ wrappers.
       if (Checkattr(p, "name", "self")) {
-	p = nextSibling(p);
+        p = nextSibling(p);
       } else {
-	// This is not supposed to happen, so warn if it does.
-	Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-	  "Unexpected first parameter \"%s\" in %s\n",
-	  Getattr(p, "name"),
-	  Getattr(n, "sym:name"));
+        // This is not supposed to happen, so warn if it does.
+        Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
+          "Unexpected first parameter \"%s\" in %s\n",
+          Getattr(p, "name"),
+          Getattr(n, "sym:name"));
       }
     }
 
@@ -1156,135 +1156,135 @@ public:
 
     if (Checkattr(n, "kind", "variable")) {
       if (Checkattr(n, "memberget", "1")) {
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, rtype_desc.type(), " ", name, "() const;\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, rtype_desc.type(), " ", name, "() const;\n",
+          NIL
+        );
 
-	rtype_desc.set_return_value(NewStringf("%s(swig_self())", Getattr(n, "sym:name")));
-	Printv(cxx_wrappers_.sect_impls,
-	  "inline ", rtype_desc.type(), " ", classname, "::", name, "() const "
-	  "{", rtype_desc.get_return_code().get(), "}\n",
-	  NIL
-	);
+        rtype_desc.set_return_value(NewStringf("%s(swig_self())", Getattr(n, "sym:name")));
+        Printv(cxx_wrappers_.sect_impls,
+          "inline ", rtype_desc.type(), " ", classname, "::", name, "() const "
+          "{", rtype_desc.get_return_code().get(), "}\n",
+          NIL
+        );
       } else if (Checkattr(n, "memberset", "1")) {
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, "void ", name, "(", parms_cxx, ");\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, "void ", name, "(", parms_cxx, ");\n",
+          NIL
+        );
 
-	Printv(cxx_wrappers_.sect_impls,
-	  "inline void ", classname, "::", name, "(", parms_cxx, ") "
-	  "{ ", Getattr(n, "sym:name"), "(swig_self(), ", parms_call, "); }\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_impls,
+          "inline void ", classname, "::", name, "(", parms_cxx, ") "
+          "{ ", Getattr(n, "sym:name"), "(swig_self(), ", parms_call, "); }\n",
+          NIL
+        );
       } else if (Checkattr(n, "varget", "1")) {
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, "static ", rtype_desc.type(), " ", name, "();\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, "static ", rtype_desc.type(), " ", name, "();\n",
+          NIL
+        );
 
-	rtype_desc.set_return_value(NewStringf("%s()", Getattr(n, "sym:name")));
-	Printv(cxx_wrappers_.sect_impls,
-	  "inline ", rtype_desc.type(), " ", classname, "::", name, "() "
-	  "{", rtype_desc.get_return_code().get(), "}\n",
-	  NIL
-	);
+        rtype_desc.set_return_value(NewStringf("%s()", Getattr(n, "sym:name")));
+        Printv(cxx_wrappers_.sect_impls,
+          "inline ", rtype_desc.type(), " ", classname, "::", name, "() "
+          "{", rtype_desc.get_return_code().get(), "}\n",
+          NIL
+        );
       } else if (Checkattr(n, "varset", "1")) {
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, "static void ", name, "(", parms_cxx, ");\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, "static void ", name, "(", parms_cxx, ");\n",
+          NIL
+        );
 
-	Printv(cxx_wrappers_.sect_impls,
-	  "inline void ", classname, "::", name, "(", parms_cxx, ") "
-	  "{ ", Getattr(n, "sym:name"), "(", parms_call, "); }\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_impls,
+          "inline void ", classname, "::", name, "(", parms_cxx, ") "
+          "{ ", Getattr(n, "sym:name"), "(", parms_call, "); }\n",
+          NIL
+        );
       } else {
-	Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-	  "Not generating C++ wrappers for variable %s\n",
-	  Getattr(n, "sym:name")
-	);
+        Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
+          "Not generating C++ wrappers for variable %s\n",
+          Getattr(n, "sym:name")
+        );
       }
     } else if (is_ctor) {
       // Delegate to the ctor from opaque C pointer taking ownership of the object.
       Printv(cxx_wrappers_.sect_decls,
-	cindent, classname, "(", parms_cxx, ");\n",
-	NIL
+        cindent, classname, "(", parms_cxx, ");\n",
+        NIL
       );
 
       Printv(cxx_wrappers_.sect_impls,
-	"inline ", classname, "::", classname, "(", parms_cxx, ") : ",
-	classname, "{",
-	  func_wrapper.except_check_start,
-	    wname, "(", parms_call, ")",
-	  func_wrapper.except_check_end,
-	"} {}\n",
-	NIL
+        "inline ", classname, "::", classname, "(", parms_cxx, ") : ",
+        classname, "{",
+          func_wrapper.except_check_start,
+            wname, "(", parms_call, ")",
+          func_wrapper.except_check_end,
+        "} {}\n",
+        NIL
       );
 
       // Remember that we had a copy ctor.
       if (Checkattr(n, "copy_constructor", "1"))
-	has_copy_ctor_ = true;
+        has_copy_ctor_ = true;
     } else if (Checkattr(n, "nodeType", "destructor")) {
       if (first_base_) {
-	// Delete the pointer and reset the ownership flag to ensure that the base class doesn't do it again.
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, get_virtual_prefix(n), "~", classname, "() {\n",
-	  cindent, cindent, "if (swig_owns_self_) {\n",
-	  cindent, cindent, cindent, wname, "(swig_self());\n",
-	  cindent, cindent, cindent, "swig_owns_self_ = false;\n",
-	  cindent, cindent, "}\n",
-	  cindent, "}\n",
-	  NIL
-	);
+        // Delete the pointer and reset the ownership flag to ensure that the base class doesn't do it again.
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, get_virtual_prefix(n), "~", classname, "() {\n",
+          cindent, cindent, "if (swig_owns_self_) {\n",
+          cindent, cindent, cindent, wname, "(swig_self());\n",
+          cindent, cindent, cindent, "swig_owns_self_ = false;\n",
+          cindent, cindent, "}\n",
+          cindent, "}\n",
+          NIL
+        );
       } else {
-	// Slightly simplified version for classes without base classes, as we don't need to reset swig_self_ then.
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, get_virtual_prefix(n), "~", classname, "() {\n",
-	  cindent, cindent, "if (swig_owns_self_)\n",
-	  cindent, cindent, cindent, wname, "(swig_self_);\n",
-	  cindent, "}\n",
-	  NIL
-	);
+        // Slightly simplified version for classes without base classes, as we don't need to reset swig_self_ then.
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, get_virtual_prefix(n), "~", classname, "() {\n",
+          cindent, cindent, "if (swig_owns_self_)\n",
+          cindent, cindent, cindent, wname, "(swig_self_);\n",
+          cindent, "}\n",
+          NIL
+        );
 
-	// We're also going to need this in move assignment operator.
-	dtor_wname_ = wname;
+        // We're also going to need this in move assignment operator.
+        dtor_wname_ = wname;
       }
     } else if (is_member) {
       // Wrapper parameters list may or not include "this" pointer and may or not have other parameters, so construct it piecewise for simplicity.
       scoped_dohptr wparms(NewStringEmpty());
       if (!is_static)
-	Append(wparms, "swig_self()");
+        Append(wparms, "swig_self()");
       if (Len(parms_call)) {
-	if (Len(wparms))
-	  Append(wparms, ", ");
-	Append(wparms, parms_call);
+        if (Len(wparms))
+          Append(wparms, ", ");
+        Append(wparms, parms_call);
       }
 
       Printv(cxx_wrappers_.sect_decls,
-	cindent,
-	is_static ? "static " : get_virtual_prefix(n), rtype_desc.type(), " ",
-	name, "(", parms_cxx, ")",
-	get_const_suffix(n), ";\n",
-	NIL
+        cindent,
+        is_static ? "static " : get_virtual_prefix(n), rtype_desc.type(), " ",
+        name, "(", parms_cxx, ")",
+        get_const_suffix(n), ";\n",
+        NIL
       );
 
       Printv(cxx_wrappers_.sect_impls,
-	"inline ", rtype_desc.type(), " ",
-	classname, "::", name, "(", parms_cxx, ")",
-	get_const_suffix(n),
-	" ",
-	NIL
+        "inline ", rtype_desc.type(), " ",
+        classname, "::", name, "(", parms_cxx, ")",
+        get_const_suffix(n),
+        " ",
+        NIL
       );
 
       func_wrapper.emit_body(wparms);
     } else {
       // This is something we don't know about
       Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-	"Not generating C++ wrappers for %s\n",
-	Getattr(n, "sym:name")
+        "Not generating C++ wrappers for %s\n",
+        Getattr(n, "sym:name")
       );
     }
   }
@@ -1304,7 +1304,7 @@ public:
     Printv(cxx_wrappers_.sect_decls,
       "\n",
       cindent, "explicit ", classname, "(", c_class_ptr.get(), " swig_self, "
-	"bool swig_owns_self = true) noexcept : ",
+        "bool swig_owns_self = true) noexcept : ",
       NIL
     );
 
@@ -1312,15 +1312,15 @@ public:
       // In this case we delegate to the base class ctor, but need a cast because it expects a different pointer type (as these types are opaque, there is no
       // relationship between them).
       Printv(cxx_wrappers_.sect_decls,
-	Getattr(first_base_, "sym:name"),
-	"{(", get_c_class_ptr(first_base_).get(), ")swig_self, swig_owns_self}",
-	NIL
+        Getattr(first_base_, "sym:name"),
+        "{(", get_c_class_ptr(first_base_).get(), ")swig_self, swig_owns_self}",
+        NIL
       );
     } else {
       // Just initialize our own field.
       Printv(cxx_wrappers_.sect_decls,
-	"swig_self_{swig_self}, swig_owns_self_{swig_owns_self}",
-	NIL
+        "swig_self_{swig_self}, swig_owns_self_{swig_owns_self}",
+        NIL
       );
     }
 
@@ -1331,8 +1331,8 @@ public:
     // To fix this, we would need to always provide our own C wrapper for the copy ctor, which is not something we do currently.
     if (!has_copy_ctor_) {
       Printv(cxx_wrappers_.sect_decls,
-	cindent, classname, "(", classname, " const&) = delete;\n",
-	NIL
+        cindent, classname, "(", classname, " const&) = delete;\n",
+        NIL
       );
     }
 
@@ -1346,35 +1346,35 @@ public:
     // OTOH we may always provide move ctor and assignment, as we can always implement them trivially ourselves.
     if (first_base_) {
       Printv(cxx_wrappers_.sect_decls,
-	cindent, classname, "(", classname, "&& obj) = default;\n",
-	cindent, classname, "& operator=(", classname, "&& obj) = default;\n",
-	NIL
+        cindent, classname, "(", classname, "&& obj) = default;\n",
+        cindent, classname, "& operator=(", classname, "&& obj) = default;\n",
+        NIL
       );
     } else {
       Printv(cxx_wrappers_.sect_decls,
-	cindent, classname, "(", classname, "&& obj) noexcept : "
-	"swig_self_{obj.swig_self_}, swig_owns_self_{obj.swig_owns_self_} { "
-	"obj.swig_owns_self_ = false; "
-	"}\n",
-	cindent, classname, "& operator=(", classname, "&& obj) noexcept {\n",
-	NIL
+        cindent, classname, "(", classname, "&& obj) noexcept : "
+        "swig_self_{obj.swig_self_}, swig_owns_self_{obj.swig_owns_self_} { "
+        "obj.swig_owns_self_ = false; "
+        "}\n",
+        cindent, classname, "& operator=(", classname, "&& obj) noexcept {\n",
+        NIL
       );
 
       if (dtor_wname_) {
-	Printv(cxx_wrappers_.sect_decls,
-	  cindent, cindent, "if (swig_owns_self_)\n",
-	  cindent, cindent, cindent, dtor_wname_, "(swig_self_);\n",
-	  NIL
-	);
+        Printv(cxx_wrappers_.sect_decls,
+          cindent, cindent, "if (swig_owns_self_)\n",
+          cindent, cindent, cindent, dtor_wname_, "(swig_self_);\n",
+          NIL
+        );
       }
 
       Printv(cxx_wrappers_.sect_decls,
-	cindent, cindent, "swig_self_ = obj.swig_self_;\n",
-	cindent, cindent, "swig_owns_self_ = obj.swig_owns_self_;\n",
-	cindent, cindent, "obj.swig_owns_self_ = false;\n",
-	cindent, cindent, "return *this;\n",
-	cindent, "}\n",
-	NIL
+        cindent, cindent, "swig_self_ = obj.swig_self_;\n",
+        cindent, cindent, "swig_owns_self_ = obj.swig_owns_self_;\n",
+        cindent, cindent, "obj.swig_owns_self_ = false;\n",
+        cindent, cindent, "return *this;\n",
+        cindent, "}\n",
+        NIL
       );
     }
 
@@ -1387,8 +1387,8 @@ public:
     if (first_base_) {
       // If we have a base class, we reuse its existing "self" pointer.
       Printv(cxx_wrappers_.sect_decls,
-	"{ return (", c_class_ptr.get(), ")", Getattr(first_base_, "sym:name"), "::swig_self(); }\n",
-	NIL
+        "{ return (", c_class_ptr.get(), ")", Getattr(first_base_, "sym:name"), "::swig_self(); }\n",
+        NIL
       );
     } else {
       // We use our own pointer, which we also have to declare, together with the ownership flag.
@@ -1397,10 +1397,10 @@ public:
       // retrieving it here in the future. If we decide to implement this optimization, the code generated here should be the only thing that would need to
       // change.
       Printv(cxx_wrappers_.sect_decls,
-	"{ return swig_self_; }\n",
-	cindent, c_class_ptr.get(), " swig_self_;\n",
-	cindent, "bool swig_owns_self_;\n",
-	NIL
+        "{ return swig_self_; }\n",
+        cindent, c_class_ptr.get(), " swig_self_;\n",
+        cindent, "bool swig_owns_self_;\n",
+        NIL
       );
     }
 
@@ -1551,9 +1551,9 @@ public:
     //  - Destructors and implicitly generated constructors don't have "ismember" for some reason, so we need to check for them specifically.
     //  - Variable getters and setters don't need to use the prefix as they don't clash with anything.
     if ((getCurrentClass() &&
-	  (Checkattr(n, "ismember", "1") ||
-	    Checkattr(n, "nodeType", "constructor") ||
-	      Checkattr(n, "nodeType", "destructor"))) ||
+          (Checkattr(n, "ismember", "1") ||
+            Checkattr(n, "nodeType", "constructor") ||
+              Checkattr(n, "nodeType", "destructor"))) ||
 -               Checkattr(n, "varget", "1") || Checkattr(n, "varset", "1")) {
       wname.assign_non_owned(name);
       return wname;
@@ -1564,8 +1564,8 @@ public:
     if (GetFlag(parentNode(n), "feature:nspace")) {
       scopename_prefix = Swig_scopename_prefix(Getattr(n, "name"));
       if (scopename_prefix) {
-	scoped_dohptr mangled_prefix(Swig_name_mangle_string(scopename_prefix));
-	scopename_prefix = mangled_prefix;
+        scoped_dohptr mangled_prefix(Swig_name_mangle_string(scopename_prefix));
+        scopename_prefix = mangled_prefix;
       }
     }
 
@@ -1575,8 +1575,8 @@ public:
     String* const prefix = scopename_prefix
       ? scopename_prefix
       : ns_prefix
-	? ns_prefix
-	: module_name;
+        ? ns_prefix
+        : module_name;
 
     wname.assign_owned(NewStringf("%s_%s", prefix, name));
     return wname;
@@ -1610,27 +1610,27 @@ public:
       // We can't use forward-declared enums because we can't define them for C wrappers (we could forward declare them in C++ if their underlying type,
       // available as "inherit" node attribute, is specified, but not in C), so we have no choice but to use "int" for them.
       if (Checkattr(n, "sym:weak", "1"))
-	return NULL;
+        return NULL;
 
       String *symname = Getattr(n, "sym:name");
       if (symname) {
-	// Add in class scope when referencing enum if not a global enum
-	String *proxyname = 0;
-	if (String *name = Getattr(n, "name")) {
-	  if (String *scopename_prefix = Swig_scopename_prefix(name)) {
-	    proxyname = getClassProxyName(scopename_prefix);
-	    Delete(scopename_prefix);
-	  }
-	}
-	if (proxyname) {
-	  enumname = NewStringf("%s_%s", proxyname, symname);
-	  Delete(proxyname);
-	} else {
-	  // global enum or enum in a namespace
-	  enumname = Copy(get_c_proxy_name(n));
-	}
-	Setattr(n, "enumname", enumname);
-	Delete(enumname);
+        // Add in class scope when referencing enum if not a global enum
+        String *proxyname = 0;
+        if (String *name = Getattr(n, "name")) {
+          if (String *scopename_prefix = Swig_scopename_prefix(name)) {
+            proxyname = getClassProxyName(scopename_prefix);
+            Delete(scopename_prefix);
+          }
+        }
+        if (proxyname) {
+          enumname = NewStringf("%s_%s", proxyname, symname);
+          Delete(proxyname);
+        } else {
+          // global enum or enum in a namespace
+          enumname = Copy(get_c_proxy_name(n));
+        }
+        Setattr(n, "enumname", enumname);
+        Delete(enumname);
       }
     }
 
@@ -1653,44 +1653,44 @@ public:
       // smaller).
       maybe_owned_dohptr c_enumname;
       if (current_output == output_wrapper_decl && enumname) {
-	// We need to add "enum" iff this is not already a typedef for the enum.
-	if (Checkattr(enum_node, "allows_typedef", "1"))
-	  c_enumname.assign_non_owned(enumname);
-	else
-	  c_enumname.assign_owned(NewStringf("enum %s", enumname));
+        // We need to add "enum" iff this is not already a typedef for the enum.
+        if (Checkattr(enum_node, "allows_typedef", "1"))
+          c_enumname.assign_non_owned(enumname);
+        else
+          c_enumname.assign_owned(NewStringf("enum %s", enumname));
       } else {
-	c_enumname.assign_owned(NewString("int"));
+        c_enumname.assign_owned(NewString("int"));
       }
 
       Replaceall(tm, classnamespecialvariable, c_enumname);
     } else {
       if (!CPlusPlus) {
-	// Just use the original C type when not using C++, we know that this type can be used in the wrappers.
-	Clear(tm);
-	String* const s = SwigType_str(classnametype, 0);
-	Append(tm, s);
-	Delete(s);
-	return;
+        // Just use the original C type when not using C++, we know that this type can be used in the wrappers.
+        Clear(tm);
+        String* const s = SwigType_str(classnametype, 0);
+        Append(tm, s);
+        Delete(s);
+        return;
       }
 
       String* typestr = NIL;
       if (current_output == output_wrapper_def || Cmp(btype, "SwigObj") == 0) {
-	// Special case, just leave it unchanged.
-	typestr = NewString("SwigObj");
+        // Special case, just leave it unchanged.
+        typestr = NewString("SwigObj");
       } else {
-	typestr = getClassProxyName(btype);
-	if (!typestr) {
-	  if (SwigType_isbuiltin(btype)) {
-	    // This should work just as well in C without any changes.
-	    typestr = SwigType_str(classnametype, 0);
-	  } else {
-	    // Swig doesn't know anything about this type, use descriptor for it.
-	    typestr = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
+        typestr = getClassProxyName(btype);
+        if (!typestr) {
+          if (SwigType_isbuiltin(btype)) {
+            // This should work just as well in C without any changes.
+            typestr = SwigType_str(classnametype, 0);
+          } else {
+            // Swig doesn't know anything about this type, use descriptor for it.
+            typestr = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
 
-	    // And make sure it is declared before it is used.
-	    Printf(sect_wrappers_types, "typedef struct %s %s;\n\n", typestr, typestr);
-	  }
-	}
+            // And make sure it is declared before it is used.
+            Printf(sect_wrappers_types, "typedef struct %s %s;\n\n", typestr, typestr);
+          }
+        }
       }
 
       Replaceall(tm, classnamespecialvariable, typestr);
@@ -1725,7 +1725,7 @@ public:
       SwigType *classnametype = Copy(strippedtype);
       Delete(SwigType_pop(classnametype));
       if (Len(classnametype) > 0) {
-	substituteResolvedTypeSpecialVariable(classnametype, tm, "$*resolved_type");
+        substituteResolvedTypeSpecialVariable(classnametype, tm, "$*resolved_type");
       }
       Delete(classnametype);
     }
@@ -1769,15 +1769,15 @@ public:
         if (strcmp(argv[i], "-help") == 0) {
           Printf(stdout, "%s", usage);
         } else if (strcmp(argv[i], "-namespace") == 0) {
-	  if (argv[i + 1]) {
-	    ns_cxx = NewString(argv[i + 1]);
-	    ns_prefix = Swig_name_mangle_string(ns_cxx);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
+          if (argv[i + 1]) {
+            ns_cxx = NewString(argv[i + 1]);
+            ns_prefix = Swig_name_mangle_string(ns_cxx);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
         } else if (strcmp(argv[i], "-nocxx") == 0) {
           use_cxx_wrappers = false;
           Swig_mark_arg(i);
@@ -1880,19 +1880,19 @@ public:
       // in the same process without conflicts. This has to be done in this hackish way because we really need to change the name of the function itself, not
       // its wrapper (which is not even generated).
       Printv(sect_runtime,
-	"#define SWIG_CException_Raise ", (ns_prefix ? ns_prefix : module_name), "_SWIG_CException_Raise\n",
-	NIL
+        "#define SWIG_CException_Raise ", (ns_prefix ? ns_prefix : module_name), "_SWIG_CException_Raise\n",
+        NIL
       );
 
       // We need to check if we have any %imported modules, as they would already define the exception support code and we want to have exactly one copy of it
       // in the generated shared library, so check for "import" nodes.
       if (find_first_named_import(n)) {
-	  // We import another module, which will have already defined SWIG_CException, so set the flag indicating that we shouldn't do it again in this one and
-	  // define the symbol to skip compiling its implementation.
-	  Printv(sect_runtime, "#define SWIG_CException_DEFINED 1\n", NIL);
+          // We import another module, which will have already defined SWIG_CException, so set the flag indicating that we shouldn't do it again in this one and
+          // define the symbol to skip compiling its implementation.
+          Printv(sect_runtime, "#define SWIG_CException_DEFINED 1\n", NIL);
 
-	  // Also set a flag telling classDeclaration() to skip creating SWIG_CException wrappers.
-	  exceptions_support_ = exceptions_support_imported;
+          // Also set a flag telling classDeclaration() to skip creating SWIG_CException wrappers.
+          exceptions_support_ = exceptions_support_imported;
       }
     }
 
@@ -1937,46 +1937,46 @@ public:
       Delete(sect_wrappers_decl);
 
       if (cxx_wrappers_.is_initialized()) {
-	if (!ns_cxx) {
-	  // We need some namespace for the C++ wrappers as otherwise their names could conflict with the C functions, so use the module name if nothing was
-	  // explicitly specified.
-	  ns_cxx = Copy(module_name);
-	}
+        if (!ns_cxx) {
+          // We need some namespace for the C++ wrappers as otherwise their names could conflict with the C functions, so use the module name if nothing was
+          // explicitly specified.
+          ns_cxx = Copy(module_name);
+        }
 
-	Printv(f_wrappers_h, "#ifdef __cplusplus\n\n", NIL);
-	Dump(cxx_wrappers_.sect_cxx_h, f_wrappers_h);
+        Printv(f_wrappers_h, "#ifdef __cplusplus\n\n", NIL);
+        Dump(cxx_wrappers_.sect_cxx_h, f_wrappers_h);
 
-	// Generate possibly nested namespace declarations, as unfortunately we can't rely on C++17 nested namespace definitions being always available.
-	scoped_dohptr cxx_ns_end(NewStringEmpty());
-	for (const char* c = Char(ns_cxx);;) {
-	  const char* const next = strstr(c, "::");
+        // Generate possibly nested namespace declarations, as unfortunately we can't rely on C++17 nested namespace definitions being always available.
+        scoped_dohptr cxx_ns_end(NewStringEmpty());
+        for (const char* c = Char(ns_cxx);;) {
+          const char* const next = strstr(c, "::");
 
-	  maybe_owned_dohptr ns_component;
-	  if (next) {
-	    ns_component.assign_owned(NewStringWithSize(c, (int)(next - c)));
-	  } else {
-	    ns_component.assign_non_owned((DOH*)c);
-	  }
+          maybe_owned_dohptr ns_component;
+          if (next) {
+            ns_component.assign_owned(NewStringWithSize(c, (int)(next - c)));
+          } else {
+            ns_component.assign_non_owned((DOH*)c);
+          }
 
-	  Printf(f_wrappers_h, "namespace %s {\n", ns_component.get());
-	  Printf(cxx_ns_end, "}\n");
+          Printf(f_wrappers_h, "namespace %s {\n", ns_component.get());
+          Printf(cxx_ns_end, "}\n");
 
-	  if (!next)
-	    break;
+          if (!next)
+            break;
 
-	  c = next + 2;
-	}
+          c = next + 2;
+        }
 
-	Printv(f_wrappers_h, "\n", NIL);
-	Dump(cxx_wrappers_.sect_types, f_wrappers_h);
+        Printv(f_wrappers_h, "\n", NIL);
+        Dump(cxx_wrappers_.sect_types, f_wrappers_h);
 
-	Printv(f_wrappers_h, "\n", NIL);
-	Dump(cxx_wrappers_.sect_decls, f_wrappers_h);
+        Printv(f_wrappers_h, "\n", NIL);
+        Dump(cxx_wrappers_.sect_decls, f_wrappers_h);
 
-	Printv(f_wrappers_h, "\n", NIL);
-	Dump(cxx_wrappers_.sect_impls, f_wrappers_h);
+        Printv(f_wrappers_h, "\n", NIL);
+        Dump(cxx_wrappers_.sect_impls, f_wrappers_h);
 
-	Printv(f_wrappers_h, "\n", cxx_ns_end.get(), "\n#endif /* __cplusplus */\n", NIL);
+        Printv(f_wrappers_h, "\n", cxx_ns_end.get(), "\n#endif /* __cplusplus */\n", NIL);
       }
     } // close wrapper header guard
 
@@ -2032,9 +2032,9 @@ public:
     if (!ns_prefix && !scoped_dohptr(Swig_scopename_prefix(Getattr(n, "name")))) {
       // If we can export the variable directly, do it, this will be more convenient to use from C code than accessor functions.
       if (String* const var_decl = make_c_var_decl(n)) {
-	Printv(sect_wrappers_decl, "SWIGIMPORT ", var_decl, ";\n\n", NIL);
-	Delete(var_decl);
-	return SWIG_OK;
+        Printv(sect_wrappers_decl, "SWIGIMPORT ", var_decl, ";\n\n", NIL);
+        Delete(var_decl);
+        return SWIG_OK;
       }
     }
 
@@ -2110,8 +2110,8 @@ public:
       SwigType_del_pointer(type);
       if (SwigType_isfunction(type)) {
         Printf(result, "f");
-	Delete(type);
-	return result;
+        Delete(type);
+        return result;
       }
       Delete(type);
       type = Copy(type_arg);
@@ -2138,7 +2138,7 @@ public:
       const char* s = Char(enumname);
       static const size_t len_enum_prefix = strlen("enum ");
       if (strncmp(s, "enum ", len_enum_prefix) == 0)
-	s += len_enum_prefix;
+        s += len_enum_prefix;
       Printf(result, "e%s", s);
     } else {
       // Use Swig_name_mangle_type() here and not Swig_name_mangle_string() to get slightly simpler mangled name for templates (notably avoiding "_Sp_" and
@@ -2248,10 +2248,10 @@ public:
       String *return_type;
 
       if ((return_type = Swig_typemap_lookup("ctype", n, "", 0))) {
-	substituteResolvedType(type, return_type);
+        substituteResolvedType(type, return_type);
       } else {
-	Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
-	return_type = NewString("");
+        Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
+        return_type = NewString("");
       }
 
       Replaceall(return_type, "::", "_");
@@ -2276,11 +2276,11 @@ public:
 
        // attach the standard typemaps
        if (wrapper) {
-	 emit_attach_parmmaps(parms, wrapper);
+         emit_attach_parmmaps(parms, wrapper);
        } else {
-	 // We can't call emit_attach_parmmaps() without a wrapper, it would just crash.
-	 // Attach "in" manually, we need it for tmap:in:numinputs below.
-	 Swig_typemap_attach_parms("in", parms, 0);
+         // We can't call emit_attach_parmmaps() without a wrapper, it would just crash.
+         // Attach "in" manually, we need it for tmap:in:numinputs below.
+         Swig_typemap_attach_parms("in", parms, 0);
        }
        Setattr(n, "wrap:parms", parms); //never read again?!
 
@@ -2304,10 +2304,10 @@ public:
                  continue;
             }
 
-	    if (SwigType_type(type) == T_VARARGS) {
-	      Swig_error(Getfile(n), Getline(n), "Vararg function %s not supported.\n", Getattr(n, "name"));
-	      return scoped_dohptr(NULL);
-	    }
+            if (SwigType_type(type) == T_VARARGS) {
+              Swig_error(Getfile(n), Getline(n), "Vararg function %s not supported.\n", Getattr(n, "name"));
+              return scoped_dohptr(NULL);
+            }
 
             String *lname = Getattr(p, "lname");
             String *c_parm_type = 0;
@@ -2315,23 +2315,23 @@ public:
 
             Printf(arg_name, "c%s", lname);
 
-	    if ((tm = Getattr(p, "tmap:ctype"))) { // set the appropriate type for parameter
-		 c_parm_type = Copy(tm);
-		 substituteResolvedType(type, c_parm_type);
+            if ((tm = Getattr(p, "tmap:ctype"))) { // set the appropriate type for parameter
+                 c_parm_type = Copy(tm);
+                 substituteResolvedType(type, c_parm_type);
 
-		 // We prefer to keep typedefs in the wrapper functions signatures as it makes them more readable, but we can't do it for nested typedefs as
-		 // they're not valid in C, so resolve them in this case.
-		 if (strstr(Char(c_parm_type), "::")) {
-		   SwigType* const tdtype = SwigType_typedef_resolve_all(c_parm_type);
-		   Delete(c_parm_type);
-		   c_parm_type = tdtype;
-		 }
+                 // We prefer to keep typedefs in the wrapper functions signatures as it makes them more readable, but we can't do it for nested typedefs as
+                 // they're not valid in C, so resolve them in this case.
+                 if (strstr(Char(c_parm_type), "::")) {
+                   SwigType* const tdtype = SwigType_typedef_resolve_all(c_parm_type);
+                   Delete(c_parm_type);
+                   c_parm_type = tdtype;
+                 }
 
-		 // template handling
-		 Replaceall(c_parm_type, "$tt", SwigType_lstr(type, 0));
-	    } else {
-		 Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
-	    }
+                 // template handling
+                 Replaceall(c_parm_type, "$tt", SwigType_lstr(type, 0));
+            } else {
+                 Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
+            }
 
             Printv(proto, gencomma ? ", " : "", c_parm_type, " ", arg_name, NIL);
             gencomma = 1;
@@ -2339,10 +2339,10 @@ public:
             // apply typemaps for input parameter
             if ((tm = Getattr(p, "tmap:in"))) {
                  Replaceall(tm, "$input", arg_name);
-		 if (wrapper) {
-		   Setattr(p, "emit:input", arg_name);
-		   Printf(wrapper->code, "%s\n", tm);
-		 }
+                 if (wrapper) {
+                   Setattr(p, "emit:input", arg_name);
+                   Printf(wrapper->code, "%s\n", tm);
+                 }
                  p = Getattr(p, "tmap:in:next");
             } else {
                  Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(type, 0));
@@ -2380,39 +2380,39 @@ public:
        // mangle name if function is overloaded
        if (Getattr(n, "sym:overloaded")) {
             if (!Getattr(n, "copy_constructor")) {
-		Parm* first_param = (Parm*)parms;
-		if (first_param) {
-		  // Skip the first "this" parameter of the wrapped methods, it doesn't participate in overload resolution and would just result in extra long
-		  // and ugly names.
-		  //
-		  // We need to avoid dropping the first argument of static methods which don't have "this" pointer, in spite of being members (and we have to
-		  // use "cplus:staticbase" for this instead of just using Swig_storage_isstatic() because "storage" is reset in staticmemberfunctionHandler()
-		  // and so is not available here.
-		  //
-		  // Of course, the constructors don't have the extra first parameter neither.
-		  if (!Checkattr(n, "nodeType", "constructor") &&
-			Checkattr(n, "ismember", "1") &&
-			  !Getattr(n, "cplus:staticbase")) {
-		    first_param = nextSibling(first_param);
+                Parm* first_param = (Parm*)parms;
+                if (first_param) {
+                  // Skip the first "this" parameter of the wrapped methods, it doesn't participate in overload resolution and would just result in extra long
+                  // and ugly names.
+                  //
+                  // We need to avoid dropping the first argument of static methods which don't have "this" pointer, in spite of being members (and we have to
+                  // use "cplus:staticbase" for this instead of just using Swig_storage_isstatic() because "storage" is reset in staticmemberfunctionHandler()
+                  // and so is not available here.
+                  //
+                  // Of course, the constructors don't have the extra first parameter neither.
+                  if (!Checkattr(n, "nodeType", "constructor") &&
+                        Checkattr(n, "ismember", "1") &&
+                          !Getattr(n, "cplus:staticbase")) {
+                    first_param = nextSibling(first_param);
 
-		    // A special case of overloading on const/non-const "this" pointer only, we still need to distinguish between those.
-		    if (SwigType_isconst(Getattr(n, "decl"))) {
-		      const char * const nonconst = Char(Getattr(n, "decl")) + 9 /* strlen("q(const).") */;
-		      for (Node* nover = Getattr(n, "sym:overloaded"); nover; nover = Getattr(nover, "sym:nextSibling")) {
-			if (nover == n)
-			  continue;
+                    // A special case of overloading on const/non-const "this" pointer only, we still need to distinguish between those.
+                    if (SwigType_isconst(Getattr(n, "decl"))) {
+                      const char * const nonconst = Char(Getattr(n, "decl")) + 9 /* strlen("q(const).") */;
+                      for (Node* nover = Getattr(n, "sym:overloaded"); nover; nover = Getattr(nover, "sym:nextSibling")) {
+                        if (nover == n)
+                          continue;
 
-			if (Cmp(Getattr(nover, "decl"), nonconst) == 0) {
-			  // We have an overload differing by const only, disambiguate.
-			  Append(name, "_const");
-			  break;
-			}
-		      }
-		    }
-		  }
+                        if (Cmp(Getattr(nover, "decl"), nonconst) == 0) {
+                          // We have an overload differing by const only, disambiguate.
+                          Append(name, "_const");
+                          break;
+                        }
+                      }
+                    }
+                  }
 
-		  functionWrapperAppendOverloaded(name, first_param);
-		}
+                  functionWrapperAppendOverloaded(name, first_param);
+                }
             }
        }
 
@@ -2443,12 +2443,12 @@ public:
 
        // add variable for holding result of original function 'cppresult'
        if (!is_void_return) {
-	 SwigType *value_type = cplus_value_type(type);
-	 SwigType* cppresult_type = value_type ? value_type : type;
-	 SwigType* ltype = SwigType_ltype(cppresult_type);
-	 Wrapper_add_local(wrapper, "cppresult", SwigType_str(ltype, "cppresult"));
-	 Delete(ltype);
-	 Delete(value_type);
+         SwigType *value_type = cplus_value_type(type);
+         SwigType* cppresult_type = value_type ? value_type : type;
+         SwigType* ltype = SwigType_ltype(cppresult_type);
+         Wrapper_add_local(wrapper, "cppresult", SwigType_str(ltype, "cppresult"));
+         Delete(ltype);
+         Delete(value_type);
        }
 
        // create wrapper function prototype
@@ -2457,11 +2457,11 @@ public:
        Printv(wrapper->def, get_wrapper_func_proto(n, wrapper).get(), NIL);
        Printv(wrapper->def, " {", NIL);
 
-	// emit variables for holding parameters
-	emit_parameter_variables(parms, wrapper);
+        // emit variables for holding parameters
+        emit_parameter_variables(parms, wrapper);
 
-	// emit variable for holding function return value
-	emit_return_variable(n, return_type, wrapper);
+        // emit variable for holding function return value
+        emit_return_variable(n, return_type, wrapper);
 
        // insert constraint checking
        for (p = parms; p; ) {
@@ -2496,21 +2496,21 @@ public:
        if (!is_void_return) {
             String *tm;
             if ((tm = Swig_typemap_lookup_out("out", n, "cppresult", wrapper, action))) {
-	      // This is ugly, but the type of our result variable is not always the same as the actual return type currently because
-	      // get_wrapper_func_return_type() applies ctype typemap to it. These types are more or less compatible though, so we should be able to cast
-	      // between them explicitly.
-	      const char* start = Char(tm);
-	      const char* p = strstr(start, "$result = ");
-	      if (p == start || (p && p[-1] == ' ')) {
-		p += strlen("$result = ");
-		scoped_dohptr result_cast(NewStringf("(%s)", return_type.get()));
+              // This is ugly, but the type of our result variable is not always the same as the actual return type currently because
+              // get_wrapper_func_return_type() applies ctype typemap to it. These types are more or less compatible though, so we should be able to cast
+              // between them explicitly.
+              const char* start = Char(tm);
+              const char* p = strstr(start, "$result = ");
+              if (p == start || (p && p[-1] == ' ')) {
+                p += strlen("$result = ");
+                scoped_dohptr result_cast(NewStringf("(%s)", return_type.get()));
 
-		// However don't add a cast which is already there.
-		if (strncmp(p, Char(result_cast), strlen(Char(result_cast))) != 0)
-		  Insert(tm, (int)(p - start), result_cast);
-	      }
+                // However don't add a cast which is already there.
+                if (strncmp(p, Char(result_cast), strlen(Char(result_cast))) != 0)
+                  Insert(tm, (int)(p - start), result_cast);
+              }
                  Replaceall(tm, "$result", "result");
-		 Replaceall(tm, "$owner", GetFlag(n, "feature:new") ? "1" : "0");
+                 Replaceall(tm, "$owner", GetFlag(n, "feature:new") ? "1" : "0");
                  Printf(wrapper->code, "%s", tm);
                  if (Len(tm))
                    Printf(wrapper->code, "\n");
@@ -2539,11 +2539,11 @@ public:
        }
 
        if (is_void_return) {
-	 Replaceall(wrapper->code, "$null", "");
-	 Replaceall(wrapper->code, "$isvoid", "1");
+         Replaceall(wrapper->code, "$null", "");
+         Replaceall(wrapper->code, "$isvoid", "1");
        } else {
-	 Replaceall(wrapper->code, "$null", "0");
-	 Replaceall(wrapper->code, "$isvoid", "0");
+         Replaceall(wrapper->code, "$null", "0");
+         Replaceall(wrapper->code, "$isvoid", "0");
 
          Append(wrapper->code, "return result;\n");
        }
@@ -2558,15 +2558,15 @@ public:
        emit_wrapper_func_decl(n, wname);
 
        if (cxx_wrappers_.is_initialized()) {
-	 temp_ptr_setter<Node*> set(&cxx_wrappers_.node_func_, n);
+         temp_ptr_setter<Node*> set(&cxx_wrappers_.node_func_, n);
 
-	 if (cxx_class_wrapper_) {
-	   cxx_class_wrapper_->emit_member_function(n);
-	 } else {
-	   cxx_function_wrapper w(cxx_wrappers_, n, Getattr(n, "parms"));
-	   if (w.can_wrap())
-	     w.emit();
-	 }
+         if (cxx_class_wrapper_) {
+           cxx_class_wrapper_->emit_member_function(n);
+         } else {
+           cxx_function_wrapper w(cxx_wrappers_, n, Getattr(n, "parms"));
+           if (w.can_wrap())
+             w.emit();
+         }
        }
 
        Delete(name);
@@ -2579,7 +2579,7 @@ public:
   virtual int functionWrapper(Node *n) {
     if (!Getattr(n, "sym:overloaded")) {
       if (!addSymbol(Getattr(n, "sym:name"), n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     if (CPlusPlus) {
@@ -2651,16 +2651,16 @@ public:
     if (Getattr(n, "unnamedinstance")) {
       // If this is an anonymous enum, we can declare the variable as int even though we can't reference this type.
       if (Strncmp(type_str, "enum $", 6) != 0) {
-	// Otherwise we're out of luck, with the current approach of exposing the variables directly we simply can't do it, we would need to use accessor
-	// functions instead to support this.
-	Swig_error(Getfile(n), Getline(n), "Variables of anonymous non-enum types are not supported.\n");
-	return SWIG_ERROR;
+        // Otherwise we're out of luck, with the current approach of exposing the variables directly we simply can't do it, we would need to use accessor
+        // functions instead to support this.
+        Swig_error(Getfile(n), Getline(n), "Variables of anonymous non-enum types are not supported.\n");
+        return SWIG_ERROR;
       }
 
       const char * const unnamed_end = strchr(Char(type_str) + 6, '$');
       if (!unnamed_end) {
-	Swig_error(Getfile(n), Getline(n), "Unsupported anonymous enum type \"%s\".\n", type_str);
-	return SWIG_ERROR;
+        Swig_error(Getfile(n), Getline(n), "Unsupported anonymous enum type \"%s\".\n", type_str);
+        return SWIG_ERROR;
       }
 
       String* const int_type_str = NewStringf("int%s", unnamed_end + 1);
@@ -2669,24 +2669,24 @@ public:
     } else {
       scoped_dohptr btype(SwigType_base(type));
       if (SwigType_isenum(btype)) {
-	// Enums are special as they can be unknown, i.e. not wrapped by SWIG. In this case we just use int instead.
-	if (!enumLookup(btype)) {
-	  Replaceall(type_str, btype, "int");
-	}
+        // Enums are special as they can be unknown, i.e. not wrapped by SWIG. In this case we just use int instead.
+        if (!enumLookup(btype)) {
+          Replaceall(type_str, btype, "int");
+        }
       } else {
-	// Don't bother with checking if type is representable in C if we're wrapping C and not C++ anyhow: of course it is.
-	if (CPlusPlus) {
-	  if (SwigType_isreference(type))
-	    return NIL;
+        // Don't bother with checking if type is representable in C if we're wrapping C and not C++ anyhow: of course it is.
+        if (CPlusPlus) {
+          if (SwigType_isreference(type))
+            return NIL;
 
-	  if (!SwigType_isbuiltin(btype))
-	    return NIL;
+          if (!SwigType_isbuiltin(btype))
+            return NIL;
 
-	  // Final complication: define bool if it is used here.
-	  if (Cmp(btype, "bool") == 0) {
-	    Printv(sect_wrappers_types, "#include <stdbool.h>\n\n", NIL);
-	  }
-	}
+          // Final complication: define bool if it is used here.
+          if (Cmp(btype, "bool") == 0) {
+            Printv(sect_wrappers_types, "#include <stdbool.h>\n\n", NIL);
+          }
+        }
       }
     }
 
@@ -2717,23 +2717,23 @@ public:
     for ( Node* node = firstChild(n); node; node = nextSibling(node)) {
       String* const ntype = nodeType(node);
       if (Cmp(ntype, "cdecl") == 0) {
-	SwigType* t = NewString(Getattr(node, "type"));
-	SwigType_push(t, Getattr(node, "decl"));
-	t = SwigType_typedef_resolve_all(t);
-	if (SwigType_isfunction(t)) {
+        SwigType* t = NewString(Getattr(node, "type"));
+        SwigType_push(t, Getattr(node, "decl"));
+        t = SwigType_typedef_resolve_all(t);
+        if (SwigType_isfunction(t)) {
             Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number, "Extending C struct with %s is not currently supported, ignored.\n", SwigType_str(t, 0));
-	} else {
-	  String* const var_decl = make_c_var_decl(node);
-	  Printv(out, cindent, var_decl, ";\n", NIL);
-	  Delete(var_decl);
-	}
+        } else {
+          String* const var_decl = make_c_var_decl(node);
+          Printv(out, cindent, var_decl, ";\n", NIL);
+          Delete(var_decl);
+        }
       } else if (Cmp(ntype, "enum") == 0) {
-	// This goes directly into sect_wrappers_types, before this struct declaration.
-	emit_one(node);
+        // This goes directly into sect_wrappers_types, before this struct declaration.
+        emit_one(node);
       } else {
-	// WARNING: proxy declaration can be different than original code
-	if (Cmp(nodeType(node), "extend") == 0)
-	  emit_c_struct_def(out, node);
+        // WARNING: proxy declaration can be different than original code
+        if (Cmp(nodeType(node), "extend") == 0)
+          emit_c_struct_def(out, node);
       }
     }
   }
@@ -2747,7 +2747,7 @@ public:
       // Ignore this class only if it was already wrapped in another module, imported from this one (if exceptions are disabled, we shouldn't be even parsing
       // SWIG_CException in the first place and if they're enabled, we handle it normally).
       if (exceptions_support_ == exceptions_support_imported)
-	  return SWIG_NOWRAP;
+          return SWIG_NOWRAP;
     }
 
     return Language::classDeclaration(n);
@@ -2766,40 +2766,40 @@ public:
 
       // inheritance support: attach all members from base classes to this class
       if (List *baselist = Getattr(n, "bases")) {
-	Iterator i;
-	for (i = First(baselist); i.item; i = Next(i)) {
-	  // look for member variables and functions
-	  Node *node;
-	  for (node = firstChild(i.item); node; node = nextSibling(node)) {
-	    if ((Cmp(Getattr(node, "kind"), "variable") == 0)
-		|| (Cmp(Getattr(node, "kind"), "function") == 0)) {
-	      if ((Cmp(Getattr(node, "access"), "public") == 0)
-		  && (Cmp(Getattr(node, "storage"), "static") != 0)) {
-		  // Assignment operators are not inherited in C++ and symbols without sym:name should be ignored, not copied into the derived class.
-		  if (Getattr(node, "sym:name") && Cmp(Getattr(node, "name"), "operator =") != 0) {
-		    String *parent_name = Getattr(parentNode(node), "name");
-		    Hash *dupl_name_node = is_in(Getattr(node, "name"), n);
-		    // if there's a duplicate inherited name, due to the C++ multiple
-		    // inheritance, change both names to avoid ambiguity
-		    if (dupl_name_node) {
-		      String *cif = Getattr(dupl_name_node, "c:inherited_from");
-		      String *old_name = Getattr(dupl_name_node, "sym:name");
-		      if (cif && parent_name && (Cmp(cif, parent_name) != 0)) {
-			Setattr(dupl_name_node, "sym:name", NewStringf("%s%s", cif ? cif : "", old_name));
-			Setattr(dupl_name_node, "c:base_name", old_name);
-			Node *new_node = copy_node(node);
-			Setattr(new_node, "name", NewStringf("%s%s", parent_name, old_name));
-			Setattr(new_node, "c:base_name", old_name);
-			appendChild(n, new_node);
-		      }
-		    } else {
-		      appendChild(n, copy_node(node));
-		    }
-		  }
-	      }
-	    }
-	  }
-	}
+        Iterator i;
+        for (i = First(baselist); i.item; i = Next(i)) {
+          // look for member variables and functions
+          Node *node;
+          for (node = firstChild(i.item); node; node = nextSibling(node)) {
+            if ((Cmp(Getattr(node, "kind"), "variable") == 0)
+                || (Cmp(Getattr(node, "kind"), "function") == 0)) {
+              if ((Cmp(Getattr(node, "access"), "public") == 0)
+                  && (Cmp(Getattr(node, "storage"), "static") != 0)) {
+                  // Assignment operators are not inherited in C++ and symbols without sym:name should be ignored, not copied into the derived class.
+                  if (Getattr(node, "sym:name") && Cmp(Getattr(node, "name"), "operator =") != 0) {
+                    String *parent_name = Getattr(parentNode(node), "name");
+                    Hash *dupl_name_node = is_in(Getattr(node, "name"), n);
+                    // if there's a duplicate inherited name, due to the C++ multiple
+                    // inheritance, change both names to avoid ambiguity
+                    if (dupl_name_node) {
+                      String *cif = Getattr(dupl_name_node, "c:inherited_from");
+                      String *old_name = Getattr(dupl_name_node, "sym:name");
+                      if (cif && parent_name && (Cmp(cif, parent_name) != 0)) {
+                        Setattr(dupl_name_node, "sym:name", NewStringf("%s%s", cif ? cif : "", old_name));
+                        Setattr(dupl_name_node, "c:base_name", old_name);
+                        Node *new_node = copy_node(node);
+                        Setattr(new_node, "name", NewStringf("%s%s", parent_name, old_name));
+                        Setattr(new_node, "c:base_name", old_name);
+                        appendChild(n, new_node);
+                      }
+                    } else {
+                      appendChild(n, copy_node(node));
+                    }
+                  }
+              }
+            }
+          }
+        }
       }
 
       // declare type for specific class in the proxy header
@@ -2923,10 +2923,10 @@ public:
     // If we're currently generating a wrapper class, we need an extra level of indent.
     if (cxx_enum_decl) {
       if (cxx_class_wrapper_) {
-	cxx_enum_indent = cxx_class_wrapper_->get_indent();
-	Append(cxx_enum_decl, cxx_enum_indent);
+        cxx_enum_indent = cxx_class_wrapper_->get_indent();
+        Append(cxx_enum_decl, cxx_enum_indent);
       } else {
-	cxx_enum_indent = "";
+        cxx_enum_indent = "";
       }
     }
 
@@ -2937,7 +2937,7 @@ public:
     if (is_typedef) {
       Printv(enum_decl, "typedef ", NIL);
       if (cxx_enum_decl)
-	Printv(cxx_enum_decl, "typedef ", NIL);
+        Printv(cxx_enum_decl, "typedef ", NIL);
     }
     Printv(enum_decl, "enum", NIL);
     if (cxx_enum_decl)
@@ -2961,36 +2961,36 @@ public:
       // If it's a typedef, its sym:name is the typedef name, but we don't want to use it here (we already use it for the typedef we generate), so use the
       // actual C++ name instead.
       if (is_typedef) {
-	// But the name may include the containing class, so get rid of it.
-	enumname = Swig_scopename_last(Getattr(n, "name"));
+        // But the name may include the containing class, so get rid of it.
+        enumname = Swig_scopename_last(Getattr(n, "name"));
       } else {
-	enumname = Copy(name);
+        enumname = Copy(name);
       }
 
       const bool scoped_enum = Checkattr(n, "scopedenum", "1");
 
       if (cxx_enum_decl) {
-	// In C++ we can use actual scoped enums instead of emulating them with element prefixes.
-	if (scoped_enum)
-	  Printv(cxx_enum_decl, " class", NIL);
+        // In C++ we can use actual scoped enums instead of emulating them with element prefixes.
+        if (scoped_enum)
+          Printv(cxx_enum_decl, " class", NIL);
 
-	// And enum name itself shouldn't include the prefix neither, as this enum is either inside a namespace or inside a class, so use enumname before it
-	// gets updated below.
-	Printv(cxx_enum_decl, " ", enumname.get(), NIL);
+        // And enum name itself shouldn't include the prefix neither, as this enum is either inside a namespace or inside a class, so use enumname before it
+        // gets updated below.
+        Printv(cxx_enum_decl, " ", enumname.get(), NIL);
       }
 
       if (enum_prefix) {
-	enumname = NewStringf("%s_%s", enum_prefix, enumname.get());
+        enumname = NewStringf("%s_%s", enum_prefix, enumname.get());
       }
 
       Printv(enum_decl, " ", enumname.get(), NIL);
       if (cxx_enum_decl)
-	Printv(cxx_enum_decl, " ", cxx_enumname.get(), NIL);
+        Printv(cxx_enum_decl, " ", cxx_enumname.get(), NIL);
 
       // For scoped enums, their name should be prefixed to their elements in addition to any other prefix we use.
       if (scoped_enum) {
-	enum_prefix = enumname.get();
-	cxx_enum_prefix = cxx_enumname.get();
+        enum_prefix = enumname.get();
+        cxx_enum_prefix = cxx_enumname.get();
       }
     }
 
@@ -3010,22 +3010,22 @@ public:
     if (Len(enum_decl) > len_orig) {
       Printv(enum_decl, "\n}", NIL);
       if (cxx_enum_decl)
-	Printv(cxx_enum_decl, "\n", cxx_enum_indent, "}", NIL);
+        Printv(cxx_enum_decl, "\n", cxx_enum_indent, "}", NIL);
 
       if (is_typedef) {
-	Printv(enum_decl, " ", enum_prefix_.get(), symname, NIL);
-	if (cxx_enum_decl)
-	  Printv(cxx_enum_decl, " ", symname, NIL);
+        Printv(enum_decl, " ", enum_prefix_.get(), symname, NIL);
+        if (cxx_enum_decl)
+          Printv(cxx_enum_decl, " ", symname, NIL);
       }
       Printv(enum_decl, ";\n\n", NIL);
       if (cxx_enum_decl)
-	Printv(cxx_enum_decl, ";\n\n", NIL);
+        Printv(cxx_enum_decl, ";\n\n", NIL);
 
       Append(sect_wrappers_types, enum_decl);
       if (cxx_enum_decl) {
-	// Enums declared in global scopes can be just defined before everything else, but nested enums have to be defined inside the declaration of the class,
-	// which we must be in process of creating, so output them in the appropriate section.
-	Append(cxx_class_wrapper_ ? cxx_wrappers_.sect_decls : cxx_wrappers_.sect_types, cxx_enum_decl);
+        // Enums declared in global scopes can be just defined before everything else, but nested enums have to be defined inside the declaration of the class,
+        // which we must be in process of creating, so output them in the appropriate section.
+        Append(cxx_class_wrapper_ ? cxx_wrappers_.sect_decls : cxx_wrappers_.sect_types, cxx_enum_decl);
       }
     }
 
@@ -3048,7 +3048,7 @@ public:
     if (!GetFlag(n, "firstenumitem")) {
       Printv(enum_decl, ",\n", NIL);
       if (cxx_enum_decl)
-	Printv(cxx_enum_decl, ",\n", NIL);
+        Printv(cxx_enum_decl, ",\n", NIL);
     }
 
     String* const symname = Getattr(n, "sym:name");
@@ -3063,25 +3063,25 @@ public:
       // We can't always use the raw value, check its type to see if we need to transform it.
       maybe_owned_dohptr cvalue;
       switch (SwigType_type(Getattr(n, "type"))) {
-	case T_BOOL:
-	  // Boolean constants can't appear in C code, so replace them with their values in the simplest possible case. This is not exhaustive, of course,
-	  // but better than nothing and doing the right thing is not simple at all as we'd need to really parse the expression, just textual substitution wouldn't
-	  // be enough (consider e.g. an enum element called "very_true" and another one using it as its value).
-	  if (Cmp(value, "true") == 0) {
-	    cvalue.assign_owned(NewString("1"));
-	  } else if (Cmp(value, "false") == 0) {
-	    cvalue.assign_owned(NewString("0"));
-	  } else {
-	    Swig_error(Getfile(n), Getline(n), "Unsupported boolean enum value \"%s\".\n", value);
-	  }
-	  break;
-	default:
-	  cvalue.assign_non_owned(value);
+        case T_BOOL:
+          // Boolean constants can't appear in C code, so replace them with their values in the simplest possible case. This is not exhaustive, of course,
+          // but better than nothing and doing the right thing is not simple at all as we'd need to really parse the expression, just textual substitution wouldn't
+          // be enough (consider e.g. an enum element called "very_true" and another one using it as its value).
+          if (Cmp(value, "true") == 0) {
+            cvalue.assign_owned(NewString("1"));
+          } else if (Cmp(value, "false") == 0) {
+            cvalue.assign_owned(NewString("0"));
+          } else {
+            Swig_error(Getfile(n), Getline(n), "Unsupported boolean enum value \"%s\".\n", value);
+          }
+          break;
+        default:
+          cvalue.assign_non_owned(value);
       }
 
       Printv(enum_decl, " = ", cvalue.get(), NIL);
       if (cxx_enum_decl)
-	Printv(cxx_enum_decl, " = ", cvalue.get(), NIL);
+        Printv(cxx_enum_decl, " = ", cvalue.get(), NIL);
     }
 
     Swig_restore(n);

--- a/Source/Modules/c.cxx
+++ b/Source/Modules/c.cxx
@@ -11,11 +11,11 @@
 #include "swigmod.h"
 
 extern "C" {
-  extern int UseWrapperSuffix;
+extern int UseWrapperSuffix;
 }
 
 int SwigType_isbuiltin(SwigType *t) {
-  const char* builtins[] = { "void", "short", "int", "long", "char", "float", "double", "bool", 0 };
+  const char *builtins[] = {"void", "short", "int", "long", "char", "float", "double", "bool", 0};
   int i = 0;
   char *c = Char(t);
   if (!t)
@@ -28,83 +28,89 @@ int SwigType_isbuiltin(SwigType *t) {
   return 0;
 }
 
-
 // Private helpers, could be made public and reused from other language modules in the future.
-namespace
-{
+namespace {
 
 enum exceptions_support {
-  exceptions_support_enabled,  // Default value in C++ mode.
-  exceptions_support_disabled, // Not needed at all.
-  exceptions_support_imported  // Needed, but already defined in an imported module.
+  exceptions_support_enabled,   // Default value in C++ mode.
+  exceptions_support_disabled,  // Not needed at all.
+  exceptions_support_imported   // Needed, but already defined in an imported module.
 };
 
 // When using scoped_dohptr, it's very simple to accidentally pass it to a vararg function, such as Printv() or Printf(), resulting in catastrophic results
 // during run-time (crash or, worse, junk in the generated output), so make sure gcc warning about this, which is not enabled by default for some reason (see
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64867 for more information), is enabled.
 #if defined(__GNUC__) && !defined(__clang__)
-  #pragma GCC diagnostic error "-Wconditionally-supported"
-#endif // __GNUC__
+#pragma GCC diagnostic error "-Wconditionally-supported"
+#endif  // __GNUC__
 
 // Delete a DOH object on scope exit.
-class scoped_dohptr
-{
+class scoped_dohptr {
 public:
-  scoped_dohptr() : obj_(NULL) {}
-  explicit scoped_dohptr(DOH* obj) : obj_(obj) {}
-  ~scoped_dohptr() { Delete(obj_); }
+  scoped_dohptr() : obj_(NULL) {
+  }
+  explicit scoped_dohptr(DOH *obj) : obj_(obj) {
+  }
+  ~scoped_dohptr() {
+    Delete(obj_);
+  }
 
   // This is an std::auto_ptr<>-like "destructive" copy ctor which allows to return objects of this type from functions.
-  scoped_dohptr(scoped_dohptr const& other) : obj_(other.release()) {}
+  scoped_dohptr(scoped_dohptr const &other) : obj_(other.release()) {
+  }
 
   // Same for the assignment operator.
-  scoped_dohptr& operator=(scoped_dohptr const& other) {
+  scoped_dohptr &operator=(scoped_dohptr const &other) {
     reset(other.release());
 
     return *this;
   }
 
   // Assignment operator takes ownership of the pointer, just as the ctor does.
-  scoped_dohptr& operator=(DOH* obj) {
+  scoped_dohptr &operator=(DOH *obj) {
     reset(obj);
 
     return *this;
   }
 
-  DOH* get() const { return obj_; }
+  DOH *get() const {
+    return obj_;
+  }
 
-  DOH* release() const /* not really */ {
-    DOH* obj = obj_;
-    const_cast<DOH*&>(const_cast<scoped_dohptr*>(this)->obj_) = NULL;
+  DOH *release() const /* not really */ {
+    DOH *obj = obj_;
+    const_cast<DOH *&>(const_cast<scoped_dohptr *>(this)->obj_) = NULL;
     return obj;
   }
 
-  void reset(DOH* obj = NULL) {
+  void reset(DOH *obj = NULL) {
     if (obj != obj_) {
       Delete(obj_);
       obj_ = obj;
     }
   }
 
-  operator DOH*() const { return obj_; }
+  operator DOH *() const {
+    return obj_;
+  }
 
 protected:
-  DOH* obj_;
+  DOH *obj_;
 };
 
 // Wrapper for a DOH object which can be owned or not.
-class maybe_owned_dohptr : public scoped_dohptr
-{
+class maybe_owned_dohptr : public scoped_dohptr {
 public:
-  explicit maybe_owned_dohptr(DOH* obj = NULL) : scoped_dohptr(obj), owned_(true) {}
+  explicit maybe_owned_dohptr(DOH *obj = NULL) : scoped_dohptr(obj), owned_(true) {
+  }
 
-  maybe_owned_dohptr(maybe_owned_dohptr const& other) : scoped_dohptr(other) {
+  maybe_owned_dohptr(maybe_owned_dohptr const &other) : scoped_dohptr(other) {
     owned_ = other.owned_;
 
     // We can live other.owned_ unchanged, as its pointer is null now anyhow.
   }
 
-  maybe_owned_dohptr& operator=(maybe_owned_dohptr const& other) {
+  maybe_owned_dohptr &operator=(maybe_owned_dohptr const &other) {
     reset(other.release());
     owned_ = other.owned_;
 
@@ -113,14 +119,14 @@ public:
 
   ~maybe_owned_dohptr() {
     if (!owned_)
-      obj_ = NULL; // Prevent it from being deleted by the base class dtor.
+      obj_ = NULL;  // Prevent it from being deleted by the base class dtor.
   }
 
-  void assign_owned(DOH* obj) {
+  void assign_owned(DOH *obj) {
     reset(obj);
   }
 
-  void assign_non_owned(DOH* obj) {
+  void assign_non_owned(DOH *obj) {
     reset(obj);
     owned_ = false;
   }
@@ -129,16 +135,14 @@ private:
   bool owned_;
 };
 
-
 // Helper class setting the given pointer to the given value in its ctor and resetting it in the dtor.
 //
 // Used to non-intrusively set a pointer to some object only during this object life-time.
 template <typename T>
-class temp_ptr_setter
-{
+class temp_ptr_setter {
 public:
   // Pointer must be non-null, its current value is restored when this object is destroyed.
-  temp_ptr_setter(T* ptr, T value) : ptr_(ptr), value_orig_(*ptr) {
+  temp_ptr_setter(T *ptr, T value) : ptr_(ptr), value_orig_(*ptr) {
     *ptr_ = value;
   }
 
@@ -147,66 +151,56 @@ public:
   }
 
 private:
-  T* const ptr_;
+  T *const ptr_;
   T const value_orig_;
 
   // Non copyable.
-  temp_ptr_setter(const temp_ptr_setter&);
-  temp_ptr_setter& operator=(const temp_ptr_setter&);
+  temp_ptr_setter(const temp_ptr_setter &);
+  temp_ptr_setter &operator=(const temp_ptr_setter &);
 };
 
-
 // Helper class to output "begin" fragment in the ctor and "end" in the dtor.
-class begin_end_output_guard
-{
+class begin_end_output_guard {
 public:
-  begin_end_output_guard(File* f, const_String_or_char_ptr begin, const_String_or_char_ptr end)
-    : f_(f),
-      end_(NewString(end))
-  {
-    String* const s = NewString(begin);
+  begin_end_output_guard(File *f, const_String_or_char_ptr begin, const_String_or_char_ptr end) : f_(f), end_(NewString(end)) {
+    String *const s = NewString(begin);
     Dump(s, f_);
     Delete(s);
   }
 
-  ~begin_end_output_guard()
-  {
+  ~begin_end_output_guard() {
     Dump(end_, f_);
     Delete(end_);
   }
 
 private:
   // Non copyable.
-  begin_end_output_guard(const begin_end_output_guard&);
-  begin_end_output_guard& operator=(const begin_end_output_guard&);
+  begin_end_output_guard(const begin_end_output_guard &);
+  begin_end_output_guard &operator=(const begin_end_output_guard &);
 
-  File* const f_;
-  String* const end_;
+  File *const f_;
+  String *const end_;
 };
 
 // Subclass to output extern "C" guards when compiling as C++.
-class cplusplus_output_guard : private begin_end_output_guard
-{
+class cplusplus_output_guard : private begin_end_output_guard {
 public:
-  explicit cplusplus_output_guard(File* f)
-    : begin_end_output_guard(
-        f,
-        "#ifdef __cplusplus\n"
-        "extern \"C\" {\n"
-        "#endif\n\n",
-        "#ifdef __cplusplus\n"
-        "}\n"
-        "#endif\n\n"
-      )
-  {
+  explicit cplusplus_output_guard(File *f) :
+    begin_end_output_guard(f,
+                           "#ifdef __cplusplus\n"
+                           "extern \"C\" {\n"
+                           "#endif\n\n",
+                           "#ifdef __cplusplus\n"
+                           "}\n"
+                           "#endif\n\n") {
   }
 };
 
 // String containing one indentation level for the generated code.
-const char* const cindent = "  ";
+const char *const cindent = "  ";
 
 // Returns the non-owned string to the name of the class or enum to use in C wrappers.
-String* get_c_proxy_name(Node* n) {
+String *get_c_proxy_name(Node *n) {
   String *proxyname = Getattr(n, "proxyname");
   if (!proxyname) {
     String *symname = Getattr(n, "sym:name");
@@ -214,28 +208,28 @@ String* get_c_proxy_name(Node* n) {
 
     if (nspace) {
       scoped_dohptr nspace_mangled(Swig_name_mangle_string(nspace));
-      proxyname = NewStringf("%s_%s", (DOH*)nspace_mangled, symname);
+      proxyname = NewStringf("%s_%s", (DOH *)nspace_mangled, symname);
     } else {
       proxyname = Swig_name_type(symname);
     }
     Setattr(n, "proxyname", proxyname);
 
-    Delete(proxyname); // It stays alive because it's referenced by the hash.
+    Delete(proxyname);  // It stays alive because it's referenced by the hash.
   }
 
   return proxyname;
 }
 
 // Returns the first named "import" node under the given one (which must be non-NULL). May return NULL.
-Node* find_first_named_import(Node* parent) {
-  for (Node* n = firstChild(parent); n; n = nextSibling(n)) {
+Node *find_first_named_import(Node *parent) {
+  for (Node *n = firstChild(parent); n; n = nextSibling(n)) {
     if (Cmp(nodeType(n), "import") == 0) {
       // We've almost succeeded, but there are sometimes some weird unnamed import modules that don't really count for our purposes, so skip them.
       if (Getattr(n, "module"))
         return n;
     } else if (Cmp(nodeType(n), "include") == 0) {
       // Recurse into this node as included files may contain imports too.
-      if (Node* const import = find_first_named_import(n))
+      if (Node *const import = find_first_named_import(n))
         return import;
     } else {
       // We consider that import nodes can only occur in the global scope, some don't bother recursing here. If this turns out to be false, we'd just need to
@@ -246,15 +240,14 @@ Node* find_first_named_import(Node* parent) {
   return NULL;
 }
 
-
 /*
   Information about the function return type.
  */
-class cxx_rtype_desc
-{
+class cxx_rtype_desc {
 public:
   // Default ctor creates a "void" return type.
-  cxx_rtype_desc() {}
+  cxx_rtype_desc() {
+  }
 
   // If this returns true, get_return_code() can't be called.
   bool is_void() const {
@@ -262,14 +255,14 @@ public:
   }
 
   // This function must be called before calling get_return_code().
-  void set_type(String* type) {
+  void set_type(String *type) {
     type_ = Copy(type);
   }
 
   // This function must also be called before calling get_return_code().
   //
   // NB: It takes ownership of the string, the intended use is to pass it NewStringf(...).
-  void set_return_value(String* new_string) {
+  void set_return_value(String *new_string) {
     value_ = new_string;
   }
 
@@ -281,12 +274,12 @@ public:
   // If the string doesn't start with "$result = ", it is prepended to it implicitly, for convenience.
   //
   // NB: It takes ownership of the string, which is typically returned from Swig_typemap_lookup().
-  void apply_out_typemap(String* new_out_tm_string) {
+  void apply_out_typemap(String *new_out_tm_string) {
     out_tm_ = new_out_tm_string;
   }
 
   // Return the function return type: can always be called, even for void functions (for which it just returns "void").
-  String* type() const {
+  String *type() const {
     return type_ ? type_ : get_void_type();
   }
 
@@ -309,11 +302,10 @@ public:
     // We need to start by introducing a temporary variable for the C call result because if $cresult is used twice by the typemap, we don't want to call the
     // function twice. Note that just "auto" is enough because C functions can't return references, but we need "auto&&" for C++ result which can be anything
     // (defined by the user in their typemaps).
-    scoped_dohptr code(NewStringf(
-        "\n"
-        "%sauto swig_cres = %s;\n",
-        cindent, value_.get()
-      ));
+    scoped_dohptr code(NewStringf("\n"
+                                  "%sauto swig_cres = %s;\n",
+                                  cindent,
+                                  value_.get()));
 
     // We support 2 cases: either typemap is a statement, or multiple statements, containing assignment to $result, in which case this assignment must occur at
     // its beginning.
@@ -327,7 +319,7 @@ public:
     }
 
     // Skip leading whitespace and chop the trailing whitespace from the typemap to keep indentation consistent.
-    const char* tm = Char(out_tm_);
+    const char *tm = Char(out_tm_);
     while (isspace(*tm))
       ++tm;
     Append(code, tm);
@@ -349,8 +341,8 @@ public:
   }
 
 private:
-  static String* get_void_type() {
-    static String* const void_type = NewString("void");
+  static String *get_void_type() {
+    static String *const void_type = NewString("void");
     return void_type;
   }
 
@@ -364,25 +356,29 @@ private:
 
   This is similar to cxx_rtype_desc, but is used for the parameters and not the return type.
  */
-class cxx_ptype_desc
-{
+class cxx_ptype_desc {
 public:
   // Ctor initializes the object to an empty/unknown state, call set_type() later to finish initialization.
-  cxx_ptype_desc() {}
+  cxx_ptype_desc() {
+  }
 
   // This function must be called (with a non-null string) before calling get_param_code().
-  void set_type(String* type) { type_ = Copy(type); }
+  void set_type(String *type) {
+    type_ = Copy(type);
+  }
 
   // If this one returns NULL, it means that we don't have any type information at all.
-  String* type() const { return type_; }
+  String *type() const {
+    return type_;
+  }
 
   // This may be called before calling get_param_code() if a translation from C++ to C type is necessary. By default the parameter is passed "as is".
-  void apply_in_typemap(String* new_in_tm_string) {
+  void apply_in_typemap(String *new_in_tm_string) {
     in_tm_ = new_in_tm_string;
   }
 
   // Return the full expression needed to pass the given value as parameter to C wrapper function.
-  scoped_dohptr get_param_code(String* value) const {
+  scoped_dohptr get_param_code(String *value) const {
     assert(type_);
 
     if (!in_tm_) {
@@ -400,12 +396,10 @@ private:
   scoped_dohptr in_tm_;
 };
 
-
 /*
   Struct containing information needed only for generating C++ wrappers.
 */
-struct cxx_wrappers
-{
+struct cxx_wrappers {
   // Default ctor doesn't do anything, use initialize() if C++ wrappers really need to be generated.
   cxx_wrappers() :
     except_check_start(NULL),
@@ -434,52 +428,55 @@ struct cxx_wrappers
   // initialize the object of this class in C::main(), so this one is called later from C::top().
   void initialize_exceptions(exceptions_support support) {
     switch (support) {
-      case exceptions_support_enabled:
-      case exceptions_support_imported:
-        except_check_start = "swig_check(";
-        except_check_end = ")";
-        break;
+    case exceptions_support_enabled:
+    case exceptions_support_imported:
+      except_check_start = "swig_check(";
+      except_check_end = ")";
+      break;
 
-      case exceptions_support_disabled:
-        except_check_start =
-        except_check_end = "";
-        break;
+    case exceptions_support_disabled:
+      except_check_start = except_check_end = "";
+      break;
     }
   }
 
-  bool is_initialized() const { return sect_types != NULL; }
+  bool is_initialized() const {
+    return sect_types != NULL;
+  }
 
-  bool is_exception_support_enabled() const { return *except_check_start != '\0'; }
-
+  bool is_exception_support_enabled() const {
+    return *except_check_start != '\0';
+  }
 
   // All the functions below are only used when is_initialized() returns true.
 
   // Fill the provided rtype_desc with the type information for the given function node.
   //
   // Returns false in case of error, i.e. if function wrapper can't be generated at all.
-  bool lookup_cxx_ret_type(cxx_rtype_desc& rtype_desc, Node* n) {
-    String* const func_type = Getattr(n, "type");
+  bool lookup_cxx_ret_type(cxx_rtype_desc &rtype_desc, Node *n) {
+    String *const func_type = Getattr(n, "type");
     if (SwigType_type(func_type) == T_VOID) {
       // Nothing to do, rtype_desc is void by default.
       return true;
     }
 
     // As above, ensure our replaceSpecialVariables() is used.
-    temp_ptr_setter<cxx_rtype_desc*> set(&rtype_desc_, &rtype_desc);
+    temp_ptr_setter<cxx_rtype_desc *> set(&rtype_desc_, &rtype_desc);
 
     bool use_cxxout = true;
-    String* type(Swig_typemap_lookup("cxxouttype", n, "", NULL));
+    String *type(Swig_typemap_lookup("cxxouttype", n, "", NULL));
     if (!type) {
       use_cxxout = false;
       type = Swig_typemap_lookup("ctype", n, "", NULL);
     }
 
     if (!type) {
-        Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, Getfile(n), Getline(n),
-          "No ctype typemap defined for the return type \"%s\" of %s\n",
-          SwigType_str(func_type, NULL),
-          Getattr(n, "sym:name")
-        );
+      Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF,
+                   Getfile(n),
+                   Getline(n),
+                   "No ctype typemap defined for the return type \"%s\" of %s\n",
+                   SwigType_str(func_type, NULL),
+                   Getattr(n, "sym:name"));
       return false;
     }
 
@@ -487,7 +484,7 @@ struct cxx_wrappers
       return false;
 
     if (use_cxxout) {
-      if (String* out_tm = Swig_typemap_lookup("cxxout", n, "", NULL))
+      if (String *out_tm = Swig_typemap_lookup("cxxout", n, "", NULL))
         rtype_desc.apply_out_typemap(out_tm);
     }
 
@@ -495,23 +492,24 @@ struct cxx_wrappers
   }
 
   // Return the type description for the given parameter of the function.
-  bool lookup_cxx_parm_type(cxx_ptype_desc& ptype_desc, Node* n, Parm* p) {
+  bool lookup_cxx_parm_type(cxx_ptype_desc &ptype_desc, Node *n, Parm *p) {
     // Ensure our own replaceSpecialVariables() is used for $typemap() expansion.
-    temp_ptr_setter<cxx_ptype_desc*> set(&ptype_desc_, &ptype_desc);
+    temp_ptr_setter<cxx_ptype_desc *> set(&ptype_desc_, &ptype_desc);
 
     bool use_cxxin = true;
-    String* type = Swig_typemap_lookup("cxxintype", p, "", NULL);
+    String *type = Swig_typemap_lookup("cxxintype", p, "", NULL);
     if (!type) {
       use_cxxin = false;
       type = Swig_typemap_lookup("ctype", p, "", NULL);
     }
 
     if (!type) {
-      Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, Getfile(p), Getline(p),
-        "No ctype typemap defined for the parameter \"%s\" of %s\n",
-        Getattr(p, "name"),
-        Getattr(n, "sym:name")
-      );
+      Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF,
+                   Getfile(p),
+                   Getline(p),
+                   "No ctype typemap defined for the parameter \"%s\" of %s\n",
+                   Getattr(p, "name"),
+                   Getattr(n, "sym:name"));
       return false;
     }
 
@@ -519,13 +517,12 @@ struct cxx_wrappers
       return false;
 
     if (use_cxxin) {
-      if (String* in_tm = Getattr(p, "tmap:cxxin"))
+      if (String *in_tm = Getattr(p, "tmap:cxxin"))
         ptype_desc.apply_in_typemap(Copy(in_tm));
     }
 
     return true;
   }
-
 
   // This function is called from C::replaceSpecialVariables() but only does something non-trivial when it's called by our own lookup_cxx_xxx_type() functions.
   bool replaceSpecialVariables(String *method, String *tm, Parm *parm) {
@@ -550,28 +547,24 @@ struct cxx_wrappers
     return true;
   }
 
-
-
   // Used for generating exception checks around the calls, see initialize_exceptions().
-  const char* except_check_start;
-  const char* except_check_end;
-
+  const char *except_check_start;
+  const char *except_check_end;
 
   // The order of the members here is the same as the order in which they appear in the output file.
 
   // This section doesn't contain anything by default but can be used by typemaps etc. It is the only section outside of the namespace in which all the other
   // declaration live.
-  String* sect_cxx_h;
+  String *sect_cxx_h;
 
   // This section contains forward declarations of the classes.
-  String* sect_types;
+  String *sect_types;
 
   // Full declarations of the classes.
-  String* sect_decls;
+  String *sect_decls;
 
   // Implementation of the classes.
-  String* sect_impls;
-
+  String *sect_impls;
 
 private:
   // Replace "resolved_type" occurrences in the string with the value corresponding to the given type.
@@ -581,18 +574,11 @@ private:
   //
   // Also fills in the start/end wrapper parts of the provided type descriptions if they're not null, with the casts needed to translate from C type to C++ type
   // (this is used for the parameters of C++ functions, hence the name) and from C types to C++ types (which is used for the function return values).
-  static bool do_resolve_type(Node* n, String* type, String* s, cxx_ptype_desc* ptype_desc, cxx_rtype_desc* rtype_desc) {
-    enum TypeKind
-    {
-      Type_Ptr,
-      Type_Ref,
-      Type_Obj,
-      Type_Enm,
-      Type_Max
-    } typeKind = Type_Max;
+  static bool do_resolve_type(Node *n, String *type, String *s, cxx_ptype_desc *ptype_desc, cxx_rtype_desc *rtype_desc) {
+    enum TypeKind { Type_Ptr, Type_Ref, Type_Obj, Type_Enm, Type_Max } typeKind = Type_Max;
 
     // These correspond to the typemaps for SWIGTYPE*, SWIGTYPE&, SWIGTYPE and enum SWIGTYPE, respectively, defined in c.swg.
-    static const char* typemaps[Type_Max] = {
+    static const char *typemaps[Type_Max] = {
       "$resolved_type*",
       "$*resolved_type*",
       "$&resolved_type*",
@@ -608,10 +594,7 @@ private:
 
     if (typeKind == Type_Max) {
       if (Strstr(s, "resolved_type")) {
-        Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number,
-          "Unsupported typemap \"%s\" used for type \"%s\" of \"%s\"\n",
-          s, type, Getattr(n, "name")
-        );
+        Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number, "Unsupported typemap \"%s\" used for type \"%s\" of \"%s\"\n", s, type, Getattr(n, "name"));
 
         return false;
       }
@@ -636,16 +619,16 @@ private:
 
     scoped_dohptr typestr;
     if (SwigType_isenum(base_resolved_type)) {
-      String* enumname = NULL;
-      if (Node* const enum_node = Language::instance()->enumLookup(base_resolved_type)) {
+      String *enumname = NULL;
+      if (Node *const enum_node = Language::instance()->enumLookup(base_resolved_type)) {
         // This is the name of the enum in C wrappers, it should be already set by getEnumName().
         enumname = Getattr(enum_node, "enumname");
 
         if (enumname) {
-          String* const enum_symname = Getattr(enum_node, "sym:name");
+          String *const enum_symname = Getattr(enum_node, "sym:name");
 
           if (Checkattr(enum_node, "ismember", "1")) {
-            Node* const parent_class = parentNode(enum_node);
+            Node *const parent_class = parentNode(enum_node);
             typestr = NewStringf("%s::%s", Getattr(parent_class, "sym:name"), enum_symname);
           } else {
             typestr = Copy(enum_symname);
@@ -665,40 +648,40 @@ private:
 
       if (enumname) {
         switch (typeKind) {
-          case Type_Ptr:
-            if (rtype_desc) {
-              rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
-            }
+        case Type_Ptr:
+          if (rtype_desc) {
+            rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
+          }
 
-            if (ptype_desc) {
-              ptype_desc->apply_in_typemap(NewStringf("(%s*)$1", enumname));
-            }
-            break;
+          if (ptype_desc) {
+            ptype_desc->apply_in_typemap(NewStringf("(%s*)$1", enumname));
+          }
+          break;
 
-          case Type_Ref:
-            if (rtype_desc) {
-              rtype_desc->apply_out_typemap(NewStringf("(%s)(*($cresult))", typestr.get()));
-            }
+        case Type_Ref:
+          if (rtype_desc) {
+            rtype_desc->apply_out_typemap(NewStringf("(%s)(*($cresult))", typestr.get()));
+          }
 
-            if (ptype_desc) {
-              ptype_desc->apply_in_typemap(NewStringf("(%s*)&($1)", enumname));
-            }
-            break;
+          if (ptype_desc) {
+            ptype_desc->apply_in_typemap(NewStringf("(%s*)&($1)", enumname));
+          }
+          break;
 
-          case Type_Enm:
-            if (rtype_desc) {
-              rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
-            }
+        case Type_Enm:
+          if (rtype_desc) {
+            rtype_desc->apply_out_typemap(NewStringf("(%s)$cresult", typestr.get()));
+          }
 
-            if (ptype_desc) {
-              ptype_desc->apply_in_typemap(NewStringf("(%s)$1", enumname));
-            }
-            break;
+          if (ptype_desc) {
+            ptype_desc->apply_in_typemap(NewStringf("(%s)$1", enumname));
+          }
+          break;
 
-          case Type_Obj:
-          case Type_Max:
-            // Unreachable, but keep here to avoid -Wswitch warnings.
-            assert(0);
+        case Type_Obj:
+        case Type_Max:
+          // Unreachable, but keep here to avoid -Wswitch warnings.
+          assert(0);
         }
       } else {
         // This is the only thing we need to do even when we don't have the enum name.
@@ -706,31 +689,31 @@ private:
           ptype_desc->apply_in_typemap(NewString("&($1)"));
       }
     } else {
-      String* classname;
-      if (Node* const class_node = Language::instance()->classLookup(type)) {
+      String *classname;
+      if (Node *const class_node = Language::instance()->classLookup(type)) {
         // Deal with some special cases:
         switch (typeKind) {
-          case Type_Ptr:
-            // If this is a pointer passed by const reference, we return just the pointer directly because we don't have any pointer-valued variable to give out
-            // a reference to.
-            if (strncmp(Char(resolved_type), "r.q(const).", 11) == 0) {
-              scoped_dohptr deref_type(Copy(resolved_type));
-              Delslice(deref_type, 0, 11);
-              typestr = SwigType_str(deref_type, 0);
-            }
-            break;
+        case Type_Ptr:
+          // If this is a pointer passed by const reference, we return just the pointer directly because we don't have any pointer-valued variable to give out
+          // a reference to.
+          if (strncmp(Char(resolved_type), "r.q(const).", 11) == 0) {
+            scoped_dohptr deref_type(Copy(resolved_type));
+            Delslice(deref_type, 0, 11);
+            typestr = SwigType_str(deref_type, 0);
+          }
+          break;
 
-          case Type_Obj:
-            // Const objects are just objects for our purposes here, remove the const from them to avoid having "const const" in the output.
-            if (SwigType_isconst(resolved_type))
-              SwigType_del_qualifier(resolved_type);
-            break;
+        case Type_Obj:
+          // Const objects are just objects for our purposes here, remove the const from them to avoid having "const const" in the output.
+          if (SwigType_isconst(resolved_type))
+            SwigType_del_qualifier(resolved_type);
+          break;
 
-          case Type_Ref:
-          case Type_Enm:
-          case Type_Max:
-            // Nothing special to do.
-            break;
+        case Type_Ref:
+        case Type_Enm:
+        case Type_Max:
+          // Nothing special to do.
+          break;
         }
 
         if (!typestr)
@@ -750,71 +733,67 @@ private:
       }
 
       if (!classname) {
-        Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number,
-          "Unsupported C++ wrapper function %s type \"%s\"\n",
-          ptype_desc ? "parameter" : "return", SwigType_str(type, 0)
-        );
+        Swig_warning(WARN_C_UNSUPPORTTED,
+                     input_file,
+                     line_number,
+                     "Unsupported C++ wrapper function %s type \"%s\"\n",
+                     ptype_desc ? "parameter" : "return",
+                     SwigType_str(type, 0));
         return false;
       }
 
-      const char* const owns = GetFlag(n, "feature:new") ? "true" : "false";
+      const char *const owns = GetFlag(n, "feature:new") ? "true" : "false";
       switch (typeKind) {
-        case Type_Ptr:
-          if (ptype_desc) {
-            ptype_desc->apply_in_typemap(NewString("$1->swig_self()"));
-          }
+      case Type_Ptr:
+        if (ptype_desc) {
+          ptype_desc->apply_in_typemap(NewString("$1->swig_self()"));
+        }
 
-          if (rtype_desc) {
-            rtype_desc->apply_out_typemap(NewStringf(
-                "$cresult ? new %s($cresult, %s) : nullptr;",
-                classname, owns
-              ));
-          }
-          break;
+        if (rtype_desc) {
+          rtype_desc->apply_out_typemap(NewStringf("$cresult ? new %s($cresult, %s) : nullptr;", classname, owns));
+        }
+        break;
 
-        case Type_Ref:
-          if (rtype_desc) {
-            // We can't return a reference, as this requires an existing object and we don't have any, so we have to return an object instead, and this object
-            // must be constructed using the special ctor not taking the pointer ownership.
-            typestr = Copy(classname);
+      case Type_Ref:
+        if (rtype_desc) {
+          // We can't return a reference, as this requires an existing object and we don't have any, so we have to return an object instead, and this object
+          // must be constructed using the special ctor not taking the pointer ownership.
+          typestr = Copy(classname);
 
-            rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, false}", classname));
-          }
+          rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, false}", classname));
+        }
 
-          if (ptype_desc) {
-            ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
-          }
-          break;
+        if (ptype_desc) {
+          ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
+        }
+        break;
 
-        case Type_Obj:
-          if (rtype_desc) {
-            // The pointer returned by C function wrapping a function returning an object should never be null unless an exception happened, so we don't test
-            // for it here, unlike in Type_Ptr case.
-            //
-            // Also, normally all returned objects should be owned by their wrappers, but there is a special case of objects not being returned by value: this
-            // seems not to make sense, but can actually happen when typemaps map references or pointers to objects, like they do for e.g. shared_ptr<>.
-            //
-            // Note that we must use the type of the function, retrieved from its node, here and not the type passed to us which is the result of typemap
-            // expansion and so may not be a reference any more.
-            rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, %s}",
-                typestr.get(),
-                SwigType_isreference(Getattr(n, "type")) ? owns : "true"
-              ));
-          }
+      case Type_Obj:
+        if (rtype_desc) {
+          // The pointer returned by C function wrapping a function returning an object should never be null unless an exception happened, so we don't test
+          // for it here, unlike in Type_Ptr case.
+          //
+          // Also, normally all returned objects should be owned by their wrappers, but there is a special case of objects not being returned by value: this
+          // seems not to make sense, but can actually happen when typemaps map references or pointers to objects, like they do for e.g. shared_ptr<>.
+          //
+          // Note that we must use the type of the function, retrieved from its node, here and not the type passed to us which is the result of typemap
+          // expansion and so may not be a reference any more.
+          rtype_desc->apply_out_typemap(NewStringf("%s{$cresult, %s}", typestr.get(), SwigType_isreference(Getattr(n, "type")) ? owns : "true"));
+        }
 
-          if (ptype_desc) {
-            // It doesn't seem like it can ever be useful to pass an object by value to a wrapper function and it can fail if it doesn't have a copy ctor (see
-            // code related to has_copy_ctor_ in our dtor above), so always pass it by const reference instead.
-            Append(typestr, " const&");
+        if (ptype_desc) {
+          // It doesn't seem like it can ever be useful to pass an object by value to a wrapper function and it can fail if it doesn't have a copy ctor (see
+          // code related to has_copy_ctor_ in our dtor above), so always pass it by const reference instead.
+          Append(typestr, " const&");
 
-            ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
-          }
-          break;
+          ptype_desc->apply_in_typemap(NewString("$1.swig_self()"));
+        }
+        break;
 
-        case Type_Enm:
-        case Type_Max:
-          // Unreachable, but keep here to avoid -Wswitch warnings.
-          assert(0);
+      case Type_Enm:
+      case Type_Max:
+        // Unreachable, but keep here to avoid -Wswitch warnings.
+        assert(0);
       }
     }
 
@@ -828,14 +807,13 @@ private:
     return true;
   }
 
-
   // These pointers are temporarily set to non-null value only while expanding a typemap for C++ wrappers, see replaceSpecialVariables().
-  cxx_ptype_desc* ptype_desc_;
-  cxx_rtype_desc* rtype_desc_;
+  cxx_ptype_desc *ptype_desc_;
+  cxx_rtype_desc *rtype_desc_;
 
   // This one is set from the outside, so make it public for simplicity.
 public:
-  Node* node_func_;
+  Node *node_func_;
 };
 
 /*
@@ -844,15 +822,13 @@ public:
   Outputs the C++ wrapper function. It's different from the C function because it is declared inside the namespace and so doesn't need the usual prefix and may
   also have different parameter and return types when objects and/or cxx{in,out}type typemaps are involved.
  */
-class cxx_function_wrapper
-{
+class cxx_function_wrapper {
 public:
   // Call can_wrap() to check if this wrapper can be emitted later.
-  explicit cxx_function_wrapper(cxx_wrappers& cxx_wrappers, Node* n, Parm* p) : cxx_wrappers_(cxx_wrappers) {
+  explicit cxx_function_wrapper(cxx_wrappers &cxx_wrappers, Node *n, Parm *p) : cxx_wrappers_(cxx_wrappers) {
     func_node = NULL;
 
-    except_check_start =
-    except_check_end = "";
+    except_check_start = except_check_end = "";
 
     if (Checkattr(n, "feature:cxxignore", "1"))
       return;
@@ -874,8 +850,8 @@ public:
     if (p) {
       // We want to use readable parameter names in our wrappers instead of the autogenerated arg$N if possible, so do it, and do it before calling
       // Swig_typemap_attach_parms(), as this uses the parameter names for typemap expansion.
-      for (Parm* p2 = p; p2; p2 = nextSibling(p2)) {
-        String* name = Getattr(p, "name");
+      for (Parm *p2 = p; p2; p2 = nextSibling(p2)) {
+        String *name = Getattr(p, "name");
         if (!name) {
           // Can't do anything for unnamed parameters.
           continue;
@@ -897,7 +873,7 @@ public:
         if (Checkattr(p, "tmap:in:numinputs", "0"))
           continue;
 
-        String* const name = Getattr(p, "lname");
+        String *const name = Getattr(p, "lname");
 
         cxx_ptype_desc ptype_desc;
         if (!cxx_wrappers_.lookup_cxx_parm_type(ptype_desc, n, p))
@@ -913,12 +889,9 @@ public:
       }
     }
 
-
     // Avoid checking for exceptions unnecessarily. Note that this is more than an optimization: we'd get into infinite recursion if we checked for exceptions
     // thrown by members of SWIG_CException itself if we didn't do it.
-    if (cxx_wrappers_.is_exception_support_enabled() &&
-          !Checkattr(n, "noexcept", "true") &&
-            (!Checkattr(n, "throw", "1") || Getattr(n, "throws"))) {
+    if (cxx_wrappers_.is_exception_support_enabled() && !Checkattr(n, "noexcept", "true") && (!Checkattr(n, "throw", "1") || Getattr(n, "throws"))) {
       except_check_start = cxx_wrappers_.except_check_start;
       except_check_end = cxx_wrappers_.except_check_end;
     }
@@ -927,29 +900,23 @@ public:
     func_node = n;
   }
 
-  bool can_wrap() const { return func_node != NULL; }
+  bool can_wrap() const {
+    return func_node != NULL;
+  }
 
   // Emit just the function body, including the braces around it.
   //
   // This helper is used both by our emit() and emit_member_function().
-  void emit_body(String* wparms) {
-    String* const wname = Getattr(func_node, "wrap:name");
+  void emit_body(String *wparms) {
+    String *const wname = Getattr(func_node, "wrap:name");
 
     Append(cxx_wrappers_.sect_impls, "{");
 
     if (rtype_desc.is_void()) {
-      Printv(cxx_wrappers_.sect_impls,
-        " ", wname, "(", wparms, "); ",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_impls, " ", wname, "(", wparms, "); ", NIL);
 
       if (*except_check_start != '\0') {
-        Printv(cxx_wrappers_.sect_impls,
-          except_check_start,
-          except_check_end,
-          "; ",
-          NIL
-        );
+        Printv(cxx_wrappers_.sect_impls, except_check_start, except_check_end, "; ", NIL);
       }
     } else {
       rtype_desc.set_return_value(NewStringf("%s%s(%s)%s", except_check_start, wname, wparms, except_check_end));
@@ -964,44 +931,39 @@ public:
     // The wrapper function name should be sym:name, but we change it to include the namespace prefix in our own globalvariableHandler(), so now we have to undo
     // this by using the value saved there, if available. This is definitely clumsy and it would be better to avoid it, but this would probably need to be done
     // by separating C and C++ wrapper generation in two different passes and so would require significantly more changes than this hack.
-    String* name = Getattr(func_node, "c:globalvariableHandler:sym:name");
+    String *name = Getattr(func_node, "c:globalvariableHandler:sym:name");
     if (!name)
       name = Getattr(func_node, "sym:name");
 
-    Printv(cxx_wrappers_.sect_impls,
-      "inline ", rtype_desc.type(), " ", name, "(", parms_cxx.get(), ") ",
-      NIL
-    );
+    Printv(cxx_wrappers_.sect_impls, "inline ", rtype_desc.type(), " ", name, "(", parms_cxx.get(), ") ", NIL);
 
     emit_body(parms_call);
   }
 
-
-  cxx_wrappers& cxx_wrappers_;
-  Node* func_node;
+  cxx_wrappers &cxx_wrappers_;
+  Node *func_node;
   cxx_rtype_desc rtype_desc;
   scoped_dohptr parms_cxx;
   scoped_dohptr parms_call;
-  const char* except_check_start;
-  const char* except_check_end;
+  const char *except_check_start;
+  const char *except_check_end;
 
 private:
   // Non copyable.
-  cxx_function_wrapper(const cxx_function_wrapper&);
-  cxx_function_wrapper& operator=(const cxx_function_wrapper&);
+  cxx_function_wrapper(const cxx_function_wrapper &);
+  cxx_function_wrapper &operator=(const cxx_function_wrapper &);
 };
-
 
 /*
   Return true if the class, or one of its base classes, uses multiple inheritance, i.e. has more than one base class.
 
   The output first_base parameter is optional and is filled with the first base class (if any).
 */
-bool uses_multiple_inheritance(Node* n, scoped_dohptr* first_base_out = NULL) {
+bool uses_multiple_inheritance(Node *n, scoped_dohptr *first_base_out = NULL) {
   if (first_base_out)
     first_base_out->reset();
 
-  List* const baselist = Getattr(n, "bases");
+  List *const baselist = Getattr(n, "bases");
   if (!baselist)
     return false;
 
@@ -1030,13 +992,12 @@ bool uses_multiple_inheritance(Node* n, scoped_dohptr* first_base_out = NULL) {
 
   Outputs the declaration of the class wrapping the given one if we're generating C++ wrappers, i.e. if the provided cxx_wrappers object is initialized.
 */
-class cxx_class_wrapper
-{
+class cxx_class_wrapper {
 public:
   // If the provided cxx_wrappers object is not initialized, this class doesn't do anything.
   //
   // The node pointer must be valid, point to a class and remain valid for the lifetime of this object.
-  cxx_class_wrapper(cxx_wrappers& cxx_wrappers, Node* n) : cxx_wrappers_(cxx_wrappers) {
+  cxx_class_wrapper(cxx_wrappers &cxx_wrappers, Node *n) : cxx_wrappers_(cxx_wrappers) {
     class_node_ = NULL;
 
     if (!cxx_wrappers_.is_initialized())
@@ -1045,14 +1006,11 @@ public:
     if (Checkattr(n, "feature:cxxignore", "1"))
       return;
 
-    String* const classname = Getattr(n, "sym:name");
+    String *const classname = Getattr(n, "sym:name");
 
     scoped_dohptr base_classes(NewStringEmpty());
     if (uses_multiple_inheritance(n, &first_base_)) {
-      Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-        "Multiple inheritance not supported yet, skipping C++ wrapper generation for %s\n",
-        classname
-      );
+      Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n), "Multiple inheritance not supported yet, skipping C++ wrapper generation for %s\n", classname);
 
       // Return before initializing class_node_, so that the dtor won't output anything neither.
       return;
@@ -1061,16 +1019,15 @@ public:
     if (first_base_)
       Printv(base_classes, " : public ", Getattr(first_base_, "sym:name"), NIL);
 
-    Printv(cxx_wrappers_.sect_types,
-      "class ", classname, ";\n",
-      NIL
-    );
+    Printv(cxx_wrappers_.sect_types, "class ", classname, ";\n", NIL);
 
     Printv(cxx_wrappers_.sect_decls,
-      "class ", classname, base_classes.get(), " {\n"
-      "public:",
-      NIL
-    );
+           "class ",
+           classname,
+           base_classes.get(),
+           " {\n"
+           "public:",
+           NIL);
 
     // If we have any extra code, inject it. Note that we need a hack with an artificial extra node to use Swig_typemap_lookup(), as it needs a "type" attribute
     // which the class node doesn't have.
@@ -1093,7 +1050,7 @@ public:
   }
 
   // Get indentation used inside this class declaration.
-  const char* get_indent() const {
+  const char *get_indent() const {
     // Currently we always use a single level of indent, but this would need to change if/when nested classes are supported.
     //
     // As the first step, we should probably change all occurrences of "cindent" in this class itself to use get_indent() instead.
@@ -1101,7 +1058,7 @@ public:
   }
 
   // Emit wrapper of a member function.
-  void emit_member_function(Node* n) {
+  void emit_member_function(Node *n) {
     if (!class_node_)
       return;
 
@@ -1124,17 +1081,14 @@ public:
     const bool is_static = is_member && Getattr(n, "cplus:staticbase");
     const bool is_ctor = Checkattr(n, "nodeType", "constructor");
 
-    Parm* p = Getattr(n, "parms");
+    Parm *p = Getattr(n, "parms");
     if (p && is_member && !is_ctor && !is_static) {
       // We should have "this" as the first parameter and we need to just skip it, as we handle it specially in C++ wrappers.
       if (Checkattr(p, "name", "self")) {
         p = nextSibling(p);
       } else {
         // This is not supposed to happen, so warn if it does.
-        Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-          "Unexpected first parameter \"%s\" in %s\n",
-          Getattr(p, "name"),
-          Getattr(n, "sym:name"));
+        Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n), "Unexpected first parameter \"%s\" in %s\n", Getattr(p, "name"), Getattr(n, "sym:name"));
       }
     }
 
@@ -1143,86 +1097,109 @@ public:
       return;
 
     // Define aliases for the stuff actually stored in the function wrapper object.
-    cxx_rtype_desc& rtype_desc = func_wrapper.rtype_desc;
-    String* const parms_cxx = func_wrapper.parms_cxx;
-    String* const parms_call = func_wrapper.parms_call;
+    cxx_rtype_desc &rtype_desc = func_wrapper.rtype_desc;
+    String *const parms_cxx = func_wrapper.parms_cxx;
+    String *const parms_call = func_wrapper.parms_call;
 
     // For some reason overloaded functions use fully-qualified name, so we can't just use the name directly.
     scoped_dohptr name_ptr(Swig_scopename_last(Getattr(n, "name")));
-    String* const name = name_ptr;
-    String* const wname = Getattr(n, "wrap:name");
+    String *const name = name_ptr;
+    String *const wname = Getattr(n, "wrap:name");
 
-    String* const classname = Getattr(class_node_, "sym:name");
+    String *const classname = Getattr(class_node_, "sym:name");
 
     if (Checkattr(n, "kind", "variable")) {
       if (Checkattr(n, "memberget", "1")) {
-        Printv(cxx_wrappers_.sect_decls,
-          cindent, rtype_desc.type(), " ", name, "() const;\n",
-          NIL
-        );
+        Printv(cxx_wrappers_.sect_decls, cindent, rtype_desc.type(), " ", name, "() const;\n", NIL);
 
         rtype_desc.set_return_value(NewStringf("%s(swig_self())", Getattr(n, "sym:name")));
         Printv(cxx_wrappers_.sect_impls,
-          "inline ", rtype_desc.type(), " ", classname, "::", name, "() const "
-          "{", rtype_desc.get_return_code().get(), "}\n",
-          NIL
-        );
+               "inline ",
+               rtype_desc.type(),
+               " ",
+               classname,
+               "::",
+               name,
+               "() const "
+               "{",
+               rtype_desc.get_return_code().get(),
+               "}\n",
+               NIL);
       } else if (Checkattr(n, "memberset", "1")) {
-        Printv(cxx_wrappers_.sect_decls,
-          cindent, "void ", name, "(", parms_cxx, ");\n",
-          NIL
-        );
+        Printv(cxx_wrappers_.sect_decls, cindent, "void ", name, "(", parms_cxx, ");\n", NIL);
 
         Printv(cxx_wrappers_.sect_impls,
-          "inline void ", classname, "::", name, "(", parms_cxx, ") "
-          "{ ", Getattr(n, "sym:name"), "(swig_self(), ", parms_call, "); }\n",
-          NIL
-        );
+               "inline void ",
+               classname,
+               "::",
+               name,
+               "(",
+               parms_cxx,
+               ") "
+               "{ ",
+               Getattr(n, "sym:name"),
+               "(swig_self(), ",
+               parms_call,
+               "); }\n",
+               NIL);
       } else if (Checkattr(n, "varget", "1")) {
-        Printv(cxx_wrappers_.sect_decls,
-          cindent, "static ", rtype_desc.type(), " ", name, "();\n",
-          NIL
-        );
+        Printv(cxx_wrappers_.sect_decls, cindent, "static ", rtype_desc.type(), " ", name, "();\n", NIL);
 
         rtype_desc.set_return_value(NewStringf("%s()", Getattr(n, "sym:name")));
         Printv(cxx_wrappers_.sect_impls,
-          "inline ", rtype_desc.type(), " ", classname, "::", name, "() "
-          "{", rtype_desc.get_return_code().get(), "}\n",
-          NIL
-        );
+               "inline ",
+               rtype_desc.type(),
+               " ",
+               classname,
+               "::",
+               name,
+               "() "
+               "{",
+               rtype_desc.get_return_code().get(),
+               "}\n",
+               NIL);
       } else if (Checkattr(n, "varset", "1")) {
-        Printv(cxx_wrappers_.sect_decls,
-          cindent, "static void ", name, "(", parms_cxx, ");\n",
-          NIL
-        );
+        Printv(cxx_wrappers_.sect_decls, cindent, "static void ", name, "(", parms_cxx, ");\n", NIL);
 
         Printv(cxx_wrappers_.sect_impls,
-          "inline void ", classname, "::", name, "(", parms_cxx, ") "
-          "{ ", Getattr(n, "sym:name"), "(", parms_call, "); }\n",
-          NIL
-        );
+               "inline void ",
+               classname,
+               "::",
+               name,
+               "(",
+               parms_cxx,
+               ") "
+               "{ ",
+               Getattr(n, "sym:name"),
+               "(",
+               parms_call,
+               "); }\n",
+               NIL);
       } else {
-        Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-          "Not generating C++ wrappers for variable %s\n",
-          Getattr(n, "sym:name")
-        );
+        Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n), "Not generating C++ wrappers for variable %s\n", Getattr(n, "sym:name"));
       }
     } else if (is_ctor) {
       // Delegate to the ctor from opaque C pointer taking ownership of the object.
-      Printv(cxx_wrappers_.sect_decls,
-        cindent, classname, "(", parms_cxx, ");\n",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_decls, cindent, classname, "(", parms_cxx, ");\n", NIL);
 
       Printv(cxx_wrappers_.sect_impls,
-        "inline ", classname, "::", classname, "(", parms_cxx, ") : ",
-        classname, "{",
-          func_wrapper.except_check_start,
-            wname, "(", parms_call, ")",
-          func_wrapper.except_check_end,
-        "} {}\n",
-        NIL
-      );
+             "inline ",
+             classname,
+             "::",
+             classname,
+             "(",
+             parms_cxx,
+             ") : ",
+             classname,
+             "{",
+             func_wrapper.except_check_start,
+             wname,
+             "(",
+             parms_call,
+             ")",
+             func_wrapper.except_check_end,
+             "} {}\n",
+             NIL);
 
       // Remember that we had a copy ctor.
       if (Checkattr(n, "copy_constructor", "1"))
@@ -1231,23 +1208,48 @@ public:
       if (first_base_) {
         // Delete the pointer and reset the ownership flag to ensure that the base class doesn't do it again.
         Printv(cxx_wrappers_.sect_decls,
-          cindent, get_virtual_prefix(n), "~", classname, "() {\n",
-          cindent, cindent, "if (swig_owns_self_) {\n",
-          cindent, cindent, cindent, wname, "(swig_self());\n",
-          cindent, cindent, cindent, "swig_owns_self_ = false;\n",
-          cindent, cindent, "}\n",
-          cindent, "}\n",
-          NIL
-        );
+               cindent,
+               get_virtual_prefix(n),
+               "~",
+               classname,
+               "() {\n",
+               cindent,
+               cindent,
+               "if (swig_owns_self_) {\n",
+               cindent,
+               cindent,
+               cindent,
+               wname,
+               "(swig_self());\n",
+               cindent,
+               cindent,
+               cindent,
+               "swig_owns_self_ = false;\n",
+               cindent,
+               cindent,
+               "}\n",
+               cindent,
+               "}\n",
+               NIL);
       } else {
         // Slightly simplified version for classes without base classes, as we don't need to reset swig_self_ then.
         Printv(cxx_wrappers_.sect_decls,
-          cindent, get_virtual_prefix(n), "~", classname, "() {\n",
-          cindent, cindent, "if (swig_owns_self_)\n",
-          cindent, cindent, cindent, wname, "(swig_self_);\n",
-          cindent, "}\n",
-          NIL
-        );
+               cindent,
+               get_virtual_prefix(n),
+               "~",
+               classname,
+               "() {\n",
+               cindent,
+               cindent,
+               "if (swig_owns_self_)\n",
+               cindent,
+               cindent,
+               cindent,
+               wname,
+               "(swig_self_);\n",
+               cindent,
+               "}\n",
+               NIL);
 
         // We're also going to need this in move assignment operator.
         dtor_wname_ = wname;
@@ -1264,28 +1266,24 @@ public:
       }
 
       Printv(cxx_wrappers_.sect_decls,
-        cindent,
-        is_static ? "static " : get_virtual_prefix(n), rtype_desc.type(), " ",
-        name, "(", parms_cxx, ")",
-        get_const_suffix(n), ";\n",
-        NIL
-      );
+             cindent,
+             is_static ? "static " : get_virtual_prefix(n),
+             rtype_desc.type(),
+             " ",
+             name,
+             "(",
+             parms_cxx,
+             ")",
+             get_const_suffix(n),
+             ";\n",
+             NIL);
 
-      Printv(cxx_wrappers_.sect_impls,
-        "inline ", rtype_desc.type(), " ",
-        classname, "::", name, "(", parms_cxx, ")",
-        get_const_suffix(n),
-        " ",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_impls, "inline ", rtype_desc.type(), " ", classname, "::", name, "(", parms_cxx, ")", get_const_suffix(n), " ", NIL);
 
       func_wrapper.emit_body(wparms);
     } else {
       // This is something we don't know about
-      Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n),
-        "Not generating C++ wrappers for %s\n",
-        Getattr(n, "sym:name")
-      );
+      Swig_warning(WARN_C_UNSUPPORTTED, Getfile(n), Getline(n), "Not generating C++ wrappers for %s\n", Getattr(n, "sym:name"));
     }
   }
 
@@ -1297,31 +1295,28 @@ public:
     // This is the name used for the class pointers in C wrappers.
     scoped_dohptr c_class_ptr = get_c_class_ptr(class_node_);
 
-    String* const classname = Getattr(class_node_, "sym:name");
+    String *const classname = Getattr(class_node_, "sym:name");
 
     // We need to generate a ctor from the C object pointer, which is required to be able to create objects of this class from pointers created by C wrappers
     // and also by any derived classes.
     Printv(cxx_wrappers_.sect_decls,
-      "\n",
-      cindent, "explicit ", classname, "(", c_class_ptr.get(), " swig_self, "
-        "bool swig_owns_self = true) noexcept : ",
-      NIL
-    );
+           "\n",
+           cindent,
+           "explicit ",
+           classname,
+           "(",
+           c_class_ptr.get(),
+           " swig_self, "
+           "bool swig_owns_self = true) noexcept : ",
+           NIL);
 
     if (first_base_) {
       // In this case we delegate to the base class ctor, but need a cast because it expects a different pointer type (as these types are opaque, there is no
       // relationship between them).
-      Printv(cxx_wrappers_.sect_decls,
-        Getattr(first_base_, "sym:name"),
-        "{(", get_c_class_ptr(first_base_).get(), ")swig_self, swig_owns_self}",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_decls, Getattr(first_base_, "sym:name"), "{(", get_c_class_ptr(first_base_).get(), ")swig_self, swig_owns_self}", NIL);
     } else {
       // Just initialize our own field.
-      Printv(cxx_wrappers_.sect_decls,
-        "swig_self_{swig_self}, swig_owns_self_{swig_owns_self}",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_decls, "swig_self_{swig_self}, swig_owns_self_{swig_owns_self}", NIL);
     }
 
     Append(cxx_wrappers_.sect_decls, " {}\n");
@@ -1330,85 +1325,85 @@ public:
     // because we don't wrap it and copying would use the trivial ctor that would just copy the swig_self_ pointer resulting in double destruction of it later.
     // To fix this, we would need to always provide our own C wrapper for the copy ctor, which is not something we do currently.
     if (!has_copy_ctor_) {
-      Printv(cxx_wrappers_.sect_decls,
-        cindent, classname, "(", classname, " const&) = delete;\n",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_decls, cindent, classname, "(", classname, " const&) = delete;\n", NIL);
     }
 
     // We currently never wrap the assignment operator, so we have to always disable it for the same reason we disable the copy ctor above.
     // It would definitely be nice to provide the assignment, if possible.
-    Printv(cxx_wrappers_.sect_decls,
-      cindent, classname, "& operator=(", classname, " const&) = delete;\n",
-      NIL
-    );
+    Printv(cxx_wrappers_.sect_decls, cindent, classname, "& operator=(", classname, " const&) = delete;\n", NIL);
 
     // OTOH we may always provide move ctor and assignment, as we can always implement them trivially ourselves.
     if (first_base_) {
       Printv(cxx_wrappers_.sect_decls,
-        cindent, classname, "(", classname, "&& obj) = default;\n",
-        cindent, classname, "& operator=(", classname, "&& obj) = default;\n",
-        NIL
-      );
+             cindent,
+             classname,
+             "(",
+             classname,
+             "&& obj) = default;\n",
+             cindent,
+             classname,
+             "& operator=(",
+             classname,
+             "&& obj) = default;\n",
+             NIL);
     } else {
       Printv(cxx_wrappers_.sect_decls,
-        cindent, classname, "(", classname, "&& obj) noexcept : "
-        "swig_self_{obj.swig_self_}, swig_owns_self_{obj.swig_owns_self_} { "
-        "obj.swig_owns_self_ = false; "
-        "}\n",
-        cindent, classname, "& operator=(", classname, "&& obj) noexcept {\n",
-        NIL
-      );
+             cindent,
+             classname,
+             "(",
+             classname,
+             "&& obj) noexcept : "
+             "swig_self_{obj.swig_self_}, swig_owns_self_{obj.swig_owns_self_} { "
+             "obj.swig_owns_self_ = false; "
+             "}\n",
+             cindent,
+             classname,
+             "& operator=(",
+             classname,
+             "&& obj) noexcept {\n",
+             NIL);
 
       if (dtor_wname_) {
-        Printv(cxx_wrappers_.sect_decls,
-          cindent, cindent, "if (swig_owns_self_)\n",
-          cindent, cindent, cindent, dtor_wname_, "(swig_self_);\n",
-          NIL
-        );
+        Printv(cxx_wrappers_.sect_decls, cindent, cindent, "if (swig_owns_self_)\n", cindent, cindent, cindent, dtor_wname_, "(swig_self_);\n", NIL);
       }
 
       Printv(cxx_wrappers_.sect_decls,
-        cindent, cindent, "swig_self_ = obj.swig_self_;\n",
-        cindent, cindent, "swig_owns_self_ = obj.swig_owns_self_;\n",
-        cindent, cindent, "obj.swig_owns_self_ = false;\n",
-        cindent, cindent, "return *this;\n",
-        cindent, "}\n",
-        NIL
-      );
+             cindent,
+             cindent,
+             "swig_self_ = obj.swig_self_;\n",
+             cindent,
+             cindent,
+             "swig_owns_self_ = obj.swig_owns_self_;\n",
+             cindent,
+             cindent,
+             "obj.swig_owns_self_ = false;\n",
+             cindent,
+             cindent,
+             "return *this;\n",
+             cindent,
+             "}\n",
+             NIL);
     }
 
     // We also need a swig_self() method for accessing the C object pointer.
-    Printv(cxx_wrappers_.sect_decls,
-      cindent, c_class_ptr.get(), " swig_self() const noexcept ",
-      NIL
-    );
+    Printv(cxx_wrappers_.sect_decls, cindent, c_class_ptr.get(), " swig_self() const noexcept ", NIL);
 
     if (first_base_) {
       // If we have a base class, we reuse its existing "self" pointer.
-      Printv(cxx_wrappers_.sect_decls,
-        "{ return (", c_class_ptr.get(), ")", Getattr(first_base_, "sym:name"), "::swig_self(); }\n",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_decls, "{ return (", c_class_ptr.get(), ")", Getattr(first_base_, "sym:name"), "::swig_self(); }\n", NIL);
     } else {
       // We use our own pointer, which we also have to declare, together with the ownership flag.
       //
       // Perhaps we could avoid having a separate bool flag by reusing the low-order bit of the pointer itself as the indicator of ownership and masking it when
       // retrieving it here in the future. If we decide to implement this optimization, the code generated here should be the only thing that would need to
       // change.
-      Printv(cxx_wrappers_.sect_decls,
-        "{ return swig_self_; }\n",
-        cindent, c_class_ptr.get(), " swig_self_;\n",
-        cindent, "bool swig_owns_self_;\n",
-        NIL
-      );
+      Printv(cxx_wrappers_.sect_decls, "{ return swig_self_; }\n", cindent, c_class_ptr.get(), " swig_self_;\n", cindent, "bool swig_owns_self_;\n", NIL);
     }
 
     Printv(cxx_wrappers_.sect_decls,
-      "};\n"
-      "\n",
-      NIL
-    );
+           "};\n"
+           "\n",
+           NIL);
   }
 
 private:
@@ -1417,26 +1412,25 @@ private:
   // Return the string containing the pointer type used for representing the objects of the given class in the C wrappers.
   //
   // Returned value includes "*" at the end.
-  static scoped_dohptr get_c_class_ptr(Node* class_node) {
+  static scoped_dohptr get_c_class_ptr(Node *class_node) {
     return scoped_dohptr(NewStringf("SwigObj_%s*", get_c_proxy_name(class_node)));
   }
 
   // Return "virtual " if this is a virtual function, empty string otherwise.
-  static const char* get_virtual_prefix(Node* n) {
+  static const char *get_virtual_prefix(Node *n) {
     return Checkattr(n, "storage", "virtual") ? "virtual " : "";
   }
 
   // Return " const" if this is a const function, empty string otherwise.
-  static const char* get_const_suffix(Node* n) {
-    String* const qualifier = Getattr(n, "qualifier");
+  static const char *get_const_suffix(Node *n) {
+    String *const qualifier = Getattr(n, "qualifier");
     return qualifier && strncmp(Char(qualifier), "q(const)", 8) == 0 ? " const" : "";
   }
 
-
-  cxx_wrappers& cxx_wrappers_;
+  cxx_wrappers &cxx_wrappers_;
 
   // The class node itself, left null only if we skip generating wrappers for it for whatever reason.
-  Node* class_node_;
+  Node *class_node_;
 
   // We currently don't support generating C++ wrappers for classes using multiple inheritance. This could be implemented, with some tweaks to allow
   // initializing the other base classes after creating the most-derived object, but hasn't been done yet. Until then we store just the first base class (if
@@ -1444,20 +1438,19 @@ private:
   scoped_dohptr first_base_;
 
   // Name of the C function used for deleting the owned object, if any.
-  String* dtor_wname_;
+  String *dtor_wname_;
 
   // True if the class defines an explicit copy ctor.
   bool has_copy_ctor_;
 
-
   // Non copyable.
-  cxx_class_wrapper(const cxx_class_wrapper&);
-  cxx_class_wrapper& operator=(const cxx_class_wrapper&);
+  cxx_class_wrapper(const cxx_class_wrapper &);
+  cxx_class_wrapper &operator=(const cxx_class_wrapper &);
 };
 
-} // anonymous namespace
+}  // anonymous namespace
 
-class C:public Language {
+class C : public Language {
   static const char *usage;
 
   // These files contain types used by the wrappers declarations and the declarations themselves and end up in the output header file.
@@ -1489,10 +1482,7 @@ class C:public Language {
   String *enum_decl;
 
   // Selects between the wrappers (public) declarations and (private) definitions.
-  enum {
-    output_wrapper_decl,
-    output_wrapper_def
-  } current_output;
+  enum { output_wrapper_decl, output_wrapper_def } current_output;
 
   // Selects between various kinds of needed support for exception-related code.
   exceptions_support exceptions_support_;
@@ -1501,7 +1491,7 @@ class C:public Language {
   cxx_wrappers cxx_wrappers_;
 
   // Non-owning pointer to the current C++ class wrapper if we're currently generating one or NULL.
-  cxx_class_wrapper* cxx_class_wrapper_;
+  cxx_class_wrapper *cxx_class_wrapper_;
 
   // This is parallel to enum_prefix_ but for C++ enum elements.
   scoped_dohptr cxx_enum_prefix_;
@@ -1510,27 +1500,18 @@ class C:public Language {
   String *cxx_enum_decl;
 
   // An extra indent level needed for nested C++ enums.
-  const char* cxx_enum_indent;
+  const char *cxx_enum_indent;
 
 public:
-
   /* -----------------------------------------------------------------------------
    * C()
    * ----------------------------------------------------------------------------- */
 
-  C() :
-    empty_string(NewString("")),
-    ns_cxx(NULL),
-    ns_prefix(NULL),
-    module_name(NULL),
-    outfile_h(NULL),
-    cxx_class_wrapper_(NULL)
-  {
+  C() : empty_string(NewString("")), ns_cxx(NULL), ns_prefix(NULL), module_name(NULL), outfile_h(NULL), cxx_class_wrapper_(NULL) {
     UseWrapperSuffix = 1;
   }
 
-  ~C()
-  {
+  ~C() {
     Delete(ns_cxx);
     Delete(ns_prefix);
   }
@@ -1538,8 +1519,7 @@ public:
   // Construct the name to be used for a function with the given name in C wrappers.
   //
   // The returned string must be freed by caller.
-  maybe_owned_dohptr getFunctionWrapperName(Node *n, String *name) const
-  {
+  maybe_owned_dohptr getFunctionWrapperName(Node *n, String *name) const {
     maybe_owned_dohptr wname;
 
     // The basic idea here is that for class members we don't need to use any prefix at all, as they're already prefixed by the class name, which has the
@@ -1550,11 +1530,8 @@ public:
     //  - Friend functions are declared inside the class, but are not member functions, so we have to check for both the current class and "ismember" property.
     //  - Destructors and implicitly generated constructors don't have "ismember" for some reason, so we need to check for them specifically.
     //  - Variable getters and setters don't need to use the prefix as they don't clash with anything.
-    if ((getCurrentClass() &&
-          (Checkattr(n, "ismember", "1") ||
-            Checkattr(n, "nodeType", "constructor") ||
-              Checkattr(n, "nodeType", "destructor"))) ||
--               Checkattr(n, "varget", "1") || Checkattr(n, "varset", "1")) {
+    if ((getCurrentClass() && (Checkattr(n, "ismember", "1") || Checkattr(n, "nodeType", "constructor") || Checkattr(n, "nodeType", "destructor"))) ||
+        -Checkattr(n, "varget", "1") || Checkattr(n, "varset", "1")) {
       wname.assign_non_owned(name);
       return wname;
     }
@@ -1572,11 +1549,7 @@ public:
     // Fall back to the module name if we don't use feature:nspace and don't have the global prefix neither.
     //
     // Note that we really, really need to use some prefix, as wrapper function can't have the same name as the original function being wrapped.
-    String* const prefix = scopename_prefix
-      ? scopename_prefix
-      : ns_prefix
-        ? ns_prefix
-        : module_name;
+    String *const prefix = scopename_prefix ? scopename_prefix : ns_prefix ? ns_prefix : module_name;
 
     wname.assign_owned(NewStringf("%s_%s", prefix, name));
     return wname;
@@ -1589,12 +1562,11 @@ public:
    * Return NULL if not, otherwise the proxy class name to be freed by the caller.
    * ----------------------------------------------------------------------------- */
 
-   String *getClassProxyName(SwigType *t) {
-     Node *n = classLookup(t);
+  String *getClassProxyName(SwigType *t) {
+    Node *n = classLookup(t);
 
     return n ? Copy(get_c_proxy_name(n)) : NULL;
-
-   }
+  }
 
   /* -----------------------------------------------------------------------------
    * getEnumName()
@@ -1637,7 +1609,6 @@ public:
     return enumname;
   }
 
-
   /* -----------------------------------------------------------------------------
    * substituteResolvedTypeSpecialVariable()
    * ----------------------------------------------------------------------------- */
@@ -1645,8 +1616,8 @@ public:
   void substituteResolvedTypeSpecialVariable(SwigType *classnametype, String *tm, const char *classnamespecialvariable) {
     scoped_dohptr btype(SwigType_base(classnametype));
     if (SwigType_isenum(btype)) {
-      Node* const enum_node = enumLookup(btype);
-      String* const enumname = enum_node ? getEnumName(enum_node) : NULL;
+      Node *const enum_node = enumLookup(btype);
+      String *const enumname = enum_node ? getEnumName(enum_node) : NULL;
 
       // We use the enum name in the wrapper declaration if it's available, as this makes it more type safe, but we always use just int for the function
       // definition because we don't have the enum declaration in scope there. This obviously only actually works if the actual enum underlying type is int (or
@@ -1667,13 +1638,13 @@ public:
       if (!CPlusPlus) {
         // Just use the original C type when not using C++, we know that this type can be used in the wrappers.
         Clear(tm);
-        String* const s = SwigType_str(classnametype, 0);
+        String *const s = SwigType_str(classnametype, 0);
         Append(tm, s);
         Delete(s);
         return;
       }
 
-      String* typestr = NIL;
+      String *typestr = NIL;
       if (current_output == output_wrapper_def || Cmp(btype, "SwigObj") == 0) {
         // Special case, just leave it unchanged.
         typestr = NewString("SwigObj");
@@ -1801,7 +1772,7 @@ public:
 
     SWIG_config_file("c.swg");
 
-    String* const ns_prefix_ = ns_prefix ? NewStringf("%s_", ns_prefix) : NewString("");
+    String *const ns_prefix_ = ns_prefix ? NewStringf("%s_", ns_prefix) : NewString("");
 
     // The default naming convention is to use new_Foo(), copy_Foo() and delete_Foo() for the default/copy ctor and dtor of the class Foo, but we prefer to
     // start all Foo methods with the same prefix, so change this. Notice that new/delete are chosen to ensure that we avoid conflicts with the existing class
@@ -1851,8 +1822,8 @@ public:
     const scoped_dohptr f_wrappers_h(NewFile(outfile_h, "w", SWIG_output_files()));
     if (!f_wrappers_h) {
       FileErrorDisplay(outfile_h);
-        Exit(EXIT_FAILURE);
-      }
+      Exit(EXIT_FAILURE);
+    }
 
     Swig_banner(f_wrappers_h);
 
@@ -1879,20 +1850,17 @@ public:
       // Redefine SWIG_CException_Raise() to have a unique prefix in the shared library built from SWIG-generated sources to allow using more than one extension
       // in the same process without conflicts. This has to be done in this hackish way because we really need to change the name of the function itself, not
       // its wrapper (which is not even generated).
-      Printv(sect_runtime,
-        "#define SWIG_CException_Raise ", (ns_prefix ? ns_prefix : module_name), "_SWIG_CException_Raise\n",
-        NIL
-      );
+      Printv(sect_runtime, "#define SWIG_CException_Raise ", (ns_prefix ? ns_prefix : module_name), "_SWIG_CException_Raise\n", NIL);
 
       // We need to check if we have any %imported modules, as they would already define the exception support code and we want to have exactly one copy of it
       // in the generated shared library, so check for "import" nodes.
       if (find_first_named_import(n)) {
-          // We import another module, which will have already defined SWIG_CException, so set the flag indicating that we shouldn't do it again in this one and
-          // define the symbol to skip compiling its implementation.
-          Printv(sect_runtime, "#define SWIG_CException_DEFINED 1\n", NIL);
+        // We import another module, which will have already defined SWIG_CException, so set the flag indicating that we shouldn't do it again in this one and
+        // define the symbol to skip compiling its implementation.
+        Printv(sect_runtime, "#define SWIG_CException_DEFINED 1\n", NIL);
 
-          // Also set a flag telling classDeclaration() to skip creating SWIG_CException wrappers.
-          exceptions_support_ = exceptions_support_imported;
+        // Also set a flag telling classDeclaration() to skip creating SWIG_CException wrappers.
+        exceptions_support_ = exceptions_support_imported;
       }
     }
 
@@ -1900,21 +1868,16 @@ public:
       cxx_wrappers_.initialize_exceptions(exceptions_support_);
 
     {
-      String* const include_guard_name = NewStringf("SWIG_%s_WRAP_H_", module_name);
-      String* const include_guard_begin = NewStringf(
-          "#ifndef %s\n"
-          "#define %s\n\n",
-          include_guard_name,
-          include_guard_name
-        );
-      String* const include_guard_end = NewStringf(
-          "\n"
-          "#endif /* %s */\n",
-          include_guard_name
-        );
+      String *const include_guard_name = NewStringf("SWIG_%s_WRAP_H_", module_name);
+      String *const include_guard_begin = NewStringf("#ifndef %s\n"
+                                                     "#define %s\n\n",
+                                                     include_guard_name,
+                                                     include_guard_name);
+      String *const include_guard_end = NewStringf("\n"
+                                                   "#endif /* %s */\n",
+                                                   include_guard_name);
 
-      begin_end_output_guard
-        include_guard_wrappers_h(f_wrappers_h, include_guard_begin, include_guard_end);
+      begin_end_output_guard include_guard_wrappers_h(f_wrappers_h, include_guard_begin, include_guard_end);
 
       // All the struct types used by the functions go to f_wrappers_types so that they're certain to be defined before they're used by any functions. All the
       // functions declarations go directly to f_wrappers_decl we write both of them to f_wrappers_h at the end.
@@ -1922,13 +1885,11 @@ public:
       sect_wrappers_decl = NewString("");
 
       {
-        cplusplus_output_guard
-          cplusplus_guard_wrappers(sect_wrappers),
-          cplusplus_guard_wrappers_h(sect_wrappers_decl);
+        cplusplus_output_guard cplusplus_guard_wrappers(sect_wrappers), cplusplus_guard_wrappers_h(sect_wrappers_decl);
 
         // emit code for children
         Language::top(n);
-      } // close extern "C" guards
+      }  // close extern "C" guards
 
       Dump(sect_wrappers_types, f_wrappers_h);
       Delete(sect_wrappers_types);
@@ -1948,14 +1909,14 @@ public:
 
         // Generate possibly nested namespace declarations, as unfortunately we can't rely on C++17 nested namespace definitions being always available.
         scoped_dohptr cxx_ns_end(NewStringEmpty());
-        for (const char* c = Char(ns_cxx);;) {
-          const char* const next = strstr(c, "::");
+        for (const char *c = Char(ns_cxx);;) {
+          const char *const next = strstr(c, "::");
 
           maybe_owned_dohptr ns_component;
           if (next) {
             ns_component.assign_owned(NewStringWithSize(c, (int)(next - c)));
           } else {
-            ns_component.assign_non_owned((DOH*)c);
+            ns_component.assign_non_owned((DOH *)c);
           }
 
           Printf(f_wrappers_h, "namespace %s {\n", ns_component.get());
@@ -1978,7 +1939,7 @@ public:
 
         Printv(f_wrappers_h, "\n", cxx_ns_end.get(), "\n#endif /* __cplusplus */\n", NIL);
       }
-    } // close wrapper header guard
+    }  // close wrapper header guard
 
     // write all to the file
     Dump(sect_begin, f_wrappers_cxx);
@@ -2001,7 +1962,7 @@ public:
     // specifying the name of the header explicitly.
 
     // We can only do something if we have a module name.
-    if (String* const imported_module_name = Getattr(n, "module")) {
+    if (String *const imported_module_name = Getattr(n, "module")) {
       // Start with our header name.
       scoped_dohptr header_name(Copy(outfile_h));
 
@@ -2031,7 +1992,7 @@ public:
     // can't do it when using a global namespace prefix neither.
     if (!ns_prefix && !scoped_dohptr(Swig_scopename_prefix(Getattr(n, "name")))) {
       // If we can export the variable directly, do it, this will be more convenient to use from C code than accessor functions.
-      if (String* const var_decl = make_c_var_decl(n)) {
+      if (String *const var_decl = make_c_var_decl(n)) {
         Printv(sect_wrappers_decl, "SWIGIMPORT ", var_decl, ";\n\n", NIL);
         Delete(var_decl);
         return SWIG_OK;
@@ -2060,7 +2021,7 @@ public:
    * prepend_feature()
    * ---------------------------------------------------------------------- */
 
-  String* prepend_feature(Node *n) {
+  String *prepend_feature(Node *n) {
     String *prepend_str = Getattr(n, "feature:prepend");
     if (prepend_str) {
       char *t = Char(prepend_str);
@@ -2076,7 +2037,7 @@ public:
    * append_feature()
    * ---------------------------------------------------------------------- */
 
-  String* append_feature(Node *n) {
+  String *append_feature(Node *n) {
     String *append_str = Getattr(n, "feature:append");
     if (append_str) {
       char *t = Char(append_str);
@@ -2134,8 +2095,8 @@ public:
     if (SwigType_isbuiltin(type)) {
       Printf(result, "%c", *Char(SwigType_base(type)));
     } else if (SwigType_isenum(type)) {
-      String* enumname = Swig_scopename_last(type);
-      const char* s = Char(enumname);
+      String *enumname = Swig_scopename_last(type);
+      const char *s = Char(enumname);
       static const size_t len_enum_prefix = strlen("enum ");
       if (strncmp(s, "enum ", len_enum_prefix) == 0)
         s += len_enum_prefix;
@@ -2152,112 +2113,109 @@ public:
     return result;
   }
 
-  void functionWrapperCSpecific(Node *n)
-    {
-       // this is C function, we don't apply typemaps to it
-       String *name = Getattr(n, "sym:name");
-       maybe_owned_dohptr wname = getFunctionWrapperName(n, name);
-       SwigType *type = Getattr(n, "type");
-       SwigType *return_type = NULL;
-       String *arg_names = NULL;
-       ParmList *parms = Getattr(n, "parms");
-       Parm *p;
-       String *proto = NewString("");
-       int gencomma = 0;
-       bool is_void_return = (SwigType_type(type) == T_VOID);
+  void functionWrapperCSpecific(Node *n) {
+    // this is C function, we don't apply typemaps to it
+    String *name = Getattr(n, "sym:name");
+    maybe_owned_dohptr wname = getFunctionWrapperName(n, name);
+    SwigType *type = Getattr(n, "type");
+    SwigType *return_type = NULL;
+    String *arg_names = NULL;
+    ParmList *parms = Getattr(n, "parms");
+    Parm *p;
+    String *proto = NewString("");
+    int gencomma = 0;
+    bool is_void_return = (SwigType_type(type) == T_VOID);
 
-       // create new function wrapper object
-       Wrapper *wrapper = NewWrapper();
+    // create new function wrapper object
+    Wrapper *wrapper = NewWrapper();
 
-       // create new wrapper name
-       Setattr(n, "wrap:name", wname); //Necessary to set this attribute? Apparently, it's never read!
+    // create new wrapper name
+    Setattr(n, "wrap:name", wname);  // Necessary to set this attribute? Apparently, it's never read!
 
-       // create function call
-       arg_names = Swig_cfunction_call(empty_string, parms);
-       if (arg_names) {
-            Delitem(arg_names, 0);
-            Delitem(arg_names, DOH_END);
-       }
-       return_type = SwigType_str(type, 0);
+    // create function call
+    arg_names = Swig_cfunction_call(empty_string, parms);
+    if (arg_names) {
+      Delitem(arg_names, 0);
+      Delitem(arg_names, DOH_END);
+    }
+    return_type = SwigType_str(type, 0);
 
-       // emit wrapper prototype and code
-       for (p = parms, gencomma = 0; p; p = nextSibling(p)) {
-            Printv(proto, gencomma ? ", " : "", SwigType_str(Getattr(p, "type"), 0), " ", Getattr(p, "lname"), NIL);
-            gencomma = 1;
-       }
-       Printv(wrapper->def, return_type, " ", wname.get(), "(", proto, ") {\n", NIL);
+    // emit wrapper prototype and code
+    for (p = parms, gencomma = 0; p; p = nextSibling(p)) {
+      Printv(proto, gencomma ? ", " : "", SwigType_str(Getattr(p, "type"), 0), " ", Getattr(p, "lname"), NIL);
+      gencomma = 1;
+    }
+    Printv(wrapper->def, return_type, " ", wname.get(), "(", proto, ") {\n", NIL);
 
-       if (!is_void_return) {
-            Printv(wrapper->code, return_type, " result;\n", NIL);
-       }
-
-       // attach 'check' typemaps
-       Swig_typemap_attach_parms("check", parms, wrapper);
-
-       // insert constraint checking
-       for (p = parms; p; ) {
-            String *tm;
-            if ((tm = Getattr(p, "tmap:check"))) {
-                 Replaceall(tm, "$target", Getattr(p, "lname"));
-                 Replaceall(tm, "$name", name);
-                 Printv(wrapper->code, tm, "\n", NIL);
-                 p = Getattr(p, "tmap:check:next");
-            } else {
-                 p = nextSibling(p);
-            }
-       }
-
-       Append(wrapper->code, prepend_feature(n));
-       if (!is_void_return) {
-            Printf(wrapper->code, "result = ");
-       }
-       Printv(wrapper->code, Getattr(n, "name"), "(", arg_names, ");\n", NIL);
-       Append(wrapper->code, append_feature(n));
-       if (!is_void_return)
-         Printf(wrapper->code, "return result;\n");
-       Printf(wrapper->code, "}");
-
-       Wrapper_print(wrapper, sect_wrappers);
-
-       emit_wrapper_func_decl(n, wname);
-
-       // cleanup
-       Delete(proto);
-       Delete(arg_names);
-       Delete(return_type);
-       DelWrapper(wrapper);
+    if (!is_void_return) {
+      Printv(wrapper->code, return_type, " result;\n", NIL);
     }
 
-  void functionWrapperAppendOverloaded(String *name, Parm* first_param)
-    {
-       String *over_suffix = NewString("");
-       Parm *p;
-       String *mangled;
+    // attach 'check' typemaps
+    Swig_typemap_attach_parms("check", parms, wrapper);
 
-       for (p = first_param; p; p = nextSibling(p)) {
-            mangled = get_mangled_type(Getattr(p, "type"));
-            Printv(over_suffix, "_", mangled, NIL);
-       }
-       Append(name, over_suffix);
-       Delete(over_suffix);
-    }
-
-  scoped_dohptr get_wrapper_func_return_type(Node *n)
-    {
-      SwigType *type = Getattr(n, "type");
-      String *return_type;
-
-      if ((return_type = Swig_typemap_lookup("ctype", n, "", 0))) {
-        substituteResolvedType(type, return_type);
+    // insert constraint checking
+    for (p = parms; p;) {
+      String *tm;
+      if ((tm = Getattr(p, "tmap:check"))) {
+        Replaceall(tm, "$target", Getattr(p, "lname"));
+        Replaceall(tm, "$name", name);
+        Printv(wrapper->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-        Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
-        return_type = NewString("");
+        p = nextSibling(p);
       }
-
-      Replaceall(return_type, "::", "_");
-
-      return scoped_dohptr(return_type);
     }
+
+    Append(wrapper->code, prepend_feature(n));
+    if (!is_void_return) {
+      Printf(wrapper->code, "result = ");
+    }
+    Printv(wrapper->code, Getattr(n, "name"), "(", arg_names, ");\n", NIL);
+    Append(wrapper->code, append_feature(n));
+    if (!is_void_return)
+      Printf(wrapper->code, "return result;\n");
+    Printf(wrapper->code, "}");
+
+    Wrapper_print(wrapper, sect_wrappers);
+
+    emit_wrapper_func_decl(n, wname);
+
+    // cleanup
+    Delete(proto);
+    Delete(arg_names);
+    Delete(return_type);
+    DelWrapper(wrapper);
+  }
+
+  void functionWrapperAppendOverloaded(String *name, Parm *first_param) {
+    String *over_suffix = NewString("");
+    Parm *p;
+    String *mangled;
+
+    for (p = first_param; p; p = nextSibling(p)) {
+      mangled = get_mangled_type(Getattr(p, "type"));
+      Printv(over_suffix, "_", mangled, NIL);
+    }
+    Append(name, over_suffix);
+    Delete(over_suffix);
+  }
+
+  scoped_dohptr get_wrapper_func_return_type(Node *n) {
+    SwigType *type = Getattr(n, "type");
+    String *return_type;
+
+    if ((return_type = Swig_typemap_lookup("ctype", n, "", 0))) {
+      substituteResolvedType(type, return_type);
+    } else {
+      Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
+      return_type = NewString("");
+    }
+
+    Replaceall(return_type, "::", "_");
+
+    return scoped_dohptr(return_type);
+  }
 
   /* ----------------------------------------------------------------------
    * get_wrapper_func_proto()
@@ -2266,96 +2224,95 @@ public:
    * If a non-null wrapper is specified, it is used to emit typemap-defined code in it and it also determines whether we're generating the prototype for the
    * declarations or the definitions, which changes the type used for the C++ objects.
    * ---------------------------------------------------------------------- */
-  scoped_dohptr get_wrapper_func_proto(Node *n, Wrapper* wrapper = NULL)
-    {
-       ParmList *parms = Getattr(n, "parms");
+  scoped_dohptr get_wrapper_func_proto(Node *n, Wrapper *wrapper = NULL) {
+    ParmList *parms = Getattr(n, "parms");
 
-       Parm *p;
-       String *proto = NewString("(");
-       int gencomma = 0;
+    Parm *p;
+    String *proto = NewString("(");
+    int gencomma = 0;
 
-       // attach the standard typemaps
-       if (wrapper) {
-         emit_attach_parmmaps(parms, wrapper);
-       } else {
-         // We can't call emit_attach_parmmaps() without a wrapper, it would just crash.
-         // Attach "in" manually, we need it for tmap:in:numinputs below.
-         Swig_typemap_attach_parms("in", parms, 0);
-       }
-       Setattr(n, "wrap:parms", parms); //never read again?!
-
-       // attach 'ctype' typemaps
-       Swig_typemap_attach_parms("ctype", parms, 0);
-
-
-       // prepare function definition
-       for (p = parms, gencomma = 0; p; ) {
-            String *tm;
-            SwigType *type = NULL;
-
-            while (p && checkAttribute(p, "tmap:in:numinputs", "0")) {
-                 p = Getattr(p, "tmap:in:next");
-            }
-            if (!p) break;
-
-            type = Getattr(p, "type");
-            if (SwigType_type(type) == T_VOID) {
-                 p = nextSibling(p);
-                 continue;
-            }
-
-            if (SwigType_type(type) == T_VARARGS) {
-              Swig_error(Getfile(n), Getline(n), "Vararg function %s not supported.\n", Getattr(n, "name"));
-              return scoped_dohptr(NULL);
-            }
-
-            String *lname = Getattr(p, "lname");
-            String *c_parm_type = 0;
-            String *arg_name = NewString("");
-
-            Printf(arg_name, "c%s", lname);
-
-            if ((tm = Getattr(p, "tmap:ctype"))) { // set the appropriate type for parameter
-                 c_parm_type = Copy(tm);
-                 substituteResolvedType(type, c_parm_type);
-
-                 // We prefer to keep typedefs in the wrapper functions signatures as it makes them more readable, but we can't do it for nested typedefs as
-                 // they're not valid in C, so resolve them in this case.
-                 if (strstr(Char(c_parm_type), "::")) {
-                   SwigType* const tdtype = SwigType_typedef_resolve_all(c_parm_type);
-                   Delete(c_parm_type);
-                   c_parm_type = tdtype;
-                 }
-
-                 // template handling
-                 Replaceall(c_parm_type, "$tt", SwigType_lstr(type, 0));
-            } else {
-                 Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
-            }
-
-            Printv(proto, gencomma ? ", " : "", c_parm_type, " ", arg_name, NIL);
-            gencomma = 1;
-
-            // apply typemaps for input parameter
-            if ((tm = Getattr(p, "tmap:in"))) {
-                 Replaceall(tm, "$input", arg_name);
-                 if (wrapper) {
-                   Setattr(p, "emit:input", arg_name);
-                   Printf(wrapper->code, "%s\n", tm);
-                 }
-                 p = Getattr(p, "tmap:in:next");
-            } else {
-                 Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(type, 0));
-                 p = nextSibling(p);
-            }
-
-            Delete(arg_name);
-            Delete(c_parm_type);
-       }
-
-       Printv(proto, ")", NIL);
-       return scoped_dohptr(proto);
+    // attach the standard typemaps
+    if (wrapper) {
+      emit_attach_parmmaps(parms, wrapper);
+    } else {
+      // We can't call emit_attach_parmmaps() without a wrapper, it would just crash.
+      // Attach "in" manually, we need it for tmap:in:numinputs below.
+      Swig_typemap_attach_parms("in", parms, 0);
     }
+    Setattr(n, "wrap:parms", parms);  // never read again?!
+
+    // attach 'ctype' typemaps
+    Swig_typemap_attach_parms("ctype", parms, 0);
+
+    // prepare function definition
+    for (p = parms, gencomma = 0; p;) {
+      String *tm;
+      SwigType *type = NULL;
+
+      while (p && checkAttribute(p, "tmap:in:numinputs", "0")) {
+        p = Getattr(p, "tmap:in:next");
+      }
+      if (!p)
+        break;
+
+      type = Getattr(p, "type");
+      if (SwigType_type(type) == T_VOID) {
+        p = nextSibling(p);
+        continue;
+      }
+
+      if (SwigType_type(type) == T_VARARGS) {
+        Swig_error(Getfile(n), Getline(n), "Vararg function %s not supported.\n", Getattr(n, "name"));
+        return scoped_dohptr(NULL);
+      }
+
+      String *lname = Getattr(p, "lname");
+      String *c_parm_type = 0;
+      String *arg_name = NewString("");
+
+      Printf(arg_name, "c%s", lname);
+
+      if ((tm = Getattr(p, "tmap:ctype"))) {  // set the appropriate type for parameter
+        c_parm_type = Copy(tm);
+        substituteResolvedType(type, c_parm_type);
+
+        // We prefer to keep typedefs in the wrapper functions signatures as it makes them more readable, but we can't do it for nested typedefs as
+        // they're not valid in C, so resolve them in this case.
+        if (strstr(Char(c_parm_type), "::")) {
+          SwigType *const tdtype = SwigType_typedef_resolve_all(c_parm_type);
+          Delete(c_parm_type);
+          c_parm_type = tdtype;
+        }
+
+        // template handling
+        Replaceall(c_parm_type, "$tt", SwigType_lstr(type, 0));
+      } else {
+        Swig_warning(WARN_C_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(type, 0));
+      }
+
+      Printv(proto, gencomma ? ", " : "", c_parm_type, " ", arg_name, NIL);
+      gencomma = 1;
+
+      // apply typemaps for input parameter
+      if ((tm = Getattr(p, "tmap:in"))) {
+        Replaceall(tm, "$input", arg_name);
+        if (wrapper) {
+          Setattr(p, "emit:input", arg_name);
+          Printf(wrapper->code, "%s\n", tm);
+        }
+        p = Getattr(p, "tmap:in:next");
+      } else {
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(type, 0));
+        p = nextSibling(p);
+      }
+
+      Delete(arg_name);
+      Delete(c_parm_type);
+    }
+
+    Printv(proto, ")", NIL);
+    return scoped_dohptr(proto);
+  }
 
   /* ----------------------------------------------------------------------
    * emit_wrapper_func_decl()
@@ -2363,214 +2320,210 @@ public:
    * Declares the wrapper function, using the C types used for it, in the header.
    * The node here is a function declaration.
    * ---------------------------------------------------------------------- */
-  void emit_wrapper_func_decl(Node *n, String *wname)
-    {
-       current_output = output_wrapper_decl;
+  void emit_wrapper_func_decl(Node *n, String *wname) {
+    current_output = output_wrapper_decl;
 
-       // add function declaration to the proxy header file
-       Printv(sect_wrappers_decl, "SWIGIMPORT ", get_wrapper_func_return_type(n).get(), " ", wname, get_wrapper_func_proto(n).get(), ";\n\n", NIL);
-    }
+    // add function declaration to the proxy header file
+    Printv(sect_wrappers_decl, "SWIGIMPORT ", get_wrapper_func_return_type(n).get(), " ", wname, get_wrapper_func_proto(n).get(), ";\n\n", NIL);
+  }
 
+  void functionWrapperCPPSpecific(Node *n) {
+    ParmList *parms = Getattr(n, "parms");
+    String *name = Copy(Getattr(n, "sym:name"));
 
-    void functionWrapperCPPSpecific(Node *n)
-    {
-       ParmList *parms = Getattr(n, "parms");
-       String *name = Copy(Getattr(n, "sym:name"));
+    // mangle name if function is overloaded
+    if (Getattr(n, "sym:overloaded")) {
+      if (!Getattr(n, "copy_constructor")) {
+        Parm *first_param = (Parm *)parms;
+        if (first_param) {
+          // Skip the first "this" parameter of the wrapped methods, it doesn't participate in overload resolution and would just result in extra long
+          // and ugly names.
+          //
+          // We need to avoid dropping the first argument of static methods which don't have "this" pointer, in spite of being members (and we have to
+          // use "cplus:staticbase" for this instead of just using Swig_storage_isstatic() because "storage" is reset in staticmemberfunctionHandler()
+          // and so is not available here.
+          //
+          // Of course, the constructors don't have the extra first parameter neither.
+          if (!Checkattr(n, "nodeType", "constructor") && Checkattr(n, "ismember", "1") && !Getattr(n, "cplus:staticbase")) {
+            first_param = nextSibling(first_param);
 
-       // mangle name if function is overloaded
-       if (Getattr(n, "sym:overloaded")) {
-            if (!Getattr(n, "copy_constructor")) {
-                Parm* first_param = (Parm*)parms;
-                if (first_param) {
-                  // Skip the first "this" parameter of the wrapped methods, it doesn't participate in overload resolution and would just result in extra long
-                  // and ugly names.
-                  //
-                  // We need to avoid dropping the first argument of static methods which don't have "this" pointer, in spite of being members (and we have to
-                  // use "cplus:staticbase" for this instead of just using Swig_storage_isstatic() because "storage" is reset in staticmemberfunctionHandler()
-                  // and so is not available here.
-                  //
-                  // Of course, the constructors don't have the extra first parameter neither.
-                  if (!Checkattr(n, "nodeType", "constructor") &&
-                        Checkattr(n, "ismember", "1") &&
-                          !Getattr(n, "cplus:staticbase")) {
-                    first_param = nextSibling(first_param);
+            // A special case of overloading on const/non-const "this" pointer only, we still need to distinguish between those.
+            if (SwigType_isconst(Getattr(n, "decl"))) {
+              const char *const nonconst = Char(Getattr(n, "decl")) + 9 /* strlen("q(const).") */;
+              for (Node *nover = Getattr(n, "sym:overloaded"); nover; nover = Getattr(nover, "sym:nextSibling")) {
+                if (nover == n)
+                  continue;
 
-                    // A special case of overloading on const/non-const "this" pointer only, we still need to distinguish between those.
-                    if (SwigType_isconst(Getattr(n, "decl"))) {
-                      const char * const nonconst = Char(Getattr(n, "decl")) + 9 /* strlen("q(const).") */;
-                      for (Node* nover = Getattr(n, "sym:overloaded"); nover; nover = Getattr(nover, "sym:nextSibling")) {
-                        if (nover == n)
-                          continue;
-
-                        if (Cmp(Getattr(nover, "decl"), nonconst) == 0) {
-                          // We have an overload differing by const only, disambiguate.
-                          Append(name, "_const");
-                          break;
-                        }
-                      }
-                    }
-                  }
-
-                  functionWrapperAppendOverloaded(name, first_param);
+                if (Cmp(Getattr(nover, "decl"), nonconst) == 0) {
+                  // We have an overload differing by const only, disambiguate.
+                  Append(name, "_const");
+                  break;
                 }
-            }
-       }
-
-       // make sure lnames are set
-       Parm *p;
-       int index = 1;
-       String *lname = 0;
-
-       for (p = (Parm*)parms, index = 1; p; (p = nextSibling(p)), index++) {
-            if(!(lname = Getattr(p, "lname"))) {
-                 lname = NewStringf("arg%d", index);
-                 Setattr(p, "lname", lname);
-            }
-       }
-
-       // C++ function wrapper
-       current_output = output_wrapper_def;
-
-       SwigType *type = Getattr(n, "type");
-       scoped_dohptr return_type = get_wrapper_func_return_type(n);
-       maybe_owned_dohptr wname = getFunctionWrapperName(n, name);
-       bool is_void_return = (SwigType_type(type) == T_VOID);
-       // create new function wrapper object
-       Wrapper *wrapper = NewWrapper();
-
-       // create new wrapper name
-       Setattr(n, "wrap:name", wname);
-
-       // add variable for holding result of original function 'cppresult'
-       if (!is_void_return) {
-         SwigType *value_type = cplus_value_type(type);
-         SwigType* cppresult_type = value_type ? value_type : type;
-         SwigType* ltype = SwigType_ltype(cppresult_type);
-         Wrapper_add_local(wrapper, "cppresult", SwigType_str(ltype, "cppresult"));
-         Delete(ltype);
-         Delete(value_type);
-       }
-
-       // create wrapper function prototype
-       Printv(wrapper->def, "SWIGEXPORTC ", return_type.get(), " ", wname.get(), NIL);
-
-       Printv(wrapper->def, get_wrapper_func_proto(n, wrapper).get(), NIL);
-       Printv(wrapper->def, " {", NIL);
-
-        // emit variables for holding parameters
-        emit_parameter_variables(parms, wrapper);
-
-        // emit variable for holding function return value
-        emit_return_variable(n, return_type, wrapper);
-
-       // insert constraint checking
-       for (p = parms; p; ) {
-            String *tm;
-            if ((tm = Getattr(p, "tmap:check"))) {
-                 Replaceall(tm, "$target", Getattr(p, "lname"));
-                 Replaceall(tm, "$name", name);
-                 Printv(wrapper->code, tm, "\n", NIL);
-                 p = Getattr(p, "tmap:check:next");
-            } else {
-                 p = nextSibling(p);
-            }
-       }
-
-       // create action code
-       String *action = Getattr(n, "wrap:action");
-       if (!action)
-         action = NewString("");
-
-       String *cbase_name = Getattr(n, "c:base_name");
-       if (cbase_name) {
-            Replaceall(action, "arg1)->", NewStringf("(%s*)arg1)->", Getattr(n, "c:inherited_from")));
-            Replaceall(action, Getattr(n, "name"), cbase_name);
-       }
-
-       Replaceall(action, "result =", "cppresult =");
-
-       // prepare action code to use, e.g. insert try-catch blocks
-       action = emit_action(n);
-
-       // emit output typemap if needed
-       if (!is_void_return) {
-            String *tm;
-            if ((tm = Swig_typemap_lookup_out("out", n, "cppresult", wrapper, action))) {
-              // This is ugly, but the type of our result variable is not always the same as the actual return type currently because
-              // get_wrapper_func_return_type() applies ctype typemap to it. These types are more or less compatible though, so we should be able to cast
-              // between them explicitly.
-              const char* start = Char(tm);
-              const char* p = strstr(start, "$result = ");
-              if (p == start || (p && p[-1] == ' ')) {
-                p += strlen("$result = ");
-                scoped_dohptr result_cast(NewStringf("(%s)", return_type.get()));
-
-                // However don't add a cast which is already there.
-                if (strncmp(p, Char(result_cast), strlen(Char(result_cast))) != 0)
-                  Insert(tm, (int)(p - start), result_cast);
               }
-                 Replaceall(tm, "$result", "result");
-                 Replaceall(tm, "$owner", GetFlag(n, "feature:new") ? "1" : "0");
-                 Printf(wrapper->code, "%s", tm);
-                 if (Len(tm))
-                   Printf(wrapper->code, "\n");
-            } else {
-                 Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(type, 0), Getattr(n, "name"));
             }
-       } else {
-            Append(wrapper->code, action);
-       }
+          }
 
-       // insert cleanup code
-       for (p = parms; p; ) {
-            String *tm;
-            if ((tm = Getattr(p, "tmap:freearg"))) {
-                 if (tm && (Len(tm) != 0)) {
-                      String *input = NewStringf("c%s", Getattr(p, "lname"));
-                      Replaceall(tm, "$source", Getattr(p, "lname"));
-                      Replaceall(tm, "$input", input);
-                      Delete(input);
-                      Printv(wrapper->code, tm, "\n", NIL);
-                 }
-                 p = Getattr(p, "tmap:freearg:next");
-            } else {
-                 p = nextSibling(p);
-            }
-       }
-
-       if (is_void_return) {
-         Replaceall(wrapper->code, "$null", "");
-         Replaceall(wrapper->code, "$isvoid", "1");
-       } else {
-         Replaceall(wrapper->code, "$null", "0");
-         Replaceall(wrapper->code, "$isvoid", "0");
-
-         Append(wrapper->code, "return result;\n");
-       }
-
-       Append(wrapper->code, "}\n");
-
-       Wrapper_print(wrapper, sect_wrappers);
-
-       // cleanup
-       DelWrapper(wrapper);
-
-       emit_wrapper_func_decl(n, wname);
-
-       if (cxx_wrappers_.is_initialized()) {
-         temp_ptr_setter<Node*> set(&cxx_wrappers_.node_func_, n);
-
-         if (cxx_class_wrapper_) {
-           cxx_class_wrapper_->emit_member_function(n);
-         } else {
-           cxx_function_wrapper w(cxx_wrappers_, n, Getattr(n, "parms"));
-           if (w.can_wrap())
-             w.emit();
-         }
-       }
-
-       Delete(name);
+          functionWrapperAppendOverloaded(name, first_param);
+        }
+      }
     }
+
+    // make sure lnames are set
+    Parm *p;
+    int index = 1;
+    String *lname = 0;
+
+    for (p = (Parm *)parms, index = 1; p; (p = nextSibling(p)), index++) {
+      if (!(lname = Getattr(p, "lname"))) {
+        lname = NewStringf("arg%d", index);
+        Setattr(p, "lname", lname);
+      }
+    }
+
+    // C++ function wrapper
+    current_output = output_wrapper_def;
+
+    SwigType *type = Getattr(n, "type");
+    scoped_dohptr return_type = get_wrapper_func_return_type(n);
+    maybe_owned_dohptr wname = getFunctionWrapperName(n, name);
+    bool is_void_return = (SwigType_type(type) == T_VOID);
+    // create new function wrapper object
+    Wrapper *wrapper = NewWrapper();
+
+    // create new wrapper name
+    Setattr(n, "wrap:name", wname);
+
+    // add variable for holding result of original function 'cppresult'
+    if (!is_void_return) {
+      SwigType *value_type = cplus_value_type(type);
+      SwigType *cppresult_type = value_type ? value_type : type;
+      SwigType *ltype = SwigType_ltype(cppresult_type);
+      Wrapper_add_local(wrapper, "cppresult", SwigType_str(ltype, "cppresult"));
+      Delete(ltype);
+      Delete(value_type);
+    }
+
+    // create wrapper function prototype
+    Printv(wrapper->def, "SWIGEXPORTC ", return_type.get(), " ", wname.get(), NIL);
+
+    Printv(wrapper->def, get_wrapper_func_proto(n, wrapper).get(), NIL);
+    Printv(wrapper->def, " {", NIL);
+
+    // emit variables for holding parameters
+    emit_parameter_variables(parms, wrapper);
+
+    // emit variable for holding function return value
+    emit_return_variable(n, return_type, wrapper);
+
+    // insert constraint checking
+    for (p = parms; p;) {
+      String *tm;
+      if ((tm = Getattr(p, "tmap:check"))) {
+        Replaceall(tm, "$target", Getattr(p, "lname"));
+        Replaceall(tm, "$name", name);
+        Printv(wrapper->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
+      } else {
+        p = nextSibling(p);
+      }
+    }
+
+    // create action code
+    String *action = Getattr(n, "wrap:action");
+    if (!action)
+      action = NewString("");
+
+    String *cbase_name = Getattr(n, "c:base_name");
+    if (cbase_name) {
+      Replaceall(action, "arg1)->", NewStringf("(%s*)arg1)->", Getattr(n, "c:inherited_from")));
+      Replaceall(action, Getattr(n, "name"), cbase_name);
+    }
+
+    Replaceall(action, "result =", "cppresult =");
+
+    // prepare action code to use, e.g. insert try-catch blocks
+    action = emit_action(n);
+
+    // emit output typemap if needed
+    if (!is_void_return) {
+      String *tm;
+      if ((tm = Swig_typemap_lookup_out("out", n, "cppresult", wrapper, action))) {
+        // This is ugly, but the type of our result variable is not always the same as the actual return type currently because
+        // get_wrapper_func_return_type() applies ctype typemap to it. These types are more or less compatible though, so we should be able to cast
+        // between them explicitly.
+        const char *start = Char(tm);
+        const char *p = strstr(start, "$result = ");
+        if (p == start || (p && p[-1] == ' ')) {
+          p += strlen("$result = ");
+          scoped_dohptr result_cast(NewStringf("(%s)", return_type.get()));
+
+          // However don't add a cast which is already there.
+          if (strncmp(p, Char(result_cast), strlen(Char(result_cast))) != 0)
+            Insert(tm, (int)(p - start), result_cast);
+        }
+        Replaceall(tm, "$result", "result");
+        Replaceall(tm, "$owner", GetFlag(n, "feature:new") ? "1" : "0");
+        Printf(wrapper->code, "%s", tm);
+        if (Len(tm))
+          Printf(wrapper->code, "\n");
+      } else {
+        Swig_warning(
+          WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(type, 0), Getattr(n, "name"));
+      }
+    } else {
+      Append(wrapper->code, action);
+    }
+
+    // insert cleanup code
+    for (p = parms; p;) {
+      String *tm;
+      if ((tm = Getattr(p, "tmap:freearg"))) {
+        if (tm && (Len(tm) != 0)) {
+          String *input = NewStringf("c%s", Getattr(p, "lname"));
+          Replaceall(tm, "$source", Getattr(p, "lname"));
+          Replaceall(tm, "$input", input);
+          Delete(input);
+          Printv(wrapper->code, tm, "\n", NIL);
+        }
+        p = Getattr(p, "tmap:freearg:next");
+      } else {
+        p = nextSibling(p);
+      }
+    }
+
+    if (is_void_return) {
+      Replaceall(wrapper->code, "$null", "");
+      Replaceall(wrapper->code, "$isvoid", "1");
+    } else {
+      Replaceall(wrapper->code, "$null", "0");
+      Replaceall(wrapper->code, "$isvoid", "0");
+
+      Append(wrapper->code, "return result;\n");
+    }
+
+    Append(wrapper->code, "}\n");
+
+    Wrapper_print(wrapper, sect_wrappers);
+
+    // cleanup
+    DelWrapper(wrapper);
+
+    emit_wrapper_func_decl(n, wname);
+
+    if (cxx_wrappers_.is_initialized()) {
+      temp_ptr_setter<Node *> set(&cxx_wrappers_.node_func_, n);
+
+      if (cxx_class_wrapper_) {
+        cxx_class_wrapper_->emit_member_function(n);
+      } else {
+        cxx_function_wrapper w(cxx_wrappers_, n, Getattr(n, "parms"));
+        if (w.can_wrap())
+          w.emit();
+      }
+    }
+
+    Delete(name);
+  }
 
   /* ----------------------------------------------------------------------
    * functionWrapper()
@@ -2608,7 +2561,7 @@ public:
     Setattr(new_node, "type", Copy(Getattr(node, "type")));
     Setattr(new_node, "decl", Copy(Getattr(node, "decl")));
 
-    Node* const parent = parentNode(node);
+    Node *const parent = parentNode(node);
     Setattr(new_node, "c:inherited_from", Getattr(parent, "name"));
     Setattr(new_node, "sym:name", Getattr(node, "sym:name"));
     Setattr(new_node, "sym:symtab", Getattr(parent, "symtab"));
@@ -2657,13 +2610,13 @@ public:
         return SWIG_ERROR;
       }
 
-      const char * const unnamed_end = strchr(Char(type_str) + 6, '$');
+      const char *const unnamed_end = strchr(Char(type_str) + 6, '$');
       if (!unnamed_end) {
         Swig_error(Getfile(n), Getline(n), "Unsupported anonymous enum type \"%s\".\n", type_str);
         return SWIG_ERROR;
       }
 
-      String* const int_type_str = NewStringf("int%s", unnamed_end + 1);
+      String *const int_type_str = NewStringf("int%s", unnamed_end + 1);
       Delete(type_str);
       type_str = int_type_str;
     } else {
@@ -2690,7 +2643,7 @@ public:
       }
     }
 
-    String* const var_decl = NewStringEmpty();
+    String *const var_decl = NewStringEmpty();
     if (SwigType_isarray(type)) {
       String *dims = Strchr(type_str, '[');
       char *c = Char(type_str);
@@ -2713,17 +2666,17 @@ public:
    * This is done to avoid gcc warnings "declaration does not declare anything" given for the anonymous enums inside the structs.
    * --------------------------------------------------------------------- */
 
-  void emit_c_struct_def(String* out, Node *n) {
-    for ( Node* node = firstChild(n); node; node = nextSibling(node)) {
-      String* const ntype = nodeType(node);
+  void emit_c_struct_def(String *out, Node *n) {
+    for (Node *node = firstChild(n); node; node = nextSibling(node)) {
+      String *const ntype = nodeType(node);
       if (Cmp(ntype, "cdecl") == 0) {
-        SwigType* t = NewString(Getattr(node, "type"));
+        SwigType *t = NewString(Getattr(node, "type"));
         SwigType_push(t, Getattr(node, "decl"));
         t = SwigType_typedef_resolve_all(t);
         if (SwigType_isfunction(t)) {
-            Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number, "Extending C struct with %s is not currently supported, ignored.\n", SwigType_str(t, 0));
+          Swig_warning(WARN_C_UNSUPPORTTED, input_file, line_number, "Extending C struct with %s is not currently supported, ignored.\n", SwigType_str(t, 0));
         } else {
-          String* const var_decl = make_c_var_decl(node);
+          String *const var_decl = make_c_var_decl(node);
           Printv(out, cindent, var_decl, ";\n", NIL);
           Delete(var_decl);
         }
@@ -2747,7 +2700,7 @@ public:
       // Ignore this class only if it was already wrapped in another module, imported from this one (if exceptions are disabled, we shouldn't be even parsing
       // SWIG_CException in the first place and if they're enabled, we handle it normally).
       if (exceptions_support_ == exceptions_support_imported)
-          return SWIG_NOWRAP;
+        return SWIG_NOWRAP;
     }
 
     return Language::classDeclaration(n);
@@ -2758,11 +2711,11 @@ public:
    * --------------------------------------------------------------------- */
 
   virtual int classHandler(Node *n) {
-    String* const name = get_c_proxy_name(n);
+    String *const name = get_c_proxy_name(n);
 
     if (CPlusPlus) {
       cxx_class_wrapper cxx_class_wrapper_obj(cxx_wrappers_, n);
-      temp_ptr_setter<cxx_class_wrapper*> set_cxx_class_wrapper(&cxx_class_wrapper_, &cxx_class_wrapper_obj);
+      temp_ptr_setter<cxx_class_wrapper *> set_cxx_class_wrapper(&cxx_class_wrapper_, &cxx_class_wrapper_obj);
 
       // inheritance support: attach all members from base classes to this class
       if (List *baselist = Getattr(n, "bases")) {
@@ -2771,31 +2724,29 @@ public:
           // look for member variables and functions
           Node *node;
           for (node = firstChild(i.item); node; node = nextSibling(node)) {
-            if ((Cmp(Getattr(node, "kind"), "variable") == 0)
-                || (Cmp(Getattr(node, "kind"), "function") == 0)) {
-              if ((Cmp(Getattr(node, "access"), "public") == 0)
-                  && (Cmp(Getattr(node, "storage"), "static") != 0)) {
-                  // Assignment operators are not inherited in C++ and symbols without sym:name should be ignored, not copied into the derived class.
-                  if (Getattr(node, "sym:name") && Cmp(Getattr(node, "name"), "operator =") != 0) {
-                    String *parent_name = Getattr(parentNode(node), "name");
-                    Hash *dupl_name_node = is_in(Getattr(node, "name"), n);
-                    // if there's a duplicate inherited name, due to the C++ multiple
-                    // inheritance, change both names to avoid ambiguity
-                    if (dupl_name_node) {
-                      String *cif = Getattr(dupl_name_node, "c:inherited_from");
-                      String *old_name = Getattr(dupl_name_node, "sym:name");
-                      if (cif && parent_name && (Cmp(cif, parent_name) != 0)) {
-                        Setattr(dupl_name_node, "sym:name", NewStringf("%s%s", cif ? cif : "", old_name));
-                        Setattr(dupl_name_node, "c:base_name", old_name);
-                        Node *new_node = copy_node(node);
-                        Setattr(new_node, "name", NewStringf("%s%s", parent_name, old_name));
-                        Setattr(new_node, "c:base_name", old_name);
-                        appendChild(n, new_node);
-                      }
-                    } else {
-                      appendChild(n, copy_node(node));
+            if ((Cmp(Getattr(node, "kind"), "variable") == 0) || (Cmp(Getattr(node, "kind"), "function") == 0)) {
+              if ((Cmp(Getattr(node, "access"), "public") == 0) && (Cmp(Getattr(node, "storage"), "static") != 0)) {
+                // Assignment operators are not inherited in C++ and symbols without sym:name should be ignored, not copied into the derived class.
+                if (Getattr(node, "sym:name") && Cmp(Getattr(node, "name"), "operator =") != 0) {
+                  String *parent_name = Getattr(parentNode(node), "name");
+                  Hash *dupl_name_node = is_in(Getattr(node, "name"), n);
+                  // if there's a duplicate inherited name, due to the C++ multiple
+                  // inheritance, change both names to avoid ambiguity
+                  if (dupl_name_node) {
+                    String *cif = Getattr(dupl_name_node, "c:inherited_from");
+                    String *old_name = Getattr(dupl_name_node, "sym:name");
+                    if (cif && parent_name && (Cmp(cif, parent_name) != 0)) {
+                      Setattr(dupl_name_node, "sym:name", NewStringf("%s%s", cif ? cif : "", old_name));
+                      Setattr(dupl_name_node, "c:base_name", old_name);
+                      Node *new_node = copy_node(node);
+                      Setattr(new_node, "name", NewStringf("%s%s", parent_name, old_name));
+                      Setattr(new_node, "c:base_name", old_name);
+                      appendChild(n, new_node);
                     }
+                  } else {
+                    appendChild(n, copy_node(node));
                   }
+                }
               }
             }
           }
@@ -2808,8 +2759,8 @@ public:
       return Language::classHandler(n);
     } else {
       // this is C struct, just declare it in the proxy
-      String* struct_def = NewStringEmpty();
-      String* const tdname = Getattr(n, "tdname");
+      String *struct_def = NewStringEmpty();
+      String *const tdname = Getattr(n, "tdname");
       if (tdname)
         Append(struct_def, "typedef struct {\n");
       else
@@ -2899,7 +2850,7 @@ public:
   virtual int enumforwardDeclaration(Node *n) {
     // Base implementation of this function calls enumDeclaration() for "missing" enums, i.e. those without any definition at all. This results in invalid (at
     // least in C++) enum declarations in the output, so simply don't do this here.
-    (void) n;
+    (void)n;
     return SWIG_OK;
   }
 
@@ -2930,7 +2881,7 @@ public:
       }
     }
 
-    String* const symname = Getattr(n, "sym:name");
+    String *const symname = Getattr(n, "sym:name");
 
     // Preserve the typedef if we have it in the input.
     bool const is_typedef = Checkattr(n, "allows_typedef", "1");
@@ -2943,21 +2894,21 @@ public:
     if (cxx_enum_decl)
       Printv(cxx_enum_decl, "enum", NIL);
 
-    String* enum_prefix;
-    if (Node* const klass = getCurrentClass()) {
+    String *enum_prefix;
+    if (Node *const klass = getCurrentClass()) {
       enum_prefix = get_c_proxy_name(klass);
     } else {
-      enum_prefix = ns_prefix; // Possibly NULL, but that's fine.
+      enum_prefix = ns_prefix;  // Possibly NULL, but that's fine.
     }
 
     // C++ enum names don't use the prefix, as they're defined in namespace or class scope.
-    String* cxx_enum_prefix = NULL;
+    String *cxx_enum_prefix = NULL;
 
     scoped_dohptr enumname;
     scoped_dohptr cxx_enumname;
 
     // Unnamed enums may just have no name at all or have a synthesized invalid name of the form "$unnamedN$ which is indicated by "unnamed" attribute.
-    if (String* const name = Getattr(n, "unnamed") ? NULL : symname) {
+    if (String *const name = Getattr(n, "unnamed") ? NULL : symname) {
       // If it's a typedef, its sym:name is the typedef name, but we don't want to use it here (we already use it for the typedef we generate), so use the
       // actual C++ name instead.
       if (is_typedef) {
@@ -3051,7 +3002,7 @@ public:
         Printv(cxx_enum_decl, ",\n", NIL);
     }
 
-    String* const symname = Getattr(n, "sym:name");
+    String *const symname = Getattr(n, "sym:name");
     Printv(enum_decl, cindent, enum_prefix_.get(), symname, NIL);
     if (cxx_enum_decl)
       Printv(cxx_enum_decl, cxx_enum_indent, cindent, cxx_enum_prefix_.get(), symname, NIL);
@@ -3063,20 +3014,20 @@ public:
       // We can't always use the raw value, check its type to see if we need to transform it.
       maybe_owned_dohptr cvalue;
       switch (SwigType_type(Getattr(n, "type"))) {
-        case T_BOOL:
-          // Boolean constants can't appear in C code, so replace them with their values in the simplest possible case. This is not exhaustive, of course,
-          // but better than nothing and doing the right thing is not simple at all as we'd need to really parse the expression, just textual substitution wouldn't
-          // be enough (consider e.g. an enum element called "very_true" and another one using it as its value).
-          if (Cmp(value, "true") == 0) {
-            cvalue.assign_owned(NewString("1"));
-          } else if (Cmp(value, "false") == 0) {
-            cvalue.assign_owned(NewString("0"));
-          } else {
-            Swig_error(Getfile(n), Getline(n), "Unsupported boolean enum value \"%s\".\n", value);
-          }
-          break;
-        default:
-          cvalue.assign_non_owned(value);
+      case T_BOOL:
+        // Boolean constants can't appear in C code, so replace them with their values in the simplest possible case. This is not exhaustive, of course,
+        // but better than nothing and doing the right thing is not simple at all as we'd need to really parse the expression, just textual substitution
+        // wouldn't be enough (consider e.g. an enum element called "very_true" and another one using it as its value).
+        if (Cmp(value, "true") == 0) {
+          cvalue.assign_owned(NewString("1"));
+        } else if (Cmp(value, "false") == 0) {
+          cvalue.assign_owned(NewString("0"));
+        } else {
+          Swig_error(Getfile(n), Getline(n), "Unsupported boolean enum value \"%s\".\n", value);
+        }
+        break;
+      default:
+        cvalue.assign_non_owned(value);
       }
 
       Printv(enum_decl, " = ", cvalue.get(), NIL);
@@ -3099,7 +3050,7 @@ public:
     Printv(sect_wrappers_decl, "#define ", name, " ", value, "\n", NIL);
     return SWIG_OK;
   }
-};                              /* class C */
+}; /* class C */
 
 /* -----------------------------------------------------------------------------
  * swig_c()    - Instantiate module
@@ -3123,4 +3074,3 @@ C Options (available with -c)\n\
      -nocxx          - do not generate C++ wrappers\n\
      -noexcept       - do not generate exception handling code\n\
 \n";
-

--- a/Source/Modules/contract.cxx
+++ b/Source/Modules/contract.cxx
@@ -25,8 +25,8 @@ struct contract {
 
 static contract Rules[] = {
   {"require:", "&&"},
-  {"ensure:", "||"},
-  {NULL, NULL}
+  {"ensure:",  "||"},
+  {NULL,       NULL}
 };
 
 /* ----------------------------------------------------------------------------
@@ -36,9 +36,10 @@ static contract Rules[] = {
  *         "wrap by contract" module.
  * ------------------------------------------------------------------------- */
 
-class Contracts:public Dispatcher {
+class Contracts : public Dispatcher {
   String *make_expression(String *s, Node *n);
   void substitute_parms(String *s, ParmList *p, int method);
+
 public:
   Hash *ContractSplit(Node *n);
   int emit_contract(Node *n, int method);
@@ -53,8 +54,8 @@ public:
   virtual int top(Node *n);
 };
 
-static int Contract_Mode = 0;   /* contract option */
-static int InClass = 0;         /* Parsing C++ or not */
+static int Contract_Mode = 0; /* contract option */
+static int InClass = 0;       /* Parsing C++ or not */
 static int InConstructor = 0;
 static Node *CurrentClass = 0;
 
@@ -146,8 +147,8 @@ static void inherit_contracts(Node *c, Node *n, Hash *contracts, Hash *messages)
       base_decl = Getattr(temp, "decl");
       if (base_decl) {
         base_decl = SwigType_typedef_resolve_all(base_decl);
-        if ((checkAttribute(temp, "storage", "virtual")) &&
-            (checkAttribute(temp, "name", name)) && (checkAttribute(temp, "type", type)) && (!Strcmp(local_decl, base_decl))) {
+        if ((checkAttribute(temp, "storage", "virtual")) && (checkAttribute(temp, "name", name)) && (checkAttribute(temp, "type", type)) &&
+            (!Strcmp(local_decl, base_decl))) {
           /* Yes, match found. */
           Hash *icontracts = Getattr(temp, "contract:rules");
           Hash *imessages = Getattr(temp, "contract:messages");

--- a/Source/Modules/contract.cxx
+++ b/Source/Modules/contract.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -32,7 +32,7 @@ static contract Rules[] = {
 /* ----------------------------------------------------------------------------
  * class Contracts:
  *
- * This class defines the functions that need to be used in 
+ * This class defines the functions that need to be used in
  *         "wrap by contract" module.
  * ------------------------------------------------------------------------- */
 
@@ -222,7 +222,7 @@ String *Contracts::make_expression(String *s, Node *n) {
 }
 
 /* This function substitutes parameter names for argument names in the
-   contract specification.  Note: it is assumed that the wrapper code 
+   contract specification.  Note: it is assumed that the wrapper code
    uses arg1 for self and arg2..argn for arguments. */
 
 void Contracts::substitute_parms(String *s, ParmList *p, int method) {

--- a/Source/Modules/contract.cxx
+++ b/Source/Modules/contract.cxx
@@ -53,8 +53,8 @@ public:
   virtual int top(Node *n);
 };
 
-static int Contract_Mode = 0;	/* contract option */
-static int InClass = 0;		/* Parsing C++ or not */
+static int Contract_Mode = 0;   /* contract option */
+static int InClass = 0;         /* Parsing C++ or not */
 static int InConstructor = 0;
 static Node *CurrentClass = 0;
 

--- a/Source/Modules/contract.cxx
+++ b/Source/Modules/contract.cxx
@@ -99,15 +99,15 @@ Hash *Contracts::ContractSplit(Node *n) {
       continue;
     for (int j = 0; Rules[j].section; j++) {
       if (Strstr(i.item, Rules[j].section)) {
-	if (Len(current_section)) {
-	  Setattr(result, current_section_name, current_section);
-	  current_section = Getattr(result, Rules[j].section);
-	  if (!current_section)
-	    current_section = NewString("");
-	}
-	current_section_name = Rules[j].section;
-	found = 1;
-	break;
+        if (Len(current_section)) {
+          Setattr(result, current_section_name, current_section);
+          current_section = Getattr(result, Rules[j].section);
+          if (!current_section)
+            current_section = NewString("");
+        }
+        current_section_name = Rules[j].section;
+        found = 1;
+        break;
       }
     }
     if (!found)
@@ -145,34 +145,34 @@ static void inherit_contracts(Node *c, Node *n, Hash *contracts, Hash *messages)
     while (temp) {
       base_decl = Getattr(temp, "decl");
       if (base_decl) {
-	base_decl = SwigType_typedef_resolve_all(base_decl);
-	if ((checkAttribute(temp, "storage", "virtual")) &&
-	    (checkAttribute(temp, "name", name)) && (checkAttribute(temp, "type", type)) && (!Strcmp(local_decl, base_decl))) {
-	  /* Yes, match found. */
-	  Hash *icontracts = Getattr(temp, "contract:rules");
-	  Hash *imessages = Getattr(temp, "contract:messages");
-	  found = 1;
-	  if (icontracts && imessages) {
-	    /* Add inherited contracts and messages to the contract rules above */
-	    int j = 0;
-	    for (j = 0; Rules[j].section; j++) {
-	      String *t = Getattr(contracts, Rules[j].section);
-	      String *s = Getattr(icontracts, Rules[j].section);
-	      if (s) {
-		if (t) {
-		  Insert(t, 0, "(");
-		  Printf(t, ") %s (%s)", Rules[j].combiner, s);
-		  String *m = Getattr(messages, Rules[j].section);
-		  Printf(m, " %s [%s from %s]", Rules[j].combiner, Getattr(imessages, Rules[j].section), Getattr(b, "name"));
-		} else {
-		  Setattr(contracts, Rules[j].section, NewString(s));
-		  Setattr(messages, Rules[j].section, NewStringf("[%s from %s]", Getattr(imessages, Rules[j].section), Getattr(b, "name")));
-		}
-	      }
-	    }
-	  }
-	}
-	Delete(base_decl);
+        base_decl = SwigType_typedef_resolve_all(base_decl);
+        if ((checkAttribute(temp, "storage", "virtual")) &&
+            (checkAttribute(temp, "name", name)) && (checkAttribute(temp, "type", type)) && (!Strcmp(local_decl, base_decl))) {
+          /* Yes, match found. */
+          Hash *icontracts = Getattr(temp, "contract:rules");
+          Hash *imessages = Getattr(temp, "contract:messages");
+          found = 1;
+          if (icontracts && imessages) {
+            /* Add inherited contracts and messages to the contract rules above */
+            int j = 0;
+            for (j = 0; Rules[j].section; j++) {
+              String *t = Getattr(contracts, Rules[j].section);
+              String *s = Getattr(icontracts, Rules[j].section);
+              if (s) {
+                if (t) {
+                  Insert(t, 0, "(");
+                  Printf(t, ") %s (%s)", Rules[j].combiner, s);
+                  String *m = Getattr(messages, Rules[j].section);
+                  Printf(m, " %s [%s from %s]", Rules[j].combiner, Getattr(imessages, Rules[j].section), Getattr(b, "name"));
+                } else {
+                  Setattr(contracts, Rules[j].section, NewString(s));
+                  Setattr(messages, Rules[j].section, NewStringf("[%s from %s]", Getattr(imessages, Rules[j].section), Getattr(b, "name")));
+                }
+              }
+            }
+          }
+        }
+        Delete(base_decl);
       }
       temp = nextSibling(temp);
     }
@@ -213,7 +213,7 @@ String *Contracts::make_expression(String *s, Node *n) {
     if (Len(expr)) {
       Replaceid(expr, Getattr(n, "name"), Swig_cresult_name());
       if (Len(str_assert))
-	Append(str_assert, "&&");
+        Append(str_assert, "&&");
       Printf(str_assert, "(%s)", expr);
     }
   }

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -13,14 +13,14 @@
 
 #include "swigmod.h"
 #include "cparse.h"
-#include <limits.h>             // for INT_MAX
+#include <limits.h>  // for INT_MAX
 #include <ctype.h>
 #include <csharpdoc.h>
 
 /* Hash type used for upcalls from C/C++ */
 typedef DOH UpcallData;
 
-class CSHARP:public Language {
+class CSHARP : public Language {
   static const char *usage;
   const String *empty_string;
   const String *public_string;
@@ -38,52 +38,52 @@ class CSHARP:public Language {
   File *f_single_out;
   List *filenames_list;
 
-  bool proxy_flag;              // Flag for generating proxy classes
-  bool native_function_flag;    // Flag for when wrapping a native function
-  bool enum_constant_flag;      // Flag for when wrapping an enum or constant
-  bool static_flag;             // Flag for when wrapping a static functions or member variables
-  bool variable_wrapper_flag;   // Flag for when wrapping a nonstatic member variable
-  bool wrapping_member_flag;    // Flag for when wrapping a member variable/enum/const
-  bool global_variable_flag;    // Flag for when wrapping a global variable
-  bool old_variable_names;      // Flag for old style variable names in the intermediary class
-  bool generate_property_declaration_flag;      // Flag for generating properties
-  bool doxygen; // Flag for Doxygen generation
+  bool proxy_flag;                          // Flag for generating proxy classes
+  bool native_function_flag;                // Flag for when wrapping a native function
+  bool enum_constant_flag;                  // Flag for when wrapping an enum or constant
+  bool static_flag;                         // Flag for when wrapping a static functions or member variables
+  bool variable_wrapper_flag;               // Flag for when wrapping a nonstatic member variable
+  bool wrapping_member_flag;                // Flag for when wrapping a member variable/enum/const
+  bool global_variable_flag;                // Flag for when wrapping a global variable
+  bool old_variable_names;                  // Flag for old style variable names in the intermediary class
+  bool generate_property_declaration_flag;  // Flag for generating properties
+  bool doxygen;                             // Flag for Doxygen generation
 
-  String *imclass_name;         // intermediary class name
-  String *module_class_name;    // module class name
-  String *imclass_class_code;   // intermediary class code
+  String *imclass_name;        // intermediary class name
+  String *module_class_name;   // module class name
+  String *imclass_class_code;  // intermediary class code
   String *proxy_class_def;
   String *proxy_class_code;
-  String *interface_class_code; // if %feature("interface") was declared for a class, here goes the interface declaration
+  String *interface_class_code;  // if %feature("interface") was declared for a class, here goes the interface declaration
   String *module_class_code;
-  String *proxy_class_name;     // proxy class name
-  String *full_imclass_name;    // fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
-  String *variable_name;        //Name of a variable being wrapped
+  String *proxy_class_name;   // proxy class name
+  String *full_imclass_name;  // fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
+  String *variable_name;      // Name of a variable being wrapped
   String *proxy_class_constants_code;
   String *module_class_constants_code;
   String *common_begin_code;
   String *enum_code;
-  String *dllimport;            // DllImport attribute name
-  String *namespce;             // Optional namespace name
-  String *imclass_imports;      //intermediary class imports from %pragma
-  String *module_imports;       //module imports from %pragma
-  String *imclass_baseclass;    //inheritance for intermediary class class from %pragma
-  String *module_baseclass;     //inheritance for module class from %pragma
-  String *imclass_interfaces;   //interfaces for intermediary class class from %pragma
-  String *module_interfaces;    //interfaces for module class from %pragma
-  String *imclass_class_modifiers;      //class modifiers for intermediary class overridden by %pragma
-  String *module_class_modifiers;       //class modifiers for module class overridden by %pragma
-  String *upcasts_code;         //C++ casts for inheritance hierarchies C++ code
-  String *imclass_cppcasts_code;        //C++ casts up inheritance hierarchies intermediary class code
-  String *director_callback_typedefs;   // Director function pointer typedefs for callbacks
-  String *director_callbacks;   // Director callback function pointer member variables
-  String *director_delegate_callback;   // Director callback method that delegates are set to call
-  String *director_delegate_definitions;        // Director delegates definitions in proxy class
-  String *director_delegate_instances;  // Director delegates member variables in proxy class
-  String *director_method_types;        // Director method types
-  String *director_connect_parms;       // Director delegates parameter list for director connect call
-  String *destructor_call;      //C++ destructor call if any
-  String *output_file;          // File name for single file mode. If set all generated code will be written to this file
+  String *dllimport;                      // DllImport attribute name
+  String *namespce;                       // Optional namespace name
+  String *imclass_imports;                // intermediary class imports from %pragma
+  String *module_imports;                 // module imports from %pragma
+  String *imclass_baseclass;              // inheritance for intermediary class class from %pragma
+  String *module_baseclass;               // inheritance for module class from %pragma
+  String *imclass_interfaces;             // interfaces for intermediary class class from %pragma
+  String *module_interfaces;              // interfaces for module class from %pragma
+  String *imclass_class_modifiers;        // class modifiers for intermediary class overridden by %pragma
+  String *module_class_modifiers;         // class modifiers for module class overridden by %pragma
+  String *upcasts_code;                   // C++ casts for inheritance hierarchies C++ code
+  String *imclass_cppcasts_code;          // C++ casts up inheritance hierarchies intermediary class code
+  String *director_callback_typedefs;     // Director function pointer typedefs for callbacks
+  String *director_callbacks;             // Director callback function pointer member variables
+  String *director_delegate_callback;     // Director callback method that delegates are set to call
+  String *director_delegate_definitions;  // Director delegates definitions in proxy class
+  String *director_delegate_instances;    // Director delegates member variables in proxy class
+  String *director_method_types;          // Director method types
+  String *director_connect_parms;         // Director delegates parameter list for director connect call
+  String *destructor_call;                // C++ destructor call if any
+  String *output_file;                    // File name for single file mode. If set all generated code will be written to this file
 
   // Director method stuff:
   List *dmethods_seq;
@@ -97,77 +97,77 @@ class CSHARP:public Language {
   enum EnumFeature { SimpleEnum, TypeunsafeEnum, TypesafeEnum, ProperEnum };
 
 public:
-
   /* -----------------------------------------------------------------------------
    * CSHARP()
    * ----------------------------------------------------------------------------- */
 
-   CSHARP():empty_string(NewString("")),
-      public_string(NewString("public")),
-      protected_string(NewString("protected")),
-      swig_types_hash(NULL),
-      f_begin(NULL),
-      f_runtime(NULL),
-      f_runtime_h(NULL),
-      f_header(NULL),
-      f_wrappers(NULL),
-      f_init(NULL),
-      f_directors(NULL),
-      f_directors_h(NULL),
-      f_single_out(NULL),
-      filenames_list(NULL),
-      proxy_flag(true),
-      native_function_flag(false),
-      enum_constant_flag(false),
-      static_flag(false),
-      variable_wrapper_flag(false),
-      wrapping_member_flag(false),
-      global_variable_flag(false),
-      old_variable_names(false),
-      generate_property_declaration_flag(false),
-      doxygen(false),
-      imclass_name(NULL),
-      module_class_name(NULL),
-      imclass_class_code(NULL),
-      proxy_class_def(NULL),
-      proxy_class_code(NULL),
-      interface_class_code(NULL),
-      module_class_code(NULL),
-      proxy_class_name(NULL),
-      full_imclass_name(NULL),
-      variable_name(NULL),
-      proxy_class_constants_code(NULL),
-      module_class_constants_code(NULL),
-      common_begin_code(NULL),
-      enum_code(NULL),
-      dllimport(NULL),
-      namespce(NULL),
-      imclass_imports(NULL),
-      module_imports(NULL),
-      imclass_baseclass(NULL),
-      module_baseclass(NULL),
-      imclass_interfaces(NULL),
-      module_interfaces(NULL),
-      imclass_class_modifiers(NULL),
-      module_class_modifiers(NULL),
-      upcasts_code(NULL),
-      imclass_cppcasts_code(NULL),
-      director_callback_typedefs(NULL),
-      director_callbacks(NULL),
-      director_delegate_callback(NULL),
-      director_delegate_definitions(NULL),
-      director_delegate_instances(NULL),
-      director_method_types(NULL),
-      director_connect_parms(NULL),
-      destructor_call(NULL),
-      output_file(NULL),
-      dmethods_seq(NULL),
-      dmethods_table(NULL),
-      n_dmethods(0),
-      n_directors(0),
-      first_class_dmethod(0),
-      curr_class_dmethod(0),
-      nesting_depth(0){
+  CSHARP() :
+    empty_string(NewString("")),
+    public_string(NewString("public")),
+    protected_string(NewString("protected")),
+    swig_types_hash(NULL),
+    f_begin(NULL),
+    f_runtime(NULL),
+    f_runtime_h(NULL),
+    f_header(NULL),
+    f_wrappers(NULL),
+    f_init(NULL),
+    f_directors(NULL),
+    f_directors_h(NULL),
+    f_single_out(NULL),
+    filenames_list(NULL),
+    proxy_flag(true),
+    native_function_flag(false),
+    enum_constant_flag(false),
+    static_flag(false),
+    variable_wrapper_flag(false),
+    wrapping_member_flag(false),
+    global_variable_flag(false),
+    old_variable_names(false),
+    generate_property_declaration_flag(false),
+    doxygen(false),
+    imclass_name(NULL),
+    module_class_name(NULL),
+    imclass_class_code(NULL),
+    proxy_class_def(NULL),
+    proxy_class_code(NULL),
+    interface_class_code(NULL),
+    module_class_code(NULL),
+    proxy_class_name(NULL),
+    full_imclass_name(NULL),
+    variable_name(NULL),
+    proxy_class_constants_code(NULL),
+    module_class_constants_code(NULL),
+    common_begin_code(NULL),
+    enum_code(NULL),
+    dllimport(NULL),
+    namespce(NULL),
+    imclass_imports(NULL),
+    module_imports(NULL),
+    imclass_baseclass(NULL),
+    module_baseclass(NULL),
+    imclass_interfaces(NULL),
+    module_interfaces(NULL),
+    imclass_class_modifiers(NULL),
+    module_class_modifiers(NULL),
+    upcasts_code(NULL),
+    imclass_cppcasts_code(NULL),
+    director_callback_typedefs(NULL),
+    director_callbacks(NULL),
+    director_delegate_callback(NULL),
+    director_delegate_definitions(NULL),
+    director_delegate_instances(NULL),
+    director_method_types(NULL),
+    director_connect_parms(NULL),
+    destructor_call(NULL),
+    output_file(NULL),
+    dmethods_seq(NULL),
+    dmethods_table(NULL),
+    n_dmethods(0),
+    n_directors(0),
+    first_class_dmethod(0),
+    curr_class_dmethod(0),
+    nesting_depth(0) {
     /* for now, multiple inheritance in directors is disabled, this
        should be easy to implement though */
     director_multiple_inheritance = 0;
@@ -178,9 +178,9 @@ public:
    * ~CSHARP()
    * ----------------------------------------------------------------------------- */
 
-   ~CSHARP() {
-     delete doxygenTranslator;
-   }
+  ~CSHARP() {
+    delete doxygenTranslator;
+  }
 
   /* -----------------------------------------------------------------------------
    * getProxyName()
@@ -190,41 +190,40 @@ public:
    * a namespace if the nspace feature is used.
    * ----------------------------------------------------------------------------- */
 
-   String *getProxyName(SwigType *t) {
-     String *proxyname = NULL;
-     if (proxy_flag) {
-       Node *n = classLookup(t);
-       if (n) {
-         proxyname = Getattr(n, "proxyname");
-         if (!proxyname) {
-           String *nspace = Getattr(n, "sym:nspace");
-           String *symname = Copy(Getattr(n, "sym:name"));
-           if (symname && !GetFlag(n, "feature:flatnested")) {
-             for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
-               if (String* name = Getattr(outer_class, "sym:name")) {
-                 Push(symname, ".");
-                 Push(symname, name);
-               }
-               else
-                 return NULL;
-             }
-           }
-           if (nspace) {
-             if (namespce)
-               proxyname = NewStringf("%s.%s.%s", namespce, nspace, symname);
-             else
-               proxyname = NewStringf("%s.%s", nspace, symname);
-           } else {
-             proxyname = Copy(symname);
-           }
-           Setattr(n, "proxyname", proxyname);
-           Delete(proxyname);
-           Delete(symname);
-         }
-       }
-     }
-     return proxyname;
-   }
+  String *getProxyName(SwigType *t) {
+    String *proxyname = NULL;
+    if (proxy_flag) {
+      Node *n = classLookup(t);
+      if (n) {
+        proxyname = Getattr(n, "proxyname");
+        if (!proxyname) {
+          String *nspace = Getattr(n, "sym:nspace");
+          String *symname = Copy(Getattr(n, "sym:name"));
+          if (symname && !GetFlag(n, "feature:flatnested")) {
+            for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
+              if (String *name = Getattr(outer_class, "sym:name")) {
+                Push(symname, ".");
+                Push(symname, name);
+              } else
+                return NULL;
+            }
+          }
+          if (nspace) {
+            if (namespce)
+              proxyname = NewStringf("%s.%s.%s", namespce, nspace, symname);
+            else
+              proxyname = NewStringf("%s.%s", nspace, symname);
+          } else {
+            proxyname = Copy(symname);
+          }
+          Setattr(n, "proxyname", proxyname);
+          Delete(proxyname);
+          Delete(symname);
+        }
+      }
+    }
+    return proxyname;
+  }
 
   /* ------------------------------------------------------------
    * main()
@@ -457,8 +456,7 @@ public:
       Printf(wrapper_name, "CSharp_%s_%%f", namespce);
       Swig_name_register("wrapper", wrapper_name);
       Delete(wrapper_name);
-    }
-    else {
+    } else {
       Swig_name_register("wrapper", "CSharp_%f");
     }
 
@@ -578,9 +576,13 @@ public:
         String *item2_lower = Swig_string_lower(it2.item);
         if (it1.item && it2.item) {
           if (Strcmp(item1_lower, item2_lower) == 0) {
-            Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
+            Swig_warning(WARN_LANG_PORTABILITY_FILENAME,
+                         input_file,
+                         line_number,
                          "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
-                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
+                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n",
+                         it1.item,
+                         it2.item);
           }
         }
         Delete(item2_lower);
@@ -842,7 +844,7 @@ public:
     }
 
     if ((tm = Swig_typemap_lookup("imtype", n, "", 0))) {
-      String *imtypeout = Getattr(n, "tmap:imtype:out");        // the type in the imtype typemap's out attribute overrides the type in the typemap
+      String *imtypeout = Getattr(n, "tmap:imtype:out");  // the type in the imtype typemap's out attribute overrides the type in the typemap
       if (imtypeout)
         tm = imtypeout;
       Printf(im_return_type, "%s", tm);
@@ -883,7 +885,6 @@ public:
       Printf(imclass_class_code, "  %s\n", im_outattributes);
 
     Printf(imclass_class_code, "  public static extern %s %s(", im_return_type, overloaded_name);
-
 
     /* Get number of required and total arguments */
     num_arguments = emit_num_arguments(l);
@@ -932,7 +933,7 @@ public:
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
         canThrow(n, "in", p);
-        Replaceall(tm, "$arg", arg);    /* deprecated? */
+        Replaceall(tm, "$arg", arg); /* deprecated? */
         Replaceall(tm, "$input", arg);
         Setattr(p, "emit:input", arg);
         Printf(f->code, "%s\n", tm);
@@ -950,7 +951,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
         canThrow(n, "check", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input")); /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(f->code, tm, "\n", NIL);
         p = Getattr(p, "tmap:check:next");
@@ -963,7 +964,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
         canThrow(n, "freearg", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input")); /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(cleanup, tm, "\n", NIL);
         p = Getattr(p, "tmap:freearg:next");
@@ -976,7 +977,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
         canThrow(n, "argout", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input")); /* deprecated? */
         Replaceall(tm, "$result", "jresult");
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(outarg, tm, "\n", NIL);
@@ -1019,7 +1020,8 @@ public:
         if (Len(tm))
           Printf(f->code, "\n");
       } else {
-        Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
+        Swig_warning(
+          WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
       }
       emit_return_variable(n, returntype, f);
     }
@@ -1088,11 +1090,16 @@ public:
       // so that code which checks for pending exceptions is added in the C# proxy method.
       if (!Getattr(n, "csharp:canthrow")) {
         if (Strstr(f->code, "SWIG_exception")) {
-          Swig_warning(WARN_CSHARP_CANTHROW, input_file, line_number,
+          Swig_warning(WARN_CSHARP_CANTHROW,
+                       input_file,
+                       line_number,
                        "Unmanaged code contains a call to SWIG_exception and C# code does not handle pending exceptions via the canthrow attribute.\n");
         } else if (Strstr(f->code, "SWIG_CSharpSetPendingException")) {
-          Swig_warning(WARN_CSHARP_CANTHROW, input_file, line_number,
-                       "Unmanaged code contains a call to a SWIG_CSharpSetPendingException method and C# code does not handle pending exceptions via the canthrow attribute.\n");
+          Swig_warning(WARN_CSHARP_CANTHROW,
+                       input_file,
+                       line_number,
+                       "Unmanaged code contains a call to a SWIG_CSharpSetPendingException method and C# code does not handle pending exceptions via the "
+                       "canthrow attribute.\n");
         }
       }
     }
@@ -1114,7 +1121,7 @@ public:
         Printf(getter_setter_name, "set");
       else
         Printf(getter_setter_name, "get");
-      Putc(toupper((int) *Char(variable_name)), getter_setter_name);
+      Putc(toupper((int)*Char(variable_name)), getter_setter_name);
       Printf(getter_setter_name, "%s", Char(variable_name) + 1);
 
       Setattr(n, "proxyfuncname", getter_setter_name);
@@ -1202,10 +1209,10 @@ public:
       if (getCurrentClass() && (cplus_mode != PUBLIC))
         return SWIG_NOWRAP;
 
-      String *nspace = Getattr(n, "sym:nspace"); // NSpace/getNSpace() only works during Language::enumDeclaration call
+      String *nspace = Getattr(n, "sym:nspace");  // NSpace/getNSpace() only works during Language::enumDeclaration call
       enum_code = NewString("");
       String *symname = Getattr(n, "sym:name");
-      String *constants_code = (proxy_flag && is_wrapping_class())? proxy_class_constants_code : module_class_constants_code;
+      String *constants_code = (proxy_flag && is_wrapping_class()) ? proxy_class_constants_code : module_class_constants_code;
       EnumFeature enum_feature = decodeEnumFeature(n);
       String *typemap_lookup_type = Getattr(n, "name");
 
@@ -1244,9 +1251,13 @@ public:
         if (purebase_replace) {
           wanted_base = pure_baseclass;
         } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
-          Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+          Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE,
+                       Getfile(n),
+                       Getline(n),
                        "Warning for %s, enum base %s ignored. Multiple enum bases is not supported in C# enums. "
-                       "Perhaps you need the 'replace' attribute in the csbase typemap?\n", typemap_lookup_type, pure_baseclass);
+                       "Perhaps you need the 'replace' attribute in the csbase typemap?\n",
+                       typemap_lookup_type,
+                       pure_baseclass);
         }
 
         // Class attributes
@@ -1255,8 +1266,14 @@ public:
           Printf(enum_code, "%s\n", csattributes);
 
         // Emit the enum
-        Printv(enum_code, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),        // Class modifiers (enum modifiers really)
-               " ", symname, *Char(wanted_base) ? " : " : "", wanted_base, " {\n", NIL);
+        Printv(enum_code,
+               typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),  // Class modifiers (enum modifiers really)
+               " ",
+               symname,
+               *Char(wanted_base) ? " : " : "",
+               wanted_base,
+               " {\n",
+               NIL);
         Delete(scope);
       } else {
         // Wrap C++ enum with integers - just indicate start of enum with a comment, no comment for anonymous enums of any sort
@@ -1291,9 +1308,11 @@ public:
         // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper C# enum
         // Finish the enum declaration
         // Typemaps are used to generate the enum definition in a similar manner to proxy classes.
-        Printv(enum_code, (enum_feature == ProperEnum) ? "\n" : typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),      // main body of class
-               typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),      // extra C# code
-               "}", NIL);
+        Printv(enum_code,
+               (enum_feature == ProperEnum) ? "\n" : typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),  // main body of class
+               typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),                                                               // extra C# code
+               "}",
+               NIL);
 
         Replaceall(enum_code, "$csclassname", symname);
 
@@ -1318,8 +1337,12 @@ public:
 
           addOpenNamespace(nspace, f_enum);
 
-          Printv(f_enum, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE), // Import statements
-                 "\n", enum_code, "\n", NIL);
+          Printv(f_enum,
+                 typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE),  // Import statements
+                 "\n",
+                 enum_code,
+                 "\n",
+                 NIL);
 
           addCloseNamespace(nspace, f_enum);
           if (f_enum != f_single_out)
@@ -1381,7 +1404,8 @@ public:
       }
     } else {
       String *numval = Getattr(n, "enumnumval");
-      if (numval) Setattr(n, "enumvalue", numval);
+      if (numval)
+        Setattr(n, "enumvalue", numval);
     }
 
     {
@@ -1515,7 +1539,15 @@ public:
     String *constants_code = NewString("");
     // The value as C# code.
     String *csvalue = Copy(Getattr(n, "value"));
-    Swig_save("constantWrapper", n, "tmap:ctype:out", "tmap:imtype:out", "tmap:cstype:out", "tmap:out:null", "tmap:imtype:outattributes", "tmap:cstype:outattributes", NIL);
+    Swig_save("constantWrapper",
+              n,
+              "tmap:ctype:out",
+              "tmap:imtype:out",
+              "tmap:cstype:out",
+              "tmap:out:null",
+              "tmap:imtype:outattributes",
+              "tmap:cstype:outattributes",
+              NIL);
 
     bool is_enum_item = (Cmp(nodeType(n), "enumitem") == 0);
 
@@ -1553,7 +1585,7 @@ public:
     bool classname_substituted_flag = false;
 
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
-      String *cstypeout = Getattr(n, "tmap:cstype:out");        // the type in the cstype typemap's out attribute overrides the type in the typemap
+      String *cstypeout = Getattr(n, "tmap:cstype:out");  // the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
         tm = cstypeout;
       classname_substituted_flag = substituteClassname(t, tm);
@@ -1565,14 +1597,14 @@ public:
     if (Getattr(n, "stringval")) {
       char quote = 0;
       switch (SwigType_type(t)) {
-        case T_STRING:
-        case T_WSTRING:
-          quote = '\"';
-          break;
-        case T_CHAR:
-        case T_WCHAR:
-          quote = '\'';
-          break;
+      case T_STRING:
+      case T_WSTRING:
+        quote = '\"';
+        break;
+      case T_CHAR:
+      case T_WCHAR:
+        quote = '\'';
+        break;
       }
       if (quote) {
         // Escape character literal for C#.
@@ -1611,7 +1643,11 @@ public:
           Printf(constants_code, "(%s)%s.%s();\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
         } else {
           // This handles function pointers using the %constant directive
-          Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+          Printf(constants_code,
+                 "new %s(%s.%s(), false);\n",
+                 return_type,
+                 full_imclass_name ? full_imclass_name : imclass_name,
+                 Swig_name_get(getNSpace(), symname));
         }
       } else {
         Printf(constants_code, "%s.%s();\n", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
@@ -1837,9 +1873,19 @@ public:
         String *bsmartnamestr = SwigType_namestr(bsmart);
 
         Printv(upcasts_code,
-            "SWIGEXPORT ", bsmartnamestr, " * SWIGSTDCALL ", wname, "(", smartnamestr, " *jarg1) {\n",
-            "    return jarg1 ? new ", bsmartnamestr, "(*jarg1) : 0;\n"
-            "}\n", "\n", NIL);
+               "SWIGEXPORT ",
+               bsmartnamestr,
+               " * SWIGSTDCALL ",
+               wname,
+               "(",
+               smartnamestr,
+               " *jarg1) {\n",
+               "    return jarg1 ? new ",
+               bsmartnamestr,
+               "(*jarg1) : 0;\n"
+               "}\n",
+               "\n",
+               NIL);
 
         Delete(bsmartnamestr);
         Delete(smartnamestr);
@@ -1849,9 +1895,19 @@ public:
       String *baseclassname = SwigType_namestr(c_baseclassname);
 
       Printv(upcasts_code,
-          "SWIGEXPORT ", baseclassname, " * SWIGSTDCALL ", wname, "(", classname, " *jarg1) {\n",
-          "    return (", baseclassname, " *)jarg1;\n"
-          "}\n", "\n", NIL);
+             "SWIGEXPORT ",
+             baseclassname,
+             " * SWIGSTDCALL ",
+             wname,
+             "(",
+             classname,
+             " *jarg1) {\n",
+             "    return (",
+             baseclassname,
+             " *)jarg1;\n"
+             "}\n",
+             "\n",
+             NIL);
 
       Delete(baseclassname);
       Delete(classname);
@@ -1901,8 +1957,12 @@ public:
             } else {
               /* Warn about multiple inheritance for additional base class(es) */
               String *proxyclassname = Getattr(n, "classtypeobj");
-              Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-                  "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#.\n", SwigType_namestr(proxyclassname), SwigType_namestr(baseclassname));
+              Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE,
+                           Getfile(n),
+                           Getline(n),
+                           "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#.\n",
+                           SwigType_namestr(proxyclassname),
+                           SwigType_namestr(baseclassname));
             }
           }
           base = Next(base);
@@ -1923,11 +1983,16 @@ public:
       derived = false;
       baseclass = NULL;
       if (purebase_notderived)
-        Swig_error(Getfile(n), Getline(n), "The csbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n", typemap_lookup_type);
+        Swig_error(
+          Getfile(n), Getline(n), "The csbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n", typemap_lookup_type);
     } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
-      Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+      Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE,
+                   Getfile(n),
+                   Getline(n),
                    "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#. "
-                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the csbase typemap?\n", typemap_lookup_type, pure_baseclass);
+                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the csbase typemap?\n",
+                   typemap_lookup_type,
+                   pure_baseclass);
     }
 
     // Pure C# interfaces
@@ -1937,8 +2002,10 @@ public:
     Append(interface_list, pure_interfaces);
     // Start writing the proxy class
     if (!has_outerclass)
-      Printv(proxy_class_def, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE),    // Import statements
-           "\n", NIL);
+      Printv(proxy_class_def,
+             typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE),  // Import statements
+             "\n",
+             NIL);
 
     // Translate documentation comments
     if (have_docstring(n)) {
@@ -1952,11 +2019,18 @@ public:
     if (csattributes && *Char(csattributes))
       Printf(proxy_class_def, "%s\n", csattributes);
 
-    Printv(proxy_class_def, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),      // Class modifiers
-           " $csclassname",     // Class name and base class
-           (*Char(wanted_base) || *Char(interface_list)) ? " : " : "", wanted_base, (*Char(wanted_base) && *Char(interface_list)) ?     // Interfaces
-           ", " : "", interface_list, " {", derived ? typemapLookup(n, "csbody_derived", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF) :       // main body of class
-           typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),   // main body of class
+    Printv(proxy_class_def,
+           typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),  // Class modifiers
+           " $csclassname",                                                                                // Class name and base class
+           (*Char(wanted_base) || *Char(interface_list)) ? " : " : "",
+           wanted_base,
+           (*Char(wanted_base) && *Char(interface_list)) ?  // Interfaces
+             ", "
+                                                         : "",
+           interface_list,
+           " {",
+           derived ? typemapLookup(n, "csbody_derived", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF) :  // main body of class
+             typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),                   // main body of class
            NIL);
 
     // C++ destructor is wrapped by the Finalize and Dispose methods
@@ -1964,16 +2038,22 @@ public:
     const char *tmap_method = derived ? "csdestruct_derived" : "csdestruct";
     const String *tm = typemapExists(n, tmap_method, typemap_lookup_type);
     if (tm) {
-      Swig_error(Getfile(tm), Getline(tm),
-          "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
-          tmap_method, proxy_class_name);
+      Swig_error(Getfile(tm),
+                 Getline(tm),
+                 "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the "
+                 "csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
+                 tmap_method,
+                 proxy_class_name);
     }
     tmap_method = "csfinalize";
     tm = typemapExists(n, tmap_method, typemap_lookup_type);
     if (tm) {
-      Swig_error(Getfile(tm), Getline(tm),
-          "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
-          tmap_method, proxy_class_name);
+      Swig_error(Getfile(tm),
+                 Getline(tm),
+                 "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the "
+                 "csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
+                 tmap_method,
+                 proxy_class_name);
     }
 
     tmap_method = derived ? "csdisposing_derived" : "csdisposing";
@@ -1998,8 +2078,7 @@ public:
         Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in %s typemap for %s\n", tmap_method, proxy_class_name);
       }
       if (!destruct_methodmodifiers) {
-        Swig_error(Getfile(n), Getline(n),
-                   "No methodmodifiers attribute defined in %s typemap for %s.\n", tmap_method, proxy_class_name);
+        Swig_error(Getfile(n), Getline(n), "No methodmodifiers attribute defined in %s typemap for %s.\n", tmap_method, proxy_class_name);
       }
       if (!destruct_parameters)
         destruct_parameters = empty_string;
@@ -2056,7 +2135,9 @@ public:
         Printf(proxy_class_code, "\n");
         Printf(proxy_class_code, "  private bool SwigDerivedClassHasMethod(string methodName, global::System.Type[] methodTypes) {\n");
         Printf(proxy_class_code, "    global::System.Reflection.MethodInfo[] methodInfos = this.GetType().GetMethods(\n");
-        Printf(proxy_class_code, "        global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance);\n");
+        Printf(proxy_class_code,
+               "        global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | "
+               "global::System.Reflection.BindingFlags.Instance);\n");
         Printf(proxy_class_code, "    foreach (global::System.Reflection.MethodInfo methodInfo in methodInfos) {\n");
         Printf(proxy_class_code, "      if (methodInfo.DeclaringType == null)\n");
         Printf(proxy_class_code, "        continue;\n\n");
@@ -2100,7 +2181,7 @@ public:
          }
          }
          */
-        //Printf(proxy_class_code, "    return hasDerivedMethod;\n");
+        // Printf(proxy_class_code, "    return hasDerivedMethod;\n");
         Printf(proxy_class_code, "  }\n");
       }
 
@@ -2136,8 +2217,10 @@ public:
     Delete(destruct);
 
     // Emit extra user code
-    Printv(proxy_class_def, typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE), // extra C# code
-           "\n", NIL);
+    Printv(proxy_class_def,
+           typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),  // extra C# code
+           "\n",
+           NIL);
 
     if (derived) {
       String *upcast_method_name = Swig_name_member(getNSpace(), getClassPrefix(), smart != 0 ? "SWIGSmartPtrUpcast" : "SWIGUpcast");
@@ -2167,7 +2250,7 @@ public:
     if (List *baselist = Getattr(n, "bases")) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
         if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
-          continue; // TODO: warn about skipped non-interface bases
+          continue;  // TODO: warn about skipped non-interface bases
         String *base_iname = Getattr(base.item, "interface:name");
         if (!bases)
           bases = NewStringf(" : %s", base_iname);
@@ -2264,8 +2347,7 @@ public:
 
         addOpenNamespace(nspace, f_proxy);
         Delete(output_directory);
-      }
-      else
+      } else
         ++nesting_depth;
 
       proxy_class_def = NewString("");
@@ -2289,7 +2371,7 @@ public:
 
       emitProxyClassDefAndCPPCasts(n);
 
-      String *csclazzname = Swig_name_member(getNSpace(), getClassPrefix(), ""); // mangled full proxy class name
+      String *csclazzname = Swig_name_member(getNSpace(), getClassPrefix(), "");  // mangled full proxy class name
 
       Replaceall(proxy_class_def, "$csclassname", proxy_class_name);
       Replaceall(proxy_class_code, "$csclassname", proxy_class_name);
@@ -2376,8 +2458,7 @@ public:
     return SWIG_OK;
   }
 
-  void printArgumentDeclaration(Node *n, Parm *p, String *param_type, String *arg, String *code)
-  {
+  void printArgumentDeclaration(Node *n, Parm *p, String *param_type, String *arg, String *code) {
     String *specifiedoverridekey = NewString("feature:cs:defaultargs:");
     Append(specifiedoverridekey, arg);
     String *specifiedoverridevalue = Getattr(n, specifiedoverridekey);
@@ -2385,10 +2466,10 @@ public:
       Printf(code, "%s %s=%s", param_type, arg, specifiedoverridevalue);
     } else {
       String *cppvalue = NULL;
-      //if they've not specified defaultargs, then fall back to
-      //the normal default handling of specifying one overload per possible
-      //set of arguments.  If they have, then use the default argument from
-      //c++ as a literal csharp expression.
+      // if they've not specified defaultargs, then fall back to
+      // the normal default handling of specifying one overload per possible
+      // set of arguments.  If they have, then use the default argument from
+      // c++ as a literal csharp expression.
       if (Getattr(n, "feature:cs:defaultargs"))
         cppvalue = Getattr(p, "value");
       if (cppvalue)
@@ -2398,8 +2479,6 @@ public:
     }
     Delete(specifiedoverridekey);
   }
-
-
 
   /* ----------------------------------------------------------------------
    * memberfunctionHandler()
@@ -2441,7 +2520,6 @@ public:
     return SWIG_OK;
   }
 
-
   /* -----------------------------------------------------------------------------
    * proxyClassFunctionHandler()
    *
@@ -2470,8 +2548,8 @@ public:
     String *pre_code = NewString("");
     String *post_code = NewString("");
     String *terminator_code = NewString("");
-    bool is_interface = GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable")
-      && !static_flag && Getattr(n, "interface:owner") == 0;
+    bool is_interface =
+      GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable") && !static_flag && Getattr(n, "interface:owner") == 0;
 
     if (!proxy_flag)
       return;
@@ -2509,14 +2587,17 @@ public:
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
       // Note that in the case of polymorphic (covariant) return types, the method's return type is changed to be the base of the C++ return type
       SwigType *covariant = Getattr(n, "covariant");
-      String *cstypeout = Getattr(n, "tmap:cstype:out");        // the type in the cstype typemap's out attribute overrides the type in the typemap
+      String *cstypeout = Getattr(n, "tmap:cstype:out");  // the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
         tm = cstypeout;
       substituteClassname(covariant ? covariant : t, tm);
       Printf(return_type, "%s", tm);
       if (covariant)
-        Swig_warning(WARN_CSHARP_COVARIANT_RET, input_file, line_number,
-                     "Covariant return types not supported in C#. Proxy method will return %s.\n", SwigType_str(covariant, 0));
+        Swig_warning(WARN_CSHARP_COVARIANT_RET,
+                     input_file,
+                     line_number,
+                     "Covariant return types not supported in C#. Proxy method will return %s.\n",
+                     SwigType_str(covariant, 0));
     } else {
       Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(t, 0));
     }
@@ -2543,7 +2624,7 @@ public:
         Replaceall(mmods, "override", "");
         Replaceall(mmods, "virtual", "");
         Replaceall(mmods, "new", "");
-        Chop(mmods);            // remove trailing whitespace
+        Chop(mmods);  // remove trailing whitespace
         Printf(function_code, "  %s ", mmods);
         Delete(mmods);
       } else {
@@ -2555,7 +2636,7 @@ public:
       if (!is_smart_pointer()) {
         // Smart pointer classes do not mirror the inheritance hierarchy of the underlying pointer type, so no virtual/override/new required.
         if (Getattr(n, "override"))
-            Printf(function_code, "override ");
+          Printf(function_code, "override ");
         else if (checkAttribute(n, "storage", "virtual"))
           Printf(function_code, "virtual ");
         if (Getattr(n, "hides"))
@@ -2653,7 +2734,7 @@ public:
         gencomma = 2;
         printArgumentDeclaration(n, p, param_type, arg, function_code);
         if (is_interface)
-            printArgumentDeclaration(n, p, param_type, arg, interface_class_code);
+          printArgumentDeclaration(n, p, param_type, arg, interface_class_code);
 
         Delete(arg);
         Delete(param_type);
@@ -2673,7 +2754,7 @@ public:
       bool is_post_code = Len(post_code) > 0;
       bool is_terminator_code = Len(terminator_code) > 0;
       if (is_pre_code || is_post_code || is_terminator_code) {
-        Replaceall(tm, "\n ", "\n   "); // add extra indentation to code in typemap
+        Replaceall(tm, "\n ", "\n   ");  // add extra indentation to code in typemap
         if (is_post_code) {
           Insert(tm, 0, "\n    try ");
           Printv(tm, " finally {\n", post_code, "\n    }", NIL);
@@ -2735,16 +2816,16 @@ public:
 
     if (wrapping_member_flag && !enum_constant_flag) {
       // Properties
-      if (generate_property_declaration_flag) { // Ensure the declaration is generated just once should the property contain both a set and get
+      if (generate_property_declaration_flag) {  // Ensure the declaration is generated just once should the property contain both a set and get
         // Get the C# variable type - obtained differently depending on whether a setter is required.
         String *variable_type = return_type;
         if (setter_flag) {
-          assert(last_parm);    // (last parameter is the only parameter for properties)
+          assert(last_parm);  // (last parameter is the only parameter for properties)
           /* Get variable type - ensure the variable name is fully resolved during typemap lookup via the symbol table set in NewParmNode */
           SwigType *cvariable_type = Getattr(last_parm, "type");
           Parm *variable_parm = NewParmNode(cvariable_type, n);
           if ((tm = Swig_typemap_lookup("cstype", variable_parm, "", 0))) {
-            String *cstypeout = Getattr(variable_parm, "tmap:cstype:out");      // the type in the cstype typemap's out attribute overrides the type in the typemap
+            String *cstypeout = Getattr(variable_parm, "tmap:cstype:out");  // the type in the cstype typemap's out attribute overrides the type in the typemap
             if (cstypeout)
               tm = cstypeout;
             substituteClassname(cvariable_type, tm);
@@ -2772,7 +2853,7 @@ public:
 
       if (setter_flag) {
         // Setter method
-        assert(last_parm);      // (last parameter is the only parameter for properties)
+        assert(last_parm);  // (last parameter is the only parameter for properties)
         SwigType *cvariable_type = Getattr(last_parm, "type");
         Parm *variable_parm = NewParmNode(cvariable_type, n);
         if ((tm = Swig_typemap_lookup("csvarin", variable_parm, "", 0))) {
@@ -2803,7 +2884,7 @@ public:
       }
     } else {
       // Normal function call
-      Printf(function_code, " %s\n\n", tm ? (const String *) tm : empty_string);
+      Printf(function_code, " %s\n\n", tm ? (const String *)tm : empty_string);
       Printv(proxy_class_code, comment_code, NIL);
       Printv(proxy_class_code, function_code, NIL);
     }
@@ -2829,7 +2910,8 @@ public:
     int i;
     String *function_code = NewString("");
     String *comment_code = NewString("");
-    String *helper_code = NewString(""); // Holds code for the constructor helper method generated only when the csin typemap has code in the pre or post attributes
+    String *helper_code =
+      NewString("");  // Holds code for the constructor helper method generated only when the csin typemap has code in the pre or post attributes
     String *helper_args = NewString("");
     String *pre_code = NewString("");
     String *post_code = NewString("");
@@ -2859,8 +2941,8 @@ public:
       const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
       methodmods = methodmods ? methodmods : (is_public(n) ? public_string : protected_string);
 
-      tm = Getattr(n, "tmap:imtype"); // typemaps were attached earlier to the node
-      String *imtypeout = Getattr(n, "tmap:imtype:out");        // the type in the imtype typemap's out attribute overrides the type in the typemap
+      tm = Getattr(n, "tmap:imtype");                     // typemaps were attached earlier to the node
+      String *imtypeout = Getattr(n, "tmap:imtype:out");  // the type in the imtype typemap's out attribute overrides the type in the typemap
       if (imtypeout)
         tm = imtypeout;
       Printf(im_return_type, "%s", tm);
@@ -2973,8 +3055,7 @@ public:
       /* Insert the csconstruct typemap, doing the replacement for $directorconnect, as needed */
       Hash *attributes = NewHash();
       String *typemap_lookup_type = Getattr(getCurrentClass(), "classtypeobj");
-      String *construct_tm = Copy(typemapLookup(n, "csconstruct", typemap_lookup_type,
-                                                WARN_CSHARP_TYPEMAP_CSCONSTRUCT_UNDEF, attributes));
+      String *construct_tm = Copy(typemapLookup(n, "csconstruct", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSCONSTRUCT_UNDEF, attributes));
       if (construct_tm) {
         if (!feature_director) {
           Replaceall(construct_tm, "$directorconnect", "");
@@ -2984,7 +3065,10 @@ public:
           if (connect_attr) {
             Replaceall(construct_tm, "$directorconnect", connect_attr);
           } else {
-            Swig_warning(WARN_CSHARP_NO_DIRECTORCONNECT_ATTR, input_file, line_number, "\"directorconnect\" attribute missing in %s \"csconstruct\" typemap.\n",
+            Swig_warning(WARN_CSHARP_NO_DIRECTORCONNECT_ATTR,
+                         input_file,
+                         line_number,
+                         "\"directorconnect\" attribute missing in %s \"csconstruct\" typemap.\n",
                          Getattr(n, "name"));
             Replaceall(construct_tm, "$directorconnect", "");
           }
@@ -3177,7 +3261,7 @@ public:
 
     /* Get return types */
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
-      String *cstypeout = Getattr(n, "tmap:cstype:out");        // the type in the cstype typemap's out attribute overrides the type in the typemap
+      String *cstypeout = Getattr(n, "tmap:cstype:out");  // the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
         tm = cstypeout;
       substituteClassname(t, tm);
@@ -3195,7 +3279,7 @@ public:
         Printf(func_name, "set");
       else
         Printf(func_name, "get");
-      Putc(toupper((int) *Char(variable_name)), func_name);
+      Putc(toupper((int)*Char(variable_name)), func_name);
       Printf(func_name, "%s", Char(variable_name) + 1);
       if (setter_flag)
         Swig_typemap_attach_parms("csvarin", l, NULL);
@@ -3309,7 +3393,7 @@ public:
       bool is_post_code = Len(post_code) > 0;
       bool is_terminator_code = Len(terminator_code) > 0;
       if (is_pre_code || is_post_code || is_terminator_code) {
-        Replaceall(tm, "\n ", "\n   "); // add extra indentation to code in typemap
+        Replaceall(tm, "\n ", "\n   ");  // add extra indentation to code in typemap
         if (is_post_code) {
           Insert(tm, 0, "\n    try ");
           Printv(tm, " finally {\n", post_code, "\n    }", NIL);
@@ -3339,11 +3423,11 @@ public:
 
     if (proxy_flag && global_variable_flag) {
       // Properties
-      if (generate_property_declaration_flag) { // Ensure the declaration is generated just once should the property contain both a set and get
+      if (generate_property_declaration_flag) {  // Ensure the declaration is generated just once should the property contain both a set and get
         // Get the C# variable type - obtained differently depending on whether a setter is required.
         String *variable_type = return_type;
         if (setter_flag) {
-          p = last_parm;        // (last parameter is the only parameter for properties)
+          p = last_parm;  // (last parameter is the only parameter for properties)
           SwigType *pt = Getattr(p, "type");
           if ((tm = Getattr(p, "tmap:cstype"))) {
             substituteClassname(pt, tm);
@@ -3365,7 +3449,7 @@ public:
 
       if (setter_flag) {
         // Setter method
-        p = last_parm;          // (last parameter is the only parameter for properties)
+        p = last_parm;  // (last parameter is the only parameter for properties)
         SwigType *pt = Getattr(p, "type");
         if ((tm = Getattr(p, "tmap:csvarin"))) {
           substituteClassname(pt, tm);
@@ -3395,7 +3479,7 @@ public:
       }
     } else {
       // Normal function call
-      Printf(function_code, " %s\n\n", tm ? (const String *) tm : empty_string);
+      Printf(function_code, " %s\n\n", tm ? (const String *)tm : empty_string);
       Printv(module_class_code, function_code, NIL);
     }
 
@@ -3479,12 +3563,13 @@ public:
         // Get the enumvalue from a PINVOKE call
         if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
           // Strange hack to change the name
-          Setattr(n, "name", Getattr(n, "value"));      /* for wrapping of enums in a namespace when emit_action is used */
+          Setattr(n, "name", Getattr(n, "value")); /* for wrapping of enums in a namespace when emit_action is used */
           constantWrapper(n);
           value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
         } else {
           memberconstantHandler(n);
-          value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
+          value = NewStringf(
+            "%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
         }
       }
     }
@@ -3649,7 +3734,7 @@ public:
         }
       }
     } else {
-      String *classname = getProxyName(classnametype); // getProxyName() works for pointers to classes too
+      String *classname = getProxyName(classnametype);  // getProxyName() works for pointers to classes too
       if (classname) {
         replacementname = Copy(classname);
       } else {
@@ -3698,20 +3783,30 @@ public:
     const String *pure_interfaces = typemapLookup(n, "csinterfaces", type, WARN_NONE);
 
     // Emit the class
-    Printv(swigtype, typemapLookup(n, "csimports", type, WARN_NONE),    // Import statements
-           "\n", NIL);
+    Printv(swigtype,
+           typemapLookup(n, "csimports", type, WARN_NONE),  // Import statements
+           "\n",
+           NIL);
 
     // Class attributes
     const String *csattributes = typemapLookup(n, "csattributes", type, WARN_NONE);
     if (csattributes && *Char(csattributes))
       Printf(swigtype, "%s\n", csattributes);
 
-    Printv(swigtype, typemapLookup(n, "csclassmodifiers", type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),    // Class modifiers
-           " $csclassname",     // Class name and base class
-           (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "", pure_baseclass, ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ?        // Interfaces
-           ", " : "", pure_interfaces, " {", typemapLookup(n, "csbody", type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),        // main body of class
-           typemapLookup(n, "cscode", type, WARN_NONE), // extra C# code
-           "}\n", NIL);
+    Printv(swigtype,
+           typemapLookup(n, "csclassmodifiers", type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),  // Class modifiers
+           " $csclassname",                                                                 // Class name and base class
+           (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "",
+           pure_baseclass,
+           ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ?  // Interfaces
+             ", "
+                                                               : "",
+           pure_interfaces,
+           " {",
+           typemapLookup(n, "csbody", type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),  // main body of class
+           typemapLookup(n, "cscode", type, WARN_NONE),                         // extra C# code
+           "}\n",
+           NIL);
 
     Replaceall(swigtype, "$csclassname", classname);
     Replaceall(swigtype, "$module", module_class_name);
@@ -3804,8 +3899,8 @@ public:
     if (Getattr(n, "csharp:canthrow")) {
       int count = Replaceall(code, "$excode", excode);
       if (count < 1 || !excode) {
-        Swig_warning(WARN_CSHARP_EXCODE, input_file, line_number,
-                     "C# exception may not be thrown - no $excode or excode attribute in '%s' typemap.\n", typemap);
+        Swig_warning(
+          WARN_CSHARP_EXCODE, input_file, line_number, "C# exception may not be thrown - no $excode or excode attribute in '%s' typemap.\n", typemap);
       }
     } else {
       Replaceall(code, "$excode", empty_string);
@@ -4080,7 +4175,7 @@ public:
       /* Create the intermediate class wrapper */
       tm = Swig_typemap_lookup("imtype", n, "", 0);
       if (tm) {
-        String *imtypeout = Getattr(n, "tmap:imtype:out");      // the type in the imtype typemap's out attribute overrides the type in the typemap
+        String *imtypeout = Getattr(n, "tmap:imtype:out");  // the type in the imtype typemap's out attribute overrides the type in the typemap
         if (imtypeout)
           tm = imtypeout;
         const String *im_directoroutattributes = Getattr(n, "tmap:imtype:directoroutattributes");
@@ -4092,7 +4187,8 @@ public:
 
         Printf(callback_def, "  private %s SwigDirectorMethod%s(", tm, overloaded_name);
         const String *csdirectordelegatemodifiers = Getattr(n, "feature:csdirectordelegatemodifiers");
-        String *modifiers = (csdirectordelegatemodifiers ? NewStringf("%s%s", csdirectordelegatemodifiers, Len(csdirectordelegatemodifiers) > 0 ? " " : "") : NewStringf("public "));
+        String *modifiers = (csdirectordelegatemodifiers ? NewStringf("%s%s", csdirectordelegatemodifiers, Len(csdirectordelegatemodifiers) > 0 ? " " : "")
+                                                         : NewStringf("public "));
         Printf(director_delegate_definitions, "  %sdelegate %s", modifiers, tm);
         Delete(modifiers);
       } else {
@@ -4107,8 +4203,13 @@ public:
         Delete(jretval_decl);
       }
     } else {
-      Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
-          SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+      Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF,
+                   input_file,
+                   line_number,
+                   "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                   SwigType_str(returntype, 0),
+                   SwigType_namestr(c_classname),
+                   SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4170,7 +4271,7 @@ public:
 
       /* Get parameter's intermediary C type */
       if ((c_param_type = Getattr(p, "tmap:ctype"))) {
-        String *ctypeout = Getattr(p, "tmap:ctype:out");        // the type in the ctype typemap's out attribute overrides the type in the typemap
+        String *ctypeout = Getattr(p, "tmap:ctype:out");  // the type in the ctype typemap's out attribute overrides the type in the typemap
         if (ctypeout)
           c_param_type = ctypeout;
 
@@ -4234,7 +4335,7 @@ public:
                 substituteClassname(pt, terminator);
                 Replaceall(terminator, "$iminput", ln);
                 if (Len(terminator_code) > 0)
-                Insert(terminator_code, 0, "\n");
+                  Insert(terminator_code, 0, "\n");
                 Insert(terminator_code, 0, terminator);
               }
 
@@ -4265,28 +4366,47 @@ public:
                 Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
               }
             } else {
-              Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number, "No csdirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+              Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF,
+                           input_file,
+                           line_number,
+                           "No csdirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
+                           SwigType_str(pt, 0),
+                           SwigType_namestr(c_classname),
+                           SwigType_namestr(name));
               output_director = false;
             }
           } else {
-            Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
-                SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF,
+                         input_file,
+                         line_number,
+                         "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                         SwigType_str(pt, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             output_director = false;
           }
 
           p = Getattr(p, "tmap:directorin:next");
 
         } else {
-          Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number,
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF,
+                       input_file,
+                       line_number,
                        "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
-                       SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                       SwigType_str(pt, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           p = nextSibling(p);
           output_director = false;
         }
       } else {
-        Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
-            SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF,
+                     input_file,
+                     line_number,
+                     "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                     SwigType_str(pt, 0),
+                     SwigType_namestr(c_classname),
+                     SwigType_namestr(name));
         output_director = false;
         p = nextSibling(p);
       }
@@ -4353,7 +4473,7 @@ public:
       Replaceall(tm, "$cscall", upcall);
       if (!is_void)
         Insert(tm, 0, "return ");
-      Replaceall(tm, "\n ", "\n   "); // add extra indentation to code in typemap
+      Replaceall(tm, "\n ", "\n   ");  // add extra indentation to code in typemap
 
       // pre and post attribute support
       bool is_pre_code = Len(pre_code) > 0;
@@ -4390,9 +4510,13 @@ public:
           Replaceall(tm, "$result", result_str);
           Printf(w->code, "%s\n", tm);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
                        "Unable to use return type %s used in %s::%s (skipping director method)\n",
-                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           output_director = false;
         }
 
@@ -4471,7 +4595,8 @@ public:
 
       Printf(director_delegate_definitions, " SwigDelegate%s_%s(%s);\n", classname, methid, delegate_parms);
       Printf(director_delegate_instances, "  private SwigDelegate%s_%s swigDelegate%s;\n", classname, methid, methid);
-      Printf(director_method_types, "  private static global::System.Type[] swigMethodTypes%s = new global::System.Type[] { %s };\n", methid, proxy_method_types);
+      Printf(
+        director_method_types, "  private static global::System.Type[] swigMethodTypes%s = new global::System.Type[] { %s };\n", methid, proxy_method_types);
       Printf(director_connect_parms, "SwigDirector%s%s delegate%s", classname, methid, methid);
 
       Delete(imclass_dmethod);
@@ -4572,14 +4697,13 @@ public:
     return Language::classDirectorDefaultConstructor(n);
   }
 
-
   /* ------------------------------------------------------------
    * classDirectorInit()
    * ------------------------------------------------------------ */
 
   int classDirectorInit(Node *n) {
     Delete(none_comparison);
-    none_comparison = NewString("");    // not used
+    none_comparison = NewString("");  // not used
 
     Delete(director_ctor_code);
     director_ctor_code = NewString("$director_new");
@@ -4690,7 +4814,6 @@ public:
     Printf(f_directors_h, ");\n");
     Printf(w->def, ") {");
 
-
     if (Len(director_callbacks) > 0) {
       Printf(f_directors_h, "\nprivate:\n%s", director_callbacks);
     }
@@ -4718,7 +4841,7 @@ public:
    * classDirectorDisown()
    * ------------------------------------------------------------------*/
   virtual int classDirectorDisown(Node *n) {
-    (void) n;
+    (void)n;
     return SWIG_OK;
   }
 
@@ -4889,7 +5012,7 @@ public:
   NestedClassSupport nestedClassesSupport() const {
     return NCS_Full;
   }
-};                              /* class CSHARP */
+}; /* class CSHARP */
 
 /* -----------------------------------------------------------------------------
  * swig_csharp()    - Instantiate module

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -13,7 +13,7 @@
 
 #include "swigmod.h"
 #include "cparse.h"
-#include <limits.h>		// for INT_MAX
+#include <limits.h>             // for INT_MAX
 #include <ctype.h>
 #include <csharpdoc.h>
 
@@ -38,52 +38,52 @@ class CSHARP:public Language {
   File *f_single_out;
   List *filenames_list;
 
-  bool proxy_flag;		// Flag for generating proxy classes
-  bool native_function_flag;	// Flag for when wrapping a native function
-  bool enum_constant_flag;	// Flag for when wrapping an enum or constant
-  bool static_flag;		// Flag for when wrapping a static functions or member variables
-  bool variable_wrapper_flag;	// Flag for when wrapping a nonstatic member variable
-  bool wrapping_member_flag;	// Flag for when wrapping a member variable/enum/const
-  bool global_variable_flag;	// Flag for when wrapping a global variable
-  bool old_variable_names;	// Flag for old style variable names in the intermediary class
-  bool generate_property_declaration_flag;	// Flag for generating properties
+  bool proxy_flag;              // Flag for generating proxy classes
+  bool native_function_flag;    // Flag for when wrapping a native function
+  bool enum_constant_flag;      // Flag for when wrapping an enum or constant
+  bool static_flag;             // Flag for when wrapping a static functions or member variables
+  bool variable_wrapper_flag;   // Flag for when wrapping a nonstatic member variable
+  bool wrapping_member_flag;    // Flag for when wrapping a member variable/enum/const
+  bool global_variable_flag;    // Flag for when wrapping a global variable
+  bool old_variable_names;      // Flag for old style variable names in the intermediary class
+  bool generate_property_declaration_flag;      // Flag for generating properties
   bool doxygen; // Flag for Doxygen generation
 
-  String *imclass_name;		// intermediary class name
-  String *module_class_name;	// module class name
-  String *imclass_class_code;	// intermediary class code
+  String *imclass_name;         // intermediary class name
+  String *module_class_name;    // module class name
+  String *imclass_class_code;   // intermediary class code
   String *proxy_class_def;
   String *proxy_class_code;
   String *interface_class_code; // if %feature("interface") was declared for a class, here goes the interface declaration
   String *module_class_code;
-  String *proxy_class_name;	// proxy class name
-  String *full_imclass_name;	// fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
-  String *variable_name;	//Name of a variable being wrapped
+  String *proxy_class_name;     // proxy class name
+  String *full_imclass_name;    // fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
+  String *variable_name;        //Name of a variable being wrapped
   String *proxy_class_constants_code;
   String *module_class_constants_code;
   String *common_begin_code;
   String *enum_code;
-  String *dllimport;		// DllImport attribute name
-  String *namespce;		// Optional namespace name
-  String *imclass_imports;	//intermediary class imports from %pragma
-  String *module_imports;	//module imports from %pragma
-  String *imclass_baseclass;	//inheritance for intermediary class class from %pragma
-  String *module_baseclass;	//inheritance for module class from %pragma
-  String *imclass_interfaces;	//interfaces for intermediary class class from %pragma
-  String *module_interfaces;	//interfaces for module class from %pragma
-  String *imclass_class_modifiers;	//class modifiers for intermediary class overridden by %pragma
-  String *module_class_modifiers;	//class modifiers for module class overridden by %pragma
-  String *upcasts_code;		//C++ casts for inheritance hierarchies C++ code
-  String *imclass_cppcasts_code;	//C++ casts up inheritance hierarchies intermediary class code
-  String *director_callback_typedefs;	// Director function pointer typedefs for callbacks
-  String *director_callbacks;	// Director callback function pointer member variables
-  String *director_delegate_callback;	// Director callback method that delegates are set to call
-  String *director_delegate_definitions;	// Director delegates definitions in proxy class
-  String *director_delegate_instances;	// Director delegates member variables in proxy class
-  String *director_method_types;	// Director method types
-  String *director_connect_parms;	// Director delegates parameter list for director connect call
-  String *destructor_call;	//C++ destructor call if any
-  String *output_file;		// File name for single file mode. If set all generated code will be written to this file
+  String *dllimport;            // DllImport attribute name
+  String *namespce;             // Optional namespace name
+  String *imclass_imports;      //intermediary class imports from %pragma
+  String *module_imports;       //module imports from %pragma
+  String *imclass_baseclass;    //inheritance for intermediary class class from %pragma
+  String *module_baseclass;     //inheritance for module class from %pragma
+  String *imclass_interfaces;   //interfaces for intermediary class class from %pragma
+  String *module_interfaces;    //interfaces for module class from %pragma
+  String *imclass_class_modifiers;      //class modifiers for intermediary class overridden by %pragma
+  String *module_class_modifiers;       //class modifiers for module class overridden by %pragma
+  String *upcasts_code;         //C++ casts for inheritance hierarchies C++ code
+  String *imclass_cppcasts_code;        //C++ casts up inheritance hierarchies intermediary class code
+  String *director_callback_typedefs;   // Director function pointer typedefs for callbacks
+  String *director_callbacks;   // Director callback function pointer member variables
+  String *director_delegate_callback;   // Director callback method that delegates are set to call
+  String *director_delegate_definitions;        // Director delegates definitions in proxy class
+  String *director_delegate_instances;  // Director delegates member variables in proxy class
+  String *director_method_types;        // Director method types
+  String *director_connect_parms;       // Director delegates parameter list for director connect call
+  String *destructor_call;      //C++ destructor call if any
+  String *output_file;          // File name for single file mode. If set all generated code will be written to this file
 
   // Director method stuff:
   List *dmethods_seq;
@@ -833,7 +833,7 @@ public:
 
     /* Get return types */
     if ((tm = Swig_typemap_lookup("ctype", n, "", 0))) {
-      String *ctypeout = Getattr(n, "tmap:ctype:out");	// the type in the ctype typemap's out attribute overrides the type in the typemap
+      String *ctypeout = Getattr(n, "tmap:ctype:out");  // the type in the ctype typemap's out attribute overrides the type in the typemap
       if (ctypeout)
         tm = ctypeout;
       Printf(c_return_type, "%s", tm);
@@ -842,7 +842,7 @@ public:
     }
 
     if ((tm = Swig_typemap_lookup("imtype", n, "", 0))) {
-      String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
+      String *imtypeout = Getattr(n, "tmap:imtype:out");        // the type in the imtype typemap's out attribute overrides the type in the typemap
       if (imtypeout)
         tm = imtypeout;
       Printf(im_return_type, "%s", tm);
@@ -932,7 +932,7 @@ public:
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
         canThrow(n, "in", p);
-        Replaceall(tm, "$arg", arg);	/* deprecated? */
+        Replaceall(tm, "$arg", arg);    /* deprecated? */
         Replaceall(tm, "$input", arg);
         Setattr(p, "emit:input", arg);
         Printf(f->code, "%s\n", tm);
@@ -950,7 +950,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
         canThrow(n, "check", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(f->code, tm, "\n", NIL);
         p = Getattr(p, "tmap:check:next");
@@ -963,7 +963,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
         canThrow(n, "freearg", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(cleanup, tm, "\n", NIL);
         p = Getattr(p, "tmap:freearg:next");
@@ -976,7 +976,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
         canThrow(n, "argout", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
         Replaceall(tm, "$result", "jresult");
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(outarg, tm, "\n", NIL);
@@ -1255,7 +1255,7 @@ public:
           Printf(enum_code, "%s\n", csattributes);
 
         // Emit the enum
-        Printv(enum_code, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers (enum modifiers really)
+        Printv(enum_code, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),        // Class modifiers (enum modifiers really)
                " ", symname, *Char(wanted_base) ? " : " : "", wanted_base, " {\n", NIL);
         Delete(scope);
       } else {
@@ -1291,8 +1291,8 @@ public:
         // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper C# enum
         // Finish the enum declaration
         // Typemaps are used to generate the enum definition in a similar manner to proxy classes.
-        Printv(enum_code, (enum_feature == ProperEnum) ? "\n" : typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
-               typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),	// extra C# code
+        Printv(enum_code, (enum_feature == ProperEnum) ? "\n" : typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),      // main body of class
+               typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),      // extra C# code
                "}", NIL);
 
         Replaceall(enum_code, "$csclassname", symname);
@@ -1553,7 +1553,7 @@ public:
     bool classname_substituted_flag = false;
 
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
-      String *cstypeout = Getattr(n, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
+      String *cstypeout = Getattr(n, "tmap:cstype:out");        // the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
         tm = cstypeout;
       classname_substituted_flag = substituteClassname(t, tm);
@@ -1937,7 +1937,7 @@ public:
     Append(interface_list, pure_interfaces);
     // Start writing the proxy class
     if (!has_outerclass)
-      Printv(proxy_class_def, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE),	// Import statements
+      Printv(proxy_class_def, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE),    // Import statements
            "\n", NIL);
 
     // Translate documentation comments
@@ -1952,11 +1952,11 @@ public:
     if (csattributes && *Char(csattributes))
       Printf(proxy_class_def, "%s\n", csattributes);
 
-    Printv(proxy_class_def, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-           " $csclassname",	// Class name and base class
-           (*Char(wanted_base) || *Char(interface_list)) ? " : " : "", wanted_base, (*Char(wanted_base) && *Char(interface_list)) ?	// Interfaces
-           ", " : "", interface_list, " {", derived ? typemapLookup(n, "csbody_derived", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF) :	// main body of class
-           typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
+    Printv(proxy_class_def, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),      // Class modifiers
+           " $csclassname",     // Class name and base class
+           (*Char(wanted_base) || *Char(interface_list)) ? " : " : "", wanted_base, (*Char(wanted_base) && *Char(interface_list)) ?     // Interfaces
+           ", " : "", interface_list, " {", derived ? typemapLookup(n, "csbody_derived", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF) :       // main body of class
+           typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),   // main body of class
            NIL);
 
     // C++ destructor is wrapped by the Finalize and Dispose methods
@@ -2136,7 +2136,7 @@ public:
     Delete(destruct);
 
     // Emit extra user code
-    Printv(proxy_class_def, typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),	// extra C# code
+    Printv(proxy_class_def, typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE), // extra C# code
            "\n", NIL);
 
     if (derived) {
@@ -2509,7 +2509,7 @@ public:
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
       // Note that in the case of polymorphic (covariant) return types, the method's return type is changed to be the base of the C++ return type
       SwigType *covariant = Getattr(n, "covariant");
-      String *cstypeout = Getattr(n, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
+      String *cstypeout = Getattr(n, "tmap:cstype:out");        // the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
         tm = cstypeout;
       substituteClassname(covariant ? covariant : t, tm);
@@ -2543,7 +2543,7 @@ public:
         Replaceall(mmods, "override", "");
         Replaceall(mmods, "virtual", "");
         Replaceall(mmods, "new", "");
-        Chop(mmods);		// remove trailing whitespace
+        Chop(mmods);            // remove trailing whitespace
         Printf(function_code, "  %s ", mmods);
         Delete(mmods);
       } else {
@@ -2735,16 +2735,16 @@ public:
 
     if (wrapping_member_flag && !enum_constant_flag) {
       // Properties
-      if (generate_property_declaration_flag) {	// Ensure the declaration is generated just once should the property contain both a set and get
+      if (generate_property_declaration_flag) { // Ensure the declaration is generated just once should the property contain both a set and get
         // Get the C# variable type - obtained differently depending on whether a setter is required.
         String *variable_type = return_type;
         if (setter_flag) {
-          assert(last_parm);	// (last parameter is the only parameter for properties)
+          assert(last_parm);    // (last parameter is the only parameter for properties)
           /* Get variable type - ensure the variable name is fully resolved during typemap lookup via the symbol table set in NewParmNode */
           SwigType *cvariable_type = Getattr(last_parm, "type");
           Parm *variable_parm = NewParmNode(cvariable_type, n);
           if ((tm = Swig_typemap_lookup("cstype", variable_parm, "", 0))) {
-            String *cstypeout = Getattr(variable_parm, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
+            String *cstypeout = Getattr(variable_parm, "tmap:cstype:out");      // the type in the cstype typemap's out attribute overrides the type in the typemap
             if (cstypeout)
               tm = cstypeout;
             substituteClassname(cvariable_type, tm);
@@ -2772,7 +2772,7 @@ public:
 
       if (setter_flag) {
         // Setter method
-        assert(last_parm);	// (last parameter is the only parameter for properties)
+        assert(last_parm);      // (last parameter is the only parameter for properties)
         SwigType *cvariable_type = Getattr(last_parm, "type");
         Parm *variable_parm = NewParmNode(cvariable_type, n);
         if ((tm = Swig_typemap_lookup("csvarin", variable_parm, "", 0))) {
@@ -2860,7 +2860,7 @@ public:
       methodmods = methodmods ? methodmods : (is_public(n) ? public_string : protected_string);
 
       tm = Getattr(n, "tmap:imtype"); // typemaps were attached earlier to the node
-      String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
+      String *imtypeout = Getattr(n, "tmap:imtype:out");        // the type in the imtype typemap's out attribute overrides the type in the typemap
       if (imtypeout)
         tm = imtypeout;
       Printf(im_return_type, "%s", tm);
@@ -3177,7 +3177,7 @@ public:
 
     /* Get return types */
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
-      String *cstypeout = Getattr(n, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
+      String *cstypeout = Getattr(n, "tmap:cstype:out");        // the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
         tm = cstypeout;
       substituteClassname(t, tm);
@@ -3339,15 +3339,15 @@ public:
 
     if (proxy_flag && global_variable_flag) {
       // Properties
-      if (generate_property_declaration_flag) {	// Ensure the declaration is generated just once should the property contain both a set and get
+      if (generate_property_declaration_flag) { // Ensure the declaration is generated just once should the property contain both a set and get
         // Get the C# variable type - obtained differently depending on whether a setter is required.
         String *variable_type = return_type;
         if (setter_flag) {
-          p = last_parm;	// (last parameter is the only parameter for properties)
+          p = last_parm;        // (last parameter is the only parameter for properties)
           SwigType *pt = Getattr(p, "type");
           if ((tm = Getattr(p, "tmap:cstype"))) {
             substituteClassname(pt, tm);
-            String *cstypeout = Getattr(p, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
+            String *cstypeout = Getattr(p, "tmap:cstype:out");  // the type in the cstype typemap's out attribute overrides the type in the typemap
             variable_type = cstypeout ? cstypeout : tm;
           } else {
             Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(pt, 0));
@@ -3365,7 +3365,7 @@ public:
 
       if (setter_flag) {
         // Setter method
-        p = last_parm;		// (last parameter is the only parameter for properties)
+        p = last_parm;          // (last parameter is the only parameter for properties)
         SwigType *pt = Getattr(p, "type");
         if ((tm = Getattr(p, "tmap:csvarin"))) {
           substituteClassname(pt, tm);
@@ -3479,7 +3479,7 @@ public:
         // Get the enumvalue from a PINVOKE call
         if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
           // Strange hack to change the name
-          Setattr(n, "name", Getattr(n, "value"));	/* for wrapping of enums in a namespace when emit_action is used */
+          Setattr(n, "name", Getattr(n, "value"));      /* for wrapping of enums in a namespace when emit_action is used */
           constantWrapper(n);
           value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
         } else {
@@ -3698,7 +3698,7 @@ public:
     const String *pure_interfaces = typemapLookup(n, "csinterfaces", type, WARN_NONE);
 
     // Emit the class
-    Printv(swigtype, typemapLookup(n, "csimports", type, WARN_NONE),	// Import statements
+    Printv(swigtype, typemapLookup(n, "csimports", type, WARN_NONE),    // Import statements
            "\n", NIL);
 
     // Class attributes
@@ -3706,11 +3706,11 @@ public:
     if (csattributes && *Char(csattributes))
       Printf(swigtype, "%s\n", csattributes);
 
-    Printv(swigtype, typemapLookup(n, "csclassmodifiers", type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-           " $csclassname",	// Class name and base class
-           (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "", pure_baseclass, ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ?	// Interfaces
-           ", " : "", pure_interfaces, " {", typemapLookup(n, "csbody", type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
-           typemapLookup(n, "cscode", type, WARN_NONE),	// extra C# code
+    Printv(swigtype, typemapLookup(n, "csclassmodifiers", type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),    // Class modifiers
+           " $csclassname",     // Class name and base class
+           (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "", pure_baseclass, ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ?        // Interfaces
+           ", " : "", pure_interfaces, " {", typemapLookup(n, "csbody", type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),        // main body of class
+           typemapLookup(n, "cscode", type, WARN_NONE), // extra C# code
            "}\n", NIL);
 
     Replaceall(swigtype, "$csclassname", classname);
@@ -4080,7 +4080,7 @@ public:
       /* Create the intermediate class wrapper */
       tm = Swig_typemap_lookup("imtype", n, "", 0);
       if (tm) {
-        String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
+        String *imtypeout = Getattr(n, "tmap:imtype:out");      // the type in the imtype typemap's out attribute overrides the type in the typemap
         if (imtypeout)
           tm = imtypeout;
         const String *im_directoroutattributes = Getattr(n, "tmap:imtype:directoroutattributes");
@@ -4170,7 +4170,7 @@ public:
 
       /* Get parameter's intermediary C type */
       if ((c_param_type = Getattr(p, "tmap:ctype"))) {
-        String *ctypeout = Getattr(p, "tmap:ctype:out");	// the type in the ctype typemap's out attribute overrides the type in the typemap
+        String *ctypeout = Getattr(p, "tmap:ctype:out");        // the type in the ctype typemap's out attribute overrides the type in the typemap
         if (ctypeout)
           c_param_type = ctypeout;
 
@@ -4199,7 +4199,7 @@ public:
            * intermediate's upcall code */
           if ((tm = Getattr(p, "tmap:imtype"))) {
 
-            String *imtypeout = Getattr(p, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
+            String *imtypeout = Getattr(p, "tmap:imtype:out");  // the type in the imtype typemap's out attribute overrides the type in the typemap
             if (imtypeout)
               tm = imtypeout;
             const String *im_directorinattributes = Getattr(p, "tmap:imtype:directorinattributes");
@@ -4579,7 +4579,7 @@ public:
 
   int classDirectorInit(Node *n) {
     Delete(none_comparison);
-    none_comparison = NewString("");	// not used
+    none_comparison = NewString("");    // not used
 
     Delete(director_ctor_code);
     director_ctor_code = NewString("$director_new");
@@ -4889,7 +4889,7 @@ public:
   NestedClassSupport nestedClassesSupport() const {
     return NCS_Full;
   }
-};				/* class CSHARP */
+};                              /* class CSHARP */
 
 /* -----------------------------------------------------------------------------
  * swig_csharp()    - Instantiate module

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -189,7 +189,7 @@ public:
    * Return NULL if not otherwise the proxy class name, fully qualified with
    * a namespace if the nspace feature is used.
    * ----------------------------------------------------------------------------- */
-  
+
    String *getProxyName(SwigType *t) {
      String *proxyname = NULL;
      if (proxy_flag) {
@@ -320,12 +320,12 @@ public:
     if (optionsnode) {
       if (Getattr(optionsnode, "imclassname"))
         imclass_name = Copy(Getattr(optionsnode, "imclassname"));
-      /* check if directors are enabled for this module.  note: this 
+      /* check if directors are enabled for this module.  note: this
        * is a "master" switch, without which no director code will be
        * emitted.  %feature("director") statements are also required
        * to enable directors for individual classes or methods.
        *
-       * use %module(directors="1") modulename at the start of the 
+       * use %module(directors="1") modulename at the start of the
        * interface file to enable director generation.
        */
       if (Getattr(optionsnode, "directors")) {
@@ -817,7 +817,7 @@ public:
 
     /*
        The rest of this function deals with generating the intermediary class wrapper function (that wraps
-       a c/c++ function) and generating the PInvoke c code. Each C# wrapper function has a 
+       a c/c++ function) and generating the PInvoke c code. Each C# wrapper function has a
        matching PInvoke c function call.
      */
 
@@ -1101,7 +1101,7 @@ public:
       moduleClassFunctionHandler(n);
     }
 
-    /* 
+    /*
      * Generate the proxy class properties for public member variables.
      * Not for enums and constants.
      */
@@ -1162,7 +1162,7 @@ public:
 
     return ret;
   }
-  
+
   String *getCurrentScopeName(String *nspace) {
     String *scope = 0;
     if (nspace || getCurrentClass()) {
@@ -2445,11 +2445,11 @@ public:
   /* -----------------------------------------------------------------------------
    * proxyClassFunctionHandler()
    *
-   * Function called for creating a C# wrapper function around a c++ function in the 
+   * Function called for creating a C# wrapper function around a c++ function in the
    * proxy class. Used for both static and non-static C++ class functions.
    * C++ class static functions map to C# static functions.
-   * Two extra attributes in the Node must be available. These are "proxyfuncname" - 
-   * the name of the C# class proxy function, which in turn will call "imfuncname" - 
+   * Two extra attributes in the Node must be available. These are "proxyfuncname" -
+   * the name of the C# class proxy function, which in turn will call "imfuncname" -
    * the intermediary (PInvoke) function name in the intermediary class.
    * ----------------------------------------------------------------------------- */
 
@@ -2696,7 +2696,7 @@ public:
         Replaceall(tm, "$owner", "false");
       substituteClassname(t, tm);
 
-      // For director methods: generate code to selectively make a normal polymorphic call or 
+      // For director methods: generate code to selectively make a normal polymorphic call or
       // an explicit method call - needed to prevent infinite recursion calls in director methods.
       Node *explicit_n = Getattr(n, "explicitcallnode");
       if (explicit_n) {
@@ -3536,7 +3536,7 @@ public:
   /* -----------------------------------------------------------------------------
    * substituteClassname()
    *
-   * Substitute the special variable $csclassname with the proxy class name for classes/structs/unions 
+   * Substitute the special variable $csclassname with the proxy class name for classes/structs/unions
    * that SWIG knows about. Also substitutes enums with enum name.
    * Otherwise use the $descriptor name for the C# class name. Note that the $&csclassname substitution
    * is the same as a $&descriptor substitution, ie one pointer added to descriptor name.
@@ -3737,7 +3737,7 @@ public:
    * tmap_method - typemap method name
    * type - typemap type to lookup
    * warning - warning number to issue if no typemaps found
-   * typemap_attributes - the typemap attributes are attached to this node and will 
+   * typemap_attributes - the typemap attributes are attached to this node and will
    *   also be used for temporary storage if non null
    * return is never NULL, unlike Swig_typemap_lookup()
    * ----------------------------------------------------------------------------- */
@@ -3976,7 +3976,7 @@ public:
   /* ---------------------------------------------------------------
    * classDirectorMethod()
    *
-   * Emit a virtual director method to pass a method call on to the 
+   * Emit a virtual director method to pass a method call on to the
    * underlying C# object.
    *
    * --------------------------------------------------------------- */
@@ -4107,7 +4107,7 @@ public:
         Delete(jretval_decl);
       }
     } else {
-      Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+      Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
           SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
@@ -4265,12 +4265,12 @@ public:
                 Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
               }
             } else {
-              Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number, "No csdirectorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+              Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number, "No csdirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
                   SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
               output_director = false;
             }
           } else {
-            Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+            Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
                 SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
             output_director = false;
           }
@@ -4279,13 +4279,13 @@ public:
 
         } else {
           Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number,
-                       "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n", 
+                       "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
                        SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
           p = nextSibling(p);
           output_director = false;
         }
       } else {
-        Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+        Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
             SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
         output_director = false;
         p = nextSibling(p);
@@ -4391,7 +4391,7 @@ public:
           Printf(w->code, "%s\n", tm);
         } else {
           Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-                       "Unable to use return type %s used in %s::%s (skipping director method)\n", 
+                       "Unable to use return type %s used in %s::%s (skipping director method)\n",
                        SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
           output_director = false;
         }
@@ -4736,7 +4736,7 @@ public:
    * Generate the director class's declaration
    * e.g. "class SwigDirector_myclass : public myclass, public Swig::Director {"
    *--------------------------------------------------------------------*/
- 
+
   void directorDeclaration(Node *n) {
 
     String *base = Getattr(n, "classtype");

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -195,32 +195,32 @@ public:
      if (proxy_flag) {
        Node *n = classLookup(t);
        if (n) {
-	 proxyname = Getattr(n, "proxyname");
-	 if (!proxyname) {
-	   String *nspace = Getattr(n, "sym:nspace");
-	   String *symname = Copy(Getattr(n, "sym:name"));
-	   if (symname && !GetFlag(n, "feature:flatnested")) {
-	     for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
+         proxyname = Getattr(n, "proxyname");
+         if (!proxyname) {
+           String *nspace = Getattr(n, "sym:nspace");
+           String *symname = Copy(Getattr(n, "sym:name"));
+           if (symname && !GetFlag(n, "feature:flatnested")) {
+             for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
                if (String* name = Getattr(outer_class, "sym:name")) {
                  Push(symname, ".");
                  Push(symname, name);
                }
                else
                  return NULL;
-	     }
-	   }
-	   if (nspace) {
-	     if (namespce)
-	       proxyname = NewStringf("%s.%s.%s", namespce, nspace, symname);
-	     else
-	       proxyname = NewStringf("%s.%s", nspace, symname);
-	   } else {
-	     proxyname = Copy(symname);
-	   }
-	   Setattr(n, "proxyname", proxyname);
-	   Delete(proxyname);
-	   Delete(symname);
-	 }
+             }
+           }
+           if (nspace) {
+             if (namespce)
+               proxyname = NewStringf("%s.%s.%s", namespce, nspace, symname);
+             else
+               proxyname = NewStringf("%s.%s", nspace, symname);
+           } else {
+             proxyname = Copy(symname);
+           }
+           Setattr(n, "proxyname", proxyname);
+           Delete(proxyname);
+           Delete(symname);
+         }
        }
      }
      return proxyname;
@@ -239,59 +239,59 @@ public:
     // Look for certain command line options
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-dllimport") == 0) {
-	  if (argv[i + 1]) {
-	    dllimport = NewString("");
-	    Printf(dllimport, argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-namespace") == 0) {
-	  if (argv[i + 1]) {
-	    namespce = NewString("");
-	    Printf(namespce, argv[i + 1]);
-	    if (Len(namespce) == 0) {
-	      Delete(namespce);
-	      namespce = 0;
-	    }
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if ((strcmp(argv[i], "-noproxy") == 0)) {
-	  Swig_mark_arg(i);
-	  proxy_flag = false;
-	} else if (strcmp(argv[i], "-oldvarnames") == 0) {
-	  Swig_mark_arg(i);
-	  old_variable_names = true;
-	} else if (strcmp(argv[i], "-outfile") == 0) {
-	  if (argv[i + 1]) {
-	    output_file = NewString("");
-	    Printf(output_file, argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-doxygen") == 0) {
-	  doxygen = true;
-	  scan_doxygen_comments = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-debug-doxygen-translator") == 0) {
-	  doxygen_translator_flags |= DoxygenTranslator::debug_translator;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-debug-doxygen-parser") == 0) {
-	  doxygen_translator_flags |= DoxygenTranslator::debug_parser;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  Printf(stdout, "%s", usage);
-	}
+        if (strcmp(argv[i], "-dllimport") == 0) {
+          if (argv[i + 1]) {
+            dllimport = NewString("");
+            Printf(dllimport, argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-namespace") == 0) {
+          if (argv[i + 1]) {
+            namespce = NewString("");
+            Printf(namespce, argv[i + 1]);
+            if (Len(namespce) == 0) {
+              Delete(namespce);
+              namespce = 0;
+            }
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if ((strcmp(argv[i], "-noproxy") == 0)) {
+          Swig_mark_arg(i);
+          proxy_flag = false;
+        } else if (strcmp(argv[i], "-oldvarnames") == 0) {
+          Swig_mark_arg(i);
+          old_variable_names = true;
+        } else if (strcmp(argv[i], "-outfile") == 0) {
+          if (argv[i + 1]) {
+            output_file = NewString("");
+            Printf(output_file, argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-doxygen") == 0) {
+          doxygen = true;
+          scan_doxygen_comments = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-debug-doxygen-translator") == 0) {
+          doxygen_translator_flags |= DoxygenTranslator::debug_translator;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-debug-doxygen-parser") == 0) {
+          doxygen_translator_flags |= DoxygenTranslator::debug_parser;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-help") == 0) {
+          Printf(stdout, "%s", usage);
+        }
       }
     }
 
@@ -319,7 +319,7 @@ public:
 
     if (optionsnode) {
       if (Getattr(optionsnode, "imclassname"))
-	imclass_name = Copy(Getattr(optionsnode, "imclassname"));
+        imclass_name = Copy(Getattr(optionsnode, "imclassname"));
       /* check if directors are enabled for this module.  note: this 
        * is a "master" switch, without which no director code will be
        * emitted.  %feature("director") statements are also required
@@ -329,15 +329,15 @@ public:
        * interface file to enable director generation.
        */
       if (Getattr(optionsnode, "directors")) {
-	allow_directors();
+        allow_directors();
       }
       if (Getattr(optionsnode, "dirprot")) {
-	allow_dirprot();
+        allow_dirprot();
       }
       allow_allprotected(GetFlag(optionsnode, "allprotected"));
       common_begin_code = Getattr(optionsnode, "csbegin");
       if (common_begin_code)
-	Printf(common_begin_code, "\n");
+        Printf(common_begin_code, "\n");
     }
 
     /* Initialize all of the output files */
@@ -362,8 +362,8 @@ public:
       }
       f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
       if (!f_runtime_h) {
-	FileErrorDisplay(outfile_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -393,9 +393,9 @@ public:
     } else {
       // Rename the module name if it is the same as intermediary class name - a backwards compatibility solution
       if (Cmp(imclass_name, Getattr(n, "name")) == 0)
-	module_class_name = NewStringf("%sModule", Getattr(n, "name"));
+        module_class_name = NewStringf("%sModule", Getattr(n, "name"));
       else
-	module_class_name = Copy(Getattr(n, "name"));
+        module_class_name = Copy(Getattr(n, "name"));
     }
 
     // module class and intermediary classes are always created
@@ -445,9 +445,9 @@ public:
       Printf(f_directors, " * C++ director class methods\n");
       Printf(f_directors, " * --------------------------------------------------- */\n\n");
       if (outfile_h) {
-	String *filename = Swig_file_filename(outfile_h);
-	Printf(f_directors, "#include \"%s\"\n\n", filename);
-	Delete(filename);
+        String *filename = Swig_file_filename(outfile_h);
+        Printf(f_directors, "#include \"%s\"\n\n", filename);
+        Delete(filename);
       }
     }
 
@@ -486,16 +486,16 @@ public:
       addOpenNamespace(0, f_im);
 
       if (imclass_imports)
-	Printf(f_im, "%s\n", imclass_imports);
+        Printf(f_im, "%s\n", imclass_imports);
 
       if (Len(imclass_class_modifiers) > 0)
-	Printf(f_im, "%s ", imclass_class_modifiers);
+        Printf(f_im, "%s ", imclass_class_modifiers);
       Printf(f_im, "%s ", imclass_name);
 
       if (imclass_baseclass && *Char(imclass_baseclass))
-	Printf(f_im, ": %s ", imclass_baseclass);
+        Printf(f_im, ": %s ", imclass_baseclass);
       if (Len(imclass_interfaces) > 0)
-	Printv(f_im, "implements ", imclass_interfaces, " ", NIL);
+        Printv(f_im, "implements ", imclass_interfaces, " ", NIL);
       Printf(f_im, "{\n");
 
       // Add the intermediary class methods
@@ -510,7 +510,7 @@ public:
       addCloseNamespace(0, f_im);
 
       if (f_im != f_single_out)
-	Delete(f_im);
+        Delete(f_im);
       f_im = NULL;
     }
 
@@ -521,16 +521,16 @@ public:
       addOpenNamespace(0, f_module);
 
       if (module_imports)
-	Printf(f_module, "%s\n", module_imports);
+        Printf(f_module, "%s\n", module_imports);
 
       if (Len(module_class_modifiers) > 0)
-	Printf(f_module, "%s ", module_class_modifiers);
+        Printf(f_module, "%s ", module_class_modifiers);
       Printf(f_module, "%s ", module_class_name);
 
       if (module_baseclass && *Char(module_baseclass))
-	Printf(f_module, ": %s ", module_baseclass);
+        Printf(f_module, ": %s ", module_baseclass);
       if (Len(module_interfaces) > 0)
-	Printv(f_module, "implements ", module_interfaces, " ", NIL);
+        Printv(f_module, "implements ", module_interfaces, " ", NIL);
       Printf(f_module, "{\n");
 
       Replaceall(module_class_code, "$module", module_class_name);
@@ -553,7 +553,7 @@ public:
       addCloseNamespace(0, f_module);
 
       if (f_module != f_single_out)
-	Delete(f_module);
+        Delete(f_module);
       f_module = NULL;
     }
 
@@ -575,15 +575,15 @@ public:
     for (it1 = First(filenames_list); it1.item; it1 = Next(it1)) {
       String *item1_lower = Swig_string_lower(it1.item);
       for (it2 = Next(it1); it2.item; it2 = Next(it2)) {
-	String *item2_lower = Swig_string_lower(it2.item);
-	if (it1.item && it2.item) {
-	  if (Strcmp(item1_lower, item2_lower) == 0) {
-	    Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
-			 "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
-			 "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
-	  }
-	}
-	Delete(item2_lower);
+        String *item2_lower = Swig_string_lower(it2.item);
+        if (it1.item && it2.item) {
+          if (Strcmp(item1_lower, item2_lower) == 0) {
+            Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
+                         "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
+                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
+          }
+        }
+        Delete(item2_lower);
       }
       Delete(item1_lower);
     }
@@ -697,25 +697,25 @@ public:
   File *getOutputFile(const String *dir, const String *name) {
     if (output_file) {
       if (!f_single_out) {
-	String *filen = NewStringf("%s%s", SWIG_output_directory(), output_file);
-	f_single_out = NewFile(filen, "w", SWIG_output_files());
-	if (!f_single_out) {
-	  FileErrorDisplay(filen);
-	  Exit(EXIT_FAILURE);
-	}
-	Append(filenames_list, Copy(filen));
-	Delete(filen);
-	filen = NULL;
+        String *filen = NewStringf("%s%s", SWIG_output_directory(), output_file);
+        f_single_out = NewFile(filen, "w", SWIG_output_files());
+        if (!f_single_out) {
+          FileErrorDisplay(filen);
+          Exit(EXIT_FAILURE);
+        }
+        Append(filenames_list, Copy(filen));
+        Delete(filen);
+        filen = NULL;
 
-	emitBanner(f_single_out);
+        emitBanner(f_single_out);
       }
       return f_single_out;
     } else {
       String *filen = NewStringf("%s%s.cs", dir, name);
       File *f = NewFile(filen, "w", SWIG_output_files());
       if (!f) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filen));
       Delete(filen);
@@ -812,7 +812,7 @@ public:
 
     if (!Getattr(n, "sym:overloaded")) {
       if (!addSymbol(symname, n, imclass_name))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     /*
@@ -835,7 +835,7 @@ public:
     if ((tm = Swig_typemap_lookup("ctype", n, "", 0))) {
       String *ctypeout = Getattr(n, "tmap:ctype:out");	// the type in the ctype typemap's out attribute overrides the type in the typemap
       if (ctypeout)
-	tm = ctypeout;
+        tm = ctypeout;
       Printf(c_return_type, "%s", tm);
     } else {
       Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(returntype, 0));
@@ -844,7 +844,7 @@ public:
     if ((tm = Swig_typemap_lookup("imtype", n, "", 0))) {
       String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
       if (imtypeout)
-	tm = imtypeout;
+        tm = imtypeout;
       Printf(im_return_type, "%s", tm);
       im_outattributes = Getattr(n, "tmap:imtype:outattributes");
     } else {
@@ -872,8 +872,8 @@ public:
       // Emit warnings for the few cases that can't be overloaded in C# and give up on generating wrapper
       Swig_overload_check(n);
       if (Getattr(n, "overload:ignore")) {
-	DelWrapper(f);
-	return SWIG_OK;
+        DelWrapper(f);
+        return SWIG_OK;
       }
     }
 
@@ -893,7 +893,7 @@ public:
     for (i = 0, p = l; i < num_arguments; i++) {
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -906,22 +906,22 @@ public:
 
       /* Get the ctype types of the parameter */
       if ((tm = Getattr(p, "tmap:ctype"))) {
-	Printv(c_param_type, tm, NIL);
+        Printv(c_param_type, tm, NIL);
       } else {
-	Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Get the intermediary class parameter types of the parameter */
       if ((tm = Getattr(p, "tmap:imtype"))) {
-	const String *inattributes = Getattr(p, "tmap:imtype:inattributes");
-	Printf(im_param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        const String *inattributes = Getattr(p, "tmap:imtype:inattributes");
+        Printf(im_param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-	Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to intermediary class method */
       if (gencomma)
-	Printf(imclass_class_code, ", ");
+        Printf(imclass_class_code, ", ");
       Printf(imclass_class_code, "%s %s", im_param_type, arg);
 
       // Add parameter to C function
@@ -931,15 +931,15 @@ public:
 
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
-	canThrow(n, "in", p);
-	Replaceall(tm, "$arg", arg);	/* deprecated? */
-	Replaceall(tm, "$input", arg);
-	Setattr(p, "emit:input", arg);
-	Printf(f->code, "%s\n", tm);
-	p = Getattr(p, "tmap:in:next");
+        canThrow(n, "in", p);
+        Replaceall(tm, "$arg", arg);	/* deprecated? */
+        Replaceall(tm, "$input", arg);
+        Setattr(p, "emit:input", arg);
+        Printf(f->code, "%s\n", tm);
+        p = Getattr(p, "tmap:in:next");
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	p = nextSibling(p);
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        p = nextSibling(p);
       }
       Delete(im_param_type);
       Delete(c_param_type);
@@ -949,40 +949,40 @@ public:
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	canThrow(n, "check", p);
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        canThrow(n, "check", p);
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	canThrow(n, "freearg", p);
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        canThrow(n, "freearg", p);
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert argument output code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	canThrow(n, "argout", p);
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
-	Replaceall(tm, "$result", "jresult");
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        canThrow(n, "argout", p);
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$result", "jresult");
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -991,9 +991,9 @@ public:
     if ((throw_parm_list = Getattr(n, "catchlist"))) {
       Swig_typemap_attach_parms("throws", throw_parm_list, f);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  canThrow(n, "throws", p);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          canThrow(n, "throws", p);
+        }
       }
     }
 
@@ -1006,20 +1006,20 @@ public:
 
       /* Return value if necessary  */
       if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
-	canThrow(n, "out", n);
-	Replaceall(tm, "$result", "jresult");
+        canThrow(n, "out", n);
+        Replaceall(tm, "$result", "jresult");
 
         if (GetFlag(n, "feature:new"))
           Replaceall(tm, "$owner", "1");
         else
           Replaceall(tm, "$owner", "0");
 
-	Printf(f->code, "%s", tm);
-	null_attribute = Getattr(n, "tmap:out:null");
-	if (Len(tm))
-	  Printf(f->code, "\n");
+        Printf(f->code, "%s", tm);
+        null_attribute = Getattr(n, "tmap:out:null");
+        if (Len(tm))
+          Printf(f->code, "\n");
       } else {
-	Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
+        Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
       }
       emit_return_variable(n, returntype, f);
     }
@@ -1033,16 +1033,16 @@ public:
     /* Look to see if there is any newfree cleanup code */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	canThrow(n, "newfree", n);
-	Printf(f->code, "%s\n", tm);
+        canThrow(n, "newfree", n);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
     /* See if there is any return cleanup code */
     if (!native_function_flag) {
       if ((tm = Swig_typemap_lookup("ret", n, Swig_cresult_name(), 0))) {
-	canThrow(n, "ret", n);
-	Printf(f->code, "%s\n", tm);
+        canThrow(n, "ret", n);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -1080,20 +1080,20 @@ public:
 
       // Handle %csexception which sets the canthrow attribute
       if (Getattr(n, "feature:except:canthrow"))
-	Setattr(n, "csharp:canthrow", "1");
+        Setattr(n, "csharp:canthrow", "1");
 
       // A very simple check (it is not foolproof) to help typemap/feature writers for
       // throwing C# exceptions from unmanaged code. It checks for the common methods which
       // set a pending C# exception... the 'canthrow' typemap/feature attribute must be set
       // so that code which checks for pending exceptions is added in the C# proxy method.
       if (!Getattr(n, "csharp:canthrow")) {
-	if (Strstr(f->code, "SWIG_exception")) {
-	  Swig_warning(WARN_CSHARP_CANTHROW, input_file, line_number,
-		       "Unmanaged code contains a call to SWIG_exception and C# code does not handle pending exceptions via the canthrow attribute.\n");
-	} else if (Strstr(f->code, "SWIG_CSharpSetPendingException")) {
-	  Swig_warning(WARN_CSHARP_CANTHROW, input_file, line_number,
-		       "Unmanaged code contains a call to a SWIG_CSharpSetPendingException method and C# code does not handle pending exceptions via the canthrow attribute.\n");
-	}
+        if (Strstr(f->code, "SWIG_exception")) {
+          Swig_warning(WARN_CSHARP_CANTHROW, input_file, line_number,
+                       "Unmanaged code contains a call to SWIG_exception and C# code does not handle pending exceptions via the canthrow attribute.\n");
+        } else if (Strstr(f->code, "SWIG_CSharpSetPendingException")) {
+          Swig_warning(WARN_CSHARP_CANTHROW, input_file, line_number,
+                       "Unmanaged code contains a call to a SWIG_CSharpSetPendingException method and C# code does not handle pending exceptions via the canthrow attribute.\n");
+        }
       }
     }
 
@@ -1111,9 +1111,9 @@ public:
 
       String *getter_setter_name = NewString("");
       if (!getter_flag)
-	Printf(getter_setter_name, "set");
+        Printf(getter_setter_name, "set");
       else
-	Printf(getter_setter_name, "get");
+        Printf(getter_setter_name, "get");
       Putc(toupper((int) *Char(variable_name)), getter_setter_name);
       Printf(getter_setter_name, "%s", Char(variable_name) + 1);
 
@@ -1168,18 +1168,18 @@ public:
     if (nspace || getCurrentClass()) {
       scope = NewString("");
       if (nspace)
-	Printf(scope, "%s", nspace);
+        Printf(scope, "%s", nspace);
       if (Node *cls = getCurrentClass()) {
-	if (Node *outer = Getattr(cls, "nested:outer")) {
-	  String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
-	  for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
-	    Push(outerClassesPrefix, ".");
-	    Push(outerClassesPrefix, Getattr(outer, "sym:name"));
-	  }
-	  Printv(scope, nspace ? "." : "", outerClassesPrefix, ".", proxy_class_name, NIL);
-	  Delete(outerClassesPrefix);
-	} else
-	  Printv(scope, nspace ? "." : "", proxy_class_name, NIL);
+        if (Node *outer = Getattr(cls, "nested:outer")) {
+          String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
+          for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
+            Push(outerClassesPrefix, ".");
+            Push(outerClassesPrefix, Getattr(outer, "sym:name"));
+          }
+          Printv(scope, nspace ? "." : "", outerClassesPrefix, ".", proxy_class_name, NIL);
+          Delete(outerClassesPrefix);
+        } else
+          Printv(scope, nspace ? "." : "", proxy_class_name, NIL);
       }
     }
     return scope;
@@ -1200,7 +1200,7 @@ public:
 
     if (!ImportMode) {
       if (getCurrentClass() && (cplus_mode != PUBLIC))
-	return SWIG_NOWRAP;
+        return SWIG_NOWRAP;
 
       String *nspace = Getattr(n, "sym:nspace"); // NSpace/getNSpace() only works during Language::enumDeclaration call
       enum_code = NewString("");
@@ -1211,129 +1211,129 @@ public:
 
       // Translate documentation comments
       if (have_docstring(n)) {
-	String *ds = docstring(n, "");
-	Printv(enum_code, ds, NIL);
-	Delete(ds);
+        String *ds = docstring(n, "");
+        Printv(enum_code, ds, NIL);
+        Delete(ds);
       }
 
       if ((enum_feature != SimpleEnum) && symname && typemap_lookup_type) {
-	// Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper C# enum
+        // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper C# enum
 
-	String *scope = getCurrentScopeName(nspace);
-	if (!addSymbol(symname, n, scope))
-	  return SWIG_ERROR;
+        String *scope = getCurrentScopeName(nspace);
+        if (!addSymbol(symname, n, scope))
+          return SWIG_ERROR;
 
-	// Enum base (underlying enum type)
-	Node *attributes = NewHash();
-	const String *pure_baseclass = typemapLookup(n, "csbase", typemap_lookup_type, WARN_NONE, attributes);
-	bool purebase_replace = GetFlag(attributes, "tmap:csbase:replace") ? true : false;
-	Delete(attributes);
+        // Enum base (underlying enum type)
+        Node *attributes = NewHash();
+        const String *pure_baseclass = typemapLookup(n, "csbase", typemap_lookup_type, WARN_NONE, attributes);
+        bool purebase_replace = GetFlag(attributes, "tmap:csbase:replace") ? true : false;
+        Delete(attributes);
 
-	String *baseclass = NULL;
-	if (!purebase_replace) {
-	  String *underlying_enum_type = Getattr(n, "enumbase");
-	  if (underlying_enum_type) {
-	    const String *typemap_baseclass = typemapLookup(n, "cstype", underlying_enum_type, WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF);
-	    baseclass = Copy(typemap_baseclass);
-	    substituteClassname(underlying_enum_type, baseclass);
-	  }
-	}
+        String *baseclass = NULL;
+        if (!purebase_replace) {
+          String *underlying_enum_type = Getattr(n, "enumbase");
+          if (underlying_enum_type) {
+            const String *typemap_baseclass = typemapLookup(n, "cstype", underlying_enum_type, WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF);
+            baseclass = Copy(typemap_baseclass);
+            substituteClassname(underlying_enum_type, baseclass);
+          }
+        }
 
-	const String *wanted_base = baseclass ? baseclass : pure_baseclass;
+        const String *wanted_base = baseclass ? baseclass : pure_baseclass;
 
-	if (purebase_replace) {
-	  wanted_base = pure_baseclass;
-	} else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
-	  Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		       "Warning for %s, enum base %s ignored. Multiple enum bases is not supported in C# enums. "
-		       "Perhaps you need the 'replace' attribute in the csbase typemap?\n", typemap_lookup_type, pure_baseclass);
-	}
+        if (purebase_replace) {
+          wanted_base = pure_baseclass;
+        } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
+          Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+                       "Warning for %s, enum base %s ignored. Multiple enum bases is not supported in C# enums. "
+                       "Perhaps you need the 'replace' attribute in the csbase typemap?\n", typemap_lookup_type, pure_baseclass);
+        }
 
-	// Class attributes
-	const String *csattributes = typemapLookup(n, "csattributes", typemap_lookup_type, WARN_NONE);
-	if (csattributes && *Char(csattributes))
-	  Printf(enum_code, "%s\n", csattributes);
+        // Class attributes
+        const String *csattributes = typemapLookup(n, "csattributes", typemap_lookup_type, WARN_NONE);
+        if (csattributes && *Char(csattributes))
+          Printf(enum_code, "%s\n", csattributes);
 
-	// Emit the enum
-	Printv(enum_code, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers (enum modifiers really)
-	       " ", symname, *Char(wanted_base) ? " : " : "", wanted_base, " {\n", NIL);
-	Delete(scope);
+        // Emit the enum
+        Printv(enum_code, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers (enum modifiers really)
+               " ", symname, *Char(wanted_base) ? " : " : "", wanted_base, " {\n", NIL);
+        Delete(scope);
       } else {
-	// Wrap C++ enum with integers - just indicate start of enum with a comment, no comment for anonymous enums of any sort
-	if (symname && !Getattr(n, "unnamedinstance"))
-	  Printf(constants_code, "  // %s \n", symname);
+        // Wrap C++ enum with integers - just indicate start of enum with a comment, no comment for anonymous enums of any sort
+        if (symname && !Getattr(n, "unnamedinstance"))
+          Printf(constants_code, "  // %s \n", symname);
       }
 
       if (proxy_flag && !is_wrapping_class()) {
-	// Global enums / enums in a namespace
-	assert(!full_imclass_name);
+        // Global enums / enums in a namespace
+        assert(!full_imclass_name);
 
-	if (!nspace) {
-	  full_imclass_name = NewStringf("%s", imclass_name);
-	} else {
-	  if (namespce) {
-	    full_imclass_name = NewStringf("%s.%s", namespce, imclass_name);
-	  } else {
-	    full_imclass_name = NewStringf("%s", imclass_name);
-	  }
-	}
+        if (!nspace) {
+          full_imclass_name = NewStringf("%s", imclass_name);
+        } else {
+          if (namespce) {
+            full_imclass_name = NewStringf("%s.%s", namespce, imclass_name);
+          } else {
+            full_imclass_name = NewStringf("%s", imclass_name);
+          }
+        }
       }
 
       // Emit each enum item
       Language::enumDeclaration(n);
 
       if (proxy_flag && !is_wrapping_class()) {
-	Delete(full_imclass_name);
-	full_imclass_name = 0;
+        Delete(full_imclass_name);
+        full_imclass_name = 0;
       }
 
       if ((enum_feature != SimpleEnum) && symname && typemap_lookup_type) {
-	// Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper C# enum
-	// Finish the enum declaration
-	// Typemaps are used to generate the enum definition in a similar manner to proxy classes.
-	Printv(enum_code, (enum_feature == ProperEnum) ? "\n" : typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
-	       typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),	// extra C# code
-	       "}", NIL);
+        // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper C# enum
+        // Finish the enum declaration
+        // Typemaps are used to generate the enum definition in a similar manner to proxy classes.
+        Printv(enum_code, (enum_feature == ProperEnum) ? "\n" : typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
+               typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),	// extra C# code
+               "}", NIL);
 
-	Replaceall(enum_code, "$csclassname", symname);
+        Replaceall(enum_code, "$csclassname", symname);
 
-	// Substitute $enumvalues - intended usage is for typesafe enums
-	if (Getattr(n, "enumvalues"))
-	  Replaceall(enum_code, "$enumvalues", Getattr(n, "enumvalues"));
-	else
-	  Replaceall(enum_code, "$enumvalues", "");
+        // Substitute $enumvalues - intended usage is for typesafe enums
+        if (Getattr(n, "enumvalues"))
+          Replaceall(enum_code, "$enumvalues", Getattr(n, "enumvalues"));
+        else
+          Replaceall(enum_code, "$enumvalues", "");
 
-	if (proxy_flag && is_wrapping_class()) {
-	  // Enums defined within the C++ class are defined within the proxy class
+        if (proxy_flag && is_wrapping_class()) {
+          // Enums defined within the C++ class are defined within the proxy class
 
-	  // Add extra indentation
-	  Replaceall(enum_code, "\n", "\n  ");
-	  Replaceall(enum_code, "  \n", "\n");
+          // Add extra indentation
+          Replaceall(enum_code, "\n", "\n  ");
+          Replaceall(enum_code, "  \n", "\n");
 
-	  Printv(proxy_class_constants_code, "  ", enum_code, "\n\n", NIL);
-	} else {
-	  // Global enums are defined in their own file
-	  String *output_directory = outputDirectory(nspace);
-	  File *f_enum = getOutputFile(output_directory, symname);
+          Printv(proxy_class_constants_code, "  ", enum_code, "\n\n", NIL);
+        } else {
+          // Global enums are defined in their own file
+          String *output_directory = outputDirectory(nspace);
+          File *f_enum = getOutputFile(output_directory, symname);
 
-	  addOpenNamespace(nspace, f_enum);
+          addOpenNamespace(nspace, f_enum);
 
-	  Printv(f_enum, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE), // Import statements
-		 "\n", enum_code, "\n", NIL);
+          Printv(f_enum, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE), // Import statements
+                 "\n", enum_code, "\n", NIL);
 
-	  addCloseNamespace(nspace, f_enum);
-	  if (f_enum != f_single_out)
-	    Delete(f_enum);
-	  f_enum = NULL;
-	  Delete(output_directory);
-	}
+          addCloseNamespace(nspace, f_enum);
+          if (f_enum != f_single_out)
+            Delete(f_enum);
+          f_enum = NULL;
+          Delete(output_directory);
+        }
       } else {
-	// Wrap C++ enum with simple constant
-	Printf(enum_code, "\n");
-	if (proxy_flag && is_wrapping_class())
-	  Printv(proxy_class_constants_code, enum_code, NIL);
-	else
-	  Printv(module_class_constants_code, enum_code, NIL);
+        // Wrap C++ enum with simple constant
+        Printf(enum_code, "\n");
+        if (proxy_flag && is_wrapping_class())
+          Printv(proxy_class_constants_code, enum_code, NIL);
+        else
+          Printv(module_class_constants_code, enum_code, NIL);
       }
 
       Delete(enum_code);
@@ -1374,10 +1374,10 @@ public:
     if (swigtype == T_CHAR) {
       String *enumstringval = Getattr(n, "enumstringval");
       if (enumstringval) {
-	// Escape character literal for C#.
-	String *val = NewStringf("'%(csharpescape)s'", enumstringval);
-	Setattr(n, "enumvalue", val);
-	Delete(val);
+        // Escape character literal for C#.
+        String *val = NewStringf("'%(csharpescape)s'", enumstringval);
+        Setattr(n, "enumvalue", val);
+        Delete(val);
       }
     } else {
       String *numval = Getattr(n, "enumnumval");
@@ -1388,104 +1388,104 @@ public:
       EnumFeature enum_feature = decodeEnumFeature(parent);
 
       if ((enum_feature == SimpleEnum) && GetFlag(parent, "scopedenum")) {
-	newsymname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
-	symname = newsymname;
+        newsymname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
+        symname = newsymname;
       }
 
       // Add to language symbol table
       String *scope = 0;
       if (unnamedinstance || !parent_name || enum_feature == SimpleEnum) {
-	String *enumClassPrefix = getEnumClassPrefix();
-	if (enumClassPrefix) {
-	  scope = NewString("");
-	  if (nspace)
-	    Printf(scope, "%s.", nspace);
-	  Printf(scope, "%s", enumClassPrefix);
-	} else {
-	  scope = Copy(module_class_name);
-	}
+        String *enumClassPrefix = getEnumClassPrefix();
+        if (enumClassPrefix) {
+          scope = NewString("");
+          if (nspace)
+            Printf(scope, "%s.", nspace);
+          Printf(scope, "%s", enumClassPrefix);
+        } else {
+          scope = Copy(module_class_name);
+        }
       } else {
-	scope = getCurrentScopeName(nspace);
-	if (!scope)
-	  scope = Copy(Getattr(parent, "sym:name"));
-	else
-	  Printf(scope, ".%s", Getattr(parent, "sym:name"));
+        scope = getCurrentScopeName(nspace);
+        if (!scope)
+          scope = Copy(Getattr(parent, "sym:name"));
+        else
+          Printf(scope, ".%s", Getattr(parent, "sym:name"));
       }
       if (!addSymbol(symname, n, scope))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
 
       const String *csattributes = Getattr(n, "feature:cs:attributes");
 
       if ((enum_feature == ProperEnum) && parent_name && !unnamedinstance) {
-	// Wrap (non-anonymous) C/C++ enum with a proper C# enum
-	// Emit the enum item.
-	if (!GetFlag(n, "firstenumitem"))
-	  Printf(enum_code, ",\n");
+        // Wrap (non-anonymous) C/C++ enum with a proper C# enum
+        // Emit the enum item.
+        if (!GetFlag(n, "firstenumitem"))
+          Printf(enum_code, ",\n");
 
-	if (csattributes)
-	  Printf(enum_code, "  %s\n", csattributes);
+        if (csattributes)
+          Printf(enum_code, "  %s\n", csattributes);
 
-	// Translate documentation comments
-	if (have_docstring(n)) {
-	  String *ds = docstring(n, tab2);
-	  Printv(enum_code, ds, NIL);
-	  Delete(ds);
-	}
-	Printf(enum_code, "  %s", symname);
+        // Translate documentation comments
+        if (have_docstring(n)) {
+          String *ds = docstring(n, tab2);
+          Printv(enum_code, ds, NIL);
+          Delete(ds);
+        }
+        Printf(enum_code, "  %s", symname);
 
-	// Check for the %csconstvalue feature
-	String *value = Getattr(n, "feature:cs:constvalue");
+        // Check for the %csconstvalue feature
+        String *value = Getattr(n, "feature:cs:constvalue");
 
-	// Note that the enum value must be a true constant and cannot be set from a PINVOKE call, thus no support for %csconst(0)
-	value = value ? value : Getattr(n, "enumvalue");
-	if (value) {
-	  Printf(enum_code, " = %s", value);
-	}
+        // Note that the enum value must be a true constant and cannot be set from a PINVOKE call, thus no support for %csconst(0)
+        value = value ? value : Getattr(n, "enumvalue");
+        if (value) {
+          Printf(enum_code, " = %s", value);
+        }
       } else {
-	// Wrap C/C++ enums with constant integers or use the typesafe enum pattern
-	SwigType *typemap_lookup_type = parent_name ? parent_name : NewString("enum ");
-	Setattr(n, "type", typemap_lookup_type);
-	const String *tm = typemapLookup(n, "cstype", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF);
+        // Wrap C/C++ enums with constant integers or use the typesafe enum pattern
+        SwigType *typemap_lookup_type = parent_name ? parent_name : NewString("enum ");
+        Setattr(n, "type", typemap_lookup_type);
+        const String *tm = typemapLookup(n, "cstype", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF);
 
-	String *return_type = Copy(tm);
-	substituteClassname(typemap_lookup_type, return_type);
+        String *return_type = Copy(tm);
+        substituteClassname(typemap_lookup_type, return_type);
         const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
         methodmods = methodmods ? methodmods : (is_public(n) ? public_string : protected_string);
 
-	if (csattributes)
-	  Printf(enum_code, "  %s\n", csattributes);
+        if (csattributes)
+          Printf(enum_code, "  %s\n", csattributes);
 
-	if ((enum_feature == TypesafeEnum) && parent_name && !unnamedinstance) {
-	  // Wrap (non-anonymous) enum using the typesafe enum pattern
-	  if (Getattr(n, "enumvalue")) {
-	    String *value = enumValue(n);
-	    Printf(enum_code, "  %s static readonly %s %s = new %s(\"%s\", %s);\n", methodmods, return_type, symname, return_type, symname, value);
-	    Delete(value);
-	  } else {
-	    Printf(enum_code, "  %s static readonly %s %s = new %s(\"%s\");\n", methodmods, return_type, symname, return_type, symname);
-	  }
-	} else {
-	  // Simple integer constants
-	  // Note these are always generated for anonymous enums, no matter what enum_feature is specified
-	  // Code generated is the same for SimpleEnum and TypeunsafeEnum -> the class it is generated into is determined later
+        if ((enum_feature == TypesafeEnum) && parent_name && !unnamedinstance) {
+          // Wrap (non-anonymous) enum using the typesafe enum pattern
+          if (Getattr(n, "enumvalue")) {
+            String *value = enumValue(n);
+            Printf(enum_code, "  %s static readonly %s %s = new %s(\"%s\", %s);\n", methodmods, return_type, symname, return_type, symname, value);
+            Delete(value);
+          } else {
+            Printf(enum_code, "  %s static readonly %s %s = new %s(\"%s\");\n", methodmods, return_type, symname, return_type, symname);
+          }
+        } else {
+          // Simple integer constants
+          // Note these are always generated for anonymous enums, no matter what enum_feature is specified
+          // Code generated is the same for SimpleEnum and TypeunsafeEnum -> the class it is generated into is determined later
 
-	  // The %csconst feature determines how the constant value is obtained
-	  int const_feature_flag = GetFlag(n, "feature:cs:const");
+          // The %csconst feature determines how the constant value is obtained
+          int const_feature_flag = GetFlag(n, "feature:cs:const");
 
-	  const char *const_readonly = const_feature_flag ? "const" : "static readonly";
-	  String *value = enumValue(n);
-	  Printf(enum_code, "  %s %s %s %s = %s;\n", methodmods, const_readonly, return_type, symname, value);
-	  Delete(value);
-	}
-	Delete(return_type);
+          const char *const_readonly = const_feature_flag ? "const" : "static readonly";
+          String *value = enumValue(n);
+          Printf(enum_code, "  %s %s %s %s = %s;\n", methodmods, const_readonly, return_type, symname, value);
+          Delete(value);
+        }
+        Delete(return_type);
       }
 
       // Add the enum value to the comma separated list being constructed in the enum declaration.
       String *enumvalues = Getattr(parent, "enumvalues");
       if (!enumvalues)
-	Setattr(parent, "enumvalues", Copy(symname));
+        Setattr(parent, "enumvalues", Copy(symname));
       else
-	Printv(enumvalues, ", ", symname, NIL);
+        Printv(enumvalues, ", ", symname, NIL);
       Delete(scope);
     }
 
@@ -1523,16 +1523,16 @@ public:
     if (!is_enum_item) {
       String *scope = 0;
       if (proxy_class_name) {
-	String *nspace = getNSpace();
-	scope = NewString("");
-	if (nspace)
-	  Printf(scope, "%s.", nspace);
-	Printf(scope, "%s", proxy_class_name);
+        String *nspace = getNSpace();
+        scope = NewString("");
+        if (nspace)
+          Printf(scope, "%s.", nspace);
+        Printf(scope, "%s", proxy_class_name);
       } else {
-	scope = Copy(module_class_name);
+        scope = Copy(module_class_name);
       }
       if (!addSymbol(itemname, n, scope))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
       Delete(scope);
     }
 
@@ -1555,7 +1555,7 @@ public:
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
       String *cstypeout = Getattr(n, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
-	tm = cstypeout;
+        tm = cstypeout;
       classname_substituted_flag = substituteClassname(t, tm);
       Printf(return_type, "%s", tm);
     } else {
@@ -1565,19 +1565,19 @@ public:
     if (Getattr(n, "stringval")) {
       char quote = 0;
       switch (SwigType_type(t)) {
-	case T_STRING:
-	case T_WSTRING:
-	  quote = '\"';
-	  break;
-	case T_CHAR:
-	case T_WCHAR:
-	  quote = '\'';
-	  break;
+        case T_STRING:
+        case T_WSTRING:
+          quote = '\"';
+          break;
+        case T_CHAR:
+        case T_WCHAR:
+          quote = '\'';
+          break;
       }
       if (quote) {
-	// Escape character literal for C#.
-	Delete(csvalue);
-	csvalue = NewStringf("%c%(csharpescape)s%c", quote, Getattr(n, "stringval"), quote);
+        // Escape character literal for C#.
+        Delete(csvalue);
+        csvalue = NewStringf("%c%(csharpescape)s%c", quote, Getattr(n, "stringval"), quote);
       }
     }
 
@@ -1606,15 +1606,15 @@ public:
       // Default enum and constant handling will work with any type of C constant and initialises the C# variable from C through a PINVOKE call.
 
       if (classname_substituted_flag) {
-	if (SwigType_isenum(t)) {
-	  // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
-	  Printf(constants_code, "(%s)%s.%s();\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
-	} else {
-	  // This handles function pointers using the %constant directive
-	  Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
-	}
+        if (SwigType_isenum(t)) {
+          // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
+          Printf(constants_code, "(%s)%s.%s();\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        } else {
+          // This handles function pointers using the %constant directive
+          Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        }
       } else {
-	Printf(constants_code, "%s.%s();\n", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        Printf(constants_code, "%s.%s();\n", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
       }
 
       // Each constant and enum value is wrapped with a separate PInvoke function call
@@ -1625,17 +1625,17 @@ public:
     } else {
       // Alternative constant handling will use the C syntax to make a true C# constant and hope that it compiles as C# code
       if (Getattr(n, "wrappedasconstant")) {
-	if (SwigType_type(t) == T_CHAR) {
-	  String *stringval = Getattr(n, "stringval");
-	  if (stringval)
-	    Printf(constants_code, "'%(csharpescape)s';\n", stringval);
-	  else
-	    Printf(constants_code, "(char)%s;\n", Getattr(n, "staticmembervariableHandler:value"));
-	} else {
+        if (SwigType_type(t) == T_CHAR) {
+          String *stringval = Getattr(n, "stringval");
+          if (stringval)
+            Printf(constants_code, "'%(csharpescape)s';\n", stringval);
+          else
+            Printf(constants_code, "(char)%s;\n", Getattr(n, "staticmembervariableHandler:value"));
+        } else {
           Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
-	}
+        }
       } else {
-	Printf(constants_code, "%s;\n", csvalue);
+        Printf(constants_code, "%s;\n", csvalue);
       }
     }
 
@@ -1643,9 +1643,9 @@ public:
     // Enums only emit the intermediate and PINVOKE methods, so no proxy or module class wrapper methods needed
     if (!is_enum_item) {
       if (proxy_flag && wrapping_member_flag)
-	Printv(proxy_class_constants_code, constants_code, NIL);
+        Printv(proxy_class_constants_code, constants_code, NIL);
       else
-	Printv(module_class_constants_code, constants_code, NIL);
+        Printv(module_class_constants_code, constants_code, NIL);
     }
     // Cleanup
     Swig_restore(n);
@@ -1669,9 +1669,9 @@ public:
 
     if (!ImportMode && (Cmp(section, "proxycode") == 0)) {
       if (proxy_class_code) {
-	Swig_typemap_replace_embedded_typemap(code, n);
-	int offset = Len(code) > 0 && *Char(code) == '\n' ? 1 : 0;
-	Printv(proxy_class_code, Char(code) + offset, "\n", NIL);
+        Swig_typemap_replace_embedded_typemap(code, n);
+        int offset = Len(code) > 0 && *Char(code) == '\n' ? 1 : 0;
+        Printv(proxy_class_code, Char(code) + offset, "\n", NIL);
       }
     } else {
       ret = Language::insertDirective(n);
@@ -1705,41 +1705,41 @@ public:
 
       if (Strcmp(lang, "csharp") == 0) {
 
-	String *strvalue = NewString(value);
-	Replaceall(strvalue, "\\\"", "\"");
+        String *strvalue = NewString(value);
+        Replaceall(strvalue, "\\\"", "\"");
 
-	if (Strcmp(code, "imclassbase") == 0) {
-	  Delete(imclass_baseclass);
-	  imclass_baseclass = Copy(strvalue);
-	} else if (Strcmp(code, "imclassclassmodifiers") == 0) {
-	  Delete(imclass_class_modifiers);
-	  imclass_class_modifiers = Copy(strvalue);
-	} else if (Strcmp(code, "imclasscode") == 0) {
-	  Printf(imclass_class_code, "%s\n", strvalue);
-	} else if (Strcmp(code, "imclassimports") == 0) {
-	  Delete(imclass_imports);
-	  imclass_imports = Copy(strvalue);
-	} else if (Strcmp(code, "imclassinterfaces") == 0) {
-	  Delete(imclass_interfaces);
-	  imclass_interfaces = Copy(strvalue);
-	} else if (Strcmp(code, "modulebase") == 0) {
-	  Delete(module_baseclass);
-	  module_baseclass = Copy(strvalue);
-	} else if (Strcmp(code, "moduleclassmodifiers") == 0) {
-	  Delete(module_class_modifiers);
-	  module_class_modifiers = Copy(strvalue);
-	} else if (Strcmp(code, "modulecode") == 0) {
-	  Printf(module_class_code, "%s\n", strvalue);
-	} else if (Strcmp(code, "moduleimports") == 0) {
-	  Delete(module_imports);
-	  module_imports = Copy(strvalue);
-	} else if (Strcmp(code, "moduleinterfaces") == 0) {
-	  Delete(module_interfaces);
-	  module_interfaces = Copy(strvalue);
-	} else {
-	  Swig_error(input_file, line_number, "Unrecognized pragma.\n");
-	}
-	Delete(strvalue);
+        if (Strcmp(code, "imclassbase") == 0) {
+          Delete(imclass_baseclass);
+          imclass_baseclass = Copy(strvalue);
+        } else if (Strcmp(code, "imclassclassmodifiers") == 0) {
+          Delete(imclass_class_modifiers);
+          imclass_class_modifiers = Copy(strvalue);
+        } else if (Strcmp(code, "imclasscode") == 0) {
+          Printf(imclass_class_code, "%s\n", strvalue);
+        } else if (Strcmp(code, "imclassimports") == 0) {
+          Delete(imclass_imports);
+          imclass_imports = Copy(strvalue);
+        } else if (Strcmp(code, "imclassinterfaces") == 0) {
+          Delete(imclass_interfaces);
+          imclass_interfaces = Copy(strvalue);
+        } else if (Strcmp(code, "modulebase") == 0) {
+          Delete(module_baseclass);
+          module_baseclass = Copy(strvalue);
+        } else if (Strcmp(code, "moduleclassmodifiers") == 0) {
+          Delete(module_class_modifiers);
+          module_class_modifiers = Copy(strvalue);
+        } else if (Strcmp(code, "modulecode") == 0) {
+          Printf(module_class_code, "%s\n", strvalue);
+        } else if (Strcmp(code, "moduleimports") == 0) {
+          Delete(module_imports);
+          module_imports = Copy(strvalue);
+        } else if (Strcmp(code, "moduleinterfaces") == 0) {
+          Delete(module_interfaces);
+          module_interfaces = Copy(strvalue);
+        } else {
+          Swig_error(input_file, line_number, "Unrecognized pragma.\n");
+        }
+        Delete(strvalue);
       }
     }
     return Language::pragmaDirective(n);
@@ -1755,12 +1755,12 @@ public:
       String *nspace = Getattr(n, "sym:nspace");
       String *interface_name = Getattr(n, "interface:name");
       if (nspace) {
-	if (namespce)
-	  ret = NewStringf("%s.%s.%s", namespce, nspace, interface_name);
-	else
-	  ret = NewStringf("%s.%s", nspace, interface_name);
+        if (namespce)
+          ret = NewStringf("%s.%s.%s", namespce, nspace, interface_name);
+        else
+          ret = NewStringf("%s.%s", nspace, interface_name);
       } else {
-	ret = Copy(interface_name);
+        ret = Copy(interface_name);
       }
       Setattr(n, "interface:qname", ret);
     }
@@ -1776,7 +1776,7 @@ public:
     if (proxy_flag) {
       Node *n = classLookup(t);
       if (n && Getattr(n, "interface:name"))
-	interface_name = qualified ? getQualifiedInterfaceName(n) : Getattr(n, "interface:name");
+        interface_name = qualified ? getQualifiedInterfaceName(n) : Getattr(n, "interface:name");
     }
     return interface_name;
   }
@@ -1792,7 +1792,7 @@ public:
       String *interface_name = Getattr(base, "interface:name");
       SwigType *bsmart = Getattr(base, "smart");
       if (Len(interface_list))
-	Append(interface_list, ", ");
+        Append(interface_list, ", ");
       Append(interface_list, interface_name);
 
       Node *attributes = NewHash();
@@ -1800,11 +1800,11 @@ public:
       String *cptr_method_name = 0;
       if (interface_code) {
         Replaceall(interface_code, "$interfacename", interface_name);
-	Printv(interface_upcasts, interface_code, NIL);
-	cptr_method_name = Copy(Getattr(attributes, "tmap:csinterfacecode:cptrmethod"));
+        Printv(interface_upcasts, interface_code, NIL);
+        cptr_method_name = Copy(Getattr(attributes, "tmap:csinterfacecode:cptrmethod"));
       }
       if (!cptr_method_name)
-	cptr_method_name = NewStringf("%s_GetInterfaceCPtr", interface_name);
+        cptr_method_name = NewStringf("%s_GetInterfaceCPtr", interface_name);
       Replaceall(cptr_method_name, ".", "_");
       Replaceall(cptr_method_name, "$interfacename", interface_name);
 
@@ -1833,25 +1833,25 @@ public:
 
     if (smart) {
       if (bsmart) {
-	String *smartnamestr = SwigType_namestr(smart);
-	String *bsmartnamestr = SwigType_namestr(bsmart);
+        String *smartnamestr = SwigType_namestr(smart);
+        String *bsmartnamestr = SwigType_namestr(bsmart);
 
-	Printv(upcasts_code,
-	    "SWIGEXPORT ", bsmartnamestr, " * SWIGSTDCALL ", wname, "(", smartnamestr, " *jarg1) {\n",
-	    "    return jarg1 ? new ", bsmartnamestr, "(*jarg1) : 0;\n"
-	    "}\n", "\n", NIL);
+        Printv(upcasts_code,
+            "SWIGEXPORT ", bsmartnamestr, " * SWIGSTDCALL ", wname, "(", smartnamestr, " *jarg1) {\n",
+            "    return jarg1 ? new ", bsmartnamestr, "(*jarg1) : 0;\n"
+            "}\n", "\n", NIL);
 
-	Delete(bsmartnamestr);
-	Delete(smartnamestr);
+        Delete(bsmartnamestr);
+        Delete(smartnamestr);
       }
     } else {
       String *classname = SwigType_namestr(c_classname);
       String *baseclassname = SwigType_namestr(c_baseclassname);
 
       Printv(upcasts_code,
-	  "SWIGEXPORT ", baseclassname, " * SWIGSTDCALL ", wname, "(", classname, " *jarg1) {\n",
-	  "    return (", baseclassname, " *)jarg1;\n"
-	  "}\n", "\n", NIL);
+          "SWIGEXPORT ", baseclassname, " * SWIGSTDCALL ", wname, "(", classname, " *jarg1) {\n",
+          "    return (", baseclassname, " *)jarg1;\n"
+          "}\n", "\n", NIL);
 
       Delete(baseclassname);
       Delete(classname);
@@ -1887,26 +1887,26 @@ public:
     if (!purebase_replace) {
       List *baselist = Getattr(n, "bases");
       if (baselist) {
-	Iterator base = First(baselist);
-	while (base.item) {
-	  if (!(GetFlag(base.item, "feature:ignore") || GetFlag(base.item, "feature:interface"))) {
-	    SwigType *baseclassname = Getattr(base.item, "name");
-	    if (!c_baseclassname) {
-	      String *name = getProxyName(baseclassname);
-	      if (name) {
-		c_baseclassname = baseclassname;
-		baseclass = name;
-		bsmart = Getattr(base.item, "smart");
-	      }
-	    } else {
-	      /* Warn about multiple inheritance for additional base class(es) */
-	      String *proxyclassname = Getattr(n, "classtypeobj");
-	      Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		  "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#.\n", SwigType_namestr(proxyclassname), SwigType_namestr(baseclassname));
-	    }
-	  }
-	  base = Next(base);
-	}
+        Iterator base = First(baselist);
+        while (base.item) {
+          if (!(GetFlag(base.item, "feature:ignore") || GetFlag(base.item, "feature:interface"))) {
+            SwigType *baseclassname = Getattr(base.item, "name");
+            if (!c_baseclassname) {
+              String *name = getProxyName(baseclassname);
+              if (name) {
+                c_baseclassname = baseclassname;
+                baseclass = name;
+                bsmart = Getattr(base.item, "smart");
+              }
+            } else {
+              /* Warn about multiple inheritance for additional base class(es) */
+              String *proxyclassname = Getattr(n, "classtypeobj");
+              Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+                  "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#.\n", SwigType_namestr(proxyclassname), SwigType_namestr(baseclassname));
+            }
+          }
+          base = Next(base);
+        }
       }
     }
     List *interface_bases = Getattr(n, "interface:bases");
@@ -1926,8 +1926,8 @@ public:
         Swig_error(Getfile(n), Getline(n), "The csbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n", typemap_lookup_type);
     } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
       Swig_warning(WARN_CSHARP_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		   "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#. "
-		   "Perhaps you need one of the 'replace' or 'notderived' attributes in the csbase typemap?\n", typemap_lookup_type, pure_baseclass);
+                   "Warning for %s, base %s ignored. Multiple inheritance is not supported in C#. "
+                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the csbase typemap?\n", typemap_lookup_type, pure_baseclass);
     }
 
     // Pure C# interfaces
@@ -1938,7 +1938,7 @@ public:
     // Start writing the proxy class
     if (!has_outerclass)
       Printv(proxy_class_def, typemapLookup(n, "csimports", typemap_lookup_type, WARN_NONE),	// Import statements
-	   "\n", NIL);
+           "\n", NIL);
 
     // Translate documentation comments
     if (have_docstring(n)) {
@@ -1953,11 +1953,11 @@ public:
       Printf(proxy_class_def, "%s\n", csattributes);
 
     Printv(proxy_class_def, typemapLookup(n, "csclassmodifiers", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-	   " $csclassname",	// Class name and base class
-	   (*Char(wanted_base) || *Char(interface_list)) ? " : " : "", wanted_base, (*Char(wanted_base) && *Char(interface_list)) ?	// Interfaces
-	   ", " : "", interface_list, " {", derived ? typemapLookup(n, "csbody_derived", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF) :	// main body of class
-	   typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
-	   NIL);
+           " $csclassname",	// Class name and base class
+           (*Char(wanted_base) || *Char(interface_list)) ? " : " : "", wanted_base, (*Char(wanted_base) && *Char(interface_list)) ?	// Interfaces
+           ", " : "", interface_list, " {", derived ? typemapLookup(n, "csbody_derived", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF) :	// main body of class
+           typemapLookup(n, "csbody", typemap_lookup_type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
+           NIL);
 
     // C++ destructor is wrapped by the Finalize and Dispose methods
 
@@ -1965,15 +1965,15 @@ public:
     const String *tm = typemapExists(n, tmap_method, typemap_lookup_type);
     if (tm) {
       Swig_error(Getfile(tm), Getline(tm),
-	  "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
-	  tmap_method, proxy_class_name);
+          "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
+          tmap_method, proxy_class_name);
     }
     tmap_method = "csfinalize";
     tm = typemapExists(n, tmap_method, typemap_lookup_type);
     if (tm) {
       Swig_error(Getfile(tm), Getline(tm),
-	  "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
-	  tmap_method, proxy_class_name);
+          "A deprecated %s typemap was found for %s, please remove it and replace all csdestruct, csdestruct_derived and csfinalize typemaps by the csdispose, csdispose_derived, csdisposing and csdisposing_derived typemaps.\n",
+          tmap_method, proxy_class_name);
     }
 
     tmap_method = derived ? "csdisposing_derived" : "csdisposing";
@@ -1995,14 +1995,14 @@ public:
     }
     if (tm && *Char(tm)) {
       if (!destruct_methodname) {
-	Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in %s typemap for %s\n", tmap_method, proxy_class_name);
+        Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in %s typemap for %s\n", tmap_method, proxy_class_name);
       }
       if (!destruct_methodmodifiers) {
-	Swig_error(Getfile(n), Getline(n),
-		   "No methodmodifiers attribute defined in %s typemap for %s.\n", tmap_method, proxy_class_name);
+        Swig_error(Getfile(n), Getline(n),
+                   "No methodmodifiers attribute defined in %s typemap for %s.\n", tmap_method, proxy_class_name);
       }
       if (!destruct_parameters)
-	destruct_parameters = empty_string;
+        destruct_parameters = empty_string;
     }
     // Emit the Finalize and Dispose methods
     if (tm) {
@@ -2011,17 +2011,17 @@ public:
       // Dispose(bool disposing) method
       Printv(destruct, tm, NIL);
       if (*Char(destructor_call))
-	Replaceall(destruct, "$imcall", destructor_call);
+        Replaceall(destruct, "$imcall", destructor_call);
       else
-	Replaceall(destruct, "$imcall", "throw new global::System.MethodAccessException(\"C++ destructor does not have public access\")");
+        Replaceall(destruct, "$imcall", "throw new global::System.MethodAccessException(\"C++ destructor does not have public access\")");
       if (*Char(destruct)) {
-	Printv(proxy_class_def, "\n  ", NIL);
-	const String *methodmods = Getattr(n, "destructmethodmodifiers");
-	if (methodmods)
-	  Printv(proxy_class_def, methodmods, NIL);
-	else
-	  Printv(proxy_class_def, destruct_methodmodifiers, " ", derived ? "override" : "virtual", NIL);
-	Printv(proxy_class_def, " void ", destruct_methodname, "(", destruct_parameters, ") ", destruct, "\n", NIL);
+        Printv(proxy_class_def, "\n  ", NIL);
+        const String *methodmods = Getattr(n, "destructmethodmodifiers");
+        if (methodmods)
+          Printv(proxy_class_def, methodmods, NIL);
+        else
+          Printv(proxy_class_def, destruct_methodmodifiers, " ", derived ? "override" : "virtual", NIL);
+        Printv(proxy_class_def, " void ", destruct_methodname, "(", destruct_parameters, ") ", destruct, "\n", NIL);
       }
     }
     if (*Char(interface_upcasts))
@@ -2034,84 +2034,84 @@ public:
 
       int i;
       for (i = first_class_dmethod; i < curr_class_dmethod; ++i) {
-	UpcallData *udata = Getitem(dmethods_seq, i);
-	String *method = Getattr(udata, "method");
-	String *methid = Getattr(udata, "class_methodidx");
-	String *overname = Getattr(udata, "overname");
-	Printf(proxy_class_code, "    if (SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s))\n", method, methid);
-	Printf(proxy_class_code, "      swigDelegate%s = new SwigDelegate%s_%s(SwigDirectorMethod%s);\n", methid, proxy_class_name, methid, overname);
+        UpcallData *udata = Getitem(dmethods_seq, i);
+        String *method = Getattr(udata, "method");
+        String *methid = Getattr(udata, "class_methodidx");
+        String *overname = Getattr(udata, "overname");
+        Printf(proxy_class_code, "    if (SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s))\n", method, methid);
+        Printf(proxy_class_code, "      swigDelegate%s = new SwigDelegate%s_%s(SwigDirectorMethod%s);\n", methid, proxy_class_name, methid, overname);
       }
       String *director_connect_method_name = Swig_name_member(getNSpace(), getClassPrefix(), "director_connect");
       Printf(proxy_class_code, "    %s.%s(swigCPtr", imclass_name, director_connect_method_name);
       for (i = first_class_dmethod; i < curr_class_dmethod; ++i) {
-	UpcallData *udata = Getitem(dmethods_seq, i);
-	String *methid = Getattr(udata, "class_methodidx");
-	Printf(proxy_class_code, ", swigDelegate%s", methid);
+        UpcallData *udata = Getitem(dmethods_seq, i);
+        String *methid = Getattr(udata, "class_methodidx");
+        Printf(proxy_class_code, ", swigDelegate%s", methid);
       }
       Printf(proxy_class_code, ");\n");
       Printf(proxy_class_code, "  }\n");
 
       if (first_class_dmethod < curr_class_dmethod) {
-	// Only emit if there is at least one director method
-	Printf(proxy_class_code, "\n");
-	Printf(proxy_class_code, "  private bool SwigDerivedClassHasMethod(string methodName, global::System.Type[] methodTypes) {\n");
-	Printf(proxy_class_code, "    global::System.Reflection.MethodInfo[] methodInfos = this.GetType().GetMethods(\n");
-	Printf(proxy_class_code, "        global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance);\n");
-	Printf(proxy_class_code, "    foreach (global::System.Reflection.MethodInfo methodInfo in methodInfos) {\n");
-	Printf(proxy_class_code, "      if (methodInfo.DeclaringType == null)\n");
-	Printf(proxy_class_code, "        continue;\n\n");
-	Printf(proxy_class_code, "      if (methodInfo.Name != methodName)\n");
-	Printf(proxy_class_code, "        continue;\n\n");
-	Printf(proxy_class_code, "      var parameters = methodInfo.GetParameters();\n");
-	Printf(proxy_class_code, "      if (parameters.Length != methodTypes.Length)\n");
-	Printf(proxy_class_code, "        continue;\n\n");
-	Printf(proxy_class_code, "      bool parametersMatch = true;\n");
-	Printf(proxy_class_code, "      for (var i = 0; i < parameters.Length; i++) {\n");
-	Printf(proxy_class_code, "        if (parameters[i].ParameterType != methodTypes[i]) {\n");
-	Printf(proxy_class_code, "          parametersMatch = false;\n");
-	Printf(proxy_class_code, "          break;\n");
-	Printf(proxy_class_code, "        }\n");
-	Printf(proxy_class_code, "      }\n\n");
-	Printf(proxy_class_code, "      if (!parametersMatch)\n");
-	Printf(proxy_class_code, "        continue;\n\n");
-	Printf(proxy_class_code, "      if (methodInfo.IsVirtual && (methodInfo.DeclaringType.IsSubclassOf(typeof(%s))) &&\n", proxy_class_name);
-	Printf(proxy_class_code, "        methodInfo.DeclaringType != methodInfo.GetBaseDefinition().DeclaringType) {\n");
-	Printf(proxy_class_code, "        return true;\n");
-	Printf(proxy_class_code, "      }\n");
-	Printf(proxy_class_code, "    }\n\n");
-	Printf(proxy_class_code, "    return false;\n");
+        // Only emit if there is at least one director method
+        Printf(proxy_class_code, "\n");
+        Printf(proxy_class_code, "  private bool SwigDerivedClassHasMethod(string methodName, global::System.Type[] methodTypes) {\n");
+        Printf(proxy_class_code, "    global::System.Reflection.MethodInfo[] methodInfos = this.GetType().GetMethods(\n");
+        Printf(proxy_class_code, "        global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance);\n");
+        Printf(proxy_class_code, "    foreach (global::System.Reflection.MethodInfo methodInfo in methodInfos) {\n");
+        Printf(proxy_class_code, "      if (methodInfo.DeclaringType == null)\n");
+        Printf(proxy_class_code, "        continue;\n\n");
+        Printf(proxy_class_code, "      if (methodInfo.Name != methodName)\n");
+        Printf(proxy_class_code, "        continue;\n\n");
+        Printf(proxy_class_code, "      var parameters = methodInfo.GetParameters();\n");
+        Printf(proxy_class_code, "      if (parameters.Length != methodTypes.Length)\n");
+        Printf(proxy_class_code, "        continue;\n\n");
+        Printf(proxy_class_code, "      bool parametersMatch = true;\n");
+        Printf(proxy_class_code, "      for (var i = 0; i < parameters.Length; i++) {\n");
+        Printf(proxy_class_code, "        if (parameters[i].ParameterType != methodTypes[i]) {\n");
+        Printf(proxy_class_code, "          parametersMatch = false;\n");
+        Printf(proxy_class_code, "          break;\n");
+        Printf(proxy_class_code, "        }\n");
+        Printf(proxy_class_code, "      }\n\n");
+        Printf(proxy_class_code, "      if (!parametersMatch)\n");
+        Printf(proxy_class_code, "        continue;\n\n");
+        Printf(proxy_class_code, "      if (methodInfo.IsVirtual && (methodInfo.DeclaringType.IsSubclassOf(typeof(%s))) &&\n", proxy_class_name);
+        Printf(proxy_class_code, "        methodInfo.DeclaringType != methodInfo.GetBaseDefinition().DeclaringType) {\n");
+        Printf(proxy_class_code, "        return true;\n");
+        Printf(proxy_class_code, "      }\n");
+        Printf(proxy_class_code, "    }\n\n");
+        Printf(proxy_class_code, "    return false;\n");
 
-	/* Could add this code to cover corner case where the GetMethod() returns a method which allows type
-	 * promotion, eg it will return foo(double), if looking for foo(int).
-	 if (hasDerivedMethod) {
-	 hasDerivedMethod = false;
-	 if (methodInfo != null)
-	 {
-	 hasDerivedMethod = true;
-	 ParameterInfo[] parameterArray1 = methodInfo.GetParameters();
-	 for (int i=0; i<methodTypes.Length; i++)
-	 {
-	 if (parameterArray1[0].ParameterType != methodTypes[0])
-	 {
-	 hasDerivedMethod = false;
-	 break;
-	 }
-	 }
-	 }
-	 }
-	 */
-	//Printf(proxy_class_code, "    return hasDerivedMethod;\n");
-	Printf(proxy_class_code, "  }\n");
+        /* Could add this code to cover corner case where the GetMethod() returns a method which allows type
+         * promotion, eg it will return foo(double), if looking for foo(int).
+         if (hasDerivedMethod) {
+         hasDerivedMethod = false;
+         if (methodInfo != null)
+         {
+         hasDerivedMethod = true;
+         ParameterInfo[] parameterArray1 = methodInfo.GetParameters();
+         for (int i=0; i<methodTypes.Length; i++)
+         {
+         if (parameterArray1[0].ParameterType != methodTypes[0])
+         {
+         hasDerivedMethod = false;
+         break;
+         }
+         }
+         }
+         }
+         */
+        //Printf(proxy_class_code, "    return hasDerivedMethod;\n");
+        Printf(proxy_class_code, "  }\n");
       }
 
       if (Len(director_delegate_callback) > 0)
-	Printv(proxy_class_code, director_delegate_callback, NIL);
+        Printv(proxy_class_code, director_delegate_callback, NIL);
       if (Len(director_delegate_definitions) > 0)
-	Printv(proxy_class_code, "\n", director_delegate_definitions, NIL);
+        Printv(proxy_class_code, "\n", director_delegate_definitions, NIL);
       if (Len(director_delegate_instances) > 0)
-	Printv(proxy_class_code, "\n", director_delegate_instances, NIL);
+        Printv(proxy_class_code, "\n", director_delegate_instances, NIL);
       if (Len(director_method_types) > 0)
-	Printv(proxy_class_code, "\n", director_method_types, NIL);
+        Printv(proxy_class_code, "\n", director_method_types, NIL);
 
       Delete(director_callback_typedefs);
       director_callback_typedefs = NULL;
@@ -2137,7 +2137,7 @@ public:
 
     // Emit extra user code
     Printv(proxy_class_def, typemapLookup(n, "cscode", typemap_lookup_type, WARN_NONE),	// extra C# code
-	   "\n", NIL);
+           "\n", NIL);
 
     if (derived) {
       String *upcast_method_name = Swig_name_member(getNSpace(), getClassPrefix(), smart != 0 ? "SWIGSmartPtrUpcast" : "SWIGUpcast");
@@ -2166,15 +2166,15 @@ public:
     String *bases = additional ? NewStringf(" : %s", additional) : 0;
     if (List *baselist = Getattr(n, "bases")) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
-	if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
-	  continue; // TODO: warn about skipped non-interface bases
-	String *base_iname = Getattr(base.item, "interface:name");
-	if (!bases)
-	  bases = NewStringf(" : %s", base_iname);
-	else {
-	  Append(bases, ", ");
-	  Append(bases, base_iname);
-	}
+        if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
+          continue; // TODO: warn about skipped non-interface bases
+        String *base_iname = Getattr(base.item, "interface:name");
+        if (!bases)
+          bases = NewStringf(" : %s", base_iname);
+        else {
+          Append(bases, ", ");
+          Append(bases, base_iname);
+        }
       }
     }
     if (bases) {
@@ -2189,8 +2189,8 @@ public:
       String *interface_declaration = Copy(Getattr(attributes, "tmap:csinterfacecode:declaration"));
       if (interface_declaration) {
         Replaceall(interface_declaration, "$interfacename", interface_name);
-	Printv(f_interface, interface_declaration, NIL);
-	Delete(interface_declaration);
+        Printv(f_interface, interface_declaration, NIL);
+        Delete(interface_declaration);
       }
       Delete(interface_code);
     }
@@ -2219,54 +2219,54 @@ public:
       proxy_class_name = NewString(Getattr(n, "sym:name"));
       String *interface_name = GetFlag(n, "feature:interface") ? Getattr(n, "interface:name") : 0;
       if (Node *outer = Getattr(n, "nested:outer")) {
-	String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
-	for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
-	  Push(outerClassesPrefix, ".");
-	  Push(outerClassesPrefix, Getattr(outer, "sym:name"));
-	}
-	String *fnspace = nspace ? NewStringf("%s.%s", nspace, outerClassesPrefix) : outerClassesPrefix;
-	if (!addSymbol(proxy_class_name, n, fnspace))
-	  return SWIG_ERROR;
-	if (interface_name && !addInterfaceSymbol(interface_name, n, fnspace))
-	  return SWIG_ERROR;
-	if (nspace)
-	  Delete(fnspace);
-	Delete(outerClassesPrefix);
+        String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
+        for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
+          Push(outerClassesPrefix, ".");
+          Push(outerClassesPrefix, Getattr(outer, "sym:name"));
+        }
+        String *fnspace = nspace ? NewStringf("%s.%s", nspace, outerClassesPrefix) : outerClassesPrefix;
+        if (!addSymbol(proxy_class_name, n, fnspace))
+          return SWIG_ERROR;
+        if (interface_name && !addInterfaceSymbol(interface_name, n, fnspace))
+          return SWIG_ERROR;
+        if (nspace)
+          Delete(fnspace);
+        Delete(outerClassesPrefix);
       } else {
-	if (!addSymbol(proxy_class_name, n, nspace))
-	  return SWIG_ERROR;
-	if (interface_name && !addInterfaceSymbol(interface_name, n, nspace))
-	  return SWIG_ERROR;
+        if (!addSymbol(proxy_class_name, n, nspace))
+          return SWIG_ERROR;
+        if (interface_name && !addInterfaceSymbol(interface_name, n, nspace))
+          return SWIG_ERROR;
       }
 
       if (!nspace) {
-	full_imclass_name = NewStringf("%s", imclass_name);
-	if (Cmp(proxy_class_name, imclass_name) == 0) {
-	  Printf(stderr, "Class name cannot be equal to intermediary class name: %s\n", proxy_class_name);
-	  Exit(EXIT_FAILURE);
-	}
+        full_imclass_name = NewStringf("%s", imclass_name);
+        if (Cmp(proxy_class_name, imclass_name) == 0) {
+          Printf(stderr, "Class name cannot be equal to intermediary class name: %s\n", proxy_class_name);
+          Exit(EXIT_FAILURE);
+        }
 
-	if (Cmp(proxy_class_name, module_class_name) == 0) {
-	  Printf(stderr, "Class name cannot be equal to module class name: %s\n", proxy_class_name);
-	  Exit(EXIT_FAILURE);
-	}
+        if (Cmp(proxy_class_name, module_class_name) == 0) {
+          Printf(stderr, "Class name cannot be equal to module class name: %s\n", proxy_class_name);
+          Exit(EXIT_FAILURE);
+        }
       } else {
-	if (namespce) {
-	  full_imclass_name = NewStringf("%s.%s", namespce, imclass_name);
-	} else {
-	  full_imclass_name = NewStringf("%s", imclass_name);
-	}
+        if (namespce) {
+          full_imclass_name = NewStringf("%s.%s", namespce, imclass_name);
+        } else {
+          full_imclass_name = NewStringf("%s", imclass_name);
+        }
       }
 
       if (!has_outerclass) {
-	String *output_directory = outputDirectory(nspace);
-	f_proxy = getOutputFile(output_directory, proxy_class_name);
+        String *output_directory = outputDirectory(nspace);
+        f_proxy = getOutputFile(output_directory, proxy_class_name);
 
-	addOpenNamespace(nspace, f_proxy);
+        addOpenNamespace(nspace, f_proxy);
         Delete(output_directory);
       }
       else
-	++nesting_depth;
+        ++nesting_depth;
 
       proxy_class_def = NewString("");
       proxy_class_code = NewString("");
@@ -2274,11 +2274,11 @@ public:
       proxy_class_constants_code = NewString("");
 
       if (GetFlag(n, "feature:interface")) {
-	interface_class_code = NewString("");
-	String *output_directory = outputDirectory(nspace);
-	f_interface = getOutputFile(output_directory, interface_name);
-	addOpenNamespace(nspace, f_interface);
-	emitInterfaceDeclaration(n, interface_name, interface_class_code);
+        interface_class_code = NewString("");
+        String *output_directory = outputDirectory(nspace);
+        f_interface = getOutputFile(output_directory, interface_name);
+        addOpenNamespace(nspace, f_interface);
+        emitInterfaceDeclaration(n, interface_name, interface_class_code);
         Delete(output_directory);
       }
     }
@@ -2317,42 +2317,42 @@ public:
       Replaceall(interface_class_code, "$dllimport", dllimport);
 
       if (!has_outerclass)
-	Printv(f_proxy, proxy_class_def, proxy_class_code, NIL);
+        Printv(f_proxy, proxy_class_def, proxy_class_code, NIL);
       else {
-	Swig_offset_string(proxy_class_def, nesting_depth);
-	Append(old_proxy_class_code, proxy_class_def);
-	Swig_offset_string(proxy_class_code, nesting_depth);
-	Append(old_proxy_class_code, proxy_class_code);
+        Swig_offset_string(proxy_class_def, nesting_depth);
+        Append(old_proxy_class_code, proxy_class_def);
+        Swig_offset_string(proxy_class_code, nesting_depth);
+        Append(old_proxy_class_code, proxy_class_code);
       }
 
       // Write out all the constants
       if (Len(proxy_class_constants_code) != 0) {
-	if (!has_outerclass)
-	  Printv(f_proxy, proxy_class_constants_code, NIL);
-	else {
-	  Swig_offset_string(proxy_class_constants_code, nesting_depth);
-	  Append(old_proxy_class_code, proxy_class_constants_code);
-	}
+        if (!has_outerclass)
+          Printv(f_proxy, proxy_class_constants_code, NIL);
+        else {
+          Swig_offset_string(proxy_class_constants_code, nesting_depth);
+          Append(old_proxy_class_code, proxy_class_constants_code);
+        }
       }
       if (!has_outerclass) {
-	Printf(f_proxy, "}\n");
-	addCloseNamespace(nspace, f_proxy);
-	if (f_proxy != f_single_out)
-	  Delete(f_proxy);
-	f_proxy = NULL;
+        Printf(f_proxy, "}\n");
+        addCloseNamespace(nspace, f_proxy);
+        if (f_proxy != f_single_out)
+          Delete(f_proxy);
+        f_proxy = NULL;
       } else {
-	for (int i = 0; i < nesting_depth; ++i)
-	  Append(old_proxy_class_code, "  ");
-	Append(old_proxy_class_code, "}\n\n");
-	--nesting_depth;
+        for (int i = 0; i < nesting_depth; ++i)
+          Append(old_proxy_class_code, "  ");
+        Append(old_proxy_class_code, "}\n\n");
+        --nesting_depth;
       }
 
       if (f_interface) {
-	Printv(f_interface, interface_class_code, "}\n", NIL);
-	addCloseNamespace(nspace, f_interface);
-	if (f_interface != f_single_out)
-	  Delete(f_interface);
-	f_interface = 0;
+        Printv(f_interface, interface_class_code, "}\n", NIL);
+        addCloseNamespace(nspace, f_interface);
+        if (f_interface != f_single_out)
+          Delete(f_interface);
+        f_interface = 0;
       }
 
       emitDirectorExtraMethods(n);
@@ -2496,7 +2496,7 @@ public:
 
     if (l) {
       if (SwigType_type(Getattr(l, "type")) == T_VOID) {
-	l = nextSibling(l);
+        l = nextSibling(l);
       }
     }
 
@@ -2511,12 +2511,12 @@ public:
       SwigType *covariant = Getattr(n, "covariant");
       String *cstypeout = Getattr(n, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
-	tm = cstypeout;
+        tm = cstypeout;
       substituteClassname(covariant ? covariant : t, tm);
       Printf(return_type, "%s", tm);
       if (covariant)
-	Swig_warning(WARN_CSHARP_COVARIANT_RET, input_file, line_number,
-		     "Covariant return types not supported in C#. Proxy method will return %s.\n", SwigType_str(covariant, 0));
+        Swig_warning(WARN_CSHARP_COVARIANT_RET, input_file, line_number,
+                     "Covariant return types not supported in C#. Proxy method will return %s.\n", SwigType_str(covariant, 0));
     } else {
       Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(t, 0));
     }
@@ -2538,28 +2538,28 @@ public:
     const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
     if (methodmods) {
       if (is_smart_pointer()) {
-	// Smart pointer classes do not mirror the inheritance hierarchy of the underlying pointer type, so no virtual/override/new required.
-	String *mmods = Copy(methodmods);
-	Replaceall(mmods, "override", "");
-	Replaceall(mmods, "virtual", "");
-	Replaceall(mmods, "new", "");
-	Chop(mmods);		// remove trailing whitespace
-	Printf(function_code, "  %s ", mmods);
-	Delete(mmods);
+        // Smart pointer classes do not mirror the inheritance hierarchy of the underlying pointer type, so no virtual/override/new required.
+        String *mmods = Copy(methodmods);
+        Replaceall(mmods, "override", "");
+        Replaceall(mmods, "virtual", "");
+        Replaceall(mmods, "new", "");
+        Chop(mmods);		// remove trailing whitespace
+        Printf(function_code, "  %s ", mmods);
+        Delete(mmods);
       } else {
-	Printf(function_code, "  %s ", methodmods);
+        Printf(function_code, "  %s ", methodmods);
       }
     } else {
       methodmods = (is_public(n) ? public_string : protected_string);
       Printf(function_code, "  %s ", methodmods);
       if (!is_smart_pointer()) {
-	// Smart pointer classes do not mirror the inheritance hierarchy of the underlying pointer type, so no virtual/override/new required.
-	if (Getattr(n, "override"))
-	    Printf(function_code, "override ");
-	else if (checkAttribute(n, "storage", "virtual"))
-	  Printf(function_code, "virtual ");
-	if (Getattr(n, "hides"))
-	  Printf(function_code, "new ");
+        // Smart pointer classes do not mirror the inheritance hierarchy of the underlying pointer type, so no virtual/override/new required.
+        if (Getattr(n, "override"))
+            Printf(function_code, "override ");
+        else if (checkAttribute(n, "storage", "virtual"))
+          Printf(function_code, "virtual ");
+        if (Getattr(n, "hides"))
+          Printf(function_code, "new ");
       }
     }
     if (static_flag)
@@ -2580,41 +2580,41 @@ public:
 
       /* Ignored varargs */
       if (checkAttribute(p, "varargs:ignore", "1")) {
-	p = nextSibling(p);
-	continue;
+        p = nextSibling(p);
+        continue;
       }
 
       /* Ignored parameters */
       if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
 
       /* Ignore the 'this' argument for variable wrappers */
       if (!(variable_wrapper_flag && i == 0)) {
-	SwigType *pt = Getattr(p, "type");
-	String *param_type = NewString("");
+        SwigType *pt = Getattr(p, "type");
+        String *param_type = NewString("");
         if (setter_flag)
           last_parm = p;
 
-	/* Get the C# parameter type */
-	if ((tm = Getattr(p, "tmap:cstype"))) {
-	  substituteClassname(pt, tm);
-	  const String *inattributes = Getattr(p, "tmap:cstype:inattributes");
-	  Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+        /* Get the C# parameter type */
+        if ((tm = Getattr(p, "tmap:cstype"))) {
+          substituteClassname(pt, tm);
+          const String *inattributes = Getattr(p, "tmap:cstype:inattributes");
+          Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	if (gencomma)
-	  Printf(imcall, ", ");
+        if (gencomma)
+          Printf(imcall, ", ");
 
-	String *arg = makeParameterName(n, p, i, setter_flag);
+        String *arg = makeParameterName(n, p, i, setter_flag);
 
-	// Use typemaps to transform type used in C# wrapper function (in proxy class) to type used in PInvoke function (in intermediary class)
-	if ((tm = Getattr(p, "tmap:csin"))) {
-	  substituteClassname(pt, tm);
-	  Replaceall(tm, "$csinput", arg);
+        // Use typemaps to transform type used in C# wrapper function (in proxy class) to type used in PInvoke function (in intermediary class)
+        if ((tm = Getattr(p, "tmap:csin"))) {
+          substituteClassname(pt, tm);
+          Replaceall(tm, "$csinput", arg);
           String *pre = Getattr(p, "tmap:csin:pre");
           if (pre) {
             substituteClassname(pt, pre);
@@ -2639,24 +2639,24 @@ public:
               Insert(terminator_code, 0, "\n");
             Insert(terminator_code, 0, terminator);
           }
-	  Printv(imcall, tm, NIL);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSIN_UNDEF, input_file, line_number, "No csin typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+          Printv(imcall, tm, NIL);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSIN_UNDEF, input_file, line_number, "No csin typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	/* Add parameter to proxy function */
-	if (gencomma >= 2) {
-	  Printf(function_code, ", ");
-	  if (is_interface)
-	    Printf(interface_class_code, ", ");
-	}
-	gencomma = 2;
+        /* Add parameter to proxy function */
+        if (gencomma >= 2) {
+          Printf(function_code, ", ");
+          if (is_interface)
+            Printf(interface_class_code, ", ");
+        }
+        gencomma = 2;
         printArgumentDeclaration(n, p, param_type, arg, function_code);
-	if (is_interface)
+        if (is_interface)
             printArgumentDeclaration(n, p, param_type, arg, interface_class_code);
 
-	Delete(arg);
-	Delete(param_type);
+        Delete(arg);
+        Delete(param_type);
       }
       p = Getattr(p, "tmap:in:next");
     }
@@ -2687,45 +2687,45 @@ public:
         if (is_terminator_code) {
           Printv(tm, "\n", terminator_code, NIL);
         }
-	Insert(tm, 0, "{");
-	Printf(tm, "\n  }");
+        Insert(tm, 0, "{");
+        Printf(tm, "\n  }");
       }
       if (GetFlag(n, "feature:new"))
-	Replaceall(tm, "$owner", "true");
+        Replaceall(tm, "$owner", "true");
       else
-	Replaceall(tm, "$owner", "false");
+        Replaceall(tm, "$owner", "false");
       substituteClassname(t, tm);
 
       // For director methods: generate code to selectively make a normal polymorphic call or 
       // an explicit method call - needed to prevent infinite recursion calls in director methods.
       Node *explicit_n = Getattr(n, "explicitcallnode");
       if (explicit_n) {
-	String *ex_overloaded_name = getOverloadedName(explicit_n);
-	String *ex_intermediary_function_name = Swig_name_member(getNSpace(), getClassPrefix(), ex_overloaded_name);
+        String *ex_overloaded_name = getOverloadedName(explicit_n);
+        String *ex_intermediary_function_name = Swig_name_member(getNSpace(), getClassPrefix(), ex_overloaded_name);
 
-	String *ex_imcall = Copy(imcall);
-	Replaceall(ex_imcall, "$imfuncname", ex_intermediary_function_name);
-	Replaceall(imcall, "$imfuncname", intermediary_function_name);
-	String *excode = NewString("");
-	Node *directorNode = Getattr(n, "directorNode");
-	UpcallData *udata = directorNode ? Getattr(directorNode, "upcalldata") : 0;
-	if (udata) {
-	  String *methid = Getattr(udata, "class_methodidx");
+        String *ex_imcall = Copy(imcall);
+        Replaceall(ex_imcall, "$imfuncname", ex_intermediary_function_name);
+        Replaceall(imcall, "$imfuncname", intermediary_function_name);
+        String *excode = NewString("");
+        Node *directorNode = Getattr(n, "directorNode");
+        UpcallData *udata = directorNode ? Getattr(directorNode, "upcalldata") : 0;
+        if (udata) {
+          String *methid = Getattr(udata, "class_methodidx");
 
-	  if (!Cmp(return_type, "void"))
-	    Printf(excode, "if (SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s)) %s; else %s", proxy_function_name, methid, ex_imcall, imcall);
-	  else
-	    Printf(excode, "(SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s) ? %s : %s)", proxy_function_name, methid, ex_imcall, imcall);
+          if (!Cmp(return_type, "void"))
+            Printf(excode, "if (SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s)) %s; else %s", proxy_function_name, methid, ex_imcall, imcall);
+          else
+            Printf(excode, "(SwigDerivedClassHasMethod(\"%s\", swigMethodTypes%s) ? %s : %s)", proxy_function_name, methid, ex_imcall, imcall);
 
-	  Clear(imcall);
-	  Printv(imcall, excode, NIL);
-	} else {
-	  // probably an ignored method or nodirector
-	}
-	Delete(excode);
-	Delete(ex_overloaded_name);
+          Clear(imcall);
+          Printv(imcall, excode, NIL);
+        } else {
+          // probably an ignored method or nodirector
+        }
+        Delete(excode);
+        Delete(ex_overloaded_name);
       } else {
-	Replaceall(imcall, "$imfuncname", intermediary_function_name);
+        Replaceall(imcall, "$imfuncname", intermediary_function_name);
       }
       Replaceall(tm, "$imfuncname", intermediary_function_name);
       Replaceall(tm, "$imcall", imcall);
@@ -2736,70 +2736,70 @@ public:
     if (wrapping_member_flag && !enum_constant_flag) {
       // Properties
       if (generate_property_declaration_flag) {	// Ensure the declaration is generated just once should the property contain both a set and get
-	// Get the C# variable type - obtained differently depending on whether a setter is required.
-	String *variable_type = return_type;
-	if (setter_flag) {
-	  assert(last_parm);	// (last parameter is the only parameter for properties)
-	  /* Get variable type - ensure the variable name is fully resolved during typemap lookup via the symbol table set in NewParmNode */
-	  SwigType *cvariable_type = Getattr(last_parm, "type");
-	  Parm *variable_parm = NewParmNode(cvariable_type, n);
-	  if ((tm = Swig_typemap_lookup("cstype", variable_parm, "", 0))) {
-	    String *cstypeout = Getattr(variable_parm, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
-	    if (cstypeout)
-	      tm = cstypeout;
-	    substituteClassname(cvariable_type, tm);
-	    variable_type = tm;
-	  } else {
-	    Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(cvariable_type, 0));
-	  }
-	}
-	const String *csattributes = Getattr(n, "feature:cs:attributes");
-	if (csattributes)
-	  Printf(proxy_class_code, "  %s\n", csattributes);
-	const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
-	if (!methodmods)
-	  methodmods = (is_public(n) ? public_string : protected_string);
+        // Get the C# variable type - obtained differently depending on whether a setter is required.
+        String *variable_type = return_type;
+        if (setter_flag) {
+          assert(last_parm);	// (last parameter is the only parameter for properties)
+          /* Get variable type - ensure the variable name is fully resolved during typemap lookup via the symbol table set in NewParmNode */
+          SwigType *cvariable_type = Getattr(last_parm, "type");
+          Parm *variable_parm = NewParmNode(cvariable_type, n);
+          if ((tm = Swig_typemap_lookup("cstype", variable_parm, "", 0))) {
+            String *cstypeout = Getattr(variable_parm, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
+            if (cstypeout)
+              tm = cstypeout;
+            substituteClassname(cvariable_type, tm);
+            variable_type = tm;
+          } else {
+            Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(cvariable_type, 0));
+          }
+        }
+        const String *csattributes = Getattr(n, "feature:cs:attributes");
+        if (csattributes)
+          Printf(proxy_class_code, "  %s\n", csattributes);
+        const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
+        if (!methodmods)
+          methodmods = (is_public(n) ? public_string : protected_string);
 
-	// Translate documentation comments
-	if (have_docstring(n)) {
-	  Printv(proxy_class_code, comment_code, NIL);
-	}
+        // Translate documentation comments
+        if (have_docstring(n)) {
+          Printv(proxy_class_code, comment_code, NIL);
+        }
 
-	// Start property declaration
-	Printf(proxy_class_code, "  %s %s%s %s {", methodmods, static_flag ? "static " : "", variable_type, variable_name);
+        // Start property declaration
+        Printf(proxy_class_code, "  %s %s%s %s {", methodmods, static_flag ? "static " : "", variable_type, variable_name);
       }
       generate_property_declaration_flag = false;
 
       if (setter_flag) {
-	// Setter method
-	assert(last_parm);	// (last parameter is the only parameter for properties)
-	SwigType *cvariable_type = Getattr(last_parm, "type");
-	Parm *variable_parm = NewParmNode(cvariable_type, n);
-	if ((tm = Swig_typemap_lookup("csvarin", variable_parm, "", 0))) {
-	  substituteClassname(cvariable_type, tm);
-	  Replaceall(tm, "$csinput", "value");
+        // Setter method
+        assert(last_parm);	// (last parameter is the only parameter for properties)
+        SwigType *cvariable_type = Getattr(last_parm, "type");
+        Parm *variable_parm = NewParmNode(cvariable_type, n);
+        if ((tm = Swig_typemap_lookup("csvarin", variable_parm, "", 0))) {
+          substituteClassname(cvariable_type, tm);
+          Replaceall(tm, "$csinput", "value");
           Replaceall(tm, "$imfuncname", intermediary_function_name);
-	  Replaceall(tm, "$imcall", imcall);
-	  excodeSubstitute(n, tm, "csvarin", variable_parm);
-	  Printf(proxy_class_code, "%s", tm);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(cvariable_type, 0));
-	}
+          Replaceall(tm, "$imcall", imcall);
+          excodeSubstitute(n, tm, "csvarin", variable_parm);
+          Printf(proxy_class_code, "%s", tm);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(cvariable_type, 0));
+        }
       } else {
-	// Getter method
-	if ((tm = Swig_typemap_lookup("csvarout", n, "", 0))) {
-	  if (GetFlag(n, "feature:new"))
-	    Replaceall(tm, "$owner", "true");
-	  else
-	    Replaceall(tm, "$owner", "false");
-	  substituteClassname(t, tm);
+        // Getter method
+        if ((tm = Swig_typemap_lookup("csvarout", n, "", 0))) {
+          if (GetFlag(n, "feature:new"))
+            Replaceall(tm, "$owner", "true");
+          else
+            Replaceall(tm, "$owner", "false");
+          substituteClassname(t, tm);
           Replaceall(tm, "$imfuncname", intermediary_function_name);
-	  Replaceall(tm, "$imcall", imcall);
-	  excodeSubstitute(n, tm, "csvarout", n);
-	  Printf(proxy_class_code, "%s", tm);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarout typemap defined for %s\n", SwigType_str(t, 0));
-	}
+          Replaceall(tm, "$imcall", imcall);
+          excodeSubstitute(n, tm, "csvarout", n);
+          Printf(proxy_class_code, "%s", tm);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarout typemap defined for %s\n", SwigType_str(t, 0));
+        }
       }
     } else {
       // Normal function call
@@ -2853,8 +2853,8 @@ public:
 
       const String *csattributes = Getattr(n, "feature:cs:attributes");
       if (csattributes) {
-	Printf(function_code, "  %s\n", csattributes);
-	Printf(helper_code, "  %s\n", csattributes);
+        Printf(function_code, "  %s\n", csattributes);
+        Printf(helper_code, "  %s\n", csattributes);
       }
       const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
       methodmods = methodmods ? methodmods : (is_public(n) ? public_string : protected_string);
@@ -2862,7 +2862,7 @@ public:
       tm = Getattr(n, "tmap:imtype"); // typemaps were attached earlier to the node
       String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
       if (imtypeout)
-	tm = imtypeout;
+        tm = imtypeout;
       Printf(im_return_type, "%s", tm);
 
       Printf(function_code, "  %s %s(", methodmods, proxy_class_name);
@@ -2882,40 +2882,40 @@ public:
       /* Output each parameter */
       for (i = 0, p = l; p; i++) {
 
-	/* Ignored varargs */
-	if (checkAttribute(p, "varargs:ignore", "1")) {
-	  p = nextSibling(p);
-	  continue;
-	}
+        /* Ignored varargs */
+        if (checkAttribute(p, "varargs:ignore", "1")) {
+          p = nextSibling(p);
+          continue;
+        }
 
-	/* Ignored parameters */
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
+        /* Ignored parameters */
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
 
-	SwigType *pt = Getattr(p, "type");
-	String *param_type = NewString("");
+        SwigType *pt = Getattr(p, "type");
+        String *param_type = NewString("");
 
-	/* Get the C# parameter type */
-	if ((tm = Getattr(p, "tmap:cstype"))) {
-	  substituteClassname(pt, tm);
-	  const String *inattributes = Getattr(p, "tmap:cstype:inattributes");
-	  Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+        /* Get the C# parameter type */
+        if ((tm = Getattr(p, "tmap:cstype"))) {
+          substituteClassname(pt, tm);
+          const String *inattributes = Getattr(p, "tmap:cstype:inattributes");
+          Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	if (gencomma)
-	  Printf(imcall, ", ");
+        if (gencomma)
+          Printf(imcall, ", ");
 
-	String *arg = makeParameterName(n, p, i, false);
+        String *arg = makeParameterName(n, p, i, false);
         String *cshin = 0;
 
-	// Use typemaps to transform type used in C# wrapper function (in proxy class) to type used in PInvoke function (in intermediary class)
-	if ((tm = Getattr(p, "tmap:csin"))) {
-	  substituteClassname(pt, tm);
-	  Replaceall(tm, "$csinput", arg);
+        // Use typemaps to transform type used in C# wrapper function (in proxy class) to type used in PInvoke function (in intermediary class)
+        if ((tm = Getattr(p, "tmap:csin"))) {
+          substituteClassname(pt, tm);
+          Replaceall(tm, "$csinput", arg);
           String *pre = Getattr(p, "tmap:csin:pre");
           if (pre) {
             substituteClassname(pt, pre);
@@ -2943,26 +2943,26 @@ public:
           cshin = Getattr(p, "tmap:csin:cshin");
           if (cshin)
             Replaceall(cshin, "$csinput", arg);
-	  Printv(imcall, tm, NIL);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSIN_UNDEF, input_file, line_number, "No csin typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+          Printv(imcall, tm, NIL);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSIN_UNDEF, input_file, line_number, "No csin typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	/* Add parameter to proxy function */
-	if (gencomma) {
-	  Printf(function_code, ", ");
-	  Printf(helper_code, ", ");
-	  Printf(helper_args, ", ");
+        /* Add parameter to proxy function */
+        if (gencomma) {
+          Printf(function_code, ", ");
+          Printf(helper_code, ", ");
+          Printf(helper_args, ", ");
         }
         printArgumentDeclaration(n, p, param_type, arg, function_code);
-	Printf(helper_code, "%s %s", param_type, arg);
-	Printf(helper_args, "%s", cshin ? cshin : arg);
-	++gencomma;
+        Printf(helper_code, "%s %s", param_type, arg);
+        Printf(helper_args, "%s", cshin ? cshin : arg);
+        ++gencomma;
 
-	Delete(cshin);
-	Delete(arg);
-	Delete(param_type);
-	p = Getattr(p, "tmap:in:next");
+        Delete(cshin);
+        Delete(arg);
+        Delete(param_type);
+        p = Getattr(p, "tmap:in:next");
       }
 
       Printf(imcall, ")");
@@ -2974,23 +2974,23 @@ public:
       Hash *attributes = NewHash();
       String *typemap_lookup_type = Getattr(getCurrentClass(), "classtypeobj");
       String *construct_tm = Copy(typemapLookup(n, "csconstruct", typemap_lookup_type,
-						WARN_CSHARP_TYPEMAP_CSCONSTRUCT_UNDEF, attributes));
+                                                WARN_CSHARP_TYPEMAP_CSCONSTRUCT_UNDEF, attributes));
       if (construct_tm) {
-	if (!feature_director) {
-	  Replaceall(construct_tm, "$directorconnect", "");
-	} else {
-	  String *connect_attr = Getattr(attributes, "tmap:csconstruct:directorconnect");
+        if (!feature_director) {
+          Replaceall(construct_tm, "$directorconnect", "");
+        } else {
+          String *connect_attr = Getattr(attributes, "tmap:csconstruct:directorconnect");
 
-	  if (connect_attr) {
-	    Replaceall(construct_tm, "$directorconnect", connect_attr);
-	  } else {
-	    Swig_warning(WARN_CSHARP_NO_DIRECTORCONNECT_ATTR, input_file, line_number, "\"directorconnect\" attribute missing in %s \"csconstruct\" typemap.\n",
-			 Getattr(n, "name"));
-	    Replaceall(construct_tm, "$directorconnect", "");
-	  }
-	}
+          if (connect_attr) {
+            Replaceall(construct_tm, "$directorconnect", connect_attr);
+          } else {
+            Swig_warning(WARN_CSHARP_NO_DIRECTORCONNECT_ATTR, input_file, line_number, "\"directorconnect\" attribute missing in %s \"csconstruct\" typemap.\n",
+                         Getattr(n, "name"));
+            Replaceall(construct_tm, "$directorconnect", "");
+          }
+        }
 
-	Printv(function_code, " ", construct_tm, NIL);
+        Printv(function_code, " ", construct_tm, NIL);
       }
 
       excodeSubstitute(n, function_code, "csconstruct", attributes);
@@ -3027,7 +3027,7 @@ public:
 
       // Translate documentation comments
       if (have_docstring(n)) {
-	comment_code = docstring(n, tab2);
+        comment_code = docstring(n, tab2);
       }
 
       Printv(proxy_class_code, comment_code, NIL);
@@ -3060,7 +3060,7 @@ public:
       Printv(destructor_call, full_imclass_name, ".", Swig_name_destroy(getNSpace(), symname), "(swigCPtr)", NIL);
       const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
       if (methodmods)
-	Setattr(getCurrentClass(), "destructmethodmodifiers", methodmods);
+        Setattr(getCurrentClass(), "destructmethodmodifiers", methodmods);
     }
 
     return SWIG_OK;
@@ -3167,7 +3167,7 @@ public:
 
     if (l) {
       if (SwigType_type(Getattr(l, "type")) == T_VOID) {
-	l = nextSibling(l);
+        l = nextSibling(l);
       }
     }
 
@@ -3179,7 +3179,7 @@ public:
     if ((tm = Swig_typemap_lookup("cstype", n, "", 0))) {
       String *cstypeout = Getattr(n, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
       if (cstypeout)
-	tm = cstypeout;
+        tm = cstypeout;
       substituteClassname(t, tm);
       Printf(return_type, "%s", tm);
     } else {
@@ -3192,9 +3192,9 @@ public:
       func_name = NewString("");
       setter_flag = (Cmp(Getattr(n, "sym:name"), Swig_name_set(getNSpace(), variable_name)) == 0);
       if (setter_flag)
-	Printf(func_name, "set");
+        Printf(func_name, "set");
       else
-	Printf(func_name, "get");
+        Printf(func_name, "get");
       Putc(toupper((int) *Char(variable_name)), func_name);
       Printf(func_name, "%s", Char(variable_name) + 1);
       if (setter_flag)
@@ -3234,7 +3234,7 @@ public:
 
       /* Ignored parameters */
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -3243,38 +3243,38 @@ public:
 
       /* Get the C# parameter type */
       if ((tm = Getattr(p, "tmap:cstype"))) {
-	substituteClassname(pt, tm);
-	const String *inattributes = Getattr(p, "tmap:cstype:inattributes");
-	Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        substituteClassname(pt, tm);
+        const String *inattributes = Getattr(p, "tmap:cstype:inattributes");
+        Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-	Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       if (gencomma)
-	Printf(imcall, ", ");
+        Printf(imcall, ", ");
 
       String *arg = makeParameterName(n, p, i, global_or_member_variable);
 
       // Use typemaps to transform type used in C# wrapper function (in proxy class) to type used in PInvoke function (in intermediary class)
       if ((tm = Getattr(p, "tmap:csin"))) {
-	substituteClassname(pt, tm);
-	Replaceall(tm, "$csinput", arg);
-	String *pre = Getattr(p, "tmap:csin:pre");
-	if (pre) {
-	  substituteClassname(pt, pre);
-	  Replaceall(pre, "$csinput", arg);
+        substituteClassname(pt, tm);
+        Replaceall(tm, "$csinput", arg);
+        String *pre = Getattr(p, "tmap:csin:pre");
+        if (pre) {
+          substituteClassname(pt, pre);
+          Replaceall(pre, "$csinput", arg);
           if (Len(pre_code) > 0)
             Printf(pre_code, "\n");
-	  Printv(pre_code, pre, NIL);
-	}
-	String *post = Getattr(p, "tmap:csin:post");
-	if (post) {
-	  substituteClassname(pt, post);
-	  Replaceall(post, "$csinput", arg);
+          Printv(pre_code, pre, NIL);
+        }
+        String *post = Getattr(p, "tmap:csin:post");
+        if (post) {
+          substituteClassname(pt, post);
+          Replaceall(post, "$csinput", arg);
           if (Len(post_code) > 0)
             Printf(post_code, "\n");
-	  Printv(post_code, post, NIL);
-	}
+          Printv(post_code, post, NIL);
+        }
         String *terminator = Getattr(p, "tmap:csin:terminator");
         if (terminator) {
           substituteClassname(pt, terminator);
@@ -3283,14 +3283,14 @@ public:
             Insert(terminator_code, 0, "\n");
           Insert(terminator_code, 0, terminator);
         }
-	Printv(imcall, tm, NIL);
+        Printv(imcall, tm, NIL);
       } else {
-	Swig_warning(WARN_CSHARP_TYPEMAP_CSIN_UNDEF, input_file, line_number, "No csin typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_CSHARP_TYPEMAP_CSIN_UNDEF, input_file, line_number, "No csin typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to module class function */
       if (gencomma >= 2)
-	Printf(function_code, ", ");
+        Printf(function_code, ", ");
       gencomma = 2;
       printArgumentDeclaration(n, p, param_type, arg, function_code);
 
@@ -3323,13 +3323,13 @@ public:
         if (is_terminator_code) {
           Printv(tm, "\n", terminator_code, NIL);
         }
-	Insert(tm, 0, "{");
-	Printf(tm, "\n  }");
+        Insert(tm, 0, "{");
+        Printf(tm, "\n  }");
       }
       if (GetFlag(n, "feature:new"))
-	Replaceall(tm, "$owner", "true");
+        Replaceall(tm, "$owner", "true");
       else
-	Replaceall(tm, "$owner", "false");
+        Replaceall(tm, "$owner", "false");
       substituteClassname(t, tm);
       Replaceall(tm, "$imfuncname", overloaded_name);
       Replaceall(tm, "$imcall", imcall);
@@ -3340,58 +3340,58 @@ public:
     if (proxy_flag && global_variable_flag) {
       // Properties
       if (generate_property_declaration_flag) {	// Ensure the declaration is generated just once should the property contain both a set and get
-	// Get the C# variable type - obtained differently depending on whether a setter is required.
-	String *variable_type = return_type;
-	if (setter_flag) {
-	  p = last_parm;	// (last parameter is the only parameter for properties)
-	  SwigType *pt = Getattr(p, "type");
-	  if ((tm = Getattr(p, "tmap:cstype"))) {
-	    substituteClassname(pt, tm);
+        // Get the C# variable type - obtained differently depending on whether a setter is required.
+        String *variable_type = return_type;
+        if (setter_flag) {
+          p = last_parm;	// (last parameter is the only parameter for properties)
+          SwigType *pt = Getattr(p, "type");
+          if ((tm = Getattr(p, "tmap:cstype"))) {
+            substituteClassname(pt, tm);
             String *cstypeout = Getattr(p, "tmap:cstype:out");	// the type in the cstype typemap's out attribute overrides the type in the typemap
-	    variable_type = cstypeout ? cstypeout : tm;
-	  } else {
-	    Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(pt, 0));
-	  }
-	}
-	const String *csattributes = Getattr(n, "feature:cs:attributes");
-	if (csattributes)
-	  Printf(module_class_code, "  %s\n", csattributes);
-	const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
-	if (!methodmods)
-	  methodmods = (is_public(n) ? public_string : protected_string);
-	Printf(module_class_code, "  %s static %s %s {", methodmods, variable_type, variable_name);
+            variable_type = cstypeout ? cstypeout : tm;
+          } else {
+            Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(pt, 0));
+          }
+        }
+        const String *csattributes = Getattr(n, "feature:cs:attributes");
+        if (csattributes)
+          Printf(module_class_code, "  %s\n", csattributes);
+        const String *methodmods = Getattr(n, "feature:cs:methodmodifiers");
+        if (!methodmods)
+          methodmods = (is_public(n) ? public_string : protected_string);
+        Printf(module_class_code, "  %s static %s %s {", methodmods, variable_type, variable_name);
       }
       generate_property_declaration_flag = false;
 
       if (setter_flag) {
-	// Setter method
-	p = last_parm;		// (last parameter is the only parameter for properties)
-	SwigType *pt = Getattr(p, "type");
-	if ((tm = Getattr(p, "tmap:csvarin"))) {
-	  substituteClassname(pt, tm);
-	  Replaceall(tm, "$csinput", "value");
-	  Replaceall(tm, "$imfuncname", overloaded_name);
-	  Replaceall(tm, "$imcall", imcall);
-	  excodeSubstitute(n, tm, "csvarin", p);
-	  Printf(module_class_code, "%s", tm);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+        // Setter method
+        p = last_parm;		// (last parameter is the only parameter for properties)
+        SwigType *pt = Getattr(p, "type");
+        if ((tm = Getattr(p, "tmap:csvarin"))) {
+          substituteClassname(pt, tm);
+          Replaceall(tm, "$csinput", "value");
+          Replaceall(tm, "$imfuncname", overloaded_name);
+          Replaceall(tm, "$imcall", imcall);
+          excodeSubstitute(n, tm, "csvarin", p);
+          Printf(module_class_code, "%s", tm);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(pt, 0));
+        }
       } else {
-	// Getter method
-	if ((tm = Swig_typemap_lookup("csvarout", n, "", 0))) {
-	  if (GetFlag(n, "feature:new"))
-	    Replaceall(tm, "$owner", "true");
-	  else
-	    Replaceall(tm, "$owner", "false");
-	  substituteClassname(t, tm);
-	  Replaceall(tm, "$imfuncname", overloaded_name);
-	  Replaceall(tm, "$imcall", imcall);
-	  excodeSubstitute(n, tm, "csvarout", n);
-	  Printf(module_class_code, "%s", tm);
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarout typemap defined for %s\n", SwigType_str(t, 0));
-	}
+        // Getter method
+        if ((tm = Swig_typemap_lookup("csvarout", n, "", 0))) {
+          if (GetFlag(n, "feature:new"))
+            Replaceall(tm, "$owner", "true");
+          else
+            Replaceall(tm, "$owner", "false");
+          substituteClassname(t, tm);
+          Replaceall(tm, "$imfuncname", overloaded_name);
+          Replaceall(tm, "$imcall", imcall);
+          excodeSubstitute(n, tm, "csvarout", n);
+          Printf(module_class_code, "%s", tm);
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarout typemap defined for %s\n", SwigType_str(t, 0));
+        }
       }
     } else {
       // Normal function call
@@ -3432,11 +3432,11 @@ public:
     String *feature = Getattr(n, "feature:cs:enum");
     if (feature) {
       if (Cmp(feature, "simple") == 0)
-	enum_feature = SimpleEnum;
+        enum_feature = SimpleEnum;
       else if (Cmp(feature, "typesafe") == 0)
-	enum_feature = TypesafeEnum;
+        enum_feature = TypesafeEnum;
       else if (Cmp(feature, "proper") == 0)
-	enum_feature = ProperEnum;
+        enum_feature = ProperEnum;
     }
     return enum_feature;
   }
@@ -3463,29 +3463,29 @@ public:
       int const_feature_flag = GetFlag(n, "feature:cs:const");
 
       if (const_feature_flag) {
-	// Use the C syntax to make a true C# constant and hope that it compiles as C# code
-	value = Getattr(n, "enumvalue") ? Copy(Getattr(n, "enumvalue")) : Copy(Getattr(n, "enumvalueex"));
+        // Use the C syntax to make a true C# constant and hope that it compiles as C# code
+        value = Getattr(n, "enumvalue") ? Copy(Getattr(n, "enumvalue")) : Copy(Getattr(n, "enumvalueex"));
       } else {
-	String *newsymname = 0;
-	if (!getCurrentClass() || !proxy_flag) {
-	  String *enumClassPrefix = getEnumClassPrefix();
-	  if (enumClassPrefix) {
-	    // A global scoped enum
-	    newsymname = Swig_name_member(0, enumClassPrefix, symname);
-	    symname = newsymname;
-	  }
-	}
+        String *newsymname = 0;
+        if (!getCurrentClass() || !proxy_flag) {
+          String *enumClassPrefix = getEnumClassPrefix();
+          if (enumClassPrefix) {
+            // A global scoped enum
+            newsymname = Swig_name_member(0, enumClassPrefix, symname);
+            symname = newsymname;
+          }
+        }
 
-	// Get the enumvalue from a PINVOKE call
-	if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
-	  // Strange hack to change the name
-	  Setattr(n, "name", Getattr(n, "value"));	/* for wrapping of enums in a namespace when emit_action is used */
-	  constantWrapper(n);
-	  value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
-	} else {
-	  memberconstantHandler(n);
-	  value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
-	}
+        // Get the enumvalue from a PINVOKE call
+        if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
+          // Strange hack to change the name
+          Setattr(n, "name", Getattr(n, "value"));	/* for wrapping of enums in a namespace when emit_action is used */
+          constantWrapper(n);
+          value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        } else {
+          memberconstantHandler(n);
+          value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
+        }
       }
     }
     return value;
@@ -3501,32 +3501,32 @@ public:
     if (n) {
       enumname = Getattr(n, "enumname");
       if (!enumname) {
-	String *symname = Getattr(n, "sym:name");
-	if (symname) {
-	  // Add in class scope when referencing enum if not a global enum
-	  String *scopename_prefix = Swig_scopename_prefix(Getattr(n, "name"));
-	  String *proxyname = 0;
-	  if (scopename_prefix) {
-	    proxyname = getProxyName(scopename_prefix);
-	  }
-	  if (proxyname) {
-	    enumname = NewStringf("%s.%s", proxyname, symname);
-	  } else {
-	    // global enum or enum in a namespace
-	    String *nspace = Getattr(n, "sym:nspace");
-	    if (nspace) {
-	      if (namespce)
-		enumname = NewStringf("%s.%s.%s", namespce, nspace, symname);
-	      else
-		enumname = NewStringf("%s.%s", nspace, symname);
-	    } else {
-	      enumname = Copy(symname);
-	    }
-	  }
-	  Setattr(n, "enumname", enumname);
-	  Delete(enumname);
-	  Delete(scopename_prefix);
-	}
+        String *symname = Getattr(n, "sym:name");
+        if (symname) {
+          // Add in class scope when referencing enum if not a global enum
+          String *scopename_prefix = Swig_scopename_prefix(Getattr(n, "name"));
+          String *proxyname = 0;
+          if (scopename_prefix) {
+            proxyname = getProxyName(scopename_prefix);
+          }
+          if (proxyname) {
+            enumname = NewStringf("%s.%s", proxyname, symname);
+          } else {
+            // global enum or enum in a namespace
+            String *nspace = Getattr(n, "sym:nspace");
+            if (nspace) {
+              if (namespce)
+                enumname = NewStringf("%s.%s.%s", namespce, nspace, symname);
+              else
+                enumname = NewStringf("%s.%s", nspace, symname);
+            } else {
+              enumname = Copy(symname);
+            }
+          }
+          Setattr(n, "enumname", enumname);
+          Delete(enumname);
+          Delete(scopename_prefix);
+        }
       }
     }
 
@@ -3564,8 +3564,8 @@ public:
       SwigType *classnametype = Copy(strippedtype);
       Delete(SwigType_pop(classnametype));
       if (Len(classnametype) > 0) {
-	substituteClassnameSpecialVariable(classnametype, tm, "$*csclassname");
-	substitution_performed = true;
+        substituteClassnameSpecialVariable(classnametype, tm, "$*csclassname");
+        substitution_performed = true;
       }
       Delete(classnametype);
     }
@@ -3586,8 +3586,8 @@ public:
       SwigType *interfacenametype = Copy(strippedtype);
       Delete(SwigType_pop(interfacenametype));
       if (Len(interfacenametype) > 0) {
-	substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*csinterfacename", true);
-	substitution_performed = true;
+        substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*csinterfacename", true);
+        substitution_performed = true;
       }
       Delete(interfacenametype);
     }
@@ -3608,8 +3608,8 @@ public:
       SwigType *interfacenametype = Copy(strippedtype);
       Delete(SwigType_pop(interfacenametype));
       if (Len(interfacenametype) > 0) {
-	substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*interfacename", false);
-	substitution_performed = true;
+        substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*interfacename", false);
+        substitution_performed = true;
       }
       Delete(interfacenametype);
     }
@@ -3636,28 +3636,28 @@ public:
     if (SwigType_isenum(classnametype)) {
       String *enumname = getEnumName(classnametype);
       if (enumname) {
-	replacementname = Copy(enumname);
+        replacementname = Copy(enumname);
       } else {
-	bool anonymous_enum = (Cmp(classnametype, "enum ") == 0);
-	if (anonymous_enum) {
-	  replacementname = NewString("int");
-	} else {
-	  // An unknown enum - one that has not been parsed (neither a C enum forward reference nor a definition) or an ignored enum
-	  replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
-	  Replace(replacementname, "enum ", "", DOH_REPLACE_ANY);
-	  Setattr(swig_types_hash, replacementname, classnametype);
-	}
+        bool anonymous_enum = (Cmp(classnametype, "enum ") == 0);
+        if (anonymous_enum) {
+          replacementname = NewString("int");
+        } else {
+          // An unknown enum - one that has not been parsed (neither a C enum forward reference nor a definition) or an ignored enum
+          replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
+          Replace(replacementname, "enum ", "", DOH_REPLACE_ANY);
+          Setattr(swig_types_hash, replacementname, classnametype);
+        }
       }
     } else {
       String *classname = getProxyName(classnametype); // getProxyName() works for pointers to classes too
       if (classname) {
-	replacementname = Copy(classname);
+        replacementname = Copy(classname);
       } else {
-	// use $descriptor if SWIG does not know anything about this type. Note that any typedefs are resolved.
-	replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
+        // use $descriptor if SWIG does not know anything about this type. Note that any typedefs are resolved.
+        replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
 
-	// Add to hash table so that the type wrapper classes can be created later
-	Setattr(swig_types_hash, replacementname, classnametype);
+        // Add to hash table so that the type wrapper classes can be created later
+        Setattr(swig_types_hash, replacementname, classnametype);
       }
     }
     Replaceall(tm, classnamespecialvariable, replacementname);
@@ -3699,7 +3699,7 @@ public:
 
     // Emit the class
     Printv(swigtype, typemapLookup(n, "csimports", type, WARN_NONE),	// Import statements
-	   "\n", NIL);
+           "\n", NIL);
 
     // Class attributes
     const String *csattributes = typemapLookup(n, "csattributes", type, WARN_NONE);
@@ -3707,11 +3707,11 @@ public:
       Printf(swigtype, "%s\n", csattributes);
 
     Printv(swigtype, typemapLookup(n, "csclassmodifiers", type, WARN_CSHARP_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-	   " $csclassname",	// Class name and base class
-	   (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "", pure_baseclass, ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ?	// Interfaces
-	   ", " : "", pure_interfaces, " {", typemapLookup(n, "csbody", type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
-	   typemapLookup(n, "cscode", type, WARN_NONE),	// extra C# code
-	   "}\n", NIL);
+           " $csclassname",	// Class name and base class
+           (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "", pure_baseclass, ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ?	// Interfaces
+           ", " : "", pure_interfaces, " {", typemapLookup(n, "csbody", type, WARN_CSHARP_TYPEMAP_CSBODY_UNDEF),	// main body of class
+           typemapLookup(n, "cscode", type, WARN_NONE),	// extra C# code
+           "}\n", NIL);
 
     Replaceall(swigtype, "$csclassname", classname);
     Replaceall(swigtype, "$module", module_class_name);
@@ -3751,7 +3751,7 @@ public:
     if (!tm) {
       tm = empty_string;
       if (warning != WARN_NONE)
-	Swig_warning(warning, Getfile(n), Getline(n), "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
+        Swig_warning(warning, Getfile(n), Getline(n), "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
     }
     if (!typemap_attributes)
       Delete(node);
@@ -3804,8 +3804,8 @@ public:
     if (Getattr(n, "csharp:canthrow")) {
       int count = Replaceall(code, "$excode", excode);
       if (count < 1 || !excode) {
-	Swig_warning(WARN_CSHARP_EXCODE, input_file, line_number,
-		     "C# exception may not be thrown - no $excode or excode attribute in '%s' typemap.\n", typemap);
+        Swig_warning(WARN_CSHARP_EXCODE, input_file, line_number,
+                     "C# exception may not be thrown - no $excode or excode attribute in '%s' typemap.\n", typemap);
       }
     } else {
       Replaceall(code, "$excode", empty_string);
@@ -3821,9 +3821,9 @@ public:
     if (namespce || nspace) {
       Printf(file, "namespace ");
       if (namespce)
-	Printv(file, namespce, nspace ? "." : "", NIL);
+        Printv(file, namespce, nspace ? "." : "", NIL);
       if (nspace)
-	Printv(file, nspace, NIL);
+        Printv(file, nspace, NIL);
       Printf(file, " {\n");
     }
   }
@@ -3851,9 +3851,9 @@ public:
       Replaceall(nspace_subdirectory, ".", SWIG_FILE_DELIMITER);
       String *newdir_error = Swig_new_subdirectory(output_directory, nspace_subdirectory);
       if (newdir_error) {
-	Printf(stderr, "%s\n", newdir_error);
-	Delete(newdir_error);
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "%s\n", newdir_error);
+        Delete(newdir_error);
+        Exit(EXIT_FAILURE);
       }
       Printv(output_directory, nspace_subdirectory, SWIG_FILE_DELIMITER, 0);
       Delete(nspace_subdirectory);
@@ -3879,15 +3879,15 @@ public:
 
       udata_iter = First(dmethods_seq);
       while (udata_iter.item) {
-	UpcallData *udata = udata_iter.item;
-	Printf(dmethod_data, "  { \"%s\", \"%s\" }", Getattr(udata, "imclass_method"), Getattr(udata, "imclass_fdesc"));
-	++n_methods;
+        UpcallData *udata = udata_iter.item;
+        Printf(dmethod_data, "  { \"%s\", \"%s\" }", Getattr(udata, "imclass_method"), Getattr(udata, "imclass_fdesc"));
+        ++n_methods;
 
-	udata_iter = Next(udata_iter);
+        udata_iter = Next(udata_iter);
 
-	if (udata_iter.item)
-	  Putc(',', dmethod_data);
-	Putc('\n', dmethod_data);
+        if (udata_iter.item)
+          Putc(',', dmethod_data);
+        Putc('\n', dmethod_data);
       }
 
 
@@ -3922,8 +3922,8 @@ public:
     if (!GetFlag(n, "feature:flatnested")) {
       for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
 
-	Push(qualified_classname, ".");
-	Push(qualified_classname, Getattr(outer_class, "sym:name"));
+        Push(qualified_classname, ".");
+        Push(qualified_classname, Getattr(outer_class, "sym:name"));
       }
     }
     if (nspace)
@@ -3953,7 +3953,7 @@ public:
 
       Printf(code_wrap->def, ", ");
       if (i != first_class_dmethod)
-	Printf(code_wrap->code, ", ");
+        Printf(code_wrap->code, ", ");
       Printf(code_wrap->def, "%s::SWIG_Callback%s_t callback%s", dirclassname, methid, methid);
       Printf(code_wrap->code, "callback%s", methid);
       Printf(imclass_class_code, ", %s.SwigDelegate%s_%s delegate%s", qualified_classname, sym_name, methid, methid);
@@ -4029,50 +4029,50 @@ public:
 
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  String *base_typename = SwigType_base(returntype);
-	  String *resolved_typename = SwigType_typedef_resolve_all(base_typename);
-	  Symtab *symtab = Getattr(n, "sym:symtab");
-	  Node *typenode = Swig_symbol_clookup(resolved_typename, symtab);
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          String *base_typename = SwigType_base(returntype);
+          String *resolved_typename = SwigType_typedef_resolve_all(base_typename);
+          Symtab *symtab = Getattr(n, "sym:symtab");
+          Node *typenode = Swig_symbol_clookup(resolved_typename, symtab);
 
-	  if (SwigType_ispointer(returntype) || (typenode && Getattr(typenode, "abstracts"))) {
-	    /* initialize pointers to something sane. Same for abstract
-	       classes when a reference is returned. */
-	    Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	  } else {
-	    /* If returning a reference, initialize the pointer to a sane
-	       default - if a C# exception occurs, then the pointer returns
-	       something other than a NULL-initialized reference. */
-	    SwigType *noref_type = SwigType_del_reference(Copy(returntype));
-	    String *noref_ltype = SwigType_lstr(noref_type, 0);
-	    String *return_ltype = SwigType_lstr(returntype, 0);
+          if (SwigType_ispointer(returntype) || (typenode && Getattr(typenode, "abstracts"))) {
+            /* initialize pointers to something sane. Same for abstract
+               classes when a reference is returned. */
+            Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+          } else {
+            /* If returning a reference, initialize the pointer to a sane
+               default - if a C# exception occurs, then the pointer returns
+               something other than a NULL-initialized reference. */
+            SwigType *noref_type = SwigType_del_reference(Copy(returntype));
+            String *noref_ltype = SwigType_lstr(noref_type, 0);
+            String *return_ltype = SwigType_lstr(returntype, 0);
 
-	    Wrapper_add_localv(w, "result_default", "static", noref_ltype, "result_default", NIL);
-	    Wrapper_add_localv(w, "c_result", return_ltype, "c_result", NIL);
-	    Printf(w->code, "result_default = SwigValueInit< %s >();\n", noref_ltype);
-	    Printf(w->code, "c_result = &result_default;\n");
-	    Delete(return_ltype);
-	    Delete(noref_ltype);
-	    Delete(noref_type);
-	  }
+            Wrapper_add_localv(w, "result_default", "static", noref_ltype, "result_default", NIL);
+            Wrapper_add_localv(w, "c_result", return_ltype, "c_result", NIL);
+            Printf(w->code, "result_default = SwigValueInit< %s >();\n", noref_ltype);
+            Printf(w->code, "c_result = &result_default;\n");
+            Delete(return_ltype);
+            Delete(noref_ltype);
+            Delete(noref_type);
+          }
 
-	  Delete(base_typename);
-	  Delete(resolved_typename);
-	}
+          Delete(base_typename);
+          Delete(resolved_typename);
+        }
       } else {
-	SwigType *vt;
+        SwigType *vt;
 
-	vt = cplus_value_type(returntype);
-	if (!vt) {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
-	  Delete(vt);
-	}
+        vt = cplus_value_type(returntype);
+        if (!vt) {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
+          Delete(vt);
+        }
       }
     }
 
@@ -4080,35 +4080,35 @@ public:
       /* Create the intermediate class wrapper */
       tm = Swig_typemap_lookup("imtype", n, "", 0);
       if (tm) {
-	String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
-	if (imtypeout)
-	  tm = imtypeout;
-	const String *im_directoroutattributes = Getattr(n, "tmap:imtype:directoroutattributes");
-	if (im_directoroutattributes) {
-	  Printf(callback_def, "  %s\n", im_directoroutattributes);
-	  if (!ignored_method)
-	    Printf(director_delegate_definitions, "  %s\n", im_directoroutattributes);
-	}
+        String *imtypeout = Getattr(n, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
+        if (imtypeout)
+          tm = imtypeout;
+        const String *im_directoroutattributes = Getattr(n, "tmap:imtype:directoroutattributes");
+        if (im_directoroutattributes) {
+          Printf(callback_def, "  %s\n", im_directoroutattributes);
+          if (!ignored_method)
+            Printf(director_delegate_definitions, "  %s\n", im_directoroutattributes);
+        }
 
-	Printf(callback_def, "  private %s SwigDirectorMethod%s(", tm, overloaded_name);
-	const String *csdirectordelegatemodifiers = Getattr(n, "feature:csdirectordelegatemodifiers");
-	String *modifiers = (csdirectordelegatemodifiers ? NewStringf("%s%s", csdirectordelegatemodifiers, Len(csdirectordelegatemodifiers) > 0 ? " " : "") : NewStringf("public "));
-	Printf(director_delegate_definitions, "  %sdelegate %s", modifiers, tm);
-	Delete(modifiers);
+        Printf(callback_def, "  private %s SwigDirectorMethod%s(", tm, overloaded_name);
+        const String *csdirectordelegatemodifiers = Getattr(n, "feature:csdirectordelegatemodifiers");
+        String *modifiers = (csdirectordelegatemodifiers ? NewStringf("%s%s", csdirectordelegatemodifiers, Len(csdirectordelegatemodifiers) > 0 ? " " : "") : NewStringf("public "));
+        Printf(director_delegate_definitions, "  %sdelegate %s", modifiers, tm);
+        Delete(modifiers);
       } else {
-	Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(returntype, 0));
+        Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(returntype, 0));
       }
     }
 
     if ((c_ret_type = Swig_typemap_lookup("ctype", n, "", 0))) {
       if (!is_void && !ignored_method) {
-	String *jretval_decl = NewStringf("%s jresult", c_ret_type);
-	Wrapper_add_localv(w, "jresult", jretval_decl, "= 0", NIL);
-	Delete(jretval_decl);
+        String *jretval_decl = NewStringf("%s jresult", c_ret_type);
+        Wrapper_add_localv(w, "jresult", jretval_decl, "= 0", NIL);
+        Delete(jretval_decl);
       }
     } else {
       Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n", 
-	  SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4130,19 +4130,19 @@ public:
     if (!pure_virtual) {
       String *super_call = Swig_method_call(super, l);
       if (is_void) {
-	Printf(w->code, "%s;\n", super_call);
-	if (!ignored_method)
-	  Printf(w->code, "return;\n");
+        Printf(w->code, "%s;\n", super_call);
+        if (!ignored_method)
+          Printf(w->code, "return;\n");
       } else {
-	Printf(w->code, "return %s;\n", super_call);
+        Printf(w->code, "return %s;\n", super_call);
       }
       Delete(super_call);
     } else {
       Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"%s::%s\");\n", SwigType_namestr(c_classname), SwigType_namestr(name));
       if (!is_void)
-	Printf(w->code, "return %s;", qualified_return);
+        Printf(w->code, "return %s;", qualified_return);
       else if (!ignored_method)
-	Printf(w->code, "return;\n");
+        Printf(w->code, "return;\n");
     }
 
     if (!ignored_method)
@@ -4152,7 +4152,7 @@ public:
     for (i = 0, p = l; p; ++i) {
       /* Is this superfluous? */
       while (checkAttribute(p, "tmap:directorin:numinputs", "0")) {
-	p = Getattr(p, "tmap:directorin:next");
+        p = Getattr(p, "tmap:directorin:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -4165,130 +4165,130 @@ public:
 
       /* And add to the upcall args */
       if (i > 0)
-	Printf(jupcall_args, ", ");
+        Printf(jupcall_args, ", ");
       Printf(jupcall_args, "%s", arg);
 
       /* Get parameter's intermediary C type */
       if ((c_param_type = Getattr(p, "tmap:ctype"))) {
-	String *ctypeout = Getattr(p, "tmap:ctype:out");	// the type in the ctype typemap's out attribute overrides the type in the typemap
-	if (ctypeout)
-	  c_param_type = ctypeout;
+        String *ctypeout = Getattr(p, "tmap:ctype:out");	// the type in the ctype typemap's out attribute overrides the type in the typemap
+        if (ctypeout)
+          c_param_type = ctypeout;
 
-	/* Add to local variables */
-	Printf(c_decl, "%s %s", c_param_type, arg);
-	if (!ignored_method)
-	  Wrapper_add_localv(w, arg, c_decl, (!(SwigType_ispointer(pt) || SwigType_isreference(pt)) ? "" : "= 0"), NIL);
+        /* Add to local variables */
+        Printf(c_decl, "%s %s", c_param_type, arg);
+        if (!ignored_method)
+          Wrapper_add_localv(w, arg, c_decl, (!(SwigType_ispointer(pt) || SwigType_isreference(pt)) ? "" : "= 0"), NIL);
 
-	/* Add input marshalling code */
-	if ((tm = Getattr(p, "tmap:directorin"))) {
+        /* Add input marshalling code */
+        if ((tm = Getattr(p, "tmap:directorin"))) {
 
-	  Setattr(p, "emit:directorinput", arg);
-	  Replaceall(tm, "$input", arg);
-	  Replaceall(tm, "$owner", "0");
+          Setattr(p, "emit:directorinput", arg);
+          Replaceall(tm, "$input", arg);
+          Replaceall(tm, "$owner", "0");
 
-	  if (Len(tm))
-	    if (!ignored_method)
-	      Printf(w->code, "%s\n", tm);
+          if (Len(tm))
+            if (!ignored_method)
+              Printf(w->code, "%s\n", tm);
 
-	  /* Add C type to callback typedef */
-	  if (i > 0)
-	    Printf(callback_typedef_parms, ", ");
-	  Printf(callback_typedef_parms, "%s", c_param_type);
+          /* Add C type to callback typedef */
+          if (i > 0)
+            Printf(callback_typedef_parms, ", ");
+          Printf(callback_typedef_parms, "%s", c_param_type);
 
-	  /* Add parameter to the intermediate class code if generating the
-	   * intermediate's upcall code */
-	  if ((tm = Getattr(p, "tmap:imtype"))) {
+          /* Add parameter to the intermediate class code if generating the
+           * intermediate's upcall code */
+          if ((tm = Getattr(p, "tmap:imtype"))) {
 
-	    String *imtypeout = Getattr(p, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
-	    if (imtypeout)
-	      tm = imtypeout;
+            String *imtypeout = Getattr(p, "tmap:imtype:out");	// the type in the imtype typemap's out attribute overrides the type in the typemap
+            if (imtypeout)
+              tm = imtypeout;
             const String *im_directorinattributes = Getattr(p, "tmap:imtype:directorinattributes");
 
-	    String *din = Copy(Getattr(p, "tmap:csdirectorin"));
+            String *din = Copy(Getattr(p, "tmap:csdirectorin"));
 
-	    if (din) {
-	      Replaceall(din, "$module", module_class_name);
-	      Replaceall(din, "$imclassname", imclass_name);
-	      substituteClassname(pt, din);
-	      Replaceall(din, "$iminput", ln);
+            if (din) {
+              Replaceall(din, "$module", module_class_name);
+              Replaceall(din, "$imclassname", imclass_name);
+              substituteClassname(pt, din);
+              Replaceall(din, "$iminput", ln);
 
-	      // pre and post attribute support
-	      String *pre = Getattr(p, "tmap:csdirectorin:pre");
-	      if (pre) {
-		substituteClassname(pt, pre);
-		Replaceall(pre, "$iminput", ln);
-		if (Len(pre_code) > 0)
-		  Printf(pre_code, "\n");
-		Printv(pre_code, pre, NIL);
-	      }
-	      String *post = Getattr(p, "tmap:csdirectorin:post");
-	      if (post) {
-		substituteClassname(pt, post);
-		Replaceall(post, "$iminput", ln);
-		if (Len(post_code) > 0)
-		  Printf(post_code, "\n");
-		Printv(post_code, post, NIL);
-	      }
-	      String *terminator = Getattr(p, "tmap:csdirectorin:terminator");
-	      if (terminator) {
-		substituteClassname(pt, terminator);
-		Replaceall(terminator, "$iminput", ln);
-		if (Len(terminator_code) > 0)
-		Insert(terminator_code, 0, "\n");
-		Insert(terminator_code, 0, terminator);
-	      }
+              // pre and post attribute support
+              String *pre = Getattr(p, "tmap:csdirectorin:pre");
+              if (pre) {
+                substituteClassname(pt, pre);
+                Replaceall(pre, "$iminput", ln);
+                if (Len(pre_code) > 0)
+                  Printf(pre_code, "\n");
+                Printv(pre_code, pre, NIL);
+              }
+              String *post = Getattr(p, "tmap:csdirectorin:post");
+              if (post) {
+                substituteClassname(pt, post);
+                Replaceall(post, "$iminput", ln);
+                if (Len(post_code) > 0)
+                  Printf(post_code, "\n");
+                Printv(post_code, post, NIL);
+              }
+              String *terminator = Getattr(p, "tmap:csdirectorin:terminator");
+              if (terminator) {
+                substituteClassname(pt, terminator);
+                Replaceall(terminator, "$iminput", ln);
+                if (Len(terminator_code) > 0)
+                Insert(terminator_code, 0, "\n");
+                Insert(terminator_code, 0, terminator);
+              }
 
-	      if (i > 0) {
-		Printf(delegate_parms, ", ");
-		Printf(proxy_method_types, ", ");
-		Printf(imcall_args, ", ");
-	      }
-	      Printf(delegate_parms, "%s%s %s", im_directorinattributes ? im_directorinattributes : empty_string, tm, ln);
+              if (i > 0) {
+                Printf(delegate_parms, ", ");
+                Printf(proxy_method_types, ", ");
+                Printf(imcall_args, ", ");
+              }
+              Printf(delegate_parms, "%s%s %s", im_directorinattributes ? im_directorinattributes : empty_string, tm, ln);
 
-	      if (Cmp(din, ln)) {
-		Printv(imcall_args, din, NIL);
-	      } else
-		Printv(imcall_args, ln, NIL);
+              if (Cmp(din, ln)) {
+                Printv(imcall_args, din, NIL);
+              } else
+                Printv(imcall_args, ln, NIL);
 
-	      /* Get the C# parameter type */
-	      if ((tm = Getattr(p, "tmap:cstype"))) {
-		substituteClassname(pt, tm);
-		int flags = DOH_REPLACE_FIRST | DOH_REPLACE_ID_BEGIN | DOH_REPLACE_NOCOMMENT;
-		if (Replace(tm, "ref ", "", flags) || Replace(tm, "ref\t", "", flags)) {
-		  Printf(proxy_method_types, "typeof(%s).MakeByRefType()", tm);
-		} else if (Replace(tm, "out ", "", flags) || Replace(tm, "out\t", "", flags)) {
-		  Printf(proxy_method_types, "typeof(%s).MakeByRefType()", tm);
-		} else {
-		  Printf(proxy_method_types, "typeof(%s)", tm);
-		}
-	      } else {
-		Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
-	      }
-	    } else {
-	      Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number, "No csdirectorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-		  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	      output_director = false;
-	    }
-	  } else {
-	    Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n", 
-		SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    output_director = false;
-	  }
+              /* Get the C# parameter type */
+              if ((tm = Getattr(p, "tmap:cstype"))) {
+                substituteClassname(pt, tm);
+                int flags = DOH_REPLACE_FIRST | DOH_REPLACE_ID_BEGIN | DOH_REPLACE_NOCOMMENT;
+                if (Replace(tm, "ref ", "", flags) || Replace(tm, "ref\t", "", flags)) {
+                  Printf(proxy_method_types, "typeof(%s).MakeByRefType()", tm);
+                } else if (Replace(tm, "out ", "", flags) || Replace(tm, "out\t", "", flags)) {
+                  Printf(proxy_method_types, "typeof(%s).MakeByRefType()", tm);
+                } else {
+                  Printf(proxy_method_types, "typeof(%s)", tm);
+                }
+              } else {
+                Swig_warning(WARN_CSHARP_TYPEMAP_CSWTYPE_UNDEF, input_file, line_number, "No cstype typemap defined for %s\n", SwigType_str(pt, 0));
+              }
+            } else {
+              Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number, "No csdirectorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+              output_director = false;
+            }
+          } else {
+            Swig_warning(WARN_CSHARP_TYPEMAP_CSTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            output_director = false;
+          }
 
-	  p = Getattr(p, "tmap:directorin:next");
+          p = Getattr(p, "tmap:directorin:next");
 
-	} else {
-	  Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number,
-		       "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n", 
-		       SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	  p = nextSibling(p);
-	  output_director = false;
-	}
+        } else {
+          Swig_warning(WARN_CSHARP_TYPEMAP_CSDIRECTORIN_UNDEF, input_file, line_number,
+                       "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n", 
+                       SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          p = nextSibling(p);
+          output_director = false;
+        }
       } else {
-	Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n", 
-	    SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	output_director = false;
-	p = nextSibling(p);
+        Swig_warning(WARN_CSHARP_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+            SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        output_director = false;
+        p = nextSibling(p);
       }
 
       Delete(ln);
@@ -4320,16 +4320,16 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
-	  Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
-	  Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
-	}
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
+          Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
+          Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
+        }
       }
 
       Append(w->def, ")");
@@ -4352,7 +4352,7 @@ public:
       substituteClassname(returntype, tm);
       Replaceall(tm, "$cscall", upcall);
       if (!is_void)
-	Insert(tm, 0, "return ");
+        Insert(tm, 0, "return ");
       Replaceall(tm, "\n ", "\n   "); // add extra indentation to code in typemap
 
       // pre and post attribute support
@@ -4360,15 +4360,15 @@ public:
       bool is_post_code = Len(post_code) > 0;
       bool is_terminator_code = Len(terminator_code) > 0;
       if (is_pre_code && is_post_code)
-	Printf(callback_code, "%s\n    try {\n      %s;\n    } finally {\n%s\n    }\n", pre_code, tm, post_code);
+        Printf(callback_code, "%s\n    try {\n      %s;\n    } finally {\n%s\n    }\n", pre_code, tm, post_code);
       else if (is_pre_code)
-	Printf(callback_code, "%s\n    %s;\n", pre_code, tm);
+        Printf(callback_code, "%s\n    %s;\n", pre_code, tm);
       else if (is_post_code)
-	Printf(callback_code, "    try {\n      %s;\n    } finally {\n%s\n    }\n", tm, post_code);
+        Printf(callback_code, "    try {\n      %s;\n    } finally {\n%s\n    }\n", tm, post_code);
       else
-	Printf(callback_code, "    %s;\n", tm);
+        Printf(callback_code, "    %s;\n", tm);
       if (is_terminator_code)
-	Printv(callback_code, "\n", terminator_code, NIL);
+        Printv(callback_code, "\n", terminator_code, NIL);
     }
 
     Printf(callback_code, "  }\n");
@@ -4376,47 +4376,47 @@ public:
 
     if (!ignored_method) {
       if (!is_void)
-	Printf(w->code, "jresult = (%s) ", c_ret_type);
+        Printf(w->code, "jresult = (%s) ", c_ret_type);
 
       Printf(w->code, "swig_callback%s(%s);\n", overloaded_name, jupcall_args);
 
       if (!is_void) {
-	String *jresult_str = NewString("jresult");
-	String *result_str = NewString("c_result");
+        String *jresult_str = NewString("jresult");
+        String *result_str = NewString("c_result");
 
-	/* Copy jresult into c_result... */
-	if ((tm = Swig_typemap_lookup("directorout", n, result_str, w))) {
-	  Replaceall(tm, "$input", jresult_str);
-	  Replaceall(tm, "$result", result_str);
-	  Printf(w->code, "%s\n", tm);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		       "Unable to use return type %s used in %s::%s (skipping director method)\n", 
-		       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	  output_director = false;
-	}
+        /* Copy jresult into c_result... */
+        if ((tm = Swig_typemap_lookup("directorout", n, result_str, w))) {
+          Replaceall(tm, "$input", jresult_str);
+          Replaceall(tm, "$result", result_str);
+          Printf(w->code, "%s\n", tm);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                       "Unable to use return type %s used in %s::%s (skipping director method)\n", 
+                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          output_director = false;
+        }
 
-	Delete(jresult_str);
-	Delete(result_str);
+        Delete(jresult_str);
+        Delete(result_str);
       }
 
       /* Marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout"))) {
-	  canThrow(n, "directorargout", p);
-	  Replaceall(tm, "$result", "jresult");
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout"))) {
+          canThrow(n, "directorargout", p);
+          Replaceall(tm, "$result", "jresult");
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       /* Terminate wrapper code */
       Printf(w->code, "}\n");
       if (!is_void)
-	Printf(w->code, "return %s;", qualified_return);
+        Printf(w->code, "return %s;", qualified_return);
     }
 
     Printf(w->code, "}");
@@ -4429,7 +4429,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -4439,18 +4439,18 @@ public:
     /* emit the director method */
     if (status == SWIG_OK && output_director) {
       if (!is_void) {
-	Replaceall(w->code, "$null", qualified_return);
+        Replaceall(w->code, "$null", qualified_return);
       } else {
-	Replaceall(w->code, "$null", "");
+        Replaceall(w->code, "$null", "");
       }
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!ignored_method)
-	Printv(director_delegate_callback, "\n", callback_def, callback_code, NIL);
+        Printv(director_delegate_callback, "\n", callback_def, callback_code, NIL);
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 
@@ -4514,8 +4514,8 @@ public:
       String *pname = Getattr(p, "name");
 
       if (!pname) {
-	pname = NewStringf("arg%d", argidx++);
-	Setattr(p, "name", pname);
+        pname = NewStringf("arg%d", argidx++);
+        Setattr(p, "name", pname);
       }
     }
 
@@ -4525,23 +4525,23 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, dirclassname, parms, 0);
-	String *call = Swig_csuperclass_call(0, basetype, superparms);
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, dirclassname, parms, 0);
+        String *call = Swig_csuperclass_call(0, basetype, superparms);
 
-	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
-	Printf(f_directors, "  swig_init_callbacks();\n");
-	Printf(f_directors, "}\n\n");
+        Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
+        Printf(f_directors, "  swig_init_callbacks();\n");
+        Printf(f_directors, "}\n\n");
 
-	Delete(target);
-	Delete(call);
+        Delete(target);
+        Delete(call);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, dirclassname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, dirclassname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -4682,8 +4682,8 @@ public:
       Printf(w->def, "SWIG_Callback%s_t callback%s", methid, overname);
       Printf(w->code, "swig_callback%s = callback%s;\n", overname, overname);
       if (i != curr_class_dmethod - 1) {
-	Printf(f_directors_h, ", ");
-	Printf(w->def, ", ");
+        Printf(f_directors_h, ", ");
+        Printf(w->def, ", ");
       }
     }
 
@@ -4765,9 +4765,9 @@ public:
     String *str = Getattr(n, "feature:docstring");
 
     return ((str && Len(str) > 0)
-	|| (Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc"))
-	|| (doxygen && doxygenTranslator->hasDocumentation(n))
-	);
+        || (Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc"))
+        || (doxygen && doxygenTranslator->hasDocumentation(n))
+        );
     */
     return doxygen && doxygenTranslator->hasDocumentation(n);
   }

--- a/Source/Modules/d.cxx
+++ b/Source/Modules/d.cxx
@@ -173,7 +173,7 @@ class D : public Language {
   String *proxy_class_epilogue_code;
 
   // The full code for the current proxy class, including the epilogue.
-  String* proxy_class_code;
+  String *proxy_class_code;
 
   // Code generated at the begin of every D file
   String *common_begin_code;
@@ -215,67 +215,67 @@ class D : public Language {
   // classes for the unknown types.
   Hash *unknown_types;
 
-
 public:
   /* ---------------------------------------------------------------------------
    * D::D()
    * --------------------------------------------------------------------------- */
-   D():empty_string(NewString("")),
-      public_string(NewString("public")),
-      private_string(NewString("private")),
-      protected_string(NewString("protected")),
-      f_begin(NULL),
-      f_runtime(NULL),
-      f_runtime_h(NULL),
-      f_header(NULL),
-      f_wrappers(NULL),
-      f_init(NULL),
-      f_directors(NULL),
-      f_directors_h(NULL),
-      filenames_list(NULL),
-      split_proxy_dmodule(false),
-      native_function_flag(false),
-      static_flag(false),
-      variable_wrapper_flag(false),
-      wrapping_member_flag(false),
-      global_variable_flag(false),
-      variable_name(NULL),
-      upcasts_code(NULL),
-      director_callback_typedefs(NULL),
-      director_callback_pointers(NULL),
-      im_dmodule_name(NULL),
-      im_dmodule_fq_name(NULL),
-      proxy_dmodule_name(NULL),
-      proxy_dmodule_fq_name(NULL),
-      package(NULL),
-      dmodule_directory(NULL),
-      wrap_library_name(NULL),
-      im_dmodule_imports(NULL),
-      im_dmodule_code(NULL),
-      global_proxy_imports(NULL),
-      proxy_dmodule_imports(NULL),
-      proxy_dmodule_code(NULL),
-      nspace_proxy_dmodules(NULL),
-      proxy_enum_code(NULL),
-      proxy_class_name(NULL),
-      proxy_class_qname(NULL),
-      proxy_class_imports(NULL),
-      proxy_class_enums_code(NULL),
-      proxy_class_body_code(NULL),
-      proxy_class_epilogue_code(NULL),
-      proxy_class_code(NULL),
-      common_begin_code(NULL),
-      destructor_call(NULL),
-      director_dcallbacks_code(NULL),
-      wrapper_loader_code(NULL),
-      wrapper_loader_bind_command(NULL),
-      wrapper_loader_bind_code(NULL),
-      dmethods_seq(NULL),
-      dmethods_table(NULL),
-      n_dmethods(0),
-      first_class_dmethod(0),
-      curr_class_dmethod(0),
-      unknown_types(NULL) {
+  D() :
+    empty_string(NewString("")),
+    public_string(NewString("public")),
+    private_string(NewString("private")),
+    protected_string(NewString("protected")),
+    f_begin(NULL),
+    f_runtime(NULL),
+    f_runtime_h(NULL),
+    f_header(NULL),
+    f_wrappers(NULL),
+    f_init(NULL),
+    f_directors(NULL),
+    f_directors_h(NULL),
+    filenames_list(NULL),
+    split_proxy_dmodule(false),
+    native_function_flag(false),
+    static_flag(false),
+    variable_wrapper_flag(false),
+    wrapping_member_flag(false),
+    global_variable_flag(false),
+    variable_name(NULL),
+    upcasts_code(NULL),
+    director_callback_typedefs(NULL),
+    director_callback_pointers(NULL),
+    im_dmodule_name(NULL),
+    im_dmodule_fq_name(NULL),
+    proxy_dmodule_name(NULL),
+    proxy_dmodule_fq_name(NULL),
+    package(NULL),
+    dmodule_directory(NULL),
+    wrap_library_name(NULL),
+    im_dmodule_imports(NULL),
+    im_dmodule_code(NULL),
+    global_proxy_imports(NULL),
+    proxy_dmodule_imports(NULL),
+    proxy_dmodule_code(NULL),
+    nspace_proxy_dmodules(NULL),
+    proxy_enum_code(NULL),
+    proxy_class_name(NULL),
+    proxy_class_qname(NULL),
+    proxy_class_imports(NULL),
+    proxy_class_enums_code(NULL),
+    proxy_class_body_code(NULL),
+    proxy_class_epilogue_code(NULL),
+    proxy_class_code(NULL),
+    common_begin_code(NULL),
+    destructor_call(NULL),
+    director_dcallbacks_code(NULL),
+    wrapper_loader_code(NULL),
+    wrapper_loader_bind_command(NULL),
+    wrapper_loader_bind_code(NULL),
+    dmethods_seq(NULL),
+    dmethods_table(NULL),
+    n_dmethods(0),
+    first_class_dmethod(0),
+    curr_class_dmethod(0),
+    unknown_types(NULL) {
 
     // For now, multiple inheritance with directors is not possible. It should be
     // easy to implement though.
@@ -622,9 +622,13 @@ public:
         String *item2_lower = Swig_string_lower(it2.item);
         if (it1.item && it2.item) {
           if (Strcmp(item1_lower, item2_lower) == 0) {
-            Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
+            Swig_warning(WARN_LANG_PORTABILITY_FILENAME,
+                         input_file,
+                         line_number,
                          "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
-                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
+                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n",
+                         it1.item,
+                         it2.item);
           }
         }
         Delete(item2_lower);
@@ -827,9 +831,13 @@ public:
       if (purebase_replace) {
         wanted_base = pure_baseclass;
       } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
-        Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+        Swig_warning(WARN_D_MULTIPLE_INHERITANCE,
+                     Getfile(n),
+                     Getline(n),
                      "Warning for %s, enum base %s ignored. Multiple enum bases is not supported in D enums. "
-                     "Perhaps you need the 'replace' attribute in the dbase typemap?\n", typemap_lookup_type, pure_baseclass);
+                     "Perhaps you need the 'replace' attribute in the dbase typemap?\n",
+                     typemap_lookup_type,
+                     pure_baseclass);
       }
 
       const String *enummodifiers = lookupCodeTypemap(n, "dclassmodifiers", typemap_lookup_type, WARN_D_TYPEMAP_CLASSMOD_UNDEF);
@@ -846,8 +854,9 @@ public:
       // Finish the enum.
       if (typemap_lookup_type) {
         Printv(proxy_enum_code,
-          lookupCodeTypemap(n, "dcode", typemap_lookup_type, WARN_NONE), // Extra D code
-          "\n}\n", NIL);
+               lookupCodeTypemap(n, "dcode", typemap_lookup_type, WARN_NONE),  // Extra D code
+               "\n}\n",
+               NIL);
       } else {
         // Handle anonymous enums.
         Printv(proxy_enum_code, "\n}\n", NIL);
@@ -860,9 +869,8 @@ public:
       proxy_enum_code = NewStringf("\nalias int %s;\n", symname);
     }
 
-    const String* imports =
-      lookupCodeTypemap(n, "dimports", typemap_lookup_type, WARN_NONE);
-    String* imports_trimmed;
+    const String *imports = lookupCodeTypemap(n, "dimports", typemap_lookup_type, WARN_NONE);
+    String *imports_trimmed;
     if (Len(imports) > 0) {
       imports_trimmed = Copy(imports);
       Chop(imports_trimmed);
@@ -946,7 +954,8 @@ public:
     // Deal with enum values that are not int
     {
       String *numval = Getattr(n, "enumnumval");
-      if (numval) Setattr(n, "enumvalue", numval);
+      if (numval)
+        Setattr(n, "enumvalue", numval);
     }
 
     // Emit the enum item.
@@ -982,22 +991,22 @@ public:
     Language::memberfunctionHandler(n);
 
     String *overloaded_name = getOverloadedName(n);
-    String *intermediary_function_name =
-      Swig_name_member(getNSpace(), proxy_class_name, overloaded_name);
+    String *intermediary_function_name = Swig_name_member(getNSpace(), proxy_class_name, overloaded_name);
     Setattr(n, "imfuncname", intermediary_function_name);
 
     String *proxy_func_name = Getattr(n, "sym:name");
     Setattr(n, "proxyfuncname", proxy_func_name);
-    if (split_proxy_dmodule &&
-      Len(Getattr(n, "parms")) == 0 &&
-      Strncmp(proxy_func_name, package, Len(proxy_func_name)) == 0) {
+    if (split_proxy_dmodule && Len(Getattr(n, "parms")) == 0 && Strncmp(proxy_func_name, package, Len(proxy_func_name)) == 0) {
       // If we are in split proxy mode and the function is named like the
       // target package, the D compiler is unable to resolve the ambiguity
       // between the package name and an argument-less function call.
       // TODO: This might occur with nspace as well, augment the check.
-      Swig_warning(WARN_D_NAME_COLLISION, input_file, line_number,
-        "%s::%s might collide with the package name, consider using %%rename to resolve the ambiguity.\n",
-        proxy_class_name, proxy_func_name);
+      Swig_warning(WARN_D_NAME_COLLISION,
+                   input_file,
+                   line_number,
+                   "%s::%s might collide with the package name, consider using %%rename to resolve the ambiguity.\n",
+                   proxy_class_name,
+                   proxy_func_name);
     }
 
     writeProxyClassFunction(n);
@@ -1015,8 +1024,7 @@ public:
     // DMD BUG: We have to emit the alias after the last function because
     // taking a delegate in the overload checking code fails otherwise
     // (http://d.puremagic.com/issues/show_bug.cgi?id=4860).
-    if (!Getattr(n, "sym:nextSibling") && !is_smart_pointer() &&
-        !areAllOverloadsOverridden(n)) {
+    if (!Getattr(n, "sym:nextSibling") && !is_smart_pointer() && !areAllOverloadsOverridden(n)) {
       String *name = Getattr(n, "sym:name");
       Printf(proxy_class_body_code, "\nalias $dbaseclass.%s %s;\n", name, name);
     }
@@ -1032,8 +1040,7 @@ public:
     Language::staticmemberfunctionHandler(n);
 
     String *overloaded_name = getOverloadedName(n);
-    String *intermediary_function_name =
-      Swig_name_member(getNSpace(), proxy_class_name, overloaded_name);
+    String *intermediary_function_name = Swig_name_member(getNSpace(), proxy_class_name, overloaded_name);
     Setattr(n, "proxyfuncname", Getattr(n, "sym:name"));
     Setattr(n, "imfuncname", intermediary_function_name);
     writeProxyClassFunction(n);
@@ -1142,8 +1149,7 @@ public:
     }
 
     Printf(proxy_constructor_code, "\n%s this(", methodmods);
-    Printf(helper_code, "static private %s SwigConstruct%s(",
-      wrapper_return_type, proxy_class_name);
+    Printf(helper_code, "static private %s SwigConstruct%s(", wrapper_return_type, proxy_class_name);
 
     Printv(imcall, im_dmodule_fq_name, ".", mangled_overname, "(", NIL);
 
@@ -1179,8 +1185,7 @@ public:
         const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
         Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-          "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       if (gencomma)
@@ -1222,8 +1227,7 @@ public:
           Replaceall(parmtype, "$dinput", arg);
         Printv(imcall, tm, NIL);
       } else {
-        Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
-          "No din typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number, "No din typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to proxy function */
@@ -1251,8 +1255,7 @@ public:
     // Insert the dconstructor typemap (replacing $directorconnect as needed).
     Hash *attributes = NewHash();
     String *typemap_lookup_type = Getattr(getCurrentClass(), "classtypeobj");
-    String *construct_tm = Copy(lookupCodeTypemap(n, "dconstructor",
-      typemap_lookup_type, WARN_D_TYPEMAP_DCONSTRUCTOR_UNDEF, attributes));
+    String *construct_tm = Copy(lookupCodeTypemap(n, "dconstructor", typemap_lookup_type, WARN_D_TYPEMAP_DCONSTRUCTOR_UNDEF, attributes));
     if (construct_tm) {
       const bool use_director = (parentNode(n) && Swig_directorclass(n));
       if (!use_director) {
@@ -1263,9 +1266,11 @@ public:
         if (connect_attr) {
           Replaceall(construct_tm, "$directorconnect", connect_attr);
         } else {
-          Swig_warning(WARN_D_NO_DIRECTORCONNECT_ATTR, input_file, line_number,
-            "\"directorconnect\" attribute missing in %s \"dconstructor\" typemap.\n",
-            Getattr(n, "name"));
+          Swig_warning(WARN_D_NO_DIRECTORCONNECT_ATTR,
+                       input_file,
+                       line_number,
+                       "\"directorconnect\" attribute missing in %s \"dconstructor\" typemap.\n",
+                       Getattr(n, "name"));
           Replaceall(construct_tm, "$directorconnect", "");
         }
       }
@@ -1294,8 +1299,7 @@ public:
         Printv(helper_code, "\n", terminator_code, NIL);
       }
       Printf(helper_code, "\n}\n");
-      String *helper_name = NewStringf("%s.SwigConstruct%s(%s)",
-        proxy_class_name, proxy_class_name, helper_args);
+      String *helper_name = NewStringf("%s.SwigConstruct%s(%s)", proxy_class_name, proxy_class_name, helper_args);
       Replaceall(proxy_constructor_code, "$imcall", helper_name);
       Delete(helper_name);
     } else {
@@ -1323,7 +1327,7 @@ public:
     Language::destructorHandler(n);
     String *symname = Getattr(n, "sym:name");
 
-    Printv(destructor_call, im_dmodule_fq_name, ".", Swig_name_destroy(getNSpace(),symname), "(cast(void*)swigCPtr)", NIL);
+    Printv(destructor_call, im_dmodule_fq_name, ".", Swig_name_destroy(getNSpace(), symname), "(cast(void*)swigCPtr)", NIL);
     const String *methodmods = Getattr(n, "feature:d:methodmodifiers");
     if (methodmods)
       Setattr(getCurrentClass(), "destructmethodmodifiers", methodmods);
@@ -1377,7 +1381,6 @@ public:
     Clear(proxy_class_epilogue_code);
     Clear(proxy_class_code);
     Clear(destructor_call);
-
 
     // Traverse the tree for this class, using the *Handler()s to generate code
     // to the proxy_class_* variables.
@@ -1442,7 +1445,15 @@ public:
       // Note that this is only called for global constants, static member
       // constants are already handled in staticmemberfunctionHandler().
 
-      Swig_save("constantWrapper", n, "tmap:ctype:out", "tmap:imtype:out", "tmap:dtype:out", "tmap:out:null", "tmap:imtype:outattributes", "tmap:dtype:outattributes", NIL);
+      Swig_save("constantWrapper",
+                n,
+                "tmap:ctype:out",
+                "tmap:imtype:out",
+                "tmap:dtype:out",
+                "tmap:out:null",
+                "tmap:imtype:outattributes",
+                "tmap:dtype:outattributes",
+                NIL);
 
       SetFlag(n, "feature:immutable");
       int result = globalvariableHandler(n);
@@ -1461,8 +1472,7 @@ public:
     // Get D return type.
     String *return_type = getOutDtype(n);
     if (!return_type) {
-      Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-        "No dtype typemap defined for %s\n", SwigType_str(t, 0));
+      Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(t, 0));
       return_type = NewString("");
     }
 
@@ -1551,8 +1561,7 @@ public:
       }
       Printf(c_return_type, "%s", tm);
     } else {
-      Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
-        "No ctype typemap defined for %s\n", SwigType_str(returntype, 0));
+      Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(returntype, 0));
     }
 
     if ((tm = lookupDTypemap(n, "imtype"))) {
@@ -1727,7 +1736,8 @@ public:
         if (Len(tm))
           Printf(f->code, "\n");
       } else {
-        Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
+        Swig_warning(
+          WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
       }
       emit_return_variable(n, returntype, f);
     }
@@ -1756,8 +1766,7 @@ public:
 
     // Complete D im parameter list and emit the declaration/binding code.
     Printv(im_dmodule_parameters, ")", NIL);
-    writeImDModuleFunction(overloaded_name, im_return_type,
-      im_dmodule_parameters, wname);
+    writeImDModuleFunction(overloaded_name, im_return_type, im_dmodule_parameters, wname);
     Delete(im_dmodule_parameters);
 
     // Finish C function header.
@@ -1801,11 +1810,16 @@ public:
       // in the typemap, but the »canthrow« attribute/feature is not set.
       if (!Getattr(n, "d:canthrow")) {
         if (Strstr(f->code, "SWIG_exception")) {
-          Swig_warning(WARN_D_CANTHROW_MISSING, input_file, line_number,
-          "C code contains a call to SWIG_exception and D code does not handle pending exceptions via the canthrow attribute.\n");
+          Swig_warning(WARN_D_CANTHROW_MISSING,
+                       input_file,
+                       line_number,
+                       "C code contains a call to SWIG_exception and D code does not handle pending exceptions via the canthrow attribute.\n");
         } else if (Strstr(f->code, "SWIG_DSetPendingException")) {
-          Swig_warning(WARN_D_CANTHROW_MISSING, input_file, line_number,
-          "C code contains a call to a SWIG_DSetPendingException method and D code does not handle pending exceptions via the canthrow attribute.\n");
+          Swig_warning(
+            WARN_D_CANTHROW_MISSING,
+            input_file,
+            line_number,
+            "C code contains a call to a SWIG_DSetPendingException method and D code does not handle pending exceptions via the canthrow attribute.\n");
         }
       }
     }
@@ -1880,7 +1894,6 @@ public:
     return success;
   }
 
-
   /* ---------------------------------------------------------------------------
    * D::classDirectorInit()
    * --------------------------------------------------------------------------- */
@@ -1895,8 +1908,7 @@ public:
     String *declaration = Swig_class_declaration(n, directorname);
     const String *base = Getattr(n, "classtype");
 
-    Printf(f_directors_h,
-      "%s : public %s, public Swig::Director {\n", declaration, base);
+    Printf(f_directors_h, "%s : public %s, public Swig::Director {\n", declaration, base);
     Printf(f_directors_h, "\npublic:\n");
 
     Delete(declaration);
@@ -2027,8 +2039,7 @@ public:
       Printf(callback_def, "\nprivate extern(C) %s swigDirectorCallback_%s_%s(void* dObject", tm, classname, overloaded_name);
       Printv(proxy_callback_return_type, tm, NIL);
     } else {
-      Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number,
-        "No imtype typemap defined for %s\n", SwigType_str(returntype, 0));
+      Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(returntype, 0));
     }
 
     if ((c_ret_type = Swig_typemap_lookup("ctype", n, "", 0))) {
@@ -2038,9 +2049,13 @@ public:
         Delete(jretval_decl);
       }
     } else {
-      Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
-        "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
-        SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+      Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF,
+                   input_file,
+                   line_number,
+                   "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                   SwigType_str(returntype, 0),
+                   SwigType_namestr(c_classname),
+                   SwigType_namestr(name));
       output_director = false;
     }
 
@@ -2175,34 +2190,49 @@ public:
               if ((tm = lookupDTypemap(p, "dtype", true))) {
                 Printf(proxy_method_param_list, "%s", tm);
               } else {
-                Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-                  "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+                Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
               }
             } else {
-              Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF, input_file, line_number,
-                "No ddirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+              Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF,
+                           input_file,
+                           line_number,
+                           "No ddirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
+                           SwigType_str(pt, 0),
+                           SwigType_namestr(c_classname),
+                           SwigType_namestr(name));
               output_director = false;
             }
           } else {
-            Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number,
-              "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
-              SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF,
+                         input_file,
+                         line_number,
+                         "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                         SwigType_str(pt, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             output_director = false;
           }
 
           p = Getattr(p, "tmap:directorin:next");
         } else {
-          Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF, input_file, line_number,
-            "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
-            SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF,
+                       input_file,
+                       line_number,
+                       "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
+                       SwigType_str(pt, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           p = nextSibling(p);
           output_director = false;
         }
       } else {
-        Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
-          "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
-          SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF,
+                     input_file,
+                     line_number,
+                     "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                     SwigType_str(pt, 0),
+                     SwigType_namestr(c_classname),
+                     SwigType_namestr(name));
         output_director = false;
         p = nextSibling(p);
       }
@@ -2292,9 +2322,13 @@ public:
           Replaceall(tm, "$result", result_str);
           Printf(w->code, "%s\n", tm);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
                        "Unable to use return type %s used in %s::%s (skipping director method)\n",
-                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           output_director = false;
         }
 
@@ -2365,8 +2399,7 @@ public:
       // returned.
       String *dp_return_type = getOutDtype(n);
       if (!dp_return_type) {
-        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-          "No dtype typemap defined for %s\n", SwigType_str(returntype, 0));
+        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(returntype, 0));
         dp_return_type = NewString("");
       }
 
@@ -2412,7 +2445,8 @@ public:
    * --------------------------------------------------------------------------- */
   virtual int classDirectorConstructor(Node *n) {
     Node *parent = parentNode(n);
-    String *decl = Getattr(n, "decl");;
+    String *decl = Getattr(n, "decl");
+    ;
     String *supername = Swig_class_name(parent);
     String *dirclassname = directorClassName(parent);
     String *sub = NewString("");
@@ -2572,7 +2606,7 @@ public:
    * D::classDirectorDisown()
    * --------------------------------------------------------------------------- */
   virtual int classDirectorDisown(Node *n) {
-    (void) n;
+    (void)n;
     return SWIG_OK;
   }
 
@@ -2608,13 +2642,11 @@ private:
    * wrapper_function_name - The name of the exported function in the C wrapper
    *                         (usually d_name prefixed by »D_«).
    * --------------------------------------------------------------------------- */
-  void writeImDModuleFunction(const_String_or_char_ptr d_name,
-    const_String_or_char_ptr return_type, const_String_or_char_ptr parameters,
-    const_String_or_char_ptr wrapper_function_name) {
+  void writeImDModuleFunction(const_String_or_char_ptr d_name, const_String_or_char_ptr return_type, const_String_or_char_ptr parameters,
+                              const_String_or_char_ptr wrapper_function_name) {
 
     // TODO: Add support for static linking here.
-    Printf(im_dmodule_code, "SwigExternC!(%s function%s) %s;\n", return_type,
-      parameters, d_name);
+    Printf(im_dmodule_code, "SwigExternC!(%s function%s) %s;\n", return_type, parameters, d_name);
     Printv(wrapper_loader_bind_code, wrapper_loader_bind_command, NIL);
     Replaceall(wrapper_loader_bind_code, "$function", d_name);
     Replaceall(wrapper_loader_bind_code, "$symbol", wrapper_function_name);
@@ -2670,15 +2702,13 @@ private:
     // Get return types.
     String *return_type = getOutDtype(n);
     if (!return_type) {
-      Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-        "No dtype typemap defined for %s\n", SwigType_str(t, 0));
+      Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(t, 0));
       return_type = NewString("");
     }
 
     if (wrapping_member_flag) {
       // Check if this is a setter method for a public member.
-      const String *setter_name = Swig_name_set(getNSpace(),
-        Swig_name_member(0, proxy_class_name, variable_name));
+      const String *setter_name = Swig_name_set(getNSpace(), Swig_name_member(0, proxy_class_name, variable_name));
 
       if (Cmp(Getattr(n, "sym:name"), setter_name) == 0) {
         setter_flag = true;
@@ -2759,8 +2789,7 @@ private:
             }
             Printv(imcall, tm, NIL);
           } else {
-            Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
-              "No din typemap defined for %s\n", SwigType_str(pt, 0));
+            Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number, "No din typemap defined for %s\n", SwigType_str(pt, 0));
           }
         }
 
@@ -2781,8 +2810,7 @@ private:
               }
             }
           } else {
-            Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-              "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+            Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
           }
 
           if (gencomma >= 2) {
@@ -2901,11 +2929,27 @@ private:
           }
           String *excode = NewString("");
           if (!Cmp(return_type, "void"))
-            Printf(excode, "if (swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) %s; else %s",
-             override_use_const, return_type, proxy_param_types, return_type, proxy_param_types, proxy_function_name, ex_imcall, imcall);
+            Printf(excode,
+                   "if (swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) %s; else %s",
+                   override_use_const,
+                   return_type,
+                   proxy_param_types,
+                   return_type,
+                   proxy_param_types,
+                   proxy_function_name,
+                   ex_imcall,
+                   imcall);
           else
-            Printf(excode, "((swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) ? %s : %s)",
-             override_use_const, return_type, proxy_param_types, return_type, proxy_param_types, proxy_function_name, ex_imcall, imcall);
+            Printf(excode,
+                   "((swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) ? %s : %s)",
+                   override_use_const,
+                   return_type,
+                   proxy_param_types,
+                   return_type,
+                   proxy_param_types,
+                   proxy_function_name,
+                   ex_imcall,
+                   imcall);
 
           Clear(imcall);
           Printv(imcall, excode, NIL);
@@ -2917,8 +2961,7 @@ private:
         Replaceall(tm, "$imfuncname", intermediary_function_name);
         Replaceall(tm, "$imcall", imcall);
       } else {
-        Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number,
-          "No dout typemap defined for %s\n", SwigType_str(t, 0));
+        Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number, "No dout typemap defined for %s\n", SwigType_str(t, 0));
       }
     }
 
@@ -2973,8 +3016,7 @@ private:
     /* Get return types */
     String *return_type = getOutDtype(n);
     if (!return_type) {
-      Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-        "No dtype typemap defined for %s\n", SwigType_str(t, 0));
+      Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(t, 0));
       return_type = NewString("");
     }
 
@@ -3020,8 +3062,7 @@ private:
         const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
         Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-          "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number, "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       if (gencomma)
@@ -3060,8 +3101,7 @@ private:
         }
         Printv(imcall, tm, NIL);
       } else {
-        Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
-          "No din typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number, "No din typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to module class function */
@@ -3114,13 +3154,12 @@ private:
       Replaceall(tm, "$imfuncname", overloaded_name);
       Replaceall(tm, "$imcall", imcall);
     } else {
-      Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number,
-        "No dout typemap defined for %s\n", SwigType_str(t, 0));
+      Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number, "No dout typemap defined for %s\n", SwigType_str(t, 0));
     }
 
     // The whole function code is now stored in tm (if there was a matching
     // type map, of course), so simply append it to the code buffer.
-    Printf(function_code, "%s\n", tm ? (const String *) tm : empty_string);
+    Printf(function_code, "%s\n", tm ? (const String *)tm : empty_string);
     Printv(proxyCodeBuffer(getNSpace()), function_code, NIL);
 
     Delete(pre_code);
@@ -3160,8 +3199,7 @@ private:
 
     // Inheritance from pure D classes.
     Node *attributes = NewHash();
-    const String *pure_baseclass =
-      lookupCodeTypemap(n, "dbase", typemap_lookup_type, WARN_NONE, attributes);
+    const String *pure_baseclass = lookupCodeTypemap(n, "dbase", typemap_lookup_type, WARN_NONE, attributes);
     bool purebase_replace = GetFlag(attributes, "tmap:dbase:replace") ? true : false;
     bool purebase_notderived = GetFlag(attributes, "tmap:dbase:notderived") ? true : false;
     Delete(attributes);
@@ -3185,8 +3223,12 @@ private:
             } else {
               /* Warn about multiple inheritance for additional base class(es) */
               String *proxyclassname = Getattr(n, "classtypeobj");
-              Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-                  "Base %s of class %s ignored: multiple inheritance is not supported in D.\n", SwigType_namestr(baseclassname), SwigType_namestr(proxyclassname));
+              Swig_warning(WARN_D_MULTIPLE_INHERITANCE,
+                           Getfile(n),
+                           Getline(n),
+                           "Base %s of class %s ignored: multiple inheritance is not supported in D.\n",
+                           SwigType_namestr(baseclassname),
+                           SwigType_namestr(proxyclassname));
             }
           }
           base = Next(base);
@@ -3207,14 +3249,17 @@ private:
       basenode = NULL;
       baseclass = NULL;
       if (purebase_notderived) {
-        Swig_error(Getfile(n), Getline(n),
-          "The dbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n",
-          typemap_lookup_type);
+        Swig_error(
+          Getfile(n), Getline(n), "The dbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n", typemap_lookup_type);
       }
     } else if (baseclass && Len(pure_baseclass) > 0) {
-      Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-        "Warning for %s, base class %s ignored. Multiple inheritance is not supported in D. "
-        "Perhaps you need one of the 'replace' or 'notderived' attributes in the dbase typemap?\n", typemap_lookup_type, pure_baseclass);
+      Swig_warning(WARN_D_MULTIPLE_INHERITANCE,
+                   Getfile(n),
+                   Getline(n),
+                   "Warning for %s, base class %s ignored. Multiple inheritance is not supported in D. "
+                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the dbase typemap?\n",
+                   typemap_lookup_type,
+                   pure_baseclass);
     }
 
     // Add code to do C++ casting to base class (only for classes in an inheritance hierarchy)
@@ -3234,7 +3279,7 @@ private:
     // Write any custom import statements to the proxy module header.
     const String *imports = lookupCodeTypemap(n, "dimports", typemap_lookup_type, WARN_NONE);
     if (Len(imports) > 0) {
-      String* imports_trimmed = Copy(imports);
+      String *imports_trimmed = Copy(imports);
       Chop(imports_trimmed);
       replaceImportTypeMacros(imports_trimmed);
       Printv(proxy_class_imports, imports_trimmed, "\n", NIL);
@@ -3245,25 +3290,26 @@ private:
      * Write the proxy class header.
      */
     // Class modifiers.
-    const String *modifiers =
-      lookupCodeTypemap(n, "dclassmodifiers", typemap_lookup_type, WARN_D_TYPEMAP_CLASSMOD_UNDEF);
+    const String *modifiers = lookupCodeTypemap(n, "dclassmodifiers", typemap_lookup_type, WARN_D_TYPEMAP_CLASSMOD_UNDEF);
 
     // User-defined interfaces.
-    const String *interfaces =
-      lookupCodeTypemap(n, derived ? "dinterfaces_derived" : "dinterfaces", typemap_lookup_type, WARN_NONE);
+    const String *interfaces = lookupCodeTypemap(n, derived ? "dinterfaces_derived" : "dinterfaces", typemap_lookup_type, WARN_NONE);
 
     Printv(proxy_class_code,
-      "\n",
-      modifiers,
-      " $dclassname",
-      (*Char(wanted_base) || *Char(interfaces)) ? " : " : "", wanted_base,
-      (*Char(wanted_base) && *Char(interfaces)) ? ", " : "", interfaces, " {",
-      NIL);
+           "\n",
+           modifiers,
+           " $dclassname",
+           (*Char(wanted_base) || *Char(interfaces)) ? " : " : "",
+           wanted_base,
+           (*Char(wanted_base) && *Char(interfaces)) ? ", " : "",
+           interfaces,
+           " {",
+           NIL);
 
     /*
      * Write the proxy class body.
      */
-    String* body = NewString("");
+    String *body = NewString("");
 
     // Default class body.
     const String *dbody;
@@ -3305,14 +3351,11 @@ private:
 
     if (tm && *Char(tm)) {
       if (!dispose_methodname) {
-        Swig_error(Getfile(n), Getline(n),
-          "No methodname attribute defined in the ddispose%s typemap for %s\n",
-          (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in the ddispose%s typemap for %s\n", (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!dispose_methodmodifiers) {
-        Swig_error(Getfile(n), Getline(n),
-          "No methodmodifiers attribute defined in ddispose%s typemap for %s.\n",
-          (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(
+          Getfile(n), Getline(n), "No methodmodifiers attribute defined in ddispose%s typemap for %s.\n", (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!dispose_parameters)
         dispose_parameters = empty_string;
@@ -3321,8 +3364,7 @@ private:
     if (tm) {
       // Write the destructor if the C++ one is accessible.
       if (*Char(destructor_call)) {
-        Printv(body,
-          lookupCodeTypemap(n, "ddestructor", typemap_lookup_type, WARN_NONE), NIL);
+        Printv(body, lookupCodeTypemap(n, "ddestructor", typemap_lookup_type, WARN_NONE), NIL);
       }
 
       // Write the dispose() method.
@@ -3361,8 +3403,7 @@ private:
     Printv(body, proxy_class_body_code, NIL);
 
     // Append extra user D code to the class body.
-    Printv(body,
-      lookupCodeTypemap(n, "dcode", typemap_lookup_type, WARN_NONE), "\n", NIL);
+    Printv(body, lookupCodeTypemap(n, "dcode", typemap_lookup_type, WARN_NONE), "\n", NIL);
 
     // Write the class body and the curly bracket closing the class definition
     // to the proxy module.
@@ -3375,7 +3416,6 @@ private:
     // Write the epilogue code if there is any.
     Printv(proxy_class_code, proxy_class_epilogue_code, NIL);
   }
-
 
   /* ---------------------------------------------------------------------------
    * D::writeClassUpcast()
@@ -3397,22 +3437,38 @@ private:
         String *bsmartnamestr = SwigType_namestr(bsmart);
 
         Printv(upcasts_code,
-          "SWIGEXPORT ", bsmartnamestr, " * ", upcast_wrapper_name,
-            "(", smartnamestr, " *objectRef) {\n",
-          "    return objectRef ? new ", bsmartnamestr, "(*objectRef) : 0;\n"
-          "}\n",
-          "\n", NIL);
+               "SWIGEXPORT ",
+               bsmartnamestr,
+               " * ",
+               upcast_wrapper_name,
+               "(",
+               smartnamestr,
+               " *objectRef) {\n",
+               "    return objectRef ? new ",
+               bsmartnamestr,
+               "(*objectRef) : 0;\n"
+               "}\n",
+               "\n",
+               NIL);
 
         Delete(bsmartnamestr);
         Delete(smartnamestr);
       }
     } else {
       Printv(upcasts_code,
-        "SWIGEXPORT ", baseclassname, " * ", upcast_wrapper_name,
-          "(", classname, " *objectRef) {\n",
-        "    return (", baseclassname, " *)objectRef;\n"
-        "}\n",
-        "\n", NIL);
+             "SWIGEXPORT ",
+             baseclassname,
+             " * ",
+             upcast_wrapper_name,
+             "(",
+             classname,
+             " *objectRef) {\n",
+             "    return (",
+             baseclassname,
+             " *)objectRef;\n"
+             "}\n",
+             "\n",
+             NIL);
     }
 
     Replaceall(upcasts_code, "$cclass", classname);
@@ -3434,8 +3490,8 @@ private:
 
     assertClassNameValidity(classname);
 
-    String* imports_target;
-    String* code_target;
+    String *imports_target;
+    String *code_target;
     File *class_file = NULL;
     if (split_proxy_dmodule) {
       String *filename = NewStringf("%s%s.d", dmodule_directory, classname);
@@ -3474,16 +3530,18 @@ private:
 
     // Emit the class.
     Printv(code_target,
-      "\n",
-      lookupCodeTypemap(n, "dclassmodifiers", type, WARN_D_TYPEMAP_CLASSMOD_UNDEF),
-      " $dclassname",
-      (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "", pure_baseclass,
-      ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ? ", " : "", pure_interfaces,
-      " {", NIL);
+           "\n",
+           lookupCodeTypemap(n, "dclassmodifiers", type, WARN_D_TYPEMAP_CLASSMOD_UNDEF),
+           " $dclassname",
+           (*Char(pure_baseclass) || *Char(pure_interfaces)) ? " : " : "",
+           pure_baseclass,
+           ((*Char(pure_baseclass)) && *Char(pure_interfaces)) ? ", " : "",
+           pure_interfaces,
+           " {",
+           NIL);
 
-    String* body = NewString("");
-    Printv(body, lookupCodeTypemap(n, "dbody", type, WARN_D_TYPEMAP_DBODY_UNDEF),
-      lookupCodeTypemap(n, "dcode", type, WARN_NONE), NIL);
+    String *body = NewString("");
+    Printv(body, lookupCodeTypemap(n, "dbody", type, WARN_D_TYPEMAP_DBODY_UNDEF), lookupCodeTypemap(n, "dcode", type, WARN_NONE), NIL);
     indentCode(body);
     Printv(code_target, body, "\n}\n", NIL);
     Delete(body);
@@ -3510,10 +3568,9 @@ private:
    * Writes the helper method which registers the director callbacks by calling
    * the director connect function from the D side to the proxy class.
    * --------------------------------------------------------------------------- */
-  void writeDirectorConnectProxy(Node* classNode) {
+  void writeDirectorConnectProxy(Node *classNode) {
     String *dirClassName = directorClassName(classNode);
-    String *connect_name = Swig_name_member(getNSpace(),
-      proxy_class_name, "director_connect");
+    String *connect_name = Swig_name_member(getNSpace(), proxy_class_name, "director_connect");
     Printf(proxy_class_body_code, "\nprivate void swigDirectorConnect() {\n");
 
     int i;
@@ -3525,7 +3582,13 @@ private:
       String *param_list = Getattr(udata, "param_list");
       String *methid = Getattr(udata, "class_methodidx");
       Printf(proxy_class_body_code, "  %s.%s_Callback%s callback%s;\n", im_dmodule_fq_name, dirClassName, methid, methid);
-      Printf(proxy_class_body_code, "  if (swigIsMethodOverridden!(%s delegate(%s), %s function(%s), %s)()) {\n", return_type, param_list, return_type, param_list, method);
+      Printf(proxy_class_body_code,
+             "  if (swigIsMethodOverridden!(%s delegate(%s), %s function(%s), %s)()) {\n",
+             return_type,
+             param_list,
+             return_type,
+             param_list,
+             method);
       Printf(proxy_class_body_code, "    callback%s = &swigDirectorCallback_%s_%s;\n", methid, proxy_class_name, overloaded_name);
       Printf(proxy_class_body_code, "  }\n\n");
     }
@@ -3617,8 +3680,7 @@ private:
 
     // Output the director connect method.
     String *norm_name = SwigType_namestr(Getattr(n, "name"));
-    String *connect_name = Swig_name_member(getNSpace(),
-      proxy_class_name, "director_connect");
+    String *connect_name = Swig_name_member(getNSpace(), proxy_class_name, "director_connect");
     String *dirClassName = directorClassName(n);
     Wrapper *code_wrap;
 
@@ -3716,8 +3778,7 @@ private:
    *
    * Creates a string containing an import statement for the given module.
    * --------------------------------------------------------------------------- */
-  String *createImportStatement(const String *dmodule_name,
-    bool static_import = true) const {
+  String *createImportStatement(const String *dmodule_name, bool static_import = true) const {
 
     if (static_import) {
       return NewStringf("static import %s%s;", package, dmodule_name);
@@ -3764,8 +3825,7 @@ private:
    *
    * Adds new director upcall signature.
    * --------------------------------------------------------------------------- */
-  UpcallData *addUpcallMethod(String *imclass_method, String *class_method,
-    String *decl, String *overloaded_name, String *return_type, String *param_list) {
+  UpcallData *addUpcallMethod(String *imclass_method, String *class_method, String *decl, String *overloaded_name, String *return_type, String *param_list) {
 
     String *key = NewStringf("%s|%s", imclass_method, decl);
 
@@ -3792,14 +3852,12 @@ private:
   /* ---------------------------------------------------------------------------
    * D::assertClassNameValidity()
    * --------------------------------------------------------------------------- */
-  void assertClassNameValidity(const String* class_name) const {
+  void assertClassNameValidity(const String *class_name) const {
     // TODO: With nspace support, there could arise problems also when not in
     // split proxy mode, warnings for these should be added.
     if (split_proxy_dmodule) {
       if (Cmp(class_name, im_dmodule_name) == 0) {
-        Swig_error(input_file, line_number,
-          "Class name cannot be equal to intermediary D module name: %s\n",
-          class_name);
+        Swig_error(input_file, line_number, "Class name cannot be equal to intermediary D module name: %s\n", class_name);
         Exit(EXIT_FAILURE);
       }
 
@@ -3810,18 +3868,14 @@ private:
         if (Len(package) > 0) {
           String *dotless_package = NewStringWithSize(package, Len(package) - 1);
           if (Cmp(class_name, dotless_package) == 0) {
-            Swig_error(input_file, line_number,
-              "Class name cannot be the same as the root package it is in: %s\n",
-              class_name);
+            Swig_error(input_file, line_number, "Class name cannot be the same as the root package it is in: %s\n", class_name);
             Exit(EXIT_FAILURE);
           }
           Delete(dotless_package);
         } else {
           String *outer = createFirstNamespaceName(nspace);
           if (Cmp(class_name, outer) == 0) {
-            Swig_error(input_file, line_number,
-              "Class name cannot be the same as the outermost namespace it is in: %s\n",
-              class_name);
+            Swig_error(input_file, line_number, "Class name cannot be the same as the outermost namespace it is in: %s\n", class_name);
             Exit(EXIT_FAILURE);
           }
           Delete(outer);
@@ -3831,17 +3885,13 @@ private:
         // module named like the namespace).
         String *inner = createLastNamespaceName(nspace);
         if (Cmp(class_name, inner) == 0) {
-          Swig_error(input_file, line_number,
-            "Class name cannot be the same as the innermost namespace it is in: %s\n",
-            class_name);
+          Swig_error(input_file, line_number, "Class name cannot be the same as the innermost namespace it is in: %s\n", class_name);
           Exit(EXIT_FAILURE);
         }
         Delete(inner);
       } else {
         if (Cmp(class_name, proxy_dmodule_name) == 0) {
-          Swig_error(input_file, line_number,
-            "Class name cannot be equal to proxy D module name: %s\n",
-            class_name);
+          Swig_error(input_file, line_number, "Class name cannot be equal to proxy D module name: %s\n", class_name);
           Exit(EXIT_FAILURE);
         }
       }
@@ -3923,16 +3973,14 @@ private:
         }
       }
 
-      dtype = NewStringf("%s.SwigExternC!(%s function(%s))", im_dmodule_fq_name,
-        return_dtype, param_list);
+      dtype = NewStringf("%s.SwigExternC!(%s function(%s))", im_dmodule_fq_name, return_dtype, param_list);
       Delete(param_list);
       Delete(param_dtypes);
       Delete(return_dtype);
     } else {
       Hash *attributes = NewHash();
-      const String *tm =
-        lookupCodeTypemap(node, "dtype", stripped_type, WARN_NONE, attributes);
-      if(!GetFlag(attributes, "tmap:dtype:cprimitive")) {
+      const String *tm = lookupCodeTypemap(node, "dtype", stripped_type, WARN_NONE, attributes);
+      if (!GetFlag(attributes, "tmap:dtype:cprimitive")) {
         dtype = 0;
       } else {
         dtype = Copy(tm);
@@ -3980,8 +4028,7 @@ private:
    *   also be used for temporary storage if non null
    * return is never NULL, unlike Swig_typemap_lookup()
    * --------------------------------------------------------------------------- */
-  const String *lookupCodeTypemap(Node *n, const_String_or_char_ptr tmap_method,
-    SwigType *type, int warning, Node *typemap_attributes = 0) const {
+  const String *lookupCodeTypemap(Node *n, const_String_or_char_ptr tmap_method, SwigType *type, int warning, Node *typemap_attributes = 0) const {
 
     Node *node = !typemap_attributes ? NewHash() : typemap_attributes;
     Setattr(node, "type", type);
@@ -3991,8 +4038,7 @@ private:
     if (!tm) {
       tm = empty_string;
       if (warning != WARN_NONE) {
-        Swig_warning(warning, Getfile(n), Getline(n),
-          "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
+        Swig_warning(warning, Getfile(n), Getline(n), "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
       }
     }
     if (!typemap_attributes) {
@@ -4256,9 +4302,8 @@ private:
     if (Getattr(n, "d:canthrow")) {
       int count = Replaceall(code, "$excode", excode);
       if (count < 1 || !excode) {
-        Swig_warning(WARN_D_EXCODE_MISSING, input_file, line_number,
-          "D exception may not be thrown – no $excode or excode attribute in '%s' typemap.\n",
-          typemap);
+        Swig_warning(
+          WARN_D_EXCODE_MISSING, input_file, line_number, "D exception may not be thrown – no $excode or excode attribute in '%s' typemap.\n", typemap);
       }
     } else {
       Replaceall(code, "$excode", "");
@@ -4303,7 +4348,6 @@ private:
       if (end) {
         String *current_macro = NewStringWithSize(start, (int)(end - start));
         String *current_param = NewStringWithSize(param_start, (int)(param_end - param_start));
-
 
         if (inProxyModule(current_param)) {
           Replace(target, current_macro, "", DOH_REPLACE_ANY);
@@ -4397,7 +4441,8 @@ private:
    * wrapped as D »const« or not.
    * --------------------------------------------------------------------------- */
   bool wrapMemberFunctionAsDConst(Node *n) const {
-    if (static_flag) return false; // Never emit »const« for static member functions.
+    if (static_flag)
+      return false;  // Never emit »const« for static member functions.
     return GetFlag(n, "memberget") || SwigType_isconst(Getattr(n, "decl"));
   }
 
@@ -4453,8 +4498,7 @@ private:
 
     size_t base_overload_count = 0;
     for (Node *tmp = firstSibling(base_function); tmp; tmp = Getattr(tmp, "sym:nextSibling")) {
-      if (is_protected(base_function) &&
-          !(Swig_director_mode() && Swig_director_protected_mode() && Swig_all_protected_mode())) {
+      if (is_protected(base_function) && !(Swig_director_mode() && Swig_director_protected_mode() && Swig_all_protected_mode())) {
         // If the base class function is »protected« and were are not in
         // director mode, it is not emitted to the base class and thus we do
         // not count it. Otherwise, we would run into issues if the visibility
@@ -4465,8 +4509,7 @@ private:
       ++base_overload_count;
     }
 
-    return ((base_overload_count <= overridingOverloadCount(n)) &&
-      areAllOverloadsOverridden(base_function));
+    return ((base_overload_count <= overridingOverloadCount(n)) && areAllOverloadsOverridden(base_function));
   }
 
   /* ---------------------------------------------------------------------------
@@ -4474,12 +4517,11 @@ private:
    *
    * Search a class for a method that can override the current method.
    * --------------------------------------------------------------------------- */
-  bool checkClassBaseOver(Node *b, const String *name, ParmList *l, const int llen, const String *bname = NULL)
-  {
+  bool checkClassBaseOver(Node *b, const String *name, ParmList *l, const int llen, const String *bname = NULL) {
     if (bname == NULL) {
       bname = Getattr(b, "name");
     }
-    for(Node *e = firstChild(b); e; e = nextSibling(e)) {
+    for (Node *e = firstChild(b); e; e = nextSibling(e)) {
       /* We look for D only fuctions! */
       const String *ename = Getattr(e, "name");
       const String *etype = nodeType(e);
@@ -4502,7 +4544,7 @@ private:
             bool eq = true;
             String *detd = NewString("");
             if (llen > 0) {
-              for(ParmList *le = el, *ln = l; eq && le && ln; le = nextSibling(le), ln = nextSibling(ln)) {
+              for (ParmList *le = el, *ln = l; eq && le && ln; le = nextSibling(le), ln = nextSibling(ln)) {
                 const String *ntd = Getattr(ln, "d:type");
                 const String *etd = Getattr(le, "d:type");
                 Printf(detd, "%s.%s", etd, etd);
@@ -4526,8 +4568,7 @@ private:
    *
    * Traverse all base classes and look for a method the current method override.
    * --------------------------------------------------------------------------- */
-  bool checkBaseOver(Node *c, const String *name, ParmList *l, const int llen)
-  {
+  bool checkBaseOver(Node *c, const String *name, ParmList *l, const int llen) {
     // * Member template functions?
     if (!c) {
       return false;
@@ -4554,13 +4595,13 @@ private:
    * Mark current method for methods in derived classes.
    * --------------------------------------------------------------------------- */
   void markDOverride(Node *n, const String *name, ParmList *l, Node *p, const String *pname, const String *ptype) {
-     if (!pname && Strcmp(ptype, "extend") == 0) {
-       Node *pp = parentNode(p);
-       if (pp) {
-         pname = Getattr(pp, "name");
-       }
-     }
-    for(Node *e = firstChild(p); e; e = nextSibling(e)) {
+    if (!pname && Strcmp(ptype, "extend") == 0) {
+      Node *pp = parentNode(p);
+      if (pp) {
+        pname = Getattr(pp, "name");
+      }
+    }
+    for (Node *e = firstChild(p); e; e = nextSibling(e)) {
       /* Am I in my class? */
       if (n == e) {
         SetFlag(n, "d:can_override");
@@ -4578,7 +4619,7 @@ private:
      * We need to mark the original 'using' method in our class,
      * as this node is not accessibale in derived classes.
      */
-    for(Node *e = firstChild(p); e; e = nextSibling(e)) {
+    for (Node *e = firstChild(p); e; e = nextSibling(e)) {
       const String *ename = Getattr(e, "name");
       const String *ntype = nodeType(e);
       if (ename && Strcmp(ename, name) == 0 && ntype && Strcmp(ntype, "using") == 0) {
@@ -4642,7 +4683,7 @@ private:
       if (Getattr(n, "override") || !Getattr(n, "access")) {
         ++result;
       }
-    } while((tmp = Getattr(tmp, "sym:nextSibling")));
+    } while ((tmp = Getattr(tmp, "sym:nextSibling")));
 
     return result;
   }
@@ -4665,7 +4706,7 @@ private:
    *
    * Helper function to indent a code (string) by one level.
    * --------------------------------------------------------------------------- */
-  void indentCode(String* code) const {
+  void indentCode(String *code) const {
     Replaceall(code, "\n", "\n  ");
     Replaceall(code, "  \n", "\n");
     Chop(code);
@@ -4799,7 +4840,8 @@ private:
    * »C« for the argument »A.B.C«.
    * --------------------------------------------------------------------------- */
   String *createLastNamespaceName(const String *nspace) const {
-    if (!nspace) return NULL;
+    if (!nspace)
+      return NULL;
     char *c = Char(nspace);
     char *cc = c;
     if (!strchr(c, '.'))
@@ -4821,7 +4863,8 @@ private:
    * »A.B« for the argument »A.B.C«.
    * --------------------------------------------------------------------------- */
   String *createOuterNamespaceNames(const String *nspace) const {
-    if (!nspace) return NULL;
+    if (!nspace)
+      return NULL;
     char *tmp = Char(nspace);
     char *c = tmp;
     char *cc = c;

--- a/Source/Modules/d.cxx
+++ b/Source/Modules/d.cxx
@@ -296,35 +296,35 @@ public:
     // Look for certain command line options
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if ((strcmp(argv[i], "-d2") == 0)) {
-	  /* Keep for backward compatible only */
-      	  Swig_mark_arg(i);
-      	} else if (strcmp(argv[i], "-wrapperlibrary") == 0) {
-	  if (argv[i + 1]) {
-	    wrap_library_name = NewString("");
-	    Printf(wrap_library_name, argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-package") == 0) {
-	  if (argv[i + 1]) {
-	    package = NewString("");
-	    Printf(package, argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if ((strcmp(argv[i], "-splitproxy") == 0)) {
-	  Swig_mark_arg(i);
-	  split_proxy_dmodule = true;
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  Printf(stdout, "%s", usage);
-	}
+        if ((strcmp(argv[i], "-d2") == 0)) {
+          /* Keep for backward compatible only */
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-wrapperlibrary") == 0) {
+          if (argv[i + 1]) {
+            wrap_library_name = NewString("");
+            Printf(wrap_library_name, argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-package") == 0) {
+          if (argv[i + 1]) {
+            package = NewString("");
+            Printf(package, argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if ((strcmp(argv[i], "-splitproxy") == 0)) {
+          Swig_mark_arg(i);
+          split_proxy_dmodule = true;
+        } else if (strcmp(argv[i], "-help") == 0) {
+          Printf(stdout, "%s", usage);
+        }
       }
     }
 
@@ -350,29 +350,29 @@ public:
 
     if (optionsnode) {
       if (Getattr(optionsnode, "imdmodulename")) {
-	im_dmodule_name = Copy(Getattr(optionsnode, "imdmodulename"));
+        im_dmodule_name = Copy(Getattr(optionsnode, "imdmodulename"));
       }
 
       if (Getattr(optionsnode, "directors")) {
-	// Check if directors are enabled for this module. Note: This is a
-	// "master switch", if it is not set, not director code will be emitted
-	// at all. %feature("director") statements are also required to enable
-	// directors for individual classes or methods.
-	//
-	// Use the »directors« attributte of the %module directive to enable
-	// director generation (e.g. »%module(directors="1") modulename«).
-	allow_directors();
+        // Check if directors are enabled for this module. Note: This is a
+        // "master switch", if it is not set, not director code will be emitted
+        // at all. %feature("director") statements are also required to enable
+        // directors for individual classes or methods.
+        //
+        // Use the »directors« attributte of the %module directive to enable
+        // director generation (e.g. »%module(directors="1") modulename«).
+        allow_directors();
       }
 
       if (Getattr(optionsnode, "dirprot")) {
-	allow_dirprot();
+        allow_dirprot();
       }
 
       allow_allprotected(GetFlag(optionsnode, "allprotected"));
 
       common_begin_code = Getattr(optionsnode, "dbegin");
       if (common_begin_code)
-	Printf(common_begin_code, "\n");
+        Printf(common_begin_code, "\n");
     }
 
     /* Initialize all of the output files */
@@ -392,13 +392,13 @@ public:
 
     if (Swig_directors_enabled()) {
       if (!outfile_h) {
-	Printf(stderr, "Unable to determine outfile_h\n");
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "Unable to determine outfile_h\n");
+        Exit(EXIT_FAILURE);
       }
       f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
       if (!f_runtime_h) {
-	FileErrorDisplay(outfile_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -491,9 +491,9 @@ public:
       Printf(f_directors, " * C++ director class methods\n");
       Printf(f_directors, " * --------------------------------------------------- */\n\n");
       if (outfile_h) {
-	String *filename = Swig_file_filename(outfile_h);
-	Printf(f_directors, "#include \"%s\"\n\n", filename);
-	Delete(filename);
+        String *filename = Swig_file_filename(outfile_h);
+        Printf(f_directors, "#include \"%s\"\n\n", filename);
+        Delete(filename);
       }
     }
 
@@ -520,8 +520,8 @@ public:
       String *filen = NewStringf("%s%s.d", dmodule_directory, im_dmodule_name);
       File *im_d_file = NewFile(filen, "w", SWIG_output_files());
       if (!im_d_file) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filen));
       Delete(filen);
@@ -551,8 +551,8 @@ public:
       String *filen = NewStringf("%s%s.d", dmodule_directory, proxy_dmodule_name);
       File *proxy_d_file = NewFile(filen, "w", SWIG_output_files());
       if (!proxy_d_file) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filen));
       Delete(filen);
@@ -568,7 +568,7 @@ public:
 
       // Write a D type wrapper class for each SWIG type to the proxy module code.
       for (Iterator swig_type = First(unknown_types); swig_type.key; swig_type = Next(swig_type)) {
-	writeTypeWrapperClass(swig_type.key, swig_type.item);
+        writeTypeWrapperClass(swig_type.key, swig_type.item);
       }
 
       // Add the proxy functions (and classes, if they are not written to a separate file).
@@ -585,8 +585,8 @@ public:
       String *filename = NewStringf("%s%s.d", outputDirectory(it.key), module_name);
       File *file = NewFile(filename, "w", SWIG_output_files());
       if (!file) {
-	FileErrorDisplay(filename);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filename);
+        Exit(EXIT_FAILURE);
       }
       Delete(filename);
 
@@ -619,15 +619,15 @@ public:
     for (it1 = First(filenames_list); it1.item; it1 = Next(it1)) {
       String *item1_lower = Swig_string_lower(it1.item);
       for (it2 = Next(it1); it2.item; it2 = Next(it2)) {
-	String *item2_lower = Swig_string_lower(it2.item);
-	if (it1.item && it2.item) {
-	  if (Strcmp(item1_lower, item2_lower) == 0) {
-	    Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
-			 "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
-			 "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
-	  }
-	}
-	Delete(item2_lower);
+        String *item2_lower = Swig_string_lower(it2.item);
+        if (it1.item && it2.item) {
+          if (Strcmp(item1_lower, item2_lower) == 0) {
+            Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
+                         "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
+                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
+          }
+        }
+        Delete(item2_lower);
       }
       Delete(item1_lower);
     }
@@ -727,8 +727,8 @@ public:
 
     if (!ImportMode && (Cmp(section, "proxycode") == 0)) {
       if (proxy_class_body_code) {
-	Swig_typemap_replace_embedded_typemap(code, n);
-	Printv(proxy_class_body_code, code, NIL);
+        Swig_typemap_replace_embedded_typemap(code, n);
+        Printv(proxy_class_body_code, code, NIL);
       }
     } else {
       ret = Language::insertDirective(n);
@@ -759,31 +759,31 @@ public:
       String *value = Getattr(n, "value");
 
       if (Strcmp(lang, "d") == 0) {
-	String *strvalue = NewString(value);
-	Replaceall(strvalue, "\\\"", "\"");
+        String *strvalue = NewString(value);
+        Replaceall(strvalue, "\\\"", "\"");
 
-	if (Strcmp(code, "imdmodulecode") == 0) {
-	  Printf(im_dmodule_code, "%s\n", strvalue);
-	} else if (Strcmp(code, "imdmoduleimports") == 0) {
-	  replaceImportTypeMacros(strvalue);
-	  Chop(strvalue);
-	  Printf(im_dmodule_imports, "%s\n", strvalue);
-	} else if (Strcmp(code, "proxydmodulecode") == 0) {
-	  Printf(proxyCodeBuffer(0), "%s\n", strvalue);
-	} else if (Strcmp(code, "globalproxyimports") == 0) {
-	  replaceImportTypeMacros(strvalue);
-	  Chop(strvalue);
-	  Printf(global_proxy_imports, "%s\n", strvalue);
-	} else if (Strcmp(code, "wrapperloadercode") == 0) {
-	  Delete(wrapper_loader_code);
-	  wrapper_loader_code = Copy(strvalue);
-	} else if (Strcmp(code, "wrapperloaderbindcommand") == 0) {
-	  Delete(wrapper_loader_bind_command);
-	  wrapper_loader_bind_command = Copy(strvalue);
-	} else {
-	  Swig_error(input_file, line_number, "Unrecognized pragma.\n");
-	}
-	Delete(strvalue);
+        if (Strcmp(code, "imdmodulecode") == 0) {
+          Printf(im_dmodule_code, "%s\n", strvalue);
+        } else if (Strcmp(code, "imdmoduleimports") == 0) {
+          replaceImportTypeMacros(strvalue);
+          Chop(strvalue);
+          Printf(im_dmodule_imports, "%s\n", strvalue);
+        } else if (Strcmp(code, "proxydmodulecode") == 0) {
+          Printf(proxyCodeBuffer(0), "%s\n", strvalue);
+        } else if (Strcmp(code, "globalproxyimports") == 0) {
+          replaceImportTypeMacros(strvalue);
+          Chop(strvalue);
+          Printf(global_proxy_imports, "%s\n", strvalue);
+        } else if (Strcmp(code, "wrapperloadercode") == 0) {
+          Delete(wrapper_loader_code);
+          wrapper_loader_code = Copy(strvalue);
+        } else if (Strcmp(code, "wrapperloaderbindcommand") == 0) {
+          Delete(wrapper_loader_bind_command);
+          wrapper_loader_bind_command = Copy(strvalue);
+        } else {
+          Swig_error(input_file, line_number, "Unrecognized pragma.\n");
+        }
+        Delete(strvalue);
       }
     }
     return Language::pragmaDirective(n);
@@ -816,20 +816,20 @@ public:
 
       const String *baseclass = NULL;
       if (!purebase_replace) {
-	String *underlying_enum_type = Getattr(n, "enumbase");
-	if (underlying_enum_type) {
-	  baseclass = lookupCodeTypemap(n, "dtype", underlying_enum_type, WARN_D_TYPEMAP_DTYPE_UNDEF);
-	}
+        String *underlying_enum_type = Getattr(n, "enumbase");
+        if (underlying_enum_type) {
+          baseclass = lookupCodeTypemap(n, "dtype", underlying_enum_type, WARN_D_TYPEMAP_DTYPE_UNDEF);
+        }
       }
 
       const String *wanted_base = baseclass ? baseclass : pure_baseclass;
 
       if (purebase_replace) {
-	wanted_base = pure_baseclass;
+        wanted_base = pure_baseclass;
       } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
-	Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		     "Warning for %s, enum base %s ignored. Multiple enum bases is not supported in D enums. "
-		     "Perhaps you need the 'replace' attribute in the dbase typemap?\n", typemap_lookup_type, pure_baseclass);
+        Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+                     "Warning for %s, enum base %s ignored. Multiple enum bases is not supported in D enums. "
+                     "Perhaps you need the 'replace' attribute in the dbase typemap?\n", typemap_lookup_type, pure_baseclass);
       }
 
       const String *enummodifiers = lookupCodeTypemap(n, "dclassmodifiers", typemap_lookup_type, WARN_D_TYPEMAP_CLASSMOD_UNDEF);
@@ -845,12 +845,12 @@ public:
     if (GetFlag(n, "nonempty")) {
       // Finish the enum.
       if (typemap_lookup_type) {
-	Printv(proxy_enum_code,
-	  lookupCodeTypemap(n, "dcode", typemap_lookup_type, WARN_NONE), // Extra D code
-	  "\n}\n", NIL);
+        Printv(proxy_enum_code,
+          lookupCodeTypemap(n, "dcode", typemap_lookup_type, WARN_NONE), // Extra D code
+          "\n}\n", NIL);
       } else {
-	// Handle anonymous enums.
-	Printv(proxy_enum_code, "\n}\n", NIL);
+        // Handle anonymous enums.
+        Printv(proxy_enum_code, "\n}\n", NIL);
       }
       Replaceall(proxy_enum_code, "$dclassname", symname);
     } else {
@@ -881,36 +881,36 @@ public:
       // Write non-anonymous enums to their own file if in split proxy module
       // mode.
       if (split_proxy_dmodule && typemap_lookup_type) {
-	assertClassNameValidity(proxy_class_name);
+        assertClassNameValidity(proxy_class_name);
 
-	String *nspace = Getattr(n, "sym:nspace");
-	String *output_directory = outputDirectory(nspace);
-	String *filename = NewStringf("%s%s.d", output_directory, symname);
-	Delete(output_directory);
+        String *nspace = Getattr(n, "sym:nspace");
+        String *output_directory = outputDirectory(nspace);
+        String *filename = NewStringf("%s%s.d", output_directory, symname);
+        Delete(output_directory);
 
-	File *class_file = NewFile(filename, "w", SWIG_output_files());
-	if (!class_file) {
-	  FileErrorDisplay(filename);
-	  Exit(EXIT_FAILURE);
-	}
-	Append(filenames_list, Copy(filename));
-	Delete(filename);
+        File *class_file = NewFile(filename, "w", SWIG_output_files());
+        if (!class_file) {
+          FileErrorDisplay(filename);
+          Exit(EXIT_FAILURE);
+        }
+        Append(filenames_list, Copy(filename));
+        Delete(filename);
 
-	emitBanner(class_file);
-	if (nspace) {
-	  Printf(class_file, "module %s%s.%s;\n", package, nspace, symname);
-	} else {
-	  Printf(class_file, "module %s%s;\n", package, symname);
-	}
-	Printv(class_file, imports_trimmed, NIL);
+        emitBanner(class_file);
+        if (nspace) {
+          Printf(class_file, "module %s%s.%s;\n", package, nspace, symname);
+        } else {
+          Printf(class_file, "module %s%s;\n", package, symname);
+        }
+        Printv(class_file, imports_trimmed, NIL);
 
-	Printv(class_file, proxy_enum_code, NIL);
+        Printv(class_file, proxy_enum_code, NIL);
 
-	Delete(class_file);
+        Delete(class_file);
       } else {
-	String *nspace = Getattr(n, "sym:nspace");
-	Printv(proxyImportsBuffer(nspace), imports, NIL);
-	Printv(proxyCodeBuffer(nspace), proxy_enum_code, NIL);
+        String *nspace = Getattr(n, "sym:nspace");
+        Printv(proxyImportsBuffer(nspace), imports, NIL);
+        Printv(proxyCodeBuffer(nspace), proxy_enum_code, NIL);
       }
     }
 
@@ -952,7 +952,7 @@ public:
     // Emit the enum item.
     {
       if (!GetFlag(n, "firstenumitem"))
-	Printf(proxy_enum_code, ",\n");
+        Printf(proxy_enum_code, ",\n");
 
       Printf(proxy_enum_code, "  %s", Getattr(n, "sym:name"));
 
@@ -963,7 +963,7 @@ public:
       // %dmanifestconst(0) (getting the enum values at runtime) is not supported.
       value = value ? value : Getattr(n, "enumvalue");
       if (value) {
-	Printf(proxy_enum_code, " = %s", value);
+        Printf(proxy_enum_code, " = %s", value);
       }
 
       // Keep track that the currently processed enum has at least one value.
@@ -996,8 +996,8 @@ public:
       // between the package name and an argument-less function call.
       // TODO: This might occur with nspace as well, augment the check.
       Swig_warning(WARN_D_NAME_COLLISION, input_file, line_number,
-	"%s::%s might collide with the package name, consider using %%rename to resolve the ambiguity.\n",
-	proxy_class_name, proxy_func_name);
+        "%s::%s might collide with the package name, consider using %%rename to resolve the ambiguity.\n",
+        proxy_class_name, proxy_func_name);
     }
 
     writeProxyClassFunction(n);
@@ -1016,7 +1016,7 @@ public:
     // taking a delegate in the overload checking code fails otherwise
     // (http://d.puremagic.com/issues/show_bug.cgi?id=4860).
     if (!Getattr(n, "sym:nextSibling") && !is_smart_pointer() &&
-	!areAllOverloadsOverridden(n)) {
+        !areAllOverloadsOverridden(n)) {
       String *name = Getattr(n, "sym:name");
       Printf(proxy_class_body_code, "\nalias $dbaseclass.%s %s;\n", name, name);
     }
@@ -1160,15 +1160,15 @@ public:
     Parm *p = l;
     for (i = 0; p; i++) {
       if (checkAttribute(p, "varargs:ignore", "1")) {
-	// Skip ignored varargs.
-	p = nextSibling(p);
-	continue;
+        // Skip ignored varargs.
+        p = nextSibling(p);
+        continue;
       }
 
       if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	// Skip ignored parameters.
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        // Skip ignored parameters.
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -1176,15 +1176,15 @@ public:
 
       // Get the D parameter type.
       if ((tm = lookupDTypemap(p, "dtype", true))) {
-	const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
-	Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
+        Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	  "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
+          "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       if (gencomma)
-	Printf(imcall, ", ");
+        Printf(imcall, ", ");
 
       String *arg = makeParameterName(n, p, i, false);
       String *parmtype = 0;
@@ -1192,45 +1192,45 @@ public:
       // Get the D code to convert the parameter value to the type used in the
       // intermediary D module.
       if ((tm = lookupDTypemap(p, "din", true))) {
-	Replaceall(tm, "$dinput", arg);
-	String *pre = Getattr(p, "tmap:din:pre");
-	if (pre) {
-	  replaceClassname(pre, pt);
-	  Replaceall(pre, "$dinput", arg);
-	  if (Len(pre_code) > 0)
-	    Printf(pre_code, "\n");
-	  Printv(pre_code, pre, NIL);
-	}
-	String *post = Getattr(p, "tmap:din:post");
-	if (post) {
-	  replaceClassname(post, pt);
-	  Replaceall(post, "$dinput", arg);
-	  if (Len(post_code) > 0)
-	    Printf(post_code, "\n");
-	  Printv(post_code, post, NIL);
-	}
-	String *terminator = Getattr(p, "tmap:din:terminator");
-	if (terminator) {
-	  replaceClassname(terminator, pt);
-	  Replaceall(terminator, "$dinput", arg);
-	  if (Len(terminator_code) > 0)
-	    Insert(terminator_code, 0, "\n");
-	  Insert(terminator_code, 0, terminator);
-	}
-	parmtype = Getattr(p, "tmap:din:parmtype");
-	if (parmtype)
-	  Replaceall(parmtype, "$dinput", arg);
-	Printv(imcall, tm, NIL);
+        Replaceall(tm, "$dinput", arg);
+        String *pre = Getattr(p, "tmap:din:pre");
+        if (pre) {
+          replaceClassname(pre, pt);
+          Replaceall(pre, "$dinput", arg);
+          if (Len(pre_code) > 0)
+            Printf(pre_code, "\n");
+          Printv(pre_code, pre, NIL);
+        }
+        String *post = Getattr(p, "tmap:din:post");
+        if (post) {
+          replaceClassname(post, pt);
+          Replaceall(post, "$dinput", arg);
+          if (Len(post_code) > 0)
+            Printf(post_code, "\n");
+          Printv(post_code, post, NIL);
+        }
+        String *terminator = Getattr(p, "tmap:din:terminator");
+        if (terminator) {
+          replaceClassname(terminator, pt);
+          Replaceall(terminator, "$dinput", arg);
+          if (Len(terminator_code) > 0)
+            Insert(terminator_code, 0, "\n");
+          Insert(terminator_code, 0, terminator);
+        }
+        parmtype = Getattr(p, "tmap:din:parmtype");
+        if (parmtype)
+          Replaceall(parmtype, "$dinput", arg);
+        Printv(imcall, tm, NIL);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
-	  "No din typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
+          "No din typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to proxy function */
       if (gencomma) {
-	Printf(proxy_constructor_code, ", ");
-	Printf(helper_code, ", ");
-	Printf(helper_args, ", ");
+        Printf(proxy_constructor_code, ", ");
+        Printf(helper_code, ", ");
+        Printf(helper_args, ", ");
       }
       Printf(proxy_constructor_code, "%s %s", param_type, arg);
       Printf(helper_code, "%s %s", param_type, arg);
@@ -1256,18 +1256,18 @@ public:
     if (construct_tm) {
       const bool use_director = (parentNode(n) && Swig_directorclass(n));
       if (!use_director) {
-	Replaceall(construct_tm, "$directorconnect", "");
+        Replaceall(construct_tm, "$directorconnect", "");
       } else {
-	String *connect_attr = Getattr(attributes, "tmap:dconstructor:directorconnect");
+        String *connect_attr = Getattr(attributes, "tmap:dconstructor:directorconnect");
 
-	if (connect_attr) {
-	  Replaceall(construct_tm, "$directorconnect", connect_attr);
-	} else {
-	  Swig_warning(WARN_D_NO_DIRECTORCONNECT_ATTR, input_file, line_number,
-	    "\"directorconnect\" attribute missing in %s \"dconstructor\" typemap.\n",
-	    Getattr(n, "name"));
-	  Replaceall(construct_tm, "$directorconnect", "");
-	}
+        if (connect_attr) {
+          Replaceall(construct_tm, "$directorconnect", connect_attr);
+        } else {
+          Swig_warning(WARN_D_NO_DIRECTORCONNECT_ATTR, input_file, line_number,
+            "\"directorconnect\" attribute missing in %s \"dconstructor\" typemap.\n",
+            Getattr(n, "name"));
+          Replaceall(construct_tm, "$directorconnect", "");
+        }
       }
 
       Printv(proxy_constructor_code, " ", construct_tm, NIL);
@@ -1281,21 +1281,21 @@ public:
     if (is_pre_code || is_post_code || is_terminator_code) {
       Printf(helper_code, " {\n");
       if (is_pre_code) {
-	Printv(helper_code, pre_code, "\n", NIL);
+        Printv(helper_code, pre_code, "\n", NIL);
       }
       if (is_post_code) {
-	Printf(helper_code, "  try {\n");
-	Printv(helper_code, "    return ", imcall, ";\n", NIL);
-	Printv(helper_code, "  } finally {\n", post_code, "\n    }", NIL);
+        Printf(helper_code, "  try {\n");
+        Printv(helper_code, "    return ", imcall, ";\n", NIL);
+        Printv(helper_code, "  } finally {\n", post_code, "\n    }", NIL);
       } else {
-	Printv(helper_code, "  return ", imcall, ";", NIL);
+        Printv(helper_code, "  return ", imcall, ";", NIL);
       }
       if (is_terminator_code) {
-	Printv(helper_code, "\n", terminator_code, NIL);
+        Printv(helper_code, "\n", terminator_code, NIL);
       }
       Printf(helper_code, "\n}\n");
       String *helper_name = NewStringf("%s.SwigConstruct%s(%s)",
-	proxy_class_name, proxy_class_name, helper_args);
+        proxy_class_name, proxy_class_name, helper_args);
       Replaceall(proxy_constructor_code, "$imcall", helper_name);
       Delete(helper_name);
     } else {
@@ -1357,8 +1357,8 @@ public:
       class_file = NewFile(filename, "w", SWIG_output_files());
       Delete(output_directory);
       if (!class_file) {
-	FileErrorDisplay(filename);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filename);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filename));
       Delete(filename);
@@ -1462,7 +1462,7 @@ public:
     String *return_type = getOutDtype(n);
     if (!return_type) {
       Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	"No dtype typemap defined for %s\n", SwigType_str(t, 0));
+        "No dtype typemap defined for %s\n", SwigType_str(t, 0));
       return_type = NewString("");
     }
 
@@ -1485,9 +1485,9 @@ public:
     } else {
       // Just take the value from the C definition and hope it compiles in D.
       if (Getattr(n, "wrappedasconstant")) {
-	Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
+        Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
       } else {
-	Printf(constants_code, "%s;\n", Getattr(n, "value"));
+        Printf(constants_code, "%s;\n", Getattr(n, "value"));
       }
     }
 
@@ -1528,7 +1528,7 @@ public:
 
     if (!Getattr(n, "sym:overloaded")) {
       if (!addSymbol(Getattr(n, "sym:name"), n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     // A new wrapper function object
@@ -1545,22 +1545,22 @@ public:
     if ((tm = lookupDTypemap(n, "ctype"))) {
       String *ctypeout = Getattr(n, "tmap:ctype:out");
       if (ctypeout) {
-	// The type in the ctype typemap's out attribute overrides the type in
-	// the typemap itself.
-	tm = ctypeout;
+        // The type in the ctype typemap's out attribute overrides the type in
+        // the typemap itself.
+        tm = ctypeout;
       }
       Printf(c_return_type, "%s", tm);
     } else {
       Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
-	"No ctype typemap defined for %s\n", SwigType_str(returntype, 0));
+        "No ctype typemap defined for %s\n", SwigType_str(returntype, 0));
     }
 
     if ((tm = lookupDTypemap(n, "imtype"))) {
       String *imtypeout = Getattr(n, "tmap:imtype:out");
       if (imtypeout) {
-	// The type in the imtype typemap's out attribute overrides the type in
-	// the typemap itself.
-	tm = imtypeout;
+        // The type in the imtype typemap's out attribute overrides the type in
+        // the typemap itself.
+        tm = imtypeout;
       }
       Printf(im_return_type, "%s", tm);
     } else {
@@ -1588,8 +1588,8 @@ public:
       // Emit warnings for the few cases that can't be overloaded in D and give up on generating wrapper
       Swig_overload_check(n);
       if (Getattr(n, "overload:ignore")) {
-	DelWrapper(f);
-	return SWIG_OK;
+        DelWrapper(f);
+        return SWIG_OK;
       }
     }
 
@@ -1605,7 +1605,7 @@ public:
     for (i = 0, p = l; i < num_arguments; i++) {
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -1618,22 +1618,22 @@ public:
 
       /* Get the ctype types of the parameter */
       if ((tm = lookupDTypemap(p, "ctype", true))) {
-	Printv(c_param_type, tm, NIL);
+        Printv(c_param_type, tm, NIL);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number, "No ctype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Get the intermediary class parameter types of the parameter */
       if ((tm = lookupDTypemap(p, "imtype", true))) {
-	const String *inattributes = Getattr(p, "tmap:imtype:inattributes");
-	Printf(im_param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        const String *inattributes = Getattr(p, "tmap:imtype:inattributes");
+        Printf(im_param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number, "No imtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to intermediary class method */
       if (gencomma)
-	Printf(im_dmodule_parameters, ", ");
+        Printf(im_dmodule_parameters, ", ");
       Printf(im_dmodule_parameters, "%s %s", im_param_type, arg);
 
       // Add parameter to C function
@@ -1643,14 +1643,14 @@ public:
 
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
-	canThrow(n, "in", p);
-	Replaceall(tm, "$input", arg);
-	Setattr(p, "emit:input", arg);
-	Printf(f->code, "%s\n", tm);
-	p = Getattr(p, "tmap:in:next");
+        canThrow(n, "in", p);
+        Replaceall(tm, "$input", arg);
+        Setattr(p, "emit:input", arg);
+        Printf(f->code, "%s\n", tm);
+        p = Getattr(p, "tmap:in:next");
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	p = nextSibling(p);
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        p = nextSibling(p);
       }
       Delete(im_param_type);
       Delete(c_param_type);
@@ -1660,37 +1660,37 @@ public:
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	canThrow(n, "check", p);
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        canThrow(n, "check", p);
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	canThrow(n, "freearg", p);
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        canThrow(n, "freearg", p);
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert argument output code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	canThrow(n, "argout", p);
-	Replaceall(tm, "$result", "jresult");
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        canThrow(n, "argout", p);
+        Replaceall(tm, "$result", "jresult");
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -1699,9 +1699,9 @@ public:
     if ((throw_parm_list = Getattr(n, "catchlist"))) {
       Swig_typemap_attach_parms("throws", throw_parm_list, f);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  canThrow(n, "throws", p);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          canThrow(n, "throws", p);
+        }
       }
     }
 
@@ -1714,20 +1714,20 @@ public:
 
       /* Return value if necessary  */
       if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
-	canThrow(n, "out", n);
-	Replaceall(tm, "$result", "jresult");
+        canThrow(n, "out", n);
+        Replaceall(tm, "$result", "jresult");
 
-	if (GetFlag(n, "feature:new"))
-	  Replaceall(tm, "$owner", "1");
-	else
-	  Replaceall(tm, "$owner", "0");
+        if (GetFlag(n, "feature:new"))
+          Replaceall(tm, "$owner", "1");
+        else
+          Replaceall(tm, "$owner", "0");
 
-	Printf(f->code, "%s", tm);
-	null_attribute = Getattr(n, "tmap:out:null");
-	if (Len(tm))
-	  Printf(f->code, "\n");
+        Printf(f->code, "%s", tm);
+        null_attribute = Getattr(n, "tmap:out:null");
+        if (Len(tm))
+          Printf(f->code, "\n");
       } else {
-	Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
+        Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
       }
       emit_return_variable(n, returntype, f);
     }
@@ -1741,16 +1741,16 @@ public:
     /* Look to see if there is any newfree cleanup code */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	canThrow(n, "newfree", n);
-	Printf(f->code, "%s\n", tm);
+        canThrow(n, "newfree", n);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
     /* See if there is any return cleanup code */
     if (!native_function_flag) {
       if ((tm = Swig_typemap_lookup("ret", n, Swig_cresult_name(), 0))) {
-	canThrow(n, "ret", n);
-	Printf(f->code, "%s\n", tm);
+        canThrow(n, "ret", n);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -1791,7 +1791,7 @@ public:
 
       // Handle %exception which sets the canthrow attribute.
       if (Getattr(n, "feature:except:canthrow")) {
-	Setattr(n, "d:canthrow", "1");
+        Setattr(n, "d:canthrow", "1");
       }
 
       // A very simple check (it is not foolproof) to assist typemap writers
@@ -1800,13 +1800,13 @@ public:
       // a pending D exception and issues a warning if one of them has been found
       // in the typemap, but the »canthrow« attribute/feature is not set.
       if (!Getattr(n, "d:canthrow")) {
-	if (Strstr(f->code, "SWIG_exception")) {
-	  Swig_warning(WARN_D_CANTHROW_MISSING, input_file, line_number,
-	  "C code contains a call to SWIG_exception and D code does not handle pending exceptions via the canthrow attribute.\n");
-	} else if (Strstr(f->code, "SWIG_DSetPendingException")) {
-	  Swig_warning(WARN_D_CANTHROW_MISSING, input_file, line_number,
-	  "C code contains a call to a SWIG_DSetPendingException method and D code does not handle pending exceptions via the canthrow attribute.\n");
-	}
+        if (Strstr(f->code, "SWIG_exception")) {
+          Swig_warning(WARN_D_CANTHROW_MISSING, input_file, line_number,
+          "C code contains a call to SWIG_exception and D code does not handle pending exceptions via the canthrow attribute.\n");
+        } else if (Strstr(f->code, "SWIG_DSetPendingException")) {
+          Swig_warning(WARN_D_CANTHROW_MISSING, input_file, line_number,
+          "C code contains a call to a SWIG_DSetPendingException method and D code does not handle pending exceptions via the canthrow attribute.\n");
+        }
       }
     }
 
@@ -1968,50 +1968,50 @@ public:
 
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  String *base_typename = SwigType_base(returntype);
-	  String *resolved_typename = SwigType_typedef_resolve_all(base_typename);
-	  Symtab *symtab = Getattr(n, "sym:symtab");
-	  Node *typenode = Swig_symbol_clookup(resolved_typename, symtab);
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          String *base_typename = SwigType_base(returntype);
+          String *resolved_typename = SwigType_typedef_resolve_all(base_typename);
+          Symtab *symtab = Getattr(n, "sym:symtab");
+          Node *typenode = Swig_symbol_clookup(resolved_typename, symtab);
 
-	  if (SwigType_ispointer(returntype) || (typenode && Getattr(typenode, "abstracts"))) {
-	    /* initialize pointers to something sane. Same for abstract
-	       classes when a reference is returned. */
-	    Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	  } else {
-	    /* If returning a reference, initialize the pointer to a sane
-	       default - if a D exception occurs, then the pointer returns
-	       something other than a NULL-initialized reference. */
-	    SwigType *noref_type = SwigType_del_reference(Copy(returntype));
-	    String *noref_ltype = SwigType_lstr(noref_type, 0);
-	    String *return_ltype = SwigType_lstr(returntype, 0);
+          if (SwigType_ispointer(returntype) || (typenode && Getattr(typenode, "abstracts"))) {
+            /* initialize pointers to something sane. Same for abstract
+               classes when a reference is returned. */
+            Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+          } else {
+            /* If returning a reference, initialize the pointer to a sane
+               default - if a D exception occurs, then the pointer returns
+               something other than a NULL-initialized reference. */
+            SwigType *noref_type = SwigType_del_reference(Copy(returntype));
+            String *noref_ltype = SwigType_lstr(noref_type, 0);
+            String *return_ltype = SwigType_lstr(returntype, 0);
 
-	    Wrapper_add_localv(w, "result_default", "static", noref_ltype, "result_default", NIL);
-	    Wrapper_add_localv(w, "c_result", return_ltype, "c_result", NIL);
-	    Printf(w->code, "result_default = SwigValueInit< %s >();\n", noref_ltype);
-	    Printf(w->code, "c_result = &result_default;\n");
-	    Delete(return_ltype);
-	    Delete(noref_ltype);
-	    Delete(noref_type);
-	  }
+            Wrapper_add_localv(w, "result_default", "static", noref_ltype, "result_default", NIL);
+            Wrapper_add_localv(w, "c_result", return_ltype, "c_result", NIL);
+            Printf(w->code, "result_default = SwigValueInit< %s >();\n", noref_ltype);
+            Printf(w->code, "c_result = &result_default;\n");
+            Delete(return_ltype);
+            Delete(noref_ltype);
+            Delete(noref_type);
+          }
 
-	  Delete(base_typename);
-	  Delete(resolved_typename);
-	}
+          Delete(base_typename);
+          Delete(resolved_typename);
+        }
       } else {
-	SwigType *vt;
+        SwigType *vt;
 
-	vt = cplus_value_type(returntype);
-	if (!vt) {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
-	  Delete(vt);
-	}
+        vt = cplus_value_type(returntype);
+        if (!vt) {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
+          Delete(vt);
+        }
       }
     }
 
@@ -2020,27 +2020,27 @@ public:
     if (tm) {
       String *imtypeout = Getattr(n, "tmap:imtype:out");
       if (imtypeout) {
-	// The type in the imtype typemap's out attribute overrides the type
-	// in the typemap.
-	tm = imtypeout;
+        // The type in the imtype typemap's out attribute overrides the type
+        // in the typemap.
+        tm = imtypeout;
       }
       Printf(callback_def, "\nprivate extern(C) %s swigDirectorCallback_%s_%s(void* dObject", tm, classname, overloaded_name);
       Printv(proxy_callback_return_type, tm, NIL);
     } else {
       Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number,
-	"No imtype typemap defined for %s\n", SwigType_str(returntype, 0));
+        "No imtype typemap defined for %s\n", SwigType_str(returntype, 0));
     }
 
     if ((c_ret_type = Swig_typemap_lookup("ctype", n, "", 0))) {
       if (!is_void && !ignored_method) {
-	String *jretval_decl = NewStringf("%s jresult", c_ret_type);
-	Wrapper_add_localv(w, "jresult", jretval_decl, "= 0", NIL);
-	Delete(jretval_decl);
+        String *jretval_decl = NewStringf("%s jresult", c_ret_type);
+        Wrapper_add_localv(w, "jresult", jretval_decl, "= 0", NIL);
+        Delete(jretval_decl);
       }
     } else {
       Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
-	"No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
-	SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
+        SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
 
@@ -2062,19 +2062,19 @@ public:
     if (!pure_virtual) {
       String *super_call = Swig_method_call(super, l);
       if (is_void) {
-	Printf(w->code, "%s;\n", super_call);
-	if (!ignored_method)
-	  Printf(w->code, "return;\n");
+        Printf(w->code, "%s;\n", super_call);
+        if (!ignored_method)
+          Printf(w->code, "return;\n");
       } else {
-	Printf(w->code, "return %s;\n", super_call);
+        Printf(w->code, "return %s;\n", super_call);
       }
       Delete(super_call);
     } else {
       Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"%s::%s\");\n", SwigType_namestr(c_classname), SwigType_namestr(name));
       if (!is_void)
-	Printf(w->code, "return %s;", qualified_return);
+        Printf(w->code, "return %s;", qualified_return);
       else if (!ignored_method)
-	Printf(w->code, "return;\n");
+        Printf(w->code, "return;\n");
     }
 
     if (!ignored_method)
@@ -2084,7 +2084,7 @@ public:
     for (i = 0, p = l; p; ++i) {
       /* Is this superfluous? */
       while (checkAttribute(p, "tmap:directorin:numinputs", "0")) {
-	p = Getattr(p, "tmap:directorin:next");
+        p = Getattr(p, "tmap:directorin:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -2100,111 +2100,111 @@ public:
 
       /* Get parameter's intermediary C type */
       if ((c_param_type = lookupDTypemap(p, "ctype", true))) {
-	String *ctypeout = Getattr(p, "tmap:ctype:out");
-	if (ctypeout) {
-	  // The type in the ctype typemap's out attribute overrides the type
-	  // in the typemap itself.
-	  c_param_type = ctypeout;
-	}
-	// ctype default assignment
-	const String *ctypedef = Getattr(p, "tmap:ctype:default");
-	String *ctypeassign;
-	if (ctypedef) {
-	  ctypeassign = Copy(ctypedef);
-	} else if (SwigType_ispointer(pt) || SwigType_isreference(pt)) {
-	  ctypeassign = NewString("= 0");
-	} else {
-	  ctypeassign = NewString("");
-	}
+        String *ctypeout = Getattr(p, "tmap:ctype:out");
+        if (ctypeout) {
+          // The type in the ctype typemap's out attribute overrides the type
+          // in the typemap itself.
+          c_param_type = ctypeout;
+        }
+        // ctype default assignment
+        const String *ctypedef = Getattr(p, "tmap:ctype:default");
+        String *ctypeassign;
+        if (ctypedef) {
+          ctypeassign = Copy(ctypedef);
+        } else if (SwigType_ispointer(pt) || SwigType_isreference(pt)) {
+          ctypeassign = NewString("= 0");
+        } else {
+          ctypeassign = NewString("");
+        }
 
-	/* Add to local variables */
-	Printf(c_decl, "%s %s", c_param_type, arg);
-	if (!ignored_method)
-	  Wrapper_add_localv(w, arg, c_decl, ctypeassign, NIL);
-	Delete(ctypeassign);
+        /* Add to local variables */
+        Printf(c_decl, "%s %s", c_param_type, arg);
+        if (!ignored_method)
+          Wrapper_add_localv(w, arg, c_decl, ctypeassign, NIL);
+        Delete(ctypeassign);
 
-	/* Add input marshalling code */
-	if ((tm = Getattr(p, "tmap:directorin"))) {
+        /* Add input marshalling code */
+        if ((tm = Getattr(p, "tmap:directorin"))) {
 
-	  Setattr(p, "emit:directorinput", arg);
-	  Replaceall(tm, "$input", arg);
-	  Replaceall(tm, "$owner", "0");
+          Setattr(p, "emit:directorinput", arg);
+          Replaceall(tm, "$input", arg);
+          Replaceall(tm, "$owner", "0");
 
-	  if (Len(tm))
-	    if (!ignored_method)
-	      Printf(w->code, "%s\n", tm);
+          if (Len(tm))
+            if (!ignored_method)
+              Printf(w->code, "%s\n", tm);
 
-	  // Add parameter type to the C typedef for the D callback function.
-	  Printf(callback_typedef_parms, ", %s", c_param_type);
+          // Add parameter type to the C typedef for the D callback function.
+          Printf(callback_typedef_parms, ", %s", c_param_type);
 
-	  /* Add parameter to the intermediate class code if generating the
-	   * intermediate's upcall code */
-	  if ((tm = lookupDTypemap(p, "imtype", true))) {
-	    String *imtypeout = Getattr(p, "tmap:imtype:out");
-	    if (imtypeout) {
-	      // The type in the imtype typemap's out attribute overrides the
-	      // type in the typemap itself.
-	      tm = imtypeout;
-	    }
-	    const String *im_directorinattributes = Getattr(p, "tmap:imtype:directorinattributes");
+          /* Add parameter to the intermediate class code if generating the
+           * intermediate's upcall code */
+          if ((tm = lookupDTypemap(p, "imtype", true))) {
+            String *imtypeout = Getattr(p, "tmap:imtype:out");
+            if (imtypeout) {
+              // The type in the imtype typemap's out attribute overrides the
+              // type in the typemap itself.
+              tm = imtypeout;
+            }
+            const String *im_directorinattributes = Getattr(p, "tmap:imtype:directorinattributes");
 
-	    // TODO: Is this copy really needed?
-	    String *din = Copy(lookupDTypemap(p, "ddirectorin", true));
+            // TODO: Is this copy really needed?
+            String *din = Copy(lookupDTypemap(p, "ddirectorin", true));
 
-	    if (din) {
-	      Replaceall(din, "$winput", ln);
+            if (din) {
+              Replaceall(din, "$winput", ln);
 
-	      Printf(delegate_parms, ", ");
-	      if (i > 0) {
-		Printf(proxy_method_param_list, ", ");
-		Printf(imcall_args, ", ");
-	      }
-	      Printf(delegate_parms, "%s%s %s", im_directorinattributes ? im_directorinattributes : empty_string, tm, ln);
+              Printf(delegate_parms, ", ");
+              if (i > 0) {
+                Printf(proxy_method_param_list, ", ");
+                Printf(imcall_args, ", ");
+              }
+              Printf(delegate_parms, "%s%s %s", im_directorinattributes ? im_directorinattributes : empty_string, tm, ln);
 
-	      if (Cmp(din, ln)) {
-		Printv(imcall_args, din, NIL);
-	      } else {
-		Printv(imcall_args, ln, NIL);
-	      }
+              if (Cmp(din, ln)) {
+                Printv(imcall_args, din, NIL);
+              } else {
+                Printv(imcall_args, ln, NIL);
+              }
 
-	      Delete(din);
+              Delete(din);
 
-	      // Get the parameter type in the proxy D class (used later when
-	      // generating the overload checking code for the directorConnect
-	      // function).
-	      if ((tm = lookupDTypemap(p, "dtype", true))) {
-		Printf(proxy_method_param_list, "%s", tm);
-	      } else {
-		Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	          "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
-	      }
-	    } else {
-	      Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF, input_file, line_number,
-	        "No ddirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-		SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	      output_director = false;
-	    }
-	  } else {
-	    Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number,
-	      "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
-	      SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    output_director = false;
-	  }
+              // Get the parameter type in the proxy D class (used later when
+              // generating the overload checking code for the directorConnect
+              // function).
+              if ((tm = lookupDTypemap(p, "dtype", true))) {
+                Printf(proxy_method_param_list, "%s", tm);
+              } else {
+                Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
+                  "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+              }
+            } else {
+              Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF, input_file, line_number,
+                "No ddirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
+                SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+              output_director = false;
+            }
+          } else {
+            Swig_warning(WARN_D_TYPEMAP_IMTYPE_UNDEF, input_file, line_number,
+              "No imtype typemap defined for %s for use in %s::%s (skipping director method)\n",
+              SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            output_director = false;
+          }
 
-	  p = Getattr(p, "tmap:directorin:next");
-	} else {
-	  Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF, input_file, line_number,
-	    "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
-	    SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	  p = nextSibling(p);
-	  output_director = false;
-	}
+          p = Getattr(p, "tmap:directorin:next");
+        } else {
+          Swig_warning(WARN_D_TYPEMAP_DDIRECTORIN_UNDEF, input_file, line_number,
+            "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
+            SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          p = nextSibling(p);
+          output_director = false;
+        }
       } else {
-	Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
-	  "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
-	  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	output_director = false;
-	p = nextSibling(p);
+        Swig_warning(WARN_D_TYPEMAP_CTYPE_UNDEF, input_file, line_number,
+          "No ctype typemap defined for %s for use in %s::%s (skipping director method)\n",
+          SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        output_director = false;
+        p = nextSibling(p);
       }
 
       Delete(arg);
@@ -2237,16 +2237,16 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
-	  Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
-	  Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
-	}
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
+          Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
+          Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
+        }
       }
 
       Append(w->def, ")");
@@ -2266,8 +2266,8 @@ public:
 
     if (!is_void) {
       if ((tm = lookupDTypemap(n, "ddirectorout"))) {
-	Replaceall(tm, "$dcall", upcall);
-	Printf(callback_code, "  return %s;\n", tm);
+        Replaceall(tm, "$dcall", upcall);
+        Printf(callback_code, "  return %s;\n", tm);
       }
     } else {
       Printf(callback_code, "  %s;\n", upcall);
@@ -2278,47 +2278,47 @@ public:
 
     if (!ignored_method) {
       if (!is_void)
-	Printf(w->code, "jresult = (%s) ", c_ret_type);
+        Printf(w->code, "jresult = (%s) ", c_ret_type);
 
       Printf(w->code, "swig_callback_%s(d_object%s);\n", overloaded_name, dcallback_call_args);
 
       if (!is_void) {
-	String *jresult_str = NewString("jresult");
-	String *result_str = NewString("c_result");
+        String *jresult_str = NewString("jresult");
+        String *result_str = NewString("c_result");
 
-	/* Copy jresult into c_result... */
-	if ((tm = Swig_typemap_lookup("directorout", n, result_str, w))) {
-	  Replaceall(tm, "$input", jresult_str);
-	  Replaceall(tm, "$result", result_str);
-	  Printf(w->code, "%s\n", tm);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		       "Unable to use return type %s used in %s::%s (skipping director method)\n",
-		       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	  output_director = false;
-	}
+        /* Copy jresult into c_result... */
+        if ((tm = Swig_typemap_lookup("directorout", n, result_str, w))) {
+          Replaceall(tm, "$input", jresult_str);
+          Replaceall(tm, "$result", result_str);
+          Printf(w->code, "%s\n", tm);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                       "Unable to use return type %s used in %s::%s (skipping director method)\n",
+                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          output_director = false;
+        }
 
-	Delete(jresult_str);
-	Delete(result_str);
+        Delete(jresult_str);
+        Delete(result_str);
       }
 
       /* Marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout"))) {
-	  canThrow(n, "directorargout", p);
-	  Replaceall(tm, "$result", "jresult");
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout"))) {
+          canThrow(n, "directorargout", p);
+          Replaceall(tm, "$result", "jresult");
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       /* Terminate wrapper code */
       Printf(w->code, "}\n");
       if (!is_void)
-	Printf(w->code, "return %s;", qualified_return);
+        Printf(w->code, "return %s;", qualified_return);
     }
 
     Printf(w->code, "}");
@@ -2331,7 +2331,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -2341,18 +2341,18 @@ public:
     /* emit the director method */
     if (status == SWIG_OK && output_director) {
       if (!is_void) {
-	Replaceall(w->code, "$null", qualified_return);
+        Replaceall(w->code, "$null", qualified_return);
       } else {
-	Replaceall(w->code, "$null", "");
+        Replaceall(w->code, "$null", "");
       }
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!ignored_method)
-	Printv(director_dcallbacks_code, callback_def, callback_code, NIL);
+        Printv(director_dcallbacks_code, callback_def, callback_code, NIL);
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 
@@ -2365,9 +2365,9 @@ public:
       // returned.
       String *dp_return_type = getOutDtype(n);
       if (!dp_return_type) {
-	Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	  "No dtype typemap defined for %s\n", SwigType_str(returntype, 0));
-	dp_return_type = NewString("");
+        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
+          "No dtype typemap defined for %s\n", SwigType_str(returntype, 0));
+        dp_return_type = NewString("");
       }
 
       String *member_name = Swig_name_member(getNSpace(), classname, overloaded_name);
@@ -2426,8 +2426,8 @@ public:
       String *pname = Getattr(p, "name");
 
       if (!pname) {
-	pname = NewStringf("arg%d", argidx++);
-	Setattr(p, "name", pname);
+        pname = NewStringf("arg%d", argidx++);
+        Setattr(p, "name", pname);
       }
     }
 
@@ -2437,25 +2437,25 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, dirclassname, parms, 0);
-	String *call = Swig_csuperclass_call(0, basetype, superparms);
-	String *classtype = SwigType_namestr(Getattr(n, "name"));
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, dirclassname, parms, 0);
+        String *call = Swig_csuperclass_call(0, basetype, superparms);
+        String *classtype = SwigType_namestr(Getattr(n, "name"));
 
-	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
-	Printf(f_directors, "  swig_init_callbacks();\n");
-	Printf(f_directors, "}\n\n");
+        Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
+        Printf(f_directors, "  swig_init_callbacks();\n");
+        Printf(f_directors, "}\n\n");
 
-	Delete(classtype);
-	Delete(target);
-	Delete(call);
+        Delete(classtype);
+        Delete(target);
+        Delete(call);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, dirclassname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, dirclassname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -2658,7 +2658,7 @@ private:
     // RESEARCH: What is this good for?
     if (l) {
       if (SwigType_type(Getattr(l, "type")) == T_VOID) {
-	l = nextSibling(l);
+        l = nextSibling(l);
       }
     }
 
@@ -2671,7 +2671,7 @@ private:
     String *return_type = getOutDtype(n);
     if (!return_type) {
       Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	"No dtype typemap defined for %s\n", SwigType_str(t, 0));
+        "No dtype typemap defined for %s\n", SwigType_str(t, 0));
       return_type = NewString("");
     }
 
@@ -2695,7 +2695,7 @@ private:
       // Write the wrapper function call up to the parameter list.
       Printv(imcall, im_dmodule_fq_name, ".$imfuncname(", NIL);
       if (!static_flag) {
-	Printf(imcall, "cast(void*)swigCPtr");
+        Printf(imcall, "cast(void*)swigCPtr");
       }
     }
 
@@ -2708,95 +2708,95 @@ private:
     for (i = 0, p = l; p; i++) {
       // Ignored varargs.
       if (checkAttribute(p, "varargs:ignore", "1")) {
-	Setattr(p, "d:type", NewString(""));
-	p = nextSibling(p);
-	continue;
+        Setattr(p, "d:type", NewString(""));
+        p = nextSibling(p);
+        continue;
       }
 
       // Ignored parameters.
       if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	Setattr(p, "d:type", NewString(""));
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        Setattr(p, "d:type", NewString(""));
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
 
       // Ignore the 'this' argument for variable wrappers.
       if (!(variable_wrapper_flag && i == 0)) {
-	String *param_name = makeParameterName(n, p, i, setter_flag);
-	SwigType *pt = Getattr(p, "type");
+        String *param_name = makeParameterName(n, p, i, setter_flag);
+        SwigType *pt = Getattr(p, "type");
 
-	// Write the wrapper function call argument.
-	{
-	  if (gencomma) {
-	    Printf(imcall, ", ");
-	  }
+        // Write the wrapper function call argument.
+        {
+          if (gencomma) {
+            Printf(imcall, ", ");
+          }
 
-	  if ((tm = lookupDTypemap(p, "din", true))) {
-	    Replaceall(tm, "$dinput", param_name);
-	    String *pre = Getattr(p, "tmap:din:pre");
-	    if (pre) {
-	      replaceClassname(pre, pt);
-	      Replaceall(pre, "$dinput", param_name);
-	      if (Len(pre_code) > 0)
-		Printf(pre_code, "\n");
-	      Printv(pre_code, pre, NIL);
-	    }
-	    String *post = Getattr(p, "tmap:din:post");
-	    if (post) {
-	      replaceClassname(post, pt);
-	      Replaceall(post, "$dinput", param_name);
-	      if (Len(post_code) > 0)
-		Printf(post_code, "\n");
-	      Printv(post_code, post, NIL);
-	    }
-	    String *terminator = Getattr(p, "tmap:din:terminator");
-	    if (terminator) {
-	      replaceClassname(terminator, pt);
-	      Replaceall(terminator, "$dinput", param_name);
-	      if (Len(terminator_code) > 0)
-		Insert(terminator_code, 0, "\n");
-	      Insert(terminator_code, 0, terminator);
-	    }
-	    Printv(imcall, tm, NIL);
-	  } else {
-	    Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
-	      "No din typemap defined for %s\n", SwigType_str(pt, 0));
-	  }
-	}
+          if ((tm = lookupDTypemap(p, "din", true))) {
+            Replaceall(tm, "$dinput", param_name);
+            String *pre = Getattr(p, "tmap:din:pre");
+            if (pre) {
+              replaceClassname(pre, pt);
+              Replaceall(pre, "$dinput", param_name);
+              if (Len(pre_code) > 0)
+                Printf(pre_code, "\n");
+              Printv(pre_code, pre, NIL);
+            }
+            String *post = Getattr(p, "tmap:din:post");
+            if (post) {
+              replaceClassname(post, pt);
+              Replaceall(post, "$dinput", param_name);
+              if (Len(post_code) > 0)
+                Printf(post_code, "\n");
+              Printv(post_code, post, NIL);
+            }
+            String *terminator = Getattr(p, "tmap:din:terminator");
+            if (terminator) {
+              replaceClassname(terminator, pt);
+              Replaceall(terminator, "$dinput", param_name);
+              if (Len(terminator_code) > 0)
+                Insert(terminator_code, 0, "\n");
+              Insert(terminator_code, 0, terminator);
+            }
+            Printv(imcall, tm, NIL);
+          } else {
+            Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
+              "No din typemap defined for %s\n", SwigType_str(pt, 0));
+          }
+        }
 
-	// Write the D proxy function parameter.
-	{
-	  String *proxy_type = NewString("");
+        // Write the D proxy function parameter.
+        {
+          String *proxy_type = NewString("");
 
-	  if ((tm = lookupDTypemap(p, "dtype", true))) {
-	    const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
-	    Printf(proxy_type, "%s%s", inattributes ? inattributes : empty_string, tm);
-	    {
-	      int ln = Len(package);
-	      /* If proxy_type uses the package name, it must be larger */
-	      if (Len(proxy_type) > ln && Strncmp(package, proxy_type, ln) == 0) {
-		Setattr(p, "d:type", NewString(Char(proxy_type) + ln));
-	      } else {
-		Setattr(p, "d:type", Copy(proxy_type));
-	      }
-	    }
-	  } else {
-	    Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	      "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
-	  }
+          if ((tm = lookupDTypemap(p, "dtype", true))) {
+            const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
+            Printf(proxy_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+            {
+              int ln = Len(package);
+              /* If proxy_type uses the package name, it must be larger */
+              if (Len(proxy_type) > ln && Strncmp(package, proxy_type, ln) == 0) {
+                Setattr(p, "d:type", NewString(Char(proxy_type) + ln));
+              } else {
+                Setattr(p, "d:type", Copy(proxy_type));
+              }
+            }
+          } else {
+            Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
+              "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+          }
 
-	  if (gencomma >= 2) {
-	    Printf(param_function_code, ", ");
-	    Printf(proxy_param_types, ", ");
-	  }
-	  gencomma = 2;
-	  Printf(param_function_code, "%s %s", proxy_type, param_name);
-	  Append(proxy_param_types, proxy_type);
+          if (gencomma >= 2) {
+            Printf(param_function_code, ", ");
+            Printf(proxy_param_types, ", ");
+          }
+          gencomma = 2;
+          Printf(param_function_code, "%s %s", proxy_type, param_name);
+          Append(proxy_param_types, proxy_type);
 
-	  Delete(proxy_type);
-	}
+          Delete(proxy_type);
+        }
 
-	Delete(param_name);
+        Delete(param_name);
       }
       p = Getattr(p, "tmap:in:next");
     }
@@ -2807,22 +2807,22 @@ private:
       const String *mods_override = Getattr(n, "feature:d:methodmodifiers");
       bool isPrivate = false;
       if (mods_override) {
-	isPrivate = Strcmp(mods_override, private_string) == 0;
+        isPrivate = Strcmp(mods_override, private_string) == 0;
       } else {
-	mods_override = is_public(n) ? public_string : protected_string;
+        mods_override = is_public(n) ? public_string : protected_string;
       }
       String *modifiers = Copy(mods_override);
       Setattr(n, "dmodify", Copy(mods_override));
 
       /* private function are never override */
       if (super || (!isPrivate && isDOverride(n, l))) {
-	Printf(modifiers, " override");
+        Printf(modifiers, " override");
       }
 
       Chop(modifiers);
 
       if (static_flag) {
-	Printf(modifiers, " static");
+        Printf(modifiers, " static");
       }
 
       Printf(function_code, "%s ", modifiers);
@@ -2847,78 +2847,78 @@ private:
     if (super) {
       Replaceall(imcall, "$funcname", proxy_function_name);
       if (!Cmp(return_type, "void")) {
-	tm = NewString("{\n  $imcall;\n}");
+        tm = NewString("{\n  $imcall;\n}");
       } else {
-	tm = NewString("{\n  return $imcall;\n}");
+        tm = NewString("{\n  return $imcall;\n}");
       }
       Replaceall(tm, "$imcall", imcall);
     } else {
       // Lookup the code used to convert the wrapper return value to the proxy
       // function return type.
       if ((tm = lookupDTypemap(n, "dout"))) {
-	replaceExcode(n, tm, "dout", n);
-	bool is_pre_code = Len(pre_code) > 0;
-	bool is_post_code = Len(post_code) > 0;
-	bool is_terminator_code = Len(terminator_code) > 0;
-	if (is_pre_code || is_post_code || is_terminator_code) {
-	  if (is_post_code) {
-	    Insert(tm, 0, "\n  try ");
-	    Printv(tm, " finally {\n", post_code, "\n  }", NIL);
-	  } else {
-	    Insert(tm, 0, "\n  ");
-	  }
-	  if (is_pre_code) {
-	    Insert(tm, 0, pre_code);
-	    Insert(tm, 0, "\n");
-	  }
-	  if (is_terminator_code) {
-	    Printv(tm, "\n", terminator_code, NIL);
-	  }
-	  Insert(tm, 0, "{");
-	  Printv(tm, "}", NIL);
-	}
-	if (GetFlag(n, "feature:new"))
-	  Replaceall(tm, "$owner", "true");
-	else
-	  Replaceall(tm, "$owner", "false");
-	replaceClassname(tm, t);
+        replaceExcode(n, tm, "dout", n);
+        bool is_pre_code = Len(pre_code) > 0;
+        bool is_post_code = Len(post_code) > 0;
+        bool is_terminator_code = Len(terminator_code) > 0;
+        if (is_pre_code || is_post_code || is_terminator_code) {
+          if (is_post_code) {
+            Insert(tm, 0, "\n  try ");
+            Printv(tm, " finally {\n", post_code, "\n  }", NIL);
+          } else {
+            Insert(tm, 0, "\n  ");
+          }
+          if (is_pre_code) {
+            Insert(tm, 0, pre_code);
+            Insert(tm, 0, "\n");
+          }
+          if (is_terminator_code) {
+            Printv(tm, "\n", terminator_code, NIL);
+          }
+          Insert(tm, 0, "{");
+          Printv(tm, "}", NIL);
+        }
+        if (GetFlag(n, "feature:new"))
+          Replaceall(tm, "$owner", "true");
+        else
+          Replaceall(tm, "$owner", "false");
+        replaceClassname(tm, t);
 
-	// For director methods: generate code to selectively make a normal
-	// polymorphic call or an explicit method call. Needed to prevent infinite
-	// recursion when calling director methods.
-	Node *explicit_n = Getattr(n, "explicitcallnode");
-	if (explicit_n && Swig_directorclass(getCurrentClass())) {
-	  String *ex_overloaded_name = getOverloadedName(explicit_n);
-	  String *ex_intermediary_function_name = Swig_name_member(getNSpace(), proxy_class_name, ex_overloaded_name);
+        // For director methods: generate code to selectively make a normal
+        // polymorphic call or an explicit method call. Needed to prevent infinite
+        // recursion when calling director methods.
+        Node *explicit_n = Getattr(n, "explicitcallnode");
+        if (explicit_n && Swig_directorclass(getCurrentClass())) {
+          String *ex_overloaded_name = getOverloadedName(explicit_n);
+          String *ex_intermediary_function_name = Swig_name_member(getNSpace(), proxy_class_name, ex_overloaded_name);
 
-	  String *ex_imcall = Copy(imcall);
-	  Replaceall(ex_imcall, "$imfuncname", ex_intermediary_function_name);
-	  Replaceall(imcall, "$imfuncname", intermediary_function_name);
+          String *ex_imcall = Copy(imcall);
+          Replaceall(ex_imcall, "$imfuncname", ex_intermediary_function_name);
+          Replaceall(imcall, "$imfuncname", intermediary_function_name);
 
-	  String *override_use_const = NewString("");
-	  if (wrapMemberFunctionAsDConst(n)) {
-	    Printf(override_use_const, "Const");
-	  }
-	  String *excode = NewString("");
-	  if (!Cmp(return_type, "void"))
-	    Printf(excode, "if (swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) %s; else %s",
-	     override_use_const, return_type, proxy_param_types, return_type, proxy_param_types, proxy_function_name, ex_imcall, imcall);
-	  else
-	    Printf(excode, "((swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) ? %s : %s)",
-	     override_use_const, return_type, proxy_param_types, return_type, proxy_param_types, proxy_function_name, ex_imcall, imcall);
+          String *override_use_const = NewString("");
+          if (wrapMemberFunctionAsDConst(n)) {
+            Printf(override_use_const, "Const");
+          }
+          String *excode = NewString("");
+          if (!Cmp(return_type, "void"))
+            Printf(excode, "if (swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) %s; else %s",
+             override_use_const, return_type, proxy_param_types, return_type, proxy_param_types, proxy_function_name, ex_imcall, imcall);
+          else
+            Printf(excode, "((swigIsMethodOverridden%s!(%s delegate(%s), %s function(%s), %s)()) ? %s : %s)",
+             override_use_const, return_type, proxy_param_types, return_type, proxy_param_types, proxy_function_name, ex_imcall, imcall);
 
-	  Clear(imcall);
-	  Printv(imcall, excode, NIL);
-	  Delete(ex_overloaded_name);
-	  Delete(excode);
-	} else {
-	  Replaceall(imcall, "$imfuncname", intermediary_function_name);
-	}
-	Replaceall(tm, "$imfuncname", intermediary_function_name);
-	Replaceall(tm, "$imcall", imcall);
+          Clear(imcall);
+          Printv(imcall, excode, NIL);
+          Delete(ex_overloaded_name);
+          Delete(excode);
+        } else {
+          Replaceall(imcall, "$imfuncname", intermediary_function_name);
+        }
+        Replaceall(tm, "$imfuncname", intermediary_function_name);
+        Replaceall(tm, "$imcall", imcall);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number,
-	  "No dout typemap defined for %s\n", SwigType_str(t, 0));
+        Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number,
+          "No dout typemap defined for %s\n", SwigType_str(t, 0));
       }
     }
 
@@ -2962,7 +2962,7 @@ private:
     // RESEARCH: What is this good for?
     if (l) {
       if (SwigType_type(Getattr(l, "type")) == T_VOID) {
-	l = nextSibling(l);
+        l = nextSibling(l);
       }
     }
 
@@ -2974,7 +2974,7 @@ private:
     String *return_type = getOutDtype(n);
     if (!return_type) {
       Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	"No dtype typemap defined for %s\n", SwigType_str(t, 0));
+        "No dtype typemap defined for %s\n", SwigType_str(t, 0));
       return_type = NewString("");
     }
 
@@ -3009,7 +3009,7 @@ private:
 
       /* Ignored parameters */
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -3017,15 +3017,15 @@ private:
 
       // Get the D parameter type.
       if ((tm = lookupDTypemap(p, "dtype", true))) {
-	const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
-	Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
+        const String *inattributes = Getattr(p, "tmap:dtype:inattributes");
+        Printf(param_type, "%s%s", inattributes ? inattributes : empty_string, tm);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
-	  "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DTYPE_UNDEF, input_file, line_number,
+          "No dtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       if (gencomma)
-	Printf(imcall, ", ");
+        Printf(imcall, ", ");
 
       const bool generating_setter = global_variable_flag || wrapping_member_flag;
       String *arg = makeParameterName(n, p, i, generating_setter);
@@ -3033,40 +3033,40 @@ private:
       // Get the D code to convert the parameter value to the type used in the
       // wrapper D module.
       if ((tm = lookupDTypemap(p, "din", true))) {
-	Replaceall(tm, "$dinput", arg);
-	String *pre = Getattr(p, "tmap:din:pre");
-	if (pre) {
-	  replaceClassname(pre, pt);
-	  Replaceall(pre, "$dinput", arg);
-	  if (Len(pre_code) > 0)
-	    Printf(pre_code, "\n");
-	  Printv(pre_code, pre, NIL);
-	}
-	String *post = Getattr(p, "tmap:din:post");
-	if (post) {
-	  replaceClassname(post, pt);
-	  Replaceall(post, "$dinput", arg);
-	  if (Len(post_code) > 0)
-	    Printf(post_code, "\n");
-	  Printv(post_code, post, NIL);
-	}
-	String *terminator = Getattr(p, "tmap:din:terminator");
-	if (terminator) {
-	  replaceClassname(terminator, pt);
-	  Replaceall(terminator, "$dinput", arg);
-	  if (Len(terminator_code) > 0)
-	    Insert(terminator_code, 0, "\n");
-	  Insert(terminator_code, 0, terminator);
-	}
-	Printv(imcall, tm, NIL);
+        Replaceall(tm, "$dinput", arg);
+        String *pre = Getattr(p, "tmap:din:pre");
+        if (pre) {
+          replaceClassname(pre, pt);
+          Replaceall(pre, "$dinput", arg);
+          if (Len(pre_code) > 0)
+            Printf(pre_code, "\n");
+          Printv(pre_code, pre, NIL);
+        }
+        String *post = Getattr(p, "tmap:din:post");
+        if (post) {
+          replaceClassname(post, pt);
+          Replaceall(post, "$dinput", arg);
+          if (Len(post_code) > 0)
+            Printf(post_code, "\n");
+          Printv(post_code, post, NIL);
+        }
+        String *terminator = Getattr(p, "tmap:din:terminator");
+        if (terminator) {
+          replaceClassname(terminator, pt);
+          Replaceall(terminator, "$dinput", arg);
+          if (Len(terminator_code) > 0)
+            Insert(terminator_code, 0, "\n");
+          Insert(terminator_code, 0, terminator);
+        }
+        Printv(imcall, tm, NIL);
       } else {
-	Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
-	  "No din typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_D_TYPEMAP_DIN_UNDEF, input_file, line_number,
+          "No din typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to module class function */
       if (gencomma >= 2)
-	Printf(function_code, ", ");
+        Printf(function_code, ", ");
       gencomma = 2;
       Printf(function_code, "%s %s", param_type, arg);
 
@@ -3090,32 +3090,32 @@ private:
       bool is_post_code = Len(post_code) > 0;
       bool is_terminator_code = Len(terminator_code) > 0;
       if (is_pre_code || is_post_code || is_terminator_code) {
-	if (is_post_code) {
-	  Insert(tm, 0, "\n  try ");
-	  Printv(tm, " finally {\n", post_code, "\n  }", NIL);
-	} else {
-	  Insert(tm, 0, "\n  ");
-	}
-	if (is_pre_code) {
-	  Insert(tm, 0, pre_code);
-	  Insert(tm, 0, "\n");
-	}
-	if (is_terminator_code) {
-	  Printv(tm, "\n", terminator_code, NIL);
-	}
-	Insert(tm, 0, " {");
-	Printf(tm, "\n}");
+        if (is_post_code) {
+          Insert(tm, 0, "\n  try ");
+          Printv(tm, " finally {\n", post_code, "\n  }", NIL);
+        } else {
+          Insert(tm, 0, "\n  ");
+        }
+        if (is_pre_code) {
+          Insert(tm, 0, pre_code);
+          Insert(tm, 0, "\n");
+        }
+        if (is_terminator_code) {
+          Printv(tm, "\n", terminator_code, NIL);
+        }
+        Insert(tm, 0, " {");
+        Printf(tm, "\n}");
       }
       if (GetFlag(n, "feature:new"))
-	Replaceall(tm, "$owner", "true");
+        Replaceall(tm, "$owner", "true");
       else
-	Replaceall(tm, "$owner", "false");
+        Replaceall(tm, "$owner", "false");
       replaceClassname(tm, t);
       Replaceall(tm, "$imfuncname", overloaded_name);
       Replaceall(tm, "$imcall", imcall);
     } else {
       Swig_warning(WARN_D_TYPEMAP_DOUT_UNDEF, input_file, line_number,
-	"No dout typemap defined for %s\n", SwigType_str(t, 0));
+        "No dout typemap defined for %s\n", SwigType_str(t, 0));
     }
 
     // The whole function code is now stored in tm (if there was a matching
@@ -3170,27 +3170,27 @@ private:
     if (!purebase_replace) {
       List *baselist = Getattr(n, "bases");
       if (baselist) {
-	Iterator base = First(baselist);
-	while (base.item) {
-	  if (!GetFlag(base.item, "feature:ignore")) {
-	    SwigType *baseclassname = Getattr(base.item, "name");
-	    if (!c_baseclassname) {
-	      basenode = base.item;
-	      String *name = createProxyName(baseclassname);
-	      if (name) {
-		c_baseclassname = baseclassname;
-		baseclass = name;
-		bsmart = Getattr(base.item, "smart");
-	      }
-	    } else {
-	      /* Warn about multiple inheritance for additional base class(es) */
-	      String *proxyclassname = Getattr(n, "classtypeobj");
-	      Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		  "Base %s of class %s ignored: multiple inheritance is not supported in D.\n", SwigType_namestr(baseclassname), SwigType_namestr(proxyclassname));
-	    }
-	  }
-	  base = Next(base);
-	}
+        Iterator base = First(baselist);
+        while (base.item) {
+          if (!GetFlag(base.item, "feature:ignore")) {
+            SwigType *baseclassname = Getattr(base.item, "name");
+            if (!c_baseclassname) {
+              basenode = base.item;
+              String *name = createProxyName(baseclassname);
+              if (name) {
+                c_baseclassname = baseclassname;
+                baseclass = name;
+                bsmart = Getattr(base.item, "smart");
+              }
+            } else {
+              /* Warn about multiple inheritance for additional base class(es) */
+              String *proxyclassname = Getattr(n, "classtypeobj");
+              Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+                  "Base %s of class %s ignored: multiple inheritance is not supported in D.\n", SwigType_namestr(baseclassname), SwigType_namestr(proxyclassname));
+            }
+          }
+          base = Next(base);
+        }
       }
     }
 
@@ -3207,14 +3207,14 @@ private:
       basenode = NULL;
       baseclass = NULL;
       if (purebase_notderived) {
-	Swig_error(Getfile(n), Getline(n),
-	  "The dbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n",
-	  typemap_lookup_type);
+        Swig_error(Getfile(n), Getline(n),
+          "The dbase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n",
+          typemap_lookup_type);
       }
     } else if (baseclass && Len(pure_baseclass) > 0) {
       Swig_warning(WARN_D_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-	"Warning for %s, base class %s ignored. Multiple inheritance is not supported in D. "
-	"Perhaps you need one of the 'replace' or 'notderived' attributes in the dbase typemap?\n", typemap_lookup_type, pure_baseclass);
+        "Warning for %s, base class %s ignored. Multiple inheritance is not supported in D. "
+        "Perhaps you need one of the 'replace' or 'notderived' attributes in the dbase typemap?\n", typemap_lookup_type, pure_baseclass);
     }
 
     // Add code to do C++ casting to base class (only for classes in an inheritance hierarchy)
@@ -3305,24 +3305,24 @@ private:
 
     if (tm && *Char(tm)) {
       if (!dispose_methodname) {
-	Swig_error(Getfile(n), Getline(n),
-	  "No methodname attribute defined in the ddispose%s typemap for %s\n",
-	  (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(Getfile(n), Getline(n),
+          "No methodname attribute defined in the ddispose%s typemap for %s\n",
+          (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!dispose_methodmodifiers) {
-	Swig_error(Getfile(n), Getline(n),
-	  "No methodmodifiers attribute defined in ddispose%s typemap for %s.\n",
-	  (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(Getfile(n), Getline(n),
+          "No methodmodifiers attribute defined in ddispose%s typemap for %s.\n",
+          (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!dispose_parameters)
-	dispose_parameters = empty_string;
+        dispose_parameters = empty_string;
     }
 
     if (tm) {
       // Write the destructor if the C++ one is accessible.
       if (*Char(destructor_call)) {
-	Printv(body,
-	  lookupCodeTypemap(n, "ddestructor", typemap_lookup_type, WARN_NONE), NIL);
+        Printv(body,
+          lookupCodeTypemap(n, "ddestructor", typemap_lookup_type, WARN_NONE), NIL);
       }
 
       // Write the dispose() method.
@@ -3330,19 +3330,19 @@ private:
       Printv(dispose_code, tm, NIL);
 
       if (*Char(destructor_call)) {
-	Replaceall(dispose_code, "$imcall", destructor_call);
+        Replaceall(dispose_code, "$imcall", destructor_call);
       } else {
-	Replaceall(dispose_code, "$imcall", "throw new object.Exception(\"C++ destructor does not have public access\")");
+        Replaceall(dispose_code, "$imcall", "throw new object.Exception(\"C++ destructor does not have public access\")");
       }
 
       if (*Char(dispose_code)) {
-	Printv(body, "\n", NIL);
-	const String *methodmods = Getattr(n, "destructmethodmodifiers");
-	if (methodmods)
-	  Printv(body, methodmods, NIL);
-	else
-	  Printv(body, dispose_methodmodifiers, (derived ? " override" : ""), NIL);
-	Printv(body, " void ", dispose_methodname, "(", dispose_parameters, ") ", dispose_code, "\n", NIL);
+        Printv(body, "\n", NIL);
+        const String *methodmods = Getattr(n, "destructmethodmodifiers");
+        if (methodmods)
+          Printv(body, methodmods, NIL);
+        else
+          Printv(body, dispose_methodmodifiers, (derived ? " override" : ""), NIL);
+        Printv(body, " void ", dispose_methodname, "(", dispose_parameters, ") ", dispose_code, "\n", NIL);
       }
     }
 
@@ -3393,26 +3393,26 @@ private:
 
     if (smart) {
       if (bsmart) {
-	String *smartnamestr = SwigType_namestr(smart);
-	String *bsmartnamestr = SwigType_namestr(bsmart);
+        String *smartnamestr = SwigType_namestr(smart);
+        String *bsmartnamestr = SwigType_namestr(bsmart);
 
-	Printv(upcasts_code,
-	  "SWIGEXPORT ", bsmartnamestr, " * ", upcast_wrapper_name,
-	    "(", smartnamestr, " *objectRef) {\n",
-	  "    return objectRef ? new ", bsmartnamestr, "(*objectRef) : 0;\n"
-	  "}\n",
-	  "\n", NIL);
+        Printv(upcasts_code,
+          "SWIGEXPORT ", bsmartnamestr, " * ", upcast_wrapper_name,
+            "(", smartnamestr, " *objectRef) {\n",
+          "    return objectRef ? new ", bsmartnamestr, "(*objectRef) : 0;\n"
+          "}\n",
+          "\n", NIL);
 
-	Delete(bsmartnamestr);
-	Delete(smartnamestr);
+        Delete(bsmartnamestr);
+        Delete(smartnamestr);
       }
     } else {
       Printv(upcasts_code,
-	"SWIGEXPORT ", baseclassname, " * ", upcast_wrapper_name,
-	  "(", classname, " *objectRef) {\n",
-	"    return (", baseclassname, " *)objectRef;\n"
-	"}\n",
-	"\n", NIL);
+        "SWIGEXPORT ", baseclassname, " * ", upcast_wrapper_name,
+          "(", classname, " *objectRef) {\n",
+        "    return (", baseclassname, " *)objectRef;\n"
+        "}\n",
+        "\n", NIL);
     }
 
     Replaceall(upcasts_code, "$cclass", classname);
@@ -3441,8 +3441,8 @@ private:
       String *filename = NewStringf("%s%s.d", dmodule_directory, classname);
       class_file = NewFile(filename, "w", SWIG_output_files());
       if (!class_file) {
-	FileErrorDisplay(filename);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filename);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filename));
       Delete(filename);
@@ -3592,15 +3592,15 @@ private:
     for (int i = 0; i < len; i++) {
       Node *item = Getitem(vtable, i);
       if (GetFlag(item, "director")) {
-	Node *method = Getattr(item, "methodNode");
-	Node *p = parentNode(method);
-	if (p && p != n && is_protected(method)) {
-	  const String *nodeType = nodeType(method);
-	  if (Strcmp(nodeType, "cdecl") == 0) {
-	    Setattr(method, "proxyfuncname", Getattr(method, "sym:name"));
-	    writeProxyClassFunction(method, true);
-	  }
-	}
+        Node *method = Getattr(item, "methodNode");
+        Node *p = parentNode(method);
+        if (p && p != n && is_protected(method)) {
+          const String *nodeType = nodeType(method);
+          if (Strcmp(nodeType, "cdecl") == 0) {
+            Setattr(method, "proxyfuncname", Getattr(method, "sym:name"));
+            writeProxyClassFunction(method, true);
+          }
+        }
       }
     }
   }
@@ -3674,9 +3674,9 @@ private:
       String *import = createImportStatement(dmodule);
       Append(import, "\n");
       if (is_wrapping_class()) {
-	addImportStatement(proxy_class_imports, import);
+        addImportStatement(proxy_class_imports, import);
       } else {
-	addImportStatement(proxyImportsBuffer(getNSpace()), import);
+        addImportStatement(proxyImportsBuffer(getNSpace()), import);
       }
       Delete(import);
     }
@@ -3701,10 +3701,10 @@ private:
       // characters would be part of the previous import statement then.
 
       if (position - Char(target) < 7) {
-	return;
+        return;
       }
       if (strncmp(position - 7, "static ", 7)) {
-	return;
+        return;
       }
     }
 
@@ -3746,7 +3746,7 @@ private:
       // one argument is 0 ("<").
       bool result = !nspace && !getNSpace();
       if (nspace && getNSpace())
-	result = (Strcmp(nspace, getNSpace()) == 0);
+        result = (Strcmp(nspace, getNSpace()) == 0);
 
       Delete(nspace);
       return result;
@@ -3797,53 +3797,53 @@ private:
     // split proxy mode, warnings for these should be added.
     if (split_proxy_dmodule) {
       if (Cmp(class_name, im_dmodule_name) == 0) {
-	Swig_error(input_file, line_number,
-	  "Class name cannot be equal to intermediary D module name: %s\n",
-	  class_name);
-	Exit(EXIT_FAILURE);
+        Swig_error(input_file, line_number,
+          "Class name cannot be equal to intermediary D module name: %s\n",
+          class_name);
+        Exit(EXIT_FAILURE);
       }
 
       String *nspace = getNSpace();
       if (nspace) {
-	// Check the root package/outermost namespace (a class A in module
-	// A.B leads to problems if another module A.C is also imported)
-	if (Len(package) > 0) {
-	  String *dotless_package = NewStringWithSize(package, Len(package) - 1);
-	  if (Cmp(class_name, dotless_package) == 0) {
-	    Swig_error(input_file, line_number,
-	      "Class name cannot be the same as the root package it is in: %s\n",
-	      class_name);
-	    Exit(EXIT_FAILURE);
-	  }
-	  Delete(dotless_package);
-	} else {
-	  String *outer = createFirstNamespaceName(nspace);
-	  if (Cmp(class_name, outer) == 0) {
-	    Swig_error(input_file, line_number,
-	      "Class name cannot be the same as the outermost namespace it is in: %s\n",
-	      class_name);
-	    Exit(EXIT_FAILURE);
-	  }
-	  Delete(outer);
-	}
+        // Check the root package/outermost namespace (a class A in module
+        // A.B leads to problems if another module A.C is also imported)
+        if (Len(package) > 0) {
+          String *dotless_package = NewStringWithSize(package, Len(package) - 1);
+          if (Cmp(class_name, dotless_package) == 0) {
+            Swig_error(input_file, line_number,
+              "Class name cannot be the same as the root package it is in: %s\n",
+              class_name);
+            Exit(EXIT_FAILURE);
+          }
+          Delete(dotless_package);
+        } else {
+          String *outer = createFirstNamespaceName(nspace);
+          if (Cmp(class_name, outer) == 0) {
+            Swig_error(input_file, line_number,
+              "Class name cannot be the same as the outermost namespace it is in: %s\n",
+              class_name);
+            Exit(EXIT_FAILURE);
+          }
+          Delete(outer);
+        }
 
-	// … and the innermost one (because of the conflict with the main proxy
-	// module named like the namespace).
-	String *inner = createLastNamespaceName(nspace);
-	if (Cmp(class_name, inner) == 0) {
-	  Swig_error(input_file, line_number,
-	    "Class name cannot be the same as the innermost namespace it is in: %s\n",
-	    class_name);
-	  Exit(EXIT_FAILURE);
-	}
-	Delete(inner);
+        // … and the innermost one (because of the conflict with the main proxy
+        // module named like the namespace).
+        String *inner = createLastNamespaceName(nspace);
+        if (Cmp(class_name, inner) == 0) {
+          Swig_error(input_file, line_number,
+            "Class name cannot be the same as the innermost namespace it is in: %s\n",
+            class_name);
+          Exit(EXIT_FAILURE);
+        }
+        Delete(inner);
       } else {
-	if (Cmp(class_name, proxy_dmodule_name) == 0) {
-	  Swig_error(input_file, line_number,
-	    "Class name cannot be equal to proxy D module name: %s\n",
-	    class_name);
-	  Exit(EXIT_FAILURE);
-	}
+        if (Cmp(class_name, proxy_dmodule_name) == 0) {
+          Swig_error(input_file, line_number,
+            "Class name cannot be equal to proxy D module name: %s\n",
+            class_name);
+          Exit(EXIT_FAILURE);
+        }
       }
     }
   }
@@ -3863,9 +3863,9 @@ private:
       SwigType_del_reference(stripped_type);
 
       if (SwigType_isconst(stripped_type)) {
-	SwigType_del_qualifier(stripped_type);
+        SwigType_del_qualifier(stripped_type);
       } else {
-	mutable_ref = true;
+        mutable_ref = true;
       }
     }
 
@@ -3889,38 +3889,38 @@ private:
       String *return_dtype = getPrimitiveDptype(node, return_type);
       Delete(return_type);
       if (!return_dtype) {
-	return 0;
+        return 0;
       }
 
       List *parms = SwigType_parmlist(params_type);
       List *param_dtypes = NewList();
       for (Iterator it = First(parms); it.item; it = Next(it)) {
-	String *current_dtype = getPrimitiveDptype(node, it.item);
-	if (Cmp(current_dtype, "void") == 0) {
-	  // void somefunc(void) is legal syntax in C, but not in D, so simply
-	  // skip the void parameter.
-	  Delete(current_dtype);
-	  continue;
-	}
-	if (!current_dtype) {
-	  Delete(return_dtype);
-	  Delete(param_dtypes);
-	  return 0;
-	}
-	Append(param_dtypes, current_dtype);
+        String *current_dtype = getPrimitiveDptype(node, it.item);
+        if (Cmp(current_dtype, "void") == 0) {
+          // void somefunc(void) is legal syntax in C, but not in D, so simply
+          // skip the void parameter.
+          Delete(current_dtype);
+          continue;
+        }
+        if (!current_dtype) {
+          Delete(return_dtype);
+          Delete(param_dtypes);
+          return 0;
+        }
+        Append(param_dtypes, current_dtype);
       }
 
       String *param_list = NewString("");
       {
-	bool gen_comma = false;
-	for (Iterator it = First(param_dtypes); it.item; it = Next(it)) {
-	  if (gen_comma) {
-	    Append(param_list, ", ");
-	  }
-	  Append(param_list, it.item);
-	  Delete(it.item);
-	  gen_comma = true;
-	}
+        bool gen_comma = false;
+        for (Iterator it = First(param_dtypes); it.item; it = Next(it)) {
+          if (gen_comma) {
+            Append(param_list, ", ");
+          }
+          Append(param_list, it.item);
+          Delete(it.item);
+          gen_comma = true;
+        }
       }
 
       dtype = NewStringf("%s.SwigExternC!(%s function(%s))", im_dmodule_fq_name,
@@ -3931,16 +3931,16 @@ private:
     } else {
       Hash *attributes = NewHash();
       const String *tm =
-	lookupCodeTypemap(node, "dtype", stripped_type, WARN_NONE, attributes);
+        lookupCodeTypemap(node, "dtype", stripped_type, WARN_NONE, attributes);
       if(!GetFlag(attributes, "tmap:dtype:cprimitive")) {
-	dtype = 0;
+        dtype = 0;
       } else {
-	dtype = Copy(tm);
+        dtype = Copy(tm);
 
-	// We need to call replaceClassname here with the stripped type to avoid
-	// $dclassname in the enum typemaps being replaced later with the full
-	// type.
-	replaceClassname(dtype, stripped_type);
+        // We need to call replaceClassname here with the stripped type to avoid
+        // $dclassname in the enum typemaps being replaced later with the full
+        // type.
+        replaceClassname(dtype, stripped_type);
       }
       Delete(attributes);
     }
@@ -3991,8 +3991,8 @@ private:
     if (!tm) {
       tm = empty_string;
       if (warning != WARN_NONE) {
-	Swig_warning(warning, Getfile(n), Getline(n),
-	  "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
+        Swig_warning(warning, Getfile(n), Getline(n),
+          "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
       }
     }
     if (!typemap_attributes) {
@@ -4130,71 +4130,71 @@ private:
       // RESEARCH: Make sure that we really cannot get here for anonymous enums.
       Node *n = enumLookup(type);
       if (n) {
-	String *enum_name = Getattr(n, "sym:name");
+        String *enum_name = Getattr(n, "sym:name");
 
-	Node *p = parentNode(n);
-	if (p && !Strcmp(nodeType(p), "class")) {
-	  // This is a nested enum.
-	  String *parent_name = Getattr(p, "sym:name");
-	  String *nspace = Getattr(p, "sym:nspace");
+        Node *p = parentNode(n);
+        if (p && !Strcmp(nodeType(p), "class")) {
+          // This is a nested enum.
+          String *parent_name = Getattr(p, "sym:name");
+          String *nspace = Getattr(p, "sym:nspace");
 
-	  // An enum nested in a class is not written to a separate module (this
-	  // would not even be possible in D), so just import the parent.
-	  requireDType(nspace, parent_name);
+          // An enum nested in a class is not written to a separate module (this
+          // would not even be possible in D), so just import the parent.
+          requireDType(nspace, parent_name);
 
-	  String *module = createModuleName(nspace, parent_name);
-	  if (inProxyModule(module)) {
-	    type_name = NewStringf("%s.%s", parent_name, enum_name);
-	  } else {
-	    type_name = NewStringf("%s%s.%s.%s", package, module, parent_name, enum_name);
-	  }
-	} else {
-	  // A non-nested enum is written to a separate module, import it.
-	  String *nspace = Getattr(n, "sym:nspace");
-	  requireDType(nspace, enum_name);
+          String *module = createModuleName(nspace, parent_name);
+          if (inProxyModule(module)) {
+            type_name = NewStringf("%s.%s", parent_name, enum_name);
+          } else {
+            type_name = NewStringf("%s%s.%s.%s", package, module, parent_name, enum_name);
+          }
+        } else {
+          // A non-nested enum is written to a separate module, import it.
+          String *nspace = Getattr(n, "sym:nspace");
+          requireDType(nspace, enum_name);
 
-	  String *module = createModuleName(nspace, enum_name);
-	  if (inProxyModule(module)) {
-	    type_name = Copy(enum_name);
-	  } else {
-	    type_name = NewStringf("%s%s.%s", package, module, enum_name);
-	  }
-	}
+          String *module = createModuleName(nspace, enum_name);
+          if (inProxyModule(module)) {
+            type_name = Copy(enum_name);
+          } else {
+            type_name = NewStringf("%s%s.%s", package, module, enum_name);
+          }
+        }
       } else {
-	type_name = NewStringf("int");
+        type_name = NewStringf("int");
       }
     } else {
       Node *n = classLookup(type);
       if (n) {
-	String *class_name = Getattr(n, "sym:name");
-	String *nspace = Getattr(n, "sym:nspace");
-	requireDType(nspace, class_name);
+        String *class_name = Getattr(n, "sym:name");
+        String *nspace = Getattr(n, "sym:nspace");
+        requireDType(nspace, class_name);
 
-	String *module = createModuleName(nspace, class_name);
-	if (inProxyModule(module)) {
-	  type_name = Copy(class_name);
-	} else {
-	  type_name = NewStringf("%s%s.%s", package, module, class_name);
-	}
+        String *module = createModuleName(nspace, class_name);
+        if (inProxyModule(module)) {
+          type_name = Copy(class_name);
+        } else {
+          type_name = NewStringf("%s%s.%s", package, module, class_name);
+        }
         Delete(module);
       } else {
-	// SWIG does not know anything about the type (after resolving typedefs).
-	// Just mangle the type name string like $descriptor(type) would do.
-	String *descriptor = NewStringf("SWIGTYPE%s", SwigType_manglestr(type));
-	requireDType(NULL, descriptor);
+        // SWIG does not know anything about the type (after resolving typedefs).
+        // Just mangle the type name string like $descriptor(type) would do.
+        String *descriptor = NewStringf("SWIGTYPE%s", SwigType_manglestr(type));
+        requireDType(NULL, descriptor);
 
-	String *module = createModuleName(NULL, descriptor);
-	if (inProxyModule(module)) {
-	  type_name = Copy(descriptor);
-	} else {
-	  type_name = NewStringf("%s%s.%s", package, module, descriptor);
-	}
-	Delete(module);
+        String *module = createModuleName(NULL, descriptor);
+        if (inProxyModule(module)) {
+          type_name = Copy(descriptor);
+        } else {
+          type_name = NewStringf("%s%s.%s", package, module, descriptor);
+        }
+        Delete(module);
 
-	// Add to hash table so that a type wrapper class can be created later.
-	Setattr(unknown_types, descriptor, type);
+        // Add to hash table so that a type wrapper class can be created later.
+        Setattr(unknown_types, descriptor, type);
 
-	Delete(descriptor);
+        Delete(descriptor);
       }
     }
 
@@ -4213,17 +4213,17 @@ private:
     if (nspace) {
       module = NewStringf("%s.", nspace);
       if (split_proxy_dmodule) {
-	Printv(module, type_name, NIL);
+        Printv(module, type_name, NIL);
       } else {
-	String *inner = createLastNamespaceName(nspace);
-	Printv(module, inner, NIL);
-	Delete(inner);
+        String *inner = createLastNamespaceName(nspace);
+        Printv(module, inner, NIL);
+        Delete(inner);
       }
     } else {
       if (split_proxy_dmodule) {
-	module = Copy(type_name);
+        module = Copy(type_name);
       } else {
-	module = Copy(proxy_dmodule_name);
+        module = Copy(proxy_dmodule_name);
       }
     }
     return module;
@@ -4256,9 +4256,9 @@ private:
     if (Getattr(n, "d:canthrow")) {
       int count = Replaceall(code, "$excode", excode);
       if (count < 1 || !excode) {
-	Swig_warning(WARN_D_EXCODE_MISSING, input_file, line_number,
-	  "D exception may not be thrown – no $excode or excode attribute in '%s' typemap.\n",
-	  typemap);
+        Swig_warning(WARN_D_EXCODE_MISSING, input_file, line_number,
+          "D exception may not be thrown – no $excode or excode attribute in '%s' typemap.\n",
+          typemap);
       }
     } else {
       Replaceall(code, "$excode", "");
@@ -4283,43 +4283,43 @@ private:
       int level = 0;
       char *c = start;
       while (*c) {
-	if (*c == '(') {
-	  if (level == 0) {
-	    param_start = c + 1;
-	  }
-	  level++;
-	}
-	if (*c == ')') {
-	  level--;
-	  if (level == 0) {
-	    param_end = c;
-	    end = c + 1;
-	    break;
-	  }
-	}
-	c++;
+        if (*c == '(') {
+          if (level == 0) {
+            param_start = c + 1;
+          }
+          level++;
+        }
+        if (*c == ')') {
+          level--;
+          if (level == 0) {
+            param_end = c;
+            end = c + 1;
+            break;
+          }
+        }
+        c++;
       }
 
       if (end) {
-	String *current_macro = NewStringWithSize(start, (int)(end - start));
-	String *current_param = NewStringWithSize(param_start, (int)(param_end - param_start));
+        String *current_macro = NewStringWithSize(start, (int)(end - start));
+        String *current_param = NewStringWithSize(param_start, (int)(param_end - param_start));
 
 
-	if (inProxyModule(current_param)) {
-	  Replace(target, current_macro, "", DOH_REPLACE_ANY);
-	} else {
-	  String *import = createImportStatement(current_param, false);
-	  Replace(target, current_macro, import, DOH_REPLACE_ANY);
-	  Delete(import);
-	}
+        if (inProxyModule(current_param)) {
+          Replace(target, current_macro, "", DOH_REPLACE_ANY);
+        } else {
+          String *import = createImportStatement(current_param, false);
+          Replace(target, current_macro, import, DOH_REPLACE_ANY);
+          Delete(import);
+        }
 
-	Delete(current_param);
-	Delete(current_macro);
+        Delete(current_param);
+        Delete(current_macro);
       } else {
-	String *current_macro = NewStringWithSize(start, (int)(c - start));
-	Swig_error(Getfile(target), Getline(target), "Syntax error in: %s\n", current_macro);
-	Replace(target, current_macro, "<error in $importtype macro>", DOH_REPLACE_ANY);
-	Delete(current_macro);
+        String *current_macro = NewStringWithSize(start, (int)(c - start));
+        Swig_error(Getfile(target), Getline(target), "Syntax error in: %s\n", current_macro);
+        Replace(target, current_macro, "<error in $importtype macro>", DOH_REPLACE_ANY);
+        Delete(current_macro);
       }
     }
   }
@@ -4356,9 +4356,9 @@ private:
 
       String *module = createModuleName(nspace, symname);
       if (inProxyModule(module)) {
-	proxyname = Copy(symname);
+        proxyname = Copy(symname);
       } else {
-	proxyname = NewStringf("%s%s.%s", package, module, symname);
+        proxyname = NewStringf("%s%s.%s", package, module, symname);
       }
     }
     return proxyname;
@@ -4437,11 +4437,11 @@ private:
     String *symname = Getattr(n, "sym:name");
     if (symname) {
       for (Node *tmp = firstChild(base_class); tmp; tmp = nextSibling(tmp)) {
-	String *child_symname = Getattr(tmp, "sym:name");
-	if (child_symname && (Strcmp(child_symname, symname) == 0)) {
-	  base_function = tmp;
-	  break;
-	}
+        String *child_symname = Getattr(tmp, "sym:name");
+        if (child_symname && (Strcmp(child_symname, symname) == 0)) {
+          base_function = tmp;
+          break;
+        }
       }
     }
 
@@ -4454,13 +4454,13 @@ private:
     size_t base_overload_count = 0;
     for (Node *tmp = firstSibling(base_function); tmp; tmp = Getattr(tmp, "sym:nextSibling")) {
       if (is_protected(base_function) &&
-	  !(Swig_director_mode() && Swig_director_protected_mode() && Swig_all_protected_mode())) {
-	// If the base class function is »protected« and were are not in
-	// director mode, it is not emitted to the base class and thus we do
-	// not count it. Otherwise, we would run into issues if the visibility
-	// of some functions was changed from protected to public in a child
-	// class with the using directive.
-	continue;
+          !(Swig_director_mode() && Swig_director_protected_mode() && Swig_all_protected_mode())) {
+        // If the base class function is »protected« and were are not in
+        // director mode, it is not emitted to the base class and thus we do
+        // not count it. Otherwise, we would run into issues if the visibility
+        // of some functions was changed from protected to public in a child
+        // class with the using directive.
+        continue;
       }
       ++base_overload_count;
     }
@@ -4484,38 +4484,38 @@ private:
       const String *ename = Getattr(e, "name");
       const String *etype = nodeType(e);
       if (Strcmp(etype, "extend") == 0) {
-	/* extend of class do not have a name attribute,
-	 * it is the same class. */
-	if (checkClassBaseOver(e, name, l, llen, bname)) {
-	  return true;
-	}
+        /* extend of class do not have a name attribute,
+         * it is the same class. */
+        if (checkClassBaseOver(e, name, l, llen, bname)) {
+          return true;
+        }
       } else if (Strcmp(etype, "cdecl") == 0 || Strcmp(etype, "using") == 0) {
-	/* 'using' is marked in markDOverride() same as 'cdecl' */
-	if (Strcmp(name, ename) == 0) {
-	  if (GetFlag(e, "d:override_property")) {
-	    return true;
-	  }
-	  /* Do we need a full compare of ParmList? How about in typemaps? */
-	  ParmList *el = Getattr(e, "d:override_parms");
-	  const int ellen = ParmList_len(el);
-	  if (GetFlag(e, "d:can_override") && ellen == llen) {
-	    bool eq = true;
-	    String *detd = NewString("");
-	    if (llen > 0) {
-	      for(ParmList *le = el, *ln = l; eq && le && ln; le = nextSibling(le), ln = nextSibling(ln)) {
-		const String *ntd = Getattr(ln, "d:type");
-		const String *etd = Getattr(le, "d:type");
-		Printf(detd, "%s.%s", etd, etd);
-		/* Parameter types are equal, or the type is 'class.class' */
-		eq = etd && ntd && (Strcmp(ntd, etd) == 0 || Strcmp(ntd, detd) == 0);
-	      }
-	    }
-	    Delete(detd);
-	    if (eq) {
-	      return true;
-	    }
-	  }
-	}
+        /* 'using' is marked in markDOverride() same as 'cdecl' */
+        if (Strcmp(name, ename) == 0) {
+          if (GetFlag(e, "d:override_property")) {
+            return true;
+          }
+          /* Do we need a full compare of ParmList? How about in typemaps? */
+          ParmList *el = Getattr(e, "d:override_parms");
+          const int ellen = ParmList_len(el);
+          if (GetFlag(e, "d:can_override") && ellen == llen) {
+            bool eq = true;
+            String *detd = NewString("");
+            if (llen > 0) {
+              for(ParmList *le = el, *ln = l; eq && le && ln; le = nextSibling(le), ln = nextSibling(ln)) {
+                const String *ntd = Getattr(ln, "d:type");
+                const String *etd = Getattr(le, "d:type");
+                Printf(detd, "%s.%s", etd, etd);
+                /* Parameter types are equal, or the type is 'class.class' */
+                eq = etd && ntd && (Strcmp(ntd, etd) == 0 || Strcmp(ntd, detd) == 0);
+              }
+            }
+            Delete(detd);
+            if (eq) {
+              return true;
+            }
+          }
+        }
       }
     }
     return false;
@@ -4539,10 +4539,10 @@ private:
     for (int i = 0; i < Len(bases); i++) {
       Node *b = Getitem(bases, i);
       if (checkClassBaseOver(b, name, l, llen)) {
-	return true;
+        return true;
       }
       if (checkBaseOver(b, name, l, llen)) {
-	return true;
+        return true;
       }
     }
     return false;
@@ -4557,19 +4557,19 @@ private:
      if (!pname && Strcmp(ptype, "extend") == 0) {
        Node *pp = parentNode(p);
        if (pp) {
-	 pname = Getattr(pp, "name");
+         pname = Getattr(pp, "name");
        }
      }
     for(Node *e = firstChild(p); e; e = nextSibling(e)) {
       /* Am I in my class? */
       if (n == e) {
-	SetFlag(n, "d:can_override");
-	if (wrapping_member_flag) {
-	  SetFlag(n, "d:override_property");
-	} else {
-	  Setattr(n, "d:override_parms", CopyParmList(l));
-	}
-	return;
+        SetFlag(n, "d:can_override");
+        if (wrapping_member_flag) {
+          SetFlag(n, "d:override_property");
+        } else {
+          Setattr(n, "d:override_parms", CopyParmList(l));
+        }
+        return;
       }
     }
     /*
@@ -4582,9 +4582,9 @@ private:
       const String *ename = Getattr(e, "name");
       const String *ntype = nodeType(e);
       if (ename && Strcmp(ename, name) == 0 && ntype && Strcmp(ntype, "using") == 0) {
-	SetFlag(e, "d:can_override");
-	Setattr(e, "d:override_parms", CopyParmList(l));
-	return;
+        SetFlag(e, "d:can_override");
+        Setattr(e, "d:override_parms", CopyParmList(l));
+        return;
       }
     }
   }
@@ -4640,7 +4640,7 @@ private:
       // is thus taken into account when counting the base class overloads, even
       // if it is not marked as »override« by the SWIG parser.
       if (Getattr(n, "override") || !Getattr(n, "access")) {
-	++result;
+        ++result;
       }
     } while((tmp = Getattr(tmp, "sym:nextSibling")));
 
@@ -4691,11 +4691,11 @@ private:
     if (result) {
       String *dtypeout = Copy(Getattr(n, "tmap:dtype:out"));
       if (dtypeout) {
-	/* The type in the out attribute of the typemap overrides the type
-	 * in the dtype typemap. */
-	Delete(result);
-	result = dtypeout;
-	replaceClassname(result, Getattr(n, "type"));
+        /* The type in the out attribute of the typemap overrides the type
+         * in the dtype typemap. */
+        Delete(result);
+        result = dtypeout;
+        replaceClassname(result, Getattr(n, "type"));
       }
     }
     return result;
@@ -4714,9 +4714,9 @@ private:
       Replaceall(nspace_subdirectory, ".", SWIG_FILE_DELIMITER);
       String *newdir_error = Swig_new_subdirectory(output_directory, nspace_subdirectory);
       if (newdir_error) {
-	Printf(stderr, "%s\n", newdir_error);
-	Delete(newdir_error);
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "%s\n", newdir_error);
+        Delete(newdir_error);
+        Exit(EXIT_FAILURE);
       }
       Printv(output_directory, nspace_subdirectory, SWIG_FILE_DELIMITER, 0);
       Delete(nspace_subdirectory);
@@ -4782,7 +4782,7 @@ private:
 
     while (*c && (c != co)) {
       if (*c == '.') {
-	break;
+        break;
       }
       c++;
     }
@@ -4807,7 +4807,7 @@ private:
 
     while (*c) {
       if (*c == '.') {
-	cc = c;
+        cc = c;
       }
       ++c;
     }
@@ -4830,7 +4830,7 @@ private:
 
     while (*c) {
       if (*c == '.') {
-	cc = c;
+        cc = c;
       }
       ++c;
     }

--- a/Source/Modules/directors.cxx
+++ b/Source/Modules/directors.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -195,14 +195,14 @@ String *Swig_method_decl(SwigType *return_base_type, SwigType *decl, const_Strin
  * Swig_director_emit_dynamic_cast()
  *
  * In order to call protected virtual director methods from the target language, we need
- * to add an extra dynamic_cast to call the public C++ wrapper in the director class. 
+ * to add an extra dynamic_cast to call the public C++ wrapper in the director class.
  * Also for non-static protected members when the allprotected option is on.
  * ----------------------------------------------------------------------------- */
 
 void Swig_director_emit_dynamic_cast(Node *n, Wrapper *f) {
   // TODO: why is the storage element removed in staticmemberfunctionHandler ??
-  if ((!is_public(n) && (is_member_director(n) || GetFlag(n, "explicitcall"))) || 
-      (is_non_virtual_protected_access(n) && !(Swig_storage_isstatic_custom(n, "staticmemberfunctionHandler:storage") || 
+  if ((!is_public(n) && (is_member_director(n) || GetFlag(n, "explicitcall"))) ||
+      (is_non_virtual_protected_access(n) && !(Swig_storage_isstatic_custom(n, "staticmemberfunctionHandler:storage") ||
                                                Swig_storage_isstatic(n))
                                           && !Equal(nodeType(n), "constructor"))) {
     Node *parent = Getattr(n, "parentNode");

--- a/Source/Modules/directors.cxx
+++ b/Source/Modules/directors.cxx
@@ -116,11 +116,11 @@ String *Swig_method_call(const_String_or_char_ptr name, ParmList *parms) {
       SwigType *rpt = SwigType_typedef_resolve_all(pt);
       String *pname = Getattr(p, "name");
       if (comma)
-	Append(func, ",");
+        Append(func, ",");
       if (SwigType_isrvalue_reference(rpt))
-	Printv(func, "std::move(", pname, ")", NIL);
+        Printv(func, "std::move(", pname, ")", NIL);
       else
-	Printv(func, pname, NIL);
+        Printv(func, pname, NIL);
       Delete(rpt);
       comma = 1;
     }

--- a/Source/Modules/directors.cxx
+++ b/Source/Modules/directors.cxx
@@ -98,7 +98,6 @@ String *Swig_director_declaration(Node *n) {
   return declaration;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_method_call()
  * ----------------------------------------------------------------------------- */
@@ -202,9 +201,8 @@ String *Swig_method_decl(SwigType *return_base_type, SwigType *decl, const_Strin
 void Swig_director_emit_dynamic_cast(Node *n, Wrapper *f) {
   // TODO: why is the storage element removed in staticmemberfunctionHandler ??
   if ((!is_public(n) && (is_member_director(n) || GetFlag(n, "explicitcall"))) ||
-      (is_non_virtual_protected_access(n) && !(Swig_storage_isstatic_custom(n, "staticmemberfunctionHandler:storage") ||
-                                               Swig_storage_isstatic(n))
-                                          && !Equal(nodeType(n), "constructor"))) {
+      (is_non_virtual_protected_access(n) && !(Swig_storage_isstatic_custom(n, "staticmemberfunctionHandler:storage") || Swig_storage_isstatic(n)) &&
+       !Equal(nodeType(n), "constructor"))) {
     Node *parent = Getattr(n, "parentNode");
     String *dirname;
     String *dirdecl;

--- a/Source/Modules/emit.cxx
+++ b/Source/Modules/emit.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -180,7 +180,7 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
     }
   }
 
-  /* 
+  /*
    * An equivalent type can be used in the typecheck typemap for SWIG to detect the overloading of equivalent
    * target language types. This is primarily for the smartptr feature, where a pointer and a smart pointer
    * are seen as equivalent types in the target language.
@@ -351,7 +351,7 @@ bool emit_isvarargs_function(Node *n) {
  * void emit_mark_vararg_parms()
  *
  * Marks the vararg parameters which are to be ignored.
- * Vararg parameters are marked as ignored if there is no 'in' varargs (...) 
+ * Vararg parameters are marked as ignored if there is no 'in' varargs (...)
  * typemap.
  * ----------------------------------------------------------------------------- */
 
@@ -412,7 +412,7 @@ int emit_action_code(Node *n, String *wrappercode, String *eaction) {
 /* -----------------------------------------------------------------------------
  * int emit_action()
  *
- * Emits the call to the wrapped function. 
+ * Emits the call to the wrapped function.
  * Adds in exception specification exception handling and %exception code.
  * ----------------------------------------------------------------------------- */
 String *emit_action(Node *n) {

--- a/Source/Modules/emit.cxx
+++ b/Source/Modules/emit.cxx
@@ -172,7 +172,7 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
         if (SwigType_isvarargs(Getattr(p, "type"))) {
           // Mark the head of the ParmList that it has varargs
           Setattr(l, "emit:varargs", lp);
-//Printf(stdout, "setting emit:varargs %s ... %s +++ %s\n", Getattr(l, "emit:varargs"), Getattr(l, "type"), Getattr(p, "type"));
+          // Printf(stdout, "setting emit:varargs %s ... %s +++ %s\n", Getattr(l, "emit:varargs"), Getattr(l, "type"), Getattr(p, "type"));
           break;
         }
         p = nextSibling(p);
@@ -194,13 +194,20 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
         if (equivalent) {
           String *precedence = Getattr(p, "tmap:typecheck:precedence");
           if (precedence && Strcmp(precedence, "0") != 0)
-            Swig_error(Getfile(tm), Getline(tm), "The 'typecheck' typemap for %s contains an 'equivalent' attribute for a 'precedence' that is not set to SWIG_TYPECHECK_POINTER or 0.\n", SwigType_str(Getattr(p, "type"), 0));
+            Swig_error(Getfile(tm),
+                       Getline(tm),
+                       "The 'typecheck' typemap for %s contains an 'equivalent' attribute for a 'precedence' that is not set to SWIG_TYPECHECK_POINTER or 0.\n",
+                       SwigType_str(Getattr(p, "type"), 0));
           SwigType *cpt = Swig_cparse_type(equivalent);
           if (cpt) {
             Setattr(p, "equivtype", cpt);
             Delete(cpt);
           } else {
-            Swig_error(Getfile(tm), Getline(tm), "Invalid type (%s) in 'equivalent' attribute in 'typecheck' typemap for type %s.\n", equivalent, SwigType_str(Getattr(p, "type"), 0));
+            Swig_error(Getfile(tm),
+                       Getline(tm),
+                       "Invalid type (%s) in 'equivalent' attribute in 'typecheck' typemap for type %s.\n",
+                       equivalent,
+                       SwigType_str(Getattr(p, "type"), 0));
           }
         }
         p = Getattr(p, "tmap:typecheck:next");

--- a/Source/Modules/emit.cxx
+++ b/Source/Modules/emit.cxx
@@ -111,12 +111,12 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
     while (p) {
       String *tm = Getattr(p, "tmap:in");
       if (tm) {
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  Printv(f->code, tm, "\n", NIL);
-	}
-	p = Getattr(p, "tmap:in:next");
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          Printv(f->code, tm, "\n", NIL);
+        }
+        p = Getattr(p, "tmap:in:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -131,14 +131,14 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
       npin = Getattr(p, "tmap:in:next");
 
       if (Getattr(p, "tmap:freearg")) {
-	npfreearg = Getattr(p, "tmap:freearg:next");
-	if (npin != npfreearg) {
-	  while (p != npin) {
-	    Delattr(p, "tmap:freearg");
-	    Delattr(p, "tmap:freearg:next");
-	    p = nextSibling(p);
-	  }
-	}
+        npfreearg = Getattr(p, "tmap:freearg:next");
+        if (npin != npfreearg) {
+          while (p != npin) {
+            Delattr(p, "tmap:freearg");
+            Delattr(p, "tmap:freearg:next");
+            p = nextSibling(p);
+          }
+        }
       }
       p = npin;
     }
@@ -153,13 +153,13 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
     Parm *lp = 0;
     while (p) {
       if (!checkAttribute(p, "tmap:in:numinputs", "0")) {
-	lp = p;
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        lp = p;
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
       if (SwigType_isvarargs(Getattr(p, "type"))) {
-	Swig_warning(WARN_LANG_VARARGS, input_file, line_number, "Variable length arguments discarded.\n");
-	Setattr(p, "tmap:in", "");
+        Swig_warning(WARN_LANG_VARARGS, input_file, line_number, "Variable length arguments discarded.\n");
+        Setattr(p, "tmap:in", "");
       }
       lp = 0;
       p = nextSibling(p);
@@ -169,13 +169,13 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
     if (lp) {
       p = lp;
       while (p) {
-	if (SwigType_isvarargs(Getattr(p, "type"))) {
-	  // Mark the head of the ParmList that it has varargs
-	  Setattr(l, "emit:varargs", lp);
+        if (SwigType_isvarargs(Getattr(p, "type"))) {
+          // Mark the head of the ParmList that it has varargs
+          Setattr(l, "emit:varargs", lp);
 //Printf(stdout, "setting emit:varargs %s ... %s +++ %s\n", Getattr(l, "emit:varargs"), Getattr(l, "type"), Getattr(p, "type"));
-	  break;
-	}
-	p = nextSibling(p);
+          break;
+        }
+        p = nextSibling(p);
       }
     }
   }
@@ -190,22 +190,22 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
     while (p) {
       String *tm = Getattr(p, "tmap:typecheck");
       if (tm) {
-	String *equivalent = Getattr(p, "tmap:typecheck:equivalent");
-	if (equivalent) {
-	  String *precedence = Getattr(p, "tmap:typecheck:precedence");
-	  if (precedence && Strcmp(precedence, "0") != 0)
-	    Swig_error(Getfile(tm), Getline(tm), "The 'typecheck' typemap for %s contains an 'equivalent' attribute for a 'precedence' that is not set to SWIG_TYPECHECK_POINTER or 0.\n", SwigType_str(Getattr(p, "type"), 0));
-	  SwigType *cpt = Swig_cparse_type(equivalent);
-	  if (cpt) {
-	    Setattr(p, "equivtype", cpt);
-	    Delete(cpt);
-	  } else {
-	    Swig_error(Getfile(tm), Getline(tm), "Invalid type (%s) in 'equivalent' attribute in 'typecheck' typemap for type %s.\n", equivalent, SwigType_str(Getattr(p, "type"), 0));
-	  }
-	}
-	p = Getattr(p, "tmap:typecheck:next");
+        String *equivalent = Getattr(p, "tmap:typecheck:equivalent");
+        if (equivalent) {
+          String *precedence = Getattr(p, "tmap:typecheck:precedence");
+          if (precedence && Strcmp(precedence, "0") != 0)
+            Swig_error(Getfile(tm), Getline(tm), "The 'typecheck' typemap for %s contains an 'equivalent' attribute for a 'precedence' that is not set to SWIG_TYPECHECK_POINTER or 0.\n", SwigType_str(Getattr(p, "type"), 0));
+          SwigType *cpt = Swig_cparse_type(equivalent);
+          if (cpt) {
+            Setattr(p, "equivtype", cpt);
+            Delete(cpt);
+          } else {
+            Swig_error(Getfile(tm), Getline(tm), "Invalid type (%s) in 'equivalent' attribute in 'typecheck' typemap for type %s.\n", equivalent, SwigType_str(Getattr(p, "type"), 0));
+          }
+        }
+        p = Getattr(p, "tmap:typecheck:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -263,18 +263,18 @@ int emit_num_required(ParmList *parms) {
       p = Getattr(p, "tmap:in:next");
     } else {
       if (Getattr(p, "tmap:default"))
-	break;
+        break;
       if (Getattr(p, "value")) {
-	if (!first_default_arg)
-	  first_default_arg = p;
-	if (compactdefargs)
-	  break;
+        if (!first_default_arg)
+          first_default_arg = p;
+        if (compactdefargs)
+          break;
       }
       nargs += GetInt(p, "tmap:in:numinputs");
       if (Getattr(p, "tmap:in")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -285,16 +285,16 @@ int emit_num_required(ParmList *parms) {
     p = first_default_arg;
     while (p) {
       if (Getattr(p, "tmap:in") && checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       } else {
-	if (!Getattr(p, "value") && (!Getattr(p, "tmap:default"))) {
-	  Swig_error(Getfile(p), Getline(p), "Non-optional argument '%s' follows an optional argument.\n", Getattr(p, "name"));
-	}
-	if (Getattr(p, "tmap:in")) {
-	  p = Getattr(p, "tmap:in:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if (!Getattr(p, "value") && (!Getattr(p, "tmap:default"))) {
+          Swig_error(Getfile(p), Getline(p), "Non-optional argument '%s' follows an optional argument.\n", Getattr(p, "name"));
+        }
+        if (Getattr(p, "tmap:in")) {
+          p = Getattr(p, "tmap:in:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
     }
   }
@@ -337,8 +337,8 @@ bool emit_isvarargs_function(Node *n) {
   if (over) {
     for (Node *sibling = over; sibling; sibling = Getattr(sibling, "sym:nextSibling")) {
       if (ParmList_has_varargs(Getattr(sibling, "parms"))) {
-	has_varargs = true;
-	break;
+        has_varargs = true;
+        break;
       }
     }
   } else {
@@ -360,7 +360,7 @@ void emit_mark_varargs(ParmList *l) {
   while (p) {
     if (SwigType_isvarargs(Getattr(p, "type")))
       if (!Getattr(p, "tmap:in"))
-	Setattr(p, "varargs:ignore", "1");
+        Setattr(p, "varargs:ignore", "1");
     p = nextSibling(p);
   }
 }
@@ -431,12 +431,12 @@ String *emit_action(Node *n) {
       c = Char(t);
       tok = strtok(c, ",");
       while (tok) {
-	String *fname = NewString(tok);
-	Setfile(fname, Getfile(n));
-	Setline(fname, Getline(n));
-	Swig_fragment_emit(fname);
-	Delete(fname);
-	tok = strtok(NULL, ",");
+        String *fname = NewString(tok);
+        Setfile(fname, Getfile(n));
+        Setline(fname, Getline(n));
+        Swig_fragment_emit(fname);
+        Delete(fname);
+        tok = strtok(NULL, ",");
       }
       Delete(t);
     }
@@ -506,7 +506,7 @@ String *emit_action(Node *n) {
         Printv(eaction, em, "\n", NIL);
         Printf(eaction, "}");
       } else {
-	Swig_warning(WARN_TYPEMAP_THROW, Getfile(n), Getline(n), "No 'throws' typemap defined for exception type '%s'\n", SwigType_str(Getattr(ep, "type"), 0));
+        Swig_warning(WARN_TYPEMAP_THROW, Getfile(n), Getline(n), "No 'throws' typemap defined for exception type '%s'\n", SwigType_str(Getattr(ep, "type"), 0));
         unknown_catch = 1;
       }
     }

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1480,7 +1480,7 @@ private:
 
       p = nextParm(p);
     }
-      
+
     Printv(fnname, ")", NULL);
 
     if (SwigType_type(info->result) == T_VOID) {

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -256,93 +256,93 @@ private:
     // Process command line options.
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-package") == 0) {
-	  if (argv[i + 1]) {
-	    package = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-cgo") == 0) {
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-no-cgo") == 0) {
-	  Swig_mark_arg(i);
-	  saw_nocgo_flag = true;
-	} else if (strcmp(argv[i], "-gccgo") == 0) {
-	  Swig_mark_arg(i);
-	  gccgo_flag = true;
-	} else if (strcmp(argv[i], "-go-prefix") == 0) {
-	  if (argv[i + 1]) {
-	    prefix_option = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-go-pkgpath") == 0) {
-	  if (argv[i + 1]) {
-	    pkgpath_option = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-import-prefix") == 0) {
-	  if (argv[i + 1]) {
-	    import_prefix = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-use-shlib") == 0) {
-	  Swig_mark_arg(i);
-	  use_shlib = true;
-	} else if (strcmp(argv[i], "-soname") == 0) {
-	  if (argv[i + 1]) {
-	    soname = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-longsize") == 0) {
-	  // Ignore for backward compatibility.
-	  if (argv[i + 1]) {
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    ++i;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-intgosize") == 0) {
-	  if (argv[i + 1]) {
-	    intgo_type_size = atoi(argv[i + 1]);
-	    if (intgo_type_size != 32 && intgo_type_size != 64) {
-	      Printf(stderr, "-intgosize not 32 or 64\n");
-	      Swig_arg_error();
-	    }
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    ++i;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-no-unique-id") == 0) {
+        if (strcmp(argv[i], "-package") == 0) {
+          if (argv[i + 1]) {
+            package = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-cgo") == 0) {
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-no-cgo") == 0) {
+          Swig_mark_arg(i);
+          saw_nocgo_flag = true;
+        } else if (strcmp(argv[i], "-gccgo") == 0) {
+          Swig_mark_arg(i);
+          gccgo_flag = true;
+        } else if (strcmp(argv[i], "-go-prefix") == 0) {
+          if (argv[i + 1]) {
+            prefix_option = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-go-pkgpath") == 0) {
+          if (argv[i + 1]) {
+            pkgpath_option = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-import-prefix") == 0) {
+          if (argv[i + 1]) {
+            import_prefix = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-use-shlib") == 0) {
+          Swig_mark_arg(i);
+          use_shlib = true;
+        } else if (strcmp(argv[i], "-soname") == 0) {
+          if (argv[i + 1]) {
+            soname = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-longsize") == 0) {
+          // Ignore for backward compatibility.
+          if (argv[i + 1]) {
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            ++i;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-intgosize") == 0) {
+          if (argv[i + 1]) {
+            intgo_type_size = atoi(argv[i + 1]);
+            if (intgo_type_size != 32 && intgo_type_size != 64) {
+              Printf(stderr, "-intgosize not 32 or 64\n");
+              Swig_arg_error();
+            }
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            ++i;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-no-unique-id") == 0) {
     Swig_mark_arg(i);
     generate_unique_id = false;
   } else if (strcmp(argv[i], "-unique-id") == 0) {
     Swig_mark_arg(i);
     generate_unique_id = true;
   } else if (strcmp(argv[i], "-help") == 0) {
-	  Printf(stdout, "%s", usage);
-	}
+          Printf(stdout, "%s", usage);
+        }
       }
     }
 
@@ -402,10 +402,10 @@ private:
     Node *optionsnode = Getattr(Getattr(n, "module"), "options");
     if (optionsnode) {
       if (Getattr(optionsnode, "directors")) {
-	allow_directors();
+        allow_directors();
       }
       if (Getattr(optionsnode, "dirprot")) {
-	allow_dirprot();
+        allow_dirprot();
       }
       allow_allprotected(GetFlag(optionsnode, "allprotected"));
     }
@@ -422,21 +422,21 @@ private:
     if (gccgo_flag) {
       String *pref;
       if (pkgpath_option) {
-	pref = pkgpath_option;
+        pref = pkgpath_option;
       } else {
-	pref = prefix_option;
+        pref = prefix_option;
       }
       go_prefix = NewString("");
       for (char *p = Char(pref); *p != '\0'; p++) {
-	if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || (*p >= '0' && *p <= '9') || *p == '.' || *p == '$') {
-	  Putc(*p, go_prefix);
-	} else {
-	  Putc('_', go_prefix);
-	}
+        if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || (*p >= '0' && *p <= '9') || *p == '.' || *p == '$') {
+          Putc(*p, go_prefix);
+        } else {
+          Putc('_', go_prefix);
+        }
       }
       if (!pkgpath_option) {
-	Append(go_prefix, ".");
-	Append(go_prefix, getModuleName(package));
+        Append(go_prefix, ".");
+        Append(go_prefix, getModuleName(package));
       }
     }
 
@@ -477,13 +477,13 @@ private:
 
     if (Swig_directors_enabled()) {
       if (!c_filename_h) {
-	Printf(stderr, "Unable to determine outfile_h\n");
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "Unable to determine outfile_h\n");
+        Exit(EXIT_FAILURE);
       }
       f_c_directors_h = NewFile(c_filename_h, "w", SWIG_output_files());
       if (!f_c_directors_h) {
-	FileErrorDisplay(c_filename_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(c_filename_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -605,17 +605,17 @@ private:
     for (Iterator p = First(undefined_types); p.key; p = Next(p)) {
       String *ty = goType(NULL, p.key);
       if (!Getattr(defined_types, ty)) {
-	String *cp = goCPointerType(p.key, false);
-	if (!Getattr(defined_types, cp)) {
-	  Printv(f_go_wrappers, "type ", cp, " uintptr\n", NULL);
-	  Printv(f_go_wrappers, "type ", ty, " interface {\n", NULL);
-	  Printv(f_go_wrappers, "\tSwigcptr() uintptr;\n", NULL);
-	  Printv(f_go_wrappers, "}\n", NULL);
-	  Printv(f_go_wrappers, "func (p ", cp, ") Swigcptr() uintptr {\n", NULL);
-	  Printv(f_go_wrappers, "\treturn uintptr(p)\n", NULL);
-	  Printv(f_go_wrappers, "}\n\n", NULL);
-	}
-	Delete(cp);
+        String *cp = goCPointerType(p.key, false);
+        if (!Getattr(defined_types, cp)) {
+          Printv(f_go_wrappers, "type ", cp, " uintptr\n", NULL);
+          Printv(f_go_wrappers, "type ", ty, " interface {\n", NULL);
+          Printv(f_go_wrappers, "\tSwigcptr() uintptr;\n", NULL);
+          Printv(f_go_wrappers, "}\n", NULL);
+          Printv(f_go_wrappers, "func (p ", cp, ") Swigcptr() uintptr {\n", NULL);
+          Printv(f_go_wrappers, "\treturn uintptr(p)\n", NULL);
+          Printv(f_go_wrappers, "}\n\n", NULL);
+        }
+        Delete(cp);
       }
       Delete(ty);
     }
@@ -717,10 +717,10 @@ private:
       if (!Getattr(go_imports, modname)) {
         Setattr(go_imports, modname, modname);
         Printv(f_go_imports, "import \"", NULL);
-	if (import_prefix) {
-	  Printv(f_go_imports, import_prefix, "/", NULL);
-	}
-	Printv(f_go_imports, modname, "\"\n", NULL);
+        if (import_prefix) {
+          Printv(f_go_imports, import_prefix, "/", NULL);
+        }
+        Printv(f_go_imports, modname, "\"\n", NULL);
       }
       imported_package = modname;
       saw_import = true;
@@ -800,9 +800,9 @@ private:
       // If this is a static variable, put in the class name,
       // capitalized.
       if (is_static && class_name) {
-	String *ccn = exportedName(class_name);
-	Append(go_name, ccn);
-	Delete(ccn);
+        String *ccn = exportedName(class_name);
+        Append(go_name, ccn);
+        Delete(ccn);
       }
 
       // Add the rest of the name, capitalized, dropping the _set or
@@ -812,14 +812,14 @@ private:
       char *p = Char(c2);
       int len = Len(p);
       for (int i = 0; i < len - 4; ++i) {
-	Putc(p[i], go_name);
+        Putc(p[i], go_name);
       }
       Delete(c2);
       Delete(c1);
 
       if (!checkIgnoredParameters(n, go_name)) {
-	Delete(go_name);
-	return SWIG_NOWRAP;
+        Delete(go_name);
+        return SWIG_NOWRAP;
       }
     } else if (Cmp(nodetype, "constructor") == 0) {
       is_ctor_dtor = true;
@@ -835,23 +835,23 @@ private:
       Delete(c1);
 
       if (Swig_methodclass(n) && Swig_directorclass(n)) {
-	// The core SWIG code skips the first parameter when
-	// generating the $nondirector_new string.  Recreate the
-	// action in this case.  But don't it if we are using the
-	// special code for an abstract class.
-	String *call = Swig_cppconstructor_call(getClassType(),
-						Getattr(n, "parms"));
-	SwigType *type = Copy(getClassType());
-	SwigType_add_pointer(type);
-	String *cres = Swig_cresult(type, Swig_cresult_name(), call);
-	if (!Equal(Getattr(n, "wrap:action"), director_prot_ctor_code)) {
-	  Setattr(n, "wrap:action", cres);
-	}
+        // The core SWIG code skips the first parameter when
+        // generating the $nondirector_new string.  Recreate the
+        // action in this case.  But don't it if we are using the
+        // special code for an abstract class.
+        String *call = Swig_cppconstructor_call(getClassType(),
+                                                Getattr(n, "parms"));
+        SwigType *type = Copy(getClassType());
+        SwigType_add_pointer(type);
+        String *cres = Swig_cresult(type, Swig_cresult_name(), call);
+        if (!Equal(Getattr(n, "wrap:action"), director_prot_ctor_code)) {
+          Setattr(n, "wrap:action", cres);
+        }
       }
     } else if (Cmp(nodetype, "destructor") == 0) {
       // No need to emit protected destructors.
       if (!is_public(n)) {
-	return SWIG_OK;
+        return SWIG_OK;
       }
 
       is_ctor_dtor = true;
@@ -870,14 +870,14 @@ private:
       r1 = result;
     } else {
       if (!checkFunctionVisibility(n, NULL)) {
-	return SWIG_OK;
+        return SWIG_OK;
       }
 
       go_name = buildGoName(name, is_static, is_friend);
 
       if (!checkIgnoredParameters(n, go_name)) {
-	Delete(go_name);
-	return SWIG_NOWRAP;
+        Delete(go_name);
+        return SWIG_NOWRAP;
       }
     }
 
@@ -887,14 +887,14 @@ private:
     } else {
       String *scope;
       if (!class_name || is_static || is_ctor_dtor) {
-	scope = NULL;
+        scope = NULL;
       } else {
-	scope = NewString("swiggoscope.");
-	Append(scope, class_name);
+        scope = NewString("swiggoscope.");
+        Append(scope, class_name);
       }
       if (!checkNameConflict(go_name, n, scope)) {
-	Delete(go_name);
-	return SWIG_NOWRAP;
+        Delete(go_name);
+        return SWIG_NOWRAP;
       }
     }
 
@@ -916,23 +916,23 @@ private:
     if (Getattr(n, "sym:overloaded") && !Getattr(n, "sym:nextSibling")) {
       String *scope ;
       if (!class_name || is_static || is_ctor_dtor) {
-	scope = NULL;
+        scope = NULL;
       } else {
-	scope = NewString("swiggoscope.");
-	Append(scope, class_name);
+        scope = NewString("swiggoscope.");
+        Append(scope, class_name);
       }
       if (!checkNameConflict(go_name, n, scope)) {
-	Delete(go_name);
-	return SWIG_NOWRAP;
+        Delete(go_name);
+        return SWIG_NOWRAP;
       }
 
       String *receiver = class_receiver;
       if (is_static || is_ctor_dtor) {
-	receiver = NULL;
+        receiver = NULL;
       }
       r = makeDispatchFunction(n, go_name, receiver, is_static, NULL, false);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
     }
 
@@ -1103,11 +1103,11 @@ private:
     if (info->receiver) {
       Printv(f_go_wrappers, "(", NULL);
       if (info->base && info->receiver) {
-	Printv(f_go_wrappers, "_swig_base", NULL);
+        Printv(f_go_wrappers, "_swig_base", NULL);
       } else {
-	Printv(f_go_wrappers, Getattr(p, "lname"), NULL);
-	p = nextParm(p);
-	++pi;
+        Printv(f_go_wrappers, Getattr(p, "lname"), NULL);
+        p = nextParm(p);
+        ++pi;
       }
       Printv(f_go_wrappers, " ", info->receiver, ") ", NULL);
     }
@@ -1135,23 +1135,23 @@ private:
     for (; pi < parm_count; ++pi) {
       p = getParm(p);
       if (pi == 0 && info->is_destructor) {
-	String *cl = exportedName(class_name);
-	Printv(parm_print, Getattr(p, "lname"), " ", cl, NULL);
-	Delete(cl);
-	++args;
+        String *cl = exportedName(class_name);
+        Printv(parm_print, Getattr(p, "lname"), " ", cl, NULL);
+        Delete(cl);
+        ++args;
       } else {
-	if (args > 0) {
-	  Printv(parm_print, ", ", NULL);
-	}
-	++args;
-	if (pi >= required_count) {
-	  Printv(parm_print, "_swig_args ...interface{}", NULL);
-	  break;
-	}
-	Printv(parm_print, Getattr(p, "lname"), " ", NULL);
-	String *tm = goType(p, Getattr(p, "type"));
-	Printv(parm_print, tm, NULL);
-	Delete(tm);
+        if (args > 0) {
+          Printv(parm_print, ", ", NULL);
+        }
+        ++args;
+        if (pi >= required_count) {
+          Printv(parm_print, "_swig_args ...interface{}", NULL);
+          break;
+        }
+        Printv(parm_print, Getattr(p, "lname"), " ", NULL);
+        String *tm = goType(p, Getattr(p, "type"));
+        Printv(parm_print, tm, NULL);
+        Delete(tm);
       }
       p = nextParm(p);
     }
@@ -1165,9 +1165,9 @@ private:
       Delete(cl);
     } else {
       if (SwigType_type(info->result) != T_VOID) {
-	String *tm = goType(info->n, info->result);
-	Printv(parm_print, " (_swig_ret ", tm, ")", NULL);
-	Delete(tm);
+        String *tm = goType(info->n, info->result);
+        Printv(parm_print, " (_swig_ret ", tm, ")", NULL);
+        Delete(tm);
       }
     }
 
@@ -1184,18 +1184,18 @@ private:
       Parm *p = info->parms;
       int i;
       for (i = 0; i < required_count; ++i) {
-	p = getParm(p);
-	p = nextParm(p);
+        p = getParm(p);
+        p = nextParm(p);
       }
       for (; i < parm_count; ++i) {
-	p = getParm(p);
-	String *tm = goType(p, Getattr(p, "type"));
-	Printv(f_go_wrappers, "\tvar ", Getattr(p, "lname"), " ", tm, "\n", NULL);
-	Printf(f_go_wrappers, "\tif len(_swig_args) > %d {\n", i - required_count);
-	Printf(f_go_wrappers, "\t\t%s = _swig_args[%d].(%s)\n", Getattr(p, "lname"), i - required_count, tm);
-	Printv(f_go_wrappers, "\t}\n", NULL);
-	Delete(tm);
-	p = nextParm(p);
+        p = getParm(p);
+        String *tm = goType(p, Getattr(p, "type"));
+        Printv(f_go_wrappers, "\tvar ", Getattr(p, "lname"), " ", tm, "\n", NULL);
+        Printf(f_go_wrappers, "\tif len(_swig_args) > %d {\n", i - required_count);
+        Printf(f_go_wrappers, "\t\t%s = _swig_args[%d].(%s)\n", Getattr(p, "lname"), i - required_count, tm);
+        Printv(f_go_wrappers, "\t}\n", NULL);
+        Delete(tm);
+        p = nextParm(p);
       }
     }
 
@@ -1206,31 +1206,31 @@ private:
     String *wt = NULL;
     if (SwigType_type(info->result) != T_VOID) {
       if (info->is_constructor) {
-	ret_type = exportedName(class_name);
+        ret_type = exportedName(class_name);
       } else {
-	ret_type = goImType(info->n, info->result);
+        ret_type = goImType(info->n, info->result);
       }
       Printv(f_go_wrappers, "\tvar swig_r ", ret_type, "\n", NULL);
 
       bool c_struct_type;
       Delete(cgoTypeForGoValue(info->n, info->result, &c_struct_type));
       if (c_struct_type) {
-	memcpy_ret = true;
+        memcpy_ret = true;
       }
 
       if (memcpy_ret) {
-	Printv(call, "swig_r_p := ", NULL);
+        Printv(call, "swig_r_p := ", NULL);
       } else {
-	Printv(call, "swig_r = (", ret_type, ")(", NULL);
+        Printv(call, "swig_r = (", ret_type, ")(", NULL);
       }
 
       if (info->is_constructor || goTypeIsInterface(info->n, info->result)) {
-	if (info->is_constructor) {
-	  wt = Copy(class_receiver);
-	} else {
-	  wt = goWrapperType(info->n, info->result, true);
-	}
-	Printv(call, wt, "(", NULL);
+        if (info->is_constructor) {
+          wt = Copy(class_receiver);
+        } else {
+          wt = goWrapperType(info->n, info->result, true);
+        }
+        Printv(call, wt, "(", NULL);
       }
     }
 
@@ -1245,7 +1245,7 @@ private:
 
     if (info->base && info->receiver) {
       if (args > 0) {
-	Printv(call, ", ", NULL);
+        Printv(call, ", ", NULL);
       }
       ++args;
       Printv(call, "C.uintptr_t(_swig_base)", NULL);
@@ -1255,7 +1255,7 @@ private:
     for (int i = 0; i < parm_count; ++i) {
       p = getParm(p);
       if (args > 0) {
-	Printv(call, ", ", NULL);
+        Printv(call, ", ", NULL);
       }
       ++args;
 
@@ -1266,35 +1266,35 @@ private:
 
       String *goin = goGetattr(p, "tmap:goin");
       if (goin == NULL) {
-	Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
-	bool need_close = false;
-	if ((i == 0 && info->is_destructor) || ((i > 0 || !info->receiver || info->base || info->is_constructor) && goTypeIsInterface(p, pt))) {
-	  Printv(f_go_wrappers, "getSwigcptr(", NULL);
-	  need_close = true;
-	}
-	Printv(f_go_wrappers, ln, NULL);
-	if (need_close) {
-	  Printv(f_go_wrappers, ")", NULL);
-	}
-	Printv(f_go_wrappers, "\n", NULL);
-	Setattr(p, "emit:goinput", ln);
+        Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
+        bool need_close = false;
+        if ((i == 0 && info->is_destructor) || ((i > 0 || !info->receiver || info->base || info->is_constructor) && goTypeIsInterface(p, pt))) {
+          Printv(f_go_wrappers, "getSwigcptr(", NULL);
+          need_close = true;
+        }
+        Printv(f_go_wrappers, ln, NULL);
+        if (need_close) {
+          Printv(f_go_wrappers, ")", NULL);
+        }
+        Printv(f_go_wrappers, "\n", NULL);
+        Setattr(p, "emit:goinput", ln);
       } else {
-	String *itm = goImType(p, pt);
-	Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
-	goin = Copy(goin);
-	Replaceall(goin, "$input", ln);
-	Replaceall(goin, "$result", ivar);
-	Printv(f_go_wrappers, goin, "\n", NULL);
-	Delete(goin);
-	Setattr(p, "emit:goinput", ivar);
+        String *itm = goImType(p, pt);
+        Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
+        goin = Copy(goin);
+        Replaceall(goin, "$input", ln);
+        Replaceall(goin, "$result", ivar);
+        Printv(f_go_wrappers, goin, "\n", NULL);
+        Delete(goin);
+        Setattr(p, "emit:goinput", ivar);
       }
 
       bool c_struct_type;
       String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
       if (c_struct_type) {
-	Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
+        Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
       } else {
-	Printv(call, "C.", ct, "(", ivar, ")", NULL);
+        Printv(call, "C.", ct, "(", ivar, ")", NULL);
       }
       Delete(ct);
 
@@ -1331,15 +1331,15 @@ private:
 
       String *goout = goTypemapLookup("goout", info->n, "swig_r");
       if (goout == NULL) {
-	Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
+        Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
       } else {
-	String *tm = goType(info->n, info->result);
-	Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
-	goout = Copy(goout);
-	Replaceall(goout, "$input", "swig_r");
-	Replaceall(goout, "$result", "swig_r_1");
-	Printv(f_go_wrappers, goout, "\n", NULL);
-	Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
+        String *tm = goType(info->n, info->result);
+        Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
+        goout = Copy(goout);
+        Replaceall(goout, "$input", "swig_r");
+        Replaceall(goout, "$result", "swig_r_1");
+        Printv(f_go_wrappers, goout, "\n", NULL);
+        Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
       }
 
       Swig_restore(info->n);
@@ -1382,7 +1382,7 @@ private:
 
     if (info->base && info->receiver) {
       if (args > 0) {
-	Printv(f_cgo_comment, ", ", NULL);
+        Printv(f_cgo_comment, ", ", NULL);
       }
       ++args;
       Printv(f_cgo_comment, "uintptr_t _swig_base", NULL);
@@ -1392,7 +1392,7 @@ private:
     for (int i = 0; i < parm_count; ++i) {
       p = getParm(p);
       if (args > 0) {
-	Printv(f_cgo_comment, ", ", NULL);
+        Printv(f_cgo_comment, ", ", NULL);
       }
       ++args;
 
@@ -1460,7 +1460,7 @@ private:
     Parm *p = parms;
     for (int i = 0; i < parm_count; ++i) {
       if (args > 0) {
-	Printv(fnname, ", ", NULL);
+        Printv(fnname, ", ", NULL);
       }
       ++args;
 
@@ -1468,8 +1468,8 @@ private:
 
       SwigType *pt = Copy(Getattr(p, "type"));
       if (SwigType_isarray(pt) && Getattr(p, "tmap:gotype") == NULL) {
-	SwigType_del_array(pt);
-	SwigType_add_pointer(pt);
+        SwigType_del_array(pt);
+        SwigType_add_pointer(pt);
       }
       String *pn = NewStringf("_swig_go_%d", i);
       String *ct = gcCTypeForGoValue(p, pt, pn);
@@ -1508,20 +1508,20 @@ private:
       p = getParm(p);
       String *tm = Getattr(p, "tmap:in");
       if (!tm) {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "unable to use type %s as a function argument\n", SwigType_str(Getattr(p, "type"), 0));
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "unable to use type %s as a function argument\n", SwigType_str(Getattr(p, "type"), 0));
       } else {
-	tm = Copy(tm);
-	String *pn = NewStringf("_swig_go_%d", i);
-	Replaceall(tm, "$input", pn);
-	if (i < required_count) {
-	  Printv(f->code, "\t", tm, "\n", NULL);
-	} else {
-	  Printf(f->code, "\tif (_swig_optargc > %d) {\n", i - required_count);
-	  Printv(f->code, "\t\t", tm, "\n", NULL);
-	  Printv(f->code, "\t}\n", NULL);
-	}
-	Delete(tm);
-	Setattr(p, "emit:input", pn);
+        tm = Copy(tm);
+        String *pn = NewStringf("_swig_go_%d", i);
+        Replaceall(tm, "$input", pn);
+        if (i < required_count) {
+          Printv(f->code, "\t", tm, "\n", NULL);
+        } else {
+          Printf(f->code, "\tif (_swig_optargc > %d) {\n", i - required_count);
+          Printv(f->code, "\t\t", tm, "\n", NULL);
+          Printv(f->code, "\t}\n", NULL);
+        }
+        Delete(tm);
+        Setattr(p, "emit:input", pn);
       }
       p = nextParm(p);
     }
@@ -1597,13 +1597,13 @@ private:
     while (p) {
       String *tm = Getattr(p, "tmap:check");
       if (!tm) {
-	p = nextSibling(p);
+        p = nextSibling(p);
       } else {
-	tm = Copy(tm);
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(f->code, tm, "\n\n", NULL);
-	Delete(tm);
-	p = Getattr(p, "tmap:check:next");
+        tm = Copy(tm);
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(f->code, tm, "\n\n", NULL);
+        Delete(tm);
+        p = Getattr(p, "tmap:check:next");
       }
     }
   }
@@ -1628,11 +1628,11 @@ private:
 
       int vc = 0;
       for (Iterator bi = First(base); bi.item; bi = Next(bi)) {
-	Printf(actioncode, "  %s *swig_b%d = (%s *)%s;\n", bi.item, vc, bi.item, current);
-	Delete(current);
-	current = NewString("");
-	Printf(current, "swig_b%d", vc);
-	++vc;
+        Printf(actioncode, "  %s *swig_b%d = (%s *)%s;\n", bi.item, vc, bi.item, current);
+        Delete(current);
+        current = NewString("");
+        Printf(current, "swig_b%d", vc);
+        ++vc;
       }
 
       String *code = Copy(Getattr(n, "wrap:action"));
@@ -1651,9 +1651,9 @@ private:
     } else {
       Replaceall(tm, "$result", "_swig_go_result");
       if (GetFlag(n, "feature:new")) {
-	Replaceall(tm, "$owner", "1");
+        Replaceall(tm, "$owner", "1");
       } else {
-	Replaceall(tm, "$owner", "0");
+        Replaceall(tm, "$owner", "0");
       }
       Printv(f->code, tm, "\n", NULL);
       Delete(tm);
@@ -1675,14 +1675,14 @@ private:
     while (p) {
       String *tm = Getattr(p, "tmap:argout");
       if (!tm) {
-	p = nextSibling(p);
+        p = nextSibling(p);
       } else {
-	tm = Copy(tm);
-	Replaceall(tm, "$result", Swig_cresult_name());
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(f->code, tm, "\n", NULL);
-	Delete(tm);
-	p = Getattr(p, "tmap:argout:next");
+        tm = Copy(tm);
+        Replaceall(tm, "$result", Swig_cresult_name());
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(f->code, tm, "\n", NULL);
+        Delete(tm);
+        p = Getattr(p, "tmap:argout:next");
       }
     }
   }
@@ -1700,14 +1700,14 @@ private:
     while (p) {
       String *tm = Getattr(p, "tmap:goargout");
       if (!tm) {
-	p = nextSibling(p);
+        p = nextSibling(p);
       } else {
-	tm = Copy(tm);
-	Replaceall(tm, "$result", "swig_r");
-	Replaceall(tm, "$input", Getattr(p, "emit:goinput"));
-	Printv(f_go_wrappers, tm, "\n", NULL);
-	Delete(tm);
-	p = Getattr(p, "tmap:goargout:next");
+        tm = Copy(tm);
+        Replaceall(tm, "$result", "swig_r");
+        Replaceall(tm, "$input", Getattr(p, "emit:goinput"));
+        Printv(f_go_wrappers, tm, "\n", NULL);
+        Delete(tm);
+        p = Getattr(p, "tmap:goargout:next");
       }
     }
 
@@ -1723,9 +1723,9 @@ private:
       bool c_struct_type;
       Delete(cgoTypeForGoValue(p, Getattr(p, "type"), &c_struct_type));
       if (c_struct_type) {
-	Printv(f_go_wrappers, "\tif Swig_escape_always_false {\n", NULL);
-	Printv(f_go_wrappers, "\t\tSwig_escape_val = ", Getattr(p, "emit:goinput"), "\n", NULL);
-	Printv(f_go_wrappers, "\t}\n", NULL);
+        Printv(f_go_wrappers, "\tif Swig_escape_always_false {\n", NULL);
+        Printv(f_go_wrappers, "\t\tSwig_escape_val = ", Getattr(p, "emit:goinput"), "\n", NULL);
+        Printv(f_go_wrappers, "\t}\n", NULL);
       }
       p = nextParm(p);
     }
@@ -1745,13 +1745,13 @@ private:
     while (p) {
       String *tm = Getattr(p, "tmap:freearg");
       if (!tm) {
-	p = nextSibling(p);
+        p = nextSibling(p);
       } else {
-	tm = Copy(tm);
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(ret, tm, "\n", NULL);
-	Delete(tm);
-	p = Getattr(p, "tmap:freearg:next");
+        tm = Copy(tm);
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(ret, tm, "\n", NULL);
+        Delete(tm);
+        p = Getattr(p, "tmap:freearg:next");
       }
     }
     return ret;
@@ -1771,8 +1771,8 @@ private:
     if (GetFlag(n, "feature:new")) {
       String *tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0);
       if (tm) {
-	Printv(f->code, tm, "\n", NULL);
-	Delete(tm);
+        Printv(f->code, tm, "\n", NULL);
+        Delete(tm);
       }
     }
 
@@ -1825,7 +1825,7 @@ private:
     if (typecode == T_STRING) {
       String *stringval = Getattr(n, "stringval");
       if (!stringval) {
-	return goComplexConstant(n, type);
+        return goComplexConstant(n, type);
       }
       // Backslash sequences are somewhat different in Go and C/C++.
       copy = NewStringf("\"%(goescape)s\"", stringval);
@@ -1833,7 +1833,7 @@ private:
     } else if (typecode == T_CHAR) {
       String *stringval = Getattr(n, "stringval");
       if (!stringval || Len(stringval) != 1) {
-	return goComplexConstant(n, type);
+        return goComplexConstant(n, type);
       }
       // Backslash sequences are somewhat different in Go and C/C++.
       copy = NewStringf("'%(goescape)s'", stringval);
@@ -1856,13 +1856,13 @@ private:
       // as too complicated to handle as a Go constant.
       char *p = Char(value);
       for (int i = 0; p[i]; ++i) {
-	switch (p[i]) {
-	case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
-	case '.': case 'e': case 'E': case '+': case '-':
-	  break;
-	default:
-	  return goComplexConstant(n, type);
-	}
+        switch (p[i]) {
+        case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
+        case '.': case 'e': case 'E': case '+': case '-':
+          break;
+        default:
+          return goComplexConstant(n, type);
+        }
       }
     }
 
@@ -1898,15 +1898,15 @@ private:
     String *name = goEnumName(n);
     if (Strcmp(name, "int") != 0) {
       if (!ImportMode || !imported_package) {
-	if (!checkNameConflict(name, n, NULL)) {
-	  Delete(name);
-	  return SWIG_NOWRAP;
-	}
-	Printv(f_go_wrappers, "type ", name, " int\n", NULL);
+        if (!checkNameConflict(name, n, NULL)) {
+          Delete(name);
+          return SWIG_NOWRAP;
+        }
+        Printv(f_go_wrappers, "type ", name, " int\n", NULL);
       } else {
-	String *nw = NewString("");
-	Printv(nw, getModuleName(imported_package), ".", name, NULL);
-	Setattr(n, "go:enumname", nw);
+        String *nw = NewString("");
+        Printv(nw, getModuleName(imported_package), ".", name, NULL);
+        Setattr(n, "go:enumname", nw);
       }
     }
     Delete(name);
@@ -1971,9 +1971,9 @@ private:
       String *nname = NewStringf("(%s)", Getattr(n, "value"));
       String *call;
       if (SwigType_isclass(type)) {
-	call = NewStringf("%s", nname);
+        call = NewStringf("%s", nname);
       } else {
-	call = SwigType_lcaststr(type, nname);
+        call = SwigType_lcaststr(type, nname);
       }
       String *cres = Swig_cresult(type, Swig_cresult_name(), call);
       Setattr(n, "wrap:action", cres);
@@ -2107,32 +2107,32 @@ private:
       Hash *local = NewHash();
       for (Node *ni = Getattr(n, "firstChild"); ni; ni = nextSibling(ni)) {
 
-	if (!is_public(ni)) {
-	  continue;
-	}
+        if (!is_public(ni)) {
+          continue;
+        }
 
-	String *type = Getattr(ni, "nodeType");
-	if (Cmp(type, "constructor") == 0 || Cmp(type, "destructor") == 0) {
-	  continue;
-	}
+        String *type = Getattr(ni, "nodeType");
+        if (Cmp(type, "constructor") == 0 || Cmp(type, "destructor") == 0) {
+          continue;
+        }
 
-	String *cname = Getattr(ni, "sym:name");
-	if (!cname) {
-	  cname = Getattr(ni, "name");
-	}
-	if (cname) {
-	  Setattr(local, cname, NewString(""));
-	}
+        String *cname = Getattr(ni, "sym:name");
+        if (!cname) {
+          cname = Getattr(ni, "name");
+        }
+        if (cname) {
+          Setattr(local, cname, NewString(""));
+        }
       }
 
       for (Iterator b = First(baselist); b.item; b = Next(b)) {
-	List *bases = NewList();
-	Append(bases, Getattr(b.item, "classtype"));
-	int r = addBase(n, b.item, bases, local);
-	if (r != SWIG_OK) {
-	  return r;
-	}
-	Delete(bases);
+        List *bases = NewList();
+        Append(bases, Getattr(b.item, "classtype"));
+        int r = addBase(n, b.item, bases, local);
+        if (r != SWIG_OK) {
+          return r;
+        }
+        Delete(bases);
       }
 
       Delete(local);
@@ -2142,7 +2142,7 @@ private:
       int r = addExtraBaseInterfaces(n, parents, baselist);
       Delete(parents);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
     }
 
@@ -2185,20 +2185,20 @@ private:
     for (Node *ni = Getattr(base, "firstChild"); ni; ni = nextSibling(ni)) {
       int r = goBaseEntry(n, bases, local, ni);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
     }
 
     List *baselist = Getattr(base, "bases");
     if (baselist && Len(baselist) > 0) {
       for (Iterator b = First(baselist); b.item; b = Next(b)) {
-	List *nb = Copy(bases);
-	Append(nb, Getattr(b.item, "classtype"));
-	int r = addBase(n, b.item, nb, local);
-	Delete(nb);
-	if (r != SWIG_OK) {
-	  return r;
-	}
+        List *nb = Copy(bases);
+        Append(nb, Getattr(b.item, "classtype"));
+        int r = addBase(n, b.item, nb, local);
+        Delete(nb);
+        if (r != SWIG_OK) {
+          return r;
+        }
       }
     }
 
@@ -2228,15 +2228,15 @@ private:
 
     if (Strcmp(type, "extend") == 0) {
       for (Node* extend = firstChild(entry); extend; extend = nextSibling(extend)) {
-	if (isStatic(extend)) {
-	  // If we don't do this, the extend_default test case fails.
-	  continue;
-	}
+        if (isStatic(extend)) {
+          // If we don't do this, the extend_default test case fails.
+          continue;
+        }
 
-	int r = goBaseEntry(n, bases, local, extend);
-	if (r != SWIG_OK) {
-	  return r;
-	}
+        int r = goBaseEntry(n, bases, local, extend);
+        if (r != SWIG_OK) {
+          return r;
+        }
       }
       return SWIG_OK;
     }
@@ -2270,33 +2270,33 @@ private:
     if (is_function) {
       int r = goBaseMethod(n, bases, entry);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
 
       if (Getattr(entry, "sym:overloaded")) {
-	for (Node *on = Getattr(entry, "sym:nextSibling"); on; on = Getattr(on, "sym:nextSibling")) {
-	  r = goBaseMethod(n, bases, on);
-	  if (r != SWIG_OK) {
-	    return r;
-	  }
-	}
+        for (Node *on = Getattr(entry, "sym:nextSibling"); on; on = Getattr(on, "sym:nextSibling")) {
+          r = goBaseMethod(n, bases, on);
+          if (r != SWIG_OK) {
+            return r;
+          }
+        }
 
-	String *receiver = class_receiver;
-	bool is_static = isStatic(entry);
-	if (is_static) {
-	  receiver = NULL;
-	}
-	String *go_name = buildGoName(Getattr(entry, "sym:name"), is_static, false);
-	r = makeDispatchFunction(entry, go_name, receiver, is_static, NULL, false);
-	Delete(go_name);
-	if (r != SWIG_OK) {
-	    return r;
-	}
+        String *receiver = class_receiver;
+        bool is_static = isStatic(entry);
+        if (is_static) {
+          receiver = NULL;
+        }
+        String *go_name = buildGoName(Getattr(entry, "sym:name"), is_static, false);
+        r = makeDispatchFunction(entry, go_name, receiver, is_static, NULL, false);
+        Delete(go_name);
+        if (r != SWIG_OK) {
+            return r;
+        }
       }
     } else {
       int r = goBaseVariable(n, bases, entry);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
     }
 
@@ -2345,16 +2345,16 @@ private:
     Setattr(method, "wrap:name", wname);
     if (!Getattr(method, "wrap:action")) {
       if (!is_static) {
-	Swig_MethodToFunction(method, getNSpace(), getClassType(), (Getattr(method, "template") ? SmartPointer : Extend | SmartPointer), NULL, false);
-	// Remove any self parameter that was just added.
-	ParmList *parms = Getattr(method, "parms");
-	if (parms && Getattr(parms, "self")) {
-	  parms = CopyParmList(nextSibling(parms));
-	  Setattr(method, "parms", parms);
-	}
+        Swig_MethodToFunction(method, getNSpace(), getClassType(), (Getattr(method, "template") ? SmartPointer : Extend | SmartPointer), NULL, false);
+        // Remove any self parameter that was just added.
+        ParmList *parms = Getattr(method, "parms");
+        if (parms && Getattr(parms, "self")) {
+          parms = CopyParmList(nextSibling(parms));
+          Setattr(method, "parms", parms);
+        }
       } else {
-	String *call = Swig_cfunction_call(Getattr(method, "name"), Getattr(method, "parms"));
-	Setattr(method, "wrap:action", Swig_cresult(Getattr(method, "type"), Swig_cresult_name(), call));
+        String *call = Swig_cfunction_call(Getattr(method, "name"), Getattr(method, "parms"));
+        Setattr(method, "wrap:action", Swig_cresult(Getattr(method, "type"), Swig_cresult_name(), call));
       }
     }
 
@@ -2406,14 +2406,14 @@ private:
     // Copied from Swig_wrapped_member_var_type.
     if (SwigType_isclass(vt)) {
       if (flags & CWRAP_NATURAL_VAR) {
-	if (CPlusPlus) {
-	  if (!SwigType_isconst(vt)) {
-	    SwigType_add_qualifier(vt, "const");
-	  }
-	  SwigType_add_reference(vt);
-	}
+        if (CPlusPlus) {
+          if (!SwigType_isconst(vt)) {
+            SwigType_add_qualifier(vt, "const");
+          }
+          SwigType_add_reference(vt);
+        }
       } else {
-	SwigType_add_pointer(vt);
+        SwigType_add_pointer(vt);
       }
     }
 
@@ -2421,9 +2421,9 @@ private:
 
     if (!is_immutable(var)) {
       for (Iterator ki = First(var); ki.key; ki = Next(ki)) {
-	if (Strncmp(ki.key, "tmap:", 5) == 0) {
-	  Delattr(var, ki.key);
-	}
+        if (Strncmp(ki.key, "tmap:", 5) == 0) {
+          Delattr(var, ki.key);
+        }
       }
       Swig_save("goBaseVariableSet", var, "name", "sym:name", "type", NULL);
 
@@ -2441,7 +2441,7 @@ private:
       String *result = NewString("void");
       int r = makeWrappers(var, go_name, NULL, wname, bases, parms, result, false);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
       Delete(wname);
       Delete(parms);
@@ -2451,9 +2451,9 @@ private:
 
       Swig_restore(var);
       for (Iterator ki = First(var); ki.key; ki = Next(ki)) {
-	if (Strncmp(ki.key, "tmap:", 5) == 0) {
-	  Delattr(var, ki.key);
-	}
+        if (Strncmp(ki.key, "tmap:", 5) == 0) {
+          Delattr(var, ki.key);
+        }
       }
     }
 
@@ -2549,7 +2549,7 @@ private:
 
     for (b = Next(b); b.item; b = Next(b)) {
       if (GetFlag(b.item, "feature:ignore")) {
-	continue;
+        continue;
       }
 
       String *go_base_name = exportedName(Getattr(b.item, "sym:name"));
@@ -2586,7 +2586,7 @@ private:
 
       int r = makeWrappers(n, go_name, NULL, wname, NULL, parm, result, false);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
 
       Swig_restore(n);
@@ -2635,10 +2635,10 @@ private:
 
     if (is_base_first) {
       if (!b.item) {
-	return;
+        return;
       }
       if (!GetFlag(b.item, "feature:ignore")) {
-	addParentExtraBaseInterfaces(n, parents, b.item, true, sf);
+        addParentExtraBaseInterfaces(n, parents, b.item, true, sf);
       }
 
       b = Next(b);
@@ -2649,21 +2649,21 @@ private:
 
     for (; b.item; b = Next(b)) {
       if (GetFlag(b.item, "feature:ignore")) {
-	continue;
+        continue;
       }
 
       String *go_base_name = exportedName(Getattr(b.item, "sym:name"));
 
       if (!Getattr(parents, go_base_name)) {
-	Printv(f_go_wrappers, "func (p ", go_type_name, ") SwigGet", go_base_name, "() ", go_base_name, " {\n", NULL);
-	Printv(f_go_wrappers, "\treturn p", sf, ".SwigGet", go_base_name, "()\n", NULL);
-	Printv(f_go_wrappers, "}\n\n", NULL);
+        Printv(f_go_wrappers, "func (p ", go_type_name, ") SwigGet", go_base_name, "() ", go_base_name, " {\n", NULL);
+        Printv(f_go_wrappers, "\treturn p", sf, ".SwigGet", go_base_name, "()\n", NULL);
+        Printv(f_go_wrappers, "}\n\n", NULL);
 
-	Printv(interfaces, "\tSwigGet", go_base_name, "() ", go_base_name, "\n", NULL);
+        Printv(interfaces, "\tSwigGet", go_base_name, "() ", go_base_name, "\n", NULL);
 
-	addParentExtraBaseInterfaces(n, parents, b.item, false, sf);
+        addParentExtraBaseInterfaces(n, parents, b.item, false, sf);
 
-	Setattr(parents, go_base_name, NewString(""));
+        Setattr(parents, go_base_name, NewString(""));
       }
     }
 
@@ -2782,7 +2782,7 @@ private:
 
     if (!overname && !is_ignored) {
       if (!checkNameConflict(fn_name, n, NULL)) {
-	return SWIG_NOWRAP;
+        return SWIG_NOWRAP;
       }
     }
 
@@ -2836,11 +2836,11 @@ private:
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	bool c_struct_type;
-	String *ct = cgoTypeForGoValue(p, Getattr(p, "type"), &c_struct_type);
-	Printv(f_cgo_comment, ", ", ct, " ", Getattr(p, "lname"), NULL);
-	p = nextParm(p);
+        p = getParm(p);
+        bool c_struct_type;
+        String *ct = cgoTypeForGoValue(p, Getattr(p, "type"), &c_struct_type);
+        Printv(f_cgo_comment, ", ", ct, " ", Getattr(p, "lname"), NULL);
+        p = nextParm(p);
       }
       Printv(f_cgo_comment, ");\n", NULL);
 
@@ -2850,12 +2850,12 @@ private:
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	Printv(f_go_wrappers, ", ", Getattr(p, "lname"), " ", NULL);
-	String *tm = goType(p, Getattr(p, "type"));
-	Printv(f_go_wrappers, tm, NULL);
-	Delete(tm);
-	p = nextParm(p);
+        p = getParm(p);
+        Printv(f_go_wrappers, ", ", Getattr(p, "lname"), " ", NULL);
+        String *tm = goType(p, Getattr(p, "type"));
+        Printv(f_go_wrappers, tm, NULL);
+        Delete(tm);
+        p = nextParm(p);
       }
 
       Printv(f_go_wrappers, ") ", cn, " {\n", NULL);
@@ -2869,49 +2869,49 @@ private:
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	Printv(call, ", ", NULL);
+        Printv(call, ", ", NULL);
 
-	p = getParm(p);
-	String *pt = Getattr(p, "type");
-	String *ln = Getattr(p, "lname");
+        p = getParm(p);
+        String *pt = Getattr(p, "type");
+        String *ln = Getattr(p, "lname");
 
-	String *ivar = NewStringf("_swig_i_%d", i);
+        String *ivar = NewStringf("_swig_i_%d", i);
 
-	String *goin = goGetattr(p, "tmap:goin");
-	if (goin == NULL) {
-	  Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
-	  bool need_close = false;
-	  if (goTypeIsInterface(p, pt)) {
-	    Printv(f_go_wrappers, "getSwigcptr(", NULL);
-	    need_close = true;
-	  }
-	  Printv(f_go_wrappers, ln, NULL);
-	  if (need_close) {
-	    Printv(f_go_wrappers, ")", NULL);
-	  }
-	  Printv(f_go_wrappers, "\n", NULL);
-	} else {
-	  String *itm = goImType(p, pt);
-	  Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
-	  goin = Copy(goin);
-	  Replaceall(goin, "$input", ln);
-	  Replaceall(goin, "$result", ivar);
-	  Printv(f_go_wrappers, goin, "\n", NULL);
-	  Delete(goin);
-	}
+        String *goin = goGetattr(p, "tmap:goin");
+        if (goin == NULL) {
+          Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
+          bool need_close = false;
+          if (goTypeIsInterface(p, pt)) {
+            Printv(f_go_wrappers, "getSwigcptr(", NULL);
+            need_close = true;
+          }
+          Printv(f_go_wrappers, ln, NULL);
+          if (need_close) {
+            Printv(f_go_wrappers, ")", NULL);
+          }
+          Printv(f_go_wrappers, "\n", NULL);
+        } else {
+          String *itm = goImType(p, pt);
+          Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
+          goin = Copy(goin);
+          Replaceall(goin, "$input", ln);
+          Replaceall(goin, "$result", ivar);
+          Printv(f_go_wrappers, goin, "\n", NULL);
+          Delete(goin);
+        }
 
-	Setattr(p, "emit:goinput", ivar);
+        Setattr(p, "emit:goinput", ivar);
 
-	bool c_struct_type;
-	String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
-	if (c_struct_type) {
-	  Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
-	} else {
-	  Printv(call, "C.", ct, "(", ivar, ")", NULL);
-	}
-	Delete(ct);
+        bool c_struct_type;
+        String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
+        if (c_struct_type) {
+          Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
+        } else {
+          Printv(call, "C.", ct, "(", ivar, ")", NULL);
+        }
+        Delete(ct);
 
-	p = nextParm(p);
+        p = nextParm(p);
       }
 
       Printv(call, "))", NULL);
@@ -2933,17 +2933,17 @@ private:
       Setattr(n, "wrap:name", dwname);
 
       {
-	// It might be possible to rewrite this to use $director_new
-	String *director_class_name = NewStringf("SwigDirector_%s", class_name);
-	String *constructor_call = Swig_cppconstructor_call(director_class_name, first_parm);
-	SwigType *type = Copy(getClassType());
-	SwigType_add_pointer(type);
-	String *cres = Swig_cresult(type, Swig_cresult_name(), constructor_call);
-	Setattr(n, "wrap:action", cres);
-	Delete(cres);
-	Delete(type);
-	Delete(constructor_call);
-	Delete(director_class_name);
+        // It might be possible to rewrite this to use $director_new
+        String *director_class_name = NewStringf("SwigDirector_%s", class_name);
+        String *constructor_call = Swig_cppconstructor_call(director_class_name, first_parm);
+        SwigType *type = Copy(getClassType());
+        SwigType_add_pointer(type);
+        String *cres = Swig_cresult(type, Swig_cresult_name(), constructor_call);
+        Setattr(n, "wrap:action", cres);
+        Delete(cres);
+        Delete(type);
+        Delete(constructor_call);
+        Delete(director_class_name);
       }
 
       cgoWrapperInfo info;
@@ -2962,7 +2962,7 @@ private:
 
       int r = cgoGccWrapper(&info);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
 
       Swig_restore(n);
@@ -2988,14 +2988,14 @@ private:
       p = getParm(p);
       SwigType *type = SwigType_typedef_resolve_all(Getattr(p, "type"));
       if (i > 0) {
-	Printv(f_c_directors, ", ", NULL);
+        Printv(f_c_directors, ", ", NULL);
       }
       String *pn = Getattr(p, "name");
       assert(pn);
       if (SwigType_isrvalue_reference(type))
-	Printv(f_c_directors, "std::move(", pn, ")", NULL);
+        Printv(f_c_directors, "std::move(", pn, ")", NULL);
       else
-	Printv(f_c_directors, pn, NULL);
+        Printv(f_c_directors, pn, NULL);
       p = nextParm(p);
     }
     Printv(f_c_directors, "),\n", NULL);
@@ -3005,7 +3005,7 @@ private:
     if (Getattr(n, "sym:overloaded") && !Getattr(n, "sym:nextSibling")) {
       int r = makeDispatchFunction(n, func_name, cn, is_static, Getattr(parentNode(n), "classtypeobj"), false);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
     }
 
@@ -3057,7 +3057,7 @@ private:
       String *result = NewString("void");
       int r = makeWrappers(n, fnname, NULL, wname, NULL, parms, result, isStatic(n));
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
 
       Delete(result);
@@ -3162,7 +3162,7 @@ private:
     if (!overloaded) {
       int r = oneClassDirectorMethod(n, parent, super);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
     } else {
       // Handle overloaded methods here, because otherwise we will
@@ -3171,54 +3171,54 @@ private:
       // function in one class hides a function of the same name in a
       // parent class.
       if (!Getattr(class_methods, name)) {
-	for (Node *on = Getattr(n, "sym:overloaded"); on; on = Getattr(on, "sym:nextSibling")) {
-	  // Swig_overload_rank expects wrap:name and wrap:parms to be
-	  // set.
-	  String *wn = Swig_name_wrapper(Getattr(on, "sym:name"));
-	  Append(wn, Getattr(on, "sym:overname"));
-	  Append(wn, unique_id);
-	  Setattr(on, "wrap:name", wn);
-	  Delete(wn);
-	  Setattr(on, "wrap:parms", Getattr(on, "parms"));
-	}
+        for (Node *on = Getattr(n, "sym:overloaded"); on; on = Getattr(on, "sym:nextSibling")) {
+          // Swig_overload_rank expects wrap:name and wrap:parms to be
+          // set.
+          String *wn = Swig_name_wrapper(Getattr(on, "sym:name"));
+          Append(wn, Getattr(on, "sym:overname"));
+          Append(wn, unique_id);
+          Setattr(on, "wrap:name", wn);
+          Delete(wn);
+          Setattr(on, "wrap:parms", Getattr(on, "parms"));
+        }
       }
 
       int r = oneClassDirectorMethod(n, parent, super);
       if (r != SWIG_OK) {
-	return r;
+        return r;
       }
 
       if (!Getattr(n, "sym:nextSibling"))
       {
-	// Last overloaded function
-	Node *on = Getattr(n, "sym:overloaded");
-	bool is_static = isStatic(on);
+        // Last overloaded function
+        Node *on = Getattr(n, "sym:overloaded");
+        bool is_static = isStatic(on);
 
-	String *cn = exportedName(Getattr(parent, "sym:name"));
-	String *go_name = buildGoName(name, is_static, false);
+        String *cn = exportedName(Getattr(parent, "sym:name"));
+        String *go_name = buildGoName(name, is_static, false);
 
-	String *director_struct_name = NewString("_swig_Director");
-	Append(director_struct_name, cn);
+        String *director_struct_name = NewString("_swig_Director");
+        Append(director_struct_name, cn);
 
-	int r = makeDispatchFunction(on, go_name, director_struct_name, is_static, director_struct_name, false);
-	if (r != SWIG_OK) {
-	  return r;
-	}
+        int r = makeDispatchFunction(on, go_name, director_struct_name, is_static, director_struct_name, false);
+        if (r != SWIG_OK) {
+          return r;
+        }
 
-	if (!GetFlag(n, "abstract")) {
-	  String *go_upcall = NewString("Director");
-	  Append(go_upcall, cn);
-	  Append(go_upcall, go_name);
-	  r = makeDispatchFunction(on, go_upcall, director_struct_name, is_static, director_struct_name, true);
-	  if (r != SWIG_OK) {
-	    return r;
-	  }
-	  Delete(go_upcall);
-	}
+        if (!GetFlag(n, "abstract")) {
+          String *go_upcall = NewString("Director");
+          Append(go_upcall, cn);
+          Append(go_upcall, go_name);
+          r = makeDispatchFunction(on, go_upcall, director_struct_name, is_static, director_struct_name, true);
+          if (r != SWIG_OK) {
+            return r;
+          }
+          Delete(go_upcall);
+        }
 
-	Delete(director_struct_name);
-	Delete(go_name);
-	Delete(cn);
+        Delete(director_struct_name);
+        Delete(go_name);
+        Delete(cn);
       }
     }
     Setattr(class_methods, name, NewString(""));
@@ -3332,50 +3332,50 @@ private:
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	if (i > 0) {
-	  Printv(f_go_wrappers, ", ", NULL);
-	}
-	String *tm = goType(p, Getattr(p, "type"));
-	Printv(f_go_wrappers, tm, NULL);
-	Delete(tm);
-	p = nextParm(p);
+        p = getParm(p);
+        if (i > 0) {
+          Printv(f_go_wrappers, ", ", NULL);
+        }
+        String *tm = goType(p, Getattr(p, "type"));
+        Printv(f_go_wrappers, tm, NULL);
+        Delete(tm);
+        p = nextParm(p);
       }
 
       Printv(f_go_wrappers, ")", NULL);
 
       if (!is_void) {
-	String *tm = goType(n, returntype);
-	Printv(f_go_wrappers, " ", tm, NULL);
-	Delete(tm);
+        String *tm = goType(n, returntype);
+        Printv(f_go_wrappers, " ", tm, NULL);
+        Delete(tm);
       }
 
       Printv(f_go_wrappers, "\n", NULL);
       Printv(f_go_wrappers, "}\n\n", NULL);
 
       if (!GetFlag(n, "abstract")) {
-	Printv(f_cgo_comment, "extern ", NULL);
+        Printv(f_cgo_comment, "extern ", NULL);
 
-	if (is_void) {
-	  Printv(f_cgo_comment, "void", NULL);
-	} else {
-	  bool c_struct_type;
-	  String *ret_type = cgoTypeForGoValue(n, returntype, &c_struct_type);
-	  Printv(f_cgo_comment, ret_type, NULL);
-	  Delete(ret_type);
-	}
+        if (is_void) {
+          Printv(f_cgo_comment, "void", NULL);
+        } else {
+          bool c_struct_type;
+          String *ret_type = cgoTypeForGoValue(n, returntype, &c_struct_type);
+          Printv(f_cgo_comment, ret_type, NULL);
+          Delete(ret_type);
+        }
 
-	Printv(f_cgo_comment, " ", upcall_wname, "(uintptr_t", NULL);
+        Printv(f_cgo_comment, " ", upcall_wname, "(uintptr_t", NULL);
 
-	p = parms;
-	for (int i = 0; i < parm_count; ++i) {
-	  p = getParm(p);
-	  bool c_struct_type;
-	  String *ct = cgoTypeForGoValue(p, Getattr(p, "type"), &c_struct_type);
-	  Printv(f_cgo_comment, ", ", ct, " ", Getattr(p, "lname"), NULL);
-	  p = nextParm(p);
-	}
-	Printv(f_cgo_comment, ");\n", NULL);
+        p = parms;
+        for (int i = 0; i < parm_count; ++i) {
+          p = getParm(p);
+          bool c_struct_type;
+          String *ct = cgoTypeForGoValue(p, Getattr(p, "type"), &c_struct_type);
+          Printv(f_cgo_comment, ", ", ct, " ", Getattr(p, "lname"), NULL);
+          p = nextParm(p);
+        }
+        Printv(f_cgo_comment, ");\n", NULL);
       }
 
       // Define the method on the director class in Go.
@@ -3384,23 +3384,23 @@ private:
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	if (i > 0) {
-	  Printv(f_go_wrappers, ", ", NULL);
-	}
-	Printv(f_go_wrappers, Getattr(p, "lname"), " ", NULL);
-	String *tm = goType(p, Getattr(p, "type"));
-	Printv(f_go_wrappers, tm, NULL);
-	Delete(tm);
-	p = nextParm(p);
+        p = getParm(p);
+        if (i > 0) {
+          Printv(f_go_wrappers, ", ", NULL);
+        }
+        Printv(f_go_wrappers, Getattr(p, "lname"), " ", NULL);
+        String *tm = goType(p, Getattr(p, "type"));
+        Printv(f_go_wrappers, tm, NULL);
+        Delete(tm);
+        p = nextParm(p);
       }
 
       Printv(f_go_wrappers, ")", NULL);
 
       if (!is_void) {
-	String *tm = goType(n, returntype);
-	Printv(f_go_wrappers, " ", tm, NULL);
-	Delete(tm);
+        String *tm = goType(n, returntype);
+        Printv(f_go_wrappers, " ", tm, NULL);
+        Delete(tm);
       }
 
       Printv(f_go_wrappers, " {\n", NULL);
@@ -3408,544 +3408,544 @@ private:
       Printv(f_go_wrappers, "\tif swig_g, swig_ok := swig_p.v.(", interface_name, "); swig_ok {\n", NULL);
       Printv(f_go_wrappers, "\t\t", NULL);
       if (!is_void) {
-	Printv(f_go_wrappers, "return ", NULL);
+        Printv(f_go_wrappers, "return ", NULL);
       }
       Printv(f_go_wrappers, "swig_g.", go_with_over_name, "(", NULL);
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	if (i > 0) {
-	  Printv(f_go_wrappers, ", ", NULL);
-	}
-	Printv(f_go_wrappers, Getattr(p, "lname"), NULL);
-	p = nextParm(p);
+        p = getParm(p);
+        if (i > 0) {
+          Printv(f_go_wrappers, ", ", NULL);
+        }
+        Printv(f_go_wrappers, Getattr(p, "lname"), NULL);
+        p = nextParm(p);
       }
 
       Printv(f_go_wrappers, ")\n", NULL);
       if (is_void) {
-	Printv(f_go_wrappers, "\t\treturn\n", NULL);
+        Printv(f_go_wrappers, "\t\treturn\n", NULL);
       }
       Printv(f_go_wrappers, "\t}\n", NULL);
 
       if (GetFlag(n, "abstract")) {
-	Printv(f_go_wrappers, "\tpanic(\"call to pure virtual method\")\n", NULL);
+        Printv(f_go_wrappers, "\tpanic(\"call to pure virtual method\")\n", NULL);
       } else {
-	String *ret_type = NULL;
-	bool memcpy_ret = false;
-	String *wt = NULL;
-	String *goout = NULL;
-	if (!is_void) {
-	  ret_type = goImType(n, returntype);
-	  Printv(f_go_wrappers, "\tvar swig_r ", ret_type, "\n", NULL);
-	  goout = goTypemapLookup("goout", n, "swig_r");
+        String *ret_type = NULL;
+        bool memcpy_ret = false;
+        String *wt = NULL;
+        String *goout = NULL;
+        if (!is_void) {
+          ret_type = goImType(n, returntype);
+          Printv(f_go_wrappers, "\tvar swig_r ", ret_type, "\n", NULL);
+          goout = goTypemapLookup("goout", n, "swig_r");
 
-	  bool c_struct_type;
-	  Delete(cgoTypeForGoValue(n, returntype, &c_struct_type));
-	  if (c_struct_type) {
-	    memcpy_ret = true;
-	  }
-	}
+          bool c_struct_type;
+          Delete(cgoTypeForGoValue(n, returntype, &c_struct_type));
+          if (c_struct_type) {
+            memcpy_ret = true;
+          }
+        }
 
-	String *call = NewString("");
+        String *call = NewString("");
 
-	Printv(call, "\t", NULL);
-	if (!is_void) {
-	  if (memcpy_ret) {
-	    Printv(call, "swig_r_p := ", NULL);
-	  } else {
-	    Printv(call, "swig_r = (", ret_type, ")(", NULL);
-	  }
-	  if (goTypeIsInterface(n, returntype)) {
-	    wt = goWrapperType(n, returntype, true);
-	    Printv(call, "(", wt, ")(", NULL);
-	  }
-	}
+        Printv(call, "\t", NULL);
+        if (!is_void) {
+          if (memcpy_ret) {
+            Printv(call, "swig_r_p := ", NULL);
+          } else {
+            Printv(call, "swig_r = (", ret_type, ")(", NULL);
+          }
+          if (goTypeIsInterface(n, returntype)) {
+            wt = goWrapperType(n, returntype, true);
+            Printv(call, "(", wt, ")(", NULL);
+          }
+        }
 
-	Printv(call, "C.", upcall_wname, "(C.uintptr_t(swig_p.",
-	       go_type_name, ")", NULL);
+        Printv(call, "C.", upcall_wname, "(C.uintptr_t(swig_p.",
+               go_type_name, ")", NULL);
 
-	p = parms;
-	for (int i = 0; i < parm_count; ++i) {
-	  Printv(call, ", ", NULL);
-	  p = getParm(p);
-	  SwigType *pt = Getattr(p, "type");
+        p = parms;
+        for (int i = 0; i < parm_count; ++i) {
+          Printv(call, ", ", NULL);
+          p = getParm(p);
+          SwigType *pt = Getattr(p, "type");
 
-	  String *ln = Getattr(p, "lname");
+          String *ln = Getattr(p, "lname");
 
-	  String *ivar = NewStringf("_swig_i_%d", i);
+          String *ivar = NewStringf("_swig_i_%d", i);
 
-	  // This is an ordinary call from Go to C++, so adjust using
-	  // the goin typemap.
-	  String *goin = goGetattr(p, "tmap:goin");
-	  if (goin == NULL) {
-	    Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
-	    bool need_close = false;
-	    if (goTypeIsInterface(p, pt)) {
-	      Printv(f_go_wrappers, "getSwigcptr(", NULL);
-	      need_close = true;
-	    }
-	    Printv(f_go_wrappers, ln, NULL);
-	    if (need_close) {
-	      Printv(f_go_wrappers, ")", NULL);
-	    }
-	    Printv(f_go_wrappers, "\n", NULL);
-	  } else {
-	    String *itm = goImType(p, pt);
-	    Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
-	    goin = Copy(goin);
-	    Replaceall(goin, "$input", ln);
-	    Replaceall(goin, "$result", ivar);
-	    Printv(f_go_wrappers, goin, "\n", NULL);
-	    Delete(goin);
-	  }
+          // This is an ordinary call from Go to C++, so adjust using
+          // the goin typemap.
+          String *goin = goGetattr(p, "tmap:goin");
+          if (goin == NULL) {
+            Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
+            bool need_close = false;
+            if (goTypeIsInterface(p, pt)) {
+              Printv(f_go_wrappers, "getSwigcptr(", NULL);
+              need_close = true;
+            }
+            Printv(f_go_wrappers, ln, NULL);
+            if (need_close) {
+              Printv(f_go_wrappers, ")", NULL);
+            }
+            Printv(f_go_wrappers, "\n", NULL);
+          } else {
+            String *itm = goImType(p, pt);
+            Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
+            goin = Copy(goin);
+            Replaceall(goin, "$input", ln);
+            Replaceall(goin, "$result", ivar);
+            Printv(f_go_wrappers, goin, "\n", NULL);
+            Delete(goin);
+          }
 
-	  Setattr(p, "emit:goinput", ivar);
+          Setattr(p, "emit:goinput", ivar);
 
-	  bool c_struct_type;
-	  String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
-	  if (c_struct_type) {
-	    Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
-	  } else {
-	    Printv(call, "C.", ct, "(", ivar, ")", NULL);
-	  }
+          bool c_struct_type;
+          String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
+          if (c_struct_type) {
+            Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
+          } else {
+            Printv(call, "C.", ct, "(", ivar, ")", NULL);
+          }
 
-	  p = nextParm(p);
-	}
+          p = nextParm(p);
+        }
 
-	Printv(call, ")", NULL);
+        Printv(call, ")", NULL);
 
-	if (wt) {
-	  // Close the type conversion to the wrapper type.
-	  Printv(call, ")", NULL);
-	}
-	if (!is_void && !memcpy_ret) {
-	  // Close the type conversion of the return value.
-	  Printv(call, ")", NULL);
-	}
+        if (wt) {
+          // Close the type conversion to the wrapper type.
+          Printv(call, ")", NULL);
+        }
+        if (!is_void && !memcpy_ret) {
+          // Close the type conversion of the return value.
+          Printv(call, ")", NULL);
+        }
 
-	Printv(call, "\n", NULL);
+        Printv(call, "\n", NULL);
 
-	Printv(f_go_wrappers, call, NULL);
-	Delete(call);
+        Printv(f_go_wrappers, call, NULL);
+        Delete(call);
 
-	if (memcpy_ret) {
-	  Printv(f_go_wrappers, "\tswig_r = *(*", ret_type, ")(unsafe.Pointer(&swig_r_p))\n", NULL);
-	}
+        if (memcpy_ret) {
+          Printv(f_go_wrappers, "\tswig_r = *(*", ret_type, ")(unsafe.Pointer(&swig_r_p))\n", NULL);
+        }
 
-	goargout(parms);
+        goargout(parms);
 
-	if (!is_void) {
-	  if (goout == NULL) {
-	    Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
-	  } else {
-	    String *tm = goType(n, returntype);
-	    Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
-	    Replaceall(goout, "$input", "swig_r");
-	    Replaceall(goout, "$result", "swig_r_1");
-	    Printv(f_go_wrappers, goout, "\n", NULL);
-	    Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
-	  }
-	}
+        if (!is_void) {
+          if (goout == NULL) {
+            Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
+          } else {
+            String *tm = goType(n, returntype);
+            Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
+            Replaceall(goout, "$input", "swig_r");
+            Replaceall(goout, "$result", "swig_r_1");
+            Printv(f_go_wrappers, goout, "\n", NULL);
+            Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
+          }
+        }
 
-	if (ret_type) {
-	  Delete(ret_type);
-	}
-	if (wt) {
-	  Delete(wt);
-	}
+        if (ret_type) {
+          Delete(ret_type);
+        }
+        if (wt) {
+          Delete(wt);
+        }
       }
 
       Printv(f_go_wrappers, "}\n\n", NULL);
 
       if (!GetFlag(n, "abstract")) {
-	// Define a function that uses the Go director type that other
-	// methods in the Go type can call to get parent methods.
+        // Define a function that uses the Go director type that other
+        // methods in the Go type can call to get parent methods.
 
-	Printv(f_go_wrappers, "func Director", cn, go_with_over_name, "(swig_p ", cn, NULL);
+        Printv(f_go_wrappers, "func Director", cn, go_with_over_name, "(swig_p ", cn, NULL);
 
-	p = parms;
-	for (int i = 0; i < parm_count; ++i) {
-	  p = getParm(p);
-	  Printv(f_go_wrappers, ", ", Getattr(p, "lname"), " ", NULL);
-	  String *tm = goType(p, Getattr(p, "type"));
-	  Printv(f_go_wrappers, tm, NULL);
-	  Delete(tm);
-	  p = nextParm(p);
-	}
+        p = parms;
+        for (int i = 0; i < parm_count; ++i) {
+          p = getParm(p);
+          Printv(f_go_wrappers, ", ", Getattr(p, "lname"), " ", NULL);
+          String *tm = goType(p, Getattr(p, "type"));
+          Printv(f_go_wrappers, tm, NULL);
+          Delete(tm);
+          p = nextParm(p);
+        }
 
-	Printv(f_go_wrappers, ")", NULL);
+        Printv(f_go_wrappers, ")", NULL);
 
-	if (!is_void) {
-	  String *tm = goType(n, returntype);
-	  Printv(f_go_wrappers, " ", tm, NULL);
-	  Delete(tm);
-	}
+        if (!is_void) {
+          String *tm = goType(n, returntype);
+          Printv(f_go_wrappers, " ", tm, NULL);
+          Delete(tm);
+        }
 
-	Printv(f_go_wrappers, " {\n", NULL);
+        Printv(f_go_wrappers, " {\n", NULL);
 
-	String *ret_type = NULL;
-	bool memcpy_ret = false;
-	String *wt = NULL;
-	String *goout = NULL;
-	if (!is_void) {
-	  ret_type = goImType(n, returntype);
-	  Printv(f_go_wrappers, "\tvar swig_r ", ret_type, "\n", NULL);
-	  goout = goTypemapLookup("goout", n, "swig_r");
+        String *ret_type = NULL;
+        bool memcpy_ret = false;
+        String *wt = NULL;
+        String *goout = NULL;
+        if (!is_void) {
+          ret_type = goImType(n, returntype);
+          Printv(f_go_wrappers, "\tvar swig_r ", ret_type, "\n", NULL);
+          goout = goTypemapLookup("goout", n, "swig_r");
 
-	  bool c_struct_type;
-	  Delete(cgoTypeForGoValue(n, returntype, &c_struct_type));
-	  if (c_struct_type) {
-	    memcpy_ret = true;
-	  }
-	}
+          bool c_struct_type;
+          Delete(cgoTypeForGoValue(n, returntype, &c_struct_type));
+          if (c_struct_type) {
+            memcpy_ret = true;
+          }
+        }
 
-	String *call = NewString("");
+        String *call = NewString("");
 
-	Printv(call, "\t", NULL);
-	if (!is_void) {
-	  if (memcpy_ret) {
-	    Printv(call, "swig_r_p := ", NULL);
-	  } else {
-	    Printv(call, "swig_r = (", ret_type, ")(", NULL);
-	  }
-	  if (goTypeIsInterface(n, returntype)) {
-	    wt = goWrapperType(n, returntype, true);
-	    Printv(call, "(", wt, ")(", NULL);
-	  }
-	}
+        Printv(call, "\t", NULL);
+        if (!is_void) {
+          if (memcpy_ret) {
+            Printv(call, "swig_r_p := ", NULL);
+          } else {
+            Printv(call, "swig_r = (", ret_type, ")(", NULL);
+          }
+          if (goTypeIsInterface(n, returntype)) {
+            wt = goWrapperType(n, returntype, true);
+            Printv(call, "(", wt, ")(", NULL);
+          }
+        }
 
-	Printv(call, "C.", upcall_wname, "(C.uintptr_t(swig_p.(*",
-	       director_struct_name, ").", go_type_name, ")", NULL);
+        Printv(call, "C.", upcall_wname, "(C.uintptr_t(swig_p.(*",
+               director_struct_name, ").", go_type_name, ")", NULL);
 
-	p = parms;
-	for (int i = 0; i < parm_count; ++i) {
-	  Printv(call, ", ", NULL);
-	  p = getParm(p);
-	  SwigType *pt = Getattr(p, "type");
+        p = parms;
+        for (int i = 0; i < parm_count; ++i) {
+          Printv(call, ", ", NULL);
+          p = getParm(p);
+          SwigType *pt = Getattr(p, "type");
 
-	  String *ivar = NewStringf("_swig_i_%d", i);
+          String *ivar = NewStringf("_swig_i_%d", i);
 
-	  String *ln = Copy(Getattr(p, "lname"));
+          String *ln = Copy(Getattr(p, "lname"));
 
-	  String *goin = goGetattr(p, "tmap:goin");
-	  if (goin == NULL) {
-	    Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
-	    bool need_close = false;
-	    if (goTypeIsInterface(p, pt)) {
-	      Printv(f_go_wrappers, "getSwigcptr(", NULL);
-	      need_close = true;
-	    }
-	    Printv(f_go_wrappers, ln, NULL);
-	    if (need_close) {
-	      Printv(f_go_wrappers, ")", NULL);
-	    }
-	    Printv(f_go_wrappers, "\n", NULL);
-	  } else {
-	    String *itm = goImType(p, pt);
-	    Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
-	    goin = Copy(goin);
-	    Replaceall(goin, "$input", ln);
-	    Replaceall(goin, "$result", ivar);
-	    Printv(f_go_wrappers, goin, "\n", NULL);
-	    Delete(goin);
-	  }
+          String *goin = goGetattr(p, "tmap:goin");
+          if (goin == NULL) {
+            Printv(f_go_wrappers, "\t", ivar, " := ", NULL);
+            bool need_close = false;
+            if (goTypeIsInterface(p, pt)) {
+              Printv(f_go_wrappers, "getSwigcptr(", NULL);
+              need_close = true;
+            }
+            Printv(f_go_wrappers, ln, NULL);
+            if (need_close) {
+              Printv(f_go_wrappers, ")", NULL);
+            }
+            Printv(f_go_wrappers, "\n", NULL);
+          } else {
+            String *itm = goImType(p, pt);
+            Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
+            goin = Copy(goin);
+            Replaceall(goin, "$input", ln);
+            Replaceall(goin, "$result", ivar);
+            Printv(f_go_wrappers, goin, "\n", NULL);
+            Delete(goin);
+          }
 
-	  Setattr(p, "emit:goinput", ivar);
+          Setattr(p, "emit:goinput", ivar);
 
-	  bool c_struct_type;
-	  String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
-	  if (c_struct_type) {
-	    Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
-	  } else {
-	    Printv(call, "C.", ct, "(", ivar, ")", NULL);
-	  }
+          bool c_struct_type;
+          String *ct = cgoTypeForGoValue(p, pt, &c_struct_type);
+          if (c_struct_type) {
+            Printv(call, "*(*C.", ct, ")(unsafe.Pointer(&", ivar, "))", NULL);
+          } else {
+            Printv(call, "C.", ct, "(", ivar, ")", NULL);
+          }
 
-	  Delete(ln);
+          Delete(ln);
 
-	  p = nextParm(p);
-	}
+          p = nextParm(p);
+        }
 
-	Printv(call, ")", NULL);
+        Printv(call, ")", NULL);
 
-	if (wt) {
-	  // Close the type conversion to the wrapper type.
-	  Printv(call, ")", NULL);
-	}
-	if (!is_void && !memcpy_ret) {
-	  // Close the type conversion of the return value.
-	  Printv(call, ")", NULL);
-	}
+        if (wt) {
+          // Close the type conversion to the wrapper type.
+          Printv(call, ")", NULL);
+        }
+        if (!is_void && !memcpy_ret) {
+          // Close the type conversion of the return value.
+          Printv(call, ")", NULL);
+        }
 
-	Printv(call, "\n", NULL);
+        Printv(call, "\n", NULL);
 
-	Printv(f_go_wrappers, call, NULL);
-	Delete(call);
+        Printv(f_go_wrappers, call, NULL);
+        Delete(call);
 
-	if (memcpy_ret) {
-	  Printv(f_go_wrappers, "\tswig_r = *(*", ret_type, ")(unsafe.Pointer(&swig_r_p))\n", NULL);
-	}
+        if (memcpy_ret) {
+          Printv(f_go_wrappers, "\tswig_r = *(*", ret_type, ")(unsafe.Pointer(&swig_r_p))\n", NULL);
+        }
 
-	goargout(parms);
+        goargout(parms);
 
-	if (!is_void) {
-	  if (goout == NULL) {
-	    Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
-	  } else {
-	    String *tm = goType(n, returntype);
-	    Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
-	    Replaceall(goout, "$input", "swig_r");
-	    Replaceall(goout, "$result", "swig_r_1");
-	    Printv(f_go_wrappers, goout, "\n", NULL);
-	    Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
-	  }
-	}
+        if (!is_void) {
+          if (goout == NULL) {
+            Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
+          } else {
+            String *tm = goType(n, returntype);
+            Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
+            Replaceall(goout, "$input", "swig_r");
+            Replaceall(goout, "$result", "swig_r_1");
+            Printv(f_go_wrappers, goout, "\n", NULL);
+            Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
+          }
+        }
 
-	Printv(f_go_wrappers, "}\n\n", NULL);
+        Printv(f_go_wrappers, "}\n\n", NULL);
 
-	if (ret_type) {
-	  Delete(ret_type);
-	}
-	if (wt) {
-	  Delete(wt);
-	}
+        if (ret_type) {
+          Delete(ret_type);
+        }
+        if (wt) {
+          Delete(wt);
+        }
 
-	// Define a method in the C++ director class that the C++
-	// upcall function can call.  This permits an upcall to a
-	// protected method.
+        // Define a method in the C++ director class that the C++
+        // upcall function can call.  This permits an upcall to a
+        // protected method.
 
-	String *upcall_method_name = NewString("_swig_upcall_");
-	Append(upcall_method_name, name);
-	if (overname) {
-	  Append(upcall_method_name, overname);
-	}
-	SwigType *rtype = Getattr(n, "classDirectorMethods:type");
-	String *upcall_decl = Swig_method_decl(rtype, Getattr(n, "decl"), upcall_method_name, parms, 0);
-	Printv(f_c_directors_h, "  ", upcall_decl, " {\n", NULL);
-	Delete(upcall_decl);
+        String *upcall_method_name = NewString("_swig_upcall_");
+        Append(upcall_method_name, name);
+        if (overname) {
+          Append(upcall_method_name, overname);
+        }
+        SwigType *rtype = Getattr(n, "classDirectorMethods:type");
+        String *upcall_decl = Swig_method_decl(rtype, Getattr(n, "decl"), upcall_method_name, parms, 0);
+        Printv(f_c_directors_h, "  ", upcall_decl, " {\n", NULL);
+        Delete(upcall_decl);
 
-	Printv(f_c_directors_h, "    ", NULL);
-	if (!is_void) {
-	  Printv(f_c_directors_h, "return ", NULL);
-	}
+        Printv(f_c_directors_h, "    ", NULL);
+        if (!is_void) {
+          Printv(f_c_directors_h, "return ", NULL);
+        }
 
-	String *super_call = Swig_method_call(super, parms);
-	Printv(f_c_directors_h, super_call, ";\n", NULL);
-	Delete(super_call);
+        String *super_call = Swig_method_call(super, parms);
+        Printv(f_c_directors_h, super_call, ";\n", NULL);
+        Delete(super_call);
 
-	Printv(f_c_directors_h, "  }\n", NULL);
+        Printv(f_c_directors_h, "  }\n", NULL);
 
-	// Define the C++ function that the Go function calls.
+        // Define the C++ function that the Go function calls.
 
-	SwigType *first_type = NULL;
-	Parm *first_parm = parms;
-	if (!is_static) {
-	  first_type = NewString("SwigDirector_");
-	  Append(first_type, class_name);
-	  SwigType_add_pointer(first_type);
-	  first_parm = NewParm(first_type, "p", n);
-	  set_nextSibling(first_parm, parms);
-	}
+        SwigType *first_type = NULL;
+        Parm *first_parm = parms;
+        if (!is_static) {
+          first_type = NewString("SwigDirector_");
+          Append(first_type, class_name);
+          SwigType_add_pointer(first_type);
+          first_parm = NewParm(first_type, "p", n);
+          set_nextSibling(first_parm, parms);
+        }
 
-	Swig_save("classDirectorMethod", n, "wrap:name", "wrap:action", NULL);
+        Swig_save("classDirectorMethod", n, "wrap:name", "wrap:action", NULL);
 
-	Setattr(n, "wrap:name", upcall_wname);
+        Setattr(n, "wrap:name", upcall_wname);
 
-	String *action = NewString("");
-	if (!is_void) {
-	  Printv(action, Swig_cresult_name(), " = (", SwigType_lstr(returntype, 0), ")", NULL);
-	  if (SwigType_isreference(returntype)) {
-	    Printv(action, "&", NULL);
-	  } else if (SwigType_isrvalue_reference(returntype)) {
-	    Printv(action, "&&", NULL);
-	  }
-	}
-	Printv(action, Swig_cparm_name(NULL, 0), "->", upcall_method_name, "(", NULL);
+        String *action = NewString("");
+        if (!is_void) {
+          Printv(action, Swig_cresult_name(), " = (", SwigType_lstr(returntype, 0), ")", NULL);
+          if (SwigType_isreference(returntype)) {
+            Printv(action, "&", NULL);
+          } else if (SwigType_isrvalue_reference(returntype)) {
+            Printv(action, "&&", NULL);
+          }
+        }
+        Printv(action, Swig_cparm_name(NULL, 0), "->", upcall_method_name, "(", NULL);
 
-	p = parms;
-	int i = 0;
-	while (p != NULL) {
-	  SwigType *type = SwigType_typedef_resolve_all(Getattr(p, "type"));
-	  if (SwigType_type(type) != T_VOID) {
-	    String *pname = Swig_cparm_name(NULL, i + 1);
-	    if (i > 0) {
-	      Printv(action, ", ", NULL);
-	    }
+        p = parms;
+        int i = 0;
+        while (p != NULL) {
+          SwigType *type = SwigType_typedef_resolve_all(Getattr(p, "type"));
+          if (SwigType_type(type) != T_VOID) {
+            String *pname = Swig_cparm_name(NULL, i + 1);
+            if (i > 0) {
+              Printv(action, ", ", NULL);
+            }
 
-	    // A parameter whose type is a reference is converted into a
-	    // pointer type by gcCTypeForGoValue.  We are calling a
-	    // function which expects a reference so we need to convert
-	    // back.
-	    if (SwigType_isreference(type)) {
-	      Printv(action, "*", pname, NULL);
-	    } else if (SwigType_isrvalue_reference(type)) {
-	      Printv(action, "std::move(*", pname, ")", NULL);
-	    } else {
-	      Printv(action, pname, NULL);
-	    }
-	    Delete(pname);
-	    i++;
-	  }
-	  p = nextSibling(p);
-	}
-	Printv(action, ");", NULL);
-	Setattr(n, "wrap:action", action);
+            // A parameter whose type is a reference is converted into a
+            // pointer type by gcCTypeForGoValue.  We are calling a
+            // function which expects a reference so we need to convert
+            // back.
+            if (SwigType_isreference(type)) {
+              Printv(action, "*", pname, NULL);
+            } else if (SwigType_isrvalue_reference(type)) {
+              Printv(action, "std::move(*", pname, ")", NULL);
+            } else {
+              Printv(action, pname, NULL);
+            }
+            Delete(pname);
+            i++;
+          }
+          p = nextSibling(p);
+        }
+        Printv(action, ");", NULL);
+        Setattr(n, "wrap:action", action);
 
-	cgoWrapperInfo info;
+        cgoWrapperInfo info;
 
-	info.n = n;
-	info.go_name = go_name;
-	info.overname = overname;
-	info.wname = upcall_wname;
-	info.base = NULL;
-	info.parms = first_parm;
-	info.result = returntype;
-	info.is_static = is_static;
-	info.receiver = NULL;
-	info.is_constructor = false;
-	info.is_destructor = false;
+        info.n = n;
+        info.go_name = go_name;
+        info.overname = overname;
+        info.wname = upcall_wname;
+        info.base = NULL;
+        info.parms = first_parm;
+        info.result = returntype;
+        info.is_static = is_static;
+        info.receiver = NULL;
+        info.is_constructor = false;
+        info.is_destructor = false;
 
-	int r = cgoGccWrapper(&info);
-	if (r != SWIG_OK) {
-	  return r;
-	}
+        int r = cgoGccWrapper(&info);
+        if (r != SWIG_OK) {
+          return r;
+        }
 
-	Delete(first_type);
-	if (first_parm != parms) {
-	  Delete(first_parm);
-	}
+        Delete(first_type);
+        if (first_parm != parms) {
+          Delete(first_parm);
+        }
 
-	Swig_restore(n);
-	Delete(upcall_method_name);
+        Swig_restore(n);
+        Delete(upcall_method_name);
       }
 
       // The Go function which invokes the method.  This is called by
       // the C++ method on the director class.
 
       Printv(f_go_wrappers, "//export ", callback_name, "\n",
-	     "func ", callback_name, "(swig_c int", NULL);
+             "func ", callback_name, "(swig_c int", NULL);
 
       p = parms;
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	String *tm = goWrapperType(p, Getattr(p, "type"), false);
-	Printv(f_go_wrappers, ", ", Getattr(p, "lname"), " ", tm, NULL);
-	Delete(tm);
-	p = nextParm(p);
+        p = getParm(p);
+        String *tm = goWrapperType(p, Getattr(p, "type"), false);
+        Printv(f_go_wrappers, ", ", Getattr(p, "lname"), " ", tm, NULL);
+        Delete(tm);
+        p = nextParm(p);
       }
 
       Printv(f_go_wrappers, ") ", NULL);
       String *result_wrapper = NULL;
       if (!is_void) {
-	result_wrapper = goWrapperType(n, returntype, true);
-	Printv(f_go_wrappers, "(swig_result ", result_wrapper, ") ", NULL);
+        result_wrapper = goWrapperType(n, returntype, true);
+        Printv(f_go_wrappers, "(swig_result ", result_wrapper, ") ", NULL);
       }
       Printv(f_go_wrappers, "{\n", NULL);
 
       if (is_ignored) {
-	Printv(f_go_wrappers, "\treturn\n", NULL);
+        Printv(f_go_wrappers, "\treturn\n", NULL);
       } else {
-	bool result_is_interface = false;
-	String *goout = NULL;
-	if (!is_void) {
-	  result_is_interface = goTypeIsInterface(NULL, returntype);
-	  Printv(f_go_wrappers, "\tvar swig_r ", NULL);
-	  if (!result_is_interface) {
-	    Printv(f_go_wrappers, goType(n, returntype), NULL);
-	  } else {
-	    Printv(f_go_wrappers, result_wrapper, NULL);
-	  }
-	  Printv(f_go_wrappers, "\n", NULL);
-	  goout = goTypemapLookup("godirectorout", n, "swig_r");
-	}
+        bool result_is_interface = false;
+        String *goout = NULL;
+        if (!is_void) {
+          result_is_interface = goTypeIsInterface(NULL, returntype);
+          Printv(f_go_wrappers, "\tvar swig_r ", NULL);
+          if (!result_is_interface) {
+            Printv(f_go_wrappers, goType(n, returntype), NULL);
+          } else {
+            Printv(f_go_wrappers, result_wrapper, NULL);
+          }
+          Printv(f_go_wrappers, "\n", NULL);
+          goout = goTypemapLookup("godirectorout", n, "swig_r");
+        }
 
-	String *call = NewString("");
-	Printv(call, "\t", NULL);
+        String *call = NewString("");
+        Printv(call, "\t", NULL);
 
-	if (!is_void) {
-	  Printv(call, "swig_r = ", NULL);
-	  if (result_is_interface) {
-	    Printv(call, result_wrapper, "(getSwigcptr(", NULL);
-	  }
-	}
-	Printv(call, "swig_p.", go_with_over_name, "(", NULL);
+        if (!is_void) {
+          Printv(call, "swig_r = ", NULL);
+          if (result_is_interface) {
+            Printv(call, result_wrapper, "(getSwigcptr(", NULL);
+          }
+        }
+        Printv(call, "swig_p.", go_with_over_name, "(", NULL);
 
-	String *goincode = NewString("");
+        String *goincode = NewString("");
 
-	p = parms;
-	for (int i = 0; i < parm_count; ++i) {
-	  p = getParm(p);
-	  if (i > 0) {
-	    Printv(call, ", ", NULL);
-	  }
-	  SwigType *pt = Getattr(p, "type");
+        p = parms;
+        for (int i = 0; i < parm_count; ++i) {
+          p = getParm(p);
+          if (i > 0) {
+            Printv(call, ", ", NULL);
+          }
+          SwigType *pt = Getattr(p, "type");
 
-	  String *ln = NewString("");
+          String *ln = NewString("");
 
-	  // If the Go representation is an interface type class, then
-	  // we are receiving a uintptr, and must convert to the
-	  // interface.
-	  bool is_interface = goTypeIsInterface(p, pt);
-	  if (is_interface) {
-	    // Passing is_result as true to goWrapperType gives us the
-	    // name of the Go type we need to convert to an interface.
-	    String *wt = goWrapperType(p, pt, true);
-	    Printv(ln, wt, "(", NULL);
-	    Delete(wt);
-	  }
+          // If the Go representation is an interface type class, then
+          // we are receiving a uintptr, and must convert to the
+          // interface.
+          bool is_interface = goTypeIsInterface(p, pt);
+          if (is_interface) {
+            // Passing is_result as true to goWrapperType gives us the
+            // name of the Go type we need to convert to an interface.
+            String *wt = goWrapperType(p, pt, true);
+            Printv(ln, wt, "(", NULL);
+            Delete(wt);
+          }
 
-	  Printv(ln, Getattr(p, "lname"), NULL);
+          Printv(ln, Getattr(p, "lname"), NULL);
 
-	  if (is_interface) {
-	    Printv(ln, ")", NULL);
-	  }
+          if (is_interface) {
+            Printv(ln, ")", NULL);
+          }
 
-	  String *goin = goGetattr(p, "tmap:godirectorin");
-	  if (goin == NULL) {
-	    Printv(call, ln, NULL);
-	  } else {
-	    String *ivar = NewString("");
-	    Printf(ivar, "_swig_i_%d", i);
-	    String *itm = goType(p, pt);
-	    Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
-	    goin = Copy(goin);
-	    Replaceall(goin, "$input", ln);
-	    Replaceall(goin, "$result", ivar);
-	    Printv(goincode, goin, "\n", NULL);
-	    Delete(goin);
-	    Printv(call, ivar, NULL);
-	    Delete(ivar);
-	  }
+          String *goin = goGetattr(p, "tmap:godirectorin");
+          if (goin == NULL) {
+            Printv(call, ln, NULL);
+          } else {
+            String *ivar = NewString("");
+            Printf(ivar, "_swig_i_%d", i);
+            String *itm = goType(p, pt);
+            Printv(f_go_wrappers, "\tvar ", ivar, " ", itm, "\n", NULL);
+            goin = Copy(goin);
+            Replaceall(goin, "$input", ln);
+            Replaceall(goin, "$result", ivar);
+            Printv(goincode, goin, "\n", NULL);
+            Delete(goin);
+            Printv(call, ivar, NULL);
+            Delete(ivar);
+          }
 
-	  Delete(ln);
+          Delete(ln);
 
-	  p = nextParm(p);
-	}
+          p = nextParm(p);
+        }
 
-	Printv(call, ")", NULL);
+        Printv(call, ")", NULL);
 
-	if (result_is_interface) {
-	  Printv(call, "))", NULL);
-	}
-	Printv(call, "\n", NULL);
+        if (result_is_interface) {
+          Printv(call, "))", NULL);
+        }
+        Printv(call, "\n", NULL);
 
-	Printv(f_go_wrappers, "\tswig_p := swigDirectorLookup(swig_c).(*", director_struct_name, ")\n", NULL);
-	Printv(f_go_wrappers, goincode, NULL);
-	Printv(f_go_wrappers, call, NULL);
-	Delete(call);
+        Printv(f_go_wrappers, "\tswig_p := swigDirectorLookup(swig_c).(*", director_struct_name, ")\n", NULL);
+        Printv(f_go_wrappers, goincode, NULL);
+        Printv(f_go_wrappers, call, NULL);
+        Delete(call);
 
-	if (!is_void) {
-	  if (goout == NULL) {
-	    Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
-	  } else {
-	    String *tm = goImType(n, returntype);
-	    Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
-	    Replaceall(goout, "$input", "swig_r");
-	    Replaceall(goout, "$result", "swig_r_1");
-	    Printv(f_go_wrappers, goout, "\n", NULL);
-	    Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
-	  }
-	}
+        if (!is_void) {
+          if (goout == NULL) {
+            Printv(f_go_wrappers, "\treturn swig_r\n", NULL);
+          } else {
+            String *tm = goImType(n, returntype);
+            Printv(f_go_wrappers, "\tvar swig_r_1 ", tm, "\n", NULL);
+            Replaceall(goout, "$input", "swig_r");
+            Replaceall(goout, "$result", "swig_r_1");
+            Printv(f_go_wrappers, goout, "\n", NULL);
+            Printv(f_go_wrappers, "\treturn swig_r_1\n", NULL);
+          }
+        }
       }
 
       Printv(f_go_wrappers, "}\n\n", NULL);
@@ -3974,9 +3974,9 @@ private:
 
       String *throws = buildThrow(n);
       if (throws) {
-	Printv(f_c_directors_h, " ", throws, NULL);
-	Printv(w->def, " ", throws, NULL);
-	Delete(throws);
+        Printv(f_c_directors_h, " ", throws, NULL);
+        Printv(w->def, " ", throws, NULL);
+        Delete(throws);
       }
 
       Printv(f_c_directors_h, ";\n", NULL);
@@ -3984,31 +3984,31 @@ private:
       Printv(w->def, " {\n", NULL);
 
       if (!is_void) {
-	if (!SwigType_isclass(returntype)) {
-	  if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype) || SwigType_isrvalue_reference(returntype))) {
-	    String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	    Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	    Delete(construct_result);
-	  } else {
-	    Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	  }
-	} else {
-	  String *cres = SwigType_lstr(returntype, "c_result");
-	  Printf(w->code, "%s;\n", cres);
-	  Delete(cres);
-	}
+        if (!SwigType_isclass(returntype)) {
+          if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype) || SwigType_isrvalue_reference(returntype))) {
+            String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+            Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+            Delete(construct_result);
+          } else {
+            Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+          }
+        } else {
+          String *cres = SwigType_lstr(returntype, "c_result");
+          Printf(w->code, "%s;\n", cres);
+          Delete(cres);
+        }
       }
 
       if (!is_ignored) {
-	makeDirectorMethodWrapper(n, w, callback_name);
+        makeDirectorMethodWrapper(n, w, callback_name);
       } else {
-	assert(is_pure_virtual);
-	Printv(w->code, "  _swig_gopanic(\"call to pure virtual function ", Getattr(parent, "sym:name"), name, "\");\n", NULL);
-	if (!is_void) {
-	  String *retstr = SwigType_rcaststr(returntype, "c_result");
-	  Printv(w->code, "  return ", retstr, ";\n", NULL);
-	  Delete(retstr);
-	}
+        assert(is_pure_virtual);
+        Printv(w->code, "  _swig_gopanic(\"call to pure virtual function ", Getattr(parent, "sym:name"), name, "\");\n", NULL);
+        if (!is_void) {
+          String *retstr = SwigType_rcaststr(returntype, "c_result");
+          Printv(w->code, "  return ", retstr, ";\n", NULL);
+          Delete(retstr);
+        }
       }
 
       Printv(w->code, "}", NULL);
@@ -4048,7 +4048,7 @@ private:
     Parm *p = parms;
     while (p) {
       while (checkAttribute(p, "tmap:directorin:numinputs", "0")) {
-	p = Getattr(p, "tmap:directorin:next");
+        p = Getattr(p, "tmap:directorin:next");
       }
       String *cg = gcCTypeForGoValue(p, Getattr(p, "type"), Getattr(p, "lname"));
       Printv(fnname, ", ", cg, NULL);
@@ -4083,7 +4083,7 @@ private:
     p = parms;
     while (p) {
       while (checkAttribute(p, "tmap:directorin:numinputs", "0")) {
-	p = Getattr(p, "tmap:directorin:next");
+        p = Getattr(p, "tmap:directorin:next");
       }
 
       String *pn = NewString("swig_");
@@ -4096,16 +4096,16 @@ private:
 
       tm = Getattr(p, "tmap:directorin");
       if (!tm) {
-	Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file,
-		     line_number, "Unable to use type %s as director method argument\n", SwigType_str(Getattr(p, "type"), 0));
+        Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file,
+                     line_number, "Unable to use type %s as director method argument\n", SwigType_str(Getattr(p, "type"), 0));
       } else {
-	tm = Copy(tm);
-	Replaceall(tm, "$input", pn);
-	Replaceall(tm, "$owner", 0);
-	Printv(w->code, "  ", tm, "\n", NULL);
-	Delete(tm);
+        tm = Copy(tm);
+        Replaceall(tm, "$input", pn);
+        Replaceall(tm, "$owner", 0);
+        Printv(w->code, "  ", tm, "\n", NULL);
+        Delete(tm);
 
-	Printv(args, ", ", pn, NULL);
+        Printv(args, ", ", pn, NULL);
       }
 
       p = Getattr(p, "tmap:directorin:next");
@@ -4121,14 +4121,14 @@ private:
     for (p = parms; p; ) {
       String *tm;
       if ((tm = Getattr(p, "tmap:directorargout"))) {
-	tm = Copy(tm);
-	Replaceall(tm, "$result", "jresult");
-	Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	Printv(w->code, tm, "\n", NULL);
-	Delete(tm);
-	p = Getattr(p, "tmap:directorargout:next");
+        tm = Copy(tm);
+        Replaceall(tm, "$result", "jresult");
+        Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+        Printv(w->code, tm, "\n", NULL);
+        Delete(tm);
+        p = Getattr(p, "tmap:directorargout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -4136,17 +4136,17 @@ private:
       String *result_str = NewString("c_result");
       String *tm = Swig_typemap_lookup("directorout", n, result_str, NULL);
       if (!tm) {
-	Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		     "Unable to use type %s as director method returntype\n", SwigType_str(returntype, 0));
+        Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                     "Unable to use type %s as director method returntype\n", SwigType_str(returntype, 0));
       } else {
-	tm = Copy(tm);
-	Replaceall(tm, "$input", Swig_cresult_name());
-	Replaceall(tm, "$result", "c_result");
-	Printv(w->code, "  ", tm, "\n", NULL);
-	String *retstr = SwigType_rcaststr(returntype, "c_result");
-	Printv(w->code, "  return ", retstr, ";\n", NULL);
-	Delete(retstr);
-	Delete(tm);
+        tm = Copy(tm);
+        Replaceall(tm, "$input", Swig_cresult_name());
+        Replaceall(tm, "$result", "c_result");
+        Printv(w->code, "  ", tm, "\n", NULL);
+        String *retstr = SwigType_rcaststr(returntype, "c_result");
+        Printv(w->code, "  return ", retstr, ";\n", NULL);
+        Delete(retstr);
+        Delete(tm);
       }
       Delete(result_str);
     }
@@ -4209,14 +4209,14 @@ private:
     bool first = true;
     for (Parm *p = throw_parm_list; p; p = nextSibling(p)) {
       if (Getattr(p, "tmap:throws")) {
-	if (first) {
-	  first = false;
-	} else {
-	  Printv(ret, ", ", NULL);
-	}
-	String *s = SwigType_str(Getattr(p, "type"), 0);
-	Printv(ret, s, NULL);
-	Delete(s);
+        if (first) {
+          first = false;
+        } else {
+          Printv(ret, ", ", NULL);
+        }
+        String *s = SwigType_str(Getattr(p, "type"), 0);
+        Printv(ret, s, NULL);
+        Delete(s);
       }
     }
     Printv(ret, ")", NULL);
@@ -4263,9 +4263,9 @@ private:
     if (is_constructor) {
       assert(!is_upcall);
       if (!is_director) {
-	all_result = Copy(Getattr(class_node, "classtypeobj"));
+        all_result = Copy(Getattr(class_node, "classtypeobj"));
       } else {
-	all_result = Copy(director_struct);
+        all_result = Copy(director_struct);
       }
       mismatch = false;
     } else {
@@ -4273,33 +4273,33 @@ private:
       mismatch = false;
       bool any_void = false;
       for (int i = 0; i < nfunc; ++i) {
-	Node *nn = Getitem(dispatch, i);
-	Node *ni = Getattr(nn, "directorNode") ? Getattr(nn, "directorNode") : nn;
-	SwigType *result = Getattr(ni, "go:type");
-	assert(result);
+        Node *nn = Getitem(dispatch, i);
+        Node *ni = Getattr(nn, "directorNode") ? Getattr(nn, "directorNode") : nn;
+        SwigType *result = Getattr(ni, "go:type");
+        assert(result);
 
-	if (SwigType_type(result) == T_VOID) {
-	  if (all_result) {
-	    mismatch = true;
-	  }
-	  any_void = true;
-	} else {
-	  if (any_void) {
-	    mismatch = true;
-	  } else if (!all_result) {
-	    all_result = Copy(result);
-	  } else if (Cmp(result, all_result) != 0) {
-	    mismatch = true;
-	  }
-	}
+        if (SwigType_type(result) == T_VOID) {
+          if (all_result) {
+            mismatch = true;
+          }
+          any_void = true;
+        } else {
+          if (any_void) {
+            mismatch = true;
+          } else if (!all_result) {
+            all_result = Copy(result);
+          } else if (Cmp(result, all_result) != 0) {
+            mismatch = true;
+          }
+        }
       }
       if (mismatch) {
-	Delete(all_result);
-	all_result = NULL;
+        Delete(all_result);
+        all_result = NULL;
       } else if (all_result) {
-	;
+        ;
       } else {
-	all_result = NewString("void");
+        all_result = NewString("void");
       }
     }
 
@@ -4327,21 +4327,21 @@ private:
     if (mismatch) {
       Printv(f_go_wrappers, " interface{}", NULL);
       if (add_to_interface) {
-	Printv(interfaces, " interface{}", NULL);
+        Printv(interfaces, " interface{}", NULL);
       }
     } else if (all_result && SwigType_type(all_result) != T_VOID) {
       if (is_director && is_constructor) {
-	Printv(f_go_wrappers, " ", receiver, NULL);
-	if (add_to_interface) {
-	  Printv(interfaces, " ", receiver, NULL);
-	}
+        Printv(f_go_wrappers, " ", receiver, NULL);
+        if (add_to_interface) {
+          Printv(interfaces, " ", receiver, NULL);
+        }
       } else {
-	String *tm = goType(n, all_result);
-	Printv(f_go_wrappers, " ", tm, NULL);
-	if (add_to_interface) {
-	  Printv(interfaces, " ", tm, NULL);
-	}
-	Delete(tm);
+        String *tm = goType(n, all_result);
+        Printv(f_go_wrappers, " ", tm, NULL);
+        if (add_to_interface) {
+          Printv(interfaces, " ", tm, NULL);
+        }
+        Delete(tm);
       }
     }
     Printv(f_go_wrappers, " {\n", NULL);
@@ -4361,10 +4361,10 @@ private:
       // parameter.  Because of the way this is called, there may or
       // may not be a self parameter at this point.
       if (use_receiver && pi && Getattr(pi, "self")) {
-	pi = getParm(pi);
-	if (pi) {
-	  pi = nextParm(pi);
-	}
+        pi = getParm(pi);
+        if (pi) {
+          pi = nextParm(pi);
+        }
       }
 
       int num_required = emit_num_required(pi);
@@ -4372,104 +4372,104 @@ private:
       bool varargs = emit_isvarargs(pi) ? true : false;
 
       if (varargs) {
-	Printf(f_go_wrappers, "\tif argc >= %d {\n", num_required);
+        Printf(f_go_wrappers, "\tif argc >= %d {\n", num_required);
       } else {
-	if (num_required == num_arguments) {
-	  Printf(f_go_wrappers, "\tif argc == %d {\n", num_required);
-	} else {
-	  Printf(f_go_wrappers, "\tif argc >= %d && argc <= %d {\n", num_required, num_arguments);
-	}
+        if (num_required == num_arguments) {
+          Printf(f_go_wrappers, "\tif argc == %d {\n", num_required);
+        } else {
+          Printf(f_go_wrappers, "\tif argc >= %d && argc <= %d {\n", num_required, num_arguments);
+        }
       }
 
       // Build list of collisions with the same number of arguments.
       List *coll = NewList();
       for (int k = i + 1; k < nfunc; ++k) {
-	Node *nnk = Getitem(dispatch, k);
-	Node *nk = Getattr(nnk, "directorNode") ? Getattr(nnk, "directorNode") : nnk;
-	Parm *pk = Getattr(nk, "wrap:parms");
-	if (use_receiver && pk && Getattr(pk, "self")) {
-	  pk = getParm(pk);
-	  if (pk) {
-	    pk = nextParm(pk);
-	  }
-	}
-	int nrk = emit_num_required(pk);
-	int nak = emit_num_arguments(pk);
-	if ((nrk >= num_required && nrk <= num_arguments)
-	    || (nak >= num_required && nak <= num_arguments)
-	    || (nrk <= num_required && nak >= num_arguments)
-	    || (varargs && nrk >= num_required)) {
-	  Append(coll, nk);
-	}
+        Node *nnk = Getitem(dispatch, k);
+        Node *nk = Getattr(nnk, "directorNode") ? Getattr(nnk, "directorNode") : nnk;
+        Parm *pk = Getattr(nk, "wrap:parms");
+        if (use_receiver && pk && Getattr(pk, "self")) {
+          pk = getParm(pk);
+          if (pk) {
+            pk = nextParm(pk);
+          }
+        }
+        int nrk = emit_num_required(pk);
+        int nak = emit_num_arguments(pk);
+        if ((nrk >= num_required && nrk <= num_arguments)
+            || (nak >= num_required && nak <= num_arguments)
+            || (nrk <= num_required && nak >= num_arguments)
+            || (varargs && nrk >= num_required)) {
+          Append(coll, nk);
+        }
       }
 
       int num_braces = 0;
       if (Len(coll) > 0 && num_arguments > 0) {
-	int j = 0;
-	Parm *pj = pi;
-	while (pj) {
-	  pj = getParm(pj);
-	  if (!pj) {
-	    break;
-	  }
+        int j = 0;
+        Parm *pj = pi;
+        while (pj) {
+          pj = getParm(pj);
+          if (!pj) {
+            break;
+          }
 
-	  // If all the overloads have the same type in this position,
-	  // we can omit the check.
-	  SwigType *tm = goOverloadType(pj, Getattr(pj, "type"));
-	  bool emitcheck = false;
-	  for (int k = 0; k < Len(coll) && !emitcheck; ++k) {
-	    Node *nk = Getitem(coll, k);
-	    Parm *pk = Getattr(nk, "wrap:parms");
-	    if (use_receiver && pk && Getattr(pk, "self")) {
-	      pk = getParm(pk);
-	      if (pk) {
-		pk = nextParm(pk);
-	      }
-	    }
-	    int nak = emit_num_arguments(pk);
-	    if (nak <= j)
-	      continue;
-	    int l = 0;
-	    Parm *pl = pk;
-	    while (pl && l <= j) {
-	      pl = getParm(pl);
-	      if (!pl) {
-		break;
-	      }
-	      if (l == j) {
-		SwigType *tml = goOverloadType(pl, Getattr(pl, "type"));
-		if (Cmp(tm, tml) != 0) {
-		  emitcheck = true;
-		}
-		Delete(tml);
-	      }
-	      pl = nextParm(pl);
-	      ++l;
-	    }
-	  }
+          // If all the overloads have the same type in this position,
+          // we can omit the check.
+          SwigType *tm = goOverloadType(pj, Getattr(pj, "type"));
+          bool emitcheck = false;
+          for (int k = 0; k < Len(coll) && !emitcheck; ++k) {
+            Node *nk = Getitem(coll, k);
+            Parm *pk = Getattr(nk, "wrap:parms");
+            if (use_receiver && pk && Getattr(pk, "self")) {
+              pk = getParm(pk);
+              if (pk) {
+                pk = nextParm(pk);
+              }
+            }
+            int nak = emit_num_arguments(pk);
+            if (nak <= j)
+              continue;
+            int l = 0;
+            Parm *pl = pk;
+            while (pl && l <= j) {
+              pl = getParm(pl);
+              if (!pl) {
+                break;
+              }
+              if (l == j) {
+                SwigType *tml = goOverloadType(pl, Getattr(pl, "type"));
+                if (Cmp(tm, tml) != 0) {
+                  emitcheck = true;
+                }
+                Delete(tml);
+              }
+              pl = nextParm(pl);
+              ++l;
+            }
+          }
 
-	  if (emitcheck) {
-	    if (j >= num_required) {
-	      Printf(f_go_wrappers, "\t\tif argc > %d {\n", j);
-	      ++num_braces;
-	    }
+          if (emitcheck) {
+            if (j >= num_required) {
+              Printf(f_go_wrappers, "\t\tif argc > %d {\n", j);
+              ++num_braces;
+            }
 
-	    fn = i + 1;
-	    Printf(f_go_wrappers, "\t\tif _, ok := a[%d].(%s); !ok {\n", j, tm);
-	    Printf(f_go_wrappers, "\t\t\tgoto check_%d\n", fn);
-	    Printv(f_go_wrappers, "\t\t}\n", NULL);
-	  }
+            fn = i + 1;
+            Printf(f_go_wrappers, "\t\tif _, ok := a[%d].(%s); !ok {\n", j, tm);
+            Printf(f_go_wrappers, "\t\t\tgoto check_%d\n", fn);
+            Printv(f_go_wrappers, "\t\t}\n", NULL);
+          }
 
-	  Delete(tm);
+          Delete(tm);
 
-	  pj = nextParm(pj);
+          pj = nextParm(pj);
 
-	  ++j;
-	}
+          ++j;
+        }
       }
 
       for (; num_braces > 0; --num_braces) {
-	Printv(f_go_wrappers, "\t\t}\n", NULL);
+        Printv(f_go_wrappers, "\t\t}\n", NULL);
       }
 
       // We may need to generate multiple calls if there are variable
@@ -4480,31 +4480,31 @@ private:
       SwigType *result = Getattr(ni, "go:type");
 
       if (is_constructor) {
-	result = all_result;
+        result = all_result;
       } else if (is_destructor) {
-	result = NULL;
+        result = NULL;
       }
 
       if (result && SwigType_type(result) != T_VOID && (!all_result || SwigType_type(all_result) != T_VOID)) {
-	Printv(start, "return ", NULL);
+        Printv(start, "return ", NULL);
       }
 
       bool advance_parm = false;
 
       if (receiver && use_receiver) {
-	Printv(start, "p.", go_name, NULL);
+        Printv(start, "p.", go_name, NULL);
       } else if (can_use_receiver && !isStatic(ni) && pi && Getattr(pi, "self")) {
-	// This is an overload of a static function and a non-static
-	// function.
-	assert(num_required > 0);
-	SwigType *tm = goWrapperType(pi, Getattr(pi, "type"), true);
-	String *nm = buildGoName(Getattr(ni, "sym:name"), false, isFriend(ni));
-	Printv(start, "a[0].(", tm, ").", nm, NULL);
-	Delete(nm);
-	Delete(tm);
-	advance_parm = true;
+        // This is an overload of a static function and a non-static
+        // function.
+        assert(num_required > 0);
+        SwigType *tm = goWrapperType(pi, Getattr(pi, "type"), true);
+        String *nm = buildGoName(Getattr(ni, "sym:name"), false, isFriend(ni));
+        Printv(start, "a[0].(", tm, ").", nm, NULL);
+        Delete(nm);
+        Delete(tm);
+        advance_parm = true;
       } else {
-	Printv(start, go_name, NULL);
+        Printv(start, go_name, NULL);
       }
 
       Printv(start, Getattr(ni, "sym:overname"), "(", NULL);
@@ -4512,77 +4512,77 @@ private:
       bool need_comma = false;
 
       if (is_director && is_constructor) {
-	Printv(start, "abi", NULL);
-	need_comma = true;
+        Printv(start, "abi", NULL);
+        need_comma = true;
       }
       if (is_upcall) {
-	Printv(start, "p", NULL);
-	need_comma = true;
+        Printv(start, "p", NULL);
+        need_comma = true;
       }
       Parm *p = pi;
       int pn = 0;
       if (advance_parm) {
-	p = getParm(p);
-	if (p) {
-	  p = nextParm(p);
-	}
-	++pn;
+        p = getParm(p);
+        if (p) {
+          p = nextParm(p);
+        }
+        ++pn;
       }
       while (pn < num_required) {
-	p = getParm(p);
+        p = getParm(p);
 
-	if (need_comma) {
-	  Printv(start, ", ", NULL);
-	}
+        if (need_comma) {
+          Printv(start, ", ", NULL);
+        }
 
-	SwigType *tm = goType(p, Getattr(p, "type"));
-	Printf(start, "a[%d].(%s)", pn, tm);
-	Delete(tm);
+        SwigType *tm = goType(p, Getattr(p, "type"));
+        Printf(start, "a[%d].(%s)", pn, tm);
+        Delete(tm);
 
-	need_comma = true;
-	++pn;
-	p = nextParm(p);
+        need_comma = true;
+        ++pn;
+        p = nextParm(p);
       }
 
       String *end = NULL;
       if (!result || SwigType_type(result) == T_VOID || (all_result && SwigType_type(all_result) == T_VOID)) {
-	end = NewString("");
-	Printv(end, "return", NULL);
-	if (!all_result || SwigType_type(all_result) != T_VOID) {
-	  Printv(end, " 0", NULL);
-	}
+        end = NewString("");
+        Printv(end, "return", NULL);
+        if (!all_result || SwigType_type(all_result) != T_VOID) {
+          Printv(end, " 0", NULL);
+        }
       }
 
       if (num_required == num_arguments) {
-	Printv(f_go_wrappers, "\t\t", start, ")\n", NULL);
-	if (end) {
-	  Printv(f_go_wrappers, "\t\t", end, "\n", NULL);
-	}
+        Printv(f_go_wrappers, "\t\t", start, ")\n", NULL);
+        if (end) {
+          Printv(f_go_wrappers, "\t\t", end, "\n", NULL);
+        }
       } else {
-	Printv(f_go_wrappers, "\t\tswitch argc {\n", NULL);
-	for (int j = num_required; j <= num_arguments; ++j) {
-	  Printf(f_go_wrappers, "\t\tcase %d:\n", j);
-	  Printv(f_go_wrappers, "\t\t\t", start, NULL);
-	  bool nc = need_comma;
-	  for (int k = num_required; k < j; ++k) {
-	    if (nc) {
-	      Printv(f_go_wrappers, ", ", NULL);
-	    }
-	    Printf(f_go_wrappers, "a[%d]", k);
-	    nc = true;
-	  }
-	  Printv(f_go_wrappers, ")\n", NULL);
-	  if (end) {
-	    Printv(f_go_wrappers, "\t\t\t", end, "\n", NULL);
-	  }
-	}
-	Printv(f_go_wrappers, "\t\t}\n", NULL);
+        Printv(f_go_wrappers, "\t\tswitch argc {\n", NULL);
+        for (int j = num_required; j <= num_arguments; ++j) {
+          Printf(f_go_wrappers, "\t\tcase %d:\n", j);
+          Printv(f_go_wrappers, "\t\t\t", start, NULL);
+          bool nc = need_comma;
+          for (int k = num_required; k < j; ++k) {
+            if (nc) {
+              Printv(f_go_wrappers, ", ", NULL);
+            }
+            Printf(f_go_wrappers, "a[%d]", k);
+            nc = true;
+          }
+          Printv(f_go_wrappers, ")\n", NULL);
+          if (end) {
+            Printv(f_go_wrappers, "\t\t\t", end, "\n", NULL);
+          }
+        }
+        Printv(f_go_wrappers, "\t\t}\n", NULL);
       }
 
       Printv(f_go_wrappers, "\t}\n", NULL);
 
       if (fn != 0) {
-	Printf(f_go_wrappers, "check_%d:\n", fn);
+        Printf(f_go_wrappers, "check_%d:\n", fn);
       }
 
       Delete(coll);
@@ -4673,8 +4673,8 @@ private:
     if (class_name) {
       char *p = Char(name);
       if (Strncmp(name, class_name, Len(class_name)) == 0 && p[Len(class_name)] == '_') {
-	Replace(copy, class_name, "", DOH_REPLACE_FIRST);
-	Replace(copy, "_", "", DOH_REPLACE_FIRST);
+        Replace(copy, class_name, "", DOH_REPLACE_FIRST);
+        Replace(copy, "_", "", DOH_REPLACE_FIRST);
       }
     }
     return copy;
@@ -4741,15 +4741,15 @@ private:
     if (lk) {
       String *n1 = Getattr(n, "sym:name");
       if (!n1) {
-	n1 = Getattr(n, "name");
+        n1 = Getattr(n, "name");
       }
       String *n2 = Getattr(lk, "sym:name");
       if (!n2) {
-	n2 = Getattr(lk, "name");
+        n2 = Getattr(lk, "name");
       }
       Swig_warning(WARN_GO_NAME_CONFLICT, input_file, line_number,
-		   "Ignoring '%s' due to Go name ('%s') conflict with '%s'\n",
-		   n1, name, n2);
+                   "Ignoring '%s' due to Go name ('%s') conflict with '%s'\n",
+                   n1, name, n2);
       return false;
     }
     bool r = addSymbol(name, n, scope) ? true : false;
@@ -4775,12 +4775,12 @@ private:
       Parm *p = parms;
 
       for (int i = 0; i < parm_count; ++i) {
-	p = getParm(p);
-	if (!checkIgnoredType(n, go_name, Getattr(p, "type"))) {
-	  DelWrapper(dummy);
-	  return false;
-	}
-	p = nextParm(p);
+        p = getParm(p);
+        if (!checkIgnoredType(n, go_name, Getattr(p, "type"))) {
+          DelWrapper(dummy);
+          return false;
+        }
+        p = nextParm(p);
       }
 
       DelWrapper(dummy);
@@ -4812,31 +4812,31 @@ private:
     Node *e = Language::enumLookup(t);
     if (e) {
       if (GetFlag(e, "go:conflict")) {
-	is_conflict = true;
+        is_conflict = true;
       }
     } else if (SwigType_issimple(t)) {
       Node *cn = classLookup(t);
       if (cn) {
-	if (GetFlag(cn, "go:conflict")) {
-	  is_conflict = true;
-	}
+        if (GetFlag(cn, "go:conflict")) {
+          is_conflict = true;
+        }
       }
     } else if (SwigType_ispointer(t) || SwigType_isarray(t) || SwigType_isqualifier(t) || SwigType_isreference(t) || SwigType_isrvalue_reference(t)) {
       SwigType *r = Copy(t);
       if (SwigType_ispointer(r)) {
-	SwigType_del_pointer(r);
+        SwigType_del_pointer(r);
       } else if (SwigType_isarray(r)) {
-	SwigType_del_array(r);
+        SwigType_del_array(r);
       } else if (SwigType_isqualifier(r)) {
-	SwigType_del_qualifier(r);
+        SwigType_del_qualifier(r);
       } else if (SwigType_isreference(r)) {
-	SwigType_del_reference(r);
+        SwigType_del_reference(r);
       } else if (SwigType_isrvalue_reference(r)) {
-	SwigType_del_rvalue_reference(r);
+        SwigType_del_rvalue_reference(r);
       }
 
       if (!checkIgnoredType(n, go_name, r)) {
-	ret = false;
+        ret = false;
       }
 
       Delete(r);
@@ -4845,8 +4845,8 @@ private:
     if (is_conflict) {
       String *s = SwigType_str(t, NULL);
       Swig_warning(WARN_GO_NAME_CONFLICT, input_file, line_number,
-		   "Ignoring '%s' (Go name '%s') due to Go name conflict for parameter or result type '%s'\n",
-		   Getattr(n, "name"), go_name, s);
+                   "Ignoring '%s' (Go name '%s') due to Go name conflict for parameter or result type '%s'\n",
+                   Getattr(n, "name"), go_name, s);
       Delete(s);
       ret = false;
     }
@@ -4900,30 +4900,30 @@ private:
     String *ret = NULL;
     if (use_imtype) {
       if (n && Cmp(type, Getattr(n, "type")) == 0) {
-	if (Strcmp(Getattr(n, "nodeType"), "parm") == 0) {
-	  ret = Getattr(n, "tmap:imtype");
-	}
-	if (!ret) {
-	  ret = Swig_typemap_lookup("imtype", n, "", NULL);
-	}
+        if (Strcmp(Getattr(n, "nodeType"), "parm") == 0) {
+          ret = Getattr(n, "tmap:imtype");
+        }
+        if (!ret) {
+          ret = Swig_typemap_lookup("imtype", n, "", NULL);
+        }
       } else {
-	Parm *p = NewParm(type, "goImType", n);
-	ret = Swig_typemap_lookup("imtype", p, "", NULL);
-	Delete(p);
+        Parm *p = NewParm(type, "goImType", n);
+        ret = Swig_typemap_lookup("imtype", p, "", NULL);
+        Delete(p);
       }
     }
     if (!ret) {
       if (n && Cmp(type, Getattr(n, "type")) == 0) {
-	if (Strcmp(Getattr(n, "nodeType"), "parm") == 0) {
-	  ret = Getattr(n, "tmap:gotype");
-	}
-	if (!ret) {
-	  ret = Swig_typemap_lookup("gotype", n, "", NULL);
-	}
+        if (Strcmp(Getattr(n, "nodeType"), "parm") == 0) {
+          ret = Getattr(n, "tmap:gotype");
+        }
+        if (!ret) {
+          ret = Swig_typemap_lookup("gotype", n, "", NULL);
+        }
       } else {
-	Parm *p = NewParm(type, "goType", n);
-	ret = Swig_typemap_lookup("gotype", p, "", NULL);
-	Delete(p);
+        Parm *p = NewParm(type, "goType", n);
+        ret = Swig_typemap_lookup("gotype", p, "", NULL);
+        Delete(p);
       }
     }
 
@@ -4940,16 +4940,16 @@ private:
     if (SwigType_isenum(t)) {
       Node *e = Language::enumLookup(t);
       if (e) {
-	ret = goEnumName(e);
+        ret = goEnumName(e);
       } else if (Strcmp(t, "enum ") == 0) {
-	ret = NewString("int");
+        ret = NewString("int");
       } else {
-	// An unknown enum - one that has not been parsed (neither a C enum forward reference nor a definition) or an ignored enum
-	String *tt = Copy(t);
-	Replace(tt, "enum ", "", DOH_REPLACE_ANY);
-	ret = exportedName(tt);
-	Setattr(undefined_enum_types, t, ret);
-	Delete(tt);
+        // An unknown enum - one that has not been parsed (neither a C enum forward reference nor a definition) or an ignored enum
+        String *tt = Copy(t);
+        Replace(tt, "enum ", "", DOH_REPLACE_ANY);
+        ret = exportedName(tt);
+        Setattr(undefined_enum_types, t, ret);
+        Delete(tt);
       }
     } else if (SwigType_isfunctionpointer(t) || SwigType_isfunction(t)) {
       ret = NewString("_swig_fnptr");
@@ -4958,81 +4958,81 @@ private:
     } else if (SwigType_issimple(t)) {
       Node *cn = classLookup(t);
       if (cn) {
-	ret = Getattr(cn, "sym:name");
-	if (!ret) {
-	  ret = Getattr(cn, "name");
-	}
-	ret = exportedName(ret);
+        ret = Getattr(cn, "sym:name");
+        if (!ret) {
+          ret = Getattr(cn, "name");
+        }
+        ret = exportedName(ret);
 
-	Node *cnmod = Getattr(cn, "module");
-	if (!cnmod || Strcmp(Getattr(cnmod, "name"), module) == 0) {
-	  Setattr(undefined_types, t, t);
-	} else {
-	  String *nw = NewString("");
-	  Printv(nw, getModuleName(Getattr(cnmod, "name")), ".", ret, NULL);
-	  Delete(ret);
-	  ret = nw;
-	}
+        Node *cnmod = Getattr(cn, "module");
+        if (!cnmod || Strcmp(Getattr(cnmod, "name"), module) == 0) {
+          Setattr(undefined_types, t, t);
+        } else {
+          String *nw = NewString("");
+          Printv(nw, getModuleName(Getattr(cnmod, "name")), ".", ret, NULL);
+          Delete(ret);
+          ret = nw;
+        }
       } else {
-	// SWIG does not know about this type.
-	ret = exportedName(t);
-	Setattr(undefined_types, t, t);
+        // SWIG does not know about this type.
+        ret = exportedName(t);
+        Setattr(undefined_types, t, t);
       }
       if (p_is_interface) {
-	*p_is_interface = true;
+        *p_is_interface = true;
       }
     } else if (SwigType_ispointer(t) || SwigType_isarray(t)) {
       SwigType *r = Copy(t);
       if (SwigType_ispointer(r)) {
-	SwigType_del_pointer(r);
+        SwigType_del_pointer(r);
       } else {
-	SwigType_del_array(r);
+        SwigType_del_array(r);
       }
 
       if (SwigType_type(r) == T_VOID) {
-	ret = NewString("uintptr");
+        ret = NewString("uintptr");
       } else {
-	bool is_interface;
-	String *base = goTypeWithInfo(n, r, false, &is_interface);
+        bool is_interface;
+        String *base = goTypeWithInfo(n, r, false, &is_interface);
 
-	// At the Go level, an unknown or class type is handled as an
-	// interface wrapping a pointer.  This means that if a
-	// function returns the C type X, we will be wrapping the C
-	// type X*.  In Go we will call that type X.  That means that
-	// if a C function expects X*, we can pass the Go type X.  And
-	// that means that when we see the C type X*, we should use
-	// the Go type X.
+        // At the Go level, an unknown or class type is handled as an
+        // interface wrapping a pointer.  This means that if a
+        // function returns the C type X, we will be wrapping the C
+        // type X*.  In Go we will call that type X.  That means that
+        // if a C function expects X*, we can pass the Go type X.  And
+        // that means that when we see the C type X*, we should use
+        // the Go type X.
 
-	// The is_interface variable tells us this.  However, it will
-	// be true both for the case of X and for the case of X*.  If
-	// r is a pointer here, then we are looking at X**.  There is
-	// really no good way for us to handle that.
-	bool is_pointer_to_pointer = false;
-	if (is_interface) {
-	  SwigType *c = Copy(r);
-	  if (SwigType_isqualifier(c)) {
-	    SwigType_del_qualifier(c);
-	    if (SwigType_ispointer(c) || SwigType_isarray(c)) {
-	      is_pointer_to_pointer = true;
-	    }
-	  }
-	  Delete(c);
-	}
+        // The is_interface variable tells us this.  However, it will
+        // be true both for the case of X and for the case of X*.  If
+        // r is a pointer here, then we are looking at X**.  There is
+        // really no good way for us to handle that.
+        bool is_pointer_to_pointer = false;
+        if (is_interface) {
+          SwigType *c = Copy(r);
+          if (SwigType_isqualifier(c)) {
+            SwigType_del_qualifier(c);
+            if (SwigType_ispointer(c) || SwigType_isarray(c)) {
+              is_pointer_to_pointer = true;
+            }
+          }
+          Delete(c);
+        }
 
-	if (is_interface) {
-	  if (!is_pointer_to_pointer) {
-	    ret = base;
-	    if (p_is_interface) {
-	      *p_is_interface = true;
-	    }
-	  } else {
-	    ret = NewString("uintptr");
-	  }
-	} else {
-	  ret = NewString("*");
-	  Append(ret, base);
-	  Delete(base);
-	}
+        if (is_interface) {
+          if (!is_pointer_to_pointer) {
+            ret = base;
+            if (p_is_interface) {
+              *p_is_interface = true;
+            }
+          } else {
+            ret = NewString("uintptr");
+          }
+        } else {
+          ret = NewString("*");
+          Append(ret, base);
+          Delete(base);
+        }
       }
 
       Delete(r);
@@ -5044,18 +5044,18 @@ private:
       // to it, then we just use the pointer we already have.
       bool add_pointer = true;
       if (SwigType_isqualifier(r)) {
-	String *q = SwigType_parm(r);
-	if (Strcmp(q, "const") == 0) {
-	  SwigType *c = Copy(r);
-	  SwigType_del_qualifier(c);
-	  if (SwigType_ispointer(c)) {
-	    add_pointer = false;
-	  }
-	  Delete(c);
-	}
+        String *q = SwigType_parm(r);
+        if (Strcmp(q, "const") == 0) {
+          SwigType *c = Copy(r);
+          SwigType_del_qualifier(c);
+          if (SwigType_ispointer(c)) {
+            add_pointer = false;
+          }
+          Delete(c);
+        }
       }
       if (add_pointer) {
-	SwigType_add_pointer(r);
+        SwigType_add_pointer(r);
       }
       ret = goTypeWithInfo(n, r, false, p_is_interface);
       Delete(r);
@@ -5067,18 +5067,18 @@ private:
       // to it, then we just use the pointer we already have.
       bool add_pointer = true;
       if (SwigType_isqualifier(r)) {
-	String *q = SwigType_parm(r);
-	if (Strcmp(q, "const") == 0) {
-	  SwigType *c = Copy(r);
-	  SwigType_del_qualifier(c);
-	  if (SwigType_ispointer(c)) {
-	    add_pointer = false;
-	  }
-	  Delete(c);
-	}
+        String *q = SwigType_parm(r);
+        if (Strcmp(q, "const") == 0) {
+          SwigType *c = Copy(r);
+          SwigType_del_qualifier(c);
+          if (SwigType_ispointer(c)) {
+            add_pointer = false;
+          }
+          Delete(c);
+        }
       }
       if (add_pointer) {
-	SwigType_add_pointer(r);
+        SwigType_add_pointer(r);
       }
       ret = goTypeWithInfo(n, r, false, p_is_interface);
       Delete(r);
@@ -5167,39 +5167,39 @@ private:
     } else {
       char *p = Strstr(gct, ct);
       if (p != NULL && p > (char*)Char(gct) && p[-1] == '*' && p[Len(ct)] == '\0') {
-	// Treat all pointers as void*.  See above.
-	Delete(ct);
-	--count;
-	ct = NewString("swig_voidp");
-	add_typedef = false;
-	if (is_hidden_pointer) {
-	  // A Go type that is really a pointer, like func, map, chan,
-	  // is being represented in C by a pointer.  This is fine,
-	  // but we have to memcpy the type rather than simply
-	  // converting it.
-	  *c_struct_type = true;
-	  Setattr(n, "emit:cgotypestruct", type);
-	}
+        // Treat all pointers as void*.  See above.
+        Delete(ct);
+        --count;
+        ct = NewString("swig_voidp");
+        add_typedef = false;
+        if (is_hidden_pointer) {
+          // A Go type that is really a pointer, like func, map, chan,
+          // is being represented in C by a pointer.  This is fine,
+          // but we have to memcpy the type rather than simply
+          // converting it.
+          *c_struct_type = true;
+          Setattr(n, "emit:cgotypestruct", type);
+        }
       }
 
       if (Strncmp(gct, "bool ", 5) == 0) {
-	// Change the C++ type bool to the C type _Bool.
-	Replace(gct, "bool", "_Bool", DOH_REPLACE_FIRST);
+        // Change the C++ type bool to the C type _Bool.
+        Replace(gct, "bool", "_Bool", DOH_REPLACE_FIRST);
       }
       if (Strncmp(gct, "intgo ", 6) == 0) {
-	// We #define intgo to swig_intgo for the cgo comment.
-	Replace(gct, "intgo", "swig_intgo", DOH_REPLACE_FIRST);
+        // We #define intgo to swig_intgo for the cgo comment.
+        Replace(gct, "intgo", "swig_intgo", DOH_REPLACE_FIRST);
       }
       p = Strstr(gct, ct);
       if (p != NULL && p > (char*)Char(gct) && p[-1] == ' ' && p[Len(ct)] == '\0') {
-	String *q = NewStringWithSize(gct, Len(gct) - Len(ct) - 1);
-	if (validIdentifier(q)) {
-	  // This is a simple type name, and we can use it directly.
-	  Delete(ct);
-	  --count;
-	  ct = q;
-	  add_typedef = false;
-	}
+        String *q = NewStringWithSize(gct, Len(gct) - Len(ct) - 1);
+        if (validIdentifier(q)) {
+          // This is a simple type name, and we can use it directly.
+          Delete(ct);
+          --count;
+          ct = q;
+          add_typedef = false;
+        }
       }
     }
     if (add_typedef) {
@@ -5229,28 +5229,28 @@ private:
     if (is_interface) {
       Delete(ret);
       if (!is_result) {
-	ret = NewString("uintptr");
+        ret = NewString("uintptr");
       } else {
-	SwigType *ty = SwigType_typedef_resolve_all(type);
-	while (true) {
-	  if (SwigType_ispointer(ty)) {
-	    SwigType_del_pointer(ty);
-	  } else if (SwigType_isarray(ty)) {
-	    SwigType_del_array(ty);
-	  } else if (SwigType_isreference(ty)) {
-	    SwigType_del_reference(ty);
-	  } else if (SwigType_isrvalue_reference(ty)) {
-	    SwigType_del_rvalue_reference(ty);
-	  } else if (SwigType_isqualifier(ty)) {
-	    SwigType_del_qualifier(ty);
-	  } else {
-	    break;
-	  }
-	}
-	assert(SwigType_issimple(ty));
-	String *p = goCPointerType(ty, true);
-	Delete(ty);
-	ret = p;
+        SwigType *ty = SwigType_typedef_resolve_all(type);
+        while (true) {
+          if (SwigType_ispointer(ty)) {
+            SwigType_del_pointer(ty);
+          } else if (SwigType_isarray(ty)) {
+            SwigType_del_array(ty);
+          } else if (SwigType_isreference(ty)) {
+            SwigType_del_reference(ty);
+          } else if (SwigType_isrvalue_reference(ty)) {
+            SwigType_del_rvalue_reference(ty);
+          } else if (SwigType_isqualifier(ty)) {
+            SwigType_del_qualifier(ty);
+          } else {
+            break;
+          }
+        }
+        assert(SwigType_issimple(ty));
+        String *p = goCPointerType(ty, true);
+        Delete(ty);
+        ret = p;
       }
     }
 
@@ -5278,17 +5278,17 @@ private:
     SwigType *ty = SwigType_typedef_resolve_all(type);
     while (true) {
       if (SwigType_ispointer(ty)) {
-	SwigType_del_pointer(ty);
+        SwigType_del_pointer(ty);
       } else if (SwigType_isarray(ty)) {
-	SwigType_del_array(ty);
+        SwigType_del_array(ty);
       } else if (SwigType_isreference(ty)) {
-	SwigType_del_reference(ty);
+        SwigType_del_reference(ty);
       } else if (SwigType_isrvalue_reference(ty)) {
-	SwigType_del_rvalue_reference(ty);
+        SwigType_del_rvalue_reference(ty);
       } else if (SwigType_isqualifier(ty)) {
-	SwigType_del_qualifier(ty);
+        SwigType_del_qualifier(ty);
       } else {
-	break;
+        break;
       }
     }
 
@@ -5318,7 +5318,7 @@ private:
     String *ret;
     if (!cn) {
       if (add_to_hash) {
-	Setattr(undefined_types, ty, ty);
+        Setattr(undefined_types, ty, ty);
       }
       ret = NewString("Swigcptr");
       ex = exportedName(ty);
@@ -5326,19 +5326,19 @@ private:
     } else {
       String *cname = Getattr(cn, "sym:name");
       if (!cname) {
-	cname = Getattr(cn, "name");
+        cname = Getattr(cn, "name");
       }
       ex = exportedName(cname);
       Node *cnmod = Getattr(cn, "module");
       if (!cnmod || Strcmp(Getattr(cnmod, "name"), module) == 0) {
-	if (add_to_hash) {
-	  Setattr(undefined_types, ty, ty);
-	}
-	ret = NewString("Swigcptr");
-	Append(ret, ex);
+        if (add_to_hash) {
+          Setattr(undefined_types, ty, ty);
+        }
+        ret = NewString("Swigcptr");
+        Append(ret, ex);
       } else {
-	ret = NewString("");
-	Printv(ret, getModuleName(Getattr(cnmod, "name")), ".Swigcptr", ex, NULL);
+        ret = NewString("");
+        Printv(ret, getModuleName(Getattr(cnmod, "name")), ".Swigcptr", ex, NULL);
       }
     }
     Delete(ty);
@@ -5364,27 +5364,27 @@ private:
       SwigType* tt = Copy(t);
       SwigType_del_reference(tt);
       if (SwigType_isqualifier(tt)) {
-	String* q = SwigType_parm(tt);
-	if (Strcmp(q, "const") == 0) {
-	  is_const_ref = true;
-	}
+        String* q = SwigType_parm(tt);
+        if (Strcmp(q, "const") == 0) {
+          is_const_ref = true;
+        }
       }
       Delete(tt);
     } else if (SwigType_isrvalue_reference(t)) {
       SwigType* tt = Copy(t);
       SwigType_del_rvalue_reference(tt);
       if (SwigType_isqualifier(tt)) {
-	String* q = SwigType_parm(tt);
-	if (Strcmp(q, "const") == 0) {
-	  is_const_ref = true;
-	}
+        String* q = SwigType_parm(tt);
+        if (Strcmp(q, "const") == 0) {
+          is_const_ref = true;
+        }
       }
       Delete(tt);
     }
     if (!is_const_ref) {
       while (Strncmp(gt, "*", 1) == 0) {
-	Replace(gt, "*", "", DOH_REPLACE_FIRST);
-	Printv(tail, "*", NULL);
+        Replace(gt, "*", "", DOH_REPLACE_FIRST);
+        Printv(tail, "*", NULL);
       }
     }
     Delete(t);
@@ -5443,12 +5443,12 @@ private:
     } else if (is_interface) {
       SwigType *t = SwigType_typedef_resolve_all(type);
       if (SwigType_ispointer(t)) {
-	SwigType_del_pointer(t);
+        SwigType_del_pointer(t);
       }
       if (SwigType_isreference(t)) {
-	SwigType_del_reference(t);
+        SwigType_del_reference(t);
       } else if (SwigType_isrvalue_reference(t)) {
-	SwigType_del_rvalue_reference(t);
+        SwigType_del_rvalue_reference(t);
       }
       SwigType_add_pointer(t);
       ret = SwigType_lstr(t, name);
@@ -5458,65 +5458,65 @@ private:
     } else {
       SwigType *t = SwigType_typedef_resolve_all(type);
       if (!has_typemap && (SwigType_isreference(t) || SwigType_isrvalue_reference(t))) {
-	// A const reference to a known type, or to a pointer, is not
-	// mapped to a pointer.
-	if (SwigType_isreference(t))
-	  SwigType_del_reference(t);
-	else if (SwigType_isrvalue_reference(t))
-	  SwigType_del_rvalue_reference(t);
-	if (SwigType_isqualifier(t)) {
-	  String *q = SwigType_parm(t);
-	  if (Strcmp(q, "const") == 0) {
-	    SwigType_del_qualifier(t);
-	    if (hasGoTypemap(n, t) || SwigType_ispointer(t)) {
-	      if (is_int) {
-		ret = NewString("intgo ");
-		Append(ret, name);
-	      } else if (is_int64) {
-		ret = NewString("long long ");
-		Append(ret, name);
-	      } else {
-		ret = SwigType_lstr(t, name);
-	      }
-	      Delete(q);
-	      Delete(t);
-	      Delete(tail);
-	      return ret;
-	    }
-	  }
-	  Delete(q);
-	}
+        // A const reference to a known type, or to a pointer, is not
+        // mapped to a pointer.
+        if (SwigType_isreference(t))
+          SwigType_del_reference(t);
+        else if (SwigType_isrvalue_reference(t))
+          SwigType_del_rvalue_reference(t);
+        if (SwigType_isqualifier(t)) {
+          String *q = SwigType_parm(t);
+          if (Strcmp(q, "const") == 0) {
+            SwigType_del_qualifier(t);
+            if (hasGoTypemap(n, t) || SwigType_ispointer(t)) {
+              if (is_int) {
+                ret = NewString("intgo ");
+                Append(ret, name);
+              } else if (is_int64) {
+                ret = NewString("long long ");
+                Append(ret, name);
+              } else {
+                ret = SwigType_lstr(t, name);
+              }
+              Delete(q);
+              Delete(t);
+              Delete(tail);
+              return ret;
+            }
+          }
+          Delete(q);
+        }
       }
 
       if (Language::enumLookup(t) != NULL) {
-	is_int = true;
+        is_int = true;
       } else {
-	SwigType *tstripped = SwigType_strip_qualifiers(t);
-	if (SwigType_isenum(tstripped))
-	  is_int = true;
-	Delete(tstripped);
+        SwigType *tstripped = SwigType_strip_qualifiers(t);
+        if (SwigType_isenum(tstripped))
+          is_int = true;
+        Delete(tstripped);
       }
 
       Delete(t);
       if (is_bool) {
-	ret = NewString("bool ");
+        ret = NewString("bool ");
       } else if (is_int8) {
-	ret = NewString("char ");
+        ret = NewString("char ");
       } else if (is_int16) {
-	ret = NewString("short ");
+        ret = NewString("short ");
       } else if (is_int) {
-	ret = NewString("intgo ");
+        ret = NewString("intgo ");
       } else if (is_int32) {
-	ret = NewString("int ");
+        ret = NewString("int ");
       } else if (is_int64) {
-	ret = NewString("long long ");
+        ret = NewString("long long ");
       } else if (is_float32) {
-	ret = NewString("float ");
+        ret = NewString("float ");
       } else if (is_float64) {
-	ret = NewString("double ");
+        ret = NewString("double ");
       } else {
-	Delete(tail);
-	return SwigType_lstr(type, name);
+        Delete(tail);
+        return SwigType_lstr(type, name);
       }
     }
 
@@ -5585,15 +5585,15 @@ private:
     bool capitalize = true;
     for (int i = 0; i < len; ++i, ++p) {
       if (*p == ':') {
-	++i;
-	++p;
-	assert(*p == ':');
-	capitalize = true;
+        ++i;
+        ++p;
+        assert(*p == ':');
+        capitalize = true;
       } else if (capitalize) {
-	Putc(toupper(*p), s);
-	capitalize = false;
+        Putc(toupper(*p), s);
+        capitalize = false;
       } else {
-	Putc(*p, s);
+        Putc(*p, s);
       }
     }
 

--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -5696,7 +5696,7 @@ private:
     return Str(suffix + 1);
   }
 
-};				/* class GO */
+};                              /* class GO */
 
 /* -----------------------------------------------------------------------------
  * swig_go()    - Instantiate module

--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -642,7 +642,7 @@ public:
     } else {
       if (!addSymbol(iname, n)) {
         DelWrapper(f);
-        return SWIG_ERROR; 
+        return SWIG_ERROR;
       }
     }
     if (overname) {
@@ -1562,7 +1562,7 @@ public:
 
   /* ------------------------------------------------------------
    * goopsNameMapping()
-   * Maps the identifier from C++ to the GOOPS based * on command 
+   * Maps the identifier from C++ to the GOOPS based * on command
    * line parameters and such.
    * If class_name = "" that means the mapping is for a function or
    * variable not attached to any class.

--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -53,15 +53,14 @@ static File *f_header = 0;
 static File *f_wrappers = 0;
 static File *f_init = 0;
 
-
 static String *prefix = NewString("gswig_");
 static char *module = 0;
 static String *package = 0;
 static enum {
-  GUILE_LSTYLE_SIMPLE,          // call `SWIG_init()'
-  GUILE_LSTYLE_PASSIVE,         // passive linking (no module code)
-  GUILE_LSTYLE_MODULE,          // native guile module linking (Guile >= 1.4.1)
-  GUILE_LSTYLE_HOBBIT           // use (hobbit4d link)
+  GUILE_LSTYLE_SIMPLE,   // call `SWIG_init()'
+  GUILE_LSTYLE_PASSIVE,  // passive linking (no module code)
+  GUILE_LSTYLE_MODULE,   // native guile module linking (Guile >= 1.4.1)
+  GUILE_LSTYLE_HOBBIT    // use (hobbit4d link)
 } linkage = GUILE_LSTYLE_SIMPLE;
 
 static File *procdoc = 0;
@@ -72,11 +71,7 @@ static String *goopstext;
 static String *goopscode;
 static String *goopsexport;
 
-static enum {
-  GUILE_1_4,
-  PLAIN,
-  TEXINFO
-} docformat = GUILE_1_4;
+static enum { GUILE_1_4, PLAIN, TEXINFO } docformat = GUILE_1_4;
 
 static int emit_setters = 0;
 static int only_setters = 0;
@@ -100,21 +95,20 @@ static String *short_class_name = 0;
 static String *goops_class_methods;
 static int in_class = 0;
 static int have_constructor = 0;
-static int useclassprefix = 0;  // -useclassprefix argument
-static String *goopsprefix = 0; // -goopsprefix argument
-static int primRenamer = 0;     // if (use-modules ((...) :renamer ...) is exported to GOOPS file
-static int exportprimitive = 0; // -exportprimitive argument
+static int useclassprefix = 0;   // -useclassprefix argument
+static String *goopsprefix = 0;  // -goopsprefix argument
+static int primRenamer = 0;      // if (use-modules ((...) :renamer ...) is exported to GOOPS file
+static int exportprimitive = 0;  // -exportprimitive argument
 static String *memberfunction_name = 0;
 
 extern "C" {
-  static Node *has_classname(Node *class_node) {
-    return Getattr(class_node, "guile:goopsclassname") ? class_node : 0;
-  }
+static Node *has_classname(Node *class_node) {
+  return Getattr(class_node, "guile:goopsclassname") ? class_node : 0;
+}
 }
 
-class GUILE:public Language {
+class GUILE : public Language {
 public:
-
   /* ------------------------------------------------------------
    * main()
    * ------------------------------------------------------------ */
@@ -122,7 +116,7 @@ public:
   virtual void main(int argc, char *argv[]) {
     int i;
 
-     SWIG_library_directory("guile");
+    SWIG_library_directory("guile");
 
     // Look for certain command line options
     for (i = 1; i < argc; i++) {
@@ -240,7 +234,7 @@ public:
     if (!primsuffix)
       primsuffix = NewString("primitive");
 
-    //goops support can only be enabled if passive or module linkage is used
+    // goops support can only be enabled if passive or module linkage is used
     if (goops) {
       if (linkage != GUILE_LSTYLE_PASSIVE && linkage != GUILE_LSTYLE_MODULE) {
         Printf(stderr, "guile: GOOPS support requires passive or module linkage\n");
@@ -273,7 +267,6 @@ public:
     /* Read in default typemaps */
     SWIG_config_file("guile_scm.swg");
     allow_overloading();
-
   }
 
   /* ------------------------------------------------------------
@@ -463,9 +456,7 @@ public:
       String *mod = NewString(primitive_name);
       Replaceall(mod, "/", " ");
 
-      String *fname = NewStringf("%s%s.scm",
-                                 SWIG_output_directory(),
-                                 primitive_name);
+      String *fname = NewStringf("%s%s.scm", SWIG_output_directory(), primitive_name);
       Delete(primitive_name);
       File *scmstubfile = NewFile(fname, "w", SWIG_output_files());
       if (!scmstubfile) {
@@ -480,8 +471,7 @@ public:
         Printf(scmstubfile, "(define-module (%s))\n\n", mod);
       Delete(mod);
       Printf(scmstubfile, "%s", scmtext);
-      if ((linkage == GUILE_LSTYLE_SIMPLE || linkage == GUILE_LSTYLE_PASSIVE)
-          && Len(exported_symbols) > 0) {
+      if ((linkage == GUILE_LSTYLE_SIMPLE || linkage == GUILE_LSTYLE_PASSIVE) && Len(exported_symbols) > 0) {
         String *ex = NewString(exported_symbols);
         Replaceall(ex, ", ", "\n        ");
         Replaceall(ex, "\"", "");
@@ -496,8 +486,7 @@ public:
       String *mod = NewString(module_name);
       Replaceall(mod, "/", " ");
 
-      String *fname = NewStringf("%s%s.scm", SWIG_output_directory(),
-                                 module_name);
+      String *fname = NewStringf("%s%s.scm", SWIG_output_directory(), module_name);
       File *goopsfile = NewFile(fname, "w", SWIG_output_files());
       if (!goopsfile) {
         FileErrorDisplay(fname);
@@ -573,8 +562,8 @@ public:
   }
 
   /* returns false if the typemap is an empty string */
-  bool handle_documentation_typemap(String *output,
-                                    const String *maybe_delimiter, Parm *p, const String *typemap, const String *default_doc, const String *name = NULL) {
+  bool handle_documentation_typemap(String *output, const String *maybe_delimiter, Parm *p, const String *typemap, const String *default_doc,
+                                    const String *name = NULL) {
     String *tmp = NewString("");
     String *tm;
     if (!(tm = Getattr(p, typemap))) {
@@ -585,9 +574,9 @@ public:
     if (maybe_delimiter && Len(output) > 0 && Len(tm) > 0) {
       Printv(output, maybe_delimiter, NIL);
     }
-    const String *pn = !name ? (const String *) Getattr(p, "name") : name;
+    const String *pn = !name ? (const String *)Getattr(p, "name") : name;
     String *pt = Getattr(p, "type");
-    Replaceall(tm, "$name", pn);        // legacy for $parmname
+    Replaceall(tm, "$name", pn);  // legacy for $parmname
     Replaceall(tm, "$type", SwigType_str(pt, 0));
     /* $NAME is like $name, but marked-up as a variable. */
     String *ARGNAME = NewString("");
@@ -852,7 +841,6 @@ public:
     }
     Append(returns, returns_argout);
 
-
     // Dump the argument output code
     Printv(f->code, outarg, NIL);
 
@@ -916,7 +904,7 @@ public:
         int is_setter = (pc[len - 3] == 's');
         if (is_setter) {
           Printf(f_init, "SCM setter = ");
-          struct_member = 2;    /* have a setter */
+          struct_member = 2; /* have a setter */
         } else
           Printf(f_init, "SCM getter = ");
         /* GOOPS support uses the MEMBER-set and MEMBER-get functions,
@@ -932,7 +920,10 @@ public:
           if (struct_member == 2) {
             /* There was a setter, so create a procedure with setter */
             Printf(f_init, "scm_c_define");
-            Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(getter, setter));\n", slot_name);
+            Printf(f_init,
+                   "(\"%s\", "
+                   "scm_make_procedure_with_setter(getter, setter));\n",
+                   slot_name);
           } else {
             /* There was no setter, so make an alias to the getter */
             Printf(f_init, "scm_c_define");
@@ -945,11 +936,11 @@ public:
         /* Register the function */
         if (exporting_destructor) {
           Printf(f_init, "((swig_guile_clientdata *)(SWIGTYPE%s->clientdata))->destroy = (guile_destructor) %s;\n", swigtype_ptr, wname);
-          //Printf(f_init, "SWIG_TypeClientData(SWIGTYPE%s, (void *) %s);\n", swigtype_ptr, wname);
+          // Printf(f_init, "SWIG_TypeClientData(SWIGTYPE%s, (void *) %s);\n", swigtype_ptr, wname);
         }
         Printf(f_init, "scm_c_define_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
       }
-    } else {                    /* overloaded function; don't export the single methods */
+    } else { /* overloaded function; don't export the single methods */
       if (!Getattr(n, "sym:nextSibling")) {
         /* Emit overloading dispatch function */
 
@@ -1029,11 +1020,7 @@ public:
       else
         Printv(returns_text, return_multi_doc, NIL);
       /* Substitute documentation variables */
-      static const char *numbers[] = { "zero", "one", "two", "three",
-        "four", "five", "six", "seven",
-        "eight", "nine", "ten", "eleven",
-        "twelve"
-      };
+      static const char *numbers[] = {"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve"};
       if (num_results <= 12)
         Replaceall(returns_text, "$num_values", numbers[num_results]);
       else {
@@ -1170,12 +1157,15 @@ public:
         /* Read/write variables become a procedure with setter. */
         Printf(f_init, "{ SCM p = scm_c_define_gsubr(\"%s\", 0, 1, 0, (swig_guile_proc) %s);\n", proc_name, var_name);
         Printf(f_init, "scm_c_define");
-        Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(p, p)); }\n", proc_name);
+        Printf(f_init,
+               "(\"%s\", "
+               "scm_make_procedure_with_setter(p, p)); }\n",
+               proc_name);
       }
       Printf(exported_symbols, "\"%s\", ", proc_name);
 
       // export wrapper into goops file
-      if (!in_class) {          // only if the variable is not part of a class
+      if (!in_class) {  // only if the variable is not part of a class
         String *class_name = SwigType_typedef_resolve_all(SwigType_base(t));
         String *goops_name = goopsNameMapping(proc_name, "");
         String *primitive_name = NewString("");
@@ -1183,8 +1173,7 @@ public:
           Printv(primitive_name, "primitive:", NIL);
         Printv(primitive_name, proc_name, NIL);
         /* Simply re-export the procedure */
-        if ((!emit_setters || !assignable)
-            && GetFlag(n, "feature:constasvar")) {
+        if ((!emit_setters || !assignable) && GetFlag(n, "feature:constasvar")) {
           Printv(goopscode, "(define ", goops_name, " (", primitive_name, "))\n", NIL);
         } else {
           Printv(goopscode, "(define ", goops_name, " ", primitive_name, ")\n", NIL);
@@ -1236,7 +1225,10 @@ public:
             Delete(s);
           }
 
-          Printv(doc, "If NEW-VALUE is provided, " "set C variable to this value.\n", NIL);
+          Printv(doc,
+                 "If NEW-VALUE is provided, "
+                 "set C variable to this value.\n",
+                 NIL);
           Printv(doc, "Returns variable value ", NIL);
           if ((tm = Getattr(n, "tmap:varout:doc"))) {
             Printv(doc, tm, NIL);
@@ -1272,7 +1264,6 @@ public:
     SwigType *type = Getattr(n, "type");
     String *value = Getattr(n, "value");
     int constasvar = GetFlag(n, "feature:constasvar");
-
 
     String *proc_name;
     String *var_name;
@@ -1412,7 +1403,6 @@ public:
     Delete(goops_class_methods);
     goops_class_methods = 0;
 
-
     /* export class initialization function */
     if (goops) {
       /* export the wrapper function */
@@ -1542,23 +1532,20 @@ public:
       String *cmd = Getattr(n, "name");
       String *value = Getattr(n, "value");
 
-#     define store_pragma(PRAGMANAME)                   \
-        if (Strcmp(cmd, #PRAGMANAME) == 0) {            \
-          if (PRAGMANAME) Delete(PRAGMANAME);           \
-          PRAGMANAME = value ? NewString(value) : NULL; \
-        }
+#define store_pragma(PRAGMANAME)                  \
+  if (Strcmp(cmd, #PRAGMANAME) == 0) {            \
+    if (PRAGMANAME)                               \
+      Delete(PRAGMANAME);                         \
+    PRAGMANAME = value ? NewString(value) : NULL; \
+  }
 
       if (Strcmp(lang, "guile") == 0) {
-        store_pragma(beforereturn)
-            store_pragma(return_nothing_doc)
-            store_pragma(return_one_doc)
-            store_pragma(return_multi_doc);
-#     undef store_pragma
+        store_pragma(beforereturn) store_pragma(return_nothing_doc) store_pragma(return_one_doc) store_pragma(return_multi_doc);
+#undef store_pragma
       }
     }
     return Language::pragmaDirective(n);
   }
-
 
   /* ------------------------------------------------------------
    * goopsNameMapping()
@@ -1591,7 +1578,6 @@ public:
     return n;
   }
 
-
   /* ------------------------------------------------------------
    * validIdentifier()
    * ------------------------------------------------------------ */
@@ -1603,24 +1589,18 @@ public:
        those. */
     /* <identifier> --> <initial> <subsequent>* | <peculiar identifier> */
     /* <initial> --> <letter> | <special initial> */
-    if (!(isalpha(*c) || (*c == '!') || (*c == '$') || (*c == '%')
-          || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':')
-          || (*c == '<') || (*c == '=') || (*c == '>') || (*c == '?')
-          || (*c == '^') || (*c == '_') || (*c == '~'))) {
+    if (!(isalpha(*c) || (*c == '!') || (*c == '$') || (*c == '%') || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':') || (*c == '<') || (*c == '=') ||
+          (*c == '>') || (*c == '?') || (*c == '^') || (*c == '_') || (*c == '~'))) {
       /* <peculiar identifier> --> + | - | ... */
-      if ((strcmp(c, "+") == 0)
-          || strcmp(c, "-") == 0 || strcmp(c, "...") == 0)
+      if ((strcmp(c, "+") == 0) || strcmp(c, "-") == 0 || strcmp(c, "...") == 0)
         return 1;
       else
         return 0;
     }
     /* <subsequent> --> <initial> | <digit> | <special subsequent> */
     while (*c) {
-      if (!(isalnum(*c) || (*c == '!') || (*c == '$') || (*c == '%')
-            || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':')
-            || (*c == '<') || (*c == '=') || (*c == '>') || (*c == '?')
-            || (*c == '^') || (*c == '_') || (*c == '~') || (*c == '+')
-            || (*c == '-') || (*c == '.') || (*c == '@')))
+      if (!(isalnum(*c) || (*c == '!') || (*c == '$') || (*c == '%') || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':') || (*c == '<') ||
+            (*c == '=') || (*c == '>') || (*c == '?') || (*c == '^') || (*c == '_') || (*c == '~') || (*c == '+') || (*c == '-') || (*c == '.') || (*c == '@')))
         return 0;
       c++;
     }

--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -127,112 +127,112 @@ public:
     // Look for certain command line options
     for (i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-help") == 0) {
-	  fputs(usage1, stdout);
-	  fputs(usage2, stdout);
-	} else if (strcmp(argv[i], "-prefix") == 0) {
-	  if (argv[i + 1]) {
-	    prefix = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-package") == 0) {
-	  if (argv[i + 1]) {
-	    package = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-Linkage") == 0 || strcmp(argv[i], "-linkage") == 0) {
-	  if (argv[i + 1]) {
-	    if (0 == strcmp(argv[i + 1], "hobbit"))
-	      linkage = GUILE_LSTYLE_HOBBIT;
-	    else if (0 == strcmp(argv[i + 1], "simple"))
-	      linkage = GUILE_LSTYLE_SIMPLE;
-	    else if (0 == strcmp(argv[i + 1], "passive"))
-	      linkage = GUILE_LSTYLE_PASSIVE;
-	    else if (0 == strcmp(argv[i + 1], "module"))
-	      linkage = GUILE_LSTYLE_MODULE;
-	    else
-	      Swig_arg_error();
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-procdoc") == 0) {
-	  if (argv[i + 1]) {
-	    procdoc = NewFile(argv[i + 1], "w", SWIG_output_files());
-	    if (!procdoc) {
-	      FileErrorDisplay(argv[i + 1]);
-	      Exit(EXIT_FAILURE);
-	    }
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-procdocformat") == 0) {
-	  if (strcmp(argv[i + 1], "guile-1.4") == 0)
-	    docformat = GUILE_1_4;
-	  else if (strcmp(argv[i + 1], "plain") == 0)
-	    docformat = PLAIN;
-	  else if (strcmp(argv[i + 1], "texinfo") == 0)
-	    docformat = TEXINFO;
-	  else
-	    Swig_arg_error();
-	  Swig_mark_arg(i);
-	  Swig_mark_arg(i + 1);
-	  i++;
-	} else if (strcmp(argv[i], "-emit-setters") == 0 || strcmp(argv[i], "-emitsetters") == 0) {
-	  emit_setters = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-only-setters") == 0 || strcmp(argv[i], "-onlysetters") == 0) {
-	  emit_setters = 1;
-	  only_setters = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-emit-slot-accessors") == 0 || strcmp(argv[i], "-emitslotaccessors") == 0) {
-	  emit_slot_accessors = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-scmstub") == 0) {
-	  scmstub = true;
-	  Swig_mark_arg(i);
-	} else if ((strcmp(argv[i], "-shadow") == 0) || ((strcmp(argv[i], "-proxy") == 0))) {
-	  goops = true;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-primsuffix") == 0) {
-	  if (argv[i + 1]) {
-	    primsuffix = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-goopsprefix") == 0) {
-	  if (argv[i + 1]) {
-	    goopsprefix = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-useclassprefix") == 0) {
-	  useclassprefix = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-exportprimitive") == 0) {
-	  exportprimitive = 1;
-	  // should use Swig_warning() here?
-	  Swig_mark_arg(i);
-	}
+        if (strcmp(argv[i], "-help") == 0) {
+          fputs(usage1, stdout);
+          fputs(usage2, stdout);
+        } else if (strcmp(argv[i], "-prefix") == 0) {
+          if (argv[i + 1]) {
+            prefix = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-package") == 0) {
+          if (argv[i + 1]) {
+            package = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-Linkage") == 0 || strcmp(argv[i], "-linkage") == 0) {
+          if (argv[i + 1]) {
+            if (0 == strcmp(argv[i + 1], "hobbit"))
+              linkage = GUILE_LSTYLE_HOBBIT;
+            else if (0 == strcmp(argv[i + 1], "simple"))
+              linkage = GUILE_LSTYLE_SIMPLE;
+            else if (0 == strcmp(argv[i + 1], "passive"))
+              linkage = GUILE_LSTYLE_PASSIVE;
+            else if (0 == strcmp(argv[i + 1], "module"))
+              linkage = GUILE_LSTYLE_MODULE;
+            else
+              Swig_arg_error();
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-procdoc") == 0) {
+          if (argv[i + 1]) {
+            procdoc = NewFile(argv[i + 1], "w", SWIG_output_files());
+            if (!procdoc) {
+              FileErrorDisplay(argv[i + 1]);
+              Exit(EXIT_FAILURE);
+            }
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-procdocformat") == 0) {
+          if (strcmp(argv[i + 1], "guile-1.4") == 0)
+            docformat = GUILE_1_4;
+          else if (strcmp(argv[i + 1], "plain") == 0)
+            docformat = PLAIN;
+          else if (strcmp(argv[i + 1], "texinfo") == 0)
+            docformat = TEXINFO;
+          else
+            Swig_arg_error();
+          Swig_mark_arg(i);
+          Swig_mark_arg(i + 1);
+          i++;
+        } else if (strcmp(argv[i], "-emit-setters") == 0 || strcmp(argv[i], "-emitsetters") == 0) {
+          emit_setters = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-only-setters") == 0 || strcmp(argv[i], "-onlysetters") == 0) {
+          emit_setters = 1;
+          only_setters = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-emit-slot-accessors") == 0 || strcmp(argv[i], "-emitslotaccessors") == 0) {
+          emit_slot_accessors = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-scmstub") == 0) {
+          scmstub = true;
+          Swig_mark_arg(i);
+        } else if ((strcmp(argv[i], "-shadow") == 0) || ((strcmp(argv[i], "-proxy") == 0))) {
+          goops = true;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-primsuffix") == 0) {
+          if (argv[i + 1]) {
+            primsuffix = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-goopsprefix") == 0) {
+          if (argv[i + 1]) {
+            goopsprefix = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-useclassprefix") == 0) {
+          useclassprefix = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-exportprimitive") == 0) {
+          exportprimitive = 1;
+          // should use Swig_warning() here?
+          Swig_mark_arg(i);
+        }
       }
     }
 
@@ -243,8 +243,8 @@ public:
     //goops support can only be enabled if passive or module linkage is used
     if (goops) {
       if (linkage != GUILE_LSTYLE_PASSIVE && linkage != GUILE_LSTYLE_MODULE) {
-	Printf(stderr, "guile: GOOPS support requires passive or module linkage\n");
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "guile: GOOPS support requires passive or module linkage\n");
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -265,7 +265,7 @@ public:
     if (prefix) {
       const char *px = Char(prefix);
       if (px[Len(prefix) - 1] != '_')
-	Printf(prefix, "_");
+        Printf(prefix, "_");
     }
 
     /* Add a symbol for this module */
@@ -356,9 +356,9 @@ public:
       Printv(module_name, "swig", NIL);
     else {
       if (package)
-	Printf(module_name, "%s/%s", package, module);
+        Printf(module_name, "%s/%s", package, module);
       else
-	Printv(module_name, module, NIL);
+        Printv(module_name, module, NIL);
     }
     emit_linkage(module_name);
 
@@ -419,19 +419,19 @@ public:
       Printf(f_init, "static void SWIG_init_helper(void *data)\n");
       Printf(f_init, "{\n    SWIG_init();\n");
       if (Len(exported_symbols) > 0)
-	Printf(f_init, "    scm_c_export(%sNULL);", exported_symbols);
+        Printf(f_init, "    scm_c_export(%sNULL);", exported_symbols);
       Printf(f_init, "\n}\n\n");
 
       Printf(f_init, "SCM\n%s (void)\n{\n", module_func);
       {
-	String *mod = NewString(module_name);
-	if (goops)
-	  Printv(mod, "-", primsuffix, NIL);
-	Replaceall(mod, "/", " ");
-	Printf(f_init, "    scm_c_define_module(\"%s\",\n", mod);
-	Printf(f_init, "      SWIG_init_helper, NULL);\n");
-	Printf(f_init, "    return SCM_UNSPECIFIED;\n");
-	Delete(mod);
+        String *mod = NewString(module_name);
+        if (goops)
+          Printv(mod, "-", primsuffix, NIL);
+        Replaceall(mod, "/", " ");
+        Printf(f_init, "    scm_c_define_module(\"%s\",\n", mod);
+        Printf(f_init, "      SWIG_init_helper, NULL);\n");
+        Printf(f_init, "    return SCM_UNSPECIFIED;\n");
+        Delete(mod);
       }
       Printf(f_init, "}\n");
       break;
@@ -441,11 +441,11 @@ public:
       Insert(module_func, 0, "scm_init_");
       Printf(f_init, "SCM\n%s (void)\n{\n", module_func);
       {
-	String *mod = NewString(module_name);
-	Replaceall(mod, "/", " ");
-	Printf(f_init, "    scm_register_module_xxx (\"%s\", (void *) SWIG_init);\n", mod);
-	Printf(f_init, "    return SCM_UNSPECIFIED;\n");
-	Delete(mod);
+        String *mod = NewString(module_name);
+        Replaceall(mod, "/", " ");
+        Printf(f_init, "    scm_register_module_xxx (\"%s\", (void *) SWIG_init);\n", mod);
+        Printf(f_init, "    return SCM_UNSPECIFIED;\n");
+        Delete(mod);
       }
       Printf(f_init, "}\n");
       break;
@@ -458,36 +458,36 @@ public:
       /* Emit Scheme stub if requested */
       String *primitive_name = NewString(module_name);
       if (goops)
-	Printv(primitive_name, "-", primsuffix, NIL);
+        Printv(primitive_name, "-", primsuffix, NIL);
 
       String *mod = NewString(primitive_name);
       Replaceall(mod, "/", " ");
 
       String *fname = NewStringf("%s%s.scm",
-				 SWIG_output_directory(),
-				 primitive_name);
+                                 SWIG_output_directory(),
+                                 primitive_name);
       Delete(primitive_name);
       File *scmstubfile = NewFile(fname, "w", SWIG_output_files());
       if (!scmstubfile) {
-	FileErrorDisplay(fname);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(fname);
+        Exit(EXIT_FAILURE);
       }
       Delete(fname);
 
       Swig_banner_target_lang(scmstubfile, ";;;");
       Printf(scmstubfile, "\n");
       if (linkage == GUILE_LSTYLE_SIMPLE || linkage == GUILE_LSTYLE_PASSIVE)
-	Printf(scmstubfile, "(define-module (%s))\n\n", mod);
+        Printf(scmstubfile, "(define-module (%s))\n\n", mod);
       Delete(mod);
       Printf(scmstubfile, "%s", scmtext);
       if ((linkage == GUILE_LSTYLE_SIMPLE || linkage == GUILE_LSTYLE_PASSIVE)
-	  && Len(exported_symbols) > 0) {
-	String *ex = NewString(exported_symbols);
-	Replaceall(ex, ", ", "\n        ");
-	Replaceall(ex, "\"", "");
-	Chop(ex);
-	Printf(scmstubfile, "\n(export %s)\n", ex);
-	Delete(ex);
+          && Len(exported_symbols) > 0) {
+        String *ex = NewString(exported_symbols);
+        Replaceall(ex, ", ", "\n        ");
+        Replaceall(ex, "\"", "");
+        Chop(ex);
+        Printf(scmstubfile, "\n(export %s)\n", ex);
+        Delete(ex);
       }
       Delete(scmstubfile);
     }
@@ -497,11 +497,11 @@ public:
       Replaceall(mod, "/", " ");
 
       String *fname = NewStringf("%s%s.scm", SWIG_output_directory(),
-				 module_name);
+                                 module_name);
       File *goopsfile = NewFile(fname, "w", SWIG_output_files());
       if (!goopsfile) {
-	FileErrorDisplay(fname);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(fname);
+        Exit(EXIT_FAILURE);
       }
       Delete(fname);
       Swig_banner_target_lang(goopsfile, ";;;");
@@ -510,16 +510,16 @@ public:
       Printf(goopsfile, "%s\n", goopstext);
       Printf(goopsfile, "(use-modules (oop goops) (Swig common))\n");
       if (primRenamer) {
-	Printf(goopsfile, "(use-modules ((%s-%s) :renamer (symbol-prefix-proc 'primitive:)))\n", mod, primsuffix);
+        Printf(goopsfile, "(use-modules ((%s-%s) :renamer (symbol-prefix-proc 'primitive:)))\n", mod, primsuffix);
       }
       Printf(goopsfile, "%s\n(export %s)", goopscode, goopsexport);
       if (exportprimitive) {
-	String *ex = NewString(exported_symbols);
-	Replaceall(ex, ", ", "\n        ");
-	Replaceall(ex, "\"", "");
-	Chop(ex);
-	Printf(goopsfile, "\n(export %s)", ex);
-	Delete(ex);
+        String *ex = NewString(exported_symbols);
+        Replaceall(ex, ", ", "\n        ");
+        Replaceall(ex, "\"", "");
+        Chop(ex);
+        Printf(goopsfile, "\n(export %s)", ex);
+        Delete(ex);
       }
       Delete(mod);
       Delete(goopsfile);
@@ -551,21 +551,21 @@ public:
       Printv(procdoc, "\f\n", NIL);
       Printv(procdoc, "(", signature, ")\n", NIL);
       if (signature2)
-	Printv(procdoc, "(", signature2, ")\n", NIL);
+        Printv(procdoc, "(", signature2, ")\n", NIL);
       Printv(procdoc, doc, "\n", NIL);
       break;
     case PLAIN:
       Printv(procdoc, "\f", proc_name, "\n\n", NIL);
       Printv(procdoc, "(", signature, ")\n", NIL);
       if (signature2)
-	Printv(procdoc, "(", signature2, ")\n", NIL);
+        Printv(procdoc, "(", signature2, ")\n", NIL);
       Printv(procdoc, doc, "\n\n", NIL);
       break;
     case TEXINFO:
       Printv(procdoc, "\f", proc_name, "\n", NIL);
       Printv(procdoc, "@deffn primitive ", signature, "\n", NIL);
       if (signature2)
-	Printv(procdoc, "@deffnx primitive ", signature2, "\n", NIL);
+        Printv(procdoc, "@deffnx primitive ", signature2, "\n", NIL);
       Printv(procdoc, doc, "\n", NIL);
       Printv(procdoc, "@end deffn\n\n", NIL);
       break;
@@ -574,7 +574,7 @@ public:
 
   /* returns false if the typemap is an empty string */
   bool handle_documentation_typemap(String *output,
-				    const String *maybe_delimiter, Parm *p, const String *typemap, const String *default_doc, const String *name = NULL) {
+                                    const String *maybe_delimiter, Parm *p, const String *typemap, const String *default_doc, const String *name = NULL) {
     String *tmp = NewString("");
     String *tm;
     if (!(tm = Getattr(p, typemap))) {
@@ -642,7 +642,7 @@ public:
     } else {
       if (!addSymbol(iname, n)) {
         DelWrapper(f);
-	return SWIG_ERROR; 
+        return SWIG_ERROR; 
       }
     }
     if (overname) {
@@ -683,7 +683,7 @@ public:
     for (i = 0, p = l; i < numargs; i++) {
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -691,73 +691,73 @@ public:
 
       // Produce names of source and target
       if (args_passed_as_array)
-	sprintf(source, "argv[%d]", i);
+        sprintf(source, "argv[%d]", i);
       else
-	sprintf(source, "s_%d", i);
+        sprintf(source, "s_%d", i);
 
       if (!args_passed_as_array) {
-	if (i != 0)
-	  Printf(f->def, ", ");
-	Printf(f->def, "SCM s_%d", i);
+        if (i != 0)
+          Printf(f->def, ", ");
+        Printf(f->def, "SCM s_%d", i);
       }
       if (opt_p) {
-	Printf(f->code, "    if (%s != SCM_UNDEFINED) {\n", source);
+        Printf(f->code, "    if (%s != SCM_UNDEFINED) {\n", source);
       }
       if ((tm = Getattr(p, "tmap:in"))) {
-	Replaceall(tm, "$input", source);
-	Setattr(p, "emit:input", source);
-	Printv(f->code, tm, "\n", NIL);
+        Replaceall(tm, "$input", source);
+        Setattr(p, "emit:input", source);
+        Printv(f->code, tm, "\n", NIL);
 
-	SwigType *pb = SwigType_typedef_resolve_all(SwigType_base(pt));
-	SwigType *pn = Getattr(p, "name");
-	String *argname;
-	scheme_argnum++;
-	if (pn && !Getattr(scheme_arg_names, pn))
-	  argname = pn;
-	else {
-	  /* Anonymous arg or re-used argument name -- choose a name that cannot clash */
-	  argname = NewStringf("%%arg%d", scheme_argnum);
-	}
+        SwigType *pb = SwigType_typedef_resolve_all(SwigType_base(pt));
+        SwigType *pn = Getattr(p, "name");
+        String *argname;
+        scheme_argnum++;
+        if (pn && !Getattr(scheme_arg_names, pn))
+          argname = pn;
+        else {
+          /* Anonymous arg or re-used argument name -- choose a name that cannot clash */
+          argname = NewStringf("%%arg%d", scheme_argnum);
+        }
 
-	if (procdoc) {
-	  if (i == numreq) {
-	    /* First optional argument */
-	    Printf(signature, " #:optional");
-	  }
-	  /* Add to signature (arglist) */
-	  handle_documentation_typemap(signature, " ", p, "tmap:in:arglist", "$name", argname);
-	  /* Document the type of the arg in the documentation body */
-	  handle_documentation_typemap(doc_body, ", ", p, "tmap:in:doc", "$NAME is of type <$type>", argname);
-	}
+        if (procdoc) {
+          if (i == numreq) {
+            /* First optional argument */
+            Printf(signature, " #:optional");
+          }
+          /* Add to signature (arglist) */
+          handle_documentation_typemap(signature, " ", p, "tmap:in:arglist", "$name", argname);
+          /* Document the type of the arg in the documentation body */
+          handle_documentation_typemap(doc_body, ", ", p, "tmap:in:doc", "$NAME is of type <$type>", argname);
+        }
 
-	if (goops) {
-	  if (i < numreq) {
-	    if (strcmp("void", Char(pt)) != 0) {
-	      Node *class_node = Swig_symbol_clookup_check(pb, Getattr(n, "sym:symtab"), has_classname);
-	      String *goopsclassname = !class_node ? NULL : Getattr(class_node, "guile:goopsclassname");
-	      /* do input conversion */
-	      if (goopsclassname) {
-		Printv(method_signature, " (", argname, " ", goopsclassname, ")", NIL);
-		any_specialized_arg = true;
-	      } else {
-		Printv(method_signature, " ", argname, NIL);
-	      }
-	      Printv(primitive_args, " ", argname, NIL);
-	      Setattr(scheme_arg_names, argname, p);
-	    }
-	  }
-	}
+        if (goops) {
+          if (i < numreq) {
+            if (strcmp("void", Char(pt)) != 0) {
+              Node *class_node = Swig_symbol_clookup_check(pb, Getattr(n, "sym:symtab"), has_classname);
+              String *goopsclassname = !class_node ? NULL : Getattr(class_node, "guile:goopsclassname");
+              /* do input conversion */
+              if (goopsclassname) {
+                Printv(method_signature, " (", argname, " ", goopsclassname, ")", NIL);
+                any_specialized_arg = true;
+              } else {
+                Printv(method_signature, " ", argname, NIL);
+              }
+              Printv(primitive_args, " ", argname, NIL);
+              Setattr(scheme_arg_names, argname, p);
+            }
+          }
+        }
 
-	if (!pn) {
-	  Delete(argname);
-	}
-	p = Getattr(p, "tmap:in:next");
+        if (!pn) {
+          Delete(argname);
+        }
+        p = Getattr(p, "tmap:in:next");
       } else {
-	throw_unhandled_guile_type_error(pt);
-	p = nextSibling(p);
+        throw_unhandled_guile_type_error(pt);
+        p = nextSibling(p);
       }
       if (opt_p)
-	Printf(f->code, "    }\n");
+        Printf(f->code, "    }\n");
     }
     if (Len(doc_body) > 0)
       Printf(doc_body, ".\n");
@@ -765,10 +765,10 @@ public:
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
     /* Pass output arguments back to the caller. */
@@ -777,30 +777,30 @@ public:
     String *returns_argout = NewString("");
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	if (procdoc) {
-	  if (handle_documentation_typemap(returns_argout, ", ", p, "tmap:argout:doc", "$NAME (of type $type)")) {
-	    /* A documentation typemap that is not the empty string
-	       indicates that a value is returned to Scheme. */
-	    num_results++;
-	  }
-	}
-	p = Getattr(p, "tmap:argout:next");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        if (procdoc) {
+          if (handle_documentation_typemap(returns_argout, ", ", p, "tmap:argout:doc", "$NAME (of type $type)")) {
+            /* A documentation typemap that is not the empty string
+               indicates that a value is returned to Scheme. */
+            num_results++;
+          }
+        }
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -827,9 +827,9 @@ public:
     if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
       Replaceall(tm, "$result", "gswig_result");
       if (GetFlag(n, "feature:new"))
-	Replaceall(tm, "$owner", "1");
+        Replaceall(tm, "$owner", "1");
       else
-	Replaceall(tm, "$owner", "0");
+        Replaceall(tm, "$owner", "0");
       Printv(f->code, tm, "\n", NIL);
     } else {
       throw_unhandled_guile_type_error(returntype);
@@ -840,9 +840,9 @@ public:
     if ((tm = Getattr(n, "tmap:out:doc"))) {
       Printv(returns, tm, NIL);
       if (Len(tm) > 0)
-	num_results = 1;
+        num_results = 1;
       else
-	num_results = 0;
+        num_results = 0;
     } else {
       String *s = SwigType_str(returntype, 0);
       Chop(s);
@@ -863,7 +863,7 @@ public:
 
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printv(f->code, tm, "\n", NIL);
+        Printv(f->code, tm, "\n", NIL);
       }
     }
     // Free any memory allocated by the function being wrapped..
@@ -890,91 +890,91 @@ public:
 
     if (!Getattr(n, "sym:overloaded")) {
       if (numargs > 10) {
-	/* "The total number of these arguments should match the actual number
-	 * of arguments to fcn, but may not exceed 10" says:
-	 * https://www.gnu.org/software/guile/manual/html_node/Primitive-Procedures.html
-	 * We handle this case by passing all the arguments as "rest".
-	 */
-	int i;
-	/* Build a wrapper wrapper */
-	Printv(f_wrappers, "static SCM\n", wname, "_rest (SCM rest)\n", NIL);
-	Printv(f_wrappers, "{\n", NIL);
-	Printf(f_wrappers, "SCM arg[%d];\n", numargs);
-	Printf(f_wrappers, "SWIG_Guile_GetArgs (arg, rest, %d, %d, \"%s\");\n", numreq, numargs - numreq, proc_name);
-	Printv(f_wrappers, "return ", wname, "(", NIL);
-	Printv(f_wrappers, "arg[0]", NIL);
-	for (i = 1; i < numargs; i++)
-	  Printf(f_wrappers, ", arg[%d]", i);
-	Printv(f_wrappers, ");\n", NIL);
-	Printv(f_wrappers, "}\n", NIL);
-	/* Register it */
-	Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, 0, 1, (swig_guile_proc) %s_rest);\n", proc_name, wname);
+        /* "The total number of these arguments should match the actual number
+         * of arguments to fcn, but may not exceed 10" says:
+         * https://www.gnu.org/software/guile/manual/html_node/Primitive-Procedures.html
+         * We handle this case by passing all the arguments as "rest".
+         */
+        int i;
+        /* Build a wrapper wrapper */
+        Printv(f_wrappers, "static SCM\n", wname, "_rest (SCM rest)\n", NIL);
+        Printv(f_wrappers, "{\n", NIL);
+        Printf(f_wrappers, "SCM arg[%d];\n", numargs);
+        Printf(f_wrappers, "SWIG_Guile_GetArgs (arg, rest, %d, %d, \"%s\");\n", numreq, numargs - numreq, proc_name);
+        Printv(f_wrappers, "return ", wname, "(", NIL);
+        Printv(f_wrappers, "arg[0]", NIL);
+        for (i = 1; i < numargs; i++)
+          Printf(f_wrappers, ", arg[%d]", i);
+        Printv(f_wrappers, ");\n", NIL);
+        Printv(f_wrappers, "}\n", NIL);
+        /* Register it */
+        Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, 0, 1, (swig_guile_proc) %s_rest);\n", proc_name, wname);
       } else if (emit_setters && struct_member && strlen(Char(proc_name)) > 3) {
-	int len = Len(proc_name);
-	const char *pc = Char(proc_name);
-	/* MEMBER-set and MEMBER-get functions. */
-	int is_setter = (pc[len - 3] == 's');
-	if (is_setter) {
-	  Printf(f_init, "SCM setter = ");
-	  struct_member = 2;	/* have a setter */
-	} else
-	  Printf(f_init, "SCM getter = ");
-	/* GOOPS support uses the MEMBER-set and MEMBER-get functions,
-	   so ignore only_setters in this case. */
-	if (only_setters && !goops)
-	  Printf(f_init, "scm_c_make_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
-	else
-	  Printf(f_init, "scm_c_define_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
+        int len = Len(proc_name);
+        const char *pc = Char(proc_name);
+        /* MEMBER-set and MEMBER-get functions. */
+        int is_setter = (pc[len - 3] == 's');
+        if (is_setter) {
+          Printf(f_init, "SCM setter = ");
+          struct_member = 2;	/* have a setter */
+        } else
+          Printf(f_init, "SCM getter = ");
+        /* GOOPS support uses the MEMBER-set and MEMBER-get functions,
+           so ignore only_setters in this case. */
+        if (only_setters && !goops)
+          Printf(f_init, "scm_c_make_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
+        else
+          Printf(f_init, "scm_c_define_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
 
-	if (!is_setter) {
-	  /* Strip off "-get" */
-	  String *slot_name = NewStringWithSize(pc, len - 4);
-	  if (struct_member == 2) {
-	    /* There was a setter, so create a procedure with setter */
-	    Printf(f_init, "scm_c_define");
-	    Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(getter, setter));\n", slot_name);
-	  } else {
-	    /* There was no setter, so make an alias to the getter */
-	    Printf(f_init, "scm_c_define");
-	    Printf(f_init, "(\"%s\", getter);\n", slot_name);
-	  }
-	  Printf(exported_symbols, "\"%s\", ", slot_name);
-	  Delete(slot_name);
-	}
+        if (!is_setter) {
+          /* Strip off "-get" */
+          String *slot_name = NewStringWithSize(pc, len - 4);
+          if (struct_member == 2) {
+            /* There was a setter, so create a procedure with setter */
+            Printf(f_init, "scm_c_define");
+            Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(getter, setter));\n", slot_name);
+          } else {
+            /* There was no setter, so make an alias to the getter */
+            Printf(f_init, "scm_c_define");
+            Printf(f_init, "(\"%s\", getter);\n", slot_name);
+          }
+          Printf(exported_symbols, "\"%s\", ", slot_name);
+          Delete(slot_name);
+        }
       } else {
-	/* Register the function */
-	if (exporting_destructor) {
-	  Printf(f_init, "((swig_guile_clientdata *)(SWIGTYPE%s->clientdata))->destroy = (guile_destructor) %s;\n", swigtype_ptr, wname);
-	  //Printf(f_init, "SWIG_TypeClientData(SWIGTYPE%s, (void *) %s);\n", swigtype_ptr, wname);
-	}
-	Printf(f_init, "scm_c_define_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
+        /* Register the function */
+        if (exporting_destructor) {
+          Printf(f_init, "((swig_guile_clientdata *)(SWIGTYPE%s->clientdata))->destroy = (guile_destructor) %s;\n", swigtype_ptr, wname);
+          //Printf(f_init, "SWIG_TypeClientData(SWIGTYPE%s, (void *) %s);\n", swigtype_ptr, wname);
+        }
+        Printf(f_init, "scm_c_define_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
       }
     } else {			/* overloaded function; don't export the single methods */
       if (!Getattr(n, "sym:nextSibling")) {
-	/* Emit overloading dispatch function */
+        /* Emit overloading dispatch function */
 
-	int maxargs;
-	bool check_emitted = false;
-	String *dispatch = Swig_overload_dispatch(n, "return %s(argc,argv);", &maxargs, &check_emitted);
+        int maxargs;
+        bool check_emitted = false;
+        String *dispatch = Swig_overload_dispatch(n, "return %s(argc,argv);", &maxargs, &check_emitted);
 
-	/* Generate a dispatch wrapper for all overloaded functions */
+        /* Generate a dispatch wrapper for all overloaded functions */
 
-	Wrapper *df = NewWrapper();
-	String *dname = Swig_name_wrapper(iname);
+        Wrapper *df = NewWrapper();
+        String *dname = Swig_name_wrapper(iname);
 
-	Printv(df->def, "static SCM\n", dname, "(SCM rest)\n{\n", NIL);
-	Printf(df->code, "#define FUNC_NAME \"%s\"\n", proc_name);
-	Printf(df->code, "SCM argv[%d];\n", maxargs);
-	Printf(df->code, "int argc = SWIG_Guile_GetArgs (argv, rest, %d, %d, \"%s\");\n", 0, maxargs, proc_name);
-	Printv(df->code, dispatch, "\n", NIL);
-	Printf(df->code, "scm_misc_error(\"%s\", \"No matching method for generic function `%s'\", SCM_EOL);\n", proc_name, iname);
-	Printf(df->code, "#undef FUNC_NAME\n");
-	Printv(df->code, "}\n", NIL);
-	Wrapper_print(df, f_wrappers);
-	Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, 0, 1, (swig_guile_proc) %s);\n", proc_name, dname);
-	DelWrapper(df);
-	Delete(dispatch);
-	Delete(dname);
+        Printv(df->def, "static SCM\n", dname, "(SCM rest)\n{\n", NIL);
+        Printf(df->code, "#define FUNC_NAME \"%s\"\n", proc_name);
+        Printf(df->code, "SCM argv[%d];\n", maxargs);
+        Printf(df->code, "int argc = SWIG_Guile_GetArgs (argv, rest, %d, %d, \"%s\");\n", 0, maxargs, proc_name);
+        Printv(df->code, dispatch, "\n", NIL);
+        Printf(df->code, "scm_misc_error(\"%s\", \"No matching method for generic function `%s'\", SCM_EOL);\n", proc_name, iname);
+        Printf(df->code, "#undef FUNC_NAME\n");
+        Printv(df->code, "}\n", NIL);
+        Wrapper_print(df, f_wrappers);
+        Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, 0, 1, (swig_guile_proc) %s);\n", proc_name, dname);
+        DelWrapper(df);
+        Delete(dispatch);
+        Delete(dname);
       }
     }
     Printf(exported_symbols, "\"%s\", ", proc_name);
@@ -984,35 +984,35 @@ public:
       String *method_def = NewString("");
       String *goops_name;
       if (in_class)
-	goops_name = NewString(memberfunction_name);
+        goops_name = NewString(memberfunction_name);
       else
-	goops_name = goopsNameMapping(proc_name, "");
+        goops_name = goopsNameMapping(proc_name, "");
       String *primitive_name = NewString("");
       if (primRenamer)
-	Printv(primitive_name, "primitive:", proc_name, NIL);
+        Printv(primitive_name, "primitive:", proc_name, NIL);
       else
-	Printv(primitive_name, proc_name, NIL);
+        Printv(primitive_name, proc_name, NIL);
       Replaceall(method_signature, "_", "-");
       Replaceall(primitive_args, "_", "-");
       if (!any_specialized_arg) {
-	/* If there would not be any specialized argument in
-	   the method declaration, we simply re-export the
-	   function.  This is a performance optimization. */
-	Printv(method_def, "(define ", goops_name, " ", primitive_name, ")\n", NIL);
+        /* If there would not be any specialized argument in
+           the method declaration, we simply re-export the
+           function.  This is a performance optimization. */
+        Printv(method_def, "(define ", goops_name, " ", primitive_name, ")\n", NIL);
       } else if (numreq == numargs) {
-	Printv(method_def, "(define-method (", goops_name, method_signature, ")\n", NIL);
-	Printv(method_def, "  (", primitive_name, primitive_args, "))\n", NIL);
+        Printv(method_def, "(define-method (", goops_name, method_signature, ")\n", NIL);
+        Printv(method_def, "  (", primitive_name, primitive_args, "))\n", NIL);
       } else {
-	/* Handle optional args. For the rest argument, use a name
-	   that cannot clash. */
-	Printv(method_def, "(define-method (", goops_name, method_signature, " . %args)\n", NIL);
-	Printv(method_def, "  (apply ", primitive_name, primitive_args, " %args))\n", NIL);
+        /* Handle optional args. For the rest argument, use a name
+           that cannot clash. */
+        Printv(method_def, "(define-method (", goops_name, method_signature, " . %args)\n", NIL);
+        Printv(method_def, "  (apply ", primitive_name, primitive_args, " %args))\n", NIL);
       }
       if (in_class) {
-	/* Defer method definition till end of class definition. */
-	Printv(goops_class_methods, method_def, NIL);
+        /* Defer method definition till end of class definition. */
+        Printv(goops_class_methods, method_def, NIL);
       } else {
-	Printv(goopscode, method_def, NIL);
+        Printv(goopscode, method_def, NIL);
       }
       Printf(goopsexport, "%s ", goops_name);
       Delete(primitive_name);
@@ -1023,23 +1023,23 @@ public:
     if (procdoc) {
       String *returns_text = NewString("");
       if (num_results == 0)
-	Printv(returns_text, return_nothing_doc, NIL);
+        Printv(returns_text, return_nothing_doc, NIL);
       else if (num_results == 1)
-	Printv(returns_text, return_one_doc, NIL);
+        Printv(returns_text, return_one_doc, NIL);
       else
-	Printv(returns_text, return_multi_doc, NIL);
+        Printv(returns_text, return_multi_doc, NIL);
       /* Substitute documentation variables */
       static const char *numbers[] = { "zero", "one", "two", "three",
-	"four", "five", "six", "seven",
-	"eight", "nine", "ten", "eleven",
-	"twelve"
+        "four", "five", "six", "seven",
+        "eight", "nine", "ten", "eleven",
+        "twelve"
       };
       if (num_results <= 12)
-	Replaceall(returns_text, "$num_values", numbers[num_results]);
+        Replaceall(returns_text, "$num_values", numbers[num_results]);
       else {
-	String *num_results_str = NewStringf("%d", num_results);
-	Replaceall(returns_text, "$num_values", num_results_str);
-	Delete(num_results_str);
+        String *num_results_str = NewStringf("%d", num_results);
+        Replaceall(returns_text, "$num_values", num_results_str);
+        Delete(num_results_str);
       }
       Replaceall(returns_text, "$values", returns);
       Printf(doc_body, "\n%s", returns_text);
@@ -1108,34 +1108,34 @@ public:
       Wrapper_add_local(f, "gswig_result", "SCM gswig_result");
 
       if (assignable) {
-	/* Check for a setting of the variable value */
-	Printf(f->code, "if (s_0 != SCM_UNDEFINED) {\n");
-	if ((tm = Swig_typemap_lookup("varin", n, name, 0))) {
-	  Replaceall(tm, "$input", "s_0");
-	  /* Printv(f->code,tm,"\n",NIL); */
-	  emit_action_code(n, f->code, tm);
-	} else {
-	  // The fake variable constantWrapper() creates is immutable.
-	  assert(!GetFlag(n, "guile:reallywrappingaconstant"));
-	  throw_unhandled_guile_type_error(t);
-	}
-	Printf(f->code, "}\n");
+        /* Check for a setting of the variable value */
+        Printf(f->code, "if (s_0 != SCM_UNDEFINED) {\n");
+        if ((tm = Swig_typemap_lookup("varin", n, name, 0))) {
+          Replaceall(tm, "$input", "s_0");
+          /* Printv(f->code,tm,"\n",NIL); */
+          emit_action_code(n, f->code, tm);
+        } else {
+          // The fake variable constantWrapper() creates is immutable.
+          assert(!GetFlag(n, "guile:reallywrappingaconstant"));
+          throw_unhandled_guile_type_error(t);
+        }
+        Printf(f->code, "}\n");
       }
       // Now return the value of the variable (regardless
       // of evaluating or setting)
 
       if ((tm = Swig_typemap_lookup("varout", n, name, 0))) {
-	Replaceall(tm, "$result", "gswig_result");
-	/* Printv(f->code,tm,"\n",NIL); */
-	emit_action_code(n, f->code, tm);
+        Replaceall(tm, "$result", "gswig_result");
+        /* Printv(f->code,tm,"\n",NIL); */
+        emit_action_code(n, f->code, tm);
       } else {
-	if (GetFlag(n, "guile:reallywrappingaconstant")) {
-	  Delete(var_name);
-	  Delete(proc_name);
-	  DelWrapper(f);
-	  return SWIG_ERROR;
-	}
-	throw_unhandled_guile_type_error(t);
+        if (GetFlag(n, "guile:reallywrappingaconstant")) {
+          Delete(var_name);
+          Delete(proc_name);
+          DelWrapper(f);
+          return SWIG_ERROR;
+        }
+        throw_unhandled_guile_type_error(t);
       }
       Printf(f->code, "\nreturn gswig_result;\n");
       Printf(f->code, "#undef FUNC_NAME\n");
@@ -1146,112 +1146,112 @@ public:
       // Now add symbol to the Guile interpreter
 
       if (!emit_setters || !assignable) {
-	/* Read-only variables become a simple procedure returning the
-	   value; read-write variables become a simple procedure with
-	   an optional argument. */
+        /* Read-only variables become a simple procedure returning the
+           value; read-write variables become a simple procedure with
+           an optional argument. */
 
-	if (!goops && GetFlag(n, "feature:constasvar")) {
-	  /* need to export this function as a variable instead of a procedure */
-	  if (scmstub) {
-	    /* export the function in the wrapper, and (set!) it in scmstub */
-	    Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, %d, 0, (swig_guile_proc) %s);\n", proc_name, assignable, var_name);
-	    Printf(scmtext, "(set! %s (%s))\n", proc_name, proc_name);
-	  } else {
-	    /* export the variable directly */
-	    Printf(f_init, "scm_c_define(\"%s\", %s(SCM_UNDEFINED));\n", proc_name, var_name);
-	  }
+        if (!goops && GetFlag(n, "feature:constasvar")) {
+          /* need to export this function as a variable instead of a procedure */
+          if (scmstub) {
+            /* export the function in the wrapper, and (set!) it in scmstub */
+            Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, %d, 0, (swig_guile_proc) %s);\n", proc_name, assignable, var_name);
+            Printf(scmtext, "(set! %s (%s))\n", proc_name, proc_name);
+          } else {
+            /* export the variable directly */
+            Printf(f_init, "scm_c_define(\"%s\", %s(SCM_UNDEFINED));\n", proc_name, var_name);
+          }
 
-	} else {
-	  /* Export the function as normal */
-	  Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, %d, 0, (swig_guile_proc) %s);\n", proc_name, assignable, var_name);
-	}
+        } else {
+          /* Export the function as normal */
+          Printf(f_init, "scm_c_define_gsubr(\"%s\", 0, %d, 0, (swig_guile_proc) %s);\n", proc_name, assignable, var_name);
+        }
 
       } else {
-	/* Read/write variables become a procedure with setter. */
-	Printf(f_init, "{ SCM p = scm_c_define_gsubr(\"%s\", 0, 1, 0, (swig_guile_proc) %s);\n", proc_name, var_name);
-	Printf(f_init, "scm_c_define");
-	Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(p, p)); }\n", proc_name);
+        /* Read/write variables become a procedure with setter. */
+        Printf(f_init, "{ SCM p = scm_c_define_gsubr(\"%s\", 0, 1, 0, (swig_guile_proc) %s);\n", proc_name, var_name);
+        Printf(f_init, "scm_c_define");
+        Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(p, p)); }\n", proc_name);
       }
       Printf(exported_symbols, "\"%s\", ", proc_name);
 
       // export wrapper into goops file
       if (!in_class) {		// only if the variable is not part of a class
-	String *class_name = SwigType_typedef_resolve_all(SwigType_base(t));
-	String *goops_name = goopsNameMapping(proc_name, "");
-	String *primitive_name = NewString("");
-	if (primRenamer)
-	  Printv(primitive_name, "primitive:", NIL);
-	Printv(primitive_name, proc_name, NIL);
-	/* Simply re-export the procedure */
-	if ((!emit_setters || !assignable)
-	    && GetFlag(n, "feature:constasvar")) {
-	  Printv(goopscode, "(define ", goops_name, " (", primitive_name, "))\n", NIL);
-	} else {
-	  Printv(goopscode, "(define ", goops_name, " ", primitive_name, ")\n", NIL);
-	}
-	Printf(goopsexport, "%s ", goops_name);
-	Delete(primitive_name);
-	Delete(class_name);
-	Delete(goops_name);
+        String *class_name = SwigType_typedef_resolve_all(SwigType_base(t));
+        String *goops_name = goopsNameMapping(proc_name, "");
+        String *primitive_name = NewString("");
+        if (primRenamer)
+          Printv(primitive_name, "primitive:", NIL);
+        Printv(primitive_name, proc_name, NIL);
+        /* Simply re-export the procedure */
+        if ((!emit_setters || !assignable)
+            && GetFlag(n, "feature:constasvar")) {
+          Printv(goopscode, "(define ", goops_name, " (", primitive_name, "))\n", NIL);
+        } else {
+          Printv(goopscode, "(define ", goops_name, " ", primitive_name, ")\n", NIL);
+        }
+        Printf(goopsexport, "%s ", goops_name);
+        Delete(primitive_name);
+        Delete(class_name);
+        Delete(goops_name);
       }
 
       if (procdoc) {
-	/* Compute documentation */
-	String *signature = NewString("");
-	String *signature2 = NULL;
-	String *doc = NewString("");
+        /* Compute documentation */
+        String *signature = NewString("");
+        String *signature2 = NULL;
+        String *doc = NewString("");
 
-	if (!assignable) {
-	  Printv(signature, proc_name, NIL);
-	  if (GetFlag(n, "feature:constasvar")) {
-	    Printv(doc, "Is constant ", NIL);
-	  } else {
-	    Printv(doc, "Returns constant ", NIL);
-	  }
-	  if ((tm = Getattr(n, "tmap:varout:doc"))) {
-	    Printv(doc, tm, NIL);
-	  } else {
-	    String *s = SwigType_str(t, 0);
-	    Chop(s);
-	    Printf(doc, "<%s>", s);
-	    Delete(s);
-	  }
-	} else if (emit_setters) {
-	  Printv(signature, proc_name, NIL);
-	  signature2 = NewString("");
-	  Printv(signature2, "set! (", proc_name, ") ", NIL);
-	  handle_documentation_typemap(signature2, NIL, n, "tmap:varin:arglist", "new-value");
-	  Printv(doc, "Get or set the value of the C variable, \n", NIL);
-	  Printv(doc, "which is of type ", NIL);
-	  handle_documentation_typemap(doc, NIL, n, "tmap:varout:doc", "$1_type");
-	  Printv(doc, ".");
-	} else {
-	  Printv(signature, proc_name, " #:optional ", NIL);
-	  if ((tm = Getattr(n, "tmap:varin:doc"))) {
-	    Printv(signature, tm, NIL);
-	  } else {
-	    String *s = SwigType_str(t, 0);
-	    Chop(s);
-	    Printf(signature, "new-value <%s>", s);
-	    Delete(s);
-	  }
+        if (!assignable) {
+          Printv(signature, proc_name, NIL);
+          if (GetFlag(n, "feature:constasvar")) {
+            Printv(doc, "Is constant ", NIL);
+          } else {
+            Printv(doc, "Returns constant ", NIL);
+          }
+          if ((tm = Getattr(n, "tmap:varout:doc"))) {
+            Printv(doc, tm, NIL);
+          } else {
+            String *s = SwigType_str(t, 0);
+            Chop(s);
+            Printf(doc, "<%s>", s);
+            Delete(s);
+          }
+        } else if (emit_setters) {
+          Printv(signature, proc_name, NIL);
+          signature2 = NewString("");
+          Printv(signature2, "set! (", proc_name, ") ", NIL);
+          handle_documentation_typemap(signature2, NIL, n, "tmap:varin:arglist", "new-value");
+          Printv(doc, "Get or set the value of the C variable, \n", NIL);
+          Printv(doc, "which is of type ", NIL);
+          handle_documentation_typemap(doc, NIL, n, "tmap:varout:doc", "$1_type");
+          Printv(doc, ".");
+        } else {
+          Printv(signature, proc_name, " #:optional ", NIL);
+          if ((tm = Getattr(n, "tmap:varin:doc"))) {
+            Printv(signature, tm, NIL);
+          } else {
+            String *s = SwigType_str(t, 0);
+            Chop(s);
+            Printf(signature, "new-value <%s>", s);
+            Delete(s);
+          }
 
-	  Printv(doc, "If NEW-VALUE is provided, " "set C variable to this value.\n", NIL);
-	  Printv(doc, "Returns variable value ", NIL);
-	  if ((tm = Getattr(n, "tmap:varout:doc"))) {
-	    Printv(doc, tm, NIL);
-	  } else {
-	    String *s = SwigType_str(t, 0);
-	    Chop(s);
-	    Printf(doc, "<%s>", s);
-	    Delete(s);
-	  }
-	}
-	write_doc(proc_name, signature, doc, signature2);
-	Delete(signature);
-	if (signature2)
-	  Delete(signature2);
-	Delete(doc);
+          Printv(doc, "If NEW-VALUE is provided, " "set C variable to this value.\n", NIL);
+          Printv(doc, "Returns variable value ", NIL);
+          if ((tm = Getattr(n, "tmap:varout:doc"))) {
+            Printv(doc, tm, NIL);
+          } else {
+            String *s = SwigType_str(t, 0);
+            Chop(s);
+            Printf(doc, "<%s>", s);
+            Delete(s);
+          }
+        }
+        write_doc(proc_name, signature, doc, signature2);
+        Delete(signature);
+        if (signature2)
+          Delete(signature2);
+        Delete(doc);
       }
     }
     Delete(var_name);
@@ -1315,12 +1315,12 @@ public:
       Setattr(nn, "type", nctype);
       SetFlag(nn, "feature:immutable");
       if (constasvar) {
-	SetFlag(nn, "feature:constasvar");
+        SetFlag(nn, "feature:constasvar");
       }
       SetFlag(nn, "guile:reallywrappingaconstant");
       if (variableWrapper(nn) == SWIG_ERROR) {
-	Swig_warning(WARN_TYPEMAP_CONST_UNDEF, input_file, line_number, "Unsupported constant value.\n");
-	result = SWIG_NOWRAP;
+        Swig_warning(WARN_TYPEMAP_CONST_UNDEF, input_file, line_number, "Unsupported constant value.\n");
+        result = SWIG_NOWRAP;
       }
 
       Delete(nn);
@@ -1367,11 +1367,11 @@ public:
     if (baselist && Len(baselist)) {
       Iterator i = First(baselist);
       while (i.item) {
-	Printv(base_class, Getattr(i.item, "sym:name"), NIL);
-	i = Next(i);
-	if (i.item) {
-	  Printf(base_class, "> <");
-	}
+        Printv(base_class, Getattr(i.item, "sym:name"), NIL);
+        i = Next(i);
+        if (i.item) {
+          Printf(base_class, "> <");
+        }
       }
     }
     Printf(base_class, ">");
@@ -1501,9 +1501,9 @@ public:
     }
     if (emit_slot_accessors) {
       if (GetFlag(n, "feature:immutable")) {
-	Printv(goopscode, "\n   #:getter ", goops_name, NIL);
+        Printv(goopscode, "\n   #:getter ", goops_name, NIL);
       } else {
-	Printv(goopscode, "\n   #:accessor ", goops_name, NIL);
+        Printv(goopscode, "\n   #:accessor ", goops_name, NIL);
       }
       Printf(goopsexport, "%s ", goops_name);
     }
@@ -1544,15 +1544,15 @@ public:
 
 #     define store_pragma(PRAGMANAME)			\
         if (Strcmp(cmd, #PRAGMANAME) == 0) {		\
-	  if (PRAGMANAME) Delete(PRAGMANAME);		\
-	  PRAGMANAME = value ? NewString(value) : NULL;	\
-	}
+          if (PRAGMANAME) Delete(PRAGMANAME);		\
+          PRAGMANAME = value ? NewString(value) : NULL;	\
+        }
 
       if (Strcmp(lang, "guile") == 0) {
-	store_pragma(beforereturn)
-	    store_pragma(return_nothing_doc)
-	    store_pragma(return_one_doc)
-	    store_pragma(return_multi_doc);
+        store_pragma(beforereturn)
+            store_pragma(return_nothing_doc)
+            store_pragma(return_one_doc)
+            store_pragma(return_multi_doc);
 #     undef store_pragma
       }
     }
@@ -1573,19 +1573,19 @@ public:
     if (Strcmp(class_name, "") == 0) {
       // not part of a class, so no class name to prefix
       if (goopsprefix) {
-	Printf(n, "%s%s", goopsprefix, name);
+        Printf(n, "%s%s", goopsprefix, name);
       } else {
-	Printf(n, "%s", name);
+        Printf(n, "%s", name);
       }
     } else {
       if (useclassprefix) {
-	Printf(n, "%s-%s", class_name, name);
+        Printf(n, "%s-%s", class_name, name);
       } else {
-	if (goopsprefix) {
-	  Printf(n, "%s%s", goopsprefix, name);
-	} else {
-	  Printf(n, "%s", name);
-	}
+        if (goopsprefix) {
+          Printf(n, "%s%s", goopsprefix, name);
+        } else {
+          Printf(n, "%s", name);
+        }
       }
     }
     return n;
@@ -1604,24 +1604,24 @@ public:
     /* <identifier> --> <initial> <subsequent>* | <peculiar identifier> */
     /* <initial> --> <letter> | <special initial> */
     if (!(isalpha(*c) || (*c == '!') || (*c == '$') || (*c == '%')
-	  || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':')
-	  || (*c == '<') || (*c == '=') || (*c == '>') || (*c == '?')
-	  || (*c == '^') || (*c == '_') || (*c == '~'))) {
+          || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':')
+          || (*c == '<') || (*c == '=') || (*c == '>') || (*c == '?')
+          || (*c == '^') || (*c == '_') || (*c == '~'))) {
       /* <peculiar identifier> --> + | - | ... */
       if ((strcmp(c, "+") == 0)
-	  || strcmp(c, "-") == 0 || strcmp(c, "...") == 0)
-	return 1;
+          || strcmp(c, "-") == 0 || strcmp(c, "...") == 0)
+        return 1;
       else
-	return 0;
+        return 0;
     }
     /* <subsequent> --> <initial> | <digit> | <special subsequent> */
     while (*c) {
       if (!(isalnum(*c) || (*c == '!') || (*c == '$') || (*c == '%')
-	    || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':')
-	    || (*c == '<') || (*c == '=') || (*c == '>') || (*c == '?')
-	    || (*c == '^') || (*c == '_') || (*c == '~') || (*c == '+')
-	    || (*c == '-') || (*c == '.') || (*c == '@')))
-	return 0;
+            || (*c == '&') || (*c == '*') || (*c == '/') || (*c == ':')
+            || (*c == '<') || (*c == '=') || (*c == '>') || (*c == '?')
+            || (*c == '^') || (*c == '_') || (*c == '~') || (*c == '+')
+            || (*c == '-') || (*c == '.') || (*c == '@')))
+        return 0;
       c++;
     }
     return 1;

--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -58,10 +58,10 @@ static String *prefix = NewString("gswig_");
 static char *module = 0;
 static String *package = 0;
 static enum {
-  GUILE_LSTYLE_SIMPLE,		// call `SWIG_init()'
-  GUILE_LSTYLE_PASSIVE,		// passive linking (no module code)
-  GUILE_LSTYLE_MODULE,		// native guile module linking (Guile >= 1.4.1)
-  GUILE_LSTYLE_HOBBIT		// use (hobbit4d link)
+  GUILE_LSTYLE_SIMPLE,          // call `SWIG_init()'
+  GUILE_LSTYLE_PASSIVE,         // passive linking (no module code)
+  GUILE_LSTYLE_MODULE,          // native guile module linking (Guile >= 1.4.1)
+  GUILE_LSTYLE_HOBBIT           // use (hobbit4d link)
 } linkage = GUILE_LSTYLE_SIMPLE;
 
 static File *procdoc = 0;
@@ -100,10 +100,10 @@ static String *short_class_name = 0;
 static String *goops_class_methods;
 static int in_class = 0;
 static int have_constructor = 0;
-static int useclassprefix = 0;	// -useclassprefix argument
-static String *goopsprefix = 0;	// -goopsprefix argument
-static int primRenamer = 0;	// if (use-modules ((...) :renamer ...) is exported to GOOPS file
-static int exportprimitive = 0;	// -exportprimitive argument
+static int useclassprefix = 0;  // -useclassprefix argument
+static String *goopsprefix = 0; // -goopsprefix argument
+static int primRenamer = 0;     // if (use-modules ((...) :renamer ...) is exported to GOOPS file
+static int exportprimitive = 0; // -exportprimitive argument
 static String *memberfunction_name = 0;
 
 extern "C" {
@@ -587,7 +587,7 @@ public:
     }
     const String *pn = !name ? (const String *) Getattr(p, "name") : name;
     String *pt = Getattr(p, "type");
-    Replaceall(tm, "$name", pn);	// legacy for $parmname
+    Replaceall(tm, "$name", pn);        // legacy for $parmname
     Replaceall(tm, "$type", SwigType_str(pt, 0));
     /* $NAME is like $name, but marked-up as a variable. */
     String *ARGNAME = NewString("");
@@ -916,7 +916,7 @@ public:
         int is_setter = (pc[len - 3] == 's');
         if (is_setter) {
           Printf(f_init, "SCM setter = ");
-          struct_member = 2;	/* have a setter */
+          struct_member = 2;    /* have a setter */
         } else
           Printf(f_init, "SCM getter = ");
         /* GOOPS support uses the MEMBER-set and MEMBER-get functions,
@@ -949,7 +949,7 @@ public:
         }
         Printf(f_init, "scm_c_define_gsubr(\"%s\", %d, %d, 0, (swig_guile_proc) %s);\n", proc_name, numreq, numargs - numreq, wname);
       }
-    } else {			/* overloaded function; don't export the single methods */
+    } else {                    /* overloaded function; don't export the single methods */
       if (!Getattr(n, "sym:nextSibling")) {
         /* Emit overloading dispatch function */
 
@@ -1175,7 +1175,7 @@ public:
       Printf(exported_symbols, "\"%s\", ", proc_name);
 
       // export wrapper into goops file
-      if (!in_class) {		// only if the variable is not part of a class
+      if (!in_class) {          // only if the variable is not part of a class
         String *class_name = SwigType_typedef_resolve_all(SwigType_base(t));
         String *goops_name = goopsNameMapping(proc_name, "");
         String *primitive_name = NewString("");
@@ -1542,10 +1542,10 @@ public:
       String *cmd = Getattr(n, "name");
       String *value = Getattr(n, "value");
 
-#     define store_pragma(PRAGMANAME)			\
-        if (Strcmp(cmd, #PRAGMANAME) == 0) {		\
-          if (PRAGMANAME) Delete(PRAGMANAME);		\
-          PRAGMANAME = value ? NewString(value) : NULL;	\
+#     define store_pragma(PRAGMANAME)                   \
+        if (Strcmp(cmd, #PRAGMANAME) == 0) {            \
+          if (PRAGMANAME) Delete(PRAGMANAME);           \
+          PRAGMANAME = value ? NewString(value) : NULL; \
         }
 
       if (Strcmp(lang, "guile") == 0) {

--- a/Source/Modules/interface.cxx
+++ b/Source/Modules/interface.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -10,7 +10,7 @@
  *
  * This module contains support for the interface feature.
  * This feature is used in language modules where the target language does not
- * naturally support C++ style multiple inheritance, but does support inheritance 
+ * naturally support C++ style multiple inheritance, but does support inheritance
  * from multiple interfaces.
  * ----------------------------------------------------------------------------- */
 

--- a/Source/Modules/interface.cxx
+++ b/Source/Modules/interface.cxx
@@ -33,25 +33,25 @@ static List *collect_interface_methods(Node *n) {
     for (Iterator base = First(bases); base.item; base = Next(base)) {
       Node *cls = base.item;
       if (cls == n)
-	continue;
+        continue;
       for (Node *child = firstChild(cls); child; child = nextSibling(child)) {
-	if (Cmp(nodeType(child), "cdecl") == 0) {
-	  if (GetFlag(child, "feature:ignore") || Getattr(child, "interface:owner"))
-	    continue; // skip methods propagated to bases
-	  if (!checkAttribute(child, "kind", "function"))
-	    continue;
-	  if (checkAttribute(child, "storage", "static"))
-	    continue; // accept virtual methods, non-virtual methods too... mmm??. Warn that the interface class has something that is not a virtual method?
-	  Node *nn = copyNode(child);
-	  Setattr(nn, "interface:owner", cls);
-	  ParmList *parms = CopyParmList(Getattr(child, "parms"));
-	  Setattr(nn, "parms", parms);
-	  Delete(parms);
-	  ParmList *throw_parm_list = Getattr(child, "throws");
-	  if (throw_parm_list)
-	    Setattr(nn, "throws", CopyParmList(throw_parm_list));
-	  Append(methods, nn);
-	}
+        if (Cmp(nodeType(child), "cdecl") == 0) {
+          if (GetFlag(child, "feature:ignore") || Getattr(child, "interface:owner"))
+            continue; // skip methods propagated to bases
+          if (!checkAttribute(child, "kind", "function"))
+            continue;
+          if (checkAttribute(child, "storage", "static"))
+            continue; // accept virtual methods, non-virtual methods too... mmm??. Warn that the interface class has something that is not a virtual method?
+          Node *nn = copyNode(child);
+          Setattr(nn, "interface:owner", cls);
+          ParmList *parms = CopyParmList(Getattr(child, "parms"));
+          Setattr(nn, "parms", parms);
+          Delete(parms);
+          ParmList *throw_parm_list = Getattr(child, "throws");
+          if (throw_parm_list)
+            Setattr(nn, "throws", CopyParmList(throw_parm_list));
+          Append(methods, nn);
+        }
       }
     }
   }
@@ -71,8 +71,8 @@ static void collect_interface_bases(List *bases, Node *n) {
   if (List *baselist = Getattr(n, "bases")) {
     for (Iterator base = First(baselist); base.item; base = Next(base)) {
       if (!GetFlag(base.item, "feature:ignore")) {
-	if (GetFlag(base.item, "feature:interface"))
-	  collect_interface_bases(bases, base.item);
+        if (GetFlag(base.item, "feature:interface"))
+          collect_interface_bases(bases, base.item);
       }
     }
   }
@@ -94,12 +94,12 @@ static void collect_interface_base_classes(Node *n) {
     // check all bases are also interfaces
     if (List *baselist = Getattr(n, "bases")) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
-	if (!GetFlag(base.item, "feature:ignore")) {
-	  if (!GetFlag(base.item, "feature:interface")) {
-	    Swig_error(Getfile(n), Getline(n), "Base class '%s' of '%s' is not similarly marked as an interface.\n", SwigType_namestr(Getattr(base.item, "name")), SwigType_namestr(Getattr(n, "name")));
-	    Exit(EXIT_FAILURE);
-	  }
-	}
+        if (!GetFlag(base.item, "feature:ignore")) {
+          if (!GetFlag(base.item, "feature:interface")) {
+            Swig_error(Getfile(n), Getline(n), "Base class '%s' of '%s' is not similarly marked as an interface.\n", SwigType_namestr(Getattr(base.item, "name")), SwigType_namestr(Getattr(n, "name")));
+            Exit(EXIT_FAILURE);
+          }
+        }
       }
     }
   }
@@ -149,50 +149,50 @@ void Swig_interface_propagate_methods(Node *n) {
     bool is_interface = GetFlag(n, "feature:interface") ? true : false;
     for (Iterator mi = First(methods); mi.item; mi = Next(mi)) {
       if (!is_interface && GetFlag(mi.item, "abstract"))
-	continue;
+        continue;
       String *this_decl = Getattr(mi.item, "decl");
       String *this_decl_resolved = SwigType_typedef_resolve_all(this_decl);
       bool identically_overloaded_method = false; // true when a base class' method is implemented in n
       if (SwigType_isfunction(this_decl_resolved)) {
-	String *name = Getattr(mi.item, "name");
-	for (Node *child = firstChild(n); child; child = nextSibling(child)) {
-	  if (Getattr(child, "interface:owner"))
-	    break; // at the end of the list are newly appended methods
-	  if (Cmp(nodeType(child), "cdecl") == 0) {
-	    if (checkAttribute(child, "name", name)) {
-	      String *decl = SwigType_typedef_resolve_all(Getattr(child, "decl"));
-	      identically_overloaded_method = Strcmp(decl, this_decl_resolved) == 0;
-	      Delete(decl);
-	      if (identically_overloaded_method)
-		break;
-	    }
-	  }
-	}
+        String *name = Getattr(mi.item, "name");
+        for (Node *child = firstChild(n); child; child = nextSibling(child)) {
+          if (Getattr(child, "interface:owner"))
+            break; // at the end of the list are newly appended methods
+          if (Cmp(nodeType(child), "cdecl") == 0) {
+            if (checkAttribute(child, "name", name)) {
+              String *decl = SwigType_typedef_resolve_all(Getattr(child, "decl"));
+              identically_overloaded_method = Strcmp(decl, this_decl_resolved) == 0;
+              Delete(decl);
+              if (identically_overloaded_method)
+                break;
+            }
+          }
+        }
       }
       Delete(this_decl_resolved);
       if (!identically_overloaded_method) {
-	// Add method copied from base class to this derived class
-	Node *cn = mi.item;
-	Delattr(cn, "sym:overname");
-	String *prefix = Getattr(n, "name");
-	String *name = Getattr(cn, "name");
-	String *decl = Getattr(cn, "decl");
-	String *oldname = Getattr(cn, "sym:name");
+        // Add method copied from base class to this derived class
+        Node *cn = mi.item;
+        Delattr(cn, "sym:overname");
+        String *prefix = Getattr(n, "name");
+        String *name = Getattr(cn, "name");
+        String *decl = Getattr(cn, "decl");
+        String *oldname = Getattr(cn, "sym:name");
 
-	String *symname = Swig_name_make(cn, prefix, name, decl, oldname);
-	if (Strcmp(symname, "$ignore") != 0) {
-	  Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
-	  Node *on = Swig_symbol_add(symname, cn);
-	  (void)on;
-	  assert(on == cn);
+        String *symname = Swig_name_make(cn, prefix, name, decl, oldname);
+        if (Strcmp(symname, "$ignore") != 0) {
+          Symtab *oldscope = Swig_symbol_setscope(Getattr(n, "symtab"));
+          Node *on = Swig_symbol_add(symname, cn);
+          (void)on;
+          assert(on == cn);
 
-	  // Features from the copied base class method are already present, now add in features specific to the added method in the derived class
-	  Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
-	  Swig_symbol_setscope(oldscope);
-	  appendChild(n, cn);
-	}
+          // Features from the copied base class method are already present, now add in features specific to the added method in the derived class
+          Swig_features_get(Swig_cparse_features(), Swig_symbol_qualifiedscopename(0), name, decl, cn);
+          Swig_symbol_setscope(oldscope);
+          appendChild(n, cn);
+        }
       } else {
-	Delete(mi.item);
+        Delete(mi.item);
       }
     }
     Delete(methods);

--- a/Source/Modules/interface.cxx
+++ b/Source/Modules/interface.cxx
@@ -37,11 +37,11 @@ static List *collect_interface_methods(Node *n) {
       for (Node *child = firstChild(cls); child; child = nextSibling(child)) {
         if (Cmp(nodeType(child), "cdecl") == 0) {
           if (GetFlag(child, "feature:ignore") || Getattr(child, "interface:owner"))
-            continue; // skip methods propagated to bases
+            continue;  // skip methods propagated to bases
           if (!checkAttribute(child, "kind", "function"))
             continue;
           if (checkAttribute(child, "storage", "static"))
-            continue; // accept virtual methods, non-virtual methods too... mmm??. Warn that the interface class has something that is not a virtual method?
+            continue;  // accept virtual methods, non-virtual methods too... mmm??. Warn that the interface class has something that is not a virtual method?
           Node *nn = copyNode(child);
           Setattr(nn, "interface:owner", cls);
           ParmList *parms = CopyParmList(Getattr(child, "parms"));
@@ -96,7 +96,11 @@ static void collect_interface_base_classes(Node *n) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
         if (!GetFlag(base.item, "feature:ignore")) {
           if (!GetFlag(base.item, "feature:interface")) {
-            Swig_error(Getfile(n), Getline(n), "Base class '%s' of '%s' is not similarly marked as an interface.\n", SwigType_namestr(Getattr(base.item, "name")), SwigType_namestr(Getattr(n, "name")));
+            Swig_error(Getfile(n),
+                       Getline(n),
+                       "Base class '%s' of '%s' is not similarly marked as an interface.\n",
+                       SwigType_namestr(Getattr(base.item, "name")),
+                       SwigType_namestr(Getattr(n, "name")));
             Exit(EXIT_FAILURE);
           }
         }
@@ -152,12 +156,12 @@ void Swig_interface_propagate_methods(Node *n) {
         continue;
       String *this_decl = Getattr(mi.item, "decl");
       String *this_decl_resolved = SwigType_typedef_resolve_all(this_decl);
-      bool identically_overloaded_method = false; // true when a base class' method is implemented in n
+      bool identically_overloaded_method = false;  // true when a base class' method is implemented in n
       if (SwigType_isfunction(this_decl_resolved)) {
         String *name = Getattr(mi.item, "name");
         for (Node *child = firstChild(n); child; child = nextSibling(child)) {
           if (Getattr(child, "interface:owner"))
-            break; // at the end of the list are newly appended methods
+            break;  // at the end of the list are newly appended methods
           if (Cmp(nodeType(child), "cdecl") == 0) {
             if (checkAttribute(child, "name", name)) {
               String *decl = SwigType_typedef_resolve_all(Getattr(child, "decl"));

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -50,7 +50,7 @@ class JAVA:public Language {
   bool member_func_flag;	// flag set when wrapping a member function
   bool doxygen;			//flag for converting found doxygen to javadoc
   bool comment_creation_chatter; //flag for getting information about where comments were created in java.cxx
-  
+
   String *imclass_name;		// intermediary class name
   String *module_class_name;	// module class name
   String *constants_interface_name;	// constants interface name
@@ -174,7 +174,7 @@ public:
     director_multiple_inheritance = 0;
     directorLanguage();
   }
-  
+
   ~JAVA() {
     delete doxygenTranslator;
   }
@@ -213,7 +213,7 @@ public:
    * package name if the nspace feature is used, unless jnidescriptor is true as
    * the package name is handled differently (unfortunately for legacy reasons).
    * ----------------------------------------------------------------------------- */
-  
+
    String *getProxyName(SwigType *t, bool jnidescriptor = false) {
      String *proxyname = NULL;
      if (proxy_flag) {
@@ -313,7 +313,7 @@ public:
         }
       }
     }
-    
+
     if (doxygen)
       doxygenTranslator = new JavaDocConverter(doxygen_translator_flags);
 
@@ -339,12 +339,12 @@ public:
     if (optionsnode) {
       if (Getattr(optionsnode, "jniclassname"))
         imclass_name = Copy(Getattr(optionsnode, "jniclassname"));
-      /* check if directors are enabled for this module.  note: this 
+      /* check if directors are enabled for this module.  note: this
        * is a "master" switch, without which no director code will be
        * emitted.  %feature("director") statements are also required
        * to enable directors for individual classes or methods.
        *
-       * use %module(directors="1") modulename at the start of the 
+       * use %module(directors="1") modulename at the start of the
        * interface file to enable director generation.
        */
       if (Getattr(optionsnode, "directors")) {
@@ -883,7 +883,7 @@ public:
 
     /*
        The rest of this function deals with generating the intermediary class wrapper function (that wraps
-       a c/c++ function) and generating the JNI c code. Each Java wrapper function has a 
+       a c/c++ function) and generating the JNI c code. Each Java wrapper function has a
        matching JNI c function call.
      */
 
@@ -1157,7 +1157,7 @@ public:
       moduleClassFunctionHandler(n);
     }
 
-    /* 
+    /*
      * Generate the proxy class getters/setters for public member variables.
      * Not for enums and constants.
      */
@@ -1476,7 +1476,7 @@ public:
       }
       if (!addSymbol(symname, n, scope))
         return SWIG_ERROR;
-      
+
       if ((enum_feature == ProperEnum) && parent_name && !unnamedinstance) {
         if (!GetFlag(n, "firstenumitem"))
           Printf(enum_code, ",\n");
@@ -1573,7 +1573,7 @@ public:
       Printv(constants_code, doxygen_comments, NIL);
       Delete(doxygen_comments);
     }
-    
+
     bool is_enum_item = (Cmp(nodeType(n), "enumitem") == 0);
 
     const String *itemname = (proxy_flag && wrapping_member_flag) ? variable_name : symname;
@@ -2424,11 +2424,11 @@ public:
   /* -----------------------------------------------------------------------------
    * proxyClassFunctionHandler()
    *
-   * Function called for creating a Java wrapper function around a c++ function in the 
+   * Function called for creating a Java wrapper function around a c++ function in the
    * proxy class. Used for both static and non-static C++ class functions.
    * C++ class static functions map to Java static functions.
-   * Two extra attributes in the Node must be available. These are "proxyfuncname" - 
-   * the name of the Java class proxy function, which in turn will call "imfuncname" - 
+   * Two extra attributes in the Node must be available. These are "proxyfuncname" -
+   * the name of the Java class proxy function, which in turn will call "imfuncname" -
    * the intermediary (JNI) function name in the intermediary class.
    * ----------------------------------------------------------------------------- */
 
@@ -2655,7 +2655,7 @@ public:
         Replaceall(tm, "$owner", "false");
       substituteClassname(t, tm);
 
-      // For director methods: generate code to selectively make a normal polymorphic call or 
+      // For director methods: generate code to selectively make a normal polymorphic call or
       // an explicit method call - needed to prevent infinite recursion calls in director methods.
       Node *explicit_n = Getattr(n, "explicitcallnode");
       if (explicit_n) {
@@ -3334,7 +3334,7 @@ public:
   /* -----------------------------------------------------------------------------
    * substituteClassname()
    *
-   * Substitute the special variable $javaclassname with the proxy class name for classes/structs/unions 
+   * Substitute the special variable $javaclassname with the proxy class name for classes/structs/unions
    * that SWIG knows about. Also substitutes enums with enum name.
    * Otherwise use the $descriptor name for the Java class name. Note that the $&javaclassname substitution
    * is the same as a $&descriptor substitution, ie one pointer added to descriptor name.
@@ -3546,7 +3546,7 @@ public:
    * tmap_method - typemap method name
    * type - typemap type to lookup
    * warning - warning number to issue if no typemaps found
-   * typemap_attributes - the typemap attributes are attached to this node and will 
+   * typemap_attributes - the typemap attributes are attached to this node and will
    *   also be used for temporary storage if non null
    * return is never NULL, unlike Swig_typemap_lookup()
    * ----------------------------------------------------------------------------- */
@@ -3637,7 +3637,7 @@ public:
    * prematureGarbageCollectionPreventionParameter()
    *
    * Get the proxy class name for use in an additional generated parameter. The
-   * additional parameter is added to a native method call purely to prevent 
+   * additional parameter is added to a native method call purely to prevent
    * premature garbage collection of proxy classes which pass their C++ class pointer
    * in a Java long to the JNI layer.
    * ----------------------------------------------------------------------------- */
@@ -3859,7 +3859,7 @@ public:
     else {
       Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", norm_name, norm_name);
       Printf(code_wrap->code, "  (void)jcls;\n");
-      Printf(code_wrap->code, "  %s *director = static_cast<%s *>(obj);\n", dirClassName, dirClassName); 
+      Printf(code_wrap->code, "  %s *director = static_cast<%s *>(obj);\n", dirClassName, dirClassName);
     }
 
     Printf(code_wrap->code, "  director->swig_connect_director(jenv, jself, jenv->GetObjectClass(jself), "
@@ -3981,13 +3981,13 @@ public:
    * Canonicalize the JNI field descriptor
    *
    * Replace the $packagepath and $javaclassname family of special
-   * variables with the desired package and Java proxy name as 
+   * variables with the desired package and Java proxy name as
    * required in the JNI field descriptors.
-   * 
+   *
    * !!SFM!! If $packagepath occurs in the field descriptor, but
    * package_path isn't set (length == 0), then strip it and the
    * optional trailing '/' from the resulting name.
-   * 
+   *
    * --------------------------------------------------------------- */
 
   String *canonicalizeJNIDescriptor(String *descriptor_in, Parm *p) {
@@ -4003,7 +4003,7 @@ public:
   /* ---------------------------------------------------------------
    * classDirectorMethod()
    *
-   * Emit a virtual director method to pass a method call on to the 
+   * Emit a virtual director method to pass a method call on to the
    * underlying Java object.
    *
    * --------------------------------------------------------------- */
@@ -4131,7 +4131,7 @@ public:
       Append(classret_desc, jnidesc_canon);
       Delete(jnidesc_canon);
     } else {
-      Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number, "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+      Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number, "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
           SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
@@ -4160,14 +4160,14 @@ public:
         Delete(jnidesc_canon);
       } else {
         Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                     "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                     "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
                      SwigType_str(c_ret_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
         output_director = false;
       }
 
       Delete(tp);
     } else {
-      Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n", 
+      Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n",
           SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
@@ -4239,7 +4239,7 @@ public:
       Delete(tm);
     } else {
       Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                   "No or improper directorin typemap for type %s  for use in %s::%s (skipping director method)\n", 
+                   "No or improper directorin typemap for type %s  for use in %s::%s (skipping director method)\n",
                    SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
@@ -4284,7 +4284,7 @@ public:
             && (tm = Getattr(p, "tmap:directorin"))
             && (cdesc = Getattr(p, "tmap:directorin:descriptor"))) {
 
-          // Objects marshalled by passing a Java class across the JNI boundary use jobject as the JNI type - 
+          // Objects marshalled by passing a Java class across the JNI boundary use jobject as the JNI type -
           // the nouse flag indicates this. We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
           if (GetFlag(tp, "tmap:directorin:nouse"))
             jdesc = cdesc;
@@ -4325,12 +4325,12 @@ public:
               Append(classdesc, jni_canon);
               Delete(jni_canon);
             } else {
-              Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number, "No javadirectorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+              Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number, "No javadirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
                   SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
               output_director = false;
             }
           } else {
-            Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+            Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s for use in %s::%s (skipping director method)\n",
                 SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
             output_director = false;
           }
@@ -4341,22 +4341,22 @@ public:
         } else {
           if (!desc_tm) {
             Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
-                         "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                         "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
                          SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
             p = nextSibling(p);
           } else if (!jdesc) {
             Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
-                         "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                         "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
                          SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
             p = Getattr(p, "tmap:directorin:next");
           } else if (!tm) {
             Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
-                         "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n", 
+                         "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
                          SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
             p = nextSibling(p);
           } else if (!cdesc) {
             Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
-                         "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                         "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
                          SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
             p = Getattr(p, "tmap:directorin:next");
           }
@@ -4365,7 +4365,7 @@ public:
         }
 
       } else {
-        Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n", 
+        Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n",
             SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
         output_director = false;
         p = nextSibling(p);
@@ -4499,7 +4499,7 @@ public:
           Printf(w->code, "%s\n", tm);
         } else {
           Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-                       "Unable to use return type %s used in %s::%s (skipping director method)\n", 
+                       "Unable to use return type %s used in %s::%s (skipping director method)\n",
                        SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
           output_director = false;
         }

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -14,14 +14,14 @@
 #include "swigmod.h"
 #include "cparse.h"
 #include <errno.h>
-#include <limits.h>             // for INT_MAX
+#include <limits.h>  // for INT_MAX
 #include <ctype.h>
 #include "javadoc.h"
 
 /* Hash type used for upcalls from C/C++ */
 typedef DOH UpcallData;
 
-class JAVA:public Language {
+class JAVA : public Language {
   static const char *usage;
   const String *empty_string;
   const String *public_string;
@@ -38,53 +38,53 @@ class JAVA:public Language {
   File *f_directors_h;
   List *filenames_list;
 
-  bool proxy_flag;              // Flag for generating proxy classes
-  bool nopgcpp_flag;            // Flag for suppressing the premature garbage collection prevention parameter
-  bool native_function_flag;    // Flag for when wrapping a native function
-  bool enum_constant_flag;      // Flag for when wrapping an enum or constant
-  bool static_flag;             // Flag for when wrapping a static functions or member variables
-  bool variable_wrapper_flag;   // Flag for when wrapping a nonstatic member variable
-  bool wrapping_member_flag;    // Flag for when wrapping a member variable/enum/const
-  bool global_variable_flag;    // Flag for when wrapping a global variable
-  bool old_variable_names;      // Flag for old style variable names in the intermediary class
-  bool member_func_flag;        // flag set when wrapping a member function
-  bool doxygen;                 //flag for converting found doxygen to javadoc
-  bool comment_creation_chatter; //flag for getting information about where comments were created in java.cxx
+  bool proxy_flag;                // Flag for generating proxy classes
+  bool nopgcpp_flag;              // Flag for suppressing the premature garbage collection prevention parameter
+  bool native_function_flag;      // Flag for when wrapping a native function
+  bool enum_constant_flag;        // Flag for when wrapping an enum or constant
+  bool static_flag;               // Flag for when wrapping a static functions or member variables
+  bool variable_wrapper_flag;     // Flag for when wrapping a nonstatic member variable
+  bool wrapping_member_flag;      // Flag for when wrapping a member variable/enum/const
+  bool global_variable_flag;      // Flag for when wrapping a global variable
+  bool old_variable_names;        // Flag for old style variable names in the intermediary class
+  bool member_func_flag;          // flag set when wrapping a member function
+  bool doxygen;                   // flag for converting found doxygen to javadoc
+  bool comment_creation_chatter;  // flag for getting information about where comments were created in java.cxx
 
-  String *imclass_name;         // intermediary class name
-  String *module_class_name;    // module class name
-  String *constants_interface_name;     // constants interface name
-  String *imclass_class_code;   // intermediary class code
+  String *imclass_name;              // intermediary class name
+  String *module_class_name;         // module class name
+  String *constants_interface_name;  // constants interface name
+  String *imclass_class_code;        // intermediary class code
   String *proxy_class_def;
   String *proxy_class_code;
-  String *interface_class_code; // if %feature("interface") was declared for a class, here goes the interface declaration
+  String *interface_class_code;  // if %feature("interface") was declared for a class, here goes the interface declaration
   String *module_class_code;
-  String *proxy_class_name;     // proxy class name
-  String *full_proxy_class_name;// fully qualified proxy class name when using nspace feature, otherwise same as proxy_class_name
-  String *full_imclass_name;    // fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
-  String *variable_name;        //Name of a variable being wrapped
+  String *proxy_class_name;       // proxy class name
+  String *full_proxy_class_name;  // fully qualified proxy class name when using nspace feature, otherwise same as proxy_class_name
+  String *full_imclass_name;      // fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
+  String *variable_name;          // Name of a variable being wrapped
   String *proxy_class_constants_code;
   String *module_class_constants_code;
   String *common_begin_code;
   String *enum_code;
-  String *package;              // Optional package name
-  String *jnipackage;           // Package name used in the JNI code
-  String *package_path;         // Package name used internally by JNI (slashes)
-  String *imclass_imports;      //intermediary class imports from %pragma
-  String *module_imports;       //module imports from %pragma
-  String *imclass_baseclass;    //inheritance for intermediary class class from %pragma
-  String *imclass_package;      //package in which to generate the intermediary class
-  String *module_baseclass;     //inheritance for module class from %pragma
-  String *imclass_interfaces;   //interfaces for intermediary class class from %pragma
-  String *module_interfaces;    //interfaces for module class from %pragma
-  String *imclass_class_modifiers;      //class modifiers for intermediary class overridden by %pragma
-  String *module_class_modifiers;       //class modifiers for module class overridden by %pragma
-  String *constants_modifiers;  //access modifiers for constants interface overridden by %pragma
-  String *upcasts_code;         //C++ casts for inheritance hierarchies C++ code
-  String *imclass_cppcasts_code;        //C++ casts up inheritance hierarchies intermediary class code
-  String *imclass_directors;    // Intermediate class director code
-  String *destructor_call;      //C++ destructor call if any
-  String *destructor_throws_clause;     //C++ destructor throws clause if any
+  String *package;                   // Optional package name
+  String *jnipackage;                // Package name used in the JNI code
+  String *package_path;              // Package name used internally by JNI (slashes)
+  String *imclass_imports;           // intermediary class imports from %pragma
+  String *module_imports;            // module imports from %pragma
+  String *imclass_baseclass;         // inheritance for intermediary class class from %pragma
+  String *imclass_package;           // package in which to generate the intermediary class
+  String *module_baseclass;          // inheritance for module class from %pragma
+  String *imclass_interfaces;        // interfaces for intermediary class class from %pragma
+  String *module_interfaces;         // interfaces for module class from %pragma
+  String *imclass_class_modifiers;   // class modifiers for intermediary class overridden by %pragma
+  String *module_class_modifiers;    // class modifiers for module class overridden by %pragma
+  String *constants_modifiers;       // access modifiers for constants interface overridden by %pragma
+  String *upcasts_code;              // C++ casts for inheritance hierarchies C++ code
+  String *imclass_cppcasts_code;     // C++ casts up inheritance hierarchies intermediary class code
+  String *imclass_directors;         // Intermediate class director code
+  String *destructor_call;           // C++ destructor call if any
+  String *destructor_throws_clause;  // C++ destructor throws clause if any
 
   // Director method stuff:
   List *dmethods_seq;
@@ -98,77 +98,77 @@ class JAVA:public Language {
   enum EnumFeature { SimpleEnum, TypeunsafeEnum, TypesafeEnum, ProperEnum };
 
 public:
-
   /* -----------------------------------------------------------------------------
    * JAVA()
    * ----------------------------------------------------------------------------- */
 
-   JAVA():empty_string(NewString("")),
-      public_string(NewString("public")),
-      protected_string(NewString("protected")),
-      swig_types_hash(NULL),
-      f_begin(NULL),
-      f_runtime(NULL),
-      f_runtime_h(NULL),
-      f_header(NULL),
-      f_wrappers(NULL),
-      f_init(NULL),
-      f_directors(NULL),
-      f_directors_h(NULL),
-      filenames_list(NULL),
-      proxy_flag(true),
-      nopgcpp_flag(false),
-      native_function_flag(false),
-      enum_constant_flag(false),
-      static_flag(false),
-      variable_wrapper_flag(false),
-      wrapping_member_flag(false),
-      global_variable_flag(false),
-      old_variable_names(false),
-      member_func_flag(false),
-      doxygen(false),
-      comment_creation_chatter(false),
-      imclass_name(NULL),
-      module_class_name(NULL),
-      constants_interface_name(NULL),
-      imclass_class_code(NULL),
-      proxy_class_def(NULL),
-      proxy_class_code(NULL),
-      interface_class_code(NULL),
-      module_class_code(NULL),
-      proxy_class_name(NULL),
-      full_proxy_class_name(NULL),
-      full_imclass_name(NULL),
-      variable_name(NULL),
-      proxy_class_constants_code(NULL),
-      module_class_constants_code(NULL),
-      common_begin_code(NULL),
-      enum_code(NULL),
-      package(NULL),
-      jnipackage(NULL),
-      package_path(NULL),
-      imclass_imports(NULL),
-      module_imports(NULL),
-      imclass_baseclass(NULL),
-      imclass_package(NULL),
-      module_baseclass(NULL),
-      imclass_interfaces(NULL),
-      module_interfaces(NULL),
-      imclass_class_modifiers(NULL),
-      module_class_modifiers(NULL),
-      constants_modifiers(NULL),
-      upcasts_code(NULL),
-      imclass_cppcasts_code(NULL),
-      imclass_directors(NULL),
-      destructor_call(NULL),
-      destructor_throws_clause(NULL),
-      dmethods_seq(NULL),
-      dmethods_table(NULL),
-      n_dmethods(0),
-      n_directors(0),
-      first_class_dmethod(0),
-      curr_class_dmethod(0),
-      nesting_depth(0){
+  JAVA() :
+    empty_string(NewString("")),
+    public_string(NewString("public")),
+    protected_string(NewString("protected")),
+    swig_types_hash(NULL),
+    f_begin(NULL),
+    f_runtime(NULL),
+    f_runtime_h(NULL),
+    f_header(NULL),
+    f_wrappers(NULL),
+    f_init(NULL),
+    f_directors(NULL),
+    f_directors_h(NULL),
+    filenames_list(NULL),
+    proxy_flag(true),
+    nopgcpp_flag(false),
+    native_function_flag(false),
+    enum_constant_flag(false),
+    static_flag(false),
+    variable_wrapper_flag(false),
+    wrapping_member_flag(false),
+    global_variable_flag(false),
+    old_variable_names(false),
+    member_func_flag(false),
+    doxygen(false),
+    comment_creation_chatter(false),
+    imclass_name(NULL),
+    module_class_name(NULL),
+    constants_interface_name(NULL),
+    imclass_class_code(NULL),
+    proxy_class_def(NULL),
+    proxy_class_code(NULL),
+    interface_class_code(NULL),
+    module_class_code(NULL),
+    proxy_class_name(NULL),
+    full_proxy_class_name(NULL),
+    full_imclass_name(NULL),
+    variable_name(NULL),
+    proxy_class_constants_code(NULL),
+    module_class_constants_code(NULL),
+    common_begin_code(NULL),
+    enum_code(NULL),
+    package(NULL),
+    jnipackage(NULL),
+    package_path(NULL),
+    imclass_imports(NULL),
+    module_imports(NULL),
+    imclass_baseclass(NULL),
+    imclass_package(NULL),
+    module_baseclass(NULL),
+    imclass_interfaces(NULL),
+    module_interfaces(NULL),
+    imclass_class_modifiers(NULL),
+    module_class_modifiers(NULL),
+    constants_modifiers(NULL),
+    upcasts_code(NULL),
+    imclass_cppcasts_code(NULL),
+    imclass_directors(NULL),
+    destructor_call(NULL),
+    destructor_throws_clause(NULL),
+    dmethods_seq(NULL),
+    dmethods_table(NULL),
+    n_dmethods(0),
+    n_directors(0),
+    first_class_dmethod(0),
+    curr_class_dmethod(0),
+    nesting_depth(0) {
     /* for now, multiple inheritance in directors is disabled, this
        should be easy to implement though */
     director_multiple_inheritance = 0;
@@ -199,9 +199,13 @@ public:
 
     if (nspace && !package) {
       String *name = Getattr(n, "name") ? Getattr(n, "name") : NewString("<unnamed>");
-      Swig_warning(WARN_JAVA_NSPACE_WITHOUT_PACKAGE, Getfile(n), Getline(n),
-          "The nspace feature is used on '%s' without -package. "
-          "The generated code may not compile as Java does not support types declared in a named package accessing types declared in an unnamed package.\n", SwigType_namestr(name));
+      Swig_warning(
+        WARN_JAVA_NSPACE_WITHOUT_PACKAGE,
+        Getfile(n),
+        Getline(n),
+        "The nspace feature is used on '%s' without -package. "
+        "The generated code may not compile as Java does not support types declared in a named package accessing types declared in an unnamed package.\n",
+        SwigType_namestr(name));
     }
   }
 
@@ -214,43 +218,42 @@ public:
    * the package name is handled differently (unfortunately for legacy reasons).
    * ----------------------------------------------------------------------------- */
 
-   String *getProxyName(SwigType *t, bool jnidescriptor = false) {
-     String *proxyname = NULL;
-     if (proxy_flag) {
-       Node *n = classLookup(t);
-       if (n) {
-         proxyname = Getattr(n, "proxyname");
-         if (!proxyname || jnidescriptor) {
-           String *nspace = Getattr(n, "sym:nspace");
-           String *symname = Copy(Getattr(n, "sym:name"));
-           if (symname && !GetFlag(n, "feature:flatnested")) {
-             for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
-               if (String* name = Getattr(outer_class, "sym:name")) {
-                 Push(symname, jnidescriptor ? "$" : ".");
-                 Push(symname, name);
-               }
-               else
-                 return NULL;
-             }
-           }
-           if (nspace) {
-             if (package && !jnidescriptor)
-               proxyname = NewStringf("%s.%s.%s", package, nspace, symname);
-             else
-               proxyname = NewStringf("%s.%s", nspace, symname);
-           } else {
-             proxyname = Copy(symname);
-           }
-           if (!jnidescriptor) {
-             Setattr(n, "proxyname", proxyname); // Cache it
-             Delete(proxyname);
-           }
-           Delete(symname);
-         }
-       }
-     }
-     return proxyname;
-   }
+  String *getProxyName(SwigType *t, bool jnidescriptor = false) {
+    String *proxyname = NULL;
+    if (proxy_flag) {
+      Node *n = classLookup(t);
+      if (n) {
+        proxyname = Getattr(n, "proxyname");
+        if (!proxyname || jnidescriptor) {
+          String *nspace = Getattr(n, "sym:nspace");
+          String *symname = Copy(Getattr(n, "sym:name"));
+          if (symname && !GetFlag(n, "feature:flatnested")) {
+            for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
+              if (String *name = Getattr(outer_class, "sym:name")) {
+                Push(symname, jnidescriptor ? "$" : ".");
+                Push(symname, name);
+              } else
+                return NULL;
+            }
+          }
+          if (nspace) {
+            if (package && !jnidescriptor)
+              proxyname = NewStringf("%s.%s.%s", package, nspace, symname);
+            else
+              proxyname = NewStringf("%s.%s", nspace, symname);
+          } else {
+            proxyname = Copy(symname);
+          }
+          if (!jnidescriptor) {
+            Setattr(n, "proxyname", proxyname);  // Cache it
+            Delete(proxyname);
+          }
+          Delete(symname);
+        }
+      }
+    }
+    return proxyname;
+  }
 
   /* -----------------------------------------------------------------------------
    * makeValidJniName()
@@ -680,9 +683,13 @@ public:
         String *item2_lower = Swig_string_lower(it2.item);
         if (it1.item && it2.item) {
           if (Strcmp(item1_lower, item2_lower) == 0) {
-            Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
+            Swig_warning(WARN_LANG_PORTABILITY_FILENAME,
+                         input_file,
+                         line_number,
                          "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
-                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
+                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n",
+                         it1.item,
+                         it2.item);
           }
         }
         Delete(item2_lower);
@@ -1001,7 +1008,7 @@ public:
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
         addThrows(n, "tmap:in", p);
-        Replaceall(tm, "$arg", arg);    /* deprecated? */
+        Replaceall(tm, "$arg", arg); /* deprecated? */
         Replaceall(tm, "$input", arg);
         Setattr(p, "emit:input", arg);
 
@@ -1025,7 +1032,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
         addThrows(n, "tmap:check", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input")); /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(f->code, tm, "\n", NIL);
         p = Getattr(p, "tmap:check:next");
@@ -1038,7 +1045,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
         addThrows(n, "tmap:freearg", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input")); /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(cleanup, tm, "\n", NIL);
         p = Getattr(p, "tmap:freearg:next");
@@ -1051,7 +1058,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
         addThrows(n, "tmap:argout", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input")); /* deprecated? */
         Replaceall(tm, "$result", "jresult");
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(outarg, tm, "\n", NIL);
@@ -1095,7 +1102,8 @@ public:
         if (Len(tm))
           Printf(f->code, "\n");
       } else {
-        Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
+        Swig_warning(
+          WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
       }
       emit_return_variable(n, returntype, f);
     }
@@ -1170,7 +1178,7 @@ public:
         Printf(getter_setter_name, "set");
       else
         Printf(getter_setter_name, "get");
-      Putc(toupper((int) *Char(variable_name)), getter_setter_name);
+      Putc(toupper((int)*Char(variable_name)), getter_setter_name);
       Printf(getter_setter_name, "%s", Char(variable_name) + 1);
 
       Setattr(n, "proxyfuncname", getter_setter_name);
@@ -1196,7 +1204,7 @@ public:
 
   virtual int variableWrapper(Node *n) {
     variable_wrapper_flag = true;
-    Language::variableWrapper(n);       /* Default to functions */
+    Language::variableWrapper(n); /* Default to functions */
     variable_wrapper_flag = false;
     return SWIG_OK;
   }
@@ -1220,7 +1228,7 @@ public:
       scope = NewString("");
       if (nspace)
         Printf(scope, "%s", nspace);
-      if (Node* cls = getCurrentClass()) {
+      if (Node *cls = getCurrentClass()) {
         if (Node *outer = Getattr(cls, "nested:outer")) {
           String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
           for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
@@ -1253,11 +1261,11 @@ public:
       if (getCurrentClass() && (cplus_mode != PUBLIC))
         return SWIG_NOWRAP;
 
-      String *nspace = Getattr(n, "sym:nspace"); // NSpace/getNSpace() only works during Language::enumDeclaration call
+      String *nspace = Getattr(n, "sym:nspace");  // NSpace/getNSpace() only works during Language::enumDeclaration call
 
       enum_code = NewString("");
       String *symname = Getattr(n, "sym:name");
-      String *constants_code = (proxy_flag && is_wrapping_class())? proxy_class_constants_code : module_class_constants_code;
+      String *constants_code = (proxy_flag && is_wrapping_class()) ? proxy_class_constants_code : module_class_constants_code;
       EnumFeature enum_feature = decodeEnumFeature(n);
       String *typemap_lookup_type = Getattr(n, "name");
 
@@ -1281,10 +1289,20 @@ public:
         const String *pure_interfaces = typemapLookup(n, "javainterfaces", typemap_lookup_type, WARN_NONE);
 
         // Emit the enum
-        Printv(enum_code, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),        // Class modifiers (enum modifiers really)
-               " ", symname, *Char(pure_baseclass) ?    // Bases
-               " extends " : "", pure_baseclass, *Char(pure_interfaces) ?       // Interfaces
-               " implements " : "", pure_interfaces, " {\n", NIL);
+        Printv(enum_code,
+               typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),  // Class modifiers (enum modifiers really)
+               " ",
+               symname,
+               *Char(pure_baseclass) ?  // Bases
+                 " extends "
+                                     : "",
+               pure_baseclass,
+               *Char(pure_interfaces) ?  // Interfaces
+                 " implements "
+                                      : "",
+               pure_interfaces,
+               " {\n",
+               NIL);
         if (proxy_flag && is_wrapping_class())
           Replaceall(enum_code, "$static ", "static ");
         else
@@ -1322,9 +1340,12 @@ public:
         // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper Java enum
         // Finish the enum declaration
         // Typemaps are used to generate the enum definition in a similar manner to proxy classes.
-        Printv(enum_code, (enum_feature == ProperEnum) ? ";\n" : "", typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),       // main body of class
-               typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),    // extra Java code
-               "}", NIL);
+        Printv(enum_code,
+               (enum_feature == ProperEnum) ? ";\n" : "",
+               typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),  // main body of class
+               typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),                         // extra Java code
+               "}",
+               NIL);
 
         Replaceall(enum_code, "$javaclassname", symname);
 
@@ -1366,8 +1387,12 @@ public:
             Printf(f_enum, ";\n");
           }
 
-          Printv(f_enum, typemapLookup(n, "javaimports", typemap_lookup_type, WARN_NONE), // Import statements
-                 "\n", enum_code, "\n", NIL);
+          Printv(f_enum,
+                 typemapLookup(n, "javaimports", typemap_lookup_type, WARN_NONE),  // Import statements
+                 "\n",
+                 enum_code,
+                 "\n",
+                 NIL);
 
           Printf(f_enum, "\n");
           Delete(f_enum);
@@ -1632,10 +1657,18 @@ public:
       if (classname_substituted_flag) {
         if (SwigType_isenum(t)) {
           // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
-          Printf(constants_code, "%s.swigToEnum(%s.%s());\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+          Printf(constants_code,
+                 "%s.swigToEnum(%s.%s());\n",
+                 return_type,
+                 full_imclass_name ? full_imclass_name : imclass_name,
+                 Swig_name_get(getNSpace(), symname));
         } else {
           // This handles function pointers using the %constant directive
-          Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+          Printf(constants_code,
+                 "new %s(%s.%s(), false);\n",
+                 return_type,
+                 full_imclass_name ? full_imclass_name : imclass_name,
+                 Swig_name_get(getNSpace(), symname));
         }
       } else {
         Printf(constants_code, "%s.%s();\n", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
@@ -1872,15 +1905,27 @@ public:
         String *bsmartnamestr = SwigType_namestr(bsmart);
 
         Printv(upcasts_code,
-            "SWIGEXPORT jlong JNICALL ", wname, "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
-            "    jlong baseptr = 0;\n"
-            "    ", smartnamestr, " *argp1;\n"
-            "    (void)jenv;\n"
-            "    (void)jcls;\n"
-            "    argp1 = *(", smartnamestr, " **)&jarg1;\n"
-            "    *(", bsmartnamestr, " **)&baseptr = argp1 ? new ", bsmartnamestr, "(*argp1) : 0;\n"
-            "    return baseptr;\n"
-            "}\n", "\n", NIL);
+               "SWIGEXPORT jlong JNICALL ",
+               wname,
+               "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
+               "    jlong baseptr = 0;\n"
+               "    ",
+               smartnamestr,
+               " *argp1;\n"
+               "    (void)jenv;\n"
+               "    (void)jcls;\n"
+               "    argp1 = *(",
+               smartnamestr,
+               " **)&jarg1;\n"
+               "    *(",
+               bsmartnamestr,
+               " **)&baseptr = argp1 ? new ",
+               bsmartnamestr,
+               "(*argp1) : 0;\n"
+               "    return baseptr;\n"
+               "}\n",
+               "\n",
+               NIL);
 
         Delete(bsmartnamestr);
         Delete(smartnamestr);
@@ -1890,13 +1935,21 @@ public:
       String *baseclassname = SwigType_namestr(c_baseclassname);
 
       Printv(upcasts_code,
-          "SWIGEXPORT jlong JNICALL ", wname, "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
-          "    jlong baseptr = 0;\n"
-          "    (void)jenv;\n"
-          "    (void)jcls;\n"
-          "    *(", baseclassname, " **)&baseptr = *(", classname, " **)&jarg1;\n"
-          "    return baseptr;\n"
-          "}\n", "\n", NIL);
+             "SWIGEXPORT jlong JNICALL ",
+             wname,
+             "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
+             "    jlong baseptr = 0;\n"
+             "    (void)jenv;\n"
+             "    (void)jcls;\n"
+             "    *(",
+             baseclassname,
+             " **)&baseptr = *(",
+             classname,
+             " **)&jarg1;\n"
+             "    return baseptr;\n"
+             "}\n",
+             "\n",
+             NIL);
 
       Delete(baseclassname);
       Delete(classname);
@@ -1947,8 +2000,12 @@ public:
             } else {
               /* Warn about multiple inheritance for additional base class(es) */
               String *proxyclassname = Getattr(n, "classtypeobj");
-              Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-                  "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java.\n", SwigType_namestr(proxyclassname), SwigType_namestr(baseclassname));
+              Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE,
+                           Getfile(n),
+                           Getline(n),
+                           "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java.\n",
+                           SwigType_namestr(proxyclassname),
+                           SwigType_namestr(baseclassname));
             }
           }
           base = Next(base);
@@ -1970,11 +2027,18 @@ public:
       derived = false;
       baseclass = NULL;
       if (purebase_notderived)
-        Swig_error(Getfile(n), Getline(n), "The javabase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n", typemap_lookup_type);
+        Swig_error(Getfile(n),
+                   Getline(n),
+                   "The javabase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n",
+                   typemap_lookup_type);
     } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
-      Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+      Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE,
+                   Getfile(n),
+                   Getline(n),
                    "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java. "
-                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the javabase typemap?\n", typemap_lookup_type, pure_baseclass);
+                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the javabase typemap?\n",
+                   typemap_lookup_type,
+                   pure_baseclass);
     }
 
     // Pure Java interfaces
@@ -1984,8 +2048,8 @@ public:
       Append(interface_list, ", ");
     Append(interface_list, pure_interfaces);
     // Start writing the proxy class
-    if (!has_outerclass) // Import statements
-      Printv(proxy_class_def, typemapLookup(n, "javaimports", typemap_lookup_type, WARN_NONE),"\n", NIL);
+    if (!has_outerclass)  // Import statements
+      Printv(proxy_class_def, typemapLookup(n, "javaimports", typemap_lookup_type, WARN_NONE), "\n", NIL);
 
     // Translate and write javadoc comment if flagged
     if (doxygen && doxygenTranslator->hasDocumentation(n)) {
@@ -1997,12 +2061,19 @@ public:
     }
 
     if (has_outerclass)
-      Printv(proxy_class_def, "static ", NIL); // C++ nested classes correspond to static java classes
-    Printv(proxy_class_def, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),      // Class modifiers
-           " $javaclassname",   // Class name and bases
-           (*Char(wanted_base)) ? " extends " : "", wanted_base, *Char(interface_list) ?        // Pure Java interfaces
-           " implements " : "", interface_list, " {", derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :   // main body of class
-           typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF), // main body of class
+      Printv(proxy_class_def, "static ", NIL);  // C++ nested classes correspond to static java classes
+    Printv(proxy_class_def,
+           typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),  // Class modifiers
+           " $javaclassname",                                                                              // Class name and bases
+           (*Char(wanted_base)) ? " extends " : "",
+           wanted_base,
+           *Char(interface_list) ?  // Pure Java interfaces
+             " implements "
+                                 : "",
+           interface_list,
+           " {",
+           derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :  // main body of class
+             typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),                   // main body of class
            NIL);
 
     // C++ destructor is wrapped by the delete method
@@ -2029,7 +2100,8 @@ public:
         Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in javadestruct%s typemap for %s\n", (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!destruct_methodmodifiers) {
-        Swig_error(Getfile(n), Getline(n), "No methodmodifiers attribute defined in javadestruct%s typemap for %s.\n", (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(
+          Getfile(n), Getline(n), "No methodmodifiers attribute defined in javadestruct%s typemap for %s.\n", (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!destruct_parameters)
         destruct_parameters = empty_string;
@@ -2085,8 +2157,10 @@ public:
     Delete(destruct);
 
     // Emit extra user code
-    Printv(proxy_class_def, typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),       // extra Java code
-           "\n", NIL);
+    Printv(proxy_class_def,
+           typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),  // extra Java code
+           "\n",
+           NIL);
 
     if (derived) {
       String *upcast_method_name = Swig_name_member(getNSpace(), getClassPrefix(), smart != 0 ? "SWIGSmartPtrUpcast" : "SWIGUpcast");
@@ -2125,7 +2199,7 @@ public:
     if (List *baselist = Getattr(n, "bases")) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
         if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
-          continue; // TODO: warn about skipped non-interface bases
+          continue;  // TODO: warn about skipped non-interface bases
         String *base_iname = Getattr(base.item, "interface:name");
         if (!bases)
           bases = Copy(base_iname);
@@ -2155,16 +2229,16 @@ public:
   }
 
   /* ----------------------------------------------------------------------
-  * classDeclaration()
-  * ---------------------------------------------------------------------- */
+   * classDeclaration()
+   * ---------------------------------------------------------------------- */
 
   int classDeclaration(Node *n) {
     return Language::classDeclaration(n);
   }
 
   /* ----------------------------------------------------------------------
-  * classHandler()
-  * ---------------------------------------------------------------------- */
+   * classHandler()
+   * ---------------------------------------------------------------------- */
 
   virtual int classHandler(Node *n) {
     File *f_proxy = NULL;
@@ -2261,8 +2335,7 @@ public:
             Printv(f_proxy, nspace, NIL);
           Printf(f_proxy, ";\n");
         }
-      }
-      else
+      } else
         ++nesting_depth;
 
       proxy_class_def = NewString("");
@@ -2280,7 +2353,7 @@ public:
           FileErrorDisplay(filen);
           Exit(EXIT_FAILURE);
         }
-        Append(filenames_list, filen); // file name ownership goes to the list
+        Append(filenames_list, filen);  // file name ownership goes to the list
         emitBanner(f_interface);
         emitInterfaceDeclaration(n, interface_name, interface_class_code, nspace);
         Delete(filen);
@@ -2293,7 +2366,7 @@ public:
     if (proxy_flag) {
       emitProxyClassDefAndCPPCasts(n);
 
-      String *javaclazzname = Swig_name_member(getNSpace(), getClassPrefix(), ""); // mangled full proxy class name
+      String *javaclazzname = Swig_name_member(getNSpace(), getClassPrefix(), "");  // mangled full proxy class name
 
       Replaceall(proxy_class_def, "$javaclassname", proxy_class_name);
       Replaceall(proxy_class_code, "$javaclassname", proxy_class_name);
@@ -2446,8 +2519,8 @@ public:
     bool setter_flag = false;
     String *pre_code = NewString("");
     String *post_code = NewString("");
-    bool is_interface = GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable")
-      && !static_flag && Getattr(n, "interface:owner") == 0;
+    bool is_interface =
+      GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable") && !static_flag && Getattr(n, "interface:owner") == 0;
 
     if (!proxy_flag)
       return;
@@ -2479,8 +2552,11 @@ public:
       substituteClassname(covariant ? covariant : t, tm);
       Printf(return_type, "%s", tm);
       if (covariant)
-        Swig_warning(WARN_JAVA_COVARIANT_RET, input_file, line_number,
-                     "Covariant return types not supported in Java. Proxy method will return %s.\n", SwigType_str(covariant, 0));
+        Swig_warning(WARN_JAVA_COVARIANT_RET,
+                     input_file,
+                     line_number,
+                     "Covariant return types not supported in Java. Proxy method will return %s.\n",
+                     SwigType_str(covariant, 0));
     } else {
       Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(t, 0));
     }
@@ -2635,7 +2711,7 @@ public:
       bool is_pre_code = Len(pre_code) > 0;
       bool is_post_code = Len(post_code) > 0;
       if (is_pre_code || is_post_code) {
-        Replaceall(tm, "\n ", "\n   "); // add extra indentation to code in typemap
+        Replaceall(tm, "\n ", "\n   ");  // add extra indentation to code in typemap
         if (is_post_code) {
           Insert(tm, 0, "\n    try ");
           Printv(tm, " finally {\n", post_code, "\n    }", NIL);
@@ -2713,7 +2789,8 @@ public:
     Parm *p;
     int i;
     String *function_code = NewString("");
-    String *helper_code = NewString(""); // Holds code for the constructor helper method generated only when the javain typemap has code in the pre or post attributes
+    String *helper_code =
+      NewString("");  // Holds code for the constructor helper method generated only when the javain typemap has code in the pre or post attributes
     String *helper_args = NewString("");
     String *pre_code = NewString("");
     String *post_code = NewString("");
@@ -2749,7 +2826,7 @@ public:
       const String *methodmods = Getattr(n, "feature:java:methodmodifiers");
       methodmods = methodmods ? methodmods : (is_public(n) ? public_string : protected_string);
 
-      tm = Getattr(n, "tmap:jtype"); // typemaps were attached earlier to the node
+      tm = Getattr(n, "tmap:jtype");  // typemaps were attached earlier to the node
       Printf(im_return_type, "%s", tm);
 
       // Translate and write javadoc comment if flagged
@@ -2870,8 +2947,7 @@ public:
       /* Insert the javaconstruct typemap, doing the replacement for $directorconnect, as needed */
       Hash *attributes = NewHash();
       String *typemap_lookup_type = Getattr(getCurrentClass(), "classtypeobj");
-      String *construct_tm = Copy(typemapLookup(n, "javaconstruct", typemap_lookup_type,
-                                                WARN_JAVA_TYPEMAP_JAVACONSTRUCT_UNDEF, attributes));
+      String *construct_tm = Copy(typemapLookup(n, "javaconstruct", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVACONSTRUCT_UNDEF, attributes));
       if (construct_tm) {
         if (!feature_director) {
           Replaceall(construct_tm, "$directorconnect", "");
@@ -2881,7 +2957,10 @@ public:
           if (connect_attr) {
             Replaceall(construct_tm, "$directorconnect", connect_attr);
           } else {
-            Swig_warning(WARN_JAVA_NO_DIRECTORCONNECT_ATTR, input_file, line_number, "\"directorconnect\" attribute missing in %s \"javaconstruct\" typemap.\n",
+            Swig_warning(WARN_JAVA_NO_DIRECTORCONNECT_ATTR,
+                         input_file,
+                         line_number,
+                         "\"directorconnect\" attribute missing in %s \"javaconstruct\" typemap.\n",
                          Getattr(n, "name"));
             Replaceall(construct_tm, "$directorconnect", "");
           }
@@ -3062,7 +3141,7 @@ public:
         Printf(func_name, "set");
       else
         Printf(func_name, "get");
-      Putc(toupper((int) *Char(variable_name)), func_name);
+      Putc(toupper((int)*Char(variable_name)), func_name);
       Printf(func_name, "%s", Char(variable_name) + 1);
     } else {
       func_name = Copy(Getattr(n, "sym:name"));
@@ -3162,7 +3241,7 @@ public:
       bool is_pre_code = Len(pre_code) > 0;
       bool is_post_code = Len(post_code) > 0;
       if (is_pre_code || is_post_code) {
-        Replaceall(tm, "\n ", "\n   "); // add extra indentation to code in typemap
+        Replaceall(tm, "\n ", "\n   ");  // add extra indentation to code in typemap
         if (is_post_code) {
           Insert(tm, 0, "\n    try ");
           Printv(tm, " finally {\n", post_code, "\n    }", NIL);
@@ -3270,12 +3349,13 @@ public:
         // Get the enumvalue from a JNI call
         if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
           // Strange hack to change the name
-          Setattr(n, "name", Getattr(n, "value"));      /* for wrapping of enums in a namespace when emit_action is used */
+          Setattr(n, "name", Getattr(n, "value")); /* for wrapping of enums in a namespace when emit_action is used */
           constantWrapper(n);
           value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
         } else {
           memberconstantHandler(n);
-          value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
+          value = NewStringf(
+            "%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
         }
         Delete(newsymname);
       }
@@ -3320,7 +3400,7 @@ public:
             }
           }
           if (!jnidescriptor) {
-            Setattr(n, "enumname", enumname); // Cache it
+            Setattr(n, "enumname", enumname);  // Cache it
             Delete(enumname);
           }
           Delete(scopename_prefix);
@@ -3450,7 +3530,7 @@ public:
         }
       }
     } else {
-      String *classname = getProxyName(classnametype, jnidescriptor); // getProxyName() works for pointers to classes too
+      String *classname = getProxyName(classnametype, jnidescriptor);  // getProxyName() works for pointers to classes too
       if (classname) {
         replacementname = Copy(classname);
       } else {
@@ -3462,7 +3542,7 @@ public:
       }
     }
     if (jnidescriptor)
-      Replaceall(replacementname,".","/");
+      Replaceall(replacementname, ".", "/");
     Replaceall(tm, classnamespecialvariable, replacementname);
 
     Delete(replacementname);
@@ -3472,14 +3552,15 @@ public:
    * substituteInterfacenameSpecialVariable()
    * ----------------------------------------------------------------------------- */
 
-  void substituteInterfacenameSpecialVariable(SwigType *interfacenametype, String *tm, const char *interfacenamespecialvariable, bool jnidescriptor, bool qualified) {
+  void substituteInterfacenameSpecialVariable(SwigType *interfacenametype, String *tm, const char *interfacenamespecialvariable, bool jnidescriptor,
+                                              bool qualified) {
 
-    String *interfacename = getInterfaceName(interfacenametype/*, jnidescriptor*/, qualified);
+    String *interfacename = getInterfaceName(interfacenametype /*, jnidescriptor*/, qualified);
     if (interfacename) {
       String *replacementname = Copy(interfacename);
 
       if (jnidescriptor)
-        Replaceall(replacementname,".","/");
+        Replaceall(replacementname, ".", "/");
       Replaceall(tm, interfacenamespecialvariable, replacementname);
 
       Delete(replacementname);
@@ -3517,13 +3598,23 @@ public:
     const String *pure_interfaces = typemapLookup(n, "javainterfaces", type, WARN_NONE);
 
     // Emit the class
-    Printv(swigtype, typemapLookup(n, "javaimports", type, WARN_NONE),  // Import statements
-           "\n", typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),        // Class modifiers
-           " $javaclassname",   // Class name and bases
-           *Char(pure_baseclass) ? " extends " : "", pure_baseclass, *Char(pure_interfaces) ?   // Interfaces
-           " implements " : "", pure_interfaces, " {", typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),    // main body of class
-           typemapLookup(n, "javacode", type, WARN_NONE),       // extra Java code
-           "}\n", "\n", NIL);
+    Printv(swigtype,
+           typemapLookup(n, "javaimports", type, WARN_NONE),  // Import statements
+           "\n",
+           typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),  // Class modifiers
+           " $javaclassname",                                                               // Class name and bases
+           *Char(pure_baseclass) ? " extends " : "",
+           pure_baseclass,
+           *Char(pure_interfaces) ?  // Interfaces
+             " implements "
+                                  : "",
+           pure_interfaces,
+           " {",
+           typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),  // main body of class
+           typemapLookup(n, "javacode", type, WARN_NONE),                         // extra Java code
+           "}\n",
+           "\n",
+           NIL);
 
     Replaceall(swigtype, "$javaclassname", classname);
     Replaceall(swigtype, "$module", module_class_name);
@@ -3592,8 +3683,8 @@ public:
       if (temp_classes_list && Len(temp_classes_list) > 0) {
         for (Iterator cls = First(temp_classes_list); cls.item; cls = Next(cls)) {
           String *exception_class = NewString(cls.item);
-          Replaceall(exception_class, " ", ""); // remove spaces
-          Replaceall(exception_class, "\t", "");        // remove tabs
+          Replaceall(exception_class, " ", "");   // remove spaces
+          Replaceall(exception_class, "\t", "");  // remove tabs
           if (Len(exception_class) > 0) {
             // $javaclassname substitution
             SwigType *pt = Getattr(parameter, "type");
@@ -3736,25 +3827,24 @@ public:
       char code;
       const char *method;
     } upcall_methods[] = {
-      {
-      'B', "CallStaticByteMethod"}, {
-      'C', "CallStaticCharMethod"}, {
-      'D', "CallStaticDoubleMethod"}, {
-      'F', "CallStaticFloatMethod"}, {
-      'I', "CallStaticIntMethod"}, {
-      'J', "CallStaticLongMethod"}, {
-      'L', "CallStaticObjectMethod"}, {
-      'S', "CallStaticShortMethod"}, {
-      'V', "CallStaticVoidMethod"}, {
-      'Z', "CallStaticBooleanMethod"}, {
-      '[', "CallStaticObjectMethod"}
+      {'B', "CallStaticByteMethod"   },
+      {'C', "CallStaticCharMethod"   },
+      {'D', "CallStaticDoubleMethod" },
+      {'F', "CallStaticFloatMethod"  },
+      {'I', "CallStaticIntMethod"    },
+      {'J', "CallStaticLongMethod"   },
+      {'L', "CallStaticObjectMethod" },
+      {'S', "CallStaticShortMethod"  },
+      {'V', "CallStaticVoidMethod"   },
+      {'Z', "CallStaticBooleanMethod"},
+      {'[', "CallStaticObjectMethod" }
     };
 
     char code;
     int i;
 
     code = *Char(descrip);
-    for (i = 0; i < (int) (sizeof(upcall_methods) / sizeof(upcall_methods[0])); ++i)
+    for (i = 0; i < (int)(sizeof(upcall_methods) / sizeof(upcall_methods[0])); ++i)
       if (code == upcall_methods[i].code)
         return NewString(upcall_methods[i].method);
     return NULL;
@@ -3841,13 +3931,18 @@ public:
     String *dirClassName = directorClassName(n);
     Wrapper *code_wrap;
 
-    Printf(imclass_class_code, "  public final static native void %s(%s obj, long cptr, boolean mem_own, boolean weak_global);\n",
-           swig_director_connect, full_proxy_class_name);
+    Printf(imclass_class_code,
+           "  public final static native void %s(%s obj, long cptr, boolean mem_own, boolean weak_global);\n",
+           swig_director_connect,
+           full_proxy_class_name);
 
     code_wrap = NewWrapper();
     Printf(code_wrap->def,
            "SWIGEXPORT void JNICALL Java_%s%s_%s(JNIEnv *jenv, jclass jcls, jobject jself, jlong objarg, jboolean jswig_mem_own, "
-           "jboolean jweak_global) {\n", jnipackage, jni_imclass_name, swig_director_connect_jni);
+           "jboolean jweak_global) {\n",
+           jnipackage,
+           jni_imclass_name,
+           swig_director_connect_jni);
 
     if (smartptr) {
       Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", smartptr, smartptr);
@@ -3855,14 +3950,14 @@ public:
       Printf(code_wrap->code, "  // Keep a local instance of the smart pointer around while we are using the raw pointer\n");
       Printf(code_wrap->code, "  // Avoids using smart pointer specific API.\n");
       Printf(code_wrap->code, "  %s *director = static_cast<%s *>(obj->operator->());\n", dirClassName, dirClassName);
-    }
-    else {
+    } else {
       Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", norm_name, norm_name);
       Printf(code_wrap->code, "  (void)jcls;\n");
       Printf(code_wrap->code, "  %s *director = static_cast<%s *>(obj);\n", dirClassName, dirClassName);
     }
 
-    Printf(code_wrap->code, "  director->swig_connect_director(jenv, jself, jenv->GetObjectClass(jself), "
+    Printf(code_wrap->code,
+           "  director->swig_connect_director(jenv, jself, jenv->GetObjectClass(jself), "
            "(jswig_mem_own == JNI_TRUE), (jweak_global == JNI_TRUE));\n");
     Printf(code_wrap->code, "}\n");
 
@@ -3876,21 +3971,24 @@ public:
     String *changeown_method_name = Swig_name_member(getNSpace(), getClassPrefix(), "change_ownership");
     String *changeown_jnimethod_name = makeValidJniName(changeown_method_name);
 
-    Printf(imclass_class_code, "  public final static native void %s(%s obj, long cptr, boolean take_or_release);\n", changeown_method_name, full_proxy_class_name);
+    Printf(
+      imclass_class_code, "  public final static native void %s(%s obj, long cptr, boolean take_or_release);\n", changeown_method_name, full_proxy_class_name);
 
     code_wrap = NewWrapper();
     Printf(code_wrap->def,
            "SWIGEXPORT void JNICALL Java_%s%s_%s(JNIEnv *jenv, jclass jcls, jobject jself, jlong objarg, jboolean jtake_or_release) {\n",
-           jnipackage, jni_imclass_name, changeown_jnimethod_name);
+           jnipackage,
+           jni_imclass_name,
+           changeown_jnimethod_name);
 
     if (smartptr) {
-        Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", smartptr, smartptr);
-        Printf(code_wrap->code, "  // Keep a local instance of the smart pointer around while we are using the raw pointer\n");
-        Printf(code_wrap->code, "  // Avoids using smart pointer specific API.\n");
-        Printf(code_wrap->code, "  %s *director = dynamic_cast<%s *>(obj->operator->());\n", dirClassName, dirClassName);
+      Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", smartptr, smartptr);
+      Printf(code_wrap->code, "  // Keep a local instance of the smart pointer around while we are using the raw pointer\n");
+      Printf(code_wrap->code, "  // Avoids using smart pointer specific API.\n");
+      Printf(code_wrap->code, "  %s *director = dynamic_cast<%s *>(obj->operator->());\n", dirClassName, dirClassName);
     } else {
-        Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", norm_name, norm_name);
-        Printf(code_wrap->code, "  %s *director = dynamic_cast<%s *>(obj);\n", dirClassName, dirClassName);
+      Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", norm_name, norm_name);
+      Printf(code_wrap->code, "  %s *director = dynamic_cast<%s *>(obj);\n", dirClassName, dirClassName);
     }
 
     Printf(code_wrap->code, "  (void)jcls;\n");
@@ -3960,7 +4058,7 @@ public:
    * ----------------------------------------------------------------------------- */
 
   void substitutePackagePath(String *text, Parm *p) {
-    String *pkg_path= 0;
+    String *pkg_path = 0;
 
     if (p)
       pkg_path = Swig_typemap_lookup("javapackage", p, "", 0);
@@ -4054,7 +4152,6 @@ public:
       imclass_dmethod = Swig_name_member(getNSpace(), dirclassname, overloaded_name);
     }
 
-
     qualified_return = SwigType_rcaststr(returntype, "c_result");
 
     if (!is_void && (!ignored_method || pure_virtual)) {
@@ -4121,8 +4218,7 @@ public:
     SwigType *adjustedreturntype = covariant ? covariant : returntype;
     Parm *adjustedreturntypeparm = NewParmNode(adjustedreturntype, n);
 
-    if (Swig_typemap_lookup("directorin", adjustedreturntypeparm, "", 0)
-        && (cdesc = Getattr(adjustedreturntypeparm, "tmap:directorin:descriptor"))) {
+    if (Swig_typemap_lookup("directorin", adjustedreturntypeparm, "", 0) && (cdesc = Getattr(adjustedreturntypeparm, "tmap:directorin:descriptor"))) {
 
       // Note that in the case of polymorphic (covariant) return types, the
       // method's return type is changed to be the base of the C++ return
@@ -4131,8 +4227,13 @@ public:
       Append(classret_desc, jnidesc_canon);
       Delete(jnidesc_canon);
     } else {
-      Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number, "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-          SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+      Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                   input_file,
+                   line_number,
+                   "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
+                   SwigType_str(returntype, 0),
+                   SwigType_namestr(c_classname),
+                   SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4148,8 +4249,7 @@ public:
       }
 
       String *jdesc = NULL;
-      if (Swig_typemap_lookup("directorin", tp, "", 0)
-          && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
+      if (Swig_typemap_lookup("directorin", tp, "", 0) && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
 
         // Objects marshalled passing a Java class across JNI boundary use jobject - the nouse flag indicates this
         // We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
@@ -4159,16 +4259,25 @@ public:
         Append(jniret_desc, jnidesc_canon);
         Delete(jnidesc_canon);
       } else {
-        Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+        Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                     input_file,
+                     line_number,
                      "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                     SwigType_str(c_ret_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                     SwigType_str(c_ret_type, 0),
+                     SwigType_namestr(c_classname),
+                     SwigType_namestr(name));
         output_director = false;
       }
 
       Delete(tp);
     } else {
-      Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n",
-          SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+      Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF,
+                   input_file,
+                   line_number,
+                   "No jni typemap defined for %s for use in %s::%s (skipping director method)\n",
+                   SwigType_str(returntype, 0),
+                   SwigType_namestr(c_classname),
+                   SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4231,16 +4340,19 @@ public:
     Parm *tp = NewParmNode(c_classname, n);
     String *jdesc;
 
-    if ((tm = Swig_typemap_lookup("directorin", tp, "", 0))
-        && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
+    if ((tm = Swig_typemap_lookup("directorin", tp, "", 0)) && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
       String *jni_canon = canonicalizeJNIDescriptor(jdesc, tp);
       Append(jnidesc, jni_canon);
       Delete(jni_canon);
       Delete(tm);
     } else {
-      Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+      Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                   input_file,
+                   line_number,
                    "No or improper directorin typemap for type %s  for use in %s::%s (skipping director method)\n",
-                   SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                   SwigType_str(returntype, 0),
+                   SwigType_namestr(c_classname),
+                   SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4279,10 +4391,8 @@ public:
           Wrapper_add_localv(w, arg, c_decl, (!(SwigType_ispointer(pt) || SwigType_isreference(pt)) ? "" : "= 0"), NIL);
 
         /* Add input marshalling code and update JNI field descriptor */
-        if ((desc_tm = Swig_typemap_lookup("directorin", tp, "", 0))
-            && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))
-            && (tm = Getattr(p, "tmap:directorin"))
-            && (cdesc = Getattr(p, "tmap:directorin:descriptor"))) {
+        if ((desc_tm = Swig_typemap_lookup("directorin", tp, "", 0)) && (jdesc = Getattr(tp, "tmap:directorin:descriptor")) &&
+            (tm = Getattr(p, "tmap:directorin")) && (cdesc = Getattr(p, "tmap:directorin:descriptor"))) {
 
           // Objects marshalled by passing a Java class across the JNI boundary use jobject as the JNI type -
           // the nouse flag indicates this. We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
@@ -4325,13 +4435,23 @@ public:
               Append(classdesc, jni_canon);
               Delete(jni_canon);
             } else {
-              Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number, "No javadirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+              Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF,
+                           input_file,
+                           line_number,
+                           "No javadirectorin typemap defined for %s for use in %s::%s (skipping director method)\n",
+                           SwigType_str(pt, 0),
+                           SwigType_namestr(c_classname),
+                           SwigType_namestr(name));
               output_director = false;
             }
           } else {
-            Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s for use in %s::%s (skipping director method)\n",
-                SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF,
+                         input_file,
+                         line_number,
+                         "No jtype typemap defined for %s for use in %s::%s (skipping director method)\n",
+                         SwigType_str(pt, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             output_director = false;
           }
 
@@ -4340,24 +4460,40 @@ public:
           Delete(desc_tm);
         } else {
           if (!desc_tm) {
-            Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
+            Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF,
+                         input_file,
+                         line_number,
                          "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                         SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                         SwigType_str(c_param_type, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             p = nextSibling(p);
           } else if (!jdesc) {
-            Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
+            Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC,
+                         input_file,
+                         line_number,
                          "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                         SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                         SwigType_str(c_param_type, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             p = Getattr(p, "tmap:directorin:next");
           } else if (!tm) {
-            Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
+            Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF,
+                         input_file,
+                         line_number,
                          "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n",
-                         SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                         SwigType_str(pt, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             p = nextSibling(p);
           } else if (!cdesc) {
-            Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
+            Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC,
+                         input_file,
+                         line_number,
                          "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n",
-                         SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                         SwigType_str(pt, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             p = Getattr(p, "tmap:directorin:next");
           }
 
@@ -4365,8 +4501,13 @@ public:
         }
 
       } else {
-        Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n",
-            SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF,
+                     input_file,
+                     line_number,
+                     "No jni typemap defined for %s for use in %s::%s (skipping director method)\n",
+                     SwigType_str(pt, 0),
+                     SwigType_namestr(c_classname),
+                     SwigType_namestr(name));
         output_director = false;
         p = nextSibling(p);
       }
@@ -4498,9 +4639,13 @@ public:
           Replaceall(tm, "$result", result_str);
           Printf(w->code, "%s\n", tm);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
                        "Unable to use return type %s used in %s::%s (skipping director method)\n",
-                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           output_director = false;
         }
 
@@ -4526,8 +4671,10 @@ public:
 
       /* Terminate wrapper code */
       Printf(w->code, "} else {\n");
-      Printf(w->code, "SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, \"null upcall object in %s::%s \");\n",
-             SwigType_namestr(c_classname), SwigType_namestr(name));
+      Printf(w->code,
+             "SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, \"null upcall object in %s::%s \");\n",
+             SwigType_namestr(c_classname),
+             SwigType_namestr(name));
       Printf(w->code, "}\n");
 
       Printf(w->code, "if (swigjobj) jenv->DeleteLocalRef(swigjobj);\n");
@@ -4625,7 +4772,7 @@ public:
             Printv(directorthrowshandlers_code, directorthrows, NIL);
             Delete(directorthrows);
           } else {
-            String *t = Getattr(p,"type");
+            String *t = Getattr(p, "type");
             Swig_warning(WARN_TYPEMAP_DIRECTORTHROWS_UNDEF, Getfile(n), Getline(n), "No directorthrows typemap defined for %s\n", SwigType_str(t, 0));
           }
         }
@@ -4745,14 +4892,13 @@ public:
     return Language::classDirectorDefaultConstructor(n);
   }
 
-
   /* ------------------------------------------------------------
    * classDirectorInit()
    * ------------------------------------------------------------ */
 
   int classDirectorInit(Node *n) {
     Delete(none_comparison);
-    none_comparison = NewString("");    // not used
+    none_comparison = NewString("");  // not used
 
     Delete(director_ctor_code);
     director_ctor_code = NewString("$director_new");
@@ -4916,7 +5062,7 @@ public:
    * ------------------------------------------------------------------*/
 
   virtual int classDirectorDisown(Node *n) {
-    (void) n;
+    (void)n;
     return SWIG_OK;
   }
 
@@ -4956,7 +5102,7 @@ public:
   NestedClassSupport nestedClassesSupport() const {
     return NCS_Full;
   }
-};                              /* class JAVA */
+}; /* class JAVA */
 
 /* -----------------------------------------------------------------------------
  * swig_java()    - Instantiate module

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -200,8 +200,8 @@ public:
     if (nspace && !package) {
       String *name = Getattr(n, "name") ? Getattr(n, "name") : NewString("<unnamed>");
       Swig_warning(WARN_JAVA_NSPACE_WITHOUT_PACKAGE, Getfile(n), Getline(n),
-	  "The nspace feature is used on '%s' without -package. "
-	  "The generated code may not compile as Java does not support types declared in a named package accessing types declared in an unnamed package.\n", SwigType_namestr(name));
+          "The nspace feature is used on '%s' without -package. "
+          "The generated code may not compile as Java does not support types declared in a named package accessing types declared in an unnamed package.\n", SwigType_namestr(name));
     }
   }
 
@@ -219,11 +219,11 @@ public:
      if (proxy_flag) {
        Node *n = classLookup(t);
        if (n) {
-	 proxyname = Getattr(n, "proxyname");
-	 if (!proxyname || jnidescriptor) {
-	   String *nspace = Getattr(n, "sym:nspace");
-	   String *symname = Copy(Getattr(n, "sym:name"));
-	   if (symname && !GetFlag(n, "feature:flatnested")) {
+         proxyname = Getattr(n, "proxyname");
+         if (!proxyname || jnidescriptor) {
+           String *nspace = Getattr(n, "sym:nspace");
+           String *symname = Copy(Getattr(n, "sym:name"));
+           if (symname && !GetFlag(n, "feature:flatnested")) {
              for (Node *outer_class = Getattr(n, "nested:outer"); outer_class; outer_class = Getattr(outer_class, "nested:outer")) {
                if (String* name = Getattr(outer_class, "sym:name")) {
                  Push(symname, jnidescriptor ? "$" : ".");
@@ -232,21 +232,21 @@ public:
                else
                  return NULL;
              }
-	   }
-	   if (nspace) {
-	     if (package && !jnidescriptor)
-	       proxyname = NewStringf("%s.%s.%s", package, nspace, symname);
-	     else
-	       proxyname = NewStringf("%s.%s", nspace, symname);
-	   } else {
-	     proxyname = Copy(symname);
-	   }
-	   if (!jnidescriptor) {
-	     Setattr(n, "proxyname", proxyname); // Cache it
-	     Delete(proxyname);
-	   }
-	   Delete(symname);
-	 }
+           }
+           if (nspace) {
+             if (package && !jnidescriptor)
+               proxyname = NewStringf("%s.%s.%s", package, nspace, symname);
+             else
+               proxyname = NewStringf("%s.%s", nspace, symname);
+           } else {
+             proxyname = Copy(symname);
+           }
+           if (!jnidescriptor) {
+             Setattr(n, "proxyname", proxyname); // Cache it
+             Delete(proxyname);
+           }
+           Delete(symname);
+         }
        }
      }
      return proxyname;
@@ -275,42 +275,42 @@ public:
     // Look for certain command line options
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-package") == 0) {
-	  if (argv[i + 1]) {
-	    package = NewString("");
-	    Printf(package, argv[i + 1]);
-	    if (Len(package) == 0) {
-	      Delete(package);
-	      package = 0;
-	    }
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if ((strcmp(argv[i], "-doxygen") == 0)) {
-	  Swig_mark_arg(i);
-	  doxygen = true;
-	  scan_doxygen_comments = true;
-	} else if ((strcmp(argv[i], "-debug-doxygen-translator") == 0)) {
-	  Swig_mark_arg(i);
-	  doxygen_translator_flags |= DoxygenTranslator::debug_translator;
-	} else if ((strcmp(argv[i], "-debug-doxygen-parser") == 0)) {
-	  Swig_mark_arg(i);
-	  doxygen_translator_flags |= DoxygenTranslator::debug_parser;
-	} else if ((strcmp(argv[i], "-noproxy") == 0)) {
-	  Swig_mark_arg(i);
-	  proxy_flag = false;
-	} else if (strcmp(argv[i], "-nopgcpp") == 0) {
-	  Swig_mark_arg(i);
-	  nopgcpp_flag = true;
-	} else if (strcmp(argv[i], "-oldvarnames") == 0) {
-	  Swig_mark_arg(i);
-	  old_variable_names = true;
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  Printf(stdout, "%s", usage);
-	}
+        if (strcmp(argv[i], "-package") == 0) {
+          if (argv[i + 1]) {
+            package = NewString("");
+            Printf(package, argv[i + 1]);
+            if (Len(package) == 0) {
+              Delete(package);
+              package = 0;
+            }
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if ((strcmp(argv[i], "-doxygen") == 0)) {
+          Swig_mark_arg(i);
+          doxygen = true;
+          scan_doxygen_comments = true;
+        } else if ((strcmp(argv[i], "-debug-doxygen-translator") == 0)) {
+          Swig_mark_arg(i);
+          doxygen_translator_flags |= DoxygenTranslator::debug_translator;
+        } else if ((strcmp(argv[i], "-debug-doxygen-parser") == 0)) {
+          Swig_mark_arg(i);
+          doxygen_translator_flags |= DoxygenTranslator::debug_parser;
+        } else if ((strcmp(argv[i], "-noproxy") == 0)) {
+          Swig_mark_arg(i);
+          proxy_flag = false;
+        } else if (strcmp(argv[i], "-nopgcpp") == 0) {
+          Swig_mark_arg(i);
+          nopgcpp_flag = true;
+        } else if (strcmp(argv[i], "-oldvarnames") == 0) {
+          Swig_mark_arg(i);
+          old_variable_names = true;
+        } else if (strcmp(argv[i], "-help") == 0) {
+          Printf(stdout, "%s", usage);
+        }
       }
     }
     
@@ -338,7 +338,7 @@ public:
 
     if (optionsnode) {
       if (Getattr(optionsnode, "jniclassname"))
-	imclass_name = Copy(Getattr(optionsnode, "jniclassname"));
+        imclass_name = Copy(Getattr(optionsnode, "jniclassname"));
       /* check if directors are enabled for this module.  note: this 
        * is a "master" switch, without which no director code will be
        * emitted.  %feature("director") statements are also required
@@ -348,15 +348,15 @@ public:
        * interface file to enable director generation.
        */
       if (Getattr(optionsnode, "directors")) {
-	allow_directors();
+        allow_directors();
       }
       if (Getattr(optionsnode, "dirprot")) {
-	allow_dirprot();
+        allow_dirprot();
       }
       allow_allprotected(GetFlag(optionsnode, "allprotected"));
       common_begin_code = Getattr(optionsnode, "javabegin");
       if (common_begin_code)
-	Printf(common_begin_code, "\n");
+        Printf(common_begin_code, "\n");
     }
 
     /* Initialize all of the output files */
@@ -377,12 +377,12 @@ public:
     if (Swig_directors_enabled()) {
       if (!outfile_h) {
         Printf(stderr, "Unable to determine outfile_h\n");
-	Exit(EXIT_FAILURE);
+        Exit(EXIT_FAILURE);
       }
       f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
       if (!f_runtime_h) {
-	FileErrorDisplay(outfile_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -412,9 +412,9 @@ public:
     } else {
       // Rename the module name if it is the same as intermediary class name - a backwards compatibility solution
       if (Cmp(imclass_name, Getattr(n, "name")) == 0)
-	module_class_name = NewStringf("%sModule", Getattr(n, "name"));
+        module_class_name = NewStringf("%sModule", Getattr(n, "name"));
       else
-	module_class_name = Copy(Getattr(n, "name"));
+        module_class_name = Copy(Getattr(n, "name"));
     }
     constants_interface_name = NewStringf("%sConstants", module_class_name);
 
@@ -467,9 +467,9 @@ public:
       Printf(f_directors, " * C++ director class methods\n");
       Printf(f_directors, " * --------------------------------------------------- */\n\n");
       if (outfile_h) {
-	String *filename = Swig_file_filename(outfile_h);
-	Printf(f_directors, "#include \"%s\"\n\n", filename);
-	Delete(filename);
+        String *filename = Swig_file_filename(outfile_h);
+        Printf(f_directors, "#include \"%s\"\n\n", filename);
+        Delete(filename);
       }
     }
 
@@ -515,8 +515,8 @@ public:
       String *filen = NewStringf("%s%s.java", outputDirectory(imclass_package), imclass_name);
       File *f_im = NewFile(filen, "w", SWIG_output_files());
       if (!f_im) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filen));
       Delete(filen);
@@ -533,16 +533,16 @@ public:
         Printf(f_im, "package %s;\n", package);
 
       if (imclass_imports)
-	Printf(f_im, "%s\n", imclass_imports);
+        Printf(f_im, "%s\n", imclass_imports);
 
       if (Len(imclass_class_modifiers) > 0)
-	Printf(f_im, "%s ", imclass_class_modifiers);
+        Printf(f_im, "%s ", imclass_class_modifiers);
       Printf(f_im, "%s ", imclass_name);
 
       if (imclass_baseclass && *Char(imclass_baseclass))
-	Printf(f_im, "extends %s ", imclass_baseclass);
+        Printf(f_im, "extends %s ", imclass_baseclass);
       if (Len(imclass_interfaces) > 0)
-	Printv(f_im, "implements ", imclass_interfaces, " ", NIL);
+        Printv(f_im, "implements ", imclass_interfaces, " ", NIL);
       Printf(f_im, "{\n");
 
       // Add the intermediary class methods
@@ -551,14 +551,14 @@ public:
       Printv(f_im, imclass_class_code, NIL);
       Printv(f_im, imclass_cppcasts_code, NIL);
       if (Len(imclass_directors) > 0)
-	Printv(f_im, "\n", imclass_directors, NIL);
+        Printv(f_im, "\n", imclass_directors, NIL);
 
       if (n_dmethods > 0) {
-	Putc('\n', f_im);
-	Printf(f_im, "  private final static native void swig_module_init();\n");
-	Printf(f_im, "  static {\n");
-	Printf(f_im, "    swig_module_init();\n");
-	Printf(f_im, "  }\n");
+        Putc('\n', f_im);
+        Printf(f_im, "  private final static native void swig_module_init();\n");
+        Printf(f_im, "  static {\n");
+        Printf(f_im, "    swig_module_init();\n");
+        Printf(f_im, "  }\n");
       }
       // Finish off the class
       Printf(f_im, "}\n");
@@ -570,8 +570,8 @@ public:
       String *filen = NewStringf("%s%s.java", SWIG_output_directory(), module_class_name);
       File *f_module = NewFile(filen, "w", SWIG_output_files());
       if (!f_module) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filen));
       Delete(filen);
@@ -581,32 +581,32 @@ public:
       emitBanner(f_module);
 
       if (package)
-	Printf(f_module, "package %s;\n", package);
+        Printf(f_module, "package %s;\n", package);
 
       if (module_imports)
-	Printf(f_module, "%s\n", module_imports);
+        Printf(f_module, "%s\n", module_imports);
 
       if (doxygen && doxygenTranslator->hasDocumentation(n)) {
-	String *doxygen_comments = doxygenTranslator->getDocumentation(n, 0);
-	if (comment_creation_chatter)
-	  Printf(f_module, "/* This was generated from top() */\n");
-	Printv(f_module, doxygen_comments, NIL);
-	Delete(doxygen_comments);
+        String *doxygen_comments = doxygenTranslator->getDocumentation(n, 0);
+        if (comment_creation_chatter)
+          Printf(f_module, "/* This was generated from top() */\n");
+        Printv(f_module, doxygen_comments, NIL);
+        Delete(doxygen_comments);
       }
       if (Len(module_class_modifiers) > 0)
-	Printf(f_module, "%s ", module_class_modifiers);
+        Printf(f_module, "%s ", module_class_modifiers);
       Printf(f_module, "%s ", module_class_name);
 
       if (module_baseclass && *Char(module_baseclass))
-	Printf(f_module, "extends %s ", module_baseclass);
+        Printf(f_module, "extends %s ", module_baseclass);
       if (Len(module_interfaces) > 0) {
-	if (Len(module_class_constants_code) != 0)
-	  Printv(f_module, "implements ", constants_interface_name, ", ", module_interfaces, " ", NIL);
-	else
-	  Printv(f_module, "implements ", module_interfaces, " ", NIL);
+        if (Len(module_class_constants_code) != 0)
+          Printv(f_module, "implements ", constants_interface_name, ", ", module_interfaces, " ", NIL);
+        else
+          Printv(f_module, "implements ", module_interfaces, " ", NIL);
       } else {
-	if (Len(module_class_constants_code) != 0)
-	  Printv(f_module, "implements ", constants_interface_name, " ", NIL);
+        if (Len(module_class_constants_code) != 0)
+          Printv(f_module, "implements ", constants_interface_name, " ", NIL);
       }
       Printf(f_module, "{\n");
 
@@ -629,8 +629,8 @@ public:
       String *filen = NewStringf("%s%s.java", SWIG_output_directory(), constants_interface_name);
       File *f_module = NewFile(filen, "w", SWIG_output_files());
       if (!f_module) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Append(filenames_list, Copy(filen));
       Delete(filen);
@@ -640,13 +640,13 @@ public:
       emitBanner(f_module);
 
       if (package)
-	Printf(f_module, "package %s;\n", package);
+        Printf(f_module, "package %s;\n", package);
 
       if (module_imports)
-	Printf(f_module, "%s\n", module_imports);
+        Printf(f_module, "%s\n", module_imports);
 
       if (Len(constants_modifiers) > 0)
-	Printf(f_module, "%s ", constants_modifiers);
+        Printf(f_module, "%s ", constants_modifiers);
       Printf(f_module, "%s {\n", constants_interface_name);
 
       // Write out all the global constants
@@ -677,15 +677,15 @@ public:
     for (it1 = First(filenames_list); it1.item; it1 = Next(it1)) {
       String *item1_lower = Swig_string_lower(it1.item);
       for (it2 = Next(it1); it2.item; it2 = Next(it2)) {
-	String *item2_lower = Swig_string_lower(it2.item);
-	if (it1.item && it2.item) {
-	  if (Strcmp(item1_lower, item2_lower) == 0) {
-	    Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
-			 "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
-			 "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
-	  }
-	}
-	Delete(item2_lower);
+        String *item2_lower = Swig_string_lower(it2.item);
+        if (it1.item && it2.item) {
+          if (Strcmp(item1_lower, item2_lower) == 0) {
+            Swig_warning(WARN_LANG_PORTABILITY_FILENAME, input_file, line_number,
+                         "Portability warning: File %s will be overwritten by %s on case insensitive filesystems such as "
+                         "Windows' FAT32 and NTFS unless the class/module name is renamed\n", it1.item, it2.item);
+          }
+        }
+        Delete(item2_lower);
       }
       Delete(item1_lower);
     }
@@ -878,7 +878,7 @@ public:
 
     if (!Getattr(n, "sym:overloaded")) {
       if (!addSymbol(symname, n, imclass_name))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     /*
@@ -941,8 +941,8 @@ public:
       // Emit warnings for the few cases that can't be overloaded in Java and give up on generating wrapper
       Swig_overload_check(n);
       if (Getattr(n, "overload:ignore")) {
-	DelWrapper(f);
-	return SWIG_OK;
+        DelWrapper(f);
+        return SWIG_OK;
       }
     }
 
@@ -954,7 +954,7 @@ public:
     for (i = 0, p = l; i < num_arguments; i++) {
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -967,21 +967,21 @@ public:
 
       /* Get the JNI C types of the parameter */
       if ((tm = Getattr(p, "tmap:jni"))) {
-	Printv(c_param_type, tm, NIL);
+        Printv(c_param_type, tm, NIL);
       } else {
-	Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Get the intermediary class parameter types of the parameter */
       if ((tm = Getattr(p, "tmap:jtype"))) {
-	Printv(im_param_type, tm, NIL);
+        Printv(im_param_type, tm, NIL);
       } else {
-	Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to intermediary class method */
       if (gencomma)
-	Printf(imclass_class_code, ", ");
+        Printf(imclass_class_code, ", ");
       Printf(imclass_class_code, "%s %s", im_param_type, arg);
 
       // Add parameter to C function
@@ -991,26 +991,26 @@ public:
 
       // Premature garbage collection prevention parameter
       if (!is_destructor) {
-	String *pgc_parameter = prematureGarbageCollectionPreventionParameter(pt, p);
-	if (pgc_parameter) {
-	  Printf(imclass_class_code, ", %s %s_", pgc_parameter, arg);
-	  Printf(f->def, ", jobject %s_", arg);
-	  Printf(f->code, "    (void)%s_;\n", arg);
-	}
+        String *pgc_parameter = prematureGarbageCollectionPreventionParameter(pt, p);
+        if (pgc_parameter) {
+          Printf(imclass_class_code, ", %s %s_", pgc_parameter, arg);
+          Printf(f->def, ", jobject %s_", arg);
+          Printf(f->code, "    (void)%s_;\n", arg);
+        }
       }
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
-	addThrows(n, "tmap:in", p);
-	Replaceall(tm, "$arg", arg);	/* deprecated? */
-	Replaceall(tm, "$input", arg);
-	Setattr(p, "emit:input", arg);
+        addThrows(n, "tmap:in", p);
+        Replaceall(tm, "$arg", arg);	/* deprecated? */
+        Replaceall(tm, "$input", arg);
+        Setattr(p, "emit:input", arg);
 
-	Printf(nondir_args, "%s\n", tm);
+        Printf(nondir_args, "%s\n", tm);
 
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	p = nextSibling(p);
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        p = nextSibling(p);
       }
 
       Delete(im_param_type);
@@ -1024,40 +1024,40 @@ public:
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	addThrows(n, "tmap:check", p);
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        addThrows(n, "tmap:check", p);
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	addThrows(n, "tmap:freearg", p);
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        addThrows(n, "tmap:freearg", p);
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert argument output code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	addThrows(n, "tmap:argout", p);
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
-	Replaceall(tm, "$result", "jresult");
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        addThrows(n, "tmap:argout", p);
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$result", "jresult");
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -1066,9 +1066,9 @@ public:
     if ((throw_parm_list = Getattr(n, "catchlist"))) {
       Swig_typemap_attach_parms("throws", throw_parm_list, f);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  addThrows(n, "tmap:throws", p);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          addThrows(n, "tmap:throws", p);
+        }
       }
     }
 
@@ -1083,19 +1083,19 @@ public:
 
       /* Return value if necessary  */
       if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
-	addThrows(n, "tmap:out", n);
-	Replaceall(tm, "$result", "jresult");
+        addThrows(n, "tmap:out", n);
+        Replaceall(tm, "$result", "jresult");
 
         if (GetFlag(n, "feature:new"))
           Replaceall(tm, "$owner", "1");
         else
           Replaceall(tm, "$owner", "0");
 
-	Printf(f->code, "%s", tm);
-	if (Len(tm))
-	  Printf(f->code, "\n");
+        Printf(f->code, "%s", tm);
+        if (Len(tm))
+          Printf(f->code, "\n");
       } else {
-	Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
+        Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), Getattr(n, "name"));
       }
       emit_return_variable(n, returntype, f);
     }
@@ -1109,16 +1109,16 @@ public:
     /* Look to see if there is any newfree cleanup code */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	addThrows(n, "tmap:newfree", n);
-	Printf(f->code, "%s\n", tm);
+        addThrows(n, "tmap:newfree", n);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
     /* See if there is any return cleanup code */
     if (!native_function_flag) {
       if ((tm = Swig_typemap_lookup("ret", n, Swig_cresult_name(), 0))) {
-	addThrows(n, "tmap:ret", n);
-	Printf(f->code, "%s\n", tm);
+        addThrows(n, "tmap:ret", n);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -1167,9 +1167,9 @@ public:
 
       String *getter_setter_name = NewString("");
       if (!getter_flag)
-	Printf(getter_setter_name, "set");
+        Printf(getter_setter_name, "set");
       else
-	Printf(getter_setter_name, "get");
+        Printf(getter_setter_name, "get");
       Putc(toupper((int) *Char(variable_name)), getter_setter_name);
       Printf(getter_setter_name, "%s", Char(variable_name) + 1);
 
@@ -1219,18 +1219,18 @@ public:
     if (nspace || getCurrentClass()) {
       scope = NewString("");
       if (nspace)
-	Printf(scope, "%s", nspace);
+        Printf(scope, "%s", nspace);
       if (Node* cls = getCurrentClass()) {
-	if (Node *outer = Getattr(cls, "nested:outer")) {
-	  String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
-	  for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
-	    Push(outerClassesPrefix, ".");
-	    Push(outerClassesPrefix, Getattr(outer, "sym:name"));
-	  }
-	  Printv(scope, nspace ? "." : "", outerClassesPrefix, ".", proxy_class_name, NIL);
-	  Delete(outerClassesPrefix);
-	} else
-	  Printv(scope, nspace ? "." : "", proxy_class_name, NIL);
+        if (Node *outer = Getattr(cls, "nested:outer")) {
+          String *outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
+          for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
+            Push(outerClassesPrefix, ".");
+            Push(outerClassesPrefix, Getattr(outer, "sym:name"));
+          }
+          Printv(scope, nspace ? "." : "", outerClassesPrefix, ".", proxy_class_name, NIL);
+          Delete(outerClassesPrefix);
+        } else
+          Printv(scope, nspace ? "." : "", proxy_class_name, NIL);
       }
     }
     return scope;
@@ -1251,7 +1251,7 @@ public:
 
     if (!ImportMode) {
       if (getCurrentClass() && (cplus_mode != PUBLIC))
-	return SWIG_NOWRAP;
+        return SWIG_NOWRAP;
 
       String *nspace = Getattr(n, "sym:nspace"); // NSpace/getNSpace() only works during Language::enumDeclaration call
 
@@ -1262,124 +1262,124 @@ public:
       String *typemap_lookup_type = Getattr(n, "name");
 
       if ((enum_feature != SimpleEnum) && symname && typemap_lookup_type) {
-	// Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper Java enum
+        // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper Java enum
 
-	if (doxygen && doxygenTranslator->hasDocumentation(n)) {
-	  String *doxygen_comments = doxygenTranslator->getDocumentation(n, 0);
-	  if (comment_creation_chatter)
-	    Printf(enum_code, "/* This was generated from enumDeclaration() */\n");
-	  Printv(enum_code, doxygen_comments, NIL);
-	  Delete(doxygen_comments);
-	}
+        if (doxygen && doxygenTranslator->hasDocumentation(n)) {
+          String *doxygen_comments = doxygenTranslator->getDocumentation(n, 0);
+          if (comment_creation_chatter)
+            Printf(enum_code, "/* This was generated from enumDeclaration() */\n");
+          Printv(enum_code, doxygen_comments, NIL);
+          Delete(doxygen_comments);
+        }
 
-	String *scope = getCurrentScopeName(nspace);
-	if (!addSymbol(symname, n, scope))
-	  return SWIG_ERROR;
+        String *scope = getCurrentScopeName(nspace);
+        if (!addSymbol(symname, n, scope))
+          return SWIG_ERROR;
 
-	// Pure Java baseclass and interfaces
-	const String *pure_baseclass = typemapLookup(n, "javabase", typemap_lookup_type, WARN_NONE);
-	const String *pure_interfaces = typemapLookup(n, "javainterfaces", typemap_lookup_type, WARN_NONE);
+        // Pure Java baseclass and interfaces
+        const String *pure_baseclass = typemapLookup(n, "javabase", typemap_lookup_type, WARN_NONE);
+        const String *pure_interfaces = typemapLookup(n, "javainterfaces", typemap_lookup_type, WARN_NONE);
 
-	// Emit the enum
-	Printv(enum_code, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers (enum modifiers really)
-	       " ", symname, *Char(pure_baseclass) ?	// Bases
-	       " extends " : "", pure_baseclass, *Char(pure_interfaces) ?	// Interfaces
-	       " implements " : "", pure_interfaces, " {\n", NIL);
-	if (proxy_flag && is_wrapping_class())
-	  Replaceall(enum_code, "$static ", "static ");
-	else
-	  Replaceall(enum_code, "$static ", "");
-	Delete(scope);
+        // Emit the enum
+        Printv(enum_code, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers (enum modifiers really)
+               " ", symname, *Char(pure_baseclass) ?	// Bases
+               " extends " : "", pure_baseclass, *Char(pure_interfaces) ?	// Interfaces
+               " implements " : "", pure_interfaces, " {\n", NIL);
+        if (proxy_flag && is_wrapping_class())
+          Replaceall(enum_code, "$static ", "static ");
+        else
+          Replaceall(enum_code, "$static ", "");
+        Delete(scope);
       } else {
-	if (symname && !Getattr(n, "unnamedinstance"))
-	  Printf(constants_code, "  // %s \n", symname);
-	// Translate and write javadoc comment for the enum itself if flagged
-	if (doxygen && doxygenTranslator->hasDocumentation(n)) {
-	  String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
-	  if (comment_creation_chatter)
-	    Printf(constants_code, "/* This was generated from enumDeclaration() */\n");
-	  Printf(constants_code, Char(doxygen_comments));
-	  Printf(constants_code, "\n");
-	  Delete(doxygen_comments);
-	}
+        if (symname && !Getattr(n, "unnamedinstance"))
+          Printf(constants_code, "  // %s \n", symname);
+        // Translate and write javadoc comment for the enum itself if flagged
+        if (doxygen && doxygenTranslator->hasDocumentation(n)) {
+          String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
+          if (comment_creation_chatter)
+            Printf(constants_code, "/* This was generated from enumDeclaration() */\n");
+          Printf(constants_code, Char(doxygen_comments));
+          Printf(constants_code, "\n");
+          Delete(doxygen_comments);
+        }
       }
 
       if (proxy_flag && !is_wrapping_class()) {
-	// Global enums / enums in a namespace
-	assert(!full_imclass_name);
-	constructIntermediateClassName(n);
+        // Global enums / enums in a namespace
+        assert(!full_imclass_name);
+        constructIntermediateClassName(n);
       }
 
       // Emit each enum item
       Language::enumDeclaration(n);
 
       if (proxy_flag && !is_wrapping_class()) {
-	Delete(full_imclass_name);
-	full_imclass_name = 0;
+        Delete(full_imclass_name);
+        full_imclass_name = 0;
       }
 
       if ((enum_feature != SimpleEnum) && symname && typemap_lookup_type) {
-	// Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper Java enum
-	// Finish the enum declaration
-	// Typemaps are used to generate the enum definition in a similar manner to proxy classes.
-	Printv(enum_code, (enum_feature == ProperEnum) ? ";\n" : "", typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
-	       typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),	// extra Java code
-	       "}", NIL);
+        // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper Java enum
+        // Finish the enum declaration
+        // Typemaps are used to generate the enum definition in a similar manner to proxy classes.
+        Printv(enum_code, (enum_feature == ProperEnum) ? ";\n" : "", typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
+               typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),	// extra Java code
+               "}", NIL);
 
-	Replaceall(enum_code, "$javaclassname", symname);
+        Replaceall(enum_code, "$javaclassname", symname);
 
-	// Substitute $enumvalues - intended usage is for typesafe enums
-	if (Getattr(n, "enumvalues"))
-	  Replaceall(enum_code, "$enumvalues", Getattr(n, "enumvalues"));
-	else
-	  Replaceall(enum_code, "$enumvalues", "");
+        // Substitute $enumvalues - intended usage is for typesafe enums
+        if (Getattr(n, "enumvalues"))
+          Replaceall(enum_code, "$enumvalues", Getattr(n, "enumvalues"));
+        else
+          Replaceall(enum_code, "$enumvalues", "");
 
-	if (proxy_flag && is_wrapping_class()) {
-	  // Enums defined within the C++ class are defined within the proxy class
+        if (proxy_flag && is_wrapping_class()) {
+          // Enums defined within the C++ class are defined within the proxy class
 
-	  // Add extra indentation
-	  Replaceall(enum_code, "\n", "\n  ");
-	  Replaceall(enum_code, "  \n", "\n");
-	  Printv(proxy_class_constants_code, "  ", enum_code, "\n\n", NIL);
-	} else {
-	  // Global enums are defined in their own file
-	  String *output_directory = outputDirectory(nspace);
-	  String *filen = NewStringf("%s%s.java", output_directory, symname);
-	  File *f_enum = NewFile(filen, "w", SWIG_output_files());
-	  if (!f_enum) {
-	    FileErrorDisplay(filen);
-	    Exit(EXIT_FAILURE);
-	  }
-	  Append(filenames_list, Copy(filen));
-	  Delete(filen);
-	  filen = NULL;
+          // Add extra indentation
+          Replaceall(enum_code, "\n", "\n  ");
+          Replaceall(enum_code, "  \n", "\n");
+          Printv(proxy_class_constants_code, "  ", enum_code, "\n\n", NIL);
+        } else {
+          // Global enums are defined in their own file
+          String *output_directory = outputDirectory(nspace);
+          String *filen = NewStringf("%s%s.java", output_directory, symname);
+          File *f_enum = NewFile(filen, "w", SWIG_output_files());
+          if (!f_enum) {
+            FileErrorDisplay(filen);
+            Exit(EXIT_FAILURE);
+          }
+          Append(filenames_list, Copy(filen));
+          Delete(filen);
+          filen = NULL;
 
-	  // Start writing out the enum file
-	  emitBanner(f_enum);
+          // Start writing out the enum file
+          emitBanner(f_enum);
 
-	  if (package || nspace) {
-	    Printf(f_enum, "package ");
-	    if (package)
-	      Printv(f_enum, package, nspace ? "." : "", NIL);
-	    if (nspace)
-	      Printv(f_enum, nspace, NIL);
-	    Printf(f_enum, ";\n");
-	  }
+          if (package || nspace) {
+            Printf(f_enum, "package ");
+            if (package)
+              Printv(f_enum, package, nspace ? "." : "", NIL);
+            if (nspace)
+              Printv(f_enum, nspace, NIL);
+            Printf(f_enum, ";\n");
+          }
 
-	  Printv(f_enum, typemapLookup(n, "javaimports", typemap_lookup_type, WARN_NONE), // Import statements
-		 "\n", enum_code, "\n", NIL);
+          Printv(f_enum, typemapLookup(n, "javaimports", typemap_lookup_type, WARN_NONE), // Import statements
+                 "\n", enum_code, "\n", NIL);
 
-	  Printf(f_enum, "\n");
-	  Delete(f_enum);
-	  Delete(output_directory);
-	}
+          Printf(f_enum, "\n");
+          Delete(f_enum);
+          Delete(output_directory);
+        }
       } else {
-	// Wrap C++ enum with simple constant
-	Printf(enum_code, "\n");
-	if (proxy_flag && is_wrapping_class())
-	  Printv(proxy_class_constants_code, enum_code, NIL);
-	else
-	  Printv(module_class_constants_code, enum_code, NIL);
+        // Wrap C++ enum with simple constant
+        Printf(enum_code, "\n");
+        if (proxy_flag && is_wrapping_class())
+          Printv(proxy_class_constants_code, enum_code, NIL);
+        else
+          Printv(module_class_constants_code, enum_code, NIL);
       }
 
       Delete(enum_code);
@@ -1419,31 +1419,31 @@ public:
     int swigtype = SwigType_type(Getattr(n, "type"));
     if (swigtype == T_CHAR) {
       if (Getattr(n, "enumstringval")) {
-	String *val = NewStringf("'%(escape)s'", Getattr(n, "enumstringval"));
-	Setattr(n, "enumvalue", val);
-	Delete(val);
+        String *val = NewStringf("'%(escape)s'", Getattr(n, "enumstringval"));
+        Setattr(n, "enumvalue", val);
+        Delete(val);
       }
     } else {
       String *numval = Getattr(n, "enumnumval");
       if (numval) {
-	const char *p = Char(numval);
-	if (isdigit(p[0])) {
-	  char *e;
-	  errno = 0;
-	  unsigned long long value = strtoull(p, &e, 0);
-	  if (errno != ERANGE && *e == '\0' && value >= 0x80000000) {
-	    // Use hex for larger unsigned integer constants in Java code since
-	    // Java allows implicit conversion to a signed integer value.
-	    String *hexval = NewStringf("0x%llx", value);
-	    Setattr(n, "enumvalue", hexval);
-	    Delete(hexval);
-	  } else {
-	    Setattr(n, "enumvalue", numval);
-	  }
-	} else {
-	  // Emit negative values as-is.
-	  Setattr(n, "enumvalue", numval);
-	}
+        const char *p = Char(numval);
+        if (isdigit(p[0])) {
+          char *e;
+          errno = 0;
+          unsigned long long value = strtoull(p, &e, 0);
+          if (errno != ERANGE && *e == '\0' && value >= 0x80000000) {
+            // Use hex for larger unsigned integer constants in Java code since
+            // Java allows implicit conversion to a signed integer value.
+            String *hexval = NewStringf("0x%llx", value);
+            Setattr(n, "enumvalue", hexval);
+            Delete(hexval);
+          } else {
+            Setattr(n, "enumvalue", numval);
+          }
+        } else {
+          // Emit negative values as-is.
+          Setattr(n, "enumvalue", numval);
+        }
       }
     }
 
@@ -1451,92 +1451,92 @@ public:
       EnumFeature enum_feature = decodeEnumFeature(parent);
 
       if ((enum_feature == SimpleEnum) && GetFlag(parent, "scopedenum")) {
-	newsymname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
-	symname = newsymname;
+        newsymname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
+        symname = newsymname;
       }
 
       // Add to language symbol table
       String *scope = 0;
       if (unnamedinstance || !parent_name || enum_feature == SimpleEnum) {
-	String *enumClassPrefix = getEnumClassPrefix();
-	if (enumClassPrefix) {
-	  scope = NewString("");
-	  if (nspace)
-	    Printf(scope, "%s.", nspace);
-	  Printf(scope, "%s", enumClassPrefix);
-	} else {
-	  scope = Copy(constants_interface_name);
-	}
+        String *enumClassPrefix = getEnumClassPrefix();
+        if (enumClassPrefix) {
+          scope = NewString("");
+          if (nspace)
+            Printf(scope, "%s.", nspace);
+          Printf(scope, "%s", enumClassPrefix);
+        } else {
+          scope = Copy(constants_interface_name);
+        }
       } else {
-	scope = getCurrentScopeName(nspace);
-	if (!scope)
-	  scope = Copy(Getattr(parent, "sym:name"));
-	else
-	  Printf(scope, ".%s", Getattr(parent, "sym:name"));
+        scope = getCurrentScopeName(nspace);
+        if (!scope)
+          scope = Copy(Getattr(parent, "sym:name"));
+        else
+          Printf(scope, ".%s", Getattr(parent, "sym:name"));
       }
       if (!addSymbol(symname, n, scope))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
       
       if ((enum_feature == ProperEnum) && parent_name && !unnamedinstance) {
-	if (!GetFlag(n, "firstenumitem"))
-	  Printf(enum_code, ",\n");
+        if (!GetFlag(n, "firstenumitem"))
+          Printf(enum_code, ",\n");
       }
 
       // Translate and write javadoc comment if flagged
       if (doxygen && doxygenTranslator->hasDocumentation(n)) {
-	String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
-	if (comment_creation_chatter)
-	  Printf(enum_code, "/* This was generated from enumvalueDeclaration() */\n");
-	Printv(enum_code, doxygen_comments, NIL);
-	Delete(doxygen_comments);
+        String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
+        if (comment_creation_chatter)
+          Printf(enum_code, "/* This was generated from enumvalueDeclaration() */\n");
+        Printv(enum_code, doxygen_comments, NIL);
+        Delete(doxygen_comments);
       }
 
       if ((enum_feature == ProperEnum) && parent_name && !unnamedinstance) {
-	// Wrap (non-anonymous) C/C++ enum with a proper Java enum
-	// Emit the enum item.
-	Printf(enum_code, "  %s", symname);
-	if (Getattr(n, "enumvalue")) {
-	  String *value = enumValue(n);
-	  Printf(enum_code, "(%s)", value);
-	  Delete(value);
-	}
+        // Wrap (non-anonymous) C/C++ enum with a proper Java enum
+        // Emit the enum item.
+        Printf(enum_code, "  %s", symname);
+        if (Getattr(n, "enumvalue")) {
+          String *value = enumValue(n);
+          Printf(enum_code, "(%s)", value);
+          Delete(value);
+        }
       } else {
-	// Wrap C/C++ enums with constant integers or use the typesafe enum pattern
-	SwigType *typemap_lookup_type = parent_name ? parent_name : NewString("enum ");
-	Setattr(n, "type", typemap_lookup_type);
-	const String *tm = typemapLookup(n, "jstype", typemap_lookup_type, WARN_JAVA_TYPEMAP_JSTYPE_UNDEF);
+        // Wrap C/C++ enums with constant integers or use the typesafe enum pattern
+        SwigType *typemap_lookup_type = parent_name ? parent_name : NewString("enum ");
+        Setattr(n, "type", typemap_lookup_type);
+        const String *tm = typemapLookup(n, "jstype", typemap_lookup_type, WARN_JAVA_TYPEMAP_JSTYPE_UNDEF);
 
-	String *return_type = Copy(tm);
-	substituteClassname(typemap_lookup_type, return_type);
+        String *return_type = Copy(tm);
+        substituteClassname(typemap_lookup_type, return_type);
         const String *methodmods = Getattr(n, "feature:java:methodmodifiers");
         methodmods = methodmods ? methodmods : (is_public(n) ? public_string : protected_string);
 
-	if ((enum_feature == TypesafeEnum) && parent_name && !unnamedinstance) {
-	  // Wrap (non-anonymous) enum using the typesafe enum pattern
-	  if (Getattr(n, "enumvalue")) {
-	    String *value = enumValue(n);
-	    Printf(enum_code, "  %s final static %s %s = new %s(\"%s\", %s);\n", methodmods, return_type, symname, return_type, symname, value);
-	    Delete(value);
-	  } else {
-	    Printf(enum_code, "  %s final static %s %s = new %s(\"%s\");\n", methodmods, return_type, symname, return_type, symname);
-	  }
-	} else {
-	  // Simple integer constants
-	  // Note these are always generated for anonymous enums, no matter what enum_feature is specified
-	  // Code generated is the same for SimpleEnum and TypeunsafeEnum -> the class it is generated into is determined later
-	  String *value = enumValue(n);
-	  Printf(enum_code, "  %s final static %s %s = %s;\n", methodmods, return_type, symname, value);
-	  Delete(value);
-	}
-	Delete(return_type);
+        if ((enum_feature == TypesafeEnum) && parent_name && !unnamedinstance) {
+          // Wrap (non-anonymous) enum using the typesafe enum pattern
+          if (Getattr(n, "enumvalue")) {
+            String *value = enumValue(n);
+            Printf(enum_code, "  %s final static %s %s = new %s(\"%s\", %s);\n", methodmods, return_type, symname, return_type, symname, value);
+            Delete(value);
+          } else {
+            Printf(enum_code, "  %s final static %s %s = new %s(\"%s\");\n", methodmods, return_type, symname, return_type, symname);
+          }
+        } else {
+          // Simple integer constants
+          // Note these are always generated for anonymous enums, no matter what enum_feature is specified
+          // Code generated is the same for SimpleEnum and TypeunsafeEnum -> the class it is generated into is determined later
+          String *value = enumValue(n);
+          Printf(enum_code, "  %s final static %s %s = %s;\n", methodmods, return_type, symname, value);
+          Delete(value);
+        }
+        Delete(return_type);
       }
 
       // Add the enum value to the comma separated list being constructed in the enum declaration.
       String *enumvalues = Getattr(parent, "enumvalues");
       if (!enumvalues)
-	Setattr(parent, "enumvalues", Copy(symname));
+        Setattr(parent, "enumvalues", Copy(symname));
       else
-	Printv(enumvalues, ", ", symname, NIL);
+        Printv(enumvalues, ", ", symname, NIL);
       Delete(scope);
     }
 
@@ -1569,7 +1569,7 @@ public:
     if (doxygen && doxygenTranslator->hasDocumentation(n)) {
       String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
       if (comment_creation_chatter)
-	Printf(constants_code, "/* This was generated from constantWrapper() */\n");
+        Printf(constants_code, "/* This was generated from constantWrapper() */\n");
       Printv(constants_code, doxygen_comments, NIL);
       Delete(doxygen_comments);
     }
@@ -1580,16 +1580,16 @@ public:
     if (!is_enum_item) {
       String *scope = 0;
       if (proxy_class_name) {
-	String *nspace = getNSpace();
-	scope = NewString("");
-	if (nspace)
-	  Printf(scope, "%s.", nspace);
-	Printf(scope, "%s", proxy_class_name);
+        String *nspace = getNSpace();
+        scope = NewString("");
+        if (nspace)
+          Printf(scope, "%s.", nspace);
+        Printf(scope, "%s", proxy_class_name);
       } else {
-	scope = Copy(constants_interface_name);
+        scope = Copy(constants_interface_name);
       }
       if (!addSymbol(itemname, n, scope))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
       Delete(scope);
     }
 
@@ -1630,15 +1630,15 @@ public:
       // Default enum and constant handling will work with any type of C constant and initialises the Java variable from C through a JNI call.
 
       if (classname_substituted_flag) {
-	if (SwigType_isenum(t)) {
-	  // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
-	  Printf(constants_code, "%s.swigToEnum(%s.%s());\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
-	} else {
-	  // This handles function pointers using the %constant directive
-	  Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
-	}
+        if (SwigType_isenum(t)) {
+          // This handles wrapping of inline initialised const enum static member variables (not when wrapping enum items - ignored later on)
+          Printf(constants_code, "%s.swigToEnum(%s.%s());\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        } else {
+          // This handles function pointers using the %constant directive
+          Printf(constants_code, "new %s(%s.%s(), false);\n", return_type, full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        }
       } else {
-	Printf(constants_code, "%s.%s();\n", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        Printf(constants_code, "%s.%s();\n", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
       }
 
       // Each constant and enum value is wrapped with a separate JNI function call
@@ -1649,9 +1649,9 @@ public:
     } else {
       // Alternative constant handling will use the C syntax to make a true Java constant and hope that it compiles as Java code
       if (Getattr(n, "wrappedasconstant")) {
-	Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
+        Printf(constants_code, "%s;\n", Getattr(n, "staticmembervariableHandler:value"));
       } else {
-	Printf(constants_code, "%s;\n", Getattr(n, "value"));
+        Printf(constants_code, "%s;\n", Getattr(n, "value"));
       }
     }
 
@@ -1659,9 +1659,9 @@ public:
     // Enums only emit the intermediate and JNI methods, so no proxy or module class wrapper methods needed
     if (!is_enum_item) {
       if (proxy_flag && wrapping_member_flag)
-	Printv(proxy_class_constants_code, constants_code, NIL);
+        Printv(proxy_class_constants_code, constants_code, NIL);
       else
-	Printv(module_class_constants_code, constants_code, NIL);
+        Printv(module_class_constants_code, constants_code, NIL);
     }
     // Cleanup
     Swig_restore(n);
@@ -1683,9 +1683,9 @@ public:
 
     if (!ImportMode && (Cmp(section, "proxycode") == 0)) {
       if (proxy_class_code) {
-	Swig_typemap_replace_embedded_typemap(code, n);
-	int offset = Len(code) > 0 && *Char(code) == '\n' ? 1 : 0;
-	Printv(proxy_class_code, Char(code) + offset, "\n", NIL);
+        Swig_typemap_replace_embedded_typemap(code, n);
+        int offset = Len(code) > 0 && *Char(code) == '\n' ? 1 : 0;
+        Printv(proxy_class_code, Char(code) + offset, "\n", NIL);
       }
     } else {
       ret = Language::insertDirective(n);
@@ -1721,62 +1721,62 @@ public:
 
       if (Strcmp(lang, "java") == 0) {
 
-	String *strvalue = NewString(value);
-	Replaceall(strvalue, "\\\"", "\"");
+        String *strvalue = NewString(value);
+        Replaceall(strvalue, "\\\"", "\"");
 
-	if (Strcmp(code, "jniclassbase") == 0) {
-	  Delete(imclass_baseclass);
-	  imclass_baseclass = Copy(strvalue);
-	} else if (Strcmp(code, "jniclasspackage") == 0) {
-	  Delete(imclass_package);
-	  imclass_package = Copy(strvalue);
-	  String *imclass_class_package_jniname = makeValidJniName(imclass_package);
-	  Printv(jnipackage, imclass_class_package_jniname, NIL);
-	  Delete(imclass_class_package_jniname);
-	  Replaceall(jnipackage, NSPACE_SEPARATOR, "_");
-	  Append(jnipackage, "_");
+        if (Strcmp(code, "jniclassbase") == 0) {
+          Delete(imclass_baseclass);
+          imclass_baseclass = Copy(strvalue);
+        } else if (Strcmp(code, "jniclasspackage") == 0) {
+          Delete(imclass_package);
+          imclass_package = Copy(strvalue);
+          String *imclass_class_package_jniname = makeValidJniName(imclass_package);
+          Printv(jnipackage, imclass_class_package_jniname, NIL);
+          Delete(imclass_class_package_jniname);
+          Replaceall(jnipackage, NSPACE_SEPARATOR, "_");
+          Append(jnipackage, "_");
 
-	  String *wrapper_name = NewString("");
-	  String *imclass_class_jniname = makeValidJniName(imclass_name);
-	  Printf(wrapper_name, "Java_%s%s_%%f", jnipackage, imclass_class_jniname);
-	  Delete(imclass_class_jniname);
+          String *wrapper_name = NewString("");
+          String *imclass_class_jniname = makeValidJniName(imclass_name);
+          Printf(wrapper_name, "Java_%s%s_%%f", jnipackage, imclass_class_jniname);
+          Delete(imclass_class_jniname);
 
-	  Swig_name_unregister("wrapper");
-	  Swig_name_register("wrapper", Char(wrapper_name));
+          Swig_name_unregister("wrapper");
+          Swig_name_register("wrapper", Char(wrapper_name));
 
-	  Delete(wrapper_name);
-	} else if (Strcmp(code, "jniclassclassmodifiers") == 0) {
-	  Delete(imclass_class_modifiers);
-	  imclass_class_modifiers = Copy(strvalue);
-	} else if (Strcmp(code, "jniclasscode") == 0) {
-	  Printf(imclass_class_code, "%s\n", strvalue);
-	} else if (Strcmp(code, "jniclassimports") == 0) {
-	  Delete(imclass_imports);
-	  imclass_imports = Copy(strvalue);
-	} else if (Strcmp(code, "jniclassinterfaces") == 0) {
-	  Delete(imclass_interfaces);
-	  imclass_interfaces = Copy(strvalue);
-	} else if (Strcmp(code, "modulebase") == 0) {
-	  Delete(module_baseclass);
-	  module_baseclass = Copy(strvalue);
-	} else if (Strcmp(code, "moduleclassmodifiers") == 0) {
-	  Delete(module_class_modifiers);
-	  module_class_modifiers = Copy(strvalue);
-	} else if (Strcmp(code, "modulecode") == 0) {
-	  Printf(module_class_code, "%s\n", strvalue);
-	} else if (Strcmp(code, "moduleimports") == 0) {
-	  Delete(module_imports);
-	  module_imports = Copy(strvalue);
-	} else if (Strcmp(code, "moduleinterfaces") == 0) {
-	  Delete(module_interfaces);
-	  module_interfaces = Copy(strvalue);
-	} else if (Strcmp(code, "constantsmodifiers") == 0) {
-	  Delete(constants_modifiers);
-	  constants_modifiers = Copy(strvalue);
-	} else {
-	  Swig_error(input_file, line_number, "Unrecognized pragma.\n");
-	}
-	Delete(strvalue);
+          Delete(wrapper_name);
+        } else if (Strcmp(code, "jniclassclassmodifiers") == 0) {
+          Delete(imclass_class_modifiers);
+          imclass_class_modifiers = Copy(strvalue);
+        } else if (Strcmp(code, "jniclasscode") == 0) {
+          Printf(imclass_class_code, "%s\n", strvalue);
+        } else if (Strcmp(code, "jniclassimports") == 0) {
+          Delete(imclass_imports);
+          imclass_imports = Copy(strvalue);
+        } else if (Strcmp(code, "jniclassinterfaces") == 0) {
+          Delete(imclass_interfaces);
+          imclass_interfaces = Copy(strvalue);
+        } else if (Strcmp(code, "modulebase") == 0) {
+          Delete(module_baseclass);
+          module_baseclass = Copy(strvalue);
+        } else if (Strcmp(code, "moduleclassmodifiers") == 0) {
+          Delete(module_class_modifiers);
+          module_class_modifiers = Copy(strvalue);
+        } else if (Strcmp(code, "modulecode") == 0) {
+          Printf(module_class_code, "%s\n", strvalue);
+        } else if (Strcmp(code, "moduleimports") == 0) {
+          Delete(module_imports);
+          module_imports = Copy(strvalue);
+        } else if (Strcmp(code, "moduleinterfaces") == 0) {
+          Delete(module_interfaces);
+          module_interfaces = Copy(strvalue);
+        } else if (Strcmp(code, "constantsmodifiers") == 0) {
+          Delete(constants_modifiers);
+          constants_modifiers = Copy(strvalue);
+        } else {
+          Swig_error(input_file, line_number, "Unrecognized pragma.\n");
+        }
+        Delete(strvalue);
       }
     }
     return Language::pragmaDirective(n);
@@ -1792,12 +1792,12 @@ public:
       String *nspace = Getattr(n, "sym:nspace");
       String *symname = Getattr(n, "interface:name");
       if (nspace) {
-	if (package)
-	  ret = NewStringf("%s.%s.%s", package, nspace, symname);
-	else
-	  ret = NewStringf("%s.%s", nspace, symname);
+        if (package)
+          ret = NewStringf("%s.%s.%s", package, nspace, symname);
+        else
+          ret = NewStringf("%s.%s", nspace, symname);
       } else {
-	ret = Copy(symname);
+        ret = Copy(symname);
       }
       Setattr(n, "interface:qname", ret);
     }
@@ -1813,7 +1813,7 @@ public:
     if (proxy_flag) {
       Node *n = classLookup(t);
       if (n && Getattr(n, "interface:name"))
-	interface_name = qualified ? getQualifiedInterfaceName(n) : Getattr(n, "interface:name");
+        interface_name = qualified ? getQualifiedInterfaceName(n) : Getattr(n, "interface:name");
     }
     return interface_name;
   }
@@ -1829,7 +1829,7 @@ public:
       String *interface_name = Getattr(base, "interface:name");
       SwigType *bsmart = Getattr(base, "smart");
       if (Len(interface_list))
-	Append(interface_list, ", ");
+        Append(interface_list, ", ");
       Append(interface_list, interface_name);
 
       Node *attributes = NewHash();
@@ -1837,11 +1837,11 @@ public:
       String *cptr_method_name = 0;
       if (interface_code) {
         Replaceall(interface_code, "$interfacename", interface_name);
-	Printv(interface_upcasts, interface_code, NIL);
-	cptr_method_name = Copy(Getattr(attributes, "tmap:javainterfacecode:cptrmethod"));
+        Printv(interface_upcasts, interface_code, NIL);
+        cptr_method_name = Copy(Getattr(attributes, "tmap:javainterfacecode:cptrmethod"));
       }
       if (!cptr_method_name)
-	cptr_method_name = NewStringf("%s_GetInterfaceCPtr", interface_name);
+        cptr_method_name = NewStringf("%s_GetInterfaceCPtr", interface_name);
       Replaceall(cptr_method_name, ".", "_");
       Replaceall(cptr_method_name, "$interfacename", interface_name);
 
@@ -1868,35 +1868,35 @@ public:
 
     if (smart) {
       if (bsmart) {
-	String *smartnamestr = SwigType_namestr(smart);
-	String *bsmartnamestr = SwigType_namestr(bsmart);
+        String *smartnamestr = SwigType_namestr(smart);
+        String *bsmartnamestr = SwigType_namestr(bsmart);
 
-	Printv(upcasts_code,
-	    "SWIGEXPORT jlong JNICALL ", wname, "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
-	    "    jlong baseptr = 0;\n"
-	    "    ", smartnamestr, " *argp1;\n"
-	    "    (void)jenv;\n"
-	    "    (void)jcls;\n"
-	    "    argp1 = *(", smartnamestr, " **)&jarg1;\n"
-	    "    *(", bsmartnamestr, " **)&baseptr = argp1 ? new ", bsmartnamestr, "(*argp1) : 0;\n"
-	    "    return baseptr;\n"
-	    "}\n", "\n", NIL);
+        Printv(upcasts_code,
+            "SWIGEXPORT jlong JNICALL ", wname, "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
+            "    jlong baseptr = 0;\n"
+            "    ", smartnamestr, " *argp1;\n"
+            "    (void)jenv;\n"
+            "    (void)jcls;\n"
+            "    argp1 = *(", smartnamestr, " **)&jarg1;\n"
+            "    *(", bsmartnamestr, " **)&baseptr = argp1 ? new ", bsmartnamestr, "(*argp1) : 0;\n"
+            "    return baseptr;\n"
+            "}\n", "\n", NIL);
 
-	Delete(bsmartnamestr);
-	Delete(smartnamestr);
+        Delete(bsmartnamestr);
+        Delete(smartnamestr);
       }
     } else {
       String *classname = SwigType_namestr(c_classname);
       String *baseclassname = SwigType_namestr(c_baseclassname);
 
       Printv(upcasts_code,
-	  "SWIGEXPORT jlong JNICALL ", wname, "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
-	  "    jlong baseptr = 0;\n"
-	  "    (void)jenv;\n"
-	  "    (void)jcls;\n"
-	  "    *(", baseclassname, " **)&baseptr = *(", classname, " **)&jarg1;\n"
-	  "    return baseptr;\n"
-	  "}\n", "\n", NIL);
+          "SWIGEXPORT jlong JNICALL ", wname, "(JNIEnv *jenv, jclass jcls, jlong jarg1) {\n",
+          "    jlong baseptr = 0;\n"
+          "    (void)jenv;\n"
+          "    (void)jcls;\n"
+          "    *(", baseclassname, " **)&baseptr = *(", classname, " **)&jarg1;\n"
+          "    return baseptr;\n"
+          "}\n", "\n", NIL);
 
       Delete(baseclassname);
       Delete(classname);
@@ -1933,26 +1933,26 @@ public:
     if (!purebase_replace) {
       List *baselist = Getattr(n, "bases");
       if (baselist) {
-	Iterator base = First(baselist);
-	while (base.item) {
-	  if (!(GetFlag(base.item, "feature:ignore") || GetFlag(base.item, "feature:interface"))) {
-	    SwigType *baseclassname = Getattr(base.item, "name");
-	    if (!c_baseclassname) {
-	      String *name = getProxyName(baseclassname);
-	      if (name) {
-		c_baseclassname = baseclassname;
-		baseclass = name;
-		bsmart = Getattr(base.item, "smart");
-	      }
-	    } else {
-	      /* Warn about multiple inheritance for additional base class(es) */
-	      String *proxyclassname = Getattr(n, "classtypeobj");
-	      Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		  "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java.\n", SwigType_namestr(proxyclassname), SwigType_namestr(baseclassname));
-	    }
-	  }
-	  base = Next(base);
-	}
+        Iterator base = First(baselist);
+        while (base.item) {
+          if (!(GetFlag(base.item, "feature:ignore") || GetFlag(base.item, "feature:interface"))) {
+            SwigType *baseclassname = Getattr(base.item, "name");
+            if (!c_baseclassname) {
+              String *name = getProxyName(baseclassname);
+              if (name) {
+                c_baseclassname = baseclassname;
+                baseclass = name;
+                bsmart = Getattr(base.item, "smart");
+              }
+            } else {
+              /* Warn about multiple inheritance for additional base class(es) */
+              String *proxyclassname = Getattr(n, "classtypeobj");
+              Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+                  "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java.\n", SwigType_namestr(proxyclassname), SwigType_namestr(baseclassname));
+            }
+          }
+          base = Next(base);
+        }
       }
     }
 
@@ -1973,8 +1973,8 @@ public:
         Swig_error(Getfile(n), Getline(n), "The javabase typemap for proxy %s must contain just one of the 'replace' or 'notderived' attributes.\n", typemap_lookup_type);
     } else if (Len(pure_baseclass) > 0 && Len(baseclass) > 0) {
       Swig_warning(WARN_JAVA_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-		   "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java. "
-		   "Perhaps you need one of the 'replace' or 'notderived' attributes in the javabase typemap?\n", typemap_lookup_type, pure_baseclass);
+                   "Warning for %s, base %s ignored. Multiple inheritance is not supported in Java. "
+                   "Perhaps you need one of the 'replace' or 'notderived' attributes in the javabase typemap?\n", typemap_lookup_type, pure_baseclass);
     }
 
     // Pure Java interfaces
@@ -1991,7 +1991,7 @@ public:
     if (doxygen && doxygenTranslator->hasDocumentation(n)) {
       String *doxygen_comments = doxygenTranslator->getDocumentation(n, 0);
       if (comment_creation_chatter)
-	Printf(proxy_class_def, "/* This was generated from emitProxyClassDefAndCPPCasts() */\n");
+        Printf(proxy_class_def, "/* This was generated from emitProxyClassDefAndCPPCasts() */\n");
       Printv(proxy_class_def, doxygen_comments, NIL);
       Delete(doxygen_comments);
     }
@@ -1999,11 +1999,11 @@ public:
     if (has_outerclass)
       Printv(proxy_class_def, "static ", NIL); // C++ nested classes correspond to static java classes
     Printv(proxy_class_def, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-	   " $javaclassname",	// Class name and bases
-	   (*Char(wanted_base)) ? " extends " : "", wanted_base, *Char(interface_list) ?	// Pure Java interfaces
-	   " implements " : "", interface_list, " {", derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :	// main body of class
-	   typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
-	   NIL);
+           " $javaclassname",	// Class name and bases
+           (*Char(wanted_base)) ? " extends " : "", wanted_base, *Char(interface_list) ?	// Pure Java interfaces
+           " implements " : "", interface_list, " {", derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :	// main body of class
+           typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
+           NIL);
 
     // C++ destructor is wrapped by the delete method
     // Note that the method name is specified in a typemap attribute called methodname
@@ -2026,34 +2026,34 @@ public:
     }
     if (tm && *Char(tm)) {
       if (!destruct_methodname) {
-	Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in javadestruct%s typemap for %s\n", (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(Getfile(n), Getline(n), "No methodname attribute defined in javadestruct%s typemap for %s\n", (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!destruct_methodmodifiers) {
-	Swig_error(Getfile(n), Getline(n), "No methodmodifiers attribute defined in javadestruct%s typemap for %s.\n", (derived ? "_derived" : ""), proxy_class_name);
+        Swig_error(Getfile(n), Getline(n), "No methodmodifiers attribute defined in javadestruct%s typemap for %s.\n", (derived ? "_derived" : ""), proxy_class_name);
       }
       if (!destruct_parameters)
-	destruct_parameters = empty_string;
+        destruct_parameters = empty_string;
     }
     // Emit the finalize and delete methods
     if (tm) {
       // Finalize method
       if (*Char(destructor_call)) {
-	Printv(proxy_class_def, typemapLookup(n, "javafinalize", typemap_lookup_type, WARN_NONE), NIL);
+        Printv(proxy_class_def, typemapLookup(n, "javafinalize", typemap_lookup_type, WARN_NONE), NIL);
       }
       // delete method
       Printv(destruct, tm, NIL);
       if (*Char(destructor_call))
-	Replaceall(destruct, "$jnicall", destructor_call);
+        Replaceall(destruct, "$jnicall", destructor_call);
       else
-	Replaceall(destruct, "$jnicall", "throw new UnsupportedOperationException(\"C++ destructor does not have public access\")");
+        Replaceall(destruct, "$jnicall", "throw new UnsupportedOperationException(\"C++ destructor does not have public access\")");
       if (*Char(destruct)) {
-	Printv(proxy_class_def, "\n  ", NIL);
-	const String *methodmods = Getattr(n, "destructmethodmodifiers");
-	if (methodmods)
-	  Printv(proxy_class_def, methodmods, NIL);
-	else
-	  Printv(proxy_class_def, destruct_methodmodifiers, NIL);
-	Printv(proxy_class_def, " void ", destruct_methodname, "(", destruct_parameters, ")", destructor_throws_clause, " ", destruct, "\n", NIL);
+        Printv(proxy_class_def, "\n  ", NIL);
+        const String *methodmods = Getattr(n, "destructmethodmodifiers");
+        if (methodmods)
+          Printv(proxy_class_def, methodmods, NIL);
+        else
+          Printv(proxy_class_def, destruct_methodmodifiers, NIL);
+        Printv(proxy_class_def, " void ", destruct_methodname, "(", destruct_parameters, ")", destructor_throws_clause, " ", destruct, "\n", NIL);
       }
     }
     if (*Char(interface_upcasts))
@@ -2086,7 +2086,7 @@ public:
 
     // Emit extra user code
     Printv(proxy_class_def, typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),	// extra Java code
-	   "\n", NIL);
+           "\n", NIL);
 
     if (derived) {
       String *upcast_method_name = Swig_name_member(getNSpace(), getClassPrefix(), smart != 0 ? "SWIGSmartPtrUpcast" : "SWIGUpcast");
@@ -2103,9 +2103,9 @@ public:
     if (package || nspace) {
       Printf(f_interface, "package ");
       if (package)
-	Printv(f_interface, package, nspace ? "." : "", NIL);
+        Printv(f_interface, package, nspace ? "." : "", NIL);
       if (nspace)
-	Printv(f_interface, nspace, NIL);
+        Printv(f_interface, nspace, NIL);
       Printf(f_interface, ";\n");
     }
 
@@ -2124,15 +2124,15 @@ public:
     String *bases = additional ? Copy(additional) : 0;
     if (List *baselist = Getattr(n, "bases")) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
-	if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
-	  continue; // TODO: warn about skipped non-interface bases
-	String *base_iname = Getattr(base.item, "interface:name");
-	if (!bases)
-	  bases = Copy(base_iname);
-	else {
-	  Append(bases, ", ");
-	  Append(bases, base_iname);
-	}
+        if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
+          continue; // TODO: warn about skipped non-interface bases
+        String *base_iname = Getattr(base.item, "interface:name");
+        if (!bases)
+          bases = Copy(base_iname);
+        else {
+          Append(bases, ", ");
+          Append(bases, base_iname);
+        }
       }
     }
     if (bases) {
@@ -2147,8 +2147,8 @@ public:
       String *interface_declaration = Copy(Getattr(attributes, "tmap:javainterfacecode:declaration"));
       if (interface_declaration) {
         Replaceall(interface_declaration, "$interfacename", interface_name);
-	Printv(f_interface, interface_declaration, NIL);
-	Delete(interface_declaration);
+        Printv(f_interface, interface_declaration, NIL);
+        Delete(interface_declaration);
       }
       Delete(interface_code);
     }
@@ -2188,82 +2188,82 @@ public:
 
       String *outerClassesPrefix = 0;
       if (Node *outer = Getattr(n, "nested:outer")) {
-	outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
-	for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
-	  Push(outerClassesPrefix, ".");
-	  Push(outerClassesPrefix, Getattr(outer, "sym:name"));
-	}
+        outerClassesPrefix = Copy(Getattr(outer, "sym:name"));
+        for (outer = Getattr(outer, "nested:outer"); outer != 0; outer = Getattr(outer, "nested:outer")) {
+          Push(outerClassesPrefix, ".");
+          Push(outerClassesPrefix, Getattr(outer, "sym:name"));
+        }
       }
       if (!nspace) {
-	full_proxy_class_name = outerClassesPrefix ? NewStringf("%s.%s", outerClassesPrefix, proxy_class_name) : NewStringf("%s", proxy_class_name);
+        full_proxy_class_name = outerClassesPrefix ? NewStringf("%s.%s", outerClassesPrefix, proxy_class_name) : NewStringf("%s", proxy_class_name);
 
-	if (Cmp(proxy_class_name, imclass_name) == 0) {
-	  Printf(stderr, "Class name cannot be equal to intermediary class name: %s\n", proxy_class_name);
-	  Exit(EXIT_FAILURE);
-	}
+        if (Cmp(proxy_class_name, imclass_name) == 0) {
+          Printf(stderr, "Class name cannot be equal to intermediary class name: %s\n", proxy_class_name);
+          Exit(EXIT_FAILURE);
+        }
 
-	if (Cmp(proxy_class_name, module_class_name) == 0) {
-	  Printf(stderr, "Class name cannot be equal to module class name: %s\n", proxy_class_name);
-	  Exit(EXIT_FAILURE);
-	}
+        if (Cmp(proxy_class_name, module_class_name) == 0) {
+          Printf(stderr, "Class name cannot be equal to module class name: %s\n", proxy_class_name);
+          Exit(EXIT_FAILURE);
+        }
       } else {
-	if (outerClassesPrefix) {
-	  if (package)
-	    full_proxy_class_name = NewStringf("%s.%s.%s.%s", package, nspace, outerClassesPrefix, proxy_class_name);
-	  else
-	    full_proxy_class_name = NewStringf("%s.%s.%s", nspace, outerClassesPrefix, proxy_class_name);
-	} else {
-	  if (package)
-	    full_proxy_class_name = NewStringf("%s.%s.%s", package, nspace, proxy_class_name);
-	  else
-	    full_proxy_class_name = NewStringf("%s.%s", nspace, proxy_class_name);
-	}
+        if (outerClassesPrefix) {
+          if (package)
+            full_proxy_class_name = NewStringf("%s.%s.%s.%s", package, nspace, outerClassesPrefix, proxy_class_name);
+          else
+            full_proxy_class_name = NewStringf("%s.%s.%s", nspace, outerClassesPrefix, proxy_class_name);
+        } else {
+          if (package)
+            full_proxy_class_name = NewStringf("%s.%s.%s", package, nspace, proxy_class_name);
+          else
+            full_proxy_class_name = NewStringf("%s.%s", nspace, proxy_class_name);
+        }
       }
 
       String *interface_name = GetFlag(n, "feature:interface") ? Getattr(n, "interface:name") : 0;
       if (outerClassesPrefix) {
-	String *fnspace = nspace ? NewStringf("%s.%s", nspace, outerClassesPrefix) : outerClassesPrefix;
-	if (!addSymbol(proxy_class_name, n, fnspace))
-	  return SWIG_ERROR;
-	if (interface_name && !addInterfaceSymbol(interface_name, n, fnspace))
-	  return SWIG_ERROR;
-	if (nspace)
-	  Delete(fnspace);
-	Delete(outerClassesPrefix);
+        String *fnspace = nspace ? NewStringf("%s.%s", nspace, outerClassesPrefix) : outerClassesPrefix;
+        if (!addSymbol(proxy_class_name, n, fnspace))
+          return SWIG_ERROR;
+        if (interface_name && !addInterfaceSymbol(interface_name, n, fnspace))
+          return SWIG_ERROR;
+        if (nspace)
+          Delete(fnspace);
+        Delete(outerClassesPrefix);
       } else {
-	if (!addSymbol(proxy_class_name, n, nspace))
-	  return SWIG_ERROR;
-	if (interface_name && !addInterfaceSymbol(interface_name, n, nspace))
-	  return SWIG_ERROR;
+        if (!addSymbol(proxy_class_name, n, nspace))
+          return SWIG_ERROR;
+        if (interface_name && !addInterfaceSymbol(interface_name, n, nspace))
+          return SWIG_ERROR;
       }
 
       // Each outer proxy class goes into a separate file
       if (!has_outerclass) {
-	String *output_directory = outputDirectory(nspace);
-	String *filen = NewStringf("%s%s.java", output_directory, proxy_class_name);
-	f_proxy = NewFile(filen, "w", SWIG_output_files());
-	if (!f_proxy) {
-	  FileErrorDisplay(filen);
-	  Exit(EXIT_FAILURE);
-	}
-	Append(filenames_list, Copy(filen));
-	Delete(filen);
-	Delete(output_directory);
+        String *output_directory = outputDirectory(nspace);
+        String *filen = NewStringf("%s%s.java", output_directory, proxy_class_name);
+        f_proxy = NewFile(filen, "w", SWIG_output_files());
+        if (!f_proxy) {
+          FileErrorDisplay(filen);
+          Exit(EXIT_FAILURE);
+        }
+        Append(filenames_list, Copy(filen));
+        Delete(filen);
+        Delete(output_directory);
 
-	// Start writing out the proxy class file
-	emitBanner(f_proxy);
+        // Start writing out the proxy class file
+        emitBanner(f_proxy);
 
-	if (package || nspace) {
-	  Printf(f_proxy, "package ");
-	  if (package)
-	    Printv(f_proxy, package, nspace ? "." : "", NIL);
-	  if (nspace)
-	    Printv(f_proxy, nspace, NIL);
-	  Printf(f_proxy, ";\n");
-	}
+        if (package || nspace) {
+          Printf(f_proxy, "package ");
+          if (package)
+            Printv(f_proxy, package, nspace ? "." : "", NIL);
+          if (nspace)
+            Printv(f_proxy, nspace, NIL);
+          Printf(f_proxy, ";\n");
+        }
       }
       else
-	++nesting_depth;
+        ++nesting_depth;
 
       proxy_class_def = NewString("");
       proxy_class_code = NewString("");
@@ -2273,18 +2273,18 @@ public:
 
       if (GetFlag(n, "feature:interface")) {
         interface_class_code = NewString("");
-	String *output_directory = outputDirectory(nspace);
-	String *filen = NewStringf("%s%s.java", output_directory, interface_name);
-	f_interface = NewFile(filen, "w", SWIG_output_files());
-	if (!f_interface) {
-	  FileErrorDisplay(filen);
-	  Exit(EXIT_FAILURE);
-	}
-	Append(filenames_list, filen); // file name ownership goes to the list
-	emitBanner(f_interface);
-	emitInterfaceDeclaration(n, interface_name, interface_class_code, nspace);
-	Delete(filen);
-	Delete(output_directory);
+        String *output_directory = outputDirectory(nspace);
+        String *filen = NewStringf("%s%s.java", output_directory, interface_name);
+        f_interface = NewFile(filen, "w", SWIG_output_files());
+        if (!f_interface) {
+          FileErrorDisplay(filen);
+          Exit(EXIT_FAILURE);
+        }
+        Append(filenames_list, filen); // file name ownership goes to the list
+        emitBanner(f_interface);
+        emitInterfaceDeclaration(n, interface_name, interface_class_code, nspace);
+        Delete(filen);
+        Delete(output_directory);
       }
     }
 
@@ -2316,39 +2316,39 @@ public:
       Replaceall(interface_class_code, "$imclassname", full_imclass_name);
 
       if (!has_outerclass)
-	Printv(f_proxy, proxy_class_def, proxy_class_code, NIL);
+        Printv(f_proxy, proxy_class_def, proxy_class_code, NIL);
       else {
-	Swig_offset_string(proxy_class_def, nesting_depth);
-	Append(old_proxy_class_code, proxy_class_def);
-	Swig_offset_string(proxy_class_code, nesting_depth);
-	Append(old_proxy_class_code, proxy_class_code);
+        Swig_offset_string(proxy_class_def, nesting_depth);
+        Append(old_proxy_class_code, proxy_class_def);
+        Swig_offset_string(proxy_class_code, nesting_depth);
+        Append(old_proxy_class_code, proxy_class_code);
       }
 
       // Write out all the constants
       if (Len(proxy_class_constants_code) != 0) {
-	if (!has_outerclass)
-	  Printv(f_proxy, proxy_class_constants_code, NIL);
-	else {
-	  Swig_offset_string(proxy_class_constants_code, nesting_depth);
-	  Append(old_proxy_class_code, proxy_class_constants_code);
-	}
+        if (!has_outerclass)
+          Printv(f_proxy, proxy_class_constants_code, NIL);
+        else {
+          Swig_offset_string(proxy_class_constants_code, nesting_depth);
+          Append(old_proxy_class_code, proxy_class_constants_code);
+        }
       }
 
       if (!has_outerclass) {
-	Printf(f_proxy, "}\n");
+        Printf(f_proxy, "}\n");
         Delete(f_proxy);
         f_proxy = NULL;
       } else {
-	for (int i = 0; i < nesting_depth; ++i)
-	  Append(old_proxy_class_code, "  ");
-	Append(old_proxy_class_code, "}\n\n");
-	--nesting_depth;
+        for (int i = 0; i < nesting_depth; ++i)
+          Append(old_proxy_class_code, "  ");
+        Append(old_proxy_class_code, "}\n\n");
+        --nesting_depth;
       }
 
       if (f_interface) {
-	Printv(f_interface, interface_class_code, "}\n", NIL);
-	Delete(f_interface);
-	f_interface = 0;
+        Printv(f_interface, interface_class_code, "}\n", NIL);
+        Delete(f_interface);
+        f_interface = 0;
       }
 
       emitDirectorExtraMethods(n);
@@ -2462,7 +2462,7 @@ public:
 
     if (l) {
       if (SwigType_type(Getattr(l, "type")) == T_VOID) {
-	l = nextSibling(l);
+        l = nextSibling(l);
       }
     }
 
@@ -2479,8 +2479,8 @@ public:
       substituteClassname(covariant ? covariant : t, tm);
       Printf(return_type, "%s", tm);
       if (covariant)
-	Swig_warning(WARN_JAVA_COVARIANT_RET, input_file, line_number,
-		     "Covariant return types not supported in Java. Proxy method will return %s.\n", SwigType_str(covariant, 0));
+        Swig_warning(WARN_JAVA_COVARIANT_RET, input_file, line_number,
+                     "Covariant return types not supported in Java. Proxy method will return %s.\n", SwigType_str(covariant, 0));
     } else {
       Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(t, 0));
     }
@@ -2494,10 +2494,10 @@ public:
     if (doxygen && doxygenTranslator->hasDocumentation(n)) {
       String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
       if (comment_creation_chatter)
-	Printf(function_code, "/* This was generated from proxyclassfunctionhandler() */\n");
+        Printf(function_code, "/* This was generated from proxyclassfunctionhandler() */\n");
       Printv(function_code, doxygen_comments, NIL);
       if (is_interface)
-	Printv(interface_class_code, "\n", doxygen_comments, NIL);
+        Printv(interface_class_code, "\n", doxygen_comments, NIL);
       Delete(doxygen_comments);
     }
 
@@ -2520,14 +2520,14 @@ public:
       String *name = NewString("jself");
       String *qualifier = Getattr(n, "qualifier");
       if (qualifier)
-	SwigType_push(this_type, qualifier);
+        SwigType_push(this_type, qualifier);
       SwigType_add_pointer(this_type);
       Parm *this_parm = NewParm(this_type, name, n);
       Swig_typemap_attach_parms("jtype", this_parm, NULL);
       Swig_typemap_attach_parms("jstype", this_parm, NULL);
 
       if (prematureGarbageCollectionPreventionParameter(this_type, this_parm))
-	Printf(imcall, ", this");
+        Printf(imcall, ", this");
 
       Delete(this_parm);
       Delete(name);
@@ -2543,39 +2543,39 @@ public:
 
       /* Ignored varargs */
       if (checkAttribute(p, "varargs:ignore", "1")) {
-	p = nextSibling(p);
-	continue;
+        p = nextSibling(p);
+        continue;
       }
 
       /* Ignored parameters */
       if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
 
       /* Ignore the 'this' argument for variable wrappers */
       if (!(variable_wrapper_flag && i == 0) || static_flag) {
-	SwigType *pt = Getattr(p, "type");
-	String *param_type = NewString("");
+        SwigType *pt = Getattr(p, "type");
+        String *param_type = NewString("");
 
-	/* Get the Java parameter type */
-	if ((tm = Getattr(p, "tmap:jstype"))) {
-	  substituteClassname(pt, tm);
-	  Printf(param_type, "%s", tm);
-	} else {
-	  Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+        /* Get the Java parameter type */
+        if ((tm = Getattr(p, "tmap:jstype"))) {
+          substituteClassname(pt, tm);
+          Printf(param_type, "%s", tm);
+        } else {
+          Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	if (gencomma)
-	  Printf(imcall, ", ");
+        if (gencomma)
+          Printf(imcall, ", ");
 
-	String *arg = makeParameterName(n, p, i, setter_flag);
+        String *arg = makeParameterName(n, p, i, setter_flag);
 
-	// Use typemaps to transform type used in Java proxy wrapper (in proxy class) to type used in JNI function (in intermediary class)
-	if ((tm = Getattr(p, "tmap:javain"))) {
-	  addThrows(n, "tmap:javain", p);
-	  substituteClassname(pt, tm);
-	  Replaceall(tm, "$javainput", arg);
+        // Use typemaps to transform type used in Java proxy wrapper (in proxy class) to type used in JNI function (in intermediary class)
+        if ((tm = Getattr(p, "tmap:javain"))) {
+          addThrows(n, "tmap:javain", p);
+          substituteClassname(pt, tm);
+          Replaceall(tm, "$javainput", arg);
           String *pre = Getattr(p, "tmap:javain:pre");
           if (pre) {
             substituteClassname(pt, pre);
@@ -2592,23 +2592,23 @@ public:
               Printf(post_code, "\n");
             Printv(post_code, post, NIL);
           }
-	  Printv(imcall, tm, NIL);
-	} else {
-	  Swig_warning(WARN_JAVA_TYPEMAP_JAVAIN_UNDEF, input_file, line_number, "No javain typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+          Printv(imcall, tm, NIL);
+        } else {
+          Swig_warning(WARN_JAVA_TYPEMAP_JAVAIN_UNDEF, input_file, line_number, "No javain typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	/* Add parameter to proxy function */
-	if (gencomma >= 2) {
-	  Printf(function_code, ", ");
-	  if (is_interface)
-	    Printf(interface_class_code, ", ");
-	}
-	gencomma = 2;
-	Printf(function_code, "%s %s", param_type, arg);
-	if (is_interface)
-	  Printf(interface_class_code, "%s %s", param_type, arg);
+        /* Add parameter to proxy function */
+        if (gencomma >= 2) {
+          Printf(function_code, ", ");
+          if (is_interface)
+            Printf(interface_class_code, ", ");
+        }
+        gencomma = 2;
+        Printf(function_code, "%s %s", param_type, arg);
+        if (is_interface)
+          Printf(interface_class_code, "%s %s", param_type, arg);
 
-	if (prematureGarbageCollectionPreventionParameter(pt, p)) {
+        if (prematureGarbageCollectionPreventionParameter(pt, p)) {
           String *pgcppname = Getattr(p, "tmap:javain:pgcppname");
           if (pgcppname) {
             String *argname = Copy(pgcppname);
@@ -2620,8 +2620,8 @@ public:
           }
         }
 
-	Delete(arg);
-	Delete(param_type);
+        Delete(arg);
+        Delete(param_type);
       }
       p = Getattr(p, "tmap:in:next");
     }
@@ -2646,38 +2646,38 @@ public:
           Insert(tm, 0, pre_code);
           Insert(tm, 0, "\n");
         }
-	Insert(tm, 0, "{");
-	Printf(tm, "\n  }");
+        Insert(tm, 0, "{");
+        Printf(tm, "\n  }");
       }
       if (GetFlag(n, "feature:new"))
-	Replaceall(tm, "$owner", "true");
+        Replaceall(tm, "$owner", "true");
       else
-	Replaceall(tm, "$owner", "false");
+        Replaceall(tm, "$owner", "false");
       substituteClassname(t, tm);
 
       // For director methods: generate code to selectively make a normal polymorphic call or 
       // an explicit method call - needed to prevent infinite recursion calls in director methods.
       Node *explicit_n = Getattr(n, "explicitcallnode");
       if (explicit_n) {
-	String *ex_overloaded_name = getOverloadedName(explicit_n);
-	String *ex_intermediary_function_name = Swig_name_member(getNSpace(), getClassPrefix(), ex_overloaded_name);
+        String *ex_overloaded_name = getOverloadedName(explicit_n);
+        String *ex_intermediary_function_name = Swig_name_member(getNSpace(), getClassPrefix(), ex_overloaded_name);
 
-	String *ex_imcall = Copy(imcall);
-	Replaceall(ex_imcall, "$imfuncname", ex_intermediary_function_name);
-	Replaceall(imcall, "$imfuncname", intermediary_function_name);
+        String *ex_imcall = Copy(imcall);
+        Replaceall(ex_imcall, "$imfuncname", ex_intermediary_function_name);
+        Replaceall(imcall, "$imfuncname", intermediary_function_name);
 
-	String *excode = NewString("");
-	if (!Cmp(return_type, "void"))
-	  Printf(excode, "if (getClass() == %s.class) %s; else %s", proxy_class_name, imcall, ex_imcall);
-	else
-	  Printf(excode, "(getClass() == %s.class) ? %s : %s", proxy_class_name, imcall, ex_imcall);
+        String *excode = NewString("");
+        if (!Cmp(return_type, "void"))
+          Printf(excode, "if (getClass() == %s.class) %s; else %s", proxy_class_name, imcall, ex_imcall);
+        else
+          Printf(excode, "(getClass() == %s.class) ? %s : %s", proxy_class_name, imcall, ex_imcall);
 
-	Clear(imcall);
-	Printv(imcall, excode, NIL);
-	Delete(ex_overloaded_name);
-	Delete(excode);
+        Clear(imcall);
+        Printv(imcall, excode, NIL);
+        Delete(ex_overloaded_name);
+        Delete(excode);
       } else {
-	Replaceall(imcall, "$imfuncname", intermediary_function_name);
+        Replaceall(imcall, "$imfuncname", intermediary_function_name);
       }
 
       Replaceall(tm, "$imfuncname", intermediary_function_name);
@@ -2740,10 +2740,10 @@ public:
       // Default annotation for director constructors is a warning suppression
       static const String *suppress_warning_this_escape = NewString("@SuppressWarnings(\"this-escape\")");
       if (!annotations && feature_director)
-	annotations = suppress_warning_this_escape;
+        annotations = suppress_warning_this_escape;
       if (annotations) {
-	Printf(function_code, "  %s\n", annotations);
-	Printf(helper_code, "  %s\n", annotations);
+        Printf(function_code, "  %s\n", annotations);
+        Printf(helper_code, "  %s\n", annotations);
       }
 
       const String *methodmods = Getattr(n, "feature:java:methodmodifiers");
@@ -2754,11 +2754,11 @@ public:
 
       // Translate and write javadoc comment if flagged
       if (doxygen && doxygenTranslator->hasDocumentation(n)) {
-	String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
-	if (comment_creation_chatter)
-	  Printf(function_code, "/* This was generated from constructionhandler() */\n");
-	Printv(function_code, doxygen_comments, NIL);
-	Delete(doxygen_comments);
+        String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
+        if (comment_creation_chatter)
+          Printf(function_code, "/* This was generated from constructionhandler() */\n");
+        Printv(function_code, doxygen_comments, NIL);
+        Delete(doxygen_comments);
       }
 
       Printf(function_code, "  %s %s(", methodmods, proxy_class_name);
@@ -2779,39 +2779,39 @@ public:
       /* Output each parameter */
       for (i = 0, p = l; p; i++) {
 
-	/* Ignored varargs */
-	if (checkAttribute(p, "varargs:ignore", "1")) {
-	  p = nextSibling(p);
-	  continue;
-	}
+        /* Ignored varargs */
+        if (checkAttribute(p, "varargs:ignore", "1")) {
+          p = nextSibling(p);
+          continue;
+        }
 
-	/* Ignored parameters */
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
+        /* Ignored parameters */
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
 
-	SwigType *pt = Getattr(p, "type");
-	String *param_type = NewString("");
+        SwigType *pt = Getattr(p, "type");
+        String *param_type = NewString("");
 
-	/* Get the Java parameter type */
-	if ((tm = Getattr(p, "tmap:jstype"))) {
-	  substituteClassname(pt, tm);
-	  Printf(param_type, "%s", tm);
-	} else {
-	  Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(pt, 0));
-	}
+        /* Get the Java parameter type */
+        if ((tm = Getattr(p, "tmap:jstype"))) {
+          substituteClassname(pt, tm);
+          Printf(param_type, "%s", tm);
+        } else {
+          Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(pt, 0));
+        }
 
-	if (gencomma)
-	  Printf(imcall, ", ");
+        if (gencomma)
+          Printf(imcall, ", ");
 
-	String *arg = makeParameterName(n, p, i, false);
+        String *arg = makeParameterName(n, p, i, false);
 
-	// Use typemaps to transform type used in Java wrapper function (in proxy class) to type used in JNI function (in intermediary class)
-	if ((tm = Getattr(p, "tmap:javain"))) {
-	  addThrows(n, "tmap:javain", p);
-	  substituteClassname(pt, tm);
-	  Replaceall(tm, "$javainput", arg);
+        // Use typemaps to transform type used in Java wrapper function (in proxy class) to type used in JNI function (in intermediary class)
+        if ((tm = Getattr(p, "tmap:javain"))) {
+          addThrows(n, "tmap:javain", p);
+          substituteClassname(pt, tm);
+          Replaceall(tm, "$javainput", arg);
           String *pre = Getattr(p, "tmap:javain:pre");
           if (pre) {
             substituteClassname(pt, pre);
@@ -2828,23 +2828,23 @@ public:
               Printf(post_code, "\n");
             Printv(post_code, post, NIL);
           }
-	  Printv(imcall, tm, NIL);
-	} else {
-	  Swig_warning(WARN_JAVA_TYPEMAP_JAVAIN_UNDEF, input_file, line_number, "No javain typemap defined for %s\n", SwigType_str(pt, 0));
-	}
-
-	/* Add parameter to proxy function */
-	if (gencomma) {
-	  Printf(function_code, ", ");
-	  Printf(helper_code, ", ");
-	  Printf(helper_args, ", ");
+          Printv(imcall, tm, NIL);
+        } else {
+          Swig_warning(WARN_JAVA_TYPEMAP_JAVAIN_UNDEF, input_file, line_number, "No javain typemap defined for %s\n", SwigType_str(pt, 0));
         }
-	Printf(function_code, "%s %s", param_type, arg);
-	Printf(helper_code, "%s %s", param_type, arg);
-	Printf(helper_args, "%s", arg);
-	++gencomma;
 
-	if (prematureGarbageCollectionPreventionParameter(pt, p)) {
+        /* Add parameter to proxy function */
+        if (gencomma) {
+          Printf(function_code, ", ");
+          Printf(helper_code, ", ");
+          Printf(helper_args, ", ");
+        }
+        Printf(function_code, "%s %s", param_type, arg);
+        Printf(helper_code, "%s %s", param_type, arg);
+        Printf(helper_args, "%s", arg);
+        ++gencomma;
+
+        if (prematureGarbageCollectionPreventionParameter(pt, p)) {
           String *pgcppname = Getattr(p, "tmap:javain:pgcppname");
           if (pgcppname) {
             String *argname = Copy(pgcppname);
@@ -2856,9 +2856,9 @@ public:
           }
         }
 
-	Delete(arg);
-	Delete(param_type);
-	p = Getattr(p, "tmap:in:next");
+        Delete(arg);
+        Delete(param_type);
+        p = Getattr(p, "tmap:in:next");
       }
 
       Printf(imcall, ")");
@@ -2871,23 +2871,23 @@ public:
       Hash *attributes = NewHash();
       String *typemap_lookup_type = Getattr(getCurrentClass(), "classtypeobj");
       String *construct_tm = Copy(typemapLookup(n, "javaconstruct", typemap_lookup_type,
-						WARN_JAVA_TYPEMAP_JAVACONSTRUCT_UNDEF, attributes));
+                                                WARN_JAVA_TYPEMAP_JAVACONSTRUCT_UNDEF, attributes));
       if (construct_tm) {
-	if (!feature_director) {
-	  Replaceall(construct_tm, "$directorconnect", "");
-	} else {
-	  String *connect_attr = Getattr(attributes, "tmap:javaconstruct:directorconnect");
+        if (!feature_director) {
+          Replaceall(construct_tm, "$directorconnect", "");
+        } else {
+          String *connect_attr = Getattr(attributes, "tmap:javaconstruct:directorconnect");
 
-	  if (connect_attr) {
-	    Replaceall(construct_tm, "$directorconnect", connect_attr);
-	  } else {
-	    Swig_warning(WARN_JAVA_NO_DIRECTORCONNECT_ATTR, input_file, line_number, "\"directorconnect\" attribute missing in %s \"javaconstruct\" typemap.\n",
-			 Getattr(n, "name"));
-	    Replaceall(construct_tm, "$directorconnect", "");
-	  }
-	}
+          if (connect_attr) {
+            Replaceall(construct_tm, "$directorconnect", connect_attr);
+          } else {
+            Swig_warning(WARN_JAVA_NO_DIRECTORCONNECT_ATTR, input_file, line_number, "\"directorconnect\" attribute missing in %s \"javaconstruct\" typemap.\n",
+                         Getattr(n, "name"));
+            Replaceall(construct_tm, "$directorconnect", "");
+          }
+        }
 
-	Printv(function_code, " ", construct_tm, "\n", NIL);
+        Printv(function_code, " ", construct_tm, "\n", NIL);
       }
 
       bool is_pre_code = Len(pre_code) > 0;
@@ -2942,7 +2942,7 @@ public:
       generateThrowsClause(n, destructor_throws_clause);
       const String *methodmods = Getattr(n, "feature:java:methodmodifiers");
       if (methodmods)
-	Setattr(getCurrentClass(), "destructmethodmodifiers", methodmods);
+        Setattr(getCurrentClass(), "destructmethodmodifiers", methodmods);
     }
     return SWIG_OK;
   }
@@ -3030,14 +3030,14 @@ public:
     if (doxygen && doxygenTranslator->hasDocumentation(n)) {
       String *doxygen_comments = doxygenTranslator->getDocumentation(n, "  ");
       if (comment_creation_chatter)
-	Printf(function_code, "/* This was generated from moduleClassFunctionHandler() */\n");
+        Printf(function_code, "/* This was generated from moduleClassFunctionHandler() */\n");
       Printv(function_code, doxygen_comments, NIL);
       Delete(doxygen_comments);
     }
 
     if (l) {
       if (SwigType_type(Getattr(l, "type")) == T_VOID) {
-	l = nextSibling(l);
+        l = nextSibling(l);
       }
     }
 
@@ -3059,9 +3059,9 @@ public:
       func_name = NewString("");
       setter_flag = (Cmp(Getattr(n, "sym:name"), Swig_name_set(getNSpace(), variable_name)) == 0);
       if (setter_flag)
-	Printf(func_name, "set");
+        Printf(func_name, "set");
       else
-	Printf(func_name, "get");
+        Printf(func_name, "get");
       Putc(toupper((int) *Char(variable_name)), func_name);
       Printf(func_name, "%s", Char(variable_name) + 1);
     } else {
@@ -3085,7 +3085,7 @@ public:
 
       /* Ignored parameters */
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -3093,46 +3093,46 @@ public:
 
       /* Get the Java parameter type */
       if ((tm = Getattr(p, "tmap:jstype"))) {
-	substituteClassname(pt, tm);
-	Printf(param_type, "%s", tm);
+        substituteClassname(pt, tm);
+        Printf(param_type, "%s", tm);
       } else {
-	Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_JAVA_TYPEMAP_JSTYPE_UNDEF, input_file, line_number, "No jstype typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       if (gencomma)
-	Printf(imcall, ", ");
+        Printf(imcall, ", ");
 
       String *arg = makeParameterName(n, p, i, global_or_member_variable);
 
       // Use typemaps to transform type used in Java wrapper function (in proxy class) to type used in JNI function (in intermediary class)
       if ((tm = Getattr(p, "tmap:javain"))) {
-	addThrows(n, "tmap:javain", p);
-	substituteClassname(pt, tm);
-	Replaceall(tm, "$javainput", arg);
-	String *pre = Getattr(p, "tmap:javain:pre");
-	if (pre) {
-	  substituteClassname(pt, pre);
-	  Replaceall(pre, "$javainput", arg);
+        addThrows(n, "tmap:javain", p);
+        substituteClassname(pt, tm);
+        Replaceall(tm, "$javainput", arg);
+        String *pre = Getattr(p, "tmap:javain:pre");
+        if (pre) {
+          substituteClassname(pt, pre);
+          Replaceall(pre, "$javainput", arg);
           if (Len(pre_code) > 0)
             Printf(pre_code, "\n");
-	  Printv(pre_code, pre, NIL);
-	}
-	String *post = Getattr(p, "tmap:javain:post");
-	if (post) {
-	  substituteClassname(pt, post);
-	  Replaceall(post, "$javainput", arg);
+          Printv(pre_code, pre, NIL);
+        }
+        String *post = Getattr(p, "tmap:javain:post");
+        if (post) {
+          substituteClassname(pt, post);
+          Replaceall(post, "$javainput", arg);
           if (Len(post_code) > 0)
             Printf(post_code, "\n");
-	  Printv(post_code, post, NIL);
-	}
-	Printv(imcall, tm, NIL);
+          Printv(post_code, post, NIL);
+        }
+        Printv(imcall, tm, NIL);
       } else {
-	Swig_warning(WARN_JAVA_TYPEMAP_JAVAIN_UNDEF, input_file, line_number, "No javain typemap defined for %s\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_JAVA_TYPEMAP_JAVAIN_UNDEF, input_file, line_number, "No javain typemap defined for %s\n", SwigType_str(pt, 0));
       }
 
       /* Add parameter to module class function */
       if (gencomma >= 2)
-	Printf(function_code, ", ");
+        Printf(function_code, ", ");
       gencomma = 2;
       Printf(function_code, "%s %s", param_type, arg);
 
@@ -3173,13 +3173,13 @@ public:
           Insert(tm, 0, pre_code);
           Insert(tm, 0, "\n");
         }
-	Insert(tm, 0, "{");
-	Printf(tm, "\n  }");
+        Insert(tm, 0, "{");
+        Printf(tm, "\n  }");
       }
       if (GetFlag(n, "feature:new"))
-	Replaceall(tm, "$owner", "true");
+        Replaceall(tm, "$owner", "true");
       else
-	Replaceall(tm, "$owner", "false");
+        Replaceall(tm, "$owner", "false");
       substituteClassname(t, tm);
       Replaceall(tm, "$imfuncname", overloaded_name);
       Replaceall(tm, "$jnicall", imcall);
@@ -3223,11 +3223,11 @@ public:
     String *feature = Getattr(n, "feature:java:enum");
     if (feature) {
       if (Cmp(feature, "simple") == 0)
-	enum_feature = SimpleEnum;
+        enum_feature = SimpleEnum;
       else if (Cmp(feature, "typesafe") == 0)
-	enum_feature = TypesafeEnum;
+        enum_feature = TypesafeEnum;
       else if (Cmp(feature, "proper") == 0)
-	enum_feature = ProperEnum;
+        enum_feature = ProperEnum;
     }
     return enum_feature;
   }
@@ -3254,30 +3254,30 @@ public:
       int const_feature_flag = GetFlag(n, "feature:java:const");
 
       if (const_feature_flag) {
-	// Use the C syntax to make a true Java constant and hope that it compiles as Java code
-	value = Getattr(n, "enumvalue") ? Copy(Getattr(n, "enumvalue")) : Copy(Getattr(n, "enumvalueex"));
+        // Use the C syntax to make a true Java constant and hope that it compiles as Java code
+        value = Getattr(n, "enumvalue") ? Copy(Getattr(n, "enumvalue")) : Copy(Getattr(n, "enumvalueex"));
       } else {
-	String *newsymname = 0;
-	if (!getCurrentClass() || !proxy_flag) {
-	  String *enumClassPrefix = getEnumClassPrefix();
-	  if (enumClassPrefix) {
-	    // A global scoped enum
-	    newsymname = Swig_name_member(0, enumClassPrefix, symname);
-	    symname = newsymname;
-	  }
-	}
+        String *newsymname = 0;
+        if (!getCurrentClass() || !proxy_flag) {
+          String *enumClassPrefix = getEnumClassPrefix();
+          if (enumClassPrefix) {
+            // A global scoped enum
+            newsymname = Swig_name_member(0, enumClassPrefix, symname);
+            symname = newsymname;
+          }
+        }
 
-	// Get the enumvalue from a JNI call
-	if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
-	  // Strange hack to change the name
-	  Setattr(n, "name", Getattr(n, "value"));	/* for wrapping of enums in a namespace when emit_action is used */
-	  constantWrapper(n);
-	  value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
-	} else {
-	  memberconstantHandler(n);
-	  value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
-	}
-	Delete(newsymname);
+        // Get the enumvalue from a JNI call
+        if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
+          // Strange hack to change the name
+          Setattr(n, "name", Getattr(n, "value"));	/* for wrapping of enums in a namespace when emit_action is used */
+          constantWrapper(n);
+          value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
+        } else {
+          memberconstantHandler(n);
+          value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), Swig_name_member(0, getEnumClassPrefix(), symname)));
+        }
+        Delete(newsymname);
       }
     }
     return value;
@@ -3296,35 +3296,35 @@ public:
     if (n) {
       enumname = Getattr(n, "enumname");
       if (!enumname || jnidescriptor) {
-	String *symname = Getattr(n, "sym:name");
-	if (symname) {
-	  // Add in class scope when referencing enum if not a global enum
-	  String *scopename_prefix = Swig_scopename_prefix(Getattr(n, "name"));
-	  String *proxyname = 0;
-	  if (scopename_prefix) {
-	    proxyname = getProxyName(scopename_prefix, jnidescriptor);
-	  }
-	  if (proxyname) {
-	    const char *class_separator = jnidescriptor ? "$" : ".";
-	    enumname = NewStringf("%s%s%s", proxyname, class_separator, symname);
-	  } else {
-	    // global enum or enum in a namespace
-	    String *nspace = Getattr(n, "sym:nspace");
-	    if (nspace) {
-	      if (package && !jnidescriptor)
-		enumname = NewStringf("%s.%s.%s", package, nspace, symname);
-	      else
-		enumname = NewStringf("%s.%s", nspace, symname);
-	    } else {
-	      enumname = Copy(symname);
-	    }
-	  }
-	  if (!jnidescriptor) {
-	    Setattr(n, "enumname", enumname); // Cache it
-	    Delete(enumname);
-	  }
-	  Delete(scopename_prefix);
-	}
+        String *symname = Getattr(n, "sym:name");
+        if (symname) {
+          // Add in class scope when referencing enum if not a global enum
+          String *scopename_prefix = Swig_scopename_prefix(Getattr(n, "name"));
+          String *proxyname = 0;
+          if (scopename_prefix) {
+            proxyname = getProxyName(scopename_prefix, jnidescriptor);
+          }
+          if (proxyname) {
+            const char *class_separator = jnidescriptor ? "$" : ".";
+            enumname = NewStringf("%s%s%s", proxyname, class_separator, symname);
+          } else {
+            // global enum or enum in a namespace
+            String *nspace = Getattr(n, "sym:nspace");
+            if (nspace) {
+              if (package && !jnidescriptor)
+                enumname = NewStringf("%s.%s.%s", package, nspace, symname);
+              else
+                enumname = NewStringf("%s.%s", nspace, symname);
+            } else {
+              enumname = Copy(symname);
+            }
+          }
+          if (!jnidescriptor) {
+            Setattr(n, "enumname", enumname); // Cache it
+            Delete(enumname);
+          }
+          Delete(scopename_prefix);
+        }
       }
     }
 
@@ -3364,8 +3364,8 @@ public:
       SwigType *classnametype = Copy(strippedtype);
       Delete(SwigType_pop(classnametype));
       if (Len(classnametype) > 0) {
-	substituteClassnameSpecialVariable(classnametype, tm, "$*javaclassname", jnidescriptor);
-	substitution_performed = true;
+        substituteClassnameSpecialVariable(classnametype, tm, "$*javaclassname", jnidescriptor);
+        substitution_performed = true;
       }
       Delete(classnametype);
     }
@@ -3386,8 +3386,8 @@ public:
       SwigType *interfacenametype = Copy(strippedtype);
       Delete(SwigType_pop(interfacenametype));
       if (Len(interfacenametype) > 0) {
-	substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*javainterfacename", jnidescriptor, true);
-	substitution_performed = true;
+        substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*javainterfacename", jnidescriptor, true);
+        substitution_performed = true;
       }
       Delete(interfacenametype);
     }
@@ -3408,8 +3408,8 @@ public:
       SwigType *interfacenametype = Copy(strippedtype);
       Delete(SwigType_pop(interfacenametype));
       if (Len(interfacenametype) > 0) {
-	substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*interfacename", jnidescriptor, false);
-	substitution_performed = true;
+        substituteInterfacenameSpecialVariable(interfacenametype, tm, "$*interfacename", jnidescriptor, false);
+        substitution_performed = true;
       }
       Delete(interfacenametype);
     }
@@ -3437,28 +3437,28 @@ public:
     if (SwigType_isenum(classnametype)) {
       String *enumname = getEnumName(classnametype, jnidescriptor);
       if (enumname) {
-	replacementname = Copy(enumname);
+        replacementname = Copy(enumname);
       } else {
         bool anonymous_enum = (Cmp(classnametype, "enum ") == 0);
-	if (anonymous_enum) {
-	  replacementname = NewString("int");
-	} else {
-	  // An unknown enum - one that has not been parsed (neither a C enum forward reference nor a definition) or an ignored enum
-	  replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
-	  Replace(replacementname, "enum ", "", DOH_REPLACE_ANY);
-	  Setattr(swig_types_hash, replacementname, classnametype);
-	}
+        if (anonymous_enum) {
+          replacementname = NewString("int");
+        } else {
+          // An unknown enum - one that has not been parsed (neither a C enum forward reference nor a definition) or an ignored enum
+          replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
+          Replace(replacementname, "enum ", "", DOH_REPLACE_ANY);
+          Setattr(swig_types_hash, replacementname, classnametype);
+        }
       }
     } else {
       String *classname = getProxyName(classnametype, jnidescriptor); // getProxyName() works for pointers to classes too
       if (classname) {
-	replacementname = Copy(classname);
+        replacementname = Copy(classname);
       } else {
-	// use $descriptor if SWIG does not know anything about this type. Note that any typedefs are resolved.
-	replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
+        // use $descriptor if SWIG does not know anything about this type. Note that any typedefs are resolved.
+        replacementname = NewStringf("SWIGTYPE%s", SwigType_manglestr(classnametype));
 
-	// Add to hash table so that the type wrapper classes can be created later
-	Setattr(swig_types_hash, replacementname, classnametype);
+        // Add to hash table so that the type wrapper classes can be created later
+        Setattr(swig_types_hash, replacementname, classnametype);
       }
     }
     if (jnidescriptor)
@@ -3479,7 +3479,7 @@ public:
       String *replacementname = Copy(interfacename);
 
       if (jnidescriptor)
-	Replaceall(replacementname,".","/");
+        Replaceall(replacementname,".","/");
       Replaceall(tm, interfacenamespecialvariable, replacementname);
 
       Delete(replacementname);
@@ -3518,12 +3518,12 @@ public:
 
     // Emit the class
     Printv(swigtype, typemapLookup(n, "javaimports", type, WARN_NONE),	// Import statements
-	   "\n", typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-	   " $javaclassname",	// Class name and bases
-	   *Char(pure_baseclass) ? " extends " : "", pure_baseclass, *Char(pure_interfaces) ?	// Interfaces
-	   " implements " : "", pure_interfaces, " {", typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
-	   typemapLookup(n, "javacode", type, WARN_NONE),	// extra Java code
-	   "}\n", "\n", NIL);
+           "\n", typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
+           " $javaclassname",	// Class name and bases
+           *Char(pure_baseclass) ? " extends " : "", pure_baseclass, *Char(pure_interfaces) ?	// Interfaces
+           " implements " : "", pure_interfaces, " {", typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
+           typemapLookup(n, "javacode", type, WARN_NONE),	// extra Java code
+           "}\n", "\n", NIL);
 
     Replaceall(swigtype, "$javaclassname", classname);
     Replaceall(swigtype, "$module", module_class_name);
@@ -3560,7 +3560,7 @@ public:
     if (!tm) {
       tm = empty_string;
       if (warning != WARN_NONE)
-	Swig_warning(warning, Getfile(n), Getline(n), "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
+        Swig_warning(warning, Getfile(n), Getline(n), "No %s typemap defined for %s\n", tmap_method, SwigType_str(type, 0));
     }
     if (!typemap_attributes)
       Delete(node);
@@ -3582,34 +3582,34 @@ public:
     if (throws && Len(throws) > 0) {
       String *throws_list = Getattr(n, "java:throwslist");
       if (!throws_list) {
-	throws_list = NewList();
-	Setattr(n, "java:throwslist", throws_list);
+        throws_list = NewList();
+        Setattr(n, "java:throwslist", throws_list);
       }
       // Put the exception classes in the throws clause into a temporary List
       List *temp_classes_list = Split(throws, ',', INT_MAX);
 
       // Add the exception classes to the node throws list, but don't duplicate if already in list
       if (temp_classes_list && Len(temp_classes_list) > 0) {
-	for (Iterator cls = First(temp_classes_list); cls.item; cls = Next(cls)) {
-	  String *exception_class = NewString(cls.item);
-	  Replaceall(exception_class, " ", "");	// remove spaces
-	  Replaceall(exception_class, "\t", "");	// remove tabs
-	  if (Len(exception_class) > 0) {
-	    // $javaclassname substitution
-	    SwigType *pt = Getattr(parameter, "type");
-	    substituteClassname(pt, exception_class);
+        for (Iterator cls = First(temp_classes_list); cls.item; cls = Next(cls)) {
+          String *exception_class = NewString(cls.item);
+          Replaceall(exception_class, " ", "");	// remove spaces
+          Replaceall(exception_class, "\t", "");	// remove tabs
+          if (Len(exception_class) > 0) {
+            // $javaclassname substitution
+            SwigType *pt = Getattr(parameter, "type");
+            substituteClassname(pt, exception_class);
 
-	    // Don't duplicate the Java exception class in the throws clause
-	    bool found_flag = false;
-	    for (Iterator item = First(throws_list); item.item; item = Next(item)) {
-	      if (Strcmp(item.item, exception_class) == 0)
-		found_flag = true;
-	    }
-	    if (!found_flag)
-	      Append(throws_list, exception_class);
-	  }
-	  Delete(exception_class);
-	}
+            // Don't duplicate the Java exception class in the throws clause
+            bool found_flag = false;
+            for (Iterator item = First(throws_list); item.item; item = Next(item)) {
+              if (Strcmp(item.item, exception_class) == 0)
+                found_flag = true;
+            }
+            if (!found_flag)
+              Append(throws_list, exception_class);
+          }
+          Delete(exception_class);
+        }
       }
       Delete(temp_classes_list);
     }
@@ -3629,7 +3629,7 @@ public:
       Iterator cls = First(throws_list);
       Printf(code, " throws %s", cls.item);
       while ((cls = Next(cls)).item)
-	Printf(code, ", %s", cls.item);
+        Printf(code, ", %s", cls.item);
     }
   }
 
@@ -3659,8 +3659,8 @@ public:
 
     if (Cmp(jtype, "long") == 0) {
       if (proxy_flag) {
-	if (!GetFlag(p, "tmap:jtype:nopgcpp") && !nopgcpp_flag) {
-	  String *interface_name = getInterfaceName(t, true);
+        if (!GetFlag(p, "tmap:jtype:nopgcpp") && !nopgcpp_flag) {
+          String *interface_name = getInterfaceName(t, true);
           pgcpp_java_type = interface_name ? interface_name : getProxyName(t);
           if (!pgcpp_java_type) {
             // Look for proxy class parameters passed to C++ layer using non-default typemaps, ie not one of above types
@@ -3692,7 +3692,7 @@ public:
             }
             Delete(jstype);
           }
-	}
+        }
       }
     }
     Delete(jtype);
@@ -3713,9 +3713,9 @@ public:
       Replaceall(nspace_subdirectory, ".", SWIG_FILE_DELIMITER);
       String *newdir_error = Swig_new_subdirectory(output_directory, nspace_subdirectory);
       if (newdir_error) {
-	Printf(stderr, "%s\n", newdir_error);
-	Delete(newdir_error);
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "%s\n", newdir_error);
+        Delete(newdir_error);
+        Exit(EXIT_FAILURE);
       }
       Printv(output_directory, nspace_subdirectory, SWIG_FILE_DELIMITER, 0);
       Delete(nspace_subdirectory);
@@ -3756,7 +3756,7 @@ public:
     code = *Char(descrip);
     for (i = 0; i < (int) (sizeof(upcall_methods) / sizeof(upcall_methods[0])); ++i)
       if (code == upcall_methods[i].code)
-	return NewString(upcall_methods[i].method);
+        return NewString(upcall_methods[i].method);
     return NULL;
   }
 
@@ -3776,15 +3776,15 @@ public:
 
       udata_iter = First(dmethods_seq);
       while (udata_iter.item) {
-	UpcallData *udata = udata_iter.item;
-	Printf(dmethod_data, "  { \"%s\", \"%s\" }", Getattr(udata, "imclass_method"), Getattr(udata, "imclass_fdesc"));
-	++n_methods;
+        UpcallData *udata = udata_iter.item;
+        Printf(dmethod_data, "  { \"%s\", \"%s\" }", Getattr(udata, "imclass_method"), Getattr(udata, "imclass_fdesc"));
+        ++n_methods;
 
-	udata_iter = Next(udata_iter);
+        udata_iter = Next(udata_iter);
 
-	if (udata_iter.item)
-	  Putc(',', dmethod_data);
-	Putc('\n', dmethod_data);
+        if (udata_iter.item)
+          Putc(',', dmethod_data);
+        Putc('\n', dmethod_data);
       }
 
       Printf(f_runtime, "namespace Swig {\n");
@@ -3842,12 +3842,12 @@ public:
     Wrapper *code_wrap;
 
     Printf(imclass_class_code, "  public final static native void %s(%s obj, long cptr, boolean mem_own, boolean weak_global);\n",
-	   swig_director_connect, full_proxy_class_name);
+           swig_director_connect, full_proxy_class_name);
 
     code_wrap = NewWrapper();
     Printf(code_wrap->def,
-	   "SWIGEXPORT void JNICALL Java_%s%s_%s(JNIEnv *jenv, jclass jcls, jobject jself, jlong objarg, jboolean jswig_mem_own, "
-	   "jboolean jweak_global) {\n", jnipackage, jni_imclass_name, swig_director_connect_jni);
+           "SWIGEXPORT void JNICALL Java_%s%s_%s(JNIEnv *jenv, jclass jcls, jobject jself, jlong objarg, jboolean jswig_mem_own, "
+           "jboolean jweak_global) {\n", jnipackage, jni_imclass_name, swig_director_connect_jni);
 
     if (smartptr) {
       Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", smartptr, smartptr);
@@ -3863,7 +3863,7 @@ public:
     }
 
     Printf(code_wrap->code, "  director->swig_connect_director(jenv, jself, jenv->GetObjectClass(jself), "
-	   "(jswig_mem_own == JNI_TRUE), (jweak_global == JNI_TRUE));\n");
+           "(jswig_mem_own == JNI_TRUE), (jweak_global == JNI_TRUE));\n");
     Printf(code_wrap->code, "}\n");
 
     Wrapper_print(code_wrap, f_wrappers);
@@ -3880,8 +3880,8 @@ public:
 
     code_wrap = NewWrapper();
     Printf(code_wrap->def,
-	   "SWIGEXPORT void JNICALL Java_%s%s_%s(JNIEnv *jenv, jclass jcls, jobject jself, jlong objarg, jboolean jtake_or_release) {\n",
-	   jnipackage, jni_imclass_name, changeown_jnimethod_name);
+           "SWIGEXPORT void JNICALL Java_%s%s_%s(JNIEnv *jenv, jclass jcls, jobject jself, jlong objarg, jboolean jtake_or_release) {\n",
+           jnipackage, jni_imclass_name, changeown_jnimethod_name);
 
     if (smartptr) {
         Printf(code_wrap->code, "  %s *obj = *((%s **)&objarg);\n", smartptr, smartptr);
@@ -3934,13 +3934,13 @@ public:
 
     if (*Char(tm)) {
       if (method_attr) {
-	String *codebody = Copy(tm);
-	Replaceall(codebody, "$methodname", method_attr);
-	Replaceall(codebody, "$jnicall", jnicall);
-	Append(proxy_class_def, codebody);
-	Delete(codebody);
+        String *codebody = Copy(tm);
+        Replaceall(codebody, "$methodname", method_attr);
+        Replaceall(codebody, "$jnicall", jnicall);
+        Append(proxy_class_def, codebody);
+        Delete(codebody);
       } else {
-	Swig_error(input_file, line_number, "No %s method name attribute for %s\n", lookup_tmname, proxy_class_name);
+        Swig_error(input_file, line_number, "No %s method name attribute for %s\n", lookup_tmname, proxy_class_name);
       }
     } else {
       Swig_error(input_file, line_number, "No %s typemap for %s\n", lookup_tmname, proxy_class_name);
@@ -4059,50 +4059,50 @@ public:
 
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  String *base_typename = SwigType_base(returntype);
-	  String *resolved_typename = SwigType_typedef_resolve_all(base_typename);
-	  Symtab *symtab = Getattr(n, "sym:symtab");
-	  Node *typenode = Swig_symbol_clookup(resolved_typename, symtab);
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          String *base_typename = SwigType_base(returntype);
+          String *resolved_typename = SwigType_typedef_resolve_all(base_typename);
+          Symtab *symtab = Getattr(n, "sym:symtab");
+          Node *typenode = Swig_symbol_clookup(resolved_typename, symtab);
 
-	  if (SwigType_ispointer(returntype) || (typenode && Getattr(typenode, "abstracts"))) {
-	    /* initialize pointers to something sane. Same for abstract
-	       classes when a reference is returned. */
-	    Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	  } else {
-	    /* If returning a reference, initialize the pointer to a sane
-	       default - if a Java exception occurs, then the pointer returns
-	       something other than a NULL-initialized reference. */
-	    SwigType *noref_type = SwigType_del_reference(Copy(returntype));
-	    String *noref_ltype = SwigType_lstr(noref_type, 0);
-	    String *return_ltype = SwigType_lstr(returntype, 0);
+          if (SwigType_ispointer(returntype) || (typenode && Getattr(typenode, "abstracts"))) {
+            /* initialize pointers to something sane. Same for abstract
+               classes when a reference is returned. */
+            Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+          } else {
+            /* If returning a reference, initialize the pointer to a sane
+               default - if a Java exception occurs, then the pointer returns
+               something other than a NULL-initialized reference. */
+            SwigType *noref_type = SwigType_del_reference(Copy(returntype));
+            String *noref_ltype = SwigType_lstr(noref_type, 0);
+            String *return_ltype = SwigType_lstr(returntype, 0);
 
-	    Wrapper_add_localv(w, "result_default", "static", noref_ltype, "result_default", NIL);
-	    Wrapper_add_localv(w, "c_result", return_ltype, "c_result", NIL);
-	    Printf(w->code, "result_default = SwigValueInit< %s >();\n", noref_ltype);
-	    Printf(w->code, "c_result = &result_default;\n");
-	    Delete(return_ltype);
-	    Delete(noref_ltype);
-	    Delete(noref_type);
-	  }
+            Wrapper_add_localv(w, "result_default", "static", noref_ltype, "result_default", NIL);
+            Wrapper_add_localv(w, "c_result", return_ltype, "c_result", NIL);
+            Printf(w->code, "result_default = SwigValueInit< %s >();\n", noref_ltype);
+            Printf(w->code, "c_result = &result_default;\n");
+            Delete(return_ltype);
+            Delete(noref_ltype);
+            Delete(noref_type);
+          }
 
-	  Delete(base_typename);
-	  Delete(resolved_typename);
-	}
+          Delete(base_typename);
+          Delete(resolved_typename);
+        }
       } else {
-	SwigType *vt;
+        SwigType *vt;
 
-	vt = cplus_value_type(returntype);
-	if (!vt) {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
-	  Delete(vt);
-	}
+        vt = cplus_value_type(returntype);
+        if (!vt) {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), NIL);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(vt, "c_result"), NIL);
+          Delete(vt);
+        }
       }
     }
 
@@ -4110,9 +4110,9 @@ public:
       /* Create the intermediate class wrapper */
       tm = Swig_typemap_lookup("jtype", n, "", 0);
       if (tm) {
-	Printf(callback_def, "  public static %s %s(%s jself", tm, imclass_dmethod, qualified_classname);
+        Printf(callback_def, "  public static %s %s(%s jself", tm, imclass_dmethod, qualified_classname);
       } else {
-	Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s\n", SwigType_str(returntype, 0));
+        Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s\n", SwigType_str(returntype, 0));
       }
     }
 
@@ -4122,7 +4122,7 @@ public:
     Parm *adjustedreturntypeparm = NewParmNode(adjustedreturntype, n);
 
     if (Swig_typemap_lookup("directorin", adjustedreturntypeparm, "", 0)
-	&& (cdesc = Getattr(adjustedreturntypeparm, "tmap:directorin:descriptor"))) {
+        && (cdesc = Getattr(adjustedreturntypeparm, "tmap:directorin:descriptor"))) {
 
       // Note that in the case of polymorphic (covariant) return types, the
       // method's return type is changed to be the base of the C++ return
@@ -4132,7 +4132,7 @@ public:
       Delete(jnidesc_canon);
     } else {
       Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number, "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-	  SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4142,33 +4142,33 @@ public:
       Parm *tp = NewParmNode(c_ret_type, n);
 
       if (!is_void && !ignored_method) {
-	String *jretval_decl = NewStringf("%s jresult", c_ret_type);
-	Wrapper_add_localv(w, "jresult", jretval_decl, "= 0", NIL);
-	Delete(jretval_decl);
+        String *jretval_decl = NewStringf("%s jresult", c_ret_type);
+        Wrapper_add_localv(w, "jresult", jretval_decl, "= 0", NIL);
+        Delete(jretval_decl);
       }
 
       String *jdesc = NULL;
       if (Swig_typemap_lookup("directorin", tp, "", 0)
-	  && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
+          && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
 
-	// Objects marshalled passing a Java class across JNI boundary use jobject - the nouse flag indicates this
-	// We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
-	if (GetFlag(tp, "tmap:directorin:nouse"))
-	  jdesc = cdesc;
-	String *jnidesc_canon = canonicalizeJNIDescriptor(jdesc, tp);
-	Append(jniret_desc, jnidesc_canon);
-	Delete(jnidesc_canon);
+        // Objects marshalled passing a Java class across JNI boundary use jobject - the nouse flag indicates this
+        // We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
+        if (GetFlag(tp, "tmap:directorin:nouse"))
+          jdesc = cdesc;
+        String *jnidesc_canon = canonicalizeJNIDescriptor(jdesc, tp);
+        Append(jniret_desc, jnidesc_canon);
+        Delete(jnidesc_canon);
       } else {
-	Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-		     "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-		     SwigType_str(c_ret_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	output_director = false;
+        Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+                     "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                     SwigType_str(c_ret_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        output_director = false;
       }
 
       Delete(tp);
     } else {
       Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n", 
-	  SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4202,11 +4202,11 @@ public:
     if (!pure_virtual) {
       String *super_call = Swig_method_call(super, l);
       if (is_void) {
-	Printf(w->code, "%s;\n", super_call);
-	if (!ignored_method)
-	  Printf(w->code, "return;\n");
+        Printf(w->code, "%s;\n", super_call);
+        if (!ignored_method)
+          Printf(w->code, "return;\n");
       } else {
-	Printf(w->code, "return %s;\n", super_call);
+        Printf(w->code, "return %s;\n", super_call);
       }
       Delete(super_call);
     } else {
@@ -4216,9 +4216,9 @@ public:
       /* Make sure that we return something in the case of a pure
        * virtual method call for syntactical reasons. */
       if (!is_void)
-	Printf(w->code, "return %s;", qualified_return);
+        Printf(w->code, "return %s;", qualified_return);
       else if (!ignored_method)
-	Printf(w->code, "return;\n");
+        Printf(w->code, "return;\n");
     }
 
     if (!ignored_method) {
@@ -4232,15 +4232,15 @@ public:
     String *jdesc;
 
     if ((tm = Swig_typemap_lookup("directorin", tp, "", 0))
-	&& (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
+        && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))) {
       String *jni_canon = canonicalizeJNIDescriptor(jdesc, tp);
       Append(jnidesc, jni_canon);
       Delete(jni_canon);
       Delete(tm);
     } else {
       Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-		   "No or improper directorin typemap for type %s  for use in %s::%s (skipping director method)\n", 
-		   SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                   "No or improper directorin typemap for type %s  for use in %s::%s (skipping director method)\n", 
+                   SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
       output_director = false;
     }
 
@@ -4250,7 +4250,7 @@ public:
     for (i = 0, p = l; p; ++i) {
       /* Is this superfluous? */
       while (checkAttribute(p, "tmap:directorin:numinputs", "0")) {
-	p = Getattr(p, "tmap:directorin:next");
+        p = Getattr(p, "tmap:directorin:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -4270,105 +4270,105 @@ public:
 
       /* Get parameter's intermediary C type */
       if ((c_param_type = Getattr(p, "tmap:jni"))) {
-	Parm *tp = NewParm(c_param_type, Getattr(p, "name"), n);
-	String *desc_tm = NULL, *jdesc = NULL, *cdesc = NULL;
+        Parm *tp = NewParm(c_param_type, Getattr(p, "name"), n);
+        String *desc_tm = NULL, *jdesc = NULL, *cdesc = NULL;
 
-	/* Add to local variables */
-	Printf(c_decl, "%s %s", c_param_type, arg);
-	if (!ignored_method)
-	  Wrapper_add_localv(w, arg, c_decl, (!(SwigType_ispointer(pt) || SwigType_isreference(pt)) ? "" : "= 0"), NIL);
+        /* Add to local variables */
+        Printf(c_decl, "%s %s", c_param_type, arg);
+        if (!ignored_method)
+          Wrapper_add_localv(w, arg, c_decl, (!(SwigType_ispointer(pt) || SwigType_isreference(pt)) ? "" : "= 0"), NIL);
 
-	/* Add input marshalling code and update JNI field descriptor */
-	if ((desc_tm = Swig_typemap_lookup("directorin", tp, "", 0))
-	    && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))
-	    && (tm = Getattr(p, "tmap:directorin"))
-	    && (cdesc = Getattr(p, "tmap:directorin:descriptor"))) {
+        /* Add input marshalling code and update JNI field descriptor */
+        if ((desc_tm = Swig_typemap_lookup("directorin", tp, "", 0))
+            && (jdesc = Getattr(tp, "tmap:directorin:descriptor"))
+            && (tm = Getattr(p, "tmap:directorin"))
+            && (cdesc = Getattr(p, "tmap:directorin:descriptor"))) {
 
-	  // Objects marshalled by passing a Java class across the JNI boundary use jobject as the JNI type - 
-	  // the nouse flag indicates this. We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
-	  if (GetFlag(tp, "tmap:directorin:nouse"))
-	    jdesc = cdesc;
-	  String *jni_canon = canonicalizeJNIDescriptor(jdesc, tp);
-	  Append(jnidesc, jni_canon);
-	  Delete(jni_canon);
+          // Objects marshalled by passing a Java class across the JNI boundary use jobject as the JNI type - 
+          // the nouse flag indicates this. We need the specific Java class name instead of the generic 'Ljava/lang/Object;'
+          if (GetFlag(tp, "tmap:directorin:nouse"))
+            jdesc = cdesc;
+          String *jni_canon = canonicalizeJNIDescriptor(jdesc, tp);
+          Append(jnidesc, jni_canon);
+          Delete(jni_canon);
 
-	  Setattr(p, "emit:directorinput", arg);
-	  Replaceall(tm, "$input", arg);
-	  Replaceall(tm, "$owner", "0");
+          Setattr(p, "emit:directorinput", arg);
+          Replaceall(tm, "$input", arg);
+          Replaceall(tm, "$owner", "0");
 
-	  if (Len(tm))
-	    if (!ignored_method)
-	      Printf(w->code, "%s\n", tm);
+          if (Len(tm))
+            if (!ignored_method)
+              Printf(w->code, "%s\n", tm);
 
-	  /* Add parameter to the intermediate class code if generating the
-	   * intermediate's upcall code */
-	  if ((tm = Getattr(p, "tmap:jtype"))) {
-	    String *din = Copy(Getattr(p, "tmap:javadirectorin"));
+          /* Add parameter to the intermediate class code if generating the
+           * intermediate's upcall code */
+          if ((tm = Getattr(p, "tmap:jtype"))) {
+            String *din = Copy(Getattr(p, "tmap:javadirectorin"));
             addThrows(n, "tmap:javadirectorin", p);
 
-	    if (din) {
-	      Replaceall(din, "$module", module_class_name);
-	      Replaceall(din, "$imclassname", imclass_name);
-	      substituteClassname(pt, din);
-	      Replaceall(din, "$jniinput", ln);
+            if (din) {
+              Replaceall(din, "$module", module_class_name);
+              Replaceall(din, "$imclassname", imclass_name);
+              substituteClassname(pt, din);
+              Replaceall(din, "$jniinput", ln);
 
-	      if (i > 0)
-		Printf(imcall_args, ", ");
-	      Printf(callback_def, ", %s %s", tm, ln);
+              if (i > 0)
+                Printf(imcall_args, ", ");
+              Printf(callback_def, ", %s %s", tm, ln);
 
-	      if (Cmp(din, ln)) {
-		Printv(imcall_args, din, NIL);
-	      } else
-		Printv(imcall_args, ln, NIL);
+              if (Cmp(din, ln)) {
+                Printv(imcall_args, din, NIL);
+              } else
+                Printv(imcall_args, ln, NIL);
 
-	      jni_canon = canonicalizeJNIDescriptor(cdesc, p);
-	      Append(classdesc, jni_canon);
-	      Delete(jni_canon);
-	    } else {
-	      Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number, "No javadirectorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-		  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	      output_director = false;
-	    }
-	  } else {
-	    Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s for use in %s::%s (skipping director method)\n", 
-		SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    output_director = false;
-	  }
+              jni_canon = canonicalizeJNIDescriptor(cdesc, p);
+              Append(classdesc, jni_canon);
+              Delete(jni_canon);
+            } else {
+              Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number, "No javadirectorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                  SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+              output_director = false;
+            }
+          } else {
+            Swig_warning(WARN_JAVA_TYPEMAP_JTYPE_UNDEF, input_file, line_number, "No jtype typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            output_director = false;
+          }
 
-	  p = Getattr(p, "tmap:directorin:next");
+          p = Getattr(p, "tmap:directorin:next");
 
-	  Delete(desc_tm);
-	} else {
-	  if (!desc_tm) {
-	    Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
-			 "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-			 SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    p = nextSibling(p);
-	  } else if (!jdesc) {
-	    Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
-			 "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-			 SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    p = Getattr(p, "tmap:directorin:next");
-	  } else if (!tm) {
-	    Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
-			 "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n", 
-			 SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    p = nextSibling(p);
-	  } else if (!cdesc) {
-	    Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
-			 "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
-			 SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    p = Getattr(p, "tmap:directorin:next");
-	  }
+          Delete(desc_tm);
+        } else {
+          if (!desc_tm) {
+            Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
+                         "No or improper directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                         SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            p = nextSibling(p);
+          } else if (!jdesc) {
+            Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
+                         "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                         SwigType_str(c_param_type, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            p = Getattr(p, "tmap:directorin:next");
+          } else if (!tm) {
+            Swig_warning(WARN_JAVA_TYPEMAP_JAVADIRECTORIN_UNDEF, input_file, line_number,
+                         "No or improper directorin typemap defined for argument %s for use in %s::%s (skipping director method)\n", 
+                         SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            p = nextSibling(p);
+          } else if (!cdesc) {
+            Swig_warning(WARN_JAVA_TYPEMAP_DIRECTORIN_NODESC, input_file, line_number,
+                         "Missing JNI descriptor in directorin typemap defined for %s for use in %s::%s (skipping director method)\n", 
+                         SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            p = Getattr(p, "tmap:directorin:next");
+          }
 
-	  output_director = false;
-	}
+          output_director = false;
+        }
 
       } else {
-	Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n", 
-	    SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	output_director = false;
-	p = nextSibling(p);
+        Swig_warning(WARN_JAVA_TYPEMAP_JNI_UNDEF, input_file, line_number, "No jni typemap defined for %s for use in %s::%s (skipping director method)\n", 
+            SwigType_str(pt, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+        output_director = false;
+        p = nextSibling(p);
       }
 
       Delete(arg);
@@ -4398,7 +4398,7 @@ public:
       Swig_typemap_attach_parms("throws", catches_list, 0);
       Swig_typemap_attach_parms("directorthrows", catches_list, 0);
       for (p = catches_list; p; p = nextSibling(p)) {
-	addThrows(n, "tmap:throws", p);
+        addThrows(n, "tmap:throws", p);
       }
     }
 
@@ -4413,24 +4413,24 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list) {
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
-	Swig_typemap_attach_parms("directorthrows", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("directorthrows", throw_parm_list, 0);
       }
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  // %catches replaces the specified exception specification
-	  if (!catches_list) {
-	    addThrows(n, "tmap:throws", p);
-	  }
+        if (Getattr(p, "tmap:throws")) {
+          // %catches replaces the specified exception specification
+          if (!catches_list) {
+            addThrows(n, "tmap:throws", p);
+          }
 
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
 
-	  Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
-	  Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
-	}
+          Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
+          Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
+        }
       }
 
       Append(w->def, ")");
@@ -4450,10 +4450,10 @@ public:
     if (!is_void) {
       if ((tm = Swig_typemap_lookup("javadirectorout", n, "", 0))) {
         addThrows(n, "tmap:javadirectorout", n);
-	substituteClassname(returntype, tm);
-	Replaceall(tm, "$javacall", upcall);
+        substituteClassname(returntype, tm);
+        Replaceall(tm, "$javacall", upcall);
 
-	Printf(callback_code, "    return %s;\n", tm);
+        Printf(callback_code, "    return %s;\n", tm);
       }
 
       if ((tm = Swig_typemap_lookup("out", n, "", 0)))
@@ -4480,7 +4480,7 @@ public:
       String *methop = getUpcallJNIMethod(jniret_desc);
 
       if (!is_void)
-	Printf(w->code, "jresult = (%s) ", c_ret_type);
+        Printf(w->code, "jresult = (%s) ", c_ret_type);
 
       Printf(w->code, "jenv->%s(Swig::jclass_%s, Swig::director_method_ids[%s], %s);\n", methop, imclass_name, methid, jupcall_args);
 
@@ -4488,37 +4488,37 @@ public:
       directorExceptHandler(n, catches_list ? catches_list : throw_parm_list, w);
 
       if (!is_void) {
-	String *jresult_str = NewString("jresult");
-	String *result_str = NewString("c_result");
+        String *jresult_str = NewString("jresult");
+        String *result_str = NewString("c_result");
 
-	/* Copy jresult into c_result... */
-	if ((tm = Swig_typemap_lookup("directorout", n, result_str, w))) {
-	  addThrows(n, "tmap:directorout", n);
-	  Replaceall(tm, "$input", jresult_str);
-	  Replaceall(tm, "$result", result_str);
-	  Printf(w->code, "%s\n", tm);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		       "Unable to use return type %s used in %s::%s (skipping director method)\n", 
-		       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	  output_director = false;
-	}
+        /* Copy jresult into c_result... */
+        if ((tm = Swig_typemap_lookup("directorout", n, result_str, w))) {
+          addThrows(n, "tmap:directorout", n);
+          Replaceall(tm, "$input", jresult_str);
+          Replaceall(tm, "$result", result_str);
+          Printf(w->code, "%s\n", tm);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                       "Unable to use return type %s used in %s::%s (skipping director method)\n", 
+                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+          output_director = false;
+        }
 
-	Delete(jresult_str);
-	Delete(result_str);
+        Delete(jresult_str);
+        Delete(result_str);
       }
 
       /* Marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout"))) {
-	  addThrows(n, "tmap:directorargout", p);
-	  Replaceall(tm, "$result", makeParameterName(n, p, i, false));
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout"))) {
+          addThrows(n, "tmap:directorargout", p);
+          Replaceall(tm, "$result", makeParameterName(n, p, i, false));
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       Delete(imclass_desc);
@@ -4527,13 +4527,13 @@ public:
       /* Terminate wrapper code */
       Printf(w->code, "} else {\n");
       Printf(w->code, "SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, \"null upcall object in %s::%s \");\n",
-	     SwigType_namestr(c_classname), SwigType_namestr(name));
+             SwigType_namestr(c_classname), SwigType_namestr(name));
       Printf(w->code, "}\n");
 
       Printf(w->code, "if (swigjobj) jenv->DeleteLocalRef(swigjobj);\n");
 
       if (!is_void)
-	Printf(w->code, "return %s;", qualified_return);
+        Printf(w->code, "return %s;", qualified_return);
     }
 
     Printf(w->code, "}");
@@ -4546,7 +4546,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -4556,18 +4556,18 @@ public:
     /* emit the director method */
     if (status == SWIG_OK && output_director) {
       if (!is_void) {
-	Replaceall(w->code, "$null", qualified_return);
+        Replaceall(w->code, "$null", qualified_return);
       } else {
-	Replaceall(w->code, "$null", "");
+        Replaceall(w->code, "$null", "");
       }
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!GetFlag(n, "feature:ignore"))
-	Printv(imclass_directors, callback_def, callback_code, NIL);
+        Printv(imclass_directors, callback_def, callback_code, NIL);
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 
@@ -4614,23 +4614,23 @@ public:
 
       // Replace $directorthrowshandlers with any defined typemap handlers (or nothing)
       if (Strstr(directorexcept, "$directorthrowshandlers")) {
-	String *directorthrowshandlers_code = NewString("");
+        String *directorthrowshandlers_code = NewString("");
 
-	for (Parm *p = throw_parm_list; p; p = nextSibling(p)) {
-	  String *tm = Getattr(p, "tmap:directorthrows");
+        for (Parm *p = throw_parm_list; p; p = nextSibling(p)) {
+          String *tm = Getattr(p, "tmap:directorthrows");
 
-	  if (tm) {
-	    // replace $packagepath/$javaclassname
-	    String *directorthrows = canonicalizeJNIDescriptor(tm, p);
-	    Printv(directorthrowshandlers_code, directorthrows, NIL);
-	    Delete(directorthrows);
-	  } else {
-	    String *t = Getattr(p,"type");
-	    Swig_warning(WARN_TYPEMAP_DIRECTORTHROWS_UNDEF, Getfile(n), Getline(n), "No directorthrows typemap defined for %s\n", SwigType_str(t, 0));
-	  }
-	}
-	Replaceall(directorexcept, "$directorthrowshandlers", directorthrowshandlers_code);
-	Delete(directorthrowshandlers_code);
+          if (tm) {
+            // replace $packagepath/$javaclassname
+            String *directorthrows = canonicalizeJNIDescriptor(tm, p);
+            Printv(directorthrowshandlers_code, directorthrows, NIL);
+            Delete(directorthrows);
+          } else {
+            String *t = Getattr(p,"type");
+            Swig_warning(WARN_TYPEMAP_DIRECTORTHROWS_UNDEF, Getfile(n), Getline(n), "No directorthrows typemap defined for %s\n", SwigType_str(t, 0));
+          }
+        }
+        Replaceall(directorexcept, "$directorthrowshandlers", directorthrowshandlers_code);
+        Delete(directorthrowshandlers_code);
       }
 
       Replaceall(directorexcept, "$error", "swigerror");
@@ -4674,8 +4674,8 @@ public:
       String *pname = Getattr(p, "name");
 
       if (!pname) {
-	pname = NewStringf("arg%d", argidx++);
-	Setattr(p, "name", pname);
+        pname = NewStringf("arg%d", argidx++);
+        Setattr(p, "name", pname);
       }
     }
 
@@ -4693,24 +4693,24 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, dirclassname, parms, 0);
-	String *call = Swig_csuperclass_call(0, basetype, superparms);
-	String *classtype = SwigType_namestr(Getattr(n, "name"));
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, dirclassname, parms, 0);
+        String *call = Swig_csuperclass_call(0, basetype, superparms);
+        String *classtype = SwigType_namestr(Getattr(n, "name"));
 
-	Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
-	Printf(f_directors, "}\n\n");
+        Printf(f_directors, "%s::%s : %s, %s {\n", dirclassname, target, call, Getattr(parent, "director:ctor"));
+        Printf(f_directors, "}\n\n");
 
-	Delete(classtype);
-	Delete(target);
-	Delete(call);
+        Delete(classtype);
+        Delete(target);
+        Delete(call);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, dirclassname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, dirclassname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -4871,18 +4871,18 @@ public:
       if (GetFlag(n, "feature:director:assumeoverride")) {
         Printf(w->code, "  swig_override[i] = derived;\n");
       } else {
-	Printf(w->def, "static SwigDirectorMethod methods[] = {\n");
+        Printf(w->def, "static SwigDirectorMethod methods[] = {\n");
 
-	for (int i = first_class_dmethod; i < curr_class_dmethod; ++i) {
-	  UpcallData *udata = Getitem(dmethods_seq, i);
+        for (int i = first_class_dmethod; i < curr_class_dmethod; ++i) {
+          UpcallData *udata = Getitem(dmethods_seq, i);
 
-	  Printf(w->def, "SwigDirectorMethod(jenv, baseclass, \"%s\", \"%s\")", Getattr(udata, "method"), Getattr(udata, "fdesc"));
-	  if (i != curr_class_dmethod - 1)
-	    Putc(',', w->def);
-	  Putc('\n', w->def);
-	}
+          Printf(w->def, "SwigDirectorMethod(jenv, baseclass, \"%s\", \"%s\")", Getattr(udata, "method"), Getattr(udata, "fdesc"));
+          if (i != curr_class_dmethod - 1)
+            Putc(',', w->def);
+          Putc('\n', w->def);
+        }
 
-	Printf(w->def, "};");
+        Printf(w->def, "};");
 
         Printf(w->code, "  swig_override[i] = false;\n");
         Printf(w->code, "  if (derived) {\n");

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -14,7 +14,7 @@
 #include "swigmod.h"
 #include "cparse.h"
 #include <errno.h>
-#include <limits.h>		// for INT_MAX
+#include <limits.h>             // for INT_MAX
 #include <ctype.h>
 #include "javadoc.h"
 
@@ -38,53 +38,53 @@ class JAVA:public Language {
   File *f_directors_h;
   List *filenames_list;
 
-  bool proxy_flag;		// Flag for generating proxy classes
-  bool nopgcpp_flag;		// Flag for suppressing the premature garbage collection prevention parameter
-  bool native_function_flag;	// Flag for when wrapping a native function
-  bool enum_constant_flag;	// Flag for when wrapping an enum or constant
-  bool static_flag;		// Flag for when wrapping a static functions or member variables
-  bool variable_wrapper_flag;	// Flag for when wrapping a nonstatic member variable
-  bool wrapping_member_flag;	// Flag for when wrapping a member variable/enum/const
-  bool global_variable_flag;	// Flag for when wrapping a global variable
-  bool old_variable_names;	// Flag for old style variable names in the intermediary class
-  bool member_func_flag;	// flag set when wrapping a member function
-  bool doxygen;			//flag for converting found doxygen to javadoc
+  bool proxy_flag;              // Flag for generating proxy classes
+  bool nopgcpp_flag;            // Flag for suppressing the premature garbage collection prevention parameter
+  bool native_function_flag;    // Flag for when wrapping a native function
+  bool enum_constant_flag;      // Flag for when wrapping an enum or constant
+  bool static_flag;             // Flag for when wrapping a static functions or member variables
+  bool variable_wrapper_flag;   // Flag for when wrapping a nonstatic member variable
+  bool wrapping_member_flag;    // Flag for when wrapping a member variable/enum/const
+  bool global_variable_flag;    // Flag for when wrapping a global variable
+  bool old_variable_names;      // Flag for old style variable names in the intermediary class
+  bool member_func_flag;        // flag set when wrapping a member function
+  bool doxygen;                 //flag for converting found doxygen to javadoc
   bool comment_creation_chatter; //flag for getting information about where comments were created in java.cxx
 
-  String *imclass_name;		// intermediary class name
-  String *module_class_name;	// module class name
-  String *constants_interface_name;	// constants interface name
-  String *imclass_class_code;	// intermediary class code
+  String *imclass_name;         // intermediary class name
+  String *module_class_name;    // module class name
+  String *constants_interface_name;     // constants interface name
+  String *imclass_class_code;   // intermediary class code
   String *proxy_class_def;
   String *proxy_class_code;
   String *interface_class_code; // if %feature("interface") was declared for a class, here goes the interface declaration
   String *module_class_code;
-  String *proxy_class_name;	// proxy class name
+  String *proxy_class_name;     // proxy class name
   String *full_proxy_class_name;// fully qualified proxy class name when using nspace feature, otherwise same as proxy_class_name
-  String *full_imclass_name;	// fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
-  String *variable_name;	//Name of a variable being wrapped
+  String *full_imclass_name;    // fully qualified intermediary class name when using nspace feature, otherwise same as imclass_name
+  String *variable_name;        //Name of a variable being wrapped
   String *proxy_class_constants_code;
   String *module_class_constants_code;
   String *common_begin_code;
   String *enum_code;
-  String *package;		// Optional package name
-  String *jnipackage;		// Package name used in the JNI code
-  String *package_path;		// Package name used internally by JNI (slashes)
-  String *imclass_imports;	//intermediary class imports from %pragma
-  String *module_imports;	//module imports from %pragma
-  String *imclass_baseclass;	//inheritance for intermediary class class from %pragma
-  String *imclass_package;	//package in which to generate the intermediary class
-  String *module_baseclass;	//inheritance for module class from %pragma
-  String *imclass_interfaces;	//interfaces for intermediary class class from %pragma
-  String *module_interfaces;	//interfaces for module class from %pragma
-  String *imclass_class_modifiers;	//class modifiers for intermediary class overridden by %pragma
-  String *module_class_modifiers;	//class modifiers for module class overridden by %pragma
-  String *constants_modifiers;	//access modifiers for constants interface overridden by %pragma
-  String *upcasts_code;		//C++ casts for inheritance hierarchies C++ code
-  String *imclass_cppcasts_code;	//C++ casts up inheritance hierarchies intermediary class code
-  String *imclass_directors;	// Intermediate class director code
-  String *destructor_call;	//C++ destructor call if any
-  String *destructor_throws_clause;	//C++ destructor throws clause if any
+  String *package;              // Optional package name
+  String *jnipackage;           // Package name used in the JNI code
+  String *package_path;         // Package name used internally by JNI (slashes)
+  String *imclass_imports;      //intermediary class imports from %pragma
+  String *module_imports;       //module imports from %pragma
+  String *imclass_baseclass;    //inheritance for intermediary class class from %pragma
+  String *imclass_package;      //package in which to generate the intermediary class
+  String *module_baseclass;     //inheritance for module class from %pragma
+  String *imclass_interfaces;   //interfaces for intermediary class class from %pragma
+  String *module_interfaces;    //interfaces for module class from %pragma
+  String *imclass_class_modifiers;      //class modifiers for intermediary class overridden by %pragma
+  String *module_class_modifiers;       //class modifiers for module class overridden by %pragma
+  String *constants_modifiers;  //access modifiers for constants interface overridden by %pragma
+  String *upcasts_code;         //C++ casts for inheritance hierarchies C++ code
+  String *imclass_cppcasts_code;        //C++ casts up inheritance hierarchies intermediary class code
+  String *imclass_directors;    // Intermediate class director code
+  String *destructor_call;      //C++ destructor call if any
+  String *destructor_throws_clause;     //C++ destructor throws clause if any
 
   // Director method stuff:
   List *dmethods_seq;
@@ -1001,7 +1001,7 @@ public:
       // Get typemap for this argument
       if ((tm = Getattr(p, "tmap:in"))) {
         addThrows(n, "tmap:in", p);
-        Replaceall(tm, "$arg", arg);	/* deprecated? */
+        Replaceall(tm, "$arg", arg);    /* deprecated? */
         Replaceall(tm, "$input", arg);
         Setattr(p, "emit:input", arg);
 
@@ -1025,7 +1025,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
         addThrows(n, "tmap:check", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(f->code, tm, "\n", NIL);
         p = Getattr(p, "tmap:check:next");
@@ -1038,7 +1038,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
         addThrows(n, "tmap:freearg", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(cleanup, tm, "\n", NIL);
         p = Getattr(p, "tmap:freearg:next");
@@ -1051,7 +1051,7 @@ public:
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
         addThrows(n, "tmap:argout", p);
-        Replaceall(tm, "$arg", Getattr(p, "emit:input"));	/* deprecated? */
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));       /* deprecated? */
         Replaceall(tm, "$result", "jresult");
         Replaceall(tm, "$input", Getattr(p, "emit:input"));
         Printv(outarg, tm, "\n", NIL);
@@ -1196,7 +1196,7 @@ public:
 
   virtual int variableWrapper(Node *n) {
     variable_wrapper_flag = true;
-    Language::variableWrapper(n);	/* Default to functions */
+    Language::variableWrapper(n);       /* Default to functions */
     variable_wrapper_flag = false;
     return SWIG_OK;
   }
@@ -1281,9 +1281,9 @@ public:
         const String *pure_interfaces = typemapLookup(n, "javainterfaces", typemap_lookup_type, WARN_NONE);
 
         // Emit the enum
-        Printv(enum_code, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers (enum modifiers really)
-               " ", symname, *Char(pure_baseclass) ?	// Bases
-               " extends " : "", pure_baseclass, *Char(pure_interfaces) ?	// Interfaces
+        Printv(enum_code, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),        // Class modifiers (enum modifiers really)
+               " ", symname, *Char(pure_baseclass) ?    // Bases
+               " extends " : "", pure_baseclass, *Char(pure_interfaces) ?       // Interfaces
                " implements " : "", pure_interfaces, " {\n", NIL);
         if (proxy_flag && is_wrapping_class())
           Replaceall(enum_code, "$static ", "static ");
@@ -1322,8 +1322,8 @@ public:
         // Wrap (non-anonymous) C/C++ enum within a typesafe, typeunsafe or proper Java enum
         // Finish the enum declaration
         // Typemaps are used to generate the enum definition in a similar manner to proxy classes.
-        Printv(enum_code, (enum_feature == ProperEnum) ? ";\n" : "", typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
-               typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),	// extra Java code
+        Printv(enum_code, (enum_feature == ProperEnum) ? ";\n" : "", typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),       // main body of class
+               typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),    // extra Java code
                "}", NIL);
 
         Replaceall(enum_code, "$javaclassname", symname);
@@ -1998,11 +1998,11 @@ public:
 
     if (has_outerclass)
       Printv(proxy_class_def, "static ", NIL); // C++ nested classes correspond to static java classes
-    Printv(proxy_class_def, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-           " $javaclassname",	// Class name and bases
-           (*Char(wanted_base)) ? " extends " : "", wanted_base, *Char(interface_list) ?	// Pure Java interfaces
-           " implements " : "", interface_list, " {", derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :	// main body of class
-           typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
+    Printv(proxy_class_def, typemapLookup(n, "javaclassmodifiers", typemap_lookup_type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),      // Class modifiers
+           " $javaclassname",   // Class name and bases
+           (*Char(wanted_base)) ? " extends " : "", wanted_base, *Char(interface_list) ?        // Pure Java interfaces
+           " implements " : "", interface_list, " {", derived ? typemapLookup(n, "javabody_derived", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF) :   // main body of class
+           typemapLookup(n, "javabody", typemap_lookup_type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF), // main body of class
            NIL);
 
     // C++ destructor is wrapped by the delete method
@@ -2085,7 +2085,7 @@ public:
     Delete(destruct);
 
     // Emit extra user code
-    Printv(proxy_class_def, typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),	// extra Java code
+    Printv(proxy_class_def, typemapLookup(n, "javacode", typemap_lookup_type, WARN_NONE),       // extra Java code
            "\n", NIL);
 
     if (derived) {
@@ -3270,7 +3270,7 @@ public:
         // Get the enumvalue from a JNI call
         if (!getCurrentClass() || !cparse_cplusplus || !proxy_flag) {
           // Strange hack to change the name
-          Setattr(n, "name", Getattr(n, "value"));	/* for wrapping of enums in a namespace when emit_action is used */
+          Setattr(n, "name", Getattr(n, "value"));      /* for wrapping of enums in a namespace when emit_action is used */
           constantWrapper(n);
           value = NewStringf("%s.%s()", full_imclass_name ? full_imclass_name : imclass_name, Swig_name_get(getNSpace(), symname));
         } else {
@@ -3517,12 +3517,12 @@ public:
     const String *pure_interfaces = typemapLookup(n, "javainterfaces", type, WARN_NONE);
 
     // Emit the class
-    Printv(swigtype, typemapLookup(n, "javaimports", type, WARN_NONE),	// Import statements
-           "\n", typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),	// Class modifiers
-           " $javaclassname",	// Class name and bases
-           *Char(pure_baseclass) ? " extends " : "", pure_baseclass, *Char(pure_interfaces) ?	// Interfaces
-           " implements " : "", pure_interfaces, " {", typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),	// main body of class
-           typemapLookup(n, "javacode", type, WARN_NONE),	// extra Java code
+    Printv(swigtype, typemapLookup(n, "javaimports", type, WARN_NONE),  // Import statements
+           "\n", typemapLookup(n, "javaclassmodifiers", type, WARN_JAVA_TYPEMAP_CLASSMOD_UNDEF),        // Class modifiers
+           " $javaclassname",   // Class name and bases
+           *Char(pure_baseclass) ? " extends " : "", pure_baseclass, *Char(pure_interfaces) ?   // Interfaces
+           " implements " : "", pure_interfaces, " {", typemapLookup(n, "javabody", type, WARN_JAVA_TYPEMAP_JAVABODY_UNDEF),    // main body of class
+           typemapLookup(n, "javacode", type, WARN_NONE),       // extra Java code
            "}\n", "\n", NIL);
 
     Replaceall(swigtype, "$javaclassname", classname);
@@ -3592,8 +3592,8 @@ public:
       if (temp_classes_list && Len(temp_classes_list) > 0) {
         for (Iterator cls = First(temp_classes_list); cls.item; cls = Next(cls)) {
           String *exception_class = NewString(cls.item);
-          Replaceall(exception_class, " ", "");	// remove spaces
-          Replaceall(exception_class, "\t", "");	// remove tabs
+          Replaceall(exception_class, " ", ""); // remove spaces
+          Replaceall(exception_class, "\t", "");        // remove tabs
           if (Len(exception_class) > 0) {
             // $javaclassname substitution
             SwigType *pt = Getattr(parameter, "type");
@@ -4752,7 +4752,7 @@ public:
 
   int classDirectorInit(Node *n) {
     Delete(none_comparison);
-    none_comparison = NewString("");	// not used
+    none_comparison = NewString("");    // not used
 
     Delete(director_ctor_code);
     director_ctor_code = NewString("$director_new");
@@ -4956,7 +4956,7 @@ public:
   NestedClassSupport nestedClassesSupport() const {
     return NCS_Full;
   }
-};				/* class JAVA */
+};                              /* class JAVA */
 
 /* -----------------------------------------------------------------------------
  * swig_java()    - Instantiate module

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -1306,7 +1306,7 @@ int JSEmitter::emitFunctionDispatcher(Node *n, bool is_member) {
   Node *sibl = n;
 
   while (Getattr(sibl, "sym:previousSibling"))
-    sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+    sibl = Getattr(sibl, "sym:previousSibling");        // go all the way up
 
   do {
     String *siblname = Getattr(sibl, "wrap:name");

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -557,39 +557,39 @@ void JAVASCRIPT::main(int argc, char *argv[]) {
   for (int i = 1; i < argc; i++) {
     if (argv[i]) {
       if (strcmp(argv[i], "-v8") == 0) {
-	if (engine != -1) {
-	  Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
-	  Exit(EXIT_FAILURE);
-	}
-	Swig_mark_arg(i);
-	engine = JSEmitter::V8;
+        if (engine != -1) {
+          Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
+          Exit(EXIT_FAILURE);
+        }
+        Swig_mark_arg(i);
+        engine = JSEmitter::V8;
       } else if (strcmp(argv[i], "-jsc") == 0) {
-	if (engine != -1) {
-	  Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
-	  Exit(EXIT_FAILURE);
-	}
-	Swig_mark_arg(i);
-	engine = JSEmitter::JavascriptCore;
+        if (engine != -1) {
+          Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
+          Exit(EXIT_FAILURE);
+        }
+        Swig_mark_arg(i);
+        engine = JSEmitter::JavascriptCore;
       } else if (strcmp(argv[i], "-node") == 0) {
-	if (engine != -1) {
-	  Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
-	  Exit(EXIT_FAILURE);
-	}
-	Swig_mark_arg(i);
-	engine = JSEmitter::NodeJS;
+        if (engine != -1) {
+          Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
+          Exit(EXIT_FAILURE);
+        }
+        Swig_mark_arg(i);
+        engine = JSEmitter::NodeJS;
       } else if (strcmp(argv[i], "-napi") == 0) {
-	if (engine != -1) {
-	  Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
-	  Exit(EXIT_FAILURE);
-	}
-	Swig_mark_arg(i);
-	engine = JSEmitter::NAPI;
+        if (engine != -1) {
+          Printf(stderr, ERR_MSG_ONLY_ONE_ENGINE_PLEASE);
+          Exit(EXIT_FAILURE);
+        }
+        Swig_mark_arg(i);
+        engine = JSEmitter::NAPI;
       } else if (strcmp(argv[i], "-debug-codetemplates") == 0) {
-	Swig_mark_arg(i);
-	js_template_enable_debug = true;
+        Swig_mark_arg(i);
+        js_template_enable_debug = true;
       } else if (strcmp(argv[i], "-help") == 0) {
-	fputs(usage, stdout);
-	return;
+        fputs(usage, stdout);
+        return;
       }
     }
   }
@@ -603,10 +603,10 @@ void JAVASCRIPT::main(int argc, char *argv[]) {
       SWIG_library_directory("javascript/v8");
       // V8 API is C++, so output must be C++ compatible even when wrapping C code
       if (!cparse_cplusplus) {
-	Swig_cparse_cplusplusout(1);
+        Swig_cparse_cplusplusout(1);
       }
       if (engine == JSEmitter::NodeJS) {
-	Preprocessor_define("BUILDING_NODE_EXTENSION 1", 0);
+        Preprocessor_define("BUILDING_NODE_EXTENSION 1", 0);
       }
       break;
     }
@@ -624,7 +624,7 @@ void JAVASCRIPT::main(int argc, char *argv[]) {
       SWIG_library_directory("javascript/napi");
       Preprocessor_define("BUILDING_NODE_EXTENSION 1", 0);
       if (!cparse_cplusplus) {
-	Swig_cparse_cplusplusout(1);
+        Swig_cparse_cplusplusout(1);
       }
       break;
     }
@@ -761,10 +761,10 @@ int JSEmitter::emitWrapperFunction(Node *n) {
   if (kind) {
 
     if (Equal(kind, "function")
-	// HACK: sneaky.ctest revealed that typedef'd (global) functions must be
-	// detected via the 'view' attribute.
-	|| (Equal(kind, "variable") && Equal(Getattr(n, "view"), "globalfunctionHandler"))
-	) {
+        // HACK: sneaky.ctest revealed that typedef'd (global) functions must be
+        // detected via the 'view' attribute.
+        || (Equal(kind, "variable") && Equal(Getattr(n, "view"), "globalfunctionHandler"))
+        ) {
       bool is_member = GetFlag(n, "ismember") != 0 || GetFlag(n, "feature:extend") != 0;
       bool is_static = GetFlag(state.function(), IS_STATIC) != 0;
       ret = emitFunction(n, is_member, is_static);
@@ -772,16 +772,16 @@ int JSEmitter::emitWrapperFunction(Node *n) {
       bool is_static = GetFlag(state.variable(), IS_STATIC) != 0;
       // HACK: smartpointeraccessed static variables are not treated as statics
       if (GetFlag(n, "allocate:smartpointeraccess")) {
-	is_static = false;
+        is_static = false;
       }
 
       bool is_member = GetFlag(n, "ismember") != 0;
       bool is_setter = GetFlag(n, "memberset") != 0 || GetFlag(n, "varset") != 0;
       bool is_getter = GetFlag(n, "memberget") != 0 || GetFlag(n, "varget") != 0;
       if (is_setter) {
-	ret = emitSetter(n, is_member, is_static);
+        ret = emitSetter(n, is_member, is_static);
       } else if (is_getter) {
-	ret = emitGetter(n, is_member, is_static);
+        ret = emitGetter(n, is_member, is_static);
       }
 
     } else {
@@ -979,11 +979,11 @@ int JSEmitter::emitCtor(Node *n) {
       String *wrap_name = Swig_name_wrapper(Getattr(n, "sym:name"));
       Template t_mainctor(getTemplate("js_ctor_dispatcher"));
       t_mainctor.replace("$jswrapper", wrap_name)
-	  .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-	  .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsdispatchcases", state.clazz(CTOR_DISPATCHERS))
-	  .replace("$jsparent", state.clazz(PARENT_MANGLED))
-	  .pretty_print(f_wrappers);
+          .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+          .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+          .replace("$jsdispatchcases", state.clazz(CTOR_DISPATCHERS))
+          .replace("$jsparent", state.clazz(PARENT_MANGLED))
+          .pretty_print(f_wrappers);
       state.clazz(CTOR, wrap_name);
     }
   } else {
@@ -1094,9 +1094,9 @@ int JSEmitter::emitDtor(Node *n) {
     Template t_dtor = getTemplate("js_dtoroverride");
     state.clazz(DTOR, wrap_name);
     t_dtor.replace("${classname_mangled}", state.clazz(NAME_MANGLED))
-	.replace("$jswrapper", wrap_name)
-	.replace("$jsfree", jsfree)
-	.replace("$jstype", ctype);
+        .replace("$jswrapper", wrap_name)
+        .replace("$jsfree", jsfree)
+        .replace("$jstype", ctype);
 
     t_dtor.replace("${destructor_action}", destructor_action);
     Wrapper_pretty_print(t_dtor.str(), f_wrappers);
@@ -1104,10 +1104,10 @@ int JSEmitter::emitDtor(Node *n) {
     Template t_dtor = getTemplate("js_dtor");
     state.clazz(DTOR, wrap_name);
     t_dtor.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	.replace("$jswrapper", wrap_name)
-	.replace("$jsfree", jsfree)
-	.replace("$jstype", ctype)
-	.pretty_print(f_wrappers);
+        .replace("$jswrapper", wrap_name)
+        .replace("$jsfree", jsfree)
+        .replace("$jstype", ctype)
+        .pretty_print(f_wrappers);
   }
 
   Delete(p_classtype);
@@ -1315,8 +1315,8 @@ int JSEmitter::emitFunctionDispatcher(Node *n, bool is_member) {
       // handle function overloading
       Template t_dispatch_case = getTemplate("js_function_dispatch_case");
       t_dispatch_case.replace("$jswrapper", siblname)
-	  .replace("$jsargcount", Getattr(sibl, ARGCOUNT))
-	  .replace("$jsargrequired", Getattr(sibl, ARGREQUIRED));
+          .replace("$jsargcount", Getattr(sibl, ARGCOUNT))
+          .replace("$jsargrequired", Getattr(sibl, ARGREQUIRED));
 
       Append(wrapper->code, t_dispatch_case.str());
     }
@@ -1478,11 +1478,11 @@ void JSEmitter::marshalOutput(Node *n, ParmList *params, Wrapper *wrapper, Strin
   if (params) {
     for (p = params; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(wrapper->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(wrapper->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -1689,21 +1689,21 @@ void JSCEmitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, Ma
     case Getter:
     case Function:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "thisObject", 0);
-	i++;
+        Printv(arg, "thisObject", 0);
+        i++;
       } else {
-	Printf(arg, "argv[%d]", i - startIdx);
-	SetInt(p, INDEX, i - startIdx);
-	i += GetInt(p, "tmap:in:numinputs");
+        Printf(arg, "argv[%d]", i - startIdx);
+        SetInt(p, INDEX, i - startIdx);
+        i += GetInt(p, "tmap:in:numinputs");
       }
       break;
     case Setter:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "thisObject", 0);
-	i++;
+        Printv(arg, "thisObject", 0);
+        i++;
       } else {
-	Printv(arg, "value", 0);
-	i++;
+        Printv(arg, "value", 0);
+        i++;
       }
       break;
     case Ctor:
@@ -1867,7 +1867,7 @@ int JSCEmitter::exitVariable(Node *n) {
 
   if (GetFlag(n, "ismember")) {
     if (GetFlag(state.variable(), IS_STATIC)
-	|| Equal(Getattr(n, "nodeType"), "enumitem")) {
+        || Equal(Getattr(n, "nodeType"), "enumitem")) {
       t_variable.pretty_print(state.clazz(STATIC_VARIABLES));
     } else {
       t_variable.pretty_print(state.clazz(MEMBER_VARIABLES));
@@ -1910,8 +1910,8 @@ int JSCEmitter::exitClass(Node *n) {
   if (GetFlag(state.clazz(), IS_ABSTRACT)) {
     Template t_veto_ctor(getTemplate("js_veto_ctor"));
     t_veto_ctor.replace("$jswrapper", state.clazz(CTOR))
-	.replace("$jsname", state.clazz(NAME))
-	.pretty_print(f_wrappers);
+        .replace("$jsname", state.clazz(NAME))
+        .pretty_print(f_wrappers);
   }
 
   /* adds a class template statement to initializer function */
@@ -1923,12 +1923,12 @@ int JSCEmitter::exitClass(Node *n) {
   if (base_class != NULL) {
     Template t_inherit(getTemplate("jsc_class_inherit"));
     t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	.replace("$jsbaseclassmangled", SwigType_manglestr(Getattr(base_class, "name")))
-	.pretty_print(jsclass_inheritance);
+        .replace("$jsbaseclassmangled", SwigType_manglestr(Getattr(base_class, "name")))
+        .pretty_print(jsclass_inheritance);
   } else {
     Template t_inherit(getTemplate("jsc_class_noinherit"));
     t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	.pretty_print(jsclass_inheritance);
+        .pretty_print(jsclass_inheritance);
   }
 
   t_classtemplate.replace("$jsmangledname", state.clazz(NAME_MANGLED))
@@ -1973,10 +1973,10 @@ int JSCEmitter::emitNamespaces() {
 
     Template namespace_definition(getTemplate("jsc_nspace_declaration"));
     namespace_definition.replace("$jsglobalvariables", variables)
-	.replace("$jsglobalfunctions", functions)
-	.replace("$jsnspace", name_mangled)
-	.replace("$jsmangledname", name_mangled)
-	.pretty_print(f_wrap_cpp);
+        .replace("$jsglobalfunctions", functions)
+        .replace("$jsnspace", name_mangled)
+        .replace("$jsmangledname", name_mangled)
+        .pretty_print(f_wrap_cpp);
 
     Template t_createNamespace(getTemplate("jsc_nspace_definition"));
     t_createNamespace.replace("$jsmangledname", name_mangled);
@@ -1986,8 +1986,8 @@ int JSCEmitter::emitNamespaces() {
     if (!Equal("exports", name)) {
       Template t_registerNamespace(getTemplate("jsc_nspace_registration"));
       t_registerNamespace.replace("$jsmangledname", name_mangled)
-	  .replace("$jsname", name)
-	  .replace("$jsparent", parent_mangled);
+          .replace("$jsname", name)
+          .replace("$jsparent", parent_mangled);
       Append(state.globals(REGISTER_NAMESPACES), t_registerNamespace.str());
     }
   }
@@ -2176,8 +2176,8 @@ int V8Emitter::exitClass(Node *n) {
   if (GetFlag(state.clazz(), IS_ABSTRACT)) {
     Template t_veto_ctor(getTemplate("js_veto_ctor"));
     t_veto_ctor.replace("$jswrapper", state.clazz(CTOR))
-	.replace("$jsname", state.clazz(NAME))
-	.pretty_print(f_wrappers);
+        .replace("$jsname", state.clazz(NAME))
+        .pretty_print(f_wrappers);
   }
 
   /* Note: this makes sure that there is a swig_type added for this class */
@@ -2212,9 +2212,9 @@ int V8Emitter::exitClass(Node *n) {
 
     String *base_name_mangled = SwigType_manglestr(base_name);
     t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	.replace("$jsbaseclass", base_name_mangled)
-	.trim()
-	.pretty_print(f_init_inheritance);
+        .replace("$jsbaseclass", base_name_mangled)
+        .trim()
+        .pretty_print(f_init_inheritance);
     Delete(base_name_mangled);
   }
   //  emit registration of class template
@@ -2242,30 +2242,30 @@ int V8Emitter::exitVariable(Node *n) {
     if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {
       Template t_register = getTemplate("jsv8_register_static_variable");
       t_register.replace("$jsparent", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.variable(NAME))
-	  .replace("$jsgetter", state.variable(GETTER))
-	  .replace("$jssetter", state.variable(SETTER))
-	  .trim()
-	  .pretty_print(f_init_static_wrappers);
+          .replace("$jsname", state.variable(NAME))
+          .replace("$jsgetter", state.variable(GETTER))
+          .replace("$jssetter", state.variable(SETTER))
+          .trim()
+          .pretty_print(f_init_static_wrappers);
     } else {
       Template t_register = getTemplate("jsv8_register_member_variable");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.variable(NAME))
-	  .replace("$jsgetter", state.variable(GETTER))
-	  .replace("$jssetter", state.variable(SETTER))
-	  .trim()
-	  .pretty_print(f_init_wrappers);
+          .replace("$jsname", state.variable(NAME))
+          .replace("$jsgetter", state.variable(GETTER))
+          .replace("$jssetter", state.variable(SETTER))
+          .trim()
+          .pretty_print(f_init_wrappers);
     }
   } else {
     // Note: a global variable is treated like a static variable
     //       with the parent being a nspace object (instead of class object)
     Template t_register = getTemplate("jsv8_register_static_variable");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-	.replace("$jsname", state.variable(NAME))
-	.replace("$jsgetter", state.variable(GETTER))
-	.replace("$jssetter", state.variable(SETTER))
-	.trim()
-	.pretty_print(f_init_wrappers);
+        .replace("$jsname", state.variable(NAME))
+        .replace("$jsgetter", state.variable(GETTER))
+        .replace("$jssetter", state.variable(SETTER))
+        .trim()
+        .pretty_print(f_init_wrappers);
   }
 
   return SWIG_OK;
@@ -2290,27 +2290,27 @@ int V8Emitter::exitFunction(Node *n) {
     if (GetFlag(state.function(), IS_STATIC)) {
       Template t_register = getTemplate("jsv8_register_static_function");
       t_register.replace("$jsparent", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.function(NAME))
-	  .replace("$jswrapper", state.function(WRAPPER_NAME))
-	  .trim()
-	  .pretty_print(f_init_static_wrappers);
+          .replace("$jsname", state.function(NAME))
+          .replace("$jswrapper", state.function(WRAPPER_NAME))
+          .trim()
+          .pretty_print(f_init_static_wrappers);
     } else {
       Template t_register = getTemplate("jsv8_register_member_function");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.function(NAME))
-	  .replace("$jswrapper", state.function(WRAPPER_NAME))
-	  .trim()
-	  .pretty_print(f_init_wrappers);
+          .replace("$jsname", state.function(NAME))
+          .replace("$jswrapper", state.function(WRAPPER_NAME))
+          .trim()
+          .pretty_print(f_init_wrappers);
     }
   } else {
     // Note: a global function is treated like a static function
     //       with the parent being a nspace object instead of class object
     Template t_register = getTemplate("jsv8_register_static_function");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-	.replace("$jsname", state.function(NAME))
-	.replace("$jswrapper", state.function(WRAPPER_NAME))
-	.trim()
-	.pretty_print(f_init_static_wrappers);
+        .replace("$jsname", state.function(NAME))
+        .replace("$jswrapper", state.function(WRAPPER_NAME))
+        .trim()
+        .pretty_print(f_init_static_wrappers);
   }
 
   return SWIG_OK;
@@ -2344,31 +2344,31 @@ void V8Emitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, Mar
     switch (mode) {
     case Getter:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "info.Holder()", 0);
-	i++;
+        Printv(arg, "info.Holder()", 0);
+        i++;
       } else {
-	Printf(arg, "args[%d]", i - startIdx);
-	SetInt(p, INDEX, i - startIdx);
-	i += GetInt(p, "tmap:in:numinputs");
+        Printf(arg, "args[%d]", i - startIdx);
+        SetInt(p, INDEX, i - startIdx);
+        i += GetInt(p, "tmap:in:numinputs");
       }
       break;
     case Function:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "args.Holder()", 0);
-	i++;
+        Printv(arg, "args.Holder()", 0);
+        i++;
       } else {
-	Printf(arg, "args[%d]", i - startIdx);
-	SetInt(p, INDEX, i - startIdx);
-	i += GetInt(p, "tmap:in:numinputs");
+        Printf(arg, "args[%d]", i - startIdx);
+        SetInt(p, INDEX, i - startIdx);
+        i += GetInt(p, "tmap:in:numinputs");
       }
       break;
     case Setter:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "info.Holder()", 0);
-	i++;
+        Printv(arg, "info.Holder()", 0);
+        i++;
       } else {
-	Printv(arg, "value", 0);
-	i++;
+        Printv(arg, "value", 0);
+        i++;
       }
       break;
     case Ctor:
@@ -2426,16 +2426,16 @@ int V8Emitter::emitNamespaces() {
       // create namespace object and register it to the parent scope
       Template t_create_ns = getTemplate("jsv8_create_namespace");
       t_create_ns.replace("$jsmangledname", name_mangled)
-	  .trim()
-	  .pretty_print(f_init_namespaces);
+          .trim()
+          .pretty_print(f_init_namespaces);
     }
 
     if (do_register) {
       Template t_register_ns = getTemplate("jsv8_register_namespace");
       t_register_ns.replace("$jsmangledname", name_mangled)
-	  .replace("$jsname", name)
-	  .replace("$jsparent", parent_mangled)
-	  .trim();
+          .replace("$jsname", name)
+          .replace("$jsparent", parent_mangled)
+          .trim();
 
       // prepend in order to achieve reversed order of registration statements
       String *tmp_register_stmt = NewString("");
@@ -2698,10 +2698,10 @@ int NAPIEmitter::exitClass(Node *n) {
   if (GetFlag(state.clazz(), IS_ABSTRACT)) {
     Template t_veto_ctor(getTemplate("js_veto_ctor"));
     t_veto_ctor.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	.replace("$jswrapper", state.clazz(CTOR))
-	.replace("$jsname", state.clazz(NAME))
-	.replace("$jsparent", state.clazz(PARENT_MANGLED))
-	.pretty_print(f_wrappers);
+        .replace("$jswrapper", state.clazz(CTOR))
+        .replace("$jsname", state.clazz(NAME))
+        .replace("$jsparent", state.clazz(PARENT_MANGLED))
+        .pretty_print(f_wrappers);
   }
 
   /* Note: this makes sure that there is a swig_type added for this class */
@@ -2769,53 +2769,53 @@ int NAPIEmitter::exitVariable(Node *n) {
     if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {
       Template t_register = getTemplate("jsnapi_register_static_variable");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.variable(NAME))
-	  .replace("$jsgetter", state.variable(GETTER))
-	  .replace("$jssetter", state.variable(SETTER) != VETO_SET ? state.variable(SETTER)
-		   : "JS_veto_set_static_variable")
-	  .trim()
-	  .pretty_print(f_init_static_wrappers);
+          .replace("$jsname", state.variable(NAME))
+          .replace("$jsgetter", state.variable(GETTER))
+          .replace("$jssetter", state.variable(SETTER) != VETO_SET ? state.variable(SETTER)
+                   : "JS_veto_set_static_variable")
+          .trim()
+          .pretty_print(f_init_static_wrappers);
       Append(modifier, "static");
     } else {
       Template t_register = getTemplate("jsnapi_register_member_variable");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.variable(NAME))
-	  .replace("$jsgetter", state.variable(GETTER))
-	  .replace("$jssetter", state.variable(SETTER))
-	  .trim()
-	  .pretty_print(f_init_wrappers);
+          .replace("$jsname", state.variable(NAME))
+          .replace("$jsgetter", state.variable(GETTER))
+          .replace("$jssetter", state.variable(SETTER))
+          .trim()
+          .pretty_print(f_init_wrappers);
     }
 
     // emit declaration of a class member function
     Template t_getter = getTemplate("jsnapi_class_method_declaration");
     t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	.replace("$jsname", state.clazz(NAME))
-	.replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-	.replace("$jsdtor", state.clazz(DTOR))
-	.replace("$jswrapper", state.variable(GETTER))
-	.replace("$jsstatic", modifier)
-	.trim()
-	.pretty_print(f_class_declarations);
+        .replace("$jsname", state.clazz(NAME))
+        .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+        .replace("$jsdtor", state.clazz(DTOR))
+        .replace("$jswrapper", state.variable(GETTER))
+        .replace("$jsstatic", modifier)
+        .trim()
+        .pretty_print(f_class_declarations);
     if (state.variable(SETTER) != VETO_SET) {
       Template t_setter = getTemplate("jsnapi_class_setter_declaration");
       t_setter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.clazz(NAME))
-	  .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-	  .replace("$jsdtor", state.clazz(DTOR))
-	  .replace("$jswrapper", state.variable(SETTER))
-	  .replace("$jsstatic", modifier)
-	  .trim()
-	  .pretty_print(f_class_declarations);
+          .replace("$jsname", state.clazz(NAME))
+          .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+          .replace("$jsdtor", state.clazz(DTOR))
+          .replace("$jswrapper", state.variable(SETTER))
+          .replace("$jsstatic", modifier)
+          .trim()
+          .pretty_print(f_class_declarations);
     }
     Delete(modifier);
   } else {
     Template t_register = getTemplate("jsnapi_register_global_variable");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-	.replace("$jsname", state.variable(NAME))
-	.replace("$jsgetter", state.variable(GETTER))
-	.replace("$jssetter", state.variable(SETTER))
-	.trim()
-	.pretty_print(f_init_register_namespaces);
+        .replace("$jsname", state.variable(NAME))
+        .replace("$jsgetter", state.variable(GETTER))
+        .replace("$jssetter", state.variable(SETTER))
+        .trim()
+        .pretty_print(f_init_register_namespaces);
   }
 
   return SWIG_OK;
@@ -2854,17 +2854,17 @@ int NAPIEmitter::exitFunction(Node *n) {
     if (GetFlag(state.function(), IS_STATIC)) {
       Template t_register = getTemplate("jsnapi_register_static_function");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.function(NAME))
-	  .replace("$jswrapper", state.function(WRAPPER_NAME))
-	  .trim()
-	  .pretty_print(f_init_static_wrappers);
+          .replace("$jsname", state.function(NAME))
+          .replace("$jswrapper", state.function(WRAPPER_NAME))
+          .trim()
+          .pretty_print(f_init_static_wrappers);
     } else {
       Template t_register = getTemplate("jsnapi_register_member_function");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-	  .replace("$jsname", state.function(NAME))
-	  .replace("$jswrapper", state.function(WRAPPER_NAME))
-	  .trim()
-	  .pretty_print(f_init_wrappers);
+          .replace("$jsname", state.function(NAME))
+          .replace("$jswrapper", state.function(WRAPPER_NAME))
+          .trim()
+          .pretty_print(f_init_wrappers);
     }
 
     emitClassMethodDeclaration(n);
@@ -2873,10 +2873,10 @@ int NAPIEmitter::exitFunction(Node *n) {
     //       with the parent being a nspace object instead of class object
     Template t_register = getTemplate("jsnapi_register_global_function");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-	.replace("$jsname", state.function(NAME))
-	.replace("$jswrapper", state.function(WRAPPER_NAME))
-	.trim()
-	.pretty_print(f_init_register_namespaces);
+        .replace("$jsname", state.function(NAME))
+        .replace("$jswrapper", state.function(WRAPPER_NAME))
+        .trim()
+        .pretty_print(f_init_register_namespaces);
   }
 
   return SWIG_OK;
@@ -2910,31 +2910,31 @@ void NAPIEmitter::marshalInputArgs(Node *n, ParmList *parms, Wrapper *wrapper, M
     switch (mode) {
     case Getter:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "info.This()", 0);
-	i++;
+        Printv(arg, "info.This()", 0);
+        i++;
       } else {
-	Printf(arg, "info[%d]", i - startIdx);
-	SetInt(p, INDEX, i - startIdx);
-	i += GetInt(p, "tmap:in:numinputs");
+        Printf(arg, "info[%d]", i - startIdx);
+        SetInt(p, INDEX, i - startIdx);
+        i += GetInt(p, "tmap:in:numinputs");
       }
       break;
     case Function:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "info.This()", 0);
-	i++;
+        Printv(arg, "info.This()", 0);
+        i++;
       } else {
-	Printf(arg, "info[%d]", i - startIdx);
-	SetInt(p, INDEX, i - startIdx);
-	i += GetInt(p, "tmap:in:numinputs");
+        Printf(arg, "info[%d]", i - startIdx);
+        SetInt(p, INDEX, i - startIdx);
+        i += GetInt(p, "tmap:in:numinputs");
       }
       break;
     case Setter:
       if (is_member && !is_static && i == 0) {
-	Printv(arg, "info.This()", 0);
-	i++;
+        Printv(arg, "info.This()", 0);
+        i++;
       } else {
-	Printv(arg, "value", 0);
-	i++;
+        Printv(arg, "value", 0);
+        i++;
       }
       break;
     case Ctor:
@@ -2992,16 +2992,16 @@ int NAPIEmitter::emitNamespaces() {
       // create namespace object and register it to the parent scope
       Template t_create_ns = getTemplate("jsnapi_create_namespace");
       t_create_ns.replace("$jsmangledname", name_mangled)
-	  .trim()
-	  .pretty_print(f_init_namespaces);
+          .trim()
+          .pretty_print(f_init_namespaces);
     }
 
     if (do_register) {
       Template t_register_ns = getTemplate("jsnapi_register_namespace");
       t_register_ns.replace("$jsmangledname", name_mangled)
-	  .replace("$jsname", name)
-	  .replace("$jsparent", parent_mangled)
-	  .trim();
+          .replace("$jsname", name)
+          .replace("$jsparent", parent_mangled)
+          .trim();
 
       // prepend in order to achieve reversed order of registration statements
       String *tmp_register_stmt = NewString("");

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -22,41 +22,40 @@ static bool js_template_enable_debug = false;
 #define ERR_MSG_ONLY_ONE_ENGINE_PLEASE "Only one engine can be specified at a time."
 
 // keywords used for state variables
-#define NAME "name"
-#define NAME_MANGLED "name_mangled"
-#define INDEX "idx"
-#define TYPE "type"
-#define TYPE_MANGLED "type_mangled"
-#define WRAPPER_NAME "wrapper"
-#define IS_IMMUTABLE "is_immutable"
-#define IS_STATIC "is_static"
-#define IS_ABSTRACT "is_abstract"
-#define IS_WRAPPED "is_wrapped"
-#define GETTER "getter"
-#define SETTER "setter"
-#define PARENT "parent"
-#define PARENT_MANGLED "parent_mangled"
-#define CTOR "ctor"
-#define CTOR_WRAPPERS "ctor_wrappers"
-#define CTOR_DISPATCHERS "ctor_dispatchers"
-#define DTOR "dtor"
-#define ARGCOUNT "wrap:argc"
-#define ARGREQUIRED "wrap:argmin"
-#define HAS_TEMPLATES "has_templates"
-#define FORCE_CPP "force_cpp"
-#define RESET true
+#define NAME                           "name"
+#define NAME_MANGLED                   "name_mangled"
+#define INDEX                          "idx"
+#define TYPE                           "type"
+#define TYPE_MANGLED                   "type_mangled"
+#define WRAPPER_NAME                   "wrapper"
+#define IS_IMMUTABLE                   "is_immutable"
+#define IS_STATIC                      "is_static"
+#define IS_ABSTRACT                    "is_abstract"
+#define IS_WRAPPED                     "is_wrapped"
+#define GETTER                         "getter"
+#define SETTER                         "setter"
+#define PARENT                         "parent"
+#define PARENT_MANGLED                 "parent_mangled"
+#define CTOR                           "ctor"
+#define CTOR_WRAPPERS                  "ctor_wrappers"
+#define CTOR_DISPATCHERS               "ctor_dispatchers"
+#define DTOR                           "dtor"
+#define ARGCOUNT                       "wrap:argc"
+#define ARGREQUIRED                    "wrap:argmin"
+#define HAS_TEMPLATES                  "has_templates"
+#define FORCE_CPP                      "force_cpp"
+#define RESET                          true
 
 // keys for global state variables
-#define CREATE_NAMESPACES "create_namespaces"
-#define REGISTER_NAMESPACES "register_namespaces"
-#define INITIALIZER "initializer"
+#define CREATE_NAMESPACES              "create_namespaces"
+#define REGISTER_NAMESPACES            "register_namespaces"
+#define INITIALIZER                    "initializer"
 
 // keys for class scoped state variables
-#define MEMBER_VARIABLES "member_variables"
-#define MEMBER_FUNCTIONS "member_functions"
-#define STATIC_FUNCTIONS "static_functions"
-#define STATIC_VARIABLES "static_variables"
-
+#define MEMBER_VARIABLES               "member_variables"
+#define MEMBER_FUNCTIONS               "member_functions"
+#define STATIC_FUNCTIONS               "static_functions"
+#define STATIC_VARIABLES               "static_variables"
 
 /**
  * A convenience class to manage state variables for emitters.
@@ -92,14 +91,14 @@ class Template {
 public:
   Template(const String *code);
   Template(const String *code, const String *templateName);
-  Template(const Template & other);
+  Template(const Template &other);
   ~Template();
   String *str();
-  Template & replace(const String *pattern, const String *repl);
-  Template & print(DOH *doh);
-  Template & pretty_print(DOH *doh);
-  void operator=(const Template & t);
-  Template & trim();
+  Template &replace(const String *pattern, const String *repl);
+  Template &print(DOH *doh);
+  Template &pretty_print(DOH *doh);
+  void operator=(const Template &t);
+  Template &trim();
 
 private:
   String *code;
@@ -113,28 +112,16 @@ private:
 class JSEmitter {
 
 protected:
-
   typedef JSEmitterState State;
 
-  enum MarshallingMode {
-    Setter,
-    Getter,
-    Ctor,
-    Function
-  };
+  enum MarshallingMode { Setter, Getter, Ctor, Function };
 
 public:
+  enum JSEngine { JavascriptCore, V8, NodeJS, NAPI };
 
-   enum JSEngine {
-     JavascriptCore,
-     V8,
-     NodeJS,
-     NAPI
-   };
+  JSEmitter(JSEngine engine);
 
-   JSEmitter(JSEngine engine);
-
-   virtual ~ JSEmitter();
+  virtual ~JSEmitter();
 
   /**
    * Opens output files and temporary output DOHs.
@@ -224,10 +211,9 @@ public:
    */
   Template getTemplate(const String *name);
 
-  State & getState();
+  State &getState();
 
 protected:
-
   /**
    * Helper function for detecting if the constructor Node does not use a name that matches
    * the expected name for a constructor. Occurs when %rename is used for just a constructor
@@ -250,7 +236,7 @@ protected:
    */
   virtual int emitFunction(Node *n, bool is_member, bool is_static);
 
-  virtual int emitFunctionDispatcher(Node *n, bool /*is_member */ );
+  virtual int emitFunctionDispatcher(Node *n, bool /*is_member */);
 
   /**
    * Generates code for a getter function.
@@ -294,7 +280,6 @@ protected:
   virtual const char *getGetterTemplate(bool);
 
 protected:
-
   JSEngine engine;
   Hash *templates;
   State state;
@@ -319,11 +304,10 @@ JSEmitter *swig_javascript_create_NAPIEmitter();
  * JAVASCRIPT: SWIG module implementation
  **********************************************************************/
 
-class JAVASCRIPT:public Language {
+class JAVASCRIPT : public Language {
 
 public:
-
-  JAVASCRIPT():emitter(NULL) {
+  JAVASCRIPT() : emitter(NULL) {
   }
   ~JAVASCRIPT() {
     delete emitter;
@@ -347,11 +331,9 @@ public:
   virtual int fragmentDirective(Node *n);
 
 public:
-
   virtual String *getNSpace() const;
 
 private:
-
   JSEmitter *emitter;
 };
 
@@ -665,8 +647,13 @@ extern "C" Language *swig_javascript(void) {
  * JSEmitter()
  * ----------------------------------------------------------------------------- */
 
-JSEmitter::JSEmitter(JSEmitter::JSEngine engine)
-:  engine(engine), templates(NewHash()), namespaces(NULL), current_namespace(NULL), defaultResultName(NewString("result")), f_wrappers(NULL) {
+JSEmitter::JSEmitter(JSEmitter::JSEngine engine) :
+  engine(engine),
+  templates(NewHash()),
+  namespaces(NULL),
+  current_namespace(NULL),
+  defaultResultName(NewString("result")),
+  f_wrappers(NULL) {
 }
 
 /* -----------------------------------------------------------------------------
@@ -706,11 +693,11 @@ Template JSEmitter::getTemplate(const String *name) {
   return t;
 }
 
-JSEmitterState & JSEmitter::getState() {
+JSEmitterState &JSEmitter::getState() {
   return state;
 }
 
-int JSEmitter::initialize(Node * /*n */ ) {
+int JSEmitter::initialize(Node * /*n */) {
 
   if (namespaces != NULL) {
     Delete(namespaces);
@@ -746,12 +733,12 @@ Node *JSEmitter::getBaseClass(Node *n) {
   return NULL;
 }
 
- /* -----------------------------------------------------------------------------
-  * JSEmitter::emitWrapperFunction() :  dispatches emitter functions.
-  *
-  * This allows having small sized, dedicated emitting functions.
-  * All state dependent branching is done here.
-  * ----------------------------------------------------------------------------- */
+/* -----------------------------------------------------------------------------
+ * JSEmitter::emitWrapperFunction() :  dispatches emitter functions.
+ *
+ * This allows having small sized, dedicated emitting functions.
+ * All state dependent branching is done here.
+ * ----------------------------------------------------------------------------- */
 
 int JSEmitter::emitWrapperFunction(Node *n) {
   int ret = SWIG_OK;
@@ -763,8 +750,7 @@ int JSEmitter::emitWrapperFunction(Node *n) {
     if (Equal(kind, "function")
         // HACK: sneaky.ctest revealed that typedef'd (global) functions must be
         // detected via the 'view' attribute.
-        || (Equal(kind, "variable") && Equal(Getattr(n, "view"), "globalfunctionHandler"))
-        ) {
+        || (Equal(kind, "variable") && Equal(Getattr(n, "view"), "globalfunctionHandler"))) {
       bool is_member = GetFlag(n, "ismember") != 0 || GetFlag(n, "feature:extend") != 0;
       bool is_static = GetFlag(state.function(), IS_STATIC) != 0;
       ret = emitFunction(n, is_member, is_static);
@@ -956,19 +942,17 @@ int JSEmitter::emitCtor(Node *n) {
   Replaceall(wrapper->code, "$symname", iname);
 
   t_ctor.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", wrap_name)
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jslocals", wrapper->locals)
-      .replace("$jscode", wrapper->code)
-      .replace("$jsargcount", Getattr(n, ARGCOUNT))
-      .replace("$jsparent", state.clazz(PARENT_MANGLED))
-      .replace("$jsargrequired", Getattr(n, ARGREQUIRED))
-      .pretty_print(f_wrappers);
+    .replace("$jswrapper", wrap_name)
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jslocals", wrapper->locals)
+    .replace("$jscode", wrapper->code)
+    .replace("$jsargcount", Getattr(n, ARGCOUNT))
+    .replace("$jsparent", state.clazz(PARENT_MANGLED))
+    .replace("$jsargrequired", Getattr(n, ARGREQUIRED))
+    .pretty_print(f_wrappers);
 
   Template t_ctor_case(getTemplate("js_ctor_dispatch_case"));
-  t_ctor_case.replace("$jswrapper", wrap_name)
-      .replace("$jsargcount", Getattr(n, ARGCOUNT))
-      .replace("$jsargrequired", Getattr(n, ARGREQUIRED));
+  t_ctor_case.replace("$jswrapper", wrap_name).replace("$jsargcount", Getattr(n, ARGCOUNT)).replace("$jsargrequired", Getattr(n, ARGREQUIRED));
   Append(state.clazz(CTOR_DISPATCHERS), t_ctor_case.str());
 
   DelWrapper(wrapper);
@@ -979,11 +963,11 @@ int JSEmitter::emitCtor(Node *n) {
       String *wrap_name = Swig_name_wrapper(Getattr(n, "sym:name"));
       Template t_mainctor(getTemplate("js_ctor_dispatcher"));
       t_mainctor.replace("$jswrapper", wrap_name)
-          .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-          .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsdispatchcases", state.clazz(CTOR_DISPATCHERS))
-          .replace("$jsparent", state.clazz(PARENT_MANGLED))
-          .pretty_print(f_wrappers);
+        .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+        .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+        .replace("$jsdispatchcases", state.clazz(CTOR_DISPATCHERS))
+        .replace("$jsparent", state.clazz(PARENT_MANGLED))
+        .pretty_print(f_wrappers);
       state.clazz(CTOR, wrap_name);
     }
   } else {
@@ -1093,10 +1077,7 @@ int JSEmitter::emitDtor(Node *n) {
   if (destructor_action) {
     Template t_dtor = getTemplate("js_dtoroverride");
     state.clazz(DTOR, wrap_name);
-    t_dtor.replace("${classname_mangled}", state.clazz(NAME_MANGLED))
-        .replace("$jswrapper", wrap_name)
-        .replace("$jsfree", jsfree)
-        .replace("$jstype", ctype);
+    t_dtor.replace("${classname_mangled}", state.clazz(NAME_MANGLED)).replace("$jswrapper", wrap_name).replace("$jsfree", jsfree).replace("$jstype", ctype);
 
     t_dtor.replace("${destructor_action}", destructor_action);
     Wrapper_pretty_print(t_dtor.str(), f_wrappers);
@@ -1104,10 +1085,10 @@ int JSEmitter::emitDtor(Node *n) {
     Template t_dtor = getTemplate("js_dtor");
     state.clazz(DTOR, wrap_name);
     t_dtor.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-        .replace("$jswrapper", wrap_name)
-        .replace("$jsfree", jsfree)
-        .replace("$jstype", ctype)
-        .pretty_print(f_wrappers);
+      .replace("$jswrapper", wrap_name)
+      .replace("$jsfree", jsfree)
+      .replace("$jstype", ctype)
+      .pretty_print(f_wrappers);
   }
 
   Delete(p_classtype);
@@ -1139,10 +1120,10 @@ int JSEmitter::emitGetter(Node *n, bool is_member, bool is_static) {
   emitCleanupCode(n, wrapper, params);
 
   t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", wrap_name)
-      .replace("$jslocals", wrapper->locals)
-      .replace("$jscode", wrapper->code)
-      .pretty_print(f_wrappers);
+    .replace("$jswrapper", wrap_name)
+    .replace("$jslocals", wrapper->locals)
+    .replace("$jscode", wrapper->code)
+    .pretty_print(f_wrappers);
 
   DelWrapper(wrapper);
 
@@ -1178,10 +1159,10 @@ int JSEmitter::emitSetter(Node *n, bool is_member, bool is_static) {
   emitCleanupCode(n, wrapper, params);
 
   t_setter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", wrap_name)
-      .replace("$jslocals", wrapper->locals)
-      .replace("$jscode", wrapper->code)
-      .pretty_print(f_wrappers);
+    .replace("$jswrapper", wrap_name)
+    .replace("$jslocals", wrapper->locals)
+    .replace("$jscode", wrapper->code)
+    .pretty_print(f_wrappers);
 
   DelWrapper(wrapper);
 
@@ -1237,10 +1218,10 @@ int JSEmitter::emitConstant(Node *n) {
   marshalOutput(n, 0, wrapper, NewString(""), value, false);
 
   t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", wname)
-      .replace("$jslocals", wrapper->locals)
-      .replace("$jscode", wrapper->code)
-      .pretty_print(f_wrappers);
+    .replace("$jswrapper", wname)
+    .replace("$jslocals", wrapper->locals)
+    .replace("$jscode", wrapper->code)
+    .pretty_print(f_wrappers);
 
   exitVariable(n);
 
@@ -1287,12 +1268,12 @@ int JSEmitter::emitFunction(Node *n, bool is_member, bool is_static) {
   Replaceall(wrapper->code, "$symname", iname);
 
   t_function.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", wrap_name)
-      .replace("$jslocals", wrapper->locals)
-      .replace("$jscode", wrapper->code)
-      .replace("$jsargcount", Getattr(n, ARGCOUNT))
-      .replace("$jsargrequired", Getattr(n, ARGREQUIRED))
-      .pretty_print(f_wrappers);
+    .replace("$jswrapper", wrap_name)
+    .replace("$jslocals", wrapper->locals)
+    .replace("$jscode", wrapper->code)
+    .replace("$jsargcount", Getattr(n, ARGCOUNT))
+    .replace("$jsargrequired", Getattr(n, ARGREQUIRED))
+    .pretty_print(f_wrappers);
 
   DelWrapper(wrapper);
 
@@ -1306,7 +1287,7 @@ int JSEmitter::emitFunctionDispatcher(Node *n, bool is_member) {
   Node *sibl = n;
 
   while (Getattr(sibl, "sym:previousSibling"))
-    sibl = Getattr(sibl, "sym:previousSibling");        // go all the way up
+    sibl = Getattr(sibl, "sym:previousSibling");  // go all the way up
 
   do {
     String *siblname = Getattr(sibl, "wrap:name");
@@ -1314,9 +1295,7 @@ int JSEmitter::emitFunctionDispatcher(Node *n, bool is_member) {
     if (siblname) {
       // handle function overloading
       Template t_dispatch_case = getTemplate("js_function_dispatch_case");
-      t_dispatch_case.replace("$jswrapper", siblname)
-          .replace("$jsargcount", Getattr(sibl, ARGCOUNT))
-          .replace("$jsargrequired", Getattr(sibl, ARGREQUIRED));
+      t_dispatch_case.replace("$jswrapper", siblname).replace("$jsargcount", Getattr(sibl, ARGCOUNT)).replace("$jsargrequired", Getattr(sibl, ARGREQUIRED));
 
       Append(wrapper->code, t_dispatch_case.str());
     }
@@ -1345,16 +1324,13 @@ int JSEmitter::emitFunctionDispatcher(Node *n, bool is_member) {
   Setattr(n, "wrap:name", final_wrap_name);
   state.function(WRAPPER_NAME, final_wrap_name);
 
-
-
-  t_function.replace("$jslocals", wrapper->locals)
-      .replace("$jscode", wrapper->code);
+  t_function.replace("$jslocals", wrapper->locals).replace("$jscode", wrapper->code);
 
   // call this here, to replace all variables
   t_function.replace("$jswrapper", final_wrap_name)
-      .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsname", state.function(NAME))
-      .pretty_print(f_wrappers);
+    .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+    .replace("$jsname", state.function(NAME))
+    .pretty_print(f_wrappers);
 
   // Delete the state variable
   DelWrapper(wrapper);
@@ -1496,7 +1472,7 @@ void JSEmitter::emitCleanupCode(Node *n, Wrapper *wrapper, ParmList *params) {
 
   for (p = params; p;) {
     if ((tm = Getattr(p, "tmap:freearg"))) {
-      //addThrows(n, "tmap:freearg", p);
+      // addThrows(n, "tmap:freearg", p);
       Replaceall(tm, "$input", Getattr(p, "emit:input"));
       Printv(wrapper->code, tm, "\n", NIL);
       p = Getattr(p, "tmap:freearg:next");
@@ -1508,7 +1484,7 @@ void JSEmitter::emitCleanupCode(Node *n, Wrapper *wrapper, ParmList *params) {
   if (GetFlag(n, "feature:new")) {
     tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0);
     if (tm != NIL) {
-      //addThrows(throws_hash, "newfree", n);
+      // addThrows(throws_hash, "newfree", n);
       Printv(wrapper->code, tm, "\n", NIL);
     }
   }
@@ -1606,11 +1582,11 @@ Hash *JSEmitter::createNamespaceEntry(const char *_name, const char *parent, con
  * JavascriptCore: JSEmitter implementation for JavascriptCore engine
  **********************************************************************/
 
-class JSCEmitter:public JSEmitter {
+class JSCEmitter : public JSEmitter {
 
 public:
   JSCEmitter();
-  virtual ~ JSCEmitter();
+  virtual ~JSCEmitter();
   virtual int initialize(Node *n);
   virtual int dump(Node *n);
   virtual int close();
@@ -1627,7 +1603,6 @@ protected:
   virtual int emitNamespaces();
 
 private:
-
   String *NULL_STR;
   String *VETO_SET;
 
@@ -1636,18 +1611,22 @@ private:
   File *f_runtime;
   File *f_header;
   File *f_init;
-
 };
 
-JSCEmitter::JSCEmitter()
-:  JSEmitter(JSEmitter::JavascriptCore), NULL_STR(NewString("NULL")), VETO_SET(NewString("JS_veto_set_variable")), f_wrap_cpp(NULL), f_runtime(NULL), f_header(NULL), f_init(NULL) {
+JSCEmitter::JSCEmitter() :
+  JSEmitter(JSEmitter::JavascriptCore),
+  NULL_STR(NewString("NULL")),
+  VETO_SET(NewString("JS_veto_set_variable")),
+  f_wrap_cpp(NULL),
+  f_runtime(NULL),
+  f_header(NULL),
+  f_init(NULL) {
 }
 
 JSCEmitter::~JSCEmitter() {
   Delete(NULL_STR);
   Delete(VETO_SET);
 }
-
 
 /* ---------------------------------------------------------------------
  * marshalInputArgs()
@@ -1791,10 +1770,10 @@ int JSCEmitter::dump(Node *n) {
   // compose the initializer function using a template
   Template initializer(getTemplate("js_initializer"));
   initializer.replace("$jsname", module)
-      .replace("$jsregisterclasses", state.globals(INITIALIZER))
-      .replace("$jscreatenamespaces", state.globals(CREATE_NAMESPACES))
-      .replace("$jsregisternamespaces", state.globals(REGISTER_NAMESPACES))
-      .pretty_print(f_init);
+    .replace("$jsregisterclasses", state.globals(INITIALIZER))
+    .replace("$jscreatenamespaces", state.globals(CREATE_NAMESPACES))
+    .replace("$jsregisternamespaces", state.globals(REGISTER_NAMESPACES))
+    .pretty_print(f_init);
 
   Printv(f_wrap_cpp, f_init, 0);
 
@@ -1827,17 +1806,16 @@ int JSCEmitter::exitFunction(Node *n) {
   // handle overloaded functions
   if (is_overloaded) {
     if (!Getattr(n, "sym:nextSibling")) {
-      //state.function(WRAPPER_NAME, Swig_name_wrapper(Getattr(n, "name")));
-      // create dispatcher
+      // state.function(WRAPPER_NAME, Swig_name_wrapper(Getattr(n, "name")));
+      //  create dispatcher
       emitFunctionDispatcher(n, is_member);
     } else {
-      //don't register wrappers of overloaded functions in function tables
+      // don't register wrappers of overloaded functions in function tables
       return SWIG_OK;
     }
   }
 
-  t_function.replace("$jsname", state.function(NAME))
-      .replace("$jswrapper", state.function(WRAPPER_NAME));
+  t_function.replace("$jsname", state.function(NAME)).replace("$jswrapper", state.function(WRAPPER_NAME));
 
   if (is_member) {
     if (GetFlag(state.function(), IS_STATIC)) {
@@ -1861,13 +1839,10 @@ int JSCEmitter::enterVariable(Node *n) {
 
 int JSCEmitter::exitVariable(Node *n) {
   Template t_variable(getTemplate("jsc_variable_declaration"));
-  t_variable.replace("$jsname", state.variable(NAME))
-      .replace("$jsgetter", state.variable(GETTER))
-      .replace("$jssetter", state.variable(SETTER));
+  t_variable.replace("$jsname", state.variable(NAME)).replace("$jsgetter", state.variable(GETTER)).replace("$jssetter", state.variable(SETTER));
 
   if (GetFlag(n, "ismember")) {
-    if (GetFlag(state.variable(), IS_STATIC)
-        || Equal(Getattr(n, "nodeType"), "enumitem")) {
+    if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {
       t_variable.pretty_print(state.clazz(STATIC_VARIABLES));
     } else {
       t_variable.pretty_print(state.clazz(MEMBER_VARIABLES));
@@ -1887,8 +1862,7 @@ int JSCEmitter::enterClass(Node *n) {
   state.clazz(STATIC_FUNCTIONS, NewString(""));
 
   Template t_class_decl = getTemplate("jsc_class_declaration");
-  t_class_decl.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .pretty_print(f_wrappers);
+  t_class_decl.replace("$jsmangledname", state.clazz(NAME_MANGLED)).pretty_print(f_wrappers);
 
   return SWIG_OK;
 }
@@ -1896,22 +1870,20 @@ int JSCEmitter::enterClass(Node *n) {
 int JSCEmitter::exitClass(Node *n) {
   Template t_class_tables(getTemplate("jsc_class_tables"));
   t_class_tables.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsclassvariables", state.clazz(MEMBER_VARIABLES))
-      .replace("$jsclassfunctions", state.clazz(MEMBER_FUNCTIONS))
-      .replace("$jsstaticclassfunctions", state.clazz(STATIC_FUNCTIONS))
-      .replace("$jsstaticclassvariables", state.clazz(STATIC_VARIABLES))
-      .pretty_print(f_wrappers);
+    .replace("$jsclassvariables", state.clazz(MEMBER_VARIABLES))
+    .replace("$jsclassfunctions", state.clazz(MEMBER_FUNCTIONS))
+    .replace("$jsstaticclassfunctions", state.clazz(STATIC_FUNCTIONS))
+    .replace("$jsstaticclassvariables", state.clazz(STATIC_VARIABLES))
+    .pretty_print(f_wrappers);
 
   /* adds the ctor wrappers at this position */
   // Note: this is necessary to avoid extra forward declarations.
-  //Append(f_wrappers, state.clazz(CTOR_WRAPPERS));
+  // Append(f_wrappers, state.clazz(CTOR_WRAPPERS));
 
   // for abstract classes add a vetoing ctor
   if (GetFlag(state.clazz(), IS_ABSTRACT)) {
     Template t_veto_ctor(getTemplate("js_veto_ctor"));
-    t_veto_ctor.replace("$jswrapper", state.clazz(CTOR))
-        .replace("$jsname", state.clazz(NAME))
-        .pretty_print(f_wrappers);
+    t_veto_ctor.replace("$jswrapper", state.clazz(CTOR)).replace("$jsname", state.clazz(NAME)).pretty_print(f_wrappers);
   }
 
   /* adds a class template statement to initializer function */
@@ -1923,20 +1895,19 @@ int JSCEmitter::exitClass(Node *n) {
   if (base_class != NULL) {
     Template t_inherit(getTemplate("jsc_class_inherit"));
     t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-        .replace("$jsbaseclassmangled", SwigType_manglestr(Getattr(base_class, "name")))
-        .pretty_print(jsclass_inheritance);
+      .replace("$jsbaseclassmangled", SwigType_manglestr(Getattr(base_class, "name")))
+      .pretty_print(jsclass_inheritance);
   } else {
     Template t_inherit(getTemplate("jsc_class_noinherit"));
-    t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-        .pretty_print(jsclass_inheritance);
+    t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED)).pretty_print(jsclass_inheritance);
   }
 
   t_classtemplate.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jsclass_inheritance", jsclass_inheritance)
-      .replace("$jsctor", state.clazz(CTOR))
-      .replace("$jsdtor", state.clazz(DTOR))
-      .pretty_print(state.globals(INITIALIZER));
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jsclass_inheritance", jsclass_inheritance)
+    .replace("$jsctor", state.clazz(CTOR))
+    .replace("$jsdtor", state.clazz(DTOR))
+    .pretty_print(state.globals(INITIALIZER));
   Delete(jsclass_inheritance);
 
   /* Note: this makes sure that there is a swig_type added for this class */
@@ -1945,9 +1916,9 @@ int JSCEmitter::exitClass(Node *n) {
   /* adds a class registration statement to initializer function */
   Template t_registerclass(getTemplate("jsc_class_registration"));
   t_registerclass.replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsnspace", Getattr(state.clazz("nspace"), NAME_MANGLED))
-      .pretty_print(state.globals(INITIALIZER));
+    .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+    .replace("$jsnspace", Getattr(state.clazz("nspace"), NAME_MANGLED))
+    .pretty_print(state.globals(INITIALIZER));
 
   return SWIG_OK;
 }
@@ -1973,10 +1944,10 @@ int JSCEmitter::emitNamespaces() {
 
     Template namespace_definition(getTemplate("jsc_nspace_declaration"));
     namespace_definition.replace("$jsglobalvariables", variables)
-        .replace("$jsglobalfunctions", functions)
-        .replace("$jsnspace", name_mangled)
-        .replace("$jsmangledname", name_mangled)
-        .pretty_print(f_wrap_cpp);
+      .replace("$jsglobalfunctions", functions)
+      .replace("$jsnspace", name_mangled)
+      .replace("$jsmangledname", name_mangled)
+      .pretty_print(f_wrap_cpp);
 
     Template t_createNamespace(getTemplate("jsc_nspace_definition"));
     t_createNamespace.replace("$jsmangledname", name_mangled);
@@ -1985,9 +1956,7 @@ int JSCEmitter::emitNamespaces() {
     // Don't register 'exports' as namespace. It is return to the application.
     if (!Equal("exports", name)) {
       Template t_registerNamespace(getTemplate("jsc_nspace_registration"));
-      t_registerNamespace.replace("$jsmangledname", name_mangled)
-          .replace("$jsname", name)
-          .replace("$jsparent", parent_mangled);
+      t_registerNamespace.replace("$jsmangledname", name_mangled).replace("$jsname", name).replace("$jsparent", parent_mangled);
       Append(state.globals(REGISTER_NAMESPACES), t_registerNamespace.str());
     }
   }
@@ -2003,12 +1972,12 @@ JSEmitter *swig_javascript_create_JSCEmitter() {
  * V8: JSEmitter implementation for V8 engine
  **********************************************************************/
 
-class V8Emitter:public JSEmitter {
+class V8Emitter : public JSEmitter {
 
 public:
   V8Emitter();
 
-  virtual ~ V8Emitter();
+  virtual ~V8Emitter();
   virtual int initialize(Node *n);
   virtual int dump(Node *n);
   virtual int close();
@@ -2048,11 +2017,9 @@ protected:
   String *NULL_STR;
   String *VETO_SET;
   String *moduleName;
-
 };
 
-V8Emitter::V8Emitter()
-:  JSEmitter(JSEmitter::V8), NULL_STR(NewString("0")), VETO_SET(NewString("JS_veto_set_variable")) {
+V8Emitter::V8Emitter() : JSEmitter(JSEmitter::V8), NULL_STR(NewString("0")), VETO_SET(NewString("JS_veto_set_variable")) {
 }
 
 V8Emitter::~V8Emitter() {
@@ -2125,14 +2092,14 @@ int V8Emitter::dump(Node *n) {
   // filled with sub-parts
   Template initializer(getTemplate("js_initializer"));
   initializer.replace("$jsname", moduleName)
-      .replace("$jsv8nspaces", f_init_namespaces)
-      .replace("$jsv8classtemplates", f_init_class_templates)
-      .replace("$jsv8wrappers", f_init_wrappers)
-      .replace("$jsv8inheritance", f_init_inheritance)
-      .replace("$jsv8classinstances", f_init_class_instances)
-      .replace("$jsv8staticwrappers", f_init_static_wrappers)
-      .replace("$jsv8registerclasses", f_init_register_classes)
-      .replace("$jsv8registernspaces", f_init_register_namespaces);
+    .replace("$jsv8nspaces", f_init_namespaces)
+    .replace("$jsv8classtemplates", f_init_class_templates)
+    .replace("$jsv8wrappers", f_init_wrappers)
+    .replace("$jsv8inheritance", f_init_inheritance)
+    .replace("$jsv8classinstances", f_init_class_instances)
+    .replace("$jsv8staticwrappers", f_init_static_wrappers)
+    .replace("$jsv8registerclasses", f_init_register_classes)
+    .replace("$jsv8registernspaces", f_init_register_namespaces);
   Printv(f_init, initializer.str(), 0);
 
   Printv(f_wrap_cpp, f_init, 0);
@@ -2165,9 +2132,7 @@ int V8Emitter::enterClass(Node *n) {
 
   // emit declaration of a v8 class template
   Template t_decl_class(getTemplate("jsv8_declare_class_template"));
-  t_decl_class.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .trim()
-      .pretty_print(f_class_templates);
+  t_decl_class.replace("$jsmangledname", state.clazz(NAME_MANGLED)).trim().pretty_print(f_class_templates);
 
   return SWIG_OK;
 }
@@ -2175,9 +2140,7 @@ int V8Emitter::enterClass(Node *n) {
 int V8Emitter::exitClass(Node *n) {
   if (GetFlag(state.clazz(), IS_ABSTRACT)) {
     Template t_veto_ctor(getTemplate("js_veto_ctor"));
-    t_veto_ctor.replace("$jswrapper", state.clazz(CTOR))
-        .replace("$jsname", state.clazz(NAME))
-        .pretty_print(f_wrappers);
+    t_veto_ctor.replace("$jswrapper", state.clazz(CTOR)).replace("$jsname", state.clazz(NAME)).pretty_print(f_wrappers);
   }
 
   /* Note: this makes sure that there is a swig_type added for this class */
@@ -2190,18 +2153,18 @@ int V8Emitter::exitClass(Node *n) {
   // emit definition of v8 class template
   Template t_def_class = getTemplate("jsv8_define_class_template");
   t_def_class.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jsdtor", state.clazz(DTOR))
-      .trim()
-      .pretty_print(f_init_class_templates);
+    .replace("$jsname", state.clazz(NAME))
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jsdtor", state.clazz(DTOR))
+    .trim()
+    .pretty_print(f_init_class_templates);
 
   Template t_class_instance = getTemplate("jsv8_create_class_instance");
   t_class_instance.replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsctor", state.clazz(CTOR))
-      .trim()
-      .pretty_print(f_init_class_instances);
+    .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+    .replace("$jsctor", state.clazz(CTOR))
+    .trim()
+    .pretty_print(f_init_class_instances);
 
   //  emit inheritance setup
   Node *baseClass = getBaseClass(n);
@@ -2211,19 +2174,16 @@ int V8Emitter::exitClass(Node *n) {
     Template t_inherit = getTemplate("jsv8_inherit");
 
     String *base_name_mangled = SwigType_manglestr(base_name);
-    t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-        .replace("$jsbaseclass", base_name_mangled)
-        .trim()
-        .pretty_print(f_init_inheritance);
+    t_inherit.replace("$jsmangledname", state.clazz(NAME_MANGLED)).replace("$jsbaseclass", base_name_mangled).trim().pretty_print(f_init_inheritance);
     Delete(base_name_mangled);
   }
   //  emit registration of class template
   Template t_register = getTemplate("jsv8_register_class");
   t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsname", state.clazz(NAME))
-      .replace("$jsparent", Getattr(state.clazz("nspace"), NAME_MANGLED))
-      .trim()
-      .pretty_print(f_init_register_classes);
+    .replace("$jsname", state.clazz(NAME))
+    .replace("$jsparent", Getattr(state.clazz("nspace"), NAME_MANGLED))
+    .trim()
+    .pretty_print(f_init_register_classes);
 
   return SWIG_OK;
 }
@@ -2242,30 +2202,30 @@ int V8Emitter::exitVariable(Node *n) {
     if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {
       Template t_register = getTemplate("jsv8_register_static_variable");
       t_register.replace("$jsparent", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.variable(NAME))
-          .replace("$jsgetter", state.variable(GETTER))
-          .replace("$jssetter", state.variable(SETTER))
-          .trim()
-          .pretty_print(f_init_static_wrappers);
+        .replace("$jsname", state.variable(NAME))
+        .replace("$jsgetter", state.variable(GETTER))
+        .replace("$jssetter", state.variable(SETTER))
+        .trim()
+        .pretty_print(f_init_static_wrappers);
     } else {
       Template t_register = getTemplate("jsv8_register_member_variable");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.variable(NAME))
-          .replace("$jsgetter", state.variable(GETTER))
-          .replace("$jssetter", state.variable(SETTER))
-          .trim()
-          .pretty_print(f_init_wrappers);
+        .replace("$jsname", state.variable(NAME))
+        .replace("$jsgetter", state.variable(GETTER))
+        .replace("$jssetter", state.variable(SETTER))
+        .trim()
+        .pretty_print(f_init_wrappers);
     }
   } else {
     // Note: a global variable is treated like a static variable
     //       with the parent being a nspace object (instead of class object)
     Template t_register = getTemplate("jsv8_register_static_variable");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-        .replace("$jsname", state.variable(NAME))
-        .replace("$jsgetter", state.variable(GETTER))
-        .replace("$jssetter", state.variable(SETTER))
-        .trim()
-        .pretty_print(f_init_wrappers);
+      .replace("$jsname", state.variable(NAME))
+      .replace("$jsgetter", state.variable(GETTER))
+      .replace("$jssetter", state.variable(SETTER))
+      .trim()
+      .pretty_print(f_init_wrappers);
   }
 
   return SWIG_OK;
@@ -2278,10 +2238,10 @@ int V8Emitter::exitFunction(Node *n) {
   bool is_overloaded = GetFlag(n, "sym:overloaded") != 0;
   if (is_overloaded) {
     if (!Getattr(n, "sym:nextSibling")) {
-      //state.function(WRAPPER_NAME, Swig_name_wrapper(Getattr(n, "name")));
+      // state.function(WRAPPER_NAME, Swig_name_wrapper(Getattr(n, "name")));
       emitFunctionDispatcher(n, is_member);
     } else {
-      //don't register wrappers of overloaded functions in function tables
+      // don't register wrappers of overloaded functions in function tables
       return SWIG_OK;
     }
   }
@@ -2290,27 +2250,27 @@ int V8Emitter::exitFunction(Node *n) {
     if (GetFlag(state.function(), IS_STATIC)) {
       Template t_register = getTemplate("jsv8_register_static_function");
       t_register.replace("$jsparent", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.function(NAME))
-          .replace("$jswrapper", state.function(WRAPPER_NAME))
-          .trim()
-          .pretty_print(f_init_static_wrappers);
+        .replace("$jsname", state.function(NAME))
+        .replace("$jswrapper", state.function(WRAPPER_NAME))
+        .trim()
+        .pretty_print(f_init_static_wrappers);
     } else {
       Template t_register = getTemplate("jsv8_register_member_function");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.function(NAME))
-          .replace("$jswrapper", state.function(WRAPPER_NAME))
-          .trim()
-          .pretty_print(f_init_wrappers);
+        .replace("$jsname", state.function(NAME))
+        .replace("$jswrapper", state.function(WRAPPER_NAME))
+        .trim()
+        .pretty_print(f_init_wrappers);
     }
   } else {
     // Note: a global function is treated like a static function
     //       with the parent being a nspace object instead of class object
     Template t_register = getTemplate("jsv8_register_static_function");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-        .replace("$jsname", state.function(NAME))
-        .replace("$jswrapper", state.function(WRAPPER_NAME))
-        .trim()
-        .pretty_print(f_init_static_wrappers);
+      .replace("$jsname", state.function(NAME))
+      .replace("$jswrapper", state.function(WRAPPER_NAME))
+      .trim()
+      .pretty_print(f_init_static_wrappers);
   }
 
   return SWIG_OK;
@@ -2425,17 +2385,12 @@ int V8Emitter::emitNamespaces() {
     if (do_create) {
       // create namespace object and register it to the parent scope
       Template t_create_ns = getTemplate("jsv8_create_namespace");
-      t_create_ns.replace("$jsmangledname", name_mangled)
-          .trim()
-          .pretty_print(f_init_namespaces);
+      t_create_ns.replace("$jsmangledname", name_mangled).trim().pretty_print(f_init_namespaces);
     }
 
     if (do_register) {
       Template t_register_ns = getTemplate("jsv8_register_namespace");
-      t_register_ns.replace("$jsmangledname", name_mangled)
-          .replace("$jsname", name)
-          .replace("$jsparent", parent_mangled)
-          .trim();
+      t_register_ns.replace("$jsmangledname", name_mangled).replace("$jsname", name).replace("$jsparent", parent_mangled).trim();
 
       // prepend in order to achieve reversed order of registration statements
       String *tmp_register_stmt = NewString("");
@@ -2452,7 +2407,7 @@ int V8Emitter::emitNamespaces() {
  * NAPI: JSEmitter implementation for N-API
  **********************************************************************/
 
-class NAPIEmitter:public JSEmitter {
+class NAPIEmitter : public JSEmitter {
 public:
   NAPIEmitter();
 
@@ -2508,8 +2463,7 @@ protected:
   size_t class_idx;
 };
 
-NAPIEmitter::NAPIEmitter()
-:  JSEmitter(JSEmitter::NAPI), NULL_STR(NewString("0")), VETO_SET(NewString("JS_veto_set_variable")), class_idx(0) {
+NAPIEmitter::NAPIEmitter() : JSEmitter(JSEmitter::NAPI), NULL_STR(NewString("0")), VETO_SET(NewString("JS_veto_set_variable")), class_idx(0) {
 }
 
 NAPIEmitter::~NAPIEmitter() {
@@ -2587,11 +2541,11 @@ int NAPIEmitter::dump(Node *n) {
   // filled with sub-parts
   Template initializer(getTemplate("js_initializer"));
   initializer.replace("$jsname", moduleName)
-      .replace("$jsnapinspaces", f_init_namespaces)
-      .replace("$jsnapipreinheritance", inheritance)
-      .replace("$jsnapiinitinheritance", f_init_inheritance)
-      .replace("$jsnapiregisterclasses", f_init_register_classes)
-      .replace("$jsnapiregisternspaces", f_init_register_namespaces);
+    .replace("$jsnapinspaces", f_init_namespaces)
+    .replace("$jsnapipreinheritance", inheritance)
+    .replace("$jsnapiinitinheritance", f_init_inheritance)
+    .replace("$jsnapiregisterclasses", f_init_register_classes)
+    .replace("$jsnapiregisternspaces", f_init_register_namespaces);
   Printv(f_init, initializer.str(), 0);
 
   Printv(f_wrap_cpp, f_init, 0);
@@ -2646,12 +2600,12 @@ int NAPIEmitter::enterClass(Node *n) {
   Printf(idx, "%d", class_idx++);
   Template t_register = getTemplate("jsnapi_registerclass");
   t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsname", state.clazz(NAME))
-      .replace("$jsparent", Getattr(state.clazz("nspace"), NAME_MANGLED))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jsclassidx", idx)
-      .trim()
-      .pretty_print(f_init_register_classes);
+    .replace("$jsname", state.clazz(NAME))
+    .replace("$jsparent", Getattr(state.clazz("nspace"), NAME_MANGLED))
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jsclassidx", idx)
+    .trim()
+    .pretty_print(f_init_register_classes);
   Delete(idx);
 
   // emit inheritance
@@ -2678,17 +2632,14 @@ int NAPIEmitter::enterClass(Node *n) {
 
   Template t_setup_inheritance(getTemplate("jsnapi_setup_inheritance"));
   t_setup_inheritance.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", state.clazz(CTOR))
-      .replace("$jsname", state.clazz(NAME))
-      .replace("$jsparent", baseMangled)
-      .pretty_print(f_init_inheritance);
+    .replace("$jswrapper", state.clazz(CTOR))
+    .replace("$jsname", state.clazz(NAME))
+    .replace("$jsparent", baseMangled)
+    .pretty_print(f_init_inheritance);
 
   // emit declaration of a NAPI class template
   Template t_decl_class(getTemplate("jsnapi_class_prologue_template"));
-  t_decl_class.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsparent", baseMangled)
-      .trim()
-      .pretty_print(f_class_declarations);
+  t_decl_class.replace("$jsmangledname", state.clazz(NAME_MANGLED)).replace("$jsparent", baseMangled).trim().pretty_print(f_class_declarations);
 
   Delete(baseMangled);
   return SWIG_OK;
@@ -2698,10 +2649,10 @@ int NAPIEmitter::exitClass(Node *n) {
   if (GetFlag(state.clazz(), IS_ABSTRACT)) {
     Template t_veto_ctor(getTemplate("js_veto_ctor"));
     t_veto_ctor.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-        .replace("$jswrapper", state.clazz(CTOR))
-        .replace("$jsname", state.clazz(NAME))
-        .replace("$jsparent", state.clazz(PARENT_MANGLED))
-        .pretty_print(f_wrappers);
+      .replace("$jswrapper", state.clazz(CTOR))
+      .replace("$jsname", state.clazz(NAME))
+      .replace("$jsparent", state.clazz(PARENT_MANGLED))
+      .pretty_print(f_wrappers);
   }
 
   /* Note: this makes sure that there is a swig_type added for this class */
@@ -2714,27 +2665,27 @@ int NAPIEmitter::exitClass(Node *n) {
   // emit definition of NAPI class template
   Template t_def_class = getTemplate("jsnapi_class_epilogue_template");
   t_def_class.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jsdtor", state.clazz(DTOR))
-      .trim()
-      .pretty_print(f_class_declarations);
+    .replace("$jsname", state.clazz(NAME))
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jsdtor", state.clazz(DTOR))
+    .trim()
+    .pretty_print(f_class_declarations);
 
   Template t_class_instance = getTemplate("jsnapi_declare_class_instance");
   t_class_instance.replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .trim()
-      .pretty_print(f_class_declarations);
+    .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .trim()
+    .pretty_print(f_class_declarations);
 
   Template t_class_template = getTemplate("jsnapi_getclass");
   t_class_template.replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsnapiwrappers", f_init_wrappers)
-      .replace("$jsnapistaticwrappers", f_init_static_wrappers)
-      .replace("$jsparent", state.clazz(PARENT_MANGLED))
-      .trim()
-      .pretty_print(f_class_declarations);
+    .replace("$jsmangledname", state.clazz(NAME_MANGLED))
+    .replace("$jsnapiwrappers", f_init_wrappers)
+    .replace("$jsnapistaticwrappers", f_init_static_wrappers)
+    .replace("$jsparent", state.clazz(PARENT_MANGLED))
+    .trim()
+    .pretty_print(f_class_declarations);
 
   /* Save these to be reused in the child classes */
   Setattr(n, MEMBER_FUNCTIONS, f_init_wrappers);
@@ -2769,53 +2720,52 @@ int NAPIEmitter::exitVariable(Node *n) {
     if (GetFlag(state.variable(), IS_STATIC) || Equal(Getattr(n, "nodeType"), "enumitem")) {
       Template t_register = getTemplate("jsnapi_register_static_variable");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.variable(NAME))
-          .replace("$jsgetter", state.variable(GETTER))
-          .replace("$jssetter", state.variable(SETTER) != VETO_SET ? state.variable(SETTER)
-                   : "JS_veto_set_static_variable")
-          .trim()
-          .pretty_print(f_init_static_wrappers);
+        .replace("$jsname", state.variable(NAME))
+        .replace("$jsgetter", state.variable(GETTER))
+        .replace("$jssetter", state.variable(SETTER) != VETO_SET ? state.variable(SETTER) : "JS_veto_set_static_variable")
+        .trim()
+        .pretty_print(f_init_static_wrappers);
       Append(modifier, "static");
     } else {
       Template t_register = getTemplate("jsnapi_register_member_variable");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.variable(NAME))
-          .replace("$jsgetter", state.variable(GETTER))
-          .replace("$jssetter", state.variable(SETTER))
-          .trim()
-          .pretty_print(f_init_wrappers);
+        .replace("$jsname", state.variable(NAME))
+        .replace("$jsgetter", state.variable(GETTER))
+        .replace("$jssetter", state.variable(SETTER))
+        .trim()
+        .pretty_print(f_init_wrappers);
     }
 
     // emit declaration of a class member function
     Template t_getter = getTemplate("jsnapi_class_method_declaration");
     t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-        .replace("$jsname", state.clazz(NAME))
-        .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-        .replace("$jsdtor", state.clazz(DTOR))
-        .replace("$jswrapper", state.variable(GETTER))
-        .replace("$jsstatic", modifier)
-        .trim()
-        .pretty_print(f_class_declarations);
+      .replace("$jsname", state.clazz(NAME))
+      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+      .replace("$jsdtor", state.clazz(DTOR))
+      .replace("$jswrapper", state.variable(GETTER))
+      .replace("$jsstatic", modifier)
+      .trim()
+      .pretty_print(f_class_declarations);
     if (state.variable(SETTER) != VETO_SET) {
       Template t_setter = getTemplate("jsnapi_class_setter_declaration");
       t_setter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.clazz(NAME))
-          .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-          .replace("$jsdtor", state.clazz(DTOR))
-          .replace("$jswrapper", state.variable(SETTER))
-          .replace("$jsstatic", modifier)
-          .trim()
-          .pretty_print(f_class_declarations);
+        .replace("$jsname", state.clazz(NAME))
+        .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+        .replace("$jsdtor", state.clazz(DTOR))
+        .replace("$jswrapper", state.variable(SETTER))
+        .replace("$jsstatic", modifier)
+        .trim()
+        .pretty_print(f_class_declarations);
     }
     Delete(modifier);
   } else {
     Template t_register = getTemplate("jsnapi_register_global_variable");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-        .replace("$jsname", state.variable(NAME))
-        .replace("$jsgetter", state.variable(GETTER))
-        .replace("$jssetter", state.variable(SETTER))
-        .trim()
-        .pretty_print(f_init_register_namespaces);
+      .replace("$jsname", state.variable(NAME))
+      .replace("$jsgetter", state.variable(GETTER))
+      .replace("$jssetter", state.variable(SETTER))
+      .trim()
+      .pretty_print(f_init_register_namespaces);
   }
 
   return SWIG_OK;
@@ -2825,13 +2775,13 @@ int NAPIEmitter::emitClassMethodDeclaration(Node *) {
   // emit declaration of a class member function
   Template t_def_class = getTemplate("jsnapi_class_method_declaration");
   t_def_class.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jsname", state.clazz(NAME))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jsdtor", state.clazz(DTOR))
-      .replace("$jswrapper", state.function(WRAPPER_NAME))
-      .replace("$jsstatic", GetFlag(state.function(), IS_STATIC) ? "static" : "")
-      .trim()
-      .pretty_print(f_class_declarations);
+    .replace("$jsname", state.clazz(NAME))
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jsdtor", state.clazz(DTOR))
+    .replace("$jswrapper", state.function(WRAPPER_NAME))
+    .replace("$jsstatic", GetFlag(state.function(), IS_STATIC) ? "static" : "")
+    .trim()
+    .pretty_print(f_class_declarations);
 
   return SWIG_OK;
 }
@@ -2854,17 +2804,17 @@ int NAPIEmitter::exitFunction(Node *n) {
     if (GetFlag(state.function(), IS_STATIC)) {
       Template t_register = getTemplate("jsnapi_register_static_function");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.function(NAME))
-          .replace("$jswrapper", state.function(WRAPPER_NAME))
-          .trim()
-          .pretty_print(f_init_static_wrappers);
+        .replace("$jsname", state.function(NAME))
+        .replace("$jswrapper", state.function(WRAPPER_NAME))
+        .trim()
+        .pretty_print(f_init_static_wrappers);
     } else {
       Template t_register = getTemplate("jsnapi_register_member_function");
       t_register.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-          .replace("$jsname", state.function(NAME))
-          .replace("$jswrapper", state.function(WRAPPER_NAME))
-          .trim()
-          .pretty_print(f_init_wrappers);
+        .replace("$jsname", state.function(NAME))
+        .replace("$jswrapper", state.function(WRAPPER_NAME))
+        .trim()
+        .pretty_print(f_init_wrappers);
     }
 
     emitClassMethodDeclaration(n);
@@ -2873,10 +2823,10 @@ int NAPIEmitter::exitFunction(Node *n) {
     //       with the parent being a nspace object instead of class object
     Template t_register = getTemplate("jsnapi_register_global_function");
     t_register.replace("$jsparent", Getattr(current_namespace, NAME_MANGLED))
-        .replace("$jsname", state.function(NAME))
-        .replace("$jswrapper", state.function(WRAPPER_NAME))
-        .trim()
-        .pretty_print(f_init_register_namespaces);
+      .replace("$jsname", state.function(NAME))
+      .replace("$jswrapper", state.function(WRAPPER_NAME))
+      .trim()
+      .pretty_print(f_init_register_namespaces);
   }
 
   return SWIG_OK;
@@ -2991,17 +2941,12 @@ int NAPIEmitter::emitNamespaces() {
     if (do_create) {
       // create namespace object and register it to the parent scope
       Template t_create_ns = getTemplate("jsnapi_create_namespace");
-      t_create_ns.replace("$jsmangledname", name_mangled)
-          .trim()
-          .pretty_print(f_init_namespaces);
+      t_create_ns.replace("$jsmangledname", name_mangled).trim().pretty_print(f_init_namespaces);
     }
 
     if (do_register) {
       Template t_register_ns = getTemplate("jsnapi_register_namespace");
-      t_register_ns.replace("$jsmangledname", name_mangled)
-          .replace("$jsname", name)
-          .replace("$jsparent", parent_mangled)
-          .trim();
+      t_register_ns.replace("$jsmangledname", name_mangled).replace("$jsname", name).replace("$jsparent", parent_mangled).trim();
 
       // prepend in order to achieve reversed order of registration statements
       String *tmp_register_stmt = NewString("");
@@ -3021,20 +2966,18 @@ int NAPIEmitter::emitCtor(Node *n) {
 
   Template t_getter = getTemplate("jsnapi_class_method_declaration");
   t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .replace("$jswrapper", Getattr(n, "wrap:name"))
-      .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
-      .replace("$jsstatic", "")
-      .trim()
-      .pretty_print(f_class_declarations);
+    .replace("$jswrapper", Getattr(n, "wrap:name"))
+    .replace("$jsmangledtype", state.clazz(TYPE_MANGLED))
+    .replace("$jsstatic", "")
+    .trim()
+    .pretty_print(f_class_declarations);
   return SWIG_OK;
 }
 
 int NAPIEmitter::emitDtor(Node *n) {
   // NAPI destructors must have a class declaration
   Template t_getter = getTemplate("jsnapi_class_dtor_declaration");
-  t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED))
-      .trim()
-      .pretty_print(f_class_declarations);
+  t_getter.replace("$jsmangledname", state.clazz(NAME_MANGLED)).trim().pretty_print(f_class_declarations);
   return JSEmitter::emitDtor(n);
 }
 
@@ -3050,8 +2993,7 @@ JSEmitter *swig_javascript_create_NAPIEmitter() {
  * Helper implementations
  **********************************************************************/
 
-JSEmitterState::JSEmitterState()
-:  globalHash(NewHash()) {
+JSEmitterState::JSEmitterState() : globalHash(NewHash()) {
   // initialize sub-hashes
   Setattr(globalHash, "class", NewHash());
   Setattr(globalHash, "function", NewHash());
@@ -3154,7 +3096,6 @@ Template::Template(const String *code_, const String *templateName_) {
   templateName = NewString(templateName_);
 }
 
-
 /* -----------------------------------------------------------------------------
  * Template::~Template() :  cleans up of Template.
  * ----------------------------------------------------------------------------- */
@@ -3186,7 +3127,7 @@ String *Template::str() {
   return code;
 }
 
-Template & Template::trim() {
+Template &Template::trim() {
   const char *str = Char(code);
   if (str == 0)
     return *this;
@@ -3215,7 +3156,7 @@ Template & Template::trim() {
 
   Delete(code);
   code = NewString(newstr);
-  delete[]newstr;
+  delete[] newstr;
 
   return *this;
 }
@@ -3230,27 +3171,27 @@ Template & Template::trim() {
  *  - returns a reference to the Template to allow chaining of methods.
  * ----------------------------------------------------------------------------- */
 
-Template & Template::replace(const String *pattern, const String *repl) {
+Template &Template::replace(const String *pattern, const String *repl) {
   Replaceall(code, pattern, repl);
   return *this;
 }
 
-Template & Template::print(DOH *doh) {
+Template &Template::print(DOH *doh) {
   Printv(doh, str(), 0);
   return *this;
 }
 
-Template & Template::pretty_print(DOH *doh) {
+Template &Template::pretty_print(DOH *doh) {
   Wrapper_pretty_print(str(), doh);
   return *this;
 }
 
-Template::Template(const Template & t) {
+Template::Template(const Template &t) {
   code = NewString(t.code);
   templateName = NewString(t.templateName);
 }
 
-void Template::operator=(const Template & t) {
+void Template::operator=(const Template &t) {
   Delete(code);
   Delete(templateName);
   code = NewString(t.code);

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -61,13 +61,13 @@ extern "C" {
 
 /* Some status variables used during parsing */
 static int InClass = 0; /* Parsing C++ or not */
-static String *ClassName = 0;	/* This is the real name of the current class */
+static String *ClassName = 0;   /* This is the real name of the current class */
 static String *EnumClassName = 0; /* Enum class name */
-static String *ClassPrefix = 0;	/* Class prefix */
+static String *ClassPrefix = 0; /* Class prefix */
 static String *EnumClassPrefix = 0; /* Prefix for strongly typed enums (including ClassPrefix) */
-static String *NSpace = 0;	/* Namespace for the nspace feature */
-static String *ClassType = 0;	/* Fully qualified type name to use */
-static String *DirectorClassName = 0;	/* Director name of the current class */
+static String *NSpace = 0;      /* Namespace for the nspace feature */
+static String *ClassType = 0;   /* Fully qualified type name to use */
+static String *DirectorClassName = 0;   /* Director name of the current class */
 int Abstract = 0;
 int ImportMode = 0;
 int IsVirtual = 0;
@@ -680,7 +680,7 @@ int Language::insertDirective(Node *n) {
     String *code = Getattr(n, "code");
     String *section = Getattr(n, "section");
     File *f = 0;
-    if (!section) {		/* %{ ... %} */
+    if (!section) {             /* %{ ... %} */
       f = Swig_filebyname("header");
     } else {
       f = Swig_filebyname(section);
@@ -1735,7 +1735,7 @@ int Language::enumvalueDeclaration(Node *n) {
   }
 
   if (!CurrentClass || !cparse_cplusplus) {
-    Setattr(n, "name", tmpValue);	/* for wrapping of enums in a namespace when emit_action is used */
+    Setattr(n, "name", tmpValue);       /* for wrapping of enums in a namespace when emit_action is used */
     constantWrapper(n);
   } else {
     memberconstantHandler(n);
@@ -3229,10 +3229,10 @@ Node *Language::classLookup(const SwigType *s) {
       /* Found a match.  Look at the prefix.  We only allow
          the cases where we want a proxy class for the particular type */
       bool acceptable_prefix =
-        (Len(prefix) == 0) ||			      // simple type (pass by value)
-        (Strcmp(prefix, "p.") == 0) ||		      // pointer
-        (Strcmp(prefix, "r.") == 0) ||		      // reference
-        (Strcmp(prefix, "z.") == 0) ||		      // rvalue reference
+        (Len(prefix) == 0) ||                         // simple type (pass by value)
+        (Strcmp(prefix, "p.") == 0) ||                // pointer
+        (Strcmp(prefix, "r.") == 0) ||                // reference
+        (Strcmp(prefix, "z.") == 0) ||                // rvalue reference
         SwigType_prefix_is_simple_1D_array(prefix);   // Simple 1D array (not arrays of pointers/references)
       // Also accept pointer by const reference, not non-const pointer reference
       if (!acceptable_prefix && (Strcmp(prefix, "r.p.") == 0)) {
@@ -3315,7 +3315,7 @@ Node *Language::enumLookup(SwigType *s) {
     }
     if (n) {
       /* Found a match.  Look at the prefix.  We only allow simple types. */
-      if (Len(prefix) == 0) {	/* Simple type */
+      if (Len(prefix) == 0) {   /* Simple type */
         if (!enumtypes)
           enumtypes = NewHash();
         Setattr(enumtypes, Copy(s), n);
@@ -3670,7 +3670,7 @@ int Dispatcher::abstractClassTest(Node *n) {
   Printf(stderr, "testing %s %d %d\n", Getattr(n, "name"), labs, Len(allbases));
 #endif
   if (!labs)
-    return 0;			/*strange, but need to be fixed */
+    return 0;                   /*strange, but need to be fixed */
   if (abstracts && !Swig_directors_enabled())
     return 1;
   if (!GetFlag(n, "feature:director"))

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -207,11 +207,11 @@ int Dispatcher::emit_children(Node *n) {
     if (eo) {
       const char *tag = Char(nodeType(c));
       if (strcmp(tag, "cdecl") == 0) {
-	if (checkAttribute(c, "storage", "typedef"))
-	  tag = "typedef";
+        if (checkAttribute(c, "storage", "typedef"))
+          tag = "typedef";
       }
       if (strstr(eo, tag) == 0) {
-	continue;
+        continue;
       }
     }
     emit_one(c);
@@ -492,11 +492,11 @@ static void swig_pragma(char *lang, char *name, char *value) {
       String *nvalue = NewString(value);
       char *s = strchr(Char(nvalue), ':');
       if (!s) {
-	Swig_error(input_file, line_number, "Bad value for attributefunction. Expected \"fmtget:fmtset\".\n");
+        Swig_error(input_file, line_number, "Bad value for attributefunction. Expected \"fmtget:fmtset\".\n");
       } else {
-	*s = 0;
-	AttributeFunctionGet = NewString(Char(nvalue));
-	AttributeFunctionSet = NewString(s + 1);
+        *s = 0;
+        AttributeFunctionGet = NewString(Char(nvalue));
+        AttributeFunctionSet = NewString(s + 1);
       }
       Delete(nvalue);
     } else if (strcmp(name, "noattributefunction") == 0) {
@@ -529,15 +529,15 @@ int Language::use_naturalvar_mode(Node *n) const {
     if (SwigType_isclass(fullty)) {
       SwigType *tys = SwigType_strip_qualifiers(fullty);
       if (!CPlusPlus) {
-	Replaceall(tys, "struct ", "");
-	Replaceall(tys, "union ", "");
-	Replaceall(tys, "class ", "");
+        Replaceall(tys, "struct ", "");
+        Replaceall(tys, "union ", "");
+        Replaceall(tys, "class ", "");
       }
       Node *typenode = Swig_symbol_clookup(tys, 0);
       if (typenode) {
-	naturalvar = Getattr(typenode, "feature:naturalvar");
-	explicitly_off = naturalvar && Strcmp(naturalvar, "0") == 0;
-	nvar = nvar || GetFlag(typenode, "feature:naturalvar");
+        naturalvar = Getattr(typenode, "feature:naturalvar");
+        explicitly_off = naturalvar && Strcmp(naturalvar, "0") == 0;
+        nvar = nvar || GetFlag(typenode, "feature:naturalvar");
       }
       Delete(tys);
     }
@@ -557,7 +557,7 @@ int Language::top(Node *n) {
     Node *options = Getattr(mod, "options");
     if (options) {
       if (Getattr(options, "naturalvar")) {
-	naturalvar_mode = 1;
+        naturalvar_mode = 1;
       }
     }
   }
@@ -590,7 +590,7 @@ int Language::applyDirective(Node *n) {
       Swig_error(input_file, line_number, "Can't apply (%s) to (%s).  Number of arguments don't match.\n", ParmList_str(pattern), ParmList_str(apattern));
     } else {
       if (!Swig_typemap_apply(pattern, apattern)) {
-	Swig_warning(WARN_TYPEMAP_APPLY_UNDEF, input_file, line_number, "Can't apply (%s). No typemaps are defined.\n", ParmList_str(pattern));
+        Swig_warning(WARN_TYPEMAP_APPLY_UNDEF, input_file, line_number, "Can't apply (%s). No typemaps are defined.\n", ParmList_str(pattern));
       }
     }
     c = nextSibling(c);
@@ -769,11 +769,11 @@ Doc/Manual/Typemaps.html for complete details.\n");
     k = kwargs;
     while (k) {
       if (checkAttribute(k, "name", "numinputs")) {
-	if (!multiinput && (GetInt(k, "value") > 1)) {
-	  Swig_error(Getfile(n), Getline(n), "Multiple-input typemaps (numinputs > 1) not supported by this target language module.\n");
-	  return SWIG_ERROR;
-	}
-	break;
+        if (!multiinput && (GetInt(k, "value") > 1)) {
+          Swig_error(Getfile(n), Getline(n), "Multiple-input typemaps (numinputs > 1) not supported by this target language module.\n");
+          return SWIG_ERROR;
+        }
+        break;
       }
       k = nextSibling(k);
     }
@@ -830,7 +830,7 @@ int Language::typemapcopyDirective(Node *n) {
       Swig_error(input_file, line_number, "Can't copy typemap. Number of types differ.\n");
     } else {
       if (Swig_typemap_copy(method, pattern, npattern) < 0) {
-	Swig_error(input_file, line_number, "Can't copy typemap (%s) %s = %s\n", method, ParmList_str(pattern), ParmList_str(npattern));
+        Swig_error(input_file, line_number, "Can't copy typemap (%s) %s = %s\n", method, ParmList_str(pattern), ParmList_str(npattern));
       }
     }
     items = nextSibling(items);
@@ -852,7 +852,7 @@ int Language::typesDirective(Node *n) {
       SwigType_remember(t);
     } else {
       if (SwigType_issimple(t)) {
-	SwigType_inherit(t, v, 0, convcode);
+        SwigType_inherit(t, v, 0, convcode);
       }
     }
     parms = nextSibling(parms);
@@ -882,10 +882,10 @@ int Language::cDeclaration(Node *n) {
       // Found an unignored templated method that has an empty template instantiation (%template())
       // Ignore it unless it has been %rename'd
       if (Strncmp(symname, "__dummy_", 8) == 0 && Cmp(storage, "typedef") != 0) {
-	SetFlag(n, "feature:ignore");
-	Swig_warning(WARN_LANG_TEMPLATE_METHOD_IGNORE, input_file, line_number,
-	    "%%template() contains no name. Template method ignored: %s\n", Swig_name_decl(n));
-	return SWIG_NOWRAP;
+        SetFlag(n, "feature:ignore");
+        Swig_warning(WARN_LANG_TEMPLATE_METHOD_IGNORE, input_file, line_number,
+            "%%template() contains no name. Template method ignored: %s\n", Swig_name_decl(n));
+        return SWIG_NOWRAP;
       }
     }
   }
@@ -904,8 +904,8 @@ int Language::cDeclaration(Node *n) {
       // This bit of code is only needed due to the cDeclaration call in classHandler()
       String *wrapname = NewStringf("nonpublic_%s%s", symname, Getattr(n, "sym:overname"));
       if (Getattr(CurrentClass, wrapname)) {
-	Delete(wrapname);
-	return SWIG_NOWRAP;
+        Delete(wrapname);
+        return SWIG_NOWRAP;
       }
       SetFlag(CurrentClass, wrapname);
       Delete(wrapname);
@@ -971,44 +971,44 @@ int Language::cDeclaration(Node *n) {
       f_header = Swig_filebyname("header");
 
       if (AddExtern) {
-	if (f_header) {
-	  if (Swig_storage_isextern(n) || (ForceExtern && !storage)) {
-	    /* we don't need the 'extern' part in the C/C++ declaration,
-	       and it produces some problems when namespace and SUN
-	       Studio is used.
+        if (f_header) {
+          if (Swig_storage_isextern(n) || (ForceExtern && !storage)) {
+            /* we don't need the 'extern' part in the C/C++ declaration,
+               and it produces some problems when namespace and SUN
+               Studio is used.
 
-	       Printf(f_header,"extern %s", SwigType_str(ty,name));
+               Printf(f_header,"extern %s", SwigType_str(ty,name));
 
-	       In fact generating extern declarations is quite error prone and is
-	       no longer the default. Getting it right seems impossible with namespaces
-	       and default arguments and when a method is declared with the various Windows
-	       calling conventions - SWIG doesn't understand Windows (non standard) calling
-	       conventions in the first place, so can't regenerate them.
-	     */
-	    String *str = SwigType_str(ty, name);
-	    Printf(f_header, "%s", str);
-	    Delete(str);
-	    {
-	      DOH *t = Getattr(n, "throws");
-	      if (t) {
-		Printf(f_header, " throw(");
-		while (t) {
-		  Printf(f_header, "%s", Getattr(t, "type"));
-		  t = nextSibling(t);
-		  if (t)
-		    Printf(f_header, ",");
-		}
-		Printf(f_header, ")");
-	      }
-	    }
-	    Printf(f_header, ";\n");
-	  } else if (Swig_storage_isexternc(n)) {
-	    /* here 'extern "C"' is needed */
-	    String *str = SwigType_str(ty, name);
-	    Printf(f_header, "extern \"C\" %s;\n", str);
-	    Delete(str);
-	  }
-	}
+               In fact generating extern declarations is quite error prone and is
+               no longer the default. Getting it right seems impossible with namespaces
+               and default arguments and when a method is declared with the various Windows
+               calling conventions - SWIG doesn't understand Windows (non standard) calling
+               conventions in the first place, so can't regenerate them.
+             */
+            String *str = SwigType_str(ty, name);
+            Printf(f_header, "%s", str);
+            Delete(str);
+            {
+              DOH *t = Getattr(n, "throws");
+              if (t) {
+                Printf(f_header, " throw(");
+                while (t) {
+                  Printf(f_header, "%s", Getattr(t, "type"));
+                  t = nextSibling(t);
+                  if (t)
+                    Printf(f_header, ",");
+                }
+                Printf(f_header, ")");
+              }
+            }
+            Printf(f_header, ";\n");
+          } else if (Swig_storage_isexternc(n)) {
+            /* here 'extern "C"' is needed */
+            String *str = SwigType_str(ty, name);
+            Printf(f_header, "extern \"C\" %s;\n", str);
+            Delete(str);
+          }
+        }
       }
     }
     /* This needs to check qualifiers */
@@ -1033,14 +1033,14 @@ int Language::cDeclaration(Node *n) {
     Delattr(n, "decl");
     if (!CurrentClass) {
       if (Swig_storage_isextern(n) || ForceExtern) {
-	if (AddExtern) {
-	  f_header = Swig_filebyname("header");
-	  if (f_header) {
-	    String *str = SwigType_str(ty, name);
-	    Printf(f_header, "%s %s;\n", Getattr(n, "storage"), str);
-	    Delete(str);
-	  }
-	}
+        if (AddExtern) {
+          f_header = Swig_filebyname("header");
+          if (f_header) {
+            String *str = SwigType_str(ty, name);
+            Printf(f_header, "%s %s;\n", Getattr(n, "storage"), str);
+            Delete(str);
+          }
+        }
       }
     }
     DohIncref(type);
@@ -1070,7 +1070,7 @@ int Language::functionHandler(Node *n) {
       SetFlag(n, "feature:self:disown");
     } else {
       if (p)
-	SetFlag(p, "wrap:disown");
+        SetFlag(p, "wrap:disown");
     }
   }
   if (!CurrentClass) {
@@ -1088,28 +1088,28 @@ int Language::functionHandler(Node *n) {
       SetFlag(n, "memberfunction");
       Node *explicit_n = 0;
       if (Swig_directors_enabled() && is_member_director(CurrentClass, n) && !extraDirectorProtectedCPPMethodsRequired()) {
-	bool virtual_but_not_pure_virtual = (!(Cmp(storage, "virtual")) && (Cmp(Getattr(n, "value"), "0") != 0));
-	if (virtual_but_not_pure_virtual) {
-	  // Add additional wrapper which makes an explicit call to the virtual method (ie not a virtual call)
-	  explicit_n = Copy(n);
-	  String *new_symname = Copy(Getattr(n, "sym:name"));
-	  String *suffix = Getattr(parentNode(n), "sym:name");
-	  Printv(new_symname, "SwigExplicit", suffix, NIL);
-	  Setattr(explicit_n, "sym:name", new_symname);
-	  Delattr(explicit_n, "storage");
-	  Delattr(explicit_n, "override");
-	  Delattr(explicit_n, "hides");
-	  SetFlag(explicit_n, "explicitcall");
-	  Setattr(n, "explicitcallnode", explicit_n);
-	}
+        bool virtual_but_not_pure_virtual = (!(Cmp(storage, "virtual")) && (Cmp(Getattr(n, "value"), "0") != 0));
+        if (virtual_but_not_pure_virtual) {
+          // Add additional wrapper which makes an explicit call to the virtual method (ie not a virtual call)
+          explicit_n = Copy(n);
+          String *new_symname = Copy(Getattr(n, "sym:name"));
+          String *suffix = Getattr(parentNode(n), "sym:name");
+          Printv(new_symname, "SwigExplicit", suffix, NIL);
+          Setattr(explicit_n, "sym:name", new_symname);
+          Delattr(explicit_n, "storage");
+          Delattr(explicit_n, "override");
+          Delattr(explicit_n, "hides");
+          SetFlag(explicit_n, "explicitcall");
+          Setattr(n, "explicitcallnode", explicit_n);
+        }
       }
 
       memberfunctionHandler(n);
 
       if (explicit_n) {
-	memberfunctionHandler(explicit_n);
-	Delattr(explicit_n, "explicitcall");
-	Delete(explicit_n);
+        memberfunctionHandler(explicit_n);
+        Delattr(explicit_n, "explicitcall");
+        Delete(explicit_n);
       }
     }
   }
@@ -1339,17 +1339,17 @@ int Language::staticmemberfunctionHandler(Node *n) {
     if (code) {
       // See Swig_MethodToFunction() for the explanation of this code.
       if (Getattr(n, "sym:overloaded")) {
-	Append(cname, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
+        Append(cname, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
       } else if (UseWrapperSuffix) {
-	Append(cname, "__SWIG");
+        Append(cname, "__SWIG");
       }
 
       if (!defaultargs) {
-	/* Hmmm. An added static member.  We have to create a little wrapper for this */
-	String *mangled_cname = Swig_name_mangle_string(cname);
-	Swig_add_extension_code(n, mangled_cname, parms, type, code, CPlusPlus, 0);
-	Setattr(n, "extendname", mangled_cname);
-	Delete(mangled_cname);
+        /* Hmmm. An added static member.  We have to create a little wrapper for this */
+        String *mangled_cname = Swig_name_mangle_string(cname);
+        Swig_add_extension_code(n, mangled_cname, parms, type, code, CPlusPlus, 0);
+        Setattr(n, "extendname", mangled_cname);
+        Delete(mangled_cname);
       }
     }
   }
@@ -1406,7 +1406,7 @@ int Language::variableHandler(Node *n) {
     if (SmartPointer) {
       /* If a smart-pointer and it's a constant access, we have to set immutable */
       if (!Getattr(CurrentClass, "allocate:smartpointermutable")) {
-	SetFlag(n, "feature:immutable");
+        SetFlag(n, "feature:immutable");
       }
     }
     if (Swig_storage_isstatic(n) && !(SmartPointer && Getattr(n, "allocate:smartpointeraccess"))) {
@@ -1453,7 +1453,7 @@ int Language::membervariableHandler(Node *n) {
 
     if (SmartPointer) {
       if (!Getattr(CurrentClass, "allocate:smartpointermutable")) { 
-	assignable = 0;
+        assignable = 0;
       }
     }
 
@@ -1462,27 +1462,27 @@ int Language::membervariableHandler(Node *n) {
       String *tm = 0;
       String *target = 0;
       if (!Extend) {
-	if (SmartPointer) {
-	  if (Swig_storage_isstatic(n)) {
-	    Node *sn = Getattr(n, "cplus:staticbase");
-	    String *base = Getattr(sn, "name");
-	    target = NewStringf("%s::%s", base, name);
-	  } else {
-	    String *pname = Swig_cparm_name(0, 0);
-	    target = NewStringf("(*%s)->%s", pname, name);
-	    Delete(pname);
-	  }
-	} else {
-	  String *pname = isNonVirtualProtectedAccess(n) ? NewString("darg") : Swig_cparm_name(0, 0);
-	  target = NewStringf("%s->%s", pname, name);
-	  Delete(pname);
-	}
+        if (SmartPointer) {
+          if (Swig_storage_isstatic(n)) {
+            Node *sn = Getattr(n, "cplus:staticbase");
+            String *base = Getattr(sn, "name");
+            target = NewStringf("%s::%s", base, name);
+          } else {
+            String *pname = Swig_cparm_name(0, 0);
+            target = NewStringf("(*%s)->%s", pname, name);
+            Delete(pname);
+          }
+        } else {
+          String *pname = isNonVirtualProtectedAccess(n) ? NewString("darg") : Swig_cparm_name(0, 0);
+          target = NewStringf("%s->%s", pname, name);
+          Delete(pname);
+        }
 
-	// This is an input type typemap lookup and so it should not use Node n
-	// otherwise qualification is done on the parameter name for the setter function
-	Parm *nin = NewParm(type, name, n);
-	tm = Swig_typemap_lookup("memberin", nin, target, 0);
-	Delete(nin);
+        // This is an input type typemap lookup and so it should not use Node n
+        // otherwise qualification is done on the parameter name for the setter function
+        Parm *nin = NewParm(type, name, n);
+        tm = Swig_typemap_lookup("memberin", nin, target, 0);
+        Delete(nin);
       }
 
       int flags = Extend | SmartPointer | use_naturalvar_mode(n);
@@ -1492,30 +1492,30 @@ int Language::membervariableHandler(Node *n) {
       Swig_MembersetToFunction(n, ClassType, flags);
       Setattr(n, "memberset", "1");
       if (!Extend) {
-	/* Check for a member in typemap here */
+        /* Check for a member in typemap here */
 
-	if (!tm) {
-	  if (SwigType_isarray(type)) {
-	    Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(type, 0));
-	    make_set_wrapper = 0;
-	  }
-	} else {
-	  String *pname0 = Swig_cparm_name(0, 0);
-	  String *pname1 = Swig_cparm_name(0, 1);
-	  Replace(tm, "$input", pname1, DOH_REPLACE_ANY);
-	  Replace(tm, "$self", pname0, DOH_REPLACE_ANY);
-	  Setattr(n, "wrap:action", tm);
-	  Delete(tm);
-	  Delete(pname0);
-	  Delete(pname1);
-	}
-	Delete(target);
+        if (!tm) {
+          if (SwigType_isarray(type)) {
+            Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(type, 0));
+            make_set_wrapper = 0;
+          }
+        } else {
+          String *pname0 = Swig_cparm_name(0, 0);
+          String *pname1 = Swig_cparm_name(0, 1);
+          Replace(tm, "$input", pname1, DOH_REPLACE_ANY);
+          Replace(tm, "$self", pname0, DOH_REPLACE_ANY);
+          Setattr(n, "wrap:action", tm);
+          Delete(tm);
+          Delete(pname0);
+          Delete(pname1);
+        }
+        Delete(target);
       }
       if (make_set_wrapper) {
-	Setattr(n, "sym:name", mrename_set);
-	functionWrapper(n);
+        Setattr(n, "sym:name", mrename_set);
+        functionWrapper(n);
       } else {
-	SetFlag(n, "feature:immutable");
+        SetFlag(n, "feature:immutable");
       }
       /* Restore parameters */
       Setattr(n, "type", type);
@@ -1526,8 +1526,8 @@ int Language::membervariableHandler(Node *n) {
       /* Delete all attached typemaps and typemap attributes */
       Iterator ki;
       for (ki = First(n); ki.key; ki = Next(ki)) {
-	if (Strncmp(ki.key, "tmap:", 5) == 0)
-	  Delattr(n, ki.key);
+        if (Strncmp(ki.key, "tmap:", 5) == 0)
+          Delattr(n, ki.key);
       }
     }
     /* Emit get function */
@@ -1570,13 +1570,13 @@ int Language::membervariableHandler(Node *n) {
       gname = NewStringf(AttributeFunctionSet, symname);
       vty = NewString("void");
       if (!Extend) {
-	ActionFunc = Copy(Swig_cmemberset_call(name, type));
-	cpp_member_func(Char(gname), Char(gname), vty, p);
-	Delete(ActionFunc);
+        ActionFunc = Copy(Swig_cmemberset_call(name, type));
+        cpp_member_func(Char(gname), Char(gname), vty, p);
+        Delete(ActionFunc);
       } else {
-	String *cname = Swig_name_set(NSpace, name);
-	cpp_member_func(Char(cname), Char(gname), vty, p);
-	Delete(cname);
+        String *cname = Swig_name_set(NSpace, name);
+        cpp_member_func(Char(cname), Char(gname), vty, p);
+        Delete(cname);
       }
       Delete(gname);
     }
@@ -1893,13 +1893,13 @@ void Language::unrollOneVirtualMethod(String *classname, Node *n, Node *parent, 
       const int DO_NOT_REPLACE = -1;
       int replace = DO_NOT_REPLACE;
       for (int i = 0; i < len; i++) {
-	Node *item = Getitem(vm, i);
-	String *check_vmid = Getattr(item, "vmid");
+        Node *item = Getitem(vm, i);
+        String *check_vmid = Getattr(item, "vmid");
 
-	if (Strcmp(method_id, check_vmid) == 0) {
-	  replace = i;
-	  break;
-	}
+        if (Strcmp(method_id, check_vmid) == 0) {
+          replace = i;
+          break;
+        }
       }
       /* filling a new method item */
       String *fqdname = NewStringf("%s::%s", classname, name);
@@ -1911,7 +1911,7 @@ void Language::unrollOneVirtualMethod(String *classname, Node *n, Node *parent, 
       SwigType *ty = NewString(Getattr(m, "type"));
       SwigType_push(ty, decl);
       if (SwigType_isqualifier(ty)) {
-	Delete(SwigType_pop(ty));
+        Delete(SwigType_pop(ty));
       }
       Delete(SwigType_pop_function(ty));
       Setattr(m, "returntype", ty);
@@ -1922,9 +1922,9 @@ void Language::unrollOneVirtualMethod(String *classname, Node *n, Node *parent, 
       Setattr(item, "methodNode", m);
       Setattr(item, "vmid", method_id);
       if (replace == DO_NOT_REPLACE)
-	Append(vm, item);
+        Append(vm, item);
       else
-	Setitem(vm, replace, item);
+        Setitem(vm, replace, item);
       Setattr(n, "directorNode", m);
 
       Delete(mname);
@@ -1946,7 +1946,7 @@ int Language::unrollVirtualMethods(Node *n, Node *parent, List *vm, int &virtual
     Iterator bi;
     for (bi = First(bl); bi.item; bi = Next(bi)) {
       if (first_base && !director_multiple_inheritance)
-	break;
+        break;
       unrollVirtualMethods(bi.item, parent, vm, virtual_destructor);
       first_base = true;
     }
@@ -1958,7 +1958,7 @@ int Language::unrollVirtualMethods(Node *n, Node *parent, List *vm, int &virtual
     Iterator bi;
     for (bi = First(bl); bi.item; bi = Next(bi)) {
       if (first_base && !director_multiple_inheritance)
-	break;
+        break;
       unrollVirtualMethods(bi.item, parent, vm, virtual_destructor, 1);
       first_base = true;
     }
@@ -1970,7 +1970,7 @@ int Language::unrollVirtualMethods(Node *n, Node *parent, List *vm, int &virtual
     /* we only need to check the virtual members */
     if (Equal(nodeType(ni), "using")) {
       for (Node *nn = firstChild(ni); nn; nn = Getattr(nn, "sym:nextSibling")) {
-	unrollOneVirtualMethod(classname, nn, parent, vm, virtual_destructor, protectedbase);
+        unrollOneVirtualMethod(classname, nn, parent, vm, virtual_destructor, protectedbase);
       }
     }
     unrollOneVirtualMethod(classname, ni, parent, vm, virtual_destructor, protectedbase);
@@ -1995,22 +1995,22 @@ int Language::unrollVirtualMethods(Node *n, Node *parent, List *vm, int &virtual
       /* check if the method was found only in a base class */
       Node *p = Getattr(m, "parentNode");
       if (p != n) {
-	Node *c = Copy(m);
-	Setattr(c, "parentNode", n);
-	int cdir = GetFlag(c, "feature:director");
-	int cndir = GetFlag(c, "feature:nodirector");
-	dir = (cdir || cndir) ? (cdir && !cndir) : dir;
-	Delete(c);
+        Node *c = Copy(m);
+        Setattr(c, "parentNode", n);
+        int cdir = GetFlag(c, "feature:director");
+        int cndir = GetFlag(c, "feature:nodirector");
+        dir = (cdir || cndir) ? (cdir && !cndir) : dir;
+        Delete(c);
       }
       if (dir) {
-	/* be sure the 'nodirector' feature is disabled  */
-	if (mndir)
-	  Delattr(m, "feature:nodirector");
+        /* be sure the 'nodirector' feature is disabled  */
+        if (mndir)
+          Delattr(m, "feature:nodirector");
       } else {
-	/* or just delete from the vm, since is not a director method */
-	Delitem(vm, i);
-	len--;
-	i--;
+        /* or just delete from the vm, since is not a director method */
+        Delitem(vm, i);
+        len--;
+        i--;
       }
     }
   }
@@ -2073,7 +2073,7 @@ int Language::classDirectorConstructors(Node *n) {
       Append(constructors, ni);
     } else if (Equal(nodeType, "using") && GetFlag(ni, "usingctor")) {
       for (Node *ui = firstChild(ni); ui; ui = nextSibling(ui)) {
-	Append(constructors, ui);
+        Append(constructors, ui);
       }
     }
   }
@@ -2088,15 +2088,15 @@ int Language::classDirectorConstructors(Node *n) {
       classDirectorConstructor(ni);
       constructor = 1;
       if (default_ctor)
-	default_ctor = !ParmList_numrequired(parms);
+        default_ctor = !ParmList_numrequired(parms);
     } else {
       /* emit protected constructor if needed */
       if (need_nonpublic_ctor(ni)) {
-	classDirectorConstructor(ni);
-	constructor = 1;
-	protected_ctor = 1;
-	if (default_ctor)
-	  default_ctor = !ParmList_numrequired(parms);
+        classDirectorConstructor(ni);
+        constructor = 1;
+        protected_ctor = 1;
+        if (default_ctor)
+          default_ctor = !ParmList_numrequired(parms);
       }
     }
   }
@@ -2160,7 +2160,7 @@ int Language::classDirectorMethods(Node *n) {
       assert(Getattr(method, "returntype"));
       Setattr(method, "type", Getattr(method, "returntype"));
       if (classDirectorMethod(method, n, fqdname) == SWIG_OK)
-	SetFlag(item, "director");
+        SetFlag(item, "director");
       Swig_restore(method);
     }
     if (wrn)
@@ -2447,30 +2447,30 @@ int Language::classHandler(Node *n) {
       cplus_mode = PROTECTED;
       int len = Len(vtable);
       for (int i = 0; i < len; i++) {
-	Node *item = Getitem(vtable, i);
-	Node *method = Getattr(item, "methodNode");
-	SwigType *type = Getattr(method, "nodeType");
-	if (Strcmp(type, "cdecl") != 0)
-	  continue;
-	if (GetFlag(method, "feature:ignore"))
-	  continue;
-	String *methodname = Getattr(method, "sym:name");
-	String *wrapname = NewStringf("%s_%s", symname, methodname);
-	if (!symbolLookup(wrapname, "") && (!is_public(method))) {
-	  Node *m = Copy(method);
-	  Setattr(m, "director", "1");
-	  Setattr(m, "parentNode", n);
-	  /*
-	   * There is a bug that needs fixing still... 
-	   * This area of code is creating methods which have not been overridden in a derived class (director methods that are protected in the base)
-	   * If the method is overloaded, then Swig_overload_dispatch() incorrectly generates a call to the base wrapper, _wrap_xxx method
-	   * See director_protected_overloaded.i - Possibly sym:overname needs correcting here.
-	  Printf(stdout, "new method: %s::%s(%s)\n", Getattr(parentNode(m), "name"), Getattr(m, "name"), ParmList_str_defaultargs(Getattr(m, "parms")));
-	  */
-	  cDeclaration(m);
-	  Delete(m);
-	}
-	Delete(wrapname);
+        Node *item = Getitem(vtable, i);
+        Node *method = Getattr(item, "methodNode");
+        SwigType *type = Getattr(method, "nodeType");
+        if (Strcmp(type, "cdecl") != 0)
+          continue;
+        if (GetFlag(method, "feature:ignore"))
+          continue;
+        String *methodname = Getattr(method, "sym:name");
+        String *wrapname = NewStringf("%s_%s", symname, methodname);
+        if (!symbolLookup(wrapname, "") && (!is_public(method))) {
+          Node *m = Copy(method);
+          Setattr(m, "director", "1");
+          Setattr(m, "parentNode", n);
+          /*
+           * There is a bug that needs fixing still... 
+           * This area of code is creating methods which have not been overridden in a derived class (director methods that are protected in the base)
+           * If the method is overloaded, then Swig_overload_dispatch() incorrectly generates a call to the base wrapper, _wrap_xxx method
+           * See director_protected_overloaded.i - Possibly sym:overname needs correcting here.
+          Printf(stdout, "new method: %s::%s(%s)\n", Getattr(parentNode(m), "name"), Getattr(m, "name"), ParmList_str_defaultargs(Getattr(m, "parms")));
+          */
+          cDeclaration(m);
+          Delete(m);
+        }
+        Delete(wrapname);
       }
     }
   }
@@ -2511,7 +2511,7 @@ int Language::constructorDeclaration(Node *n) {
     if ((num_required == 1) && Getattr(CurrentClass, "has_copy_constructor")) {
       String *ccdecl = Getattr(CurrentClass, "copy_constructor_decl");
       if (ccdecl && (Strcmp(ccdecl, Getattr(n, "decl")) == 0)) {
-	return SWIG_NOWRAP;
+        return SWIG_NOWRAP;
       }
     }
   }
@@ -2523,9 +2523,9 @@ int Language::constructorDeclaration(Node *n) {
     Node *nn = over;
     while (nn) {
       if (!is_public(nn)) {
-	if (!dirclass || !need_nonpublic_ctor(nn)) {
-	  SetFlag(nn, "feature:ignore");
-	}
+        if (!dirclass || !need_nonpublic_ctor(nn)) {
+          SetFlag(nn, "feature:ignore");
+        }
       }
       nn = Getattr(nn, "sym:nextSibling");
     }
@@ -2550,7 +2550,7 @@ int Language::constructorDeclaration(Node *n) {
       // Adjust name, except when the constructor's name comes from a templated constructor,
       // where the name passed to %template is used instead.
       if (!Getattr(n, "template"))
-	Setattr(n, "sym:name", ClassPrefix);
+        Setattr(n, "sym:name", ClassPrefix);
     }
     Delete(base);
   }
@@ -2565,19 +2565,19 @@ int Language::constructorDeclaration(Node *n) {
       /* If the symbol is overloaded.  We check to see if it is a copy constructor.  If so, 
          we invoke copyconstructorHandler() as a special case. */
       if (Getattr(n, "copy_constructor") && (!Getattr(CurrentClass, "has_copy_constructor"))) {
-	copyconstructorHandler(n);
-	Setattr(CurrentClass, "has_copy_constructor", "1");
+        copyconstructorHandler(n);
+        Setattr(CurrentClass, "has_copy_constructor", "1");
       } else {
-	if (Getattr(over, "copy_constructor"))
-	  over = Getattr(over, "sym:nextSibling");
-	if (over != n) {
-	  Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, input_file, line_number,
-		       "Overloaded constructor ignored.  %s\n", Swig_name_decl(n));
-	  Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, Getfile(over), Getline(over),
-		       "Previous declaration is %s\n", Swig_name_decl(over));
-	} else {
-	  constructorHandler(n);
-	}
+        if (Getattr(over, "copy_constructor"))
+          over = Getattr(over, "sym:nextSibling");
+        if (over != n) {
+          Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, input_file, line_number,
+                       "Overloaded constructor ignored.  %s\n", Swig_name_decl(n));
+          Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, Getfile(over), Getline(over),
+                       "Previous declaration is %s\n", Swig_name_decl(over));
+        } else {
+          constructorHandler(n);
+        }
       }
     } else {
       String *expected_name = ClassName;
@@ -2585,33 +2585,33 @@ int Language::constructorDeclaration(Node *n) {
       String *actual_name = scope ? NewStringf("%s::%s", scope, name) : NewString(name);
       Delete(scope);
       if (!Equal(actual_name, expected_name) && !SwigType_istemplate(expected_name) && !SwigType_istemplate(actual_name)) {
-	// Checking templates is skipped but they ought to be checked... they are just somewhat more tricky to check correctly
-	bool illegal_name = true;
-	if (Extend) {
-	  // Check for typedef names used as a constructor name in %extend. This is deprecated except for anonymous
-	  // typedef structs which have had their symbol names adjusted to the typedef name in the parser.
-	  SwigType *name_resolved = SwigType_typedef_resolve_all(actual_name);
-	  SwigType *expected_name_resolved = SwigType_typedef_resolve_all(expected_name);
+        // Checking templates is skipped but they ought to be checked... they are just somewhat more tricky to check correctly
+        bool illegal_name = true;
+        if (Extend) {
+          // Check for typedef names used as a constructor name in %extend. This is deprecated except for anonymous
+          // typedef structs which have had their symbol names adjusted to the typedef name in the parser.
+          SwigType *name_resolved = SwigType_typedef_resolve_all(actual_name);
+          SwigType *expected_name_resolved = SwigType_typedef_resolve_all(expected_name);
 
-	  if (!CPlusPlus) {
-	    if (Strncmp(name_resolved, "struct ", 7) == 0)
-	      Replace(name_resolved, "struct ", "", DOH_REPLACE_FIRST);
-	    else if (Strncmp(name_resolved, "union ", 6) == 0)
-	      Replace(name_resolved, "union ", "", DOH_REPLACE_FIRST);
-	  }
+          if (!CPlusPlus) {
+            if (Strncmp(name_resolved, "struct ", 7) == 0)
+              Replace(name_resolved, "struct ", "", DOH_REPLACE_FIRST);
+            else if (Strncmp(name_resolved, "union ", 6) == 0)
+              Replace(name_resolved, "union ", "", DOH_REPLACE_FIRST);
+          }
 
-	  illegal_name = !Equal(name_resolved, expected_name_resolved);
-	  if (!illegal_name)
-	    Swig_warning(WARN_LANG_EXTEND_CONSTRUCTOR, input_file, line_number, "Use of an illegal constructor name '%s' in %%extend is deprecated, the constructor name should be '%s'.\n", 
-		SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
-	  Delete(name_resolved);
-	  Delete(expected_name_resolved);
-	}
-	if (illegal_name) {
-	  Swig_warning(WARN_LANG_RETURN_TYPE, input_file, line_number, "Function %s must have a return type. Ignored.\n", Swig_name_decl(n));
-	  Swig_restore(n);
-	  return SWIG_NOWRAP;
-	}
+          illegal_name = !Equal(name_resolved, expected_name_resolved);
+          if (!illegal_name)
+            Swig_warning(WARN_LANG_EXTEND_CONSTRUCTOR, input_file, line_number, "Use of an illegal constructor name '%s' in %%extend is deprecated, the constructor name should be '%s'.\n", 
+                SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
+          Delete(name_resolved);
+          Delete(expected_name_resolved);
+        }
+        if (illegal_name) {
+          Swig_warning(WARN_LANG_RETURN_TYPE, input_file, line_number, "Function %s must have a return type. Ignored.\n", Swig_name_decl(n));
+          Swig_restore(n);
+          return SWIG_NOWRAP;
+        }
       }
       constructorHandler(n);
     }
@@ -2635,16 +2635,16 @@ static String *get_director_ctor_code(Node *n, String *director_ctor_code, Strin
       int is_notabstract = GetFlag(pn, "feature:notabstract");
       int is_abstract = abstracts && !is_notabstract;
       if (is_protected(n) || is_abstract) {
-	director_ctor = director_prot_ctor_code;
-	abstracts = Copy(abstracts);
-	Delattr(pn, "abstracts");
+        director_ctor = director_prot_ctor_code;
+        abstracts = Copy(abstracts);
+        Delattr(pn, "abstracts");
       } else {
-	if (is_notabstract) {
-	  abstracts = Copy(abstracts);
-	  Delattr(pn, "abstracts");
-	} else {
-	  abstracts = 0;
-	}
+        if (is_notabstract) {
+          abstracts = Copy(abstracts);
+          Delattr(pn, "abstracts");
+        } else {
+          abstracts = 0;
+        }
       }
     }
   }
@@ -2664,8 +2664,8 @@ int Language::constructorHandler(Node *n) {
   int constructor = (!Cmp(nodeType, "constructor"));
   List *abstracts = 0;
   String *director_ctor = get_director_ctor_code(n, director_ctor_code,
-						 director_prot_ctor_code,
-						 abstracts);
+                                                 director_prot_ctor_code,
+                                                 abstracts);
   if (!constructor) {
     /* if not originally a constructor, still handle it as one */
     Setattr(n, "handled_as_constructor", "1");
@@ -2693,8 +2693,8 @@ int Language::copyconstructorHandler(Node *n) {
   String *mrename = Swig_name_copyconstructor(NSpace, symname);
   List *abstracts = 0;
   String *director_ctor = get_director_ctor_code(n, director_ctor_code,
-						 director_prot_ctor_code,
-						 abstracts);
+                                                 director_prot_ctor_code,
+                                                 abstracts);
   Swig_ConstructorToFunction(n, NSpace, ClassType, none_comparison, director_ctor, CPlusPlus, Getattr(n, "template") ? 0 : Extend, DirectorClassName);
   Setattr(n, "sym:name", mrename);
   functionWrapper(n);
@@ -2748,27 +2748,27 @@ int Language::destructorDeclaration(Node *n) {
       Replace(actual_name, "~", "", DOH_REPLACE_FIRST);
       Replace(expected_name, "~", "", DOH_REPLACE_FIRST);
       if (Len(nprefix) > 0) {
-	String *old_actual_name = actual_name;
-	String *old_expected_name = expected_name;
-	actual_name = NewStringf("%s::%s", nprefix, actual_name);
-	expected_name = NewStringf("%s::%s", nprefix, expected_name);
-	Delete(old_expected_name);
-	Delete(old_actual_name);
+        String *old_actual_name = actual_name;
+        String *old_expected_name = expected_name;
+        actual_name = NewStringf("%s::%s", nprefix, actual_name);
+        expected_name = NewStringf("%s::%s", nprefix, expected_name);
+        Delete(old_expected_name);
+        Delete(old_actual_name);
       }
       SwigType *name_resolved = SwigType_typedef_resolve_all(actual_name);
       SwigType *expected_name_resolved = SwigType_typedef_resolve_all(expected_name);
 
       if (!CPlusPlus) {
-	if (Strncmp(name_resolved, "struct ", 7) == 0)
-	  Replace(name_resolved, "struct ", "", DOH_REPLACE_FIRST);
-	else if (Strncmp(name_resolved, "union ", 6) == 0)
-	  Replace(name_resolved, "union ", "", DOH_REPLACE_FIRST);
+        if (Strncmp(name_resolved, "struct ", 7) == 0)
+          Replace(name_resolved, "struct ", "", DOH_REPLACE_FIRST);
+        else if (Strncmp(name_resolved, "union ", 6) == 0)
+          Replace(name_resolved, "union ", "", DOH_REPLACE_FIRST);
       }
 
       illegal_name = !Equal(name_resolved, expected_name_resolved);
       if (!illegal_name)
-	Swig_warning(WARN_LANG_EXTEND_DESTRUCTOR, input_file, line_number, "Use of an illegal destructor name '%s' in %%extend is deprecated, the destructor name should be '%s'.\n", 
-	    SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
+        Swig_warning(WARN_LANG_EXTEND_DESTRUCTOR, input_file, line_number, "Use of an illegal destructor name '%s' in %%extend is deprecated, the destructor name should be '%s'.\n", 
+            SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
       Delete(name_resolved);
       Delete(expected_name_resolved);
     }
@@ -2863,7 +2863,7 @@ int Language::usingDeclaration(Node *n) {
     for (c = firstChild(np); c; c = nextSibling(c)) {
       /* it seems for some cases this is needed, like A* A::boo() */
       if (CurrentClass)
-	Setattr(c, "parentNode", CurrentClass);
+        Setattr(c, "parentNode", CurrentClass);
       emit_one(c);
     }
     Delete(np);
@@ -2923,8 +2923,8 @@ int Language::variableWrapper(Node *n) {
 
     if (!tm) {
       if (SwigType_isarray(type)) {
-	Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(type, 0));
-	make_set_wrapper = 0;
+        Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(type, 0));
+        make_set_wrapper = 0;
       }
     } else {
       String *pname0 = Swig_cparm_name(0, 0);
@@ -2949,7 +2949,7 @@ int Language::variableWrapper(Node *n) {
     Iterator ki;
     for (ki = First(n); ki.key; ki = Next(ki)) {
       if (Strncmp(ki.key, "tmap:", 5) == 0)
-	Delattr(n, ki.key);
+        Delattr(n, ki.key);
     }
   }
 
@@ -3012,9 +3012,9 @@ int Language::addSymbol(const String *s, const Node *n, const_String_or_char_ptr
     Node *c = Getattr(symbols, s);
     if (c && (c != n)) {
       if (scope && Len(scope) > 0)
-	Swig_error(input_file, line_number, "'%s' is multiply defined in the generated target language module in scope '%s'.\n", s, scope);
+        Swig_error(input_file, line_number, "'%s' is multiply defined in the generated target language module in scope '%s'.\n", s, scope);
       else
-	Swig_error(input_file, line_number, "'%s' is multiply defined in the generated target language module.\n", s);
+        Swig_error(input_file, line_number, "'%s' is multiply defined in the generated target language module.\n", s);
       Swig_error(Getfile(c), Getline(c), "Previous declaration of '%s'\n", s);
       return 0;
     }
@@ -3038,7 +3038,7 @@ int Language::addInterfaceSymbol(const String *interface_name, Node *n, const_St
     if (existing_symbol) {
       String *proxy_class_name = Getattr(n, "sym:name");
       Swig_error(input_file, line_number, "The interface feature name '%s' for proxy class '%s' is already defined in the generated target language module in scope '%s'.\n",
-	  interface_name, proxy_class_name, scope);
+          interface_name, proxy_class_name, scope);
       Swig_error(Getfile(existing_symbol), Getline(existing_symbol), "Previous declaration of '%s'\n", interface_name);
       return 0;
     }
@@ -3143,10 +3143,10 @@ void Language::dumpSymbols() {
       Symtab *symtab = Getattr(table, k);
       Iterator it = First(symtab);
       while (it.key) {
-	String *symname = it.key;
-	Printf(stdout, "  %s\n", symname);
-	//Printf(stdout, "  %s (%s:%d)\n", symname, Getfile(it.item), Getline(it.item));
-	it = Next(it);
+        String *symname = it.key;
+        Printf(stdout, "  %s\n", symname);
+        //Printf(stdout, "  %s (%s:%d)\n", symname, Getfile(it.item), Getline(it.item));
+        it = Next(it);
       }
     }
     ki = Next(ki);
@@ -3204,9 +3204,9 @@ Node *Language::classLookup(const SwigType *s) {
       Hash *nstab;
       n = Swig_symbol_clookup(base, stab);
       if (!n)
-	break;
+        break;
       if (Strcmp(nodeType(n), "class") == 0)
-	break;
+        break;
       Node *sibling = n;
       while (sibling) {
        sibling = Getattr(sibling, "csym:nextSibling");
@@ -3217,11 +3217,11 @@ Node *Language::classLookup(const SwigType *s) {
        break;
       n = parentNode(n);
       if (!n)
-	break;
+        break;
       nstab = Getattr(n, "sym:symtab");
       n = 0;
       if ((!nstab) || (nstab == stab)) {
-	break;
+        break;
       }
       stab = nstab;
     }
@@ -3229,25 +3229,25 @@ Node *Language::classLookup(const SwigType *s) {
       /* Found a match.  Look at the prefix.  We only allow
          the cases where we want a proxy class for the particular type */
       bool acceptable_prefix = 
-	(Len(prefix) == 0) ||			      // simple type (pass by value)
-	(Strcmp(prefix, "p.") == 0) ||		      // pointer
-	(Strcmp(prefix, "r.") == 0) ||		      // reference
-	(Strcmp(prefix, "z.") == 0) ||		      // rvalue reference
-	SwigType_prefix_is_simple_1D_array(prefix);   // Simple 1D array (not arrays of pointers/references)
+        (Len(prefix) == 0) ||			      // simple type (pass by value)
+        (Strcmp(prefix, "p.") == 0) ||		      // pointer
+        (Strcmp(prefix, "r.") == 0) ||		      // reference
+        (Strcmp(prefix, "z.") == 0) ||		      // rvalue reference
+        SwigType_prefix_is_simple_1D_array(prefix);   // Simple 1D array (not arrays of pointers/references)
       // Also accept pointer by const reference, not non-const pointer reference
       if (!acceptable_prefix && (Strcmp(prefix, "r.p.") == 0)) {
-	Delete(prefix);
-	prefix = SwigType_prefix(ty1);
-	acceptable_prefix = (Strncmp(prefix, "r.q(const", 9) == 0);
+        Delete(prefix);
+        prefix = SwigType_prefix(ty1);
+        acceptable_prefix = (Strncmp(prefix, "r.q(const", 9) == 0);
       }
       if (acceptable_prefix) {
-	SwigType *cs = Copy(s);
-	if (!classtypes)
-	  classtypes = NewHash();
-	Setattr(classtypes, cs, n);
-	Delete(cs);
+        SwigType *cs = Copy(s);
+        if (!classtypes)
+          classtypes = NewHash();
+        Setattr(classtypes, cs, n);
+        Delete(cs);
       } else {
-	n = 0;
+        n = 0;
       }
     }
     Delete(prefix);
@@ -3298,29 +3298,29 @@ Node *Language::enumLookup(SwigType *s) {
       Hash *nstab;
       n = Swig_symbol_clookup(base, stab);
       if (!n)
-	break;
+        break;
       if (Equal(nodeType(n), "enum"))
-	break;
+        break;
       if (Equal(nodeType(n), "enumforward") && GetFlag(n, "enumMissing"))
-	break;
+        break;
       n = parentNode(n);
       if (!n)
-	break;
+        break;
       nstab = Getattr(n, "sym:symtab");
       n = 0;
       if ((!nstab) || (nstab == stab)) {
-	break;
+        break;
       }
       stab = nstab;
     }
     if (n) {
       /* Found a match.  Look at the prefix.  We only allow simple types. */
       if (Len(prefix) == 0) {	/* Simple type */
-	if (!enumtypes)
-	  enumtypes = NewHash();
-	Setattr(enumtypes, Copy(s), n);
+        if (!enumtypes)
+          enumtypes = NewHash();
+        Setattr(enumtypes, Copy(s), n);
       } else {
-	n = 0;
+        n = 0;
       }
     }
     Delete(prefix);
@@ -3444,26 +3444,26 @@ int Language::need_nonpublic_ctor(Node *n) {
   if (Swig_directors_enabled()) {
     if (is_protected(n)) {
       if (dirprot_mode()) {
-	/* when using dirprot mode, the protected constructors are
-	   always needed */
-	return 1;
+        /* when using dirprot mode, the protected constructors are
+           always needed */
+        return 1;
       } else {
-	int is_default_ctor = !ParmList_numrequired(Getattr(n, "parms"));
-	if (is_default_ctor) {
-	  /* the default protected constructor is always needed, for java compatibility */
-	  return 1;
-	} else {
-	  /* check if there is a public constructor */
-	  Node *parent = Swig_methodclass(n);
-	  int public_ctor = Getattr(parent, "allocate:default_constructor")
-	      || Getattr(parent, "allocate:public_constructor");
-	  if (!public_ctor) {
-	    /* if not, the protected constructor will be needed only
-	       if there is no protected default constructor declared */
-	    int no_prot_default_ctor = !Getattr(parent, "allocate:default_base_constructor");
-	    return no_prot_default_ctor;
-	  }
-	}
+        int is_default_ctor = !ParmList_numrequired(Getattr(n, "parms"));
+        if (is_default_ctor) {
+          /* the default protected constructor is always needed, for java compatibility */
+          return 1;
+        } else {
+          /* check if there is a public constructor */
+          Node *parent = Swig_methodclass(n);
+          int public_ctor = Getattr(parent, "allocate:default_constructor")
+              || Getattr(parent, "allocate:public_constructor");
+          if (!public_ctor) {
+            /* if not, the protected constructor will be needed only
+               if there is no protected default constructor declared */
+            int no_prot_default_ctor = !Getattr(parent, "allocate:default_base_constructor");
+            return no_prot_default_ctor;
+          }
+        }
       }
     }
   }
@@ -3477,12 +3477,12 @@ int Language::need_nonpublic_member(Node *n) {
   if (Swig_directors_enabled() && DirectorClassName) {
     if (is_protected(n)) {
       if (dirprot_mode()) {
-	/* when using dirprot mode, the protected members are always needed. */
-	return 1;
+        /* when using dirprot mode, the protected members are always needed. */
+        return 1;
       } else {
-	/* if the method is pure virtual, we need it. */
-	int pure_virtual = (Cmp(Getattr(n, "value"), "0") == 0);
-	return pure_virtual;
+        /* if the method is pure virtual, we need it. */
+        int pure_virtual = (Cmp(Getattr(n, "value"), "0") == 0);
+        return pure_virtual;
       }
     }
   }
@@ -3521,7 +3521,7 @@ String *Language::makeParameterName(Node *n, Parm *p, int arg_num, bool setter) 
   while (plist) {
     if ((Cmp(pn, Getattr(plist, "name")) == 0)) {
       if (!first_duplicate_parm)
-	first_duplicate_parm = plist;
+        first_duplicate_parm = plist;
       count++;
     }
     plist = nextSibling(plist);
@@ -3656,7 +3656,7 @@ int Dispatcher::abstractClassTest(Node *n) {
     for (int i = 0; i < Len(bases); i++) {
       Node *b = Getitem(bases, i);
       if (GetFlag(b, "allocate:private_destructor"))
-	return 1;
+        return 1;
     }
   }
 
@@ -3686,34 +3686,34 @@ int Dispatcher::abstractClassTest(Node *n) {
       Node *ni = Getitem(abstracts, i);
       String *method_id = vtable_method_id(ni);
       if (!method_id)
-	continue;
+        continue;
       bool exists_item = false;
       int len = Len(vtable);
       for (int i = 0; i < len; i++) {
-	Node *item = Getitem(vtable, i);
-	String *check_item = Getattr(item, "vmid");
-	if (Strcmp(method_id, check_item) == 0) {
-	  exists_item = true;
-	  break;
-	}
+        Node *item = Getitem(vtable, i);
+        String *check_item = Getattr(item, "vmid");
+        if (Strcmp(method_id, check_item) == 0) {
+          exists_item = true;
+          break;
+        }
       }
 #ifdef SWIG_DEBUG
       Printf(stderr, "method %s %d\n", method_id, exists_item ? 1 : 0);
 #endif
       Delete(method_id);
       if (!exists_item) {
-	dirabstract = ni;
-	break;
+        dirabstract = ni;
+        break;
       }
     }
     if (dirabstract) {
       if (is_public(dirabstract)) {
-	Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT, Getfile(n), Getline(n),
-		     "Director class '%s' is abstract, abstract method '%s' is not accessible, maybe due to multiple inheritance or 'nodirector' feature\n",
-		     SwigType_namestr(Getattr(n, "name")), Getattr(dirabstract, "name"));
+        Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT, Getfile(n), Getline(n),
+                     "Director class '%s' is abstract, abstract method '%s' is not accessible, maybe due to multiple inheritance or 'nodirector' feature\n",
+                     SwigType_namestr(Getattr(n, "name")), Getattr(dirabstract, "name"));
       } else {
-	Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT, Getfile(n), Getline(n),
-		     "Director class '%s' is abstract, abstract method '%s' is private\n", SwigType_namestr(Getattr(n, "name")), Getattr(dirabstract, "name"));
+        Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT, Getfile(n), Getline(n),
+                     "Director class '%s' is abstract, abstract method '%s' is private\n", SwigType_namestr(Getattr(n, "name")), Getattr(dirabstract, "name"));
       }
       return 1;
     }

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -483,7 +483,7 @@ static Node *first_nontemplate(Node *n) {
 /* --------------------------------------------------------------------------
  * swig_pragma()
  *
- * Handle swig pragma directives.  
+ * Handle swig pragma directives.
  * -------------------------------------------------------------------------- */
 
 static void swig_pragma(char *lang, char *name, char *value) {
@@ -548,7 +548,7 @@ int Language::use_naturalvar_mode(Node *n) const {
 }
 
 /* ----------------------------------------------------------------------
- * Language::top()   - Top of parsing tree 
+ * Language::top()   - Top of parsing tree
  * ---------------------------------------------------------------------- */
 
 int Language::top(Node *n) {
@@ -1452,7 +1452,7 @@ int Language::membervariableHandler(Node *n) {
     int assignable = !is_immutable(n);
 
     if (SmartPointer) {
-      if (!Getattr(CurrentClass, "allocate:smartpointermutable")) { 
+      if (!Getattr(CurrentClass, "allocate:smartpointermutable")) {
         assignable = 0;
       }
     }
@@ -1546,8 +1546,8 @@ int Language::membervariableHandler(Node *n) {
 
   } else {
 
-    /* This code is used to support the attributefunction directive 
-       where member variables are converted automagically to 
+    /* This code is used to support the attributefunction directive
+       where member variables are converted automagically to
        accessor functions */
 
 #if 0
@@ -1757,7 +1757,7 @@ int Language::enumforwardDeclaration(Node *n) {
   return SWIG_OK;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Language::memberconstantHandler()
  * ----------------------------------------------------------------------------- */
 
@@ -1797,7 +1797,7 @@ int Language::memberconstantHandler(Node *n) {
 }
 
 /* ----------------------------------------------------------------------
- * Language::typedefHandler() 
+ * Language::typedefHandler()
  * ---------------------------------------------------------------------- */
 
 int Language::typedefHandler(Node *n) {
@@ -1806,7 +1806,7 @@ int Language::typedefHandler(Node *n) {
      in
 
      typedef void NT;
-     int func(NT *p); 
+     int func(NT *p);
 
      see director_basic.i for example.
    */
@@ -2116,7 +2116,7 @@ int Language::classDirectorConstructors(Node *n) {
   }
   /* this is just to support old java behavior, ie, the default
      constructor is always emitted, even when protected, and not
-     needed, since there is a public constructor already defined.  
+     needed, since there is a public constructor already defined.
 
      (scottm) This code is needed here to make the director_abstract +
      test generate compilable code (Example2 in director_abstract.i).
@@ -2184,7 +2184,7 @@ int Language::classDirectorInit(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::classDirectorDestructor(Node *n) {
-  /* 
+  /*
      Always emit the virtual destructor in the declaration and in the
      compilation unit.  Being explicit here can't make any damage, and
      can solve some nasty C++ compiler problems.
@@ -2461,7 +2461,7 @@ int Language::classHandler(Node *n) {
           Setattr(m, "director", "1");
           Setattr(m, "parentNode", n);
           /*
-           * There is a bug that needs fixing still... 
+           * There is a bug that needs fixing still...
            * This area of code is creating methods which have not been overridden in a derived class (director methods that are protected in the base)
            * If the method is overloaded, then Swig_overload_dispatch() incorrectly generates a call to the base wrapper, _wrap_xxx method
            * See director_protected_overloaded.i - Possibly sym:overname needs correcting here.
@@ -2562,7 +2562,7 @@ int Language::constructorDeclaration(Node *n) {
     if (over)
       over = first_nontemplate(over);
     if ((over) && (!overloading)) {
-      /* If the symbol is overloaded.  We check to see if it is a copy constructor.  If so, 
+      /* If the symbol is overloaded.  We check to see if it is a copy constructor.  If so,
          we invoke copyconstructorHandler() as a special case. */
       if (Getattr(n, "copy_constructor") && (!Getattr(CurrentClass, "has_copy_constructor"))) {
         copyconstructorHandler(n);
@@ -2602,7 +2602,7 @@ int Language::constructorDeclaration(Node *n) {
 
           illegal_name = !Equal(name_resolved, expected_name_resolved);
           if (!illegal_name)
-            Swig_warning(WARN_LANG_EXTEND_CONSTRUCTOR, input_file, line_number, "Use of an illegal constructor name '%s' in %%extend is deprecated, the constructor name should be '%s'.\n", 
+            Swig_warning(WARN_LANG_EXTEND_CONSTRUCTOR, input_file, line_number, "Use of an illegal constructor name '%s' in %%extend is deprecated, the constructor name should be '%s'.\n",
                 SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
           Delete(name_resolved);
           Delete(expected_name_resolved);
@@ -2767,7 +2767,7 @@ int Language::destructorDeclaration(Node *n) {
 
       illegal_name = !Equal(name_resolved, expected_name_resolved);
       if (!illegal_name)
-        Swig_warning(WARN_LANG_EXTEND_DESTRUCTOR, input_file, line_number, "Use of an illegal destructor name '%s' in %%extend is deprecated, the destructor name should be '%s'.\n", 
+        Swig_warning(WARN_LANG_EXTEND_DESTRUCTOR, input_file, line_number, "Use of an illegal destructor name '%s' in %%extend is deprecated, the destructor name should be '%s'.\n",
             SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
       Delete(name_resolved);
       Delete(expected_name_resolved);
@@ -3228,7 +3228,7 @@ Node *Language::classLookup(const SwigType *s) {
     if (n) {
       /* Found a match.  Look at the prefix.  We only allow
          the cases where we want a proxy class for the particular type */
-      bool acceptable_prefix = 
+      bool acceptable_prefix =
         (Len(prefix) == 0) ||			      // simple type (pass by value)
         (Strcmp(prefix, "p.") == 0) ||		      // pointer
         (Strcmp(prefix, "r.") == 0) ||		      // reference
@@ -3265,7 +3265,7 @@ Node *Language::classLookup(const SwigType *s) {
 /* -----------------------------------------------------------------------------
  * Language::enumLookup()
  *
- * Finds and returns the Node containing the enum declaration for the (enum) 
+ * Finds and returns the Node containing the enum declaration for the (enum)
  * type passed in.
  * ----------------------------------------------------------------------------- */
 
@@ -3413,7 +3413,7 @@ int Language::dirprot_mode() const {
  * ----------------------------------------------------------------------------- */
 
 int Language::need_nonpublic_ctor(Node *n) {
-  /* 
+  /*
      detects when a protected constructor is needed, which is always
      the case if 'dirprot' mode is used.  However, if that is not the
      case, we will try to strictly emit what is minimal to don't break
@@ -3501,7 +3501,7 @@ int Language::is_smart_pointer() const {
 /* -----------------------------------------------------------------------------
  * Language::makeParameterName()
  *
- * Inputs: 
+ * Inputs:
  *   n - Node
  *   p - parameter node
  *   arg_num - parameter argument number
@@ -3554,7 +3554,7 @@ String *Language::makeParameterName(Node *n, Parm *p, int arg_num, bool setter) 
 
 bool Language::isNonVirtualProtectedAccess(Node *n) const {
   // Ideally is_non_virtual_protected_access() would contain all this logic, see
-  // comments therein about vtable. 
+  // comments therein about vtable.
   return DirectorClassName && is_non_virtual_protected_access(n);
 }
 

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -45,29 +45,29 @@ void Wrapper_naturalvar_mode_set(int flag) {
 }
 
 extern "C" {
-  int Swig_director_mode() {
-    return director_mode;
-  }
-  int Swig_director_protected_mode() {
-    return director_protected_mode;
-  }
-  int Swig_all_protected_mode() {
-    return all_protected_mode;
-  }
-  void Language_replace_special_variables(String *method, String *tm, Parm *parm) {
-    Language::instance()->replaceSpecialVariables(method, tm, parm);
-  }
+int Swig_director_mode() {
+  return director_mode;
+}
+int Swig_director_protected_mode() {
+  return director_protected_mode;
+}
+int Swig_all_protected_mode() {
+  return all_protected_mode;
+}
+void Language_replace_special_variables(String *method, String *tm, Parm *parm) {
+  Language::instance()->replaceSpecialVariables(method, tm, parm);
+}
 }
 
 /* Some status variables used during parsing */
-static int InClass = 0; /* Parsing C++ or not */
-static String *ClassName = 0;   /* This is the real name of the current class */
-static String *EnumClassName = 0; /* Enum class name */
-static String *ClassPrefix = 0; /* Class prefix */
-static String *EnumClassPrefix = 0; /* Prefix for strongly typed enums (including ClassPrefix) */
-static String *NSpace = 0;      /* Namespace for the nspace feature */
-static String *ClassType = 0;   /* Fully qualified type name to use */
-static String *DirectorClassName = 0;   /* Director name of the current class */
+static int InClass = 0;               /* Parsing C++ or not */
+static String *ClassName = 0;         /* This is the real name of the current class */
+static String *EnumClassName = 0;     /* Enum class name */
+static String *ClassPrefix = 0;       /* Class prefix */
+static String *EnumClassPrefix = 0;   /* Prefix for strongly typed enums (including ClassPrefix) */
+static String *NSpace = 0;            /* Namespace for the nspace feature */
+static String *ClassType = 0;         /* Fully qualified type name to use */
+static String *DirectorClassName = 0; /* Director name of the current class */
 int Abstract = 0;
 int ImportMode = 0;
 int IsVirtual = 0;
@@ -82,12 +82,12 @@ static Hash *classhash;
 extern int ForceExtern;
 extern int AddExtern;
 extern "C" {
-  extern int UseWrapperSuffix;
+extern int UseWrapperSuffix;
 }
 
 /* import modes */
 
-#define  IMPORT_MODE     1
+#define IMPORT_MODE 1
 
 /* ----------------------------------------------------------------------
  * Dispatcher::emit_one()
@@ -218,7 +218,6 @@ int Dispatcher::emit_children(Node *n) {
   }
   return SWIG_OK;
 }
-
 
 /* Stubs for dispatcher class.  We don't do anything by default---up to derived class
    to fill in traversal code */
@@ -357,19 +356,18 @@ Dispatcher::AccessMode Dispatcher::accessModeFromString(String *access) {
   return mode;
 }
 
-
 /* Allocators */
-Language::Language():
-none_comparison(NewString("$arg != 0")),
-director_ctor_code(NewString("")),
-director_prot_ctor_code(0),
-director_multiple_inheritance(1),
-doxygenTranslator(NULL),
-symtabs(NewHash()),
-overloading(0),
-multiinput(0),
-cplus_runtime(0) {
-  symbolAddScope(""); // create top level/global symbol table scope
+Language::Language() :
+  none_comparison(NewString("$arg != 0")),
+  director_ctor_code(NewString("")),
+  director_prot_ctor_code(0),
+  director_multiple_inheritance(1),
+  doxygenTranslator(NULL),
+  symtabs(NewHash()),
+  overloading(0),
+  multiinput(0),
+  cplus_runtime(0) {
+  symbolAddScope("");  // create top level/global symbol table scope
   argc_template_string = NewString("argc");
   argv_template_string = NewString("argv[%d]");
 
@@ -387,26 +385,26 @@ Language::~Language() {
   this_ = 0;
 }
 
-  /* -----------------------------------------------------------------------------
-   * directorClassName()
-   * ----------------------------------------------------------------------------- */
+/* -----------------------------------------------------------------------------
+ * directorClassName()
+ * ----------------------------------------------------------------------------- */
 
-  String *Language::directorClassName(Node *n) {
-    String *dirclassname;
-    String *nspace = NewString(Getattr(n, "sym:nspace"));
-    const char *attrib = "director:classname";
-    String *classname = getClassPrefix();
+String *Language::directorClassName(Node *n) {
+  String *dirclassname;
+  String *nspace = NewString(Getattr(n, "sym:nspace"));
+  const char *attrib = "director:classname";
+  String *classname = getClassPrefix();
 
-    Replace(nspace, NSPACE_SEPARATOR, "_", DOH_REPLACE_ANY);
-    if (Len(nspace) > 0)
-      dirclassname = NewStringf("SwigDirector_%s_%s", nspace, classname);
-    else
-      dirclassname = NewStringf("SwigDirector_%s", classname);
-    Setattr(n, attrib, dirclassname);
+  Replace(nspace, NSPACE_SEPARATOR, "_", DOH_REPLACE_ANY);
+  if (Len(nspace) > 0)
+    dirclassname = NewStringf("SwigDirector_%s_%s", nspace, classname);
+  else
+    dirclassname = NewStringf("SwigDirector_%s", classname);
+  Setattr(n, attrib, dirclassname);
 
-    Delete(nspace);
-    return dirclassname;
-  }
+  Delete(nspace);
+  return dirclassname;
+}
 
 /* ----------------------------------------------------------------------
    emit_one()
@@ -418,8 +416,7 @@ int Language::emit_one(Node *n) {
   if (!n)
     return SWIG_OK;
 
-  if (GetFlag(n, "feature:ignore")
-      && !Getattr(n, "feature:onlychildren"))
+  if (GetFlag(n, "feature:ignore") && !Getattr(n, "feature:onlychildren"))
     return SWIG_OK;
 
   oldext = Extend;
@@ -444,7 +441,6 @@ int Language::emit_one(Node *n) {
   Extend = oldext;
   return ret;
 }
-
 
 static Parm *nonvoid_parms(Parm *p) {
   if (p) {
@@ -477,8 +473,6 @@ static Node *first_nontemplate(Node *n) {
   }
   return n;
 }
-
-
 
 /* --------------------------------------------------------------------------
  * swig_pragma()
@@ -680,7 +674,7 @@ int Language::insertDirective(Node *n) {
     String *code = Getattr(n, "code");
     String *section = Getattr(n, "section");
     File *f = 0;
-    if (!section) {             /* %{ ... %} */
+    if (!section) { /* %{ ... %} */
       f = Swig_filebyname("header");
     } else {
       f = Swig_filebyname(section);
@@ -701,7 +695,7 @@ int Language::insertDirective(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::moduleDirective(Node *n) {
-  (void) n;
+  (void)n;
   /* %module directive */
   return SWIG_OK;
 }
@@ -746,7 +740,6 @@ int Language::typemapDirective(Node *n) {
   Parm *kwargs = Getattr(n, "kwargs");
   Node *items = firstChild(n);
   static int nameerror = 0;
-
 
   if (code && (Strstr(code, "$source") || (Strstr(code, "$target")))) {
     Swig_error(Getfile(n), Getline(n), "Obsolete typemap feature ($source/$target).\n");
@@ -811,7 +804,6 @@ Doc/Manual/Typemaps.html for complete details.\n");
     items = nextSibling(items);
   }
   return SWIG_OK;
-
 }
 
 /* ----------------------------------------------------------------------
@@ -883,8 +875,8 @@ int Language::cDeclaration(Node *n) {
       // Ignore it unless it has been %rename'd
       if (Strncmp(symname, "__dummy_", 8) == 0 && Cmp(storage, "typedef") != 0) {
         SetFlag(n, "feature:ignore");
-        Swig_warning(WARN_LANG_TEMPLATE_METHOD_IGNORE, input_file, line_number,
-            "%%template() contains no name. Template method ignored: %s\n", Swig_name_decl(n));
+        Swig_warning(
+          WARN_LANG_TEMPLATE_METHOD_IGNORE, input_file, line_number, "%%template() contains no name. Template method ignored: %s\n", Swig_name_decl(n));
         return SWIG_NOWRAP;
       }
     }
@@ -898,7 +890,7 @@ int Language::cDeclaration(Node *n) {
       /* Check what the director needs. If the method is pure virtual, it is always needed.
        * Also wrap non-virtual protected members if asked for (allprotected mode). */
       if (!(Swig_directors_enabled() && ((is_member_director(CurrentClass, n) && need_nonpublic_member(n)) || isNonVirtualProtectedAccess(n)))) {
-          return SWIG_NOWRAP;
+        return SWIG_NOWRAP;
       }
       // Prevent wrapping protected overloaded director methods more than once -
       // This bit of code is only needed due to the cDeclaration call in classHandler()
@@ -1594,7 +1586,8 @@ int Language::membervariableHandler(Node *n) {
 int Language::staticmembervariableHandler(Node *n) {
   Swig_require("staticmembervariableHandler", n, "*name", "*sym:name", "*type", "?value", NIL);
   String *value = Getattr(n, "value");
-  String *classname = !SmartPointer ? (isNonVirtualProtectedAccess(n) ? DirectorClassName : ClassName) : Getattr(CurrentClass, "allocate:smartpointerpointeeclassname");
+  String *classname =
+    !SmartPointer ? (isNonVirtualProtectedAccess(n) ? DirectorClassName : ClassName) : Getattr(CurrentClass, "allocate:smartpointerpointeeclassname");
 
   if (!value || !Getattr(n, "hasconsttype")) {
     String *name = Getattr(n, "name");
@@ -1639,7 +1632,6 @@ int Language::staticmembervariableHandler(Node *n) {
        the best we can do is to wrap the given value verbatim.
      */
 
-
     String *name = Getattr(n, "name");
     String *cname = NewStringf("%s::%s", classname, name);
     if (Extend) {
@@ -1664,7 +1656,6 @@ int Language::staticmembervariableHandler(Node *n) {
   Swig_restore(n);
   return SWIG_OK;
 }
-
 
 /* ----------------------------------------------------------------------
  * Language::externDeclaration()
@@ -1735,7 +1726,7 @@ int Language::enumvalueDeclaration(Node *n) {
   }
 
   if (!CurrentClass || !cparse_cplusplus) {
-    Setattr(n, "name", tmpValue);       /* for wrapping of enums in a namespace when emit_action is used */
+    Setattr(n, "name", tmpValue); /* for wrapping of enums in a namespace when emit_action is used */
     constantWrapper(n);
   } else {
     memberconstantHandler(n);
@@ -1751,9 +1742,9 @@ int Language::enumvalueDeclaration(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::enumforwardDeclaration(Node *n) {
-  (void) n;
+  (void)n;
   if (GetFlag(n, "enumMissing"))
-    enumDeclaration(n); // Generate an empty enum in target language
+    enumDeclaration(n);  // Generate an empty enum in target language
   return SWIG_OK;
 }
 
@@ -1772,7 +1763,7 @@ int Language::memberconstantHandler(Node *n) {
     Setattr(n, "feature:except", Getattr(n, "feature:exceptvar"));
   }
 
-  String *enumvalue_symname = Getattr(n, "enumvalueDeclaration:sym:name"); // Only set if a strongly typed enum
+  String *enumvalue_symname = Getattr(n, "enumvalueDeclaration:sym:name");  // Only set if a strongly typed enum
   String *name = Getattr(n, "name");
   String *symname = Getattr(n, "sym:name");
   String *value = Getattr(n, "value");
@@ -1828,9 +1819,9 @@ int Language::typedefHandler(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::classDirectorMethod(Node *n, Node *parent, String *super) {
-  (void) n;
-  (void) parent;
-  (void) super;
+  (void)n;
+  (void)parent;
+  (void)super;
   return SWIG_OK;
 }
 
@@ -1839,7 +1830,7 @@ int Language::classDirectorMethod(Node *n, Node *parent, String *super) {
  * ---------------------------------------------------------------------- */
 
 int Language::classDirectorConstructor(Node *n) {
-  (void) n;
+  (void)n;
   return SWIG_OK;
 }
 
@@ -1848,7 +1839,7 @@ int Language::classDirectorConstructor(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::classDirectorDefaultConstructor(Node *n) {
-  (void) n;
+  (void)n;
   return SWIG_OK;
 }
 
@@ -2018,7 +2009,6 @@ int Language::unrollVirtualMethods(Node *n, Node *parent, List *vm, int &virtual
   return SWIG_OK;
 }
 
-
 /* ----------------------------------------------------------------------
  * Language::classDirectorDisown()
  * ---------------------------------------------------------------------- */
@@ -2175,7 +2165,7 @@ int Language::classDirectorMethods(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::classDirectorInit(Node *n) {
-  (void) n;
+  (void)n;
   return SWIG_OK;
 }
 
@@ -2209,7 +2199,7 @@ int Language::classDirectorDestructor(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::classDirectorEnd(Node *n) {
-  (void) n;
+  (void)n;
   return SWIG_OK;
 }
 
@@ -2240,7 +2230,8 @@ int Language::classDirector(Node *n) {
     if (Cmp(nodeType, "destructor") == 0 && GetFlag(ni, "final")) {
       String *classtype = Getattr(n, "classtype");
       SWIG_WARN_NODE_BEGIN(ni);
-      Swig_warning(WARN_LANG_DIRECTOR_FINAL, input_file, line_number, "Destructor %s is final, %s cannot be a director class.\n", Swig_name_decl(ni), classtype);
+      Swig_warning(
+        WARN_LANG_DIRECTOR_FINAL, input_file, line_number, "Destructor %s is final, %s cannot be a director class.\n", Swig_name_decl(ni), classtype);
       SWIG_WARN_NODE_END(ni);
       SetFlag(n, "feature:nodirector");
       Delete(vtable);
@@ -2483,7 +2474,7 @@ int Language::classHandler(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int Language::classforwardDeclaration(Node *n) {
-  (void) n;
+  (void)n;
   return SWIG_OK;
 }
 
@@ -2571,10 +2562,8 @@ int Language::constructorDeclaration(Node *n) {
         if (Getattr(over, "copy_constructor"))
           over = Getattr(over, "sym:nextSibling");
         if (over != n) {
-          Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, input_file, line_number,
-                       "Overloaded constructor ignored.  %s\n", Swig_name_decl(n));
-          Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, Getfile(over), Getline(over),
-                       "Previous declaration is %s\n", Swig_name_decl(over));
+          Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, input_file, line_number, "Overloaded constructor ignored.  %s\n", Swig_name_decl(n));
+          Swig_warning(WARN_LANG_OVERLOAD_CONSTRUCT, Getfile(over), Getline(over), "Previous declaration is %s\n", Swig_name_decl(over));
         } else {
           constructorHandler(n);
         }
@@ -2602,8 +2591,12 @@ int Language::constructorDeclaration(Node *n) {
 
           illegal_name = !Equal(name_resolved, expected_name_resolved);
           if (!illegal_name)
-            Swig_warning(WARN_LANG_EXTEND_CONSTRUCTOR, input_file, line_number, "Use of an illegal constructor name '%s' in %%extend is deprecated, the constructor name should be '%s'.\n",
-                SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
+            Swig_warning(WARN_LANG_EXTEND_CONSTRUCTOR,
+                         input_file,
+                         line_number,
+                         "Use of an illegal constructor name '%s' in %%extend is deprecated, the constructor name should be '%s'.\n",
+                         SwigType_str(Swig_scopename_last(actual_name), 0),
+                         SwigType_str(Swig_scopename_last(expected_name), 0));
           Delete(name_resolved);
           Delete(expected_name_resolved);
         }
@@ -2651,7 +2644,6 @@ static String *get_director_ctor_code(Node *n, String *director_ctor_code, Strin
   return director_ctor;
 }
 
-
 /* ----------------------------------------------------------------------
  * Language::constructorHandler()
  * ---------------------------------------------------------------------- */
@@ -2663,9 +2655,7 @@ int Language::constructorHandler(Node *n) {
   String *nodeType = Getattr(n, "nodeType");
   int constructor = (!Cmp(nodeType, "constructor"));
   List *abstracts = 0;
-  String *director_ctor = get_director_ctor_code(n, director_ctor_code,
-                                                 director_prot_ctor_code,
-                                                 abstracts);
+  String *director_ctor = get_director_ctor_code(n, director_ctor_code, director_prot_ctor_code, abstracts);
   if (!constructor) {
     /* if not originally a constructor, still handle it as one */
     Setattr(n, "handled_as_constructor", "1");
@@ -2692,9 +2682,7 @@ int Language::copyconstructorHandler(Node *n) {
   String *symname = Getattr(n, "sym:name");
   String *mrename = Swig_name_copyconstructor(NSpace, symname);
   List *abstracts = 0;
-  String *director_ctor = get_director_ctor_code(n, director_ctor_code,
-                                                 director_prot_ctor_code,
-                                                 abstracts);
+  String *director_ctor = get_director_ctor_code(n, director_ctor_code, director_prot_ctor_code, abstracts);
   Swig_ConstructorToFunction(n, NSpace, ClassType, none_comparison, director_ctor, CPlusPlus, Getattr(n, "template") ? 0 : Extend, DirectorClassName);
   Setattr(n, "sym:name", mrename);
   functionWrapper(n);
@@ -2767,8 +2755,12 @@ int Language::destructorDeclaration(Node *n) {
 
       illegal_name = !Equal(name_resolved, expected_name_resolved);
       if (!illegal_name)
-        Swig_warning(WARN_LANG_EXTEND_DESTRUCTOR, input_file, line_number, "Use of an illegal destructor name '%s' in %%extend is deprecated, the destructor name should be '%s'.\n",
-            SwigType_str(Swig_scopename_last(actual_name), 0), SwigType_str(Swig_scopename_last(expected_name), 0));
+        Swig_warning(WARN_LANG_EXTEND_DESTRUCTOR,
+                     input_file,
+                     line_number,
+                     "Use of an illegal destructor name '%s' in %%extend is deprecated, the destructor name should be '%s'.\n",
+                     SwigType_str(Swig_scopename_last(actual_name), 0),
+                     SwigType_str(Swig_scopename_last(expected_name), 0));
       Delete(name_resolved);
       Delete(expected_name_resolved);
     }
@@ -2897,8 +2889,8 @@ int Language::variableWrapper(Node *n) {
   SwigType *type = Getattr(n, "type");
   String *name = Getattr(n, "name");
 
-  Delattr(n,"varset");
-  Delattr(n,"varget");
+  Delattr(n, "varset");
+  Delattr(n, "varget");
 
   String *newsymname = 0;
   if (!CurrentClass && EnumClassPrefix) {
@@ -2984,13 +2976,13 @@ int Language::functionWrapper(Node *n) {
  * ----------------------------------------------------------------------------- */
 
 int Language::nativeWrapper(Node *n) {
-  (void) n;
+  (void)n;
   return SWIG_OK;
 }
 
 void Language::main(int argc, char *argv[]) {
-  (void) argc;
-  (void) argv;
+  (void)argc;
+  (void)argv;
 }
 
 /* -----------------------------------------------------------------------------
@@ -3004,7 +2996,7 @@ void Language::main(int argc, char *argv[]) {
  * ----------------------------------------------------------------------------- */
 
 int Language::addSymbol(const String *s, const Node *n, const_String_or_char_ptr scope) {
-  //Printf( stdout, "addSymbol: %s %s %s:%d\n", s, scope, Getfile(n), Getline(n) );
+  // Printf( stdout, "addSymbol: %s %s %s:%d\n", s, scope, Getfile(n), Getline(n) );
   Hash *symbols = symbolScopeLookup(scope);
   if (!symbols) {
     symbols = symbolAddScope(scope);
@@ -3037,8 +3029,12 @@ int Language::addInterfaceSymbol(const String *interface_name, Node *n, const_St
     Node *existing_symbol = symbolLookup(interface_name, scope);
     if (existing_symbol) {
       String *proxy_class_name = Getattr(n, "sym:name");
-      Swig_error(input_file, line_number, "The interface feature name '%s' for proxy class '%s' is already defined in the generated target language module in scope '%s'.\n",
-          interface_name, proxy_class_name, scope);
+      Swig_error(input_file,
+                 line_number,
+                 "The interface feature name '%s' for proxy class '%s' is already defined in the generated target language module in scope '%s'.\n",
+                 interface_name,
+                 proxy_class_name,
+                 scope);
       Swig_error(Getfile(existing_symbol), Getline(existing_symbol), "Previous declaration of '%s'\n", interface_name);
       return 0;
     }
@@ -3056,7 +3052,7 @@ int Language::addInterfaceSymbol(const String *interface_name, Node *n, const_St
  * If scope with given name already exists, then do nothing.
  * Returns newly created (or already existing) scope.
  * ----------------------------------------------------------------------------- */
-Hash *Language::symbolAddScope(const_String_or_char_ptr scope/*, Node *n*/) {
+Hash *Language::symbolAddScope(const_String_or_char_ptr scope /*, Node *n*/) {
   Hash *symbols = symbolScopeLookup(scope);
   if (!symbols) {
     // The order in which the following code is executed is important. In the Language
@@ -3078,7 +3074,7 @@ Hash *Language::symbolAddScope(const_String_or_char_ptr scope/*, Node *n*/) {
     //   This will require explicit calls to symbolScopeLookup() in each language and removing the call from addSymbol().
     //   addSymbol() should then instead assert that the scope exists.
     //   All this just to fix up the file/line numbering of the scopes for error reporting.
-    //Node *symbol = n;
+    // Node *symbol = n;
     Node *symbol = Getattr(topscope_symbols, scope);
 
     Hash *pseudo_symbol = 0;
@@ -3118,8 +3114,7 @@ Hash *Language::symbolScopeLookup(const_String_or_char_ptr scope) {
  * There is no difference from symbolLookup() method except for signature
  * and return type.
  * ----------------------------------------------------------------------------- */
-Hash *Language::symbolScopePseudoSymbolLookup(const_String_or_char_ptr scope)
-{
+Hash *Language::symbolScopePseudoSymbolLookup(const_String_or_char_ptr scope) {
   /* Getting top scope */
   const_String_or_char_ptr top_scope = "";
   Hash *symbols = Getattr(symtabs, top_scope);
@@ -3145,7 +3140,7 @@ void Language::dumpSymbols() {
       while (it.key) {
         String *symname = it.key;
         Printf(stdout, "  %s\n", symname);
-        //Printf(stdout, "  %s (%s:%d)\n", symname, Getfile(it.item), Getline(it.item));
+        // Printf(stdout, "  %s (%s:%d)\n", symname, Getfile(it.item), Getline(it.item));
         it = Next(it);
       }
     }
@@ -3209,12 +3204,12 @@ Node *Language::classLookup(const SwigType *s) {
         break;
       Node *sibling = n;
       while (sibling) {
-       sibling = Getattr(sibling, "csym:nextSibling");
-       if (sibling && Strcmp(nodeType(sibling), "class") == 0)
-         break;
+        sibling = Getattr(sibling, "csym:nextSibling");
+        if (sibling && Strcmp(nodeType(sibling), "class") == 0)
+          break;
       }
       if (sibling)
-       break;
+        break;
       n = parentNode(n);
       if (!n)
         break;
@@ -3228,12 +3223,11 @@ Node *Language::classLookup(const SwigType *s) {
     if (n) {
       /* Found a match.  Look at the prefix.  We only allow
          the cases where we want a proxy class for the particular type */
-      bool acceptable_prefix =
-        (Len(prefix) == 0) ||                         // simple type (pass by value)
-        (Strcmp(prefix, "p.") == 0) ||                // pointer
-        (Strcmp(prefix, "r.") == 0) ||                // reference
-        (Strcmp(prefix, "z.") == 0) ||                // rvalue reference
-        SwigType_prefix_is_simple_1D_array(prefix);   // Simple 1D array (not arrays of pointers/references)
+      bool acceptable_prefix = (Len(prefix) == 0) ||                        // simple type (pass by value)
+                               (Strcmp(prefix, "p.") == 0) ||               // pointer
+                               (Strcmp(prefix, "r.") == 0) ||               // reference
+                               (Strcmp(prefix, "z.") == 0) ||               // rvalue reference
+                               SwigType_prefix_is_simple_1D_array(prefix);  // Simple 1D array (not arrays of pointers/references)
       // Also accept pointer by const reference, not non-const pointer reference
       if (!acceptable_prefix && (Strcmp(prefix, "r.p.") == 0)) {
         Delete(prefix);
@@ -3315,7 +3309,7 @@ Node *Language::enumLookup(SwigType *s) {
     }
     if (n) {
       /* Found a match.  Look at the prefix.  We only allow simple types. */
-      if (Len(prefix) == 0) {   /* Simple type */
+      if (Len(prefix) == 0) { /* Simple type */
         if (!enumtypes)
           enumtypes = NewHash();
         Setattr(enumtypes, Copy(s), n);
@@ -3455,8 +3449,7 @@ int Language::need_nonpublic_ctor(Node *n) {
         } else {
           /* check if there is a public constructor */
           Node *parent = Swig_methodclass(n);
-          int public_ctor = Getattr(parent, "allocate:default_constructor")
-              || Getattr(parent, "allocate:public_constructor");
+          int public_ctor = Getattr(parent, "allocate:default_constructor") || Getattr(parent, "allocate:public_constructor");
           if (!public_ctor) {
             /* if not, the protected constructor will be needed only
                if there is no protected default constructor declared */
@@ -3488,7 +3481,6 @@ int Language::need_nonpublic_member(Node *n) {
   }
   return 0;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Language::is_smart_pointer()
@@ -3641,7 +3633,7 @@ String *Language::getClassType() const {
 /* -----------------------------------------------------------------------------
  * Dispatcher::abstractClassTest()
  * ----------------------------------------------------------------------------- */
-//#define SWIG_DEBUG
+// #define SWIG_DEBUG
 int Dispatcher::abstractClassTest(Node *n) {
   /* check for non public operator new */
   if (GetFlag(n, "feature:notabstract"))
@@ -3670,7 +3662,7 @@ int Dispatcher::abstractClassTest(Node *n) {
   Printf(stderr, "testing %s %d %d\n", Getattr(n, "name"), labs, Len(allbases));
 #endif
   if (!labs)
-    return 0;                   /*strange, but need to be fixed */
+    return 0; /*strange, but need to be fixed */
   if (abstracts && !Swig_directors_enabled())
     return 1;
   if (!GetFlag(n, "feature:director"))
@@ -3708,12 +3700,19 @@ int Dispatcher::abstractClassTest(Node *n) {
     }
     if (dirabstract) {
       if (is_public(dirabstract)) {
-        Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT, Getfile(n), Getline(n),
+        Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT,
+                     Getfile(n),
+                     Getline(n),
                      "Director class '%s' is abstract, abstract method '%s' is not accessible, maybe due to multiple inheritance or 'nodirector' feature\n",
-                     SwigType_namestr(Getattr(n, "name")), Getattr(dirabstract, "name"));
+                     SwigType_namestr(Getattr(n, "name")),
+                     Getattr(dirabstract, "name"));
       } else {
-        Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT, Getfile(n), Getline(n),
-                     "Director class '%s' is abstract, abstract method '%s' is private\n", SwigType_namestr(Getattr(n, "name")), Getattr(dirabstract, "name"));
+        Swig_warning(WARN_LANG_DIRECTOR_ABSTRACT,
+                     Getfile(n),
+                     Getline(n),
+                     "Director class '%s' is abstract, abstract method '%s' is private\n",
+                     SwigType_namestr(Getattr(n, "name")),
+                     Getattr(dirabstract, "name"));
       }
       return 1;
     }
@@ -3768,4 +3767,3 @@ Language *Language::instance() {
 Hash *Language::getClassHash() const {
   return classhash;
 }
-

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -52,7 +52,7 @@
   This helps me search the parse tree & figure out what is going on inside SWIG
   (because it's not clear or documented)
 */
-#define REPORT(T,D)		// no info:
+#define REPORT(T,D)             // no info:
 //#define REPORT(T,D)   {Printf(stdout,T"\n");} // only title
 //#define REPORT(T,D)           {Printf(stdout,T" %p\n",n);} // title & pointer
 //#define REPORT(T,D)   {Printf(stdout,T"\n");display_mapping(D);}      // the works
@@ -111,7 +111,7 @@ static int squash_bases = 0;
  *                    2. The layout in elua mode is somewhat different
  */
 static int old_metatable_bindings = 1;
-static int old_compatible_names = 1;	// This flag can temporarily disable backward compatible names generation if old_metatable_bindings is enabled
+static int old_compatible_names = 1;    // This flag can temporarily disable backward compatible names generation if old_metatable_bindings is enabled
 
 /* NEW LANGUAGE NOTE:***********************************************
  To add a new language, you need to derive your class from
@@ -130,8 +130,8 @@ private:
   File *f_initbeforefunc;
   File *f_directors;
   File *f_directors_h;
-  String *s_luacode;		// luacode to be called during init
-  String *module;		//name of the module
+  String *s_luacode;            // luacode to be called during init
+  String *module;               //name of the module
 
   // Parameters for current class. NIL if not parsing class
   int have_constructor;
@@ -168,8 +168,8 @@ private:
     MEMBER_VAR,
     STATIC_FUNC,
     STATIC_VAR,
-    STATIC_CONST,		// enums and things like static const int x = 5;
-    ENUM_CONST,			// This is only needed for backward compatibility in C mode
+    STATIC_CONST,               // enums and things like static const int x = 5;
+    ENUM_CONST,                 // This is only needed for backward compatibility in C mode
 
     STATES_COUNT
   };
@@ -219,7 +219,7 @@ public:
     /* Look for certain command line options */
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-        if (strcmp(argv[i], "-help") == 0) {	// usage flags
+        if (strcmp(argv[i], "-help") == 0) {    // usage flags
           fputs(usage, stdout);
         } else if (strcmp(argv[i], "-nomoduleglobal") == 0) {
           nomoduleglobal = 1;
@@ -941,7 +941,7 @@ public:
 
     Node *sibl = n;
     while (Getattr(sibl, "sym:previousSibling"))
-      sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+      sibl = Getattr(sibl, "sym:previousSibling");      // go all the way up
     String *protoTypes = NewString("");
     do {
       String *fulldecl = Swig_name_decl(sibl);
@@ -1258,7 +1258,7 @@ public:
       tmpValue = NewString(name);
     Setattr(n, "value", tmpValue);
 
-    Setattr(n, "name", tmpValue);	/* for wrapping of enums in a namespace when emit_action is used */
+    Setattr(n, "name", tmpValue);       /* for wrapping of enums in a namespace when emit_action is used */
 
     if (GetFlag(parent, "scopedenum")) {
       symname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
@@ -1338,9 +1338,9 @@ public:
     mangled_full_proxy_class_name = Swig_name_mangle_string(full_proxy_class_name);
 
     SwigType *t = Copy(Getattr(n, "name"));
-    SwigType *fr_t = SwigType_typedef_resolve_all(t);	/* Create fully resolved type */
+    SwigType *fr_t = SwigType_typedef_resolve_all(t);   /* Create fully resolved type */
     SwigType *t_tmp = 0;
-    t_tmp = SwigType_typedef_qualified(fr_t);	// Temporary variable
+    t_tmp = SwigType_typedef_qualified(fr_t);   // Temporary variable
     Delete(fr_t);
     fr_t = SwigType_strip_qualifiers(t_tmp);
     String *mangled_fr_t = 0;
@@ -1638,11 +1638,11 @@ public:
 
   virtual int globalfunctionHandler(Node *n) {
     bool oldVal = current[NO_CPP];
-    if (!current[STATIC_FUNC])	// If static function, don't switch to NO_CPP
+    if (!current[STATIC_FUNC])  // If static function, don't switch to NO_CPP
       current[NO_CPP] = true;
     const int result = Language::globalfunctionHandler(n);
 
-    if (!current[STATIC_FUNC])	// Register only if not called from static function handler
+    if (!current[STATIC_FUNC])  // Register only if not called from static function handler
       registerMethod(n);
     current[NO_CPP] = oldVal;
     return result;
@@ -1763,7 +1763,7 @@ public:
    */
   String *runtimeCode() {
     String *s = NewString("");
-    const char *filenames[] = { "luarun.swg", 0 };	// must be 0 terminated
+    const char *filenames[] = { "luarun.swg", 0 };      // must be 0 terminated
 
     emitLuaFlavor(s);
 
@@ -1813,10 +1813,10 @@ public:
 
   void escapeCode(String *str) {
     //Printf(f_runtime,"/* original luacode:[[[\n%s\n]]]\n*/\n",str);
-    Chop(str);			// trim
-    Replace(str, "\\", "\\\\", DOH_REPLACE_ANY);	// \ to \\ (this must be done first)
-    Replace(str, "\"", "\\\"", DOH_REPLACE_ANY);	// " to \"
-    Replace(str, "\n", "\\n\"\n  \"", DOH_REPLACE_ANY);	// \n to \n"\n" (ie quoting every line)
+    Chop(str);                  // trim
+    Replace(str, "\\", "\\\\", DOH_REPLACE_ANY);        // \ to \\ (this must be done first)
+    Replace(str, "\"", "\\\"", DOH_REPLACE_ANY);        // " to \"
+    Replace(str, "\n", "\\n\"\n  \"", DOH_REPLACE_ANY); // \n to \n"\n" (ie quoting every line)
     //Printf(f_runtime,"/* hacked luacode:[[[\n%s\n]]]\n*/\n",str);
   }
 
@@ -1887,7 +1887,7 @@ public:
     String *methods_tab = NewString("");
     String *methods_tab_name = NewStringf("swig_%s_methods", mangled_name);
     String *methods_tab_decl = NewString("");
-    if (elua_ltr || eluac_ltr)	// In this case methods array also acts as namespace rotable
+    if (elua_ltr || eluac_ltr)  // In this case methods array also acts as namespace rotable
       Printf(methods_tab, "const LUA_REG_TYPE ");
     else
       Printf(methods_tab, "static swig_lua_method ");
@@ -1901,7 +1901,7 @@ public:
     String *const_tab = NewString("");
     String *const_tab_name = NewStringf("swig_%s_constants", mangled_name);
     String *const_tab_decl = NewString("");
-    if (elua_ltr || eluac_ltr)	// In this case const array holds rotable with namespace constants
+    if (elua_ltr || eluac_ltr)  // In this case const array holds rotable with namespace constants
       Printf(const_tab, "const LUA_REG_TYPE ");
     else
       Printf(const_tab, "static swig_lua_const_info ");
@@ -1960,7 +1960,7 @@ public:
       String *metatable_tab = NewString("");
       String *metatable_tab_name = NewStringf("swig_%s_meta", mangled_name);
       String *metatable_tab_decl = NewString("");
-      if (elua_ltr)		// In this case const array holds rotable with namespace constants
+      if (elua_ltr)             // In this case const array holds rotable with namespace constants
         Printf(metatable_tab, "const LUA_REG_TYPE ");
       else
         Printf(metatable_tab, "static swig_lua_method ");
@@ -1998,7 +1998,7 @@ public:
 
       Delete(components);
       Delete(parent_path);
-    } else if (!reg)		// This namespace shouldn't be registered. Lets remember it.
+    } else if (!reg)            // This namespace shouldn't be registered. Lets remember it.
       SetFlag(carrays_hash, "lua:no_reg");
 
     Delete(mangled_name);
@@ -2045,7 +2045,7 @@ public:
     int need_constants = 0;
     if ((elua_ltr || eluac_ltr) && (old_metatable_bindings))
       need_constants = 1;
-    else if (!is_instance)	// static part need constants tab
+    else if (!is_instance)      // static part need constants tab
       need_constants = 1;
 
     if (need_constants)
@@ -2186,8 +2186,8 @@ public:
       String *key = Getitem(to_close, i);
       closeCArraysHash(key, dataOutput);
       Hash *carrays_hash = rawGetCArraysHash(key);
-      String *name = 0;		// name - name of the namespace as it should be visible in Lua
-      if (Len(key) == 0)	// This is global module
+      String *name = 0;         // name - name of the namespace as it should be visible in Lua
+      if (Len(key) == 0)        // This is global module
         name = module;
       else
         name = Getattr(carrays_hash, "name");
@@ -2210,7 +2210,7 @@ public:
   void printCArraysDefinition(String *nspace, String *name, File *output) {
     Hash *carrays_hash = getCArraysHash(nspace, false);
 
-    String *cname = Getattr(carrays_hash, "cname");	// cname - name of the C structure that describes namespace
+    String *cname = Getattr(carrays_hash, "cname");     // cname - name of the C structure that describes namespace
     assert(cname);
     Printv(output, "static swig_lua_namespace ", cname, " = ", NIL);
 
@@ -2260,7 +2260,7 @@ public:
       } else if (current[MEMBER_VAR] || current[CONSTRUCTOR] || current[DESTRUCTOR]
                  || current[MEMBER_FUNC]) {
         scope = full_proxy_class_name;
-      } else {			// Friend functions are handled this way
+      } else {                  // Friend functions are handled this way
         scope = class_static_nspace;
       }
       assert(scope);
@@ -2314,7 +2314,7 @@ public:
      * The Lua object will be connected later via swig_connect_director().
      * We override none_comparison and director_ctor_code to always use the director constructor. */
     Delete(none_comparison);
-    none_comparison = NewString("");	/* Empty comparison - always use director */
+    none_comparison = NewString("");    /* Empty comparison - always use director */
 
     Delete(director_ctor_code);
     director_ctor_code = NewString("$director_new");

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -105,7 +105,7 @@ static int eluac_ltr = 0;
 static int elua_emulate = 0;
 static int squash_bases = 0;
 /* The new metatable bindings were introduced in SWIG 3.0.0.
- * old_metatable_bindings in v2: 
+ * old_metatable_bindings in v2:
  *                    1. static methods will be put into the scope their respective class
  *                    belongs to as well as into the class scope itself. (only for classes without %nspace given)
  *                    2. The layout in elua mode is somewhat different
@@ -155,7 +155,7 @@ private:
 
   // Many wrappers forward calls to each other, for example staticmembervariableHandler
   // forwards calls to variableHandler, which, in turn, makes to call to functionWrapper.
-  // In order to access information about whether it is a static member of class or just 
+  // In order to access information about whether it is a static member of class or just
   // a plain old variable, the current array is kept and used as a 'log' of the call stack.
   enum TState {
     NO_CPP,
@@ -856,7 +856,7 @@ public:
        Lua will automatically call the destructor when the object is free'd
        However: you cannot just skip this function as it will not emit
        any custom destructor (using %extend), as you need to call emit_action()
-       Therefore we go though the whole function, 
+       Therefore we go though the whole function,
        but do not write the code into the wrapper
      */
     if (!current[DESTRUCTOR]) {
@@ -1422,7 +1422,7 @@ public:
     // Register the class structure with the type checker
     //    Printf(f_init,"SWIG_TypeClientData(SWIGTYPE%s, (void *) &_wrap_class_%s);\n", SwigType_manglestr(t), mangled_full_proxy_class_name);
 
-    // emit a function to be called to delete the object 
+    // emit a function to be called to delete the object
     if (have_destructor) {
       destructor_name = NewStringf("swig_delete_%s", mangled_full_proxy_class_name);
       Printv(f_wrappers, "static void ", destructor_name, "(void *obj) {\n", NIL);
@@ -2271,7 +2271,7 @@ public:
   /* -----------------------------------------------------------------------------
    * luaAddSymbol()
    *
-   * Our implementation of addSymbol. Determines scope correctly, then 
+   * Our implementation of addSymbol. Determines scope correctly, then
    * forwards to Language::addSymbol
    * ----------------------------------------------------------------------------- */
 

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -52,11 +52,11 @@
   This helps me search the parse tree & figure out what is going on inside SWIG
   (because it's not clear or documented)
 */
-#define REPORT(T,D)             // no info:
-//#define REPORT(T,D)   {Printf(stdout,T"\n");} // only title
-//#define REPORT(T,D)           {Printf(stdout,T" %p\n",n);} // title & pointer
-//#define REPORT(T,D)   {Printf(stdout,T"\n");display_mapping(D);}      // the works
-//#define REPORT(T,D)   {Printf(stdout,T"\n");if(D)Swig_print_node(D);}      // the works
+#define REPORT(T, D)  // no info:
+// #define REPORT(T,D)   {Printf(stdout,T"\n");} // only title
+// #define REPORT(T,D)           {Printf(stdout,T" %p\n",n);} // title & pointer
+// #define REPORT(T,D)   {Printf(stdout,T"\n");display_mapping(D);}      // the works
+// #define REPORT(T,D)   {Printf(stdout,T"\n");if(D)Swig_print_node(D);}      // the works
 
 void display_mapping(DOH *d) {
   if (d == 0 || !DohIsMapping(d))
@@ -74,9 +74,9 @@ void display_mapping(DOH *d) {
 }
 
 extern "C" {
-  static int compareByLen(const DOH *f, const DOH *s) {
-    return Len(s) - Len(f);
-  }
+static int compareByLen(const DOH *f, const DOH *s) {
+  return Len(s) - Len(f);
+}
 }
 /* NEW LANGUAGE NOTE:***********************************************
  most of the default options are handled by SWIG
@@ -111,7 +111,7 @@ static int squash_bases = 0;
  *                    2. The layout in elua mode is somewhat different
  */
 static int old_metatable_bindings = 1;
-static int old_compatible_names = 1;    // This flag can temporarily disable backward compatible names generation if old_metatable_bindings is enabled
+static int old_compatible_names = 1;  // This flag can temporarily disable backward compatible names generation if old_metatable_bindings is enabled
 
 /* NEW LANGUAGE NOTE:***********************************************
  To add a new language, you need to derive your class from
@@ -119,9 +119,8 @@ static int old_compatible_names = 1;    // This flag can temporarily disable bac
  (more on this as I figure it out)
 NEW LANGUAGE NOTE:END ************************************************/
 
-class LUA:public Language {
+class LUA : public Language {
 private:
-
   File *f_begin;
   File *f_runtime;
   File *f_header;
@@ -130,8 +129,8 @@ private:
   File *f_initbeforefunc;
   File *f_directors;
   File *f_directors_h;
-  String *s_luacode;            // luacode to be called during init
-  String *module;               //name of the module
+  String *s_luacode;  // luacode to be called during init
+  String *module;     // name of the module
 
   // Parameters for current class. NIL if not parsing class
   int have_constructor;
@@ -168,34 +167,38 @@ private:
     MEMBER_VAR,
     STATIC_FUNC,
     STATIC_VAR,
-    STATIC_CONST,               // enums and things like static const int x = 5;
-    ENUM_CONST,                 // This is only needed for backward compatibility in C mode
+    STATIC_CONST,  // enums and things like static const int x = 5;
+    ENUM_CONST,    // This is only needed for backward compatibility in C mode
 
     STATES_COUNT
   };
   bool current[STATES_COUNT];
 
 public:
-
   /* ---------------------------------------------------------------------
    * LUA()
    *
    * Initialize member data
    * --------------------------------------------------------------------- */
 
-   LUA():
-      f_begin(0),
-      f_runtime(0),
-      f_header(0),
-      f_wrappers(0),
-      f_init(0),
-      f_initbeforefunc(0),
-      f_directors(0),
-      f_directors_h(0),
-      s_luacode(0),
-      module(0),
-      have_constructor(0),
-      have_destructor(0), destructor_action(0), proxy_class_name(0), full_proxy_class_name(0), class_static_nspace(0), constructor_name(0) {
+  LUA() :
+    f_begin(0),
+    f_runtime(0),
+    f_header(0),
+    f_wrappers(0),
+    f_init(0),
+    f_initbeforefunc(0),
+    f_directors(0),
+    f_directors_h(0),
+    s_luacode(0),
+    module(0),
+    have_constructor(0),
+    have_destructor(0),
+    destructor_action(0),
+    proxy_class_name(0),
+    full_proxy_class_name(0),
+    class_static_nspace(0),
+    constructor_name(0) {
     for (int i = 0; i < STATES_COUNT; i++)
       current[i] = false;
 
@@ -207,11 +210,13 @@ public:
      This is called to initialise the system & read any command line args
      most of this is boilerplate code, except the command line args
      which depends upon what args your code supports
-     NEW LANGUAGE NOTE:END *********************************************** *//* ---------------------------------------------------------------------
+     NEW LANGUAGE NOTE:END *********************************************** */
+  /* ---------------------------------------------------------------------
    * main()
    *
    * Parse command line options and initializes variables.
-   * --------------------------------------------------------------------- */ virtual void main(int argc, char *argv[]) {
+   * --------------------------------------------------------------------- */
+  virtual void main(int argc, char *argv[]) {
 
     /* Set location of SWIG library */
     SWIG_library_directory("lua");
@@ -219,7 +224,7 @@ public:
     /* Look for certain command line options */
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-        if (strcmp(argv[i], "-help") == 0) {    // usage flags
+        if (strcmp(argv[i], "-help") == 0) {  // usage flags
           fputs(usage, stdout);
         } else if (strcmp(argv[i], "-nomoduleglobal") == 0) {
           nomoduleglobal = 1;
@@ -268,9 +273,6 @@ public:
     allow_overloading();
   }
 
-
-
-
   /* NEW LANGUAGE NOTE:***********************************************
      After calling main, SWIG parses the code to wrap (I believe)
      then calls top()
@@ -316,7 +318,6 @@ public:
     Swig_register_filebyname("director", f_directors);
     Swig_register_filebyname("director_h", f_directors_h);
 
-
     s_luacode = NewString("");
     Swig_register_filebyname("luacode", s_luacode);
 
@@ -355,11 +356,11 @@ public:
 
     Printf(f_runtime, "\n");
 
-    //String *init_name = NewStringf("%(title)s_Init", module);
-    //Printf(f_header, "#define SWIG_init    %s\n", init_name);
-    //Printf(f_header, "#define SWIG_name    \"%s\"\n", module);
+    // String *init_name = NewStringf("%(title)s_Init", module);
+    // Printf(f_header, "#define SWIG_init    %s\n", init_name);
+    // Printf(f_header, "#define SWIG_name    \"%s\"\n", module);
     /* SWIG_import is a special function name for importing within Lua5.1 */
-    //Printf(f_header, "#define SWIG_import  luaopen_%s\n\n", module);
+    // Printf(f_header, "#define SWIG_import  luaopen_%s\n\n", module);
     Printf(f_header, "#define SWIG_name      \"%s\"\n", module);
     Printf(f_header, "#define SWIG_init      luaopen_%s\n", module);
     Printf(f_header, "#define SWIG_init_user luaopen_%s_user\n\n", module);
@@ -546,7 +547,7 @@ public:
     Parm *p;
     String *tm;
     int i;
-    //Printf(stdout,"functionWrapper %s %s %d\n",name,iname,current);
+    // Printf(stdout,"functionWrapper %s %s %d\n",name,iname,current);
 
     String *overname = 0;
     if (Getattr(n, "sym:overloaded")) {
@@ -563,7 +564,6 @@ public:
        NEW LANGUAGE NOTE:END *********************************************** */
     Wrapper *f = NewWrapper();
     Wrapper_add_local(f, "SWIG_arg", "int SWIG_arg = 0");
-
 
     String *wname = Swig_name_wrapper(iname);
     if (overname) {
@@ -630,7 +630,6 @@ public:
     if (Getattr(n, "lua:ignore_args")) {
       args_to_ignore = GetInt(n, "lua:ignore_args");
     }
-
 
     /* NEW LANGUAGE NOTE:***********************************************
        from here on in, it gets rather hairy
@@ -828,7 +827,6 @@ public:
       Printf(f->code, "%s\n", tm);
     }
 
-
     /* Close the function */
     Printv(f->code, "return SWIG_arg;\n", NIL);
     // add the failure cleanup code:
@@ -899,7 +897,7 @@ public:
      look for %typecheck(SWIG_TYPECHECK_*) in the .swg file
      NEW LANGUAGE NOTE:END *********************************************** */
   int dispatchFunction(Node *n) {
-    //REPORT("dispatchFunction", n);
+    // REPORT("dispatchFunction", n);
     /* Last node in overloaded chain */
 
     int maxargs;
@@ -915,7 +913,7 @@ public:
     assert(lua_name);
     String *wname = Swig_name_wrapper(symname);
 
-    //Printf(stdout,"Swig_overload_dispatch %s %s '%s' %d\n",symname,wname,dispatch,maxargs);
+    // Printf(stdout,"Swig_overload_dispatch %s %s '%s' %d\n",symname,wname,dispatch,maxargs);
 
     if (!luaAddSymbol(lua_name, n)) {
       DelWrapper(f);
@@ -941,15 +939,18 @@ public:
 
     Node *sibl = n;
     while (Getattr(sibl, "sym:previousSibling"))
-      sibl = Getattr(sibl, "sym:previousSibling");      // go all the way up
+      sibl = Getattr(sibl, "sym:previousSibling");  // go all the way up
     String *protoTypes = NewString("");
     do {
       String *fulldecl = Swig_name_decl(sibl);
       Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
       Delete(fulldecl);
     } while ((sibl = Getattr(sibl, "sym:nextSibling")));
-    Printf(f->code, "SWIG_Lua_pusherrstring(L,\"Wrong arguments for overloaded function '%s'\\n\"\n"
-           "\"  Possible C/C++ prototypes are:\\n\"%s);\n", symname, protoTypes);
+    Printf(f->code,
+           "SWIG_Lua_pusherrstring(L,\"Wrong arguments for overloaded function '%s'\\n\"\n"
+           "\"  Possible C/C++ prototypes are:\\n\"%s);\n",
+           symname,
+           protoTypes);
     Delete(protoTypes);
 
     Printf(f->code, "lua_error(L);return 0;\n");
@@ -1066,7 +1067,7 @@ public:
     //    REPORT("variableWrapper", n);
     String *lua_name = Getattr(n, "lua:name");
     assert(lua_name);
-    (void) lua_name;
+    (void)lua_name;
     current[VARIABLE] = true;
     // let SWIG generate the wrappers
     int result = Language::variableWrapper(n);
@@ -1077,7 +1078,6 @@ public:
     current[VARIABLE] = false;
     return result;
   }
-
 
   /* ------------------------------------------------------------
    * Add constant to appropriate C array. constantRecord is an array record.
@@ -1101,7 +1101,6 @@ public:
       assert(s_const_tab);
       Printf(s_const_tab, "    %s,\n", constantRecord);
     }
-
   }
 
   /* ------------------------------------------------------------
@@ -1258,7 +1257,7 @@ public:
       tmpValue = NewString(name);
     Setattr(n, "value", tmpValue);
 
-    Setattr(n, "name", tmpValue);       /* for wrapping of enums in a namespace when emit_action is used */
+    Setattr(n, "name", tmpValue); /* for wrapping of enums in a namespace when emit_action is used */
 
     if (GetFlag(parent, "scopedenum")) {
       symname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
@@ -1280,7 +1279,6 @@ public:
   virtual int classDeclaration(Node *n) {
     return Language::classDeclaration(n);
   }
-
 
   /* ------------------------------------------------------------
    * Helper function that adds record to appropriate C arrays
@@ -1306,7 +1304,7 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int classHandler(Node *n) {
-    //REPORT("classHandler", n);
+    // REPORT("classHandler", n);
 
     String *mangled_full_proxy_class_name = 0;
     String *destructor_name = 0;
@@ -1338,9 +1336,9 @@ public:
     mangled_full_proxy_class_name = Swig_name_mangle_string(full_proxy_class_name);
 
     SwigType *t = Copy(Getattr(n, "name"));
-    SwigType *fr_t = SwigType_typedef_resolve_all(t);   /* Create fully resolved type */
+    SwigType *fr_t = SwigType_typedef_resolve_all(t); /* Create fully resolved type */
     SwigType *t_tmp = 0;
-    t_tmp = SwigType_typedef_qualified(fr_t);   // Temporary variable
+    t_tmp = SwigType_typedef_qualified(fr_t);  // Temporary variable
     Delete(fr_t);
     fr_t = SwigType_strip_qualifiers(t_tmp);
     String *mangled_fr_t = 0;
@@ -1475,7 +1473,6 @@ public:
     closeCArraysHash(full_proxy_class_name, f_wrappers);
     closeCArraysHash(class_static_nspace, f_wrappers);
 
-
     // Handle inheritance
     // note: with the idea of class hierarchies spread over multiple modules
     // cf test-suite: imports.i
@@ -1520,8 +1517,17 @@ public:
     Printv(f_wrappers, "static const char *swig_", mangled_full_proxy_class_name, "_base_names[] = {", base_class_names, "0};\n", NIL);
     Delete(base_class_names);
 
-    Printv(f_wrappers, "static swig_lua_class _wrap_class_", mangled_full_proxy_class_name, " = { \"", proxy_class_name, "\", \"", full_proxy_class_name,
-           "\", &SWIGTYPE", SwigType_manglestr(t), ",", NIL);
+    Printv(f_wrappers,
+           "static swig_lua_class _wrap_class_",
+           mangled_full_proxy_class_name,
+           " = { \"",
+           proxy_class_name,
+           "\", \"",
+           full_proxy_class_name,
+           "\", &SWIGTYPE",
+           SwigType_manglestr(t),
+           ",",
+           NIL);
 
     if (have_constructor) {
       Printv(f_wrappers, constructor_name, NIL);
@@ -1565,14 +1571,14 @@ public:
 
   virtual int memberfunctionHandler(Node *n) {
     String *symname = GetChar(n, "sym:name");
-    //Printf(stdout,"memberfunctionHandler %s %s\n",name,iname);
+    // Printf(stdout,"memberfunctionHandler %s %s\n",name,iname);
 
     // Special case unary minus: LUA passes two parameters for the
     // wrapper function while we want only one. Tell our
     // functionWrapper to ignore a parameter.
 
     if (Cmp(symname, "__unm") == 0) {
-      //Printf(stdout, "unary minus: ignore one argument\n");
+      // Printf(stdout, "unary minus: ignore one argument\n");
       SetInt(n, "lua:ignore_args", 1);
     }
 
@@ -1608,7 +1614,7 @@ public:
     current[CONSTRUCTOR] = true;
     Language::constructorHandler(n);
     current[CONSTRUCTOR] = false;
-    //constructor_name = NewString(Getattr(n, "sym:name"));
+    // constructor_name = NewString(Getattr(n, "sym:name"));
     have_constructor = 1;
     return SWIG_OK;
   }
@@ -1667,7 +1673,6 @@ public:
     return result;
   }
 
-
   /* -----------------------------------------------------------------------
    * staticmemberfunctionHandler()
    *
@@ -1718,7 +1723,7 @@ public:
   virtual int staticmembervariableHandler(Node *n) {
     REPORT("staticmembervariableHandler", n);
     current[STATIC_VAR] = true;
-    //String *symname = Getattr(n, "sym:name");
+    // String *symname = Getattr(n, "sym:name");
     int result = Language::staticmembervariableHandler(n);
     if (!GetFlag(n, "wrappedasconstant")) {
       registerVariable(n);
@@ -1749,7 +1754,6 @@ public:
     return result;
   }
 
-
   /* ---------------------------------------------------------------------
    * external runtime generation
    * --------------------------------------------------------------------- */
@@ -1763,7 +1767,7 @@ public:
    */
   String *runtimeCode() {
     String *s = NewString("");
-    const char *filenames[] = { "luarun.swg", 0 };      // must be 0 terminated
+    const char *filenames[] = {"luarun.swg", 0};  // must be 0 terminated
 
     emitLuaFlavor(s);
 
@@ -1802,7 +1806,6 @@ public:
       Printf(s, "#define SWIG_LUA_TARGET SWIG_LUA_FLAVOR_LUA\n");
   }
 
-
   /* -----------------------------------------------------------------------------
    * escapeCode()
    *
@@ -1812,12 +1815,12 @@ public:
    * ---------------------------------------------------------------------------- */
 
   void escapeCode(String *str) {
-    //Printf(f_runtime,"/* original luacode:[[[\n%s\n]]]\n*/\n",str);
-    Chop(str);                  // trim
-    Replace(str, "\\", "\\\\", DOH_REPLACE_ANY);        // \ to \\ (this must be done first)
-    Replace(str, "\"", "\\\"", DOH_REPLACE_ANY);        // " to \"
-    Replace(str, "\n", "\\n\"\n  \"", DOH_REPLACE_ANY); // \n to \n"\n" (ie quoting every line)
-    //Printf(f_runtime,"/* hacked luacode:[[[\n%s\n]]]\n*/\n",str);
+    // Printf(f_runtime,"/* original luacode:[[[\n%s\n]]]\n*/\n",str);
+    Chop(str);                                           // trim
+    Replace(str, "\\", "\\\\", DOH_REPLACE_ANY);         // \ to \\ (this must be done first)
+    Replace(str, "\"", "\\\"", DOH_REPLACE_ANY);         // " to \"
+    Replace(str, "\n", "\\n\"\n  \"", DOH_REPLACE_ANY);  // \n to \n"\n" (ie quoting every line)
+    // Printf(f_runtime,"/* hacked luacode:[[[\n%s\n]]]\n*/\n",str);
   }
 
   /* -----------------------------------------------------------------------------
@@ -1954,13 +1957,12 @@ public:
       Setattr(carrays_hash, "set", set_tab);
       Setattr(carrays_hash, "set:name", set_tab_name);
       Setattr(carrays_hash, "set:decl", set_tab_decl);
-
     }
     if (!eluac_ltr) {
       String *metatable_tab = NewString("");
       String *metatable_tab_name = NewStringf("swig_%s_meta", mangled_name);
       String *metatable_tab_decl = NewString("");
-      if (elua_ltr)             // In this case const array holds rotable with namespace constants
+      if (elua_ltr)  // In this case const array holds rotable with namespace constants
         Printf(metatable_tab, "const LUA_REG_TYPE ");
       else
         Printf(metatable_tab, "static swig_lua_method ");
@@ -1998,7 +2000,7 @@ public:
 
       Delete(components);
       Delete(parent_path);
-    } else if (!reg)            // This namespace shouldn't be registered. Lets remember it.
+    } else if (!reg)  // This namespace shouldn't be registered. Lets remember it.
       SetFlag(carrays_hash, "lua:no_reg");
 
     Delete(mangled_name);
@@ -2028,7 +2030,6 @@ public:
     // Do arrays describe class instance part or class static part
     const int is_instance = GetFlag(carrays_hash, "lua:class_instance");
 
-
     String *attr_tab = Getattr(carrays_hash, "attributes");
     Printf(attr_tab, "    {0,0,0}\n};\n");
     Printv(output, attr_tab, NIL);
@@ -2045,7 +2046,7 @@ public:
     int need_constants = 0;
     if ((elua_ltr || eluac_ltr) && (old_metatable_bindings))
       need_constants = 1;
-    else if (!is_instance)      // static part need constants tab
+    else if (!is_instance)  // static part need constants tab
       need_constants = 1;
 
     if (need_constants)
@@ -2186,8 +2187,8 @@ public:
       String *key = Getitem(to_close, i);
       closeCArraysHash(key, dataOutput);
       Hash *carrays_hash = rawGetCArraysHash(key);
-      String *name = 0;         // name - name of the namespace as it should be visible in Lua
-      if (Len(key) == 0)        // This is global module
+      String *name = 0;   // name - name of the namespace as it should be visible in Lua
+      if (Len(key) == 0)  // This is global module
         name = module;
       else
         name = Getattr(carrays_hash, "name");
@@ -2210,7 +2211,7 @@ public:
   void printCArraysDefinition(String *nspace, String *name, File *output) {
     Hash *carrays_hash = getCArraysHash(nspace, false);
 
-    String *cname = Getattr(carrays_hash, "cname");     // cname - name of the C structure that describes namespace
+    String *cname = Getattr(carrays_hash, "cname");  // cname - name of the C structure that describes namespace
     assert(cname);
     Printv(output, "static swig_lua_namespace ", cname, " = ", NIL);
 
@@ -2223,12 +2224,28 @@ public:
     bool has_classes = GetFlag(carrays_hash, "lua:no_classes") == 0;
     bool has_namespaces = GetFlag(carrays_hash, "lua:no_namespaces") == 0;
 
-    Printv(output, "{\n",
-           tab4, "\"", name, "\",\n",
-           tab4, methods_tab_name, ",\n",
-           tab4, attr_tab_name, ",\n",
-           tab4, const_tab_name, ",\n",
-           tab4, (has_classes) ? classes_tab_name : null_string, ",\n", tab4, (has_namespaces) ? namespaces_tab_name : null_string, "\n};\n", NIL);
+    Printv(output,
+           "{\n",
+           tab4,
+           "\"",
+           name,
+           "\",\n",
+           tab4,
+           methods_tab_name,
+           ",\n",
+           tab4,
+           attr_tab_name,
+           ",\n",
+           tab4,
+           const_tab_name,
+           ",\n",
+           tab4,
+           (has_classes) ? classes_tab_name : null_string,
+           ",\n",
+           tab4,
+           (has_namespaces) ? namespaces_tab_name : null_string,
+           "\n};\n",
+           NIL);
     Delete(null_string);
   }
 
@@ -2257,10 +2274,9 @@ public:
       assert(!current[NO_CPP]);
       if (current[STATIC_FUNC] || current[STATIC_VAR] || current[STATIC_CONST]) {
         scope = class_static_nspace;
-      } else if (current[MEMBER_VAR] || current[CONSTRUCTOR] || current[DESTRUCTOR]
-                 || current[MEMBER_FUNC]) {
+      } else if (current[MEMBER_VAR] || current[CONSTRUCTOR] || current[DESTRUCTOR] || current[MEMBER_FUNC]) {
         scope = full_proxy_class_name;
-      } else {                  // Friend functions are handled this way
+      } else {  // Friend functions are handled this way
         scope = class_static_nspace;
       }
       assert(scope);
@@ -2314,7 +2330,7 @@ public:
      * The Lua object will be connected later via swig_connect_director().
      * We override none_comparison and director_ctor_code to always use the director constructor. */
     Delete(none_comparison);
-    none_comparison = NewString("");    /* Empty comparison - always use director */
+    none_comparison = NewString(""); /* Empty comparison - always use director */
 
     Delete(director_ctor_code);
     director_ctor_code = NewString("$director_new");
@@ -2560,7 +2576,9 @@ public:
         Printf(w->code, "%s;\n", super_call);
         Delete(super_call);
       } else {
-        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       }
     } else {
@@ -2609,7 +2627,9 @@ public:
       Printf(w->code, "  lua_pop(L, 1); /* pop placeholder */\n");
       Printf(w->code, "  lua_settop(L, top);\n");
       if (pure_virtual) {
-        Printf(w->code, "  Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "  Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       } else {
         // Call parent method instead
@@ -2649,9 +2669,13 @@ public:
           p = Getattr(p, "tmap:directorin:next");
           continue;
         } else if (Cmp(ptype, "void")) {
-          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                       SwigType_str(ptype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_NOWRAP;
           break;
         }
@@ -2686,8 +2710,13 @@ public:
             Printf(w->code, "%s\n", tm);
             Delete(tm);
           } else {
-            Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number, "Unable to use return type %s in director method %s::%s (skipping method).\n",
-                         SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                         input_file,
+                         line_number,
+                         "Unable to use return type %s in director method %s::%s (skipping method).\n",
+                         SwigType_str(returntype, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             status = SWIG_ERROR;
           }
         }
@@ -2760,7 +2789,7 @@ public:
    * ------------------------------------------------------------ */
 
   int classDirectorDisown(Node *n) {
-    (void) n;
+    (void)n;
     return SWIG_OK;
   }
 };

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -219,27 +219,27 @@ public:
     /* Look for certain command line options */
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-help") == 0) {	// usage flags
-	  fputs(usage, stdout);
-	} else if (strcmp(argv[i], "-nomoduleglobal") == 0) {
-	  nomoduleglobal = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-elua") == 0) {
-	  elua_ltr = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-eluac") == 0) {
-	  eluac_ltr = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-no-old-metatable-bindings") == 0) {
-	  Swig_mark_arg(i);
-	  old_metatable_bindings = 0;
-	} else if (strcmp(argv[i], "-squash-bases") == 0) {
-	  Swig_mark_arg(i);
-	  squash_bases = 1;
-	} else if (strcmp(argv[i], "-elua-emulate") == 0) {
-	  Swig_mark_arg(i);
-	  elua_emulate = 1;
-	}
+        if (strcmp(argv[i], "-help") == 0) {	// usage flags
+          fputs(usage, stdout);
+        } else if (strcmp(argv[i], "-nomoduleglobal") == 0) {
+          nomoduleglobal = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-elua") == 0) {
+          elua_ltr = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-eluac") == 0) {
+          eluac_ltr = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-no-old-metatable-bindings") == 0) {
+          Swig_mark_arg(i);
+          old_metatable_bindings = 0;
+        } else if (strcmp(argv[i], "-squash-bases") == 0) {
+          Swig_mark_arg(i);
+          squash_bases = 1;
+        } else if (strcmp(argv[i], "-elua-emulate") == 0) {
+          Swig_mark_arg(i);
+          elua_emulate = 1;
+        }
       }
     }
 
@@ -342,10 +342,10 @@ public:
     if (mod) {
       Node *options = Getattr(mod, "options");
       if (options && Getattr(options, "directors")) {
-	allow_directors();
-	if (Getattr(options, "dirprot")) {
-	  allow_dirprot();
-	}
+        allow_directors();
+        if (Getattr(options, "dirprot")) {
+          allow_dirprot();
+        }
       }
     }
 
@@ -498,9 +498,9 @@ public:
     } else {
       assert(!current[NO_CPP]);
       if (current[STATIC_FUNC] || current[MEMBER_FUNC]) {
-	mrename = Swig_name_member(getNSpace(), getClassPrefix(), symname);
+        mrename = Swig_name_member(getNSpace(), getClassPrefix(), symname);
       } else {
-	mrename = symname;
+        mrename = symname;
       }
     }
     wrapname = Swig_name_wrapper(mrename);
@@ -528,9 +528,9 @@ public:
       String *metatable_tab = Getattr(nspaceHash, "metatable");
       assert(metatable_tab);
       if (elua_ltr)
-	Printv(metatable_tab, tab4, "{LSTRKEY(\"", lua_name, "\")", ", LFUNCVAL(", wname, ")", "},\n", NIL);
+        Printv(metatable_tab, tab4, "{LSTRKEY(\"", lua_name, "\")", ", LFUNCVAL(", wname, ")", "},\n", NIL);
       else
-	Printv(metatable_tab, tab4, "{ \"", lua_name, "\", ", wname, "},\n", NIL);
+        Printv(metatable_tab, tab4, "{ \"", lua_name, "\", ", wname, "},\n", NIL);
     }
   }
 
@@ -553,7 +553,7 @@ public:
       overname = Getattr(n, "sym:overname");
     } else {
       if (!luaAddSymbol(lua_name, n)) {
-	return SWIG_ERROR;
+        return SWIG_ERROR;
       }
     }
 
@@ -571,7 +571,7 @@ public:
     }
     if (current[CONSTRUCTOR]) {
       if (constructor_name != 0)
-	Delete(constructor_name);
+        Delete(constructor_name);
       constructor_name = Copy(wname);
     }
 
@@ -655,54 +655,54 @@ public:
     for (i = 0, p = l; i < num_arguments; i++) {
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
       /* Look for an input typemap */
       sprintf(source, "%d", i + 1);
       if ((tm = Getattr(p, "tmap:in"))) {
-	Replaceall(tm, "$input", source);
-	Setattr(p, "emit:input", source);
-	if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
-	  Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	} else {
-	  Replaceall(tm, "$disown", "0");
-	}
-	/* NEW LANGUAGE NOTE:***********************************************
-	   look for a 'checkfn' typemap
-	   this an additional parameter added to the in typemap
-	   if found the type will be tested for
-	   this will result in code either in the
-	   argument_check or argument_parse string
-	   NEW LANGUAGE NOTE:END *********************************************** */
-	if ((checkfn = Getattr(p, "tmap:in:checkfn"))) {
-	  if (i < num_required) {
-	    Printf(argument_check, "if(!%s(L,%s))", checkfn, source);
-	  } else {
-	    Printf(argument_check, "if(lua_gettop(L)>=%s && !%s(L,%s))", source, checkfn, source);
-	  }
-	  Printf(argument_check, " SWIG_fail_arg(\"%s\",%s,\"%s\");\n", Swig_name_str(n), source, SwigType_str(pt, 0));
-	}
-	/* NEW LANGUAGE NOTE:***********************************************
-	   lua states the number of arguments passed to a function using the fn
-	   lua_gettop()
-	   we can use this to deal with default arguments
-	   NEW LANGUAGE NOTE:END *********************************************** */
-	if (i < num_required) {
-	  Printf(argument_parse, "%s\n", tm);
-	} else {
-	  Printf(argument_parse, "if(lua_gettop(L)>=%s){%s}\n", source, tm);
-	}
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        Replaceall(tm, "$input", source);
+        Setattr(p, "emit:input", source);
+        if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
+          Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+        } else {
+          Replaceall(tm, "$disown", "0");
+        }
+        /* NEW LANGUAGE NOTE:***********************************************
+           look for a 'checkfn' typemap
+           this an additional parameter added to the in typemap
+           if found the type will be tested for
+           this will result in code either in the
+           argument_check or argument_parse string
+           NEW LANGUAGE NOTE:END *********************************************** */
+        if ((checkfn = Getattr(p, "tmap:in:checkfn"))) {
+          if (i < num_required) {
+            Printf(argument_check, "if(!%s(L,%s))", checkfn, source);
+          } else {
+            Printf(argument_check, "if(lua_gettop(L)>=%s && !%s(L,%s))", source, checkfn, source);
+          }
+          Printf(argument_check, " SWIG_fail_arg(\"%s\",%s,\"%s\");\n", Swig_name_str(n), source, SwigType_str(pt, 0));
+        }
+        /* NEW LANGUAGE NOTE:***********************************************
+           lua states the number of arguments passed to a function using the fn
+           lua_gettop()
+           we can use this to deal with default arguments
+           NEW LANGUAGE NOTE:END *********************************************** */
+        if (i < num_required) {
+          Printf(argument_parse, "%s\n", tm);
+        } else {
+          Printf(argument_parse, "if(lua_gettop(L)>=%s){%s}\n", source, tm);
+        }
+        p = Getattr(p, "tmap:in:next");
+        continue;
       } else {
-	/* NEW LANGUAGE NOTE:***********************************************
-	   // why is this code not called when I don't have a typemap?
-	   // instead of giving a warning, no code is generated
-	   NEW LANGUAGE NOTE:END *********************************************** */
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	break;
+        /* NEW LANGUAGE NOTE:***********************************************
+           // why is this code not called when I don't have a typemap?
+           // instead of giving a warning, no code is generated
+           NEW LANGUAGE NOTE:END *********************************************** */
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        break;
       }
     }
 
@@ -718,18 +718,18 @@ public:
     /* Check for trailing varargs */
     if (varargs) {
       if (p && (tm = Getattr(p, "tmap:in"))) {
-	Replaceall(tm, "$input", "varargs");
-	Printv(f->code, tm, "\n", NIL);
+        Replaceall(tm, "$input", "varargs");
+        Printv(f->code, tm, "\n", NIL);
       }
     }
 
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -737,10 +737,10 @@ public:
     String *cleanup = NewString("");
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -748,19 +748,19 @@ public:
     String *outarg = NewString("");
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	//          // managing the number of returning variables
-	//        if (numoutputs=Getattr(p,"tmap:argout:numoutputs")){
-	//                      int i=GetInt(p,"tmap:argout:numoutputs");
-	//                      printf("got argout:numoutputs of %d\n",i);
-	//                      returnval+=GetInt(p,"tmap:argout:numoutputs");
-	//        }
-	//        else returnval++;
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        //          // managing the number of returning variables
+        //        if (numoutputs=Getattr(p,"tmap:argout:numoutputs")){
+        //                      int i=GetInt(p,"tmap:argout:numoutputs");
+        //                      printf("got argout:numoutputs of %d\n",i);
+        //                      returnval+=GetInt(p,"tmap:argout:numoutputs");
+        //        }
+        //        else returnval++;
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -788,9 +788,9 @@ public:
       //      }
       //        else returnval++;
       if (GetFlag(n, "feature:new")) {
-	Replaceall(tm, "$owner", "1");
+        Replaceall(tm, "$owner", "1");
       } else {
-	Replaceall(tm, "$owner", "0");
+        Replaceall(tm, "$owner", "0");
       }
       Printf(f->code, "%s\n", tm);
       //      returnval++;
@@ -819,7 +819,7 @@ public:
     /* Look to see if there is any newfree cleanup code */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printf(f->code, "%s\n", tm);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -871,7 +871,7 @@ public:
     int result = SWIG_OK;
     if (Getattr(n, "sym:overloaded")) {
       if (!Getattr(n, "sym:nextSibling")) {
-	result = dispatchFunction(n);
+        result = dispatchFunction(n);
       }
     }
 
@@ -929,7 +929,7 @@ public:
     if (maxargs > 0 && check_emitted) {
       Printf(tmp, "int argv[%d]={1", maxargs + 1);
       for (int i = 1; i <= maxargs; i++) {
-	Printf(tmp, ",%d", i + 1);
+        Printf(tmp, ",%d", i + 1);
       }
       Printf(tmp, "}");
       Wrapper_add_local(f, "argv", tmp);
@@ -949,7 +949,7 @@ public:
       Delete(fulldecl);
     } while ((sibl = Getattr(sibl, "sym:nextSibling")));
     Printf(f->code, "SWIG_Lua_pusherrstring(L,\"Wrong arguments for overloaded function '%s'\\n\"\n"
-	   "\"  Possible C/C++ prototypes are:\\n\"%s);\n", symname, protoTypes);
+           "\"  Possible C/C++ prototypes are:\\n\"%s);\n", symname, protoTypes);
     Delete(protoTypes);
 
     Printf(f->code, "lua_error(L);return 0;\n");
@@ -961,7 +961,7 @@ public:
 
     if (current[CONSTRUCTOR]) {
       if (constructor_name != 0)
-	Delete(constructor_name);
+        Delete(constructor_name);
       constructor_name = Copy(wname);
     }
 
@@ -998,21 +998,21 @@ public:
       // Global variable
       getName = Swig_name_get(getNSpace(), symname);
       if (assignable)
-	setName = Swig_name_set(getNSpace(), symname);
+        setName = Swig_name_set(getNSpace(), symname);
     } else {
       assert(!current[NO_CPP]);
       if (current[STATIC_VAR]) {
-	mrename = Swig_name_member(getNSpace(), getClassPrefix(), symname);
-	getName = Swig_name_get(0, mrename);
-	if (assignable)
-	  setName = Swig_name_set(0, mrename);
+        mrename = Swig_name_member(getNSpace(), getClassPrefix(), symname);
+        getName = Swig_name_get(0, mrename);
+        if (assignable)
+          setName = Swig_name_set(0, mrename);
       } else if (current[MEMBER_VAR]) {
-	mrename = Swig_name_member(0, getClassPrefix(), symname);
-	getName = Swig_name_get(getNSpace(), mrename);
-	if (assignable)
-	  setName = Swig_name_set(getNSpace(), mrename);
+        mrename = Swig_name_member(0, getClassPrefix(), symname);
+        getName = Swig_name_get(getNSpace(), mrename);
+        if (assignable)
+          setName = Swig_name_set(getNSpace(), mrename);
       } else {
-	assert(false);
+        assert(false);
       }
     }
 
@@ -1158,33 +1158,33 @@ public:
       // Don't do anything for enums in C mode - they are already
       // wrapped correctly
       if (CPlusPlus || !current[ENUM_CONST]) {
-	lua_name_v2 = Swig_name_member(0, proxy_class_name, lua_name);
-	iname_v2 = Swig_name_member(0, proxy_class_name, iname);
-	n_v2 = Copy(n);
-	if (!luaAddSymbol(iname_v2, n, getNSpace())) {
-	  Swig_restore(n);
-	  return SWIG_ERROR;
-	}
+        lua_name_v2 = Swig_name_member(0, proxy_class_name, lua_name);
+        iname_v2 = Swig_name_member(0, proxy_class_name, iname);
+        n_v2 = Copy(n);
+        if (!luaAddSymbol(iname_v2, n, getNSpace())) {
+          Swig_restore(n);
+          return SWIG_ERROR;
+        }
 
-	Setattr(n_v2, "sym:name", lua_name_v2);
-	tm_v2 = Swig_typemap_lookup("consttab", n_v2, name, 0);
-	if (tm_v2) {
-	  Replaceall(tm_v2, "$value", value);
-	  Replaceall(tm_v2, "$nsname", nsname);
-	  registerConstant(getNSpace(), tm_v2);
-	} else {
-	  tm_v2 = Swig_typemap_lookup("constcode", n_v2, name, 0);
-	  if (!tm_v2) {
-	    // This can't be.
-	    assert(false);
-	    Swig_restore(n);
-	    return SWIG_ERROR;
-	  }
-	  Replaceall(tm_v2, "$value", value);
-	  Replaceall(tm_v2, "$nsname", nsname);
-	  Printf(f_init, "%s\n", tm_v2);
-	}
-	Delete(n_v2);
+        Setattr(n_v2, "sym:name", lua_name_v2);
+        tm_v2 = Swig_typemap_lookup("consttab", n_v2, name, 0);
+        if (tm_v2) {
+          Replaceall(tm_v2, "$value", value);
+          Replaceall(tm_v2, "$nsname", nsname);
+          registerConstant(getNSpace(), tm_v2);
+        } else {
+          tm_v2 = Swig_typemap_lookup("constcode", n_v2, name, 0);
+          if (!tm_v2) {
+            // This can't be.
+            assert(false);
+            Swig_restore(n);
+            return SWIG_ERROR;
+          }
+          Replaceall(tm_v2, "$value", value);
+          Replaceall(tm_v2, "$nsname", nsname);
+          Printf(f_init, "%s\n", tm_v2);
+        }
+        Delete(n_v2);
       }
     }
 
@@ -1427,14 +1427,14 @@ public:
       destructor_name = NewStringf("swig_delete_%s", mangled_full_proxy_class_name);
       Printv(f_wrappers, "static void ", destructor_name, "(void *obj) {\n", NIL);
       if (destructor_action) {
-	Printv(f_wrappers, SwigType_str(rt, "arg1"), " = (", SwigType_str(rt, 0), ") obj;\n", NIL);
-	Printv(f_wrappers, destructor_action, "\n", NIL);
+        Printv(f_wrappers, SwigType_str(rt, "arg1"), " = (", SwigType_str(rt, 0), ") obj;\n", NIL);
+        Printv(f_wrappers, destructor_action, "\n", NIL);
       } else {
-	if (CPlusPlus) {
-	  Printv(f_wrappers, "    delete (", SwigType_str(rt, 0), ") obj;\n", NIL);
-	} else {
-	  Printv(f_wrappers, "    free((char *) obj);\n", NIL);
-	}
+        if (CPlusPlus) {
+          Printv(f_wrappers, "    delete (", SwigType_str(rt, 0), ") obj;\n", NIL);
+        } else {
+          Printv(f_wrappers, "    free((char *) obj);\n", NIL);
+        }
       }
       Printf(f_wrappers, "}\n");
     }
@@ -1455,20 +1455,20 @@ public:
       Delete(constructor_name);
       constructor_name = constructor_proxy_name;
       if (elua_ltr) {
-	String *static_cls_metatable_tab = Getattr(static_cls, "metatable");
-	assert(static_cls_metatable_tab);
-	Printf(static_cls_metatable_tab, "    {LSTRKEY(\"__call\"), LFUNCVAL(%s)},\n", constructor_name);
+        String *static_cls_metatable_tab = Getattr(static_cls, "metatable");
+        assert(static_cls_metatable_tab);
+        Printf(static_cls_metatable_tab, "    {LSTRKEY(\"__call\"), LFUNCVAL(%s)},\n", constructor_name);
       } else if (eluac_ltr) {
-	String *ns_methods_tab = Getattr(nspaceHash, "methods");
-	assert(ns_methods_tab);
-	Printv(ns_methods_tab, tab4, "{LSTRKEY(\"", "new_", proxy_class_name, "\")", ", LFUNCVAL(", constructor_name, ")", "},\n", NIL);
+        String *ns_methods_tab = Getattr(nspaceHash, "methods");
+        assert(ns_methods_tab);
+        Printv(ns_methods_tab, tab4, "{LSTRKEY(\"", "new_", proxy_class_name, "\")", ", LFUNCVAL(", constructor_name, ")", "},\n", NIL);
       }
     }
     if (have_destructor) {
       if (eluac_ltr) {
-	String *ns_methods_tab = Getattr(nspaceHash, "methods");
-	assert(ns_methods_tab);
-	Printv(ns_methods_tab, tab4, "{LSTRKEY(\"", "free_", mangled_full_proxy_class_name, "\")", ", LFUNCVAL(", destructor_name, ")", "},\n", NIL);
+        String *ns_methods_tab = Getattr(nspaceHash, "methods");
+        assert(ns_methods_tab);
+        Printv(ns_methods_tab, tab4, "{LSTRKEY(\"", "free_", mangled_full_proxy_class_name, "\")", ", LFUNCVAL(", destructor_name, ")", "},\n", NIL);
       }
     }
 
@@ -1493,16 +1493,16 @@ public:
       Iterator b;
       b = First(baselist);
       while (b.item) {
-	String *bname = Getattr(b.item, "name");
-	if ((!bname) || GetFlag(b.item, "feature:ignore") || (!Getattr(b.item, "module"))) {
-	  b = Next(b);
-	  continue;
-	}
-	// stores a null pointer & the name
-	Printf(base_class, "0,");
-	Printf(base_class_names, "\"%s *\",", SwigType_namestr(bname));
+        String *bname = Getattr(b.item, "name");
+        if ((!bname) || GetFlag(b.item, "feature:ignore") || (!Getattr(b.item, "module"))) {
+          b = Next(b);
+          continue;
+        }
+        // stores a null pointer & the name
+        Printf(base_class, "0,");
+        Printf(base_class_names, "\"%s *\",", SwigType_namestr(bname));
 
-	b = Next(b);
+        b = Next(b);
       }
     }
     // First, print class static part
@@ -1521,7 +1521,7 @@ public:
     Delete(base_class_names);
 
     Printv(f_wrappers, "static swig_lua_class _wrap_class_", mangled_full_proxy_class_name, " = { \"", proxy_class_name, "\", \"", full_proxy_class_name,
-	   "\", &SWIGTYPE", SwigType_manglestr(t), ",", NIL);
+           "\", &SWIGTYPE", SwigType_manglestr(t), ",", NIL);
 
     if (have_constructor) {
       Printv(f_wrappers, constructor_name, NIL);
@@ -1727,21 +1727,21 @@ public:
     if (result == SWIG_OK) {
       // This will add static member variable to the class namespace with name ClassName_VarName
       if (old_metatable_bindings && old_compatible_names) {
-	Swig_save("lua_staticmembervariableHandler", n, "lua:name", NIL);
-	String *lua_name = Getattr(n, "lua:name");
-	// Although this function uses Swig_name_member, it actually generates the Lua name,
-	// not the C++ name. This is because an earlier version used such a scheme for static function
-	// name generation and we have to maintain backward compatibility.
-	String *v2_name = Swig_name_member(NIL, proxy_class_name, lua_name);
-	if (!GetFlag(n, "wrappedasconstant")) {
-	  Setattr(n, "lua:name", v2_name);
-	  // Registering static var in the class parent nspace
-	  registerVariable(n, true, getNSpace());
-	}
-	// If static member variable was wrapped as a constant, then
-	// constant wrapper has already performed all actions necessary for old_metatable_bindings
-	Delete(v2_name);
-	Swig_restore(n);
+        Swig_save("lua_staticmembervariableHandler", n, "lua:name", NIL);
+        String *lua_name = Getattr(n, "lua:name");
+        // Although this function uses Swig_name_member, it actually generates the Lua name,
+        // not the C++ name. This is because an earlier version used such a scheme for static function
+        // name generation and we have to maintain backward compatibility.
+        String *v2_name = Swig_name_member(NIL, proxy_class_name, lua_name);
+        if (!GetFlag(n, "wrappedasconstant")) {
+          Setattr(n, "lua:name", v2_name);
+          // Registering static var in the class parent nspace
+          registerVariable(n, true, getNSpace());
+        }
+        // If static member variable was wrapped as a constant, then
+        // constant wrapper has already performed all actions necessary for old_metatable_bindings
+        Delete(v2_name);
+        Swig_restore(n);
       }
     }
     current[STATIC_VAR] = false;
@@ -1771,10 +1771,10 @@ public:
     for (int i = 0; filenames[i] != 0; i++) {
       sfile = Swig_include_sys(filenames[i]);
       if (!sfile) {
-	Printf(stderr, "*** Unable to open '%s'\n", filenames[i]);
+        Printf(stderr, "*** Unable to open '%s'\n", filenames[i]);
       } else {
-	Append(s, sfile);
-	Delete(sfile);
+        Append(s, sfile);
+        Delete(sfile);
       }
     }
 
@@ -1961,9 +1961,9 @@ public:
       String *metatable_tab_name = NewStringf("swig_%s_meta", mangled_name);
       String *metatable_tab_decl = NewString("");
       if (elua_ltr)		// In this case const array holds rotable with namespace constants
-	Printf(metatable_tab, "const LUA_REG_TYPE ");
+        Printf(metatable_tab, "const LUA_REG_TYPE ");
       else
-	Printf(metatable_tab, "static swig_lua_method ");
+        Printf(metatable_tab, "static swig_lua_method ");
       Printv(metatable_tab, metatable_tab_name, "[]", NIL);
       Printv(metatable_tab_decl, metatable_tab, ";", NIL);
       Printv(metatable_tab, " = {\n", NIL);
@@ -1982,17 +1982,17 @@ public:
       int len = Len(components);
       String *name = Copy(Getitem(components, len - 1));
       for (int i = 0; i < len - 1; i++) {
-	if (i > 0)
-	  Printv(parent_path, NSPACE_SEPARATOR, NIL);
-	String *item = Getitem(components, i);
-	Printv(parent_path, item, NIL);
+        if (i > 0)
+          Printv(parent_path, NSPACE_SEPARATOR, NIL);
+        String *item = Getitem(components, i);
+        Printv(parent_path, item, NIL);
       }
       Hash *parent = getCArraysHash(parent_path, true);
       String *namespaces_tab = Getattr(parent, "namespaces");
       Printv(namespaces_tab, "&", cname, ",\n", NIL);
       if (elua_ltr || eluac_ltr) {
-	String *methods_tab = Getattr(parent, "methods");
-	Printv(methods_tab, tab4, "{LSTRKEY(\"", name, "\")", ", LROVAL(", methods_tab_name, ")", "},\n", NIL);
+        String *methods_tab = Getattr(parent, "methods");
+        Printv(methods_tab, tab4, "{LSTRKEY(\"", name, "\")", ", LROVAL(", methods_tab_name, ")", "},\n", NIL);
       }
       Setattr(carrays_hash, "name", name);
 
@@ -2059,9 +2059,9 @@ public:
     String *metatable_tab_name = Getattr(carrays_hash, "metatable:name");
     if (elua_ltr || eluac_ltr) {
       if (old_metatable_bindings)
-	Printv(methods_tab, tab4, "{LSTRKEY(\"const\"), LROVAL(", const_tab_name, ")},\n", NIL);
+        Printv(methods_tab, tab4, "{LSTRKEY(\"const\"), LROVAL(", const_tab_name, ")},\n", NIL);
       if (elua_ltr) {
-	Printv(methods_tab, tab4, "{LSTRKEY(\"__metatable\"), LROVAL(", metatable_tab_name, ")},\n", NIL);
+        Printv(methods_tab, tab4, "{LSTRKEY(\"__metatable\"), LROVAL(", metatable_tab_name, ")},\n", NIL);
       }
 
       Printv(methods_tab, tab4, "{LSTRKEY(\"__disown\"), LFUNCVAL(SWIG_Lua_class_disown)},\n", NIL);
@@ -2105,43 +2105,43 @@ public:
       String *metatable_tab = Getattr(carrays_hash, "metatable");
       assert(metatable_tab);
       if (elua_ltr) {
-	String *get_tab_name = Getattr(carrays_hash, "get:name");
-	String *set_tab_name = Getattr(carrays_hash, "set:name");
+        String *get_tab_name = Getattr(carrays_hash, "get:name");
+        String *set_tab_name = Getattr(carrays_hash, "set:name");
 
-	if (GetFlag(carrays_hash, "lua:class_instance")) {
-	  Printv(metatable_tab, tab4, "{LSTRKEY(\"__index\"), LFUNCVAL(SWIG_Lua_class_get)},\n", NIL);
-	  Printv(metatable_tab, tab4, "{LSTRKEY(\"__newindex\"), LFUNCVAL(SWIG_Lua_class_set)},\n", NIL);
-	} else {
-	  Printv(metatable_tab, tab4, "{LSTRKEY(\"__index\"), LFUNCVAL(SWIG_Lua_namespace_get)},\n", NIL);
-	  Printv(metatable_tab, tab4, "{LSTRKEY(\"__newindex\"), LFUNCVAL(SWIG_Lua_namespace_set)},\n", NIL);
-	}
+        if (GetFlag(carrays_hash, "lua:class_instance")) {
+          Printv(metatable_tab, tab4, "{LSTRKEY(\"__index\"), LFUNCVAL(SWIG_Lua_class_get)},\n", NIL);
+          Printv(metatable_tab, tab4, "{LSTRKEY(\"__newindex\"), LFUNCVAL(SWIG_Lua_class_set)},\n", NIL);
+        } else {
+          Printv(metatable_tab, tab4, "{LSTRKEY(\"__index\"), LFUNCVAL(SWIG_Lua_namespace_get)},\n", NIL);
+          Printv(metatable_tab, tab4, "{LSTRKEY(\"__newindex\"), LFUNCVAL(SWIG_Lua_namespace_set)},\n", NIL);
+        }
 
-	Printv(metatable_tab, tab4, "{LSTRKEY(\"__gc\"), LFUNCVAL(SWIG_Lua_class_destruct)},\n", NIL);
-	Printv(metatable_tab, tab4, "{LSTRKEY(\".get\"), LROVAL(", get_tab_name, ")},\n", NIL);
-	Printv(metatable_tab, tab4, "{LSTRKEY(\".set\"), LROVAL(", set_tab_name, ")},\n", NIL);
-	Printv(metatable_tab, tab4, "{LSTRKEY(\".fn\"), LROVAL(", Getattr(carrays_hash, "methods:name"), ")},\n", NIL);
+        Printv(metatable_tab, tab4, "{LSTRKEY(\"__gc\"), LFUNCVAL(SWIG_Lua_class_destruct)},\n", NIL);
+        Printv(metatable_tab, tab4, "{LSTRKEY(\".get\"), LROVAL(", get_tab_name, ")},\n", NIL);
+        Printv(metatable_tab, tab4, "{LSTRKEY(\".set\"), LROVAL(", set_tab_name, ")},\n", NIL);
+        Printv(metatable_tab, tab4, "{LSTRKEY(\".fn\"), LROVAL(", Getattr(carrays_hash, "methods:name"), ")},\n", NIL);
 
-	if (GetFlag(carrays_hash, "lua:class_instance")) {
-	  String *static_cls = Getattr(carrays_hash, "lua:class_instance:static_hash");
-	  assert(static_cls);
-	  // static_cls is swig_lua_namespace. This structure can't be used with eLua(LTR)
-	  // Instead a structure describing its methods is used
-	  String *static_cls_cname = Getattr(static_cls, "methods:name");
-	  assert(static_cls_cname);
-	  Printv(metatable_tab, tab4, "{LSTRKEY(\".static\"), LROVAL(", static_cls_cname, ")},\n", NIL);
-	  // Put forward declaration of this array
-	  Printv(output, "extern ", Getattr(static_cls, "methods:decl"), "\n", NIL);
-	} else if (GetFlag(carrays_hash, "lua:class_static")) {
-	  Hash *instance_cls = Getattr(carrays_hash, "lua:class_static:instance_hash");
-	  assert(instance_cls);
-	  String *instance_cls_metatable_name = Getattr(instance_cls, "metatable:name");
-	  assert(instance_cls_metatable_name);
-	  Printv(metatable_tab, tab4, "{LSTRKEY(\".instance\"), LROVAL(", instance_cls_metatable_name, ")},\n", NIL);
-	}
+        if (GetFlag(carrays_hash, "lua:class_instance")) {
+          String *static_cls = Getattr(carrays_hash, "lua:class_instance:static_hash");
+          assert(static_cls);
+          // static_cls is swig_lua_namespace. This structure can't be used with eLua(LTR)
+          // Instead a structure describing its methods is used
+          String *static_cls_cname = Getattr(static_cls, "methods:name");
+          assert(static_cls_cname);
+          Printv(metatable_tab, tab4, "{LSTRKEY(\".static\"), LROVAL(", static_cls_cname, ")},\n", NIL);
+          // Put forward declaration of this array
+          Printv(output, "extern ", Getattr(static_cls, "methods:decl"), "\n", NIL);
+        } else if (GetFlag(carrays_hash, "lua:class_static")) {
+          Hash *instance_cls = Getattr(carrays_hash, "lua:class_static:instance_hash");
+          assert(instance_cls);
+          String *instance_cls_metatable_name = Getattr(instance_cls, "metatable:name");
+          assert(instance_cls_metatable_name);
+          Printv(metatable_tab, tab4, "{LSTRKEY(\".instance\"), LROVAL(", instance_cls_metatable_name, ")},\n", NIL);
+        }
 
-	Printv(metatable_tab, tab4, "{LNILKEY, LNILVAL}\n};\n", NIL);
+        Printv(metatable_tab, tab4, "{LNILKEY, LNILVAL}\n};\n", NIL);
       } else {
-	Printf(metatable_tab, "    {0,0}\n};\n");
+        Printf(metatable_tab, "    {0,0}\n};\n");
       }
 
       Printv(output, metatable_tab, NIL);
@@ -2172,11 +2172,11 @@ public:
     while (ki.key) {
       assert(ki.item);
       if (Getattr(ki.item, "sym:scope")) {
-	// We have a pseudo symbol. Lets get actual scope for this pseudo symbol
-	Hash *carrays_hash = rawGetCArraysHash(ki.key);
-	assert(carrays_hash);
-	if (GetFlag(carrays_hash, "lua:closed") == 0)
-	  Append(to_close, ki.key);
+        // We have a pseudo symbol. Lets get actual scope for this pseudo symbol
+        Hash *carrays_hash = rawGetCArraysHash(ki.key);
+        assert(carrays_hash);
+        if (GetFlag(carrays_hash, "lua:closed") == 0)
+          Append(to_close, ki.key);
       }
       ki = Next(ki);
     }
@@ -2188,9 +2188,9 @@ public:
       Hash *carrays_hash = rawGetCArraysHash(key);
       String *name = 0;		// name - name of the namespace as it should be visible in Lua
       if (Len(key) == 0)	// This is global module
-	name = module;
+        name = module;
       else
-	name = Getattr(carrays_hash, "name");
+        name = Getattr(carrays_hash, "name");
       assert(name);
       printCArraysDefinition(key, name, dataOutput);
     }
@@ -2224,11 +2224,11 @@ public:
     bool has_namespaces = GetFlag(carrays_hash, "lua:no_namespaces") == 0;
 
     Printv(output, "{\n",
-	   tab4, "\"", name, "\",\n",
-	   tab4, methods_tab_name, ",\n",
-	   tab4, attr_tab_name, ",\n",
-	   tab4, const_tab_name, ",\n",
-	   tab4, (has_classes) ? classes_tab_name : null_string, ",\n", tab4, (has_namespaces) ? namespaces_tab_name : null_string, "\n};\n", NIL);
+           tab4, "\"", name, "\",\n",
+           tab4, methods_tab_name, ",\n",
+           tab4, attr_tab_name, ",\n",
+           tab4, const_tab_name, ",\n",
+           tab4, (has_classes) ? classes_tab_name : null_string, ",\n", tab4, (has_namespaces) ? namespaces_tab_name : null_string, "\n};\n", NIL);
     Delete(null_string);
   }
 
@@ -2256,12 +2256,12 @@ public:
       // If inside class, then either class static namespace or class fully qualified name is used
       assert(!current[NO_CPP]);
       if (current[STATIC_FUNC] || current[STATIC_VAR] || current[STATIC_CONST]) {
-	scope = class_static_nspace;
+        scope = class_static_nspace;
       } else if (current[MEMBER_VAR] || current[CONSTRUCTOR] || current[DESTRUCTOR]
-		 || current[MEMBER_FUNC]) {
-	scope = full_proxy_class_name;
+                 || current[MEMBER_FUNC]) {
+        scope = full_proxy_class_name;
       } else {			// Friend functions are handled this way
-	scope = class_static_nspace;
+        scope = class_static_nspace;
       }
       assert(scope);
     }
@@ -2396,24 +2396,24 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* Constructor wrapper */
       {
-	Wrapper *w = NewWrapper();
-	String *call;
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, classname, parms, 0);
-	call = Swig_csuperclass_call(0, basetype, superparms);
-	Printf(w->def, "%s::%s: %s, Swig::Director(L) {\n", classname, target, call);
-	Append(w->def, "}\n");
-	Delete(target);
-	Wrapper_print(w, f_directors);
-	Delete(call);
-	DelWrapper(w);
+        Wrapper *w = NewWrapper();
+        String *call;
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, classname, parms, 0);
+        call = Swig_csuperclass_call(0, basetype, superparms);
+        Printf(w->def, "%s::%s: %s, Swig::Director(L) {\n", classname, target, call);
+        Append(w->def, "}\n");
+        Delete(target);
+        Wrapper_print(w, f_directors);
+        Delete(call);
+        DelWrapper(w);
       }
 
       /* Constructor header declaration */
       {
-	String *target = Swig_method_decl(0, decl, classname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, classname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -2477,7 +2477,7 @@ public:
 
     if (Cmp(storage, "virtual") == 0) {
       if (Cmp(value, "0") == 0) {
-	pure_virtual = true;
+        pure_virtual = true;
       }
     }
 
@@ -2514,18 +2514,18 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
-	  String *str = SwigType_str(Getattr(p, "type"), 0);
-	  Append(w->def, str);
-	  Append(declaration, str);
-	  Delete(str);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
+          String *str = SwigType_str(Getattr(p, "type"), 0);
+          Append(w->def, str);
+          Append(declaration, str);
+          Delete(str);
+        }
       }
 
       Append(w->def, ")");
@@ -2538,30 +2538,30 @@ public:
     /* declare method return value */
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	}
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        }
       } else {
-	String *cres = SwigType_lstr(returntype, "c_result");
-	Printf(w->code, "%s;\n", cres);
-	Delete(cres);
+        String *cres = SwigType_lstr(returntype, "c_result");
+        Printf(w->code, "%s;\n", cres);
+        Delete(cres);
       }
     }
 
     if (ignored_method) {
       if (!pure_virtual) {
-	if (!is_void)
-	  Printf(w->code, "return ");
-	String *super_call = Swig_method_call(super, l);
-	Printf(w->code, "%s;\n", super_call);
-	Delete(super_call);
+        if (!is_void)
+          Printf(w->code, "return ");
+        String *super_call = Swig_method_call(super, l);
+        Printf(w->code, "%s;\n", super_call);
+        Delete(super_call);
       } else {
-	Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	       SwigType_namestr(name));
+        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+               SwigType_namestr(name));
       }
     } else {
       /* attach typemaps to arguments (C++ -> Lua) */
@@ -2609,19 +2609,19 @@ public:
       Printf(w->code, "  lua_pop(L, 1); /* pop placeholder */\n");
       Printf(w->code, "  lua_settop(L, top);\n");
       if (pure_virtual) {
-	Printf(w->code, "  Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	       SwigType_namestr(name));
+        Printf(w->code, "  Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+               SwigType_namestr(name));
       } else {
-	// Call parent method instead
-	if (!is_void) {
-	  Printf(w->code, "  return ");
-	}
-	String *super_call = Swig_method_call(super, l);
-	Printf(w->code, "%s;\n", super_call);
-	Delete(super_call);
-	if (is_void) {
-	  Printf(w->code, "  return;\n");
-	}
+        // Call parent method instead
+        if (!is_void) {
+          Printf(w->code, "  return ");
+        }
+        String *super_call = Swig_method_call(super, l);
+        Printf(w->code, "%s;\n", super_call);
+        Delete(super_call);
+        if (is_void) {
+          Printf(w->code, "  return;\n");
+        }
       }
       Printf(w->code, "}\n");
 
@@ -2633,67 +2633,67 @@ public:
       int nargs = 0;
       p = l;
       while (p) {
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
 
-	String *ptype = Getattr(p, "type");
+        String *ptype = Getattr(p, "type");
 
-	if ((tm = Getattr(p, "tmap:directorin")) != 0) {
-	  sprintf(source, "obj%d", idx++);
-	  Replaceall(tm, "$input", source);
-	  Replaceall(tm, "$owner", "0");
-	  Printv(wrap_args, tm, "\n", NIL);
-	  nargs++;
-	  p = Getattr(p, "tmap:directorin:next");
-	  continue;
-	} else if (Cmp(ptype, "void")) {
-	  Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-		       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-		       SwigType_namestr(c_classname), SwigType_namestr(name));
-	  status = SWIG_NOWRAP;
-	  break;
-	}
-	p = nextSibling(p);
+        if ((tm = Getattr(p, "tmap:directorin")) != 0) {
+          sprintf(source, "obj%d", idx++);
+          Replaceall(tm, "$input", source);
+          Replaceall(tm, "$owner", "0");
+          Printv(wrap_args, tm, "\n", NIL);
+          nargs++;
+          p = Getattr(p, "tmap:directorin:next");
+          continue;
+        } else if (Cmp(ptype, "void")) {
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
+                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          status = SWIG_NOWRAP;
+          break;
+        }
+        p = nextSibling(p);
       }
 
       if (status == SWIG_OK) {
-	/* wrap complex arguments to Lua objects */
-	Printv(w->code, wrap_args, NIL);
+        /* wrap complex arguments to Lua objects */
+        Printv(w->code, wrap_args, NIL);
 
-	/* Mark that we're entering an upcall to prevent infinite recursion */
-	Printf(w->code, "swig_begin_upcall();\n");
+        /* Mark that we're entering an upcall to prevent infinite recursion */
+        Printf(w->code, "swig_begin_upcall();\n");
 
-	/* Call the Lua method */
-	Printf(w->code, "int pcall_result = lua_pcall(L, %d, %d, 0);\n", nargs + 1, is_void ? 0 : 1);
-	Printf(w->code, "swig_end_upcall();\n");
-	Printf(w->code, "if (pcall_result != 0) {\n");
-	Printf(w->code, "  std::string err = \"Error calling %s: \";\n", symname);
-	Printf(w->code, "  err += lua_tostring(L, -1);\n");
-	Printf(w->code, "  lua_settop(L, top);\n");
-	Printf(w->code, "  Swig::DirectorMethodException::raise(err.c_str());\n");
-	Printf(w->code, "}\n");
+        /* Call the Lua method */
+        Printf(w->code, "int pcall_result = lua_pcall(L, %d, %d, 0);\n", nargs + 1, is_void ? 0 : 1);
+        Printf(w->code, "swig_end_upcall();\n");
+        Printf(w->code, "if (pcall_result != 0) {\n");
+        Printf(w->code, "  std::string err = \"Error calling %s: \";\n", symname);
+        Printf(w->code, "  err += lua_tostring(L, -1);\n");
+        Printf(w->code, "  lua_settop(L, top);\n");
+        Printf(w->code, "  Swig::DirectorMethodException::raise(err.c_str());\n");
+        Printf(w->code, "}\n");
 
-	/* marshal return value */
-	if (!is_void) {
-	  /* Create a variable to hold the Lua stack index for $input */
-	  Printf(w->code, "int SWIG_lua_result = lua_gettop(L);\n");
-	  tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
-	  if (tm != 0) {
-	    Replaceall(tm, "$input", "SWIG_lua_result");
-	    Replaceall(tm, "$result", "c_result");
-	    Printf(w->code, "%s\n", tm);
-	    Delete(tm);
-	  } else {
-	    Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number, "Unable to use return type %s in director method %s::%s (skipping method).\n",
-			 SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    status = SWIG_ERROR;
-	  }
-	}
+        /* marshal return value */
+        if (!is_void) {
+          /* Create a variable to hold the Lua stack index for $input */
+          Printf(w->code, "int SWIG_lua_result = lua_gettop(L);\n");
+          tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
+          if (tm != 0) {
+            Replaceall(tm, "$input", "SWIG_lua_result");
+            Replaceall(tm, "$result", "c_result");
+            Printf(w->code, "%s\n", tm);
+            Delete(tm);
+          } else {
+            Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number, "Unable to use return type %s in director method %s::%s (skipping method).\n",
+                         SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+            status = SWIG_ERROR;
+          }
+        }
 
-	/* Clean up Lua stack */
-	Printf(w->code, "lua_settop(L, top);\n");
+        /* Clean up Lua stack */
+        Printf(w->code, "lua_settop(L, top);\n");
       }
 
       Delete(arglist);
@@ -2701,13 +2701,13 @@ public:
 
     if (!is_void) {
       if (!(ignored_method && !pure_virtual)) {
-	String *rettype = SwigType_str(returntype, 0);
-	if (!SwigType_isreference(returntype)) {
-	  Printf(w->code, "return (%s) c_result;\n", rettype);
-	} else {
-	  Printf(w->code, "return (%s) *c_result;\n", rettype);
-	}
-	Delete(rettype);
+        String *rettype = SwigType_str(returntype, 0);
+        if (!SwigType_isreference(returntype)) {
+          Printf(w->code, "return (%s) c_result;\n", rettype);
+        } else {
+          Printf(w->code, "return (%s) *c_result;\n", rettype);
+        }
+        Delete(rettype);
       }
     }
 
@@ -2721,7 +2721,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -2731,10 +2731,10 @@ public:
     /* emit the director method */
     if (status == SWIG_OK) {
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -24,19 +24,19 @@
 #include "cparse.h"
 #include <ctype.h>
 #include <errno.h>
-#include <limits.h>             // for INT_MAX
+#include <limits.h>  // for INT_MAX
 
 // Global variables
 
-static Language *lang = 0;      // Language method
+static Language *lang = 0;  // Language method
 int CPlusPlus = 0;
-int Extend = 0;                 // Extend flag
-int ForceExtern = 0;            // Force extern mode
+int Extend = 0;       // Extend flag
+int ForceExtern = 0;  // Force extern mode
 int Verbose = 0;
 int AddExtern = 0;
 int NoExcept = 0;
 extern "C" {
-  int UseWrapperSuffix = 0;     // If 1, append suffix to non-overloaded functions too.
+int UseWrapperSuffix = 0;  // If 1, append suffix to non-overloaded functions too.
 }
 
 /* Suppress warning messages for private inheritance, etc by default.
@@ -52,9 +52,9 @@ extern "C" {
 #define EXTRA_WARNINGS "309,403,405,512,321,322"
 
 extern "C" {
-  extern String *ModuleName;
-  extern int ignore_nested_classes;
-  extern int kwargs_supported;
+extern String *ModuleName;
+extern int ignore_nested_classes;
+extern int kwargs_supported;
 }
 
 /* usage string split into multiple parts otherwise string is too big for some compilers */
@@ -170,9 +170,9 @@ Arguments may also be passed in a file, separated by whitespace. For example:\n\
 \n";
 
 // Local variables
-static String *LangSubDir = 0; // Target language library subdirectory
-static String *SwigLib = 0; // Library directory
-static String *SwigLibWinUnix = 0; // Extra library directory on Windows
+static String *LangSubDir = 0;      // Target language library subdirectory
+static String *SwigLib = 0;         // Library directory
+static String *SwigLibWinUnix = 0;  // Extra library directory on Windows
 static int freeze = 0;
 static String *lang_config = 0;
 static const char *hpp_extension = "h";
@@ -208,7 +208,7 @@ static String *dependencies_file = 0;
 static String *dependencies_target = 0;
 static int external_runtime = 0;
 static String *external_runtime_name = 0;
-enum { STAGE1=1, STAGE2=2, STAGE3=4, STAGE4=8, STAGEOVERFLOW=16 };
+enum { STAGE1 = 1, STAGE2 = 2, STAGE3 = 4, STAGE4 = 8, STAGEOVERFLOW = 16 };
 static List *libfiles = 0;
 static List *all_output_files = 0;
 static const char *stdcpp_define = NULL;
@@ -227,8 +227,8 @@ static bool check_extension(String *filename) {
     return 0;
   String *extension = Swig_file_extension(name);
   const char *c = Char(extension);
-  if ((strcmp(c, ".c") == 0) ||
-      (strcmp(c, ".C") == 0) || (strcmp(c, ".cc") == 0) || (strcmp(c, ".cxx") == 0) || (strcmp(c, ".c++") == 0) || (strcmp(c, ".cpp") == 0)) {
+  if ((strcmp(c, ".c") == 0) || (strcmp(c, ".C") == 0) || (strcmp(c, ".cc") == 0) || (strcmp(c, ".cxx") == 0) || (strcmp(c, ".c++") == 0) ||
+      (strcmp(c, ".cpp") == 0)) {
     wanted = true;
   }
   Delete(extension);
@@ -252,7 +252,7 @@ static unsigned int decode_numbers_list(String *numlist) {
         // TODO: check that it is a number
         int number = atoi(Char(numstring));
         if (number > 0 && number <= 16) {
-          decoded_number |= (1 << (number-1));
+          decoded_number |= (1 << (number - 1));
         }
       }
     }
@@ -317,7 +317,6 @@ static void SWIG_setfeature(const char *cfeature, const char *cvalue) {
   Delete(fname);
   Delete(fvalue);
 }
-
 
 static void SWIG_setfeatures(const char *c) {
   char feature[64];
@@ -453,7 +452,7 @@ static void getoptions(int argc, char *argv[]) {
         Swig_mark_arg(i);
       } else if (strncmp(argv[i], "-I", 2) == 0) {
         // Add a new directory search path
-        Swig_add_directory((String_or_char*)(argv[i] + 2));
+        Swig_add_directory((String_or_char *)(argv[i] + 2));
         Swig_mark_arg(i);
       } else if (strncmp(argv[i], "-D", 2) == 0) {
         String *d = NewString(argv[i] + 2);
@@ -644,13 +643,14 @@ static void getoptions(int argc, char *argv[]) {
       } else if (strcmp(argv[i], "-version") == 0 || strcmp(argv[1], "--version") == 0) {
         fprintf(stdout, "\nSWIG Version %s\n", Swig_package_version());
         fprintf(stdout, "\nCompiled with %s [%s]\n", SWIG_CXX, SWIG_PLATFORM);
-        fprintf(stdout, "\nConfigured options: %cpcre\n",
+        fprintf(stdout,
+                "\nConfigured options: %cpcre\n",
 #ifdef HAVE_PCRE
                 '+'
 #else
                 '-'
 #endif
-            );
+        );
         fprintf(stdout, "\nPlease see %s for reporting bugs and further information\n", PACKAGE_BUGREPORT);
         Exit(EXIT_SUCCESS);
       } else if (strcmp(argv[i], "-copyright") == 0) {
@@ -905,18 +905,18 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   // Check for SWIG_LIB environment variable
   c = getenv("SWIG_LIB");
-  if (c == (char *) 0 || *c == 0) {
+  if (c == (char *)0 || *c == 0) {
 #if defined(_WIN32)
     char buf[MAX_PATH];
     char *p;
     if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
       *(p + 1) = '\0';
-      SwigLib = NewStringf("%sLib", buf); // Native windows installation path
+      SwigLib = NewStringf("%sLib", buf);  // Native windows installation path
     } else {
-      SwigLib = NewStringf(""); // Unexpected error
+      SwigLib = NewStringf("");  // Unexpected error
     }
     if (Len(SWIG_LIB_WIN_UNIX) > 0)
-      SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
+      SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX);  // Unix installation path using a drive letter (for msys/mingw)
 #else
     SwigLib = NewString(SWIG_LIB);
 #endif
@@ -934,7 +934,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   if (help) {
     Printf(stdout, "\nNote: 'swig -<lang> -help' displays options for a specific target language.\n\n");
-    Exit(EXIT_SUCCESS); // Exit if we're in help mode
+    Exit(EXIT_SUCCESS);  // Exit if we're in help mode
   }
 
   // Check all of the options to make sure we're cool.
@@ -955,7 +955,8 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   if (CPlusPlus) {
     // Default to C++98.
-    if (!stdcpp_define) stdcpp_define = "__cplusplus 199711L";
+    if (!stdcpp_define)
+      stdcpp_define = "__cplusplus 199711L";
     Preprocessor_define(stdcpp_define, 0);
   } else {
     if (stdcpp_define) {
@@ -995,9 +996,9 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     Swig_add_directory(rl);
   }
 
-  Swig_add_directory((String *) "." SWIG_FILE_DELIMITER "swig_lib");
+  Swig_add_directory((String *)"." SWIG_FILE_DELIMITER "swig_lib");
   if (SwigLibWinUnix)
-    Swig_add_directory((String *) SwigLibWinUnix);
+    Swig_add_directory((String *)SwigLibWinUnix);
   Swig_add_directory(SwigLib);
 
   if (Verbose) {
@@ -1107,7 +1108,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
           String *outfile;
           File *f_dependencies_file = 0;
 
-          String *inputfile_filename = outcurrentdir ? Swig_file_filename(input_file): Copy(input_file);
+          String *inputfile_filename = outcurrentdir ? Swig_file_filename(input_file) : Copy(input_file);
           String *basename = Swig_file_basename(inputfile_filename);
           if (!outfile_name) {
             if (CPlusPlus || lang->cplus_runtime_mode()) {
@@ -1143,7 +1144,8 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
           for (int i = 0; i < Len(files); i++) {
             int use_file = 1;
             if (depend == 2) {
-              if ((Strncmp(Getitem(files, i), SwigLib, Len(SwigLib)) == 0) || (SwigLibWinUnix && (Strncmp(Getitem(files, i), SwigLibWinUnix, Len(SwigLibWinUnix)) == 0)))
+              if ((Strncmp(Getitem(files, i), SwigLib, Len(SwigLib)) == 0) ||
+                  (SwigLibWinUnix && (Strncmp(Getitem(files, i), SwigLibWinUnix, Len(SwigLibWinUnix)) == 0)))
                 use_file = 0;
             }
             if (use_file) {
@@ -1282,10 +1284,10 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
           Printf(stderr, "Missing input file in preprocessed output.\n");
           Exit(EXIT_FAILURE);
         }
-        Setattr(top, "infile", infile); // Note: if nopreprocess then infile is the original input file, otherwise input_file
+        Setattr(top, "infile", infile);  // Note: if nopreprocess then infile is the original input file, otherwise input_file
         Setattr(top, "inputfile", input_file);
 
-        String *infile_filename = outcurrentdir ? Swig_file_filename(infile): Copy(infile);
+        String *infile_filename = outcurrentdir ? Swig_file_filename(infile) : Copy(infile);
         String *basename = Swig_file_basename(infile_filename);
         if (!outfile_name) {
           if (CPlusPlus || lang->cplus_runtime_mode()) {
@@ -1310,16 +1312,24 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
         ForceExtern = check_extension(input_file);
 
         if (tlm->status == Experimental) {
-          Swig_warning(WARN_LANG_EXPERIMENTAL, "SWIG", 1, "Experimental target language. "
-            "Target language %s specified by %s is an experimental language. "
-            "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
-            tlm->help ? tlm->help : "", tlm->name);
+          Swig_warning(WARN_LANG_EXPERIMENTAL,
+                       "SWIG",
+                       1,
+                       "Experimental target language. "
+                       "Target language %s specified by %s is an experimental language. "
+                       "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
+                       tlm->help ? tlm->help : "",
+                       tlm->name);
         } else if (tlm->status == Deprecated) {
-          Swig_warning(WARN_LANG_DEPRECATED, "SWIG", 1, "Deprecated target language. "
-            "Target language %s specified by %s is a deprecated target language. "
-            "It will be removed in the next release of SWIG unless a new maintainer steps forward to bring it up to at least experimental status. "
-            "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
-            tlm->help ? tlm->help : "", tlm->name);
+          Swig_warning(WARN_LANG_DEPRECATED,
+                       "SWIG",
+                       1,
+                       "Deprecated target language. "
+                       "Target language %s specified by %s is a deprecated target language. "
+                       "It will be removed in the next release of SWIG unless a new maintainer steps forward to bring it up to at least experimental status. "
+                       "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
+                       tlm->help ? tlm->help : "",
+                       tlm->name);
         }
 
         lang->top(top);

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -24,19 +24,19 @@
 #include "cparse.h"
 #include <ctype.h>
 #include <errno.h>
-#include <limits.h>		// for INT_MAX
+#include <limits.h>             // for INT_MAX
 
 // Global variables
 
-static Language *lang = 0;	// Language method
+static Language *lang = 0;      // Language method
 int CPlusPlus = 0;
-int Extend = 0;			// Extend flag
-int ForceExtern = 0;		// Force extern mode
+int Extend = 0;                 // Extend flag
+int ForceExtern = 0;            // Force extern mode
 int Verbose = 0;
 int AddExtern = 0;
 int NoExcept = 0;
 extern "C" {
-  int UseWrapperSuffix = 0;	// If 1, append suffix to non-overloaded functions too.
+  int UseWrapperSuffix = 0;     // If 1, append suffix to non-overloaded functions too.
 }
 
 /* Suppress warning messages for private inheritance, etc by default.
@@ -913,7 +913,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
       *(p + 1) = '\0';
       SwigLib = NewStringf("%sLib", buf); // Native windows installation path
     } else {
-      SwigLib = NewStringf("");	// Unexpected error
+      SwigLib = NewStringf(""); // Unexpected error
     }
     if (Len(SWIG_LIB_WIN_UNIX) > 0)
       SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
@@ -934,7 +934,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
   if (help) {
     Printf(stdout, "\nNote: 'swig -<lang> -help' displays options for a specific target language.\n\n");
-    Exit(EXIT_SUCCESS);	// Exit if we're in help mode
+    Exit(EXIT_SUCCESS); // Exit if we're in help mode
   }
 
   // Check all of the options to make sure we're cool.

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -340,7 +340,7 @@ static void SWIG_setfeatures(const char *c) {
       char *v = value;
       char *ve = v + 63;
       while ((v != ve) && *c != ',' && *c && !isspace(*c)) {
-	*(v++) = *(c++);
+        *(v++) = *(c++);
       }
       *v = 0;
       Printf(fvalue, "%s", value);
@@ -448,422 +448,422 @@ static void getoptions(int argc, char *argv[]) {
   for (i = 1; i < argc; i++) {
     if (argv[i] && !Swig_check_marked(i)) {
       if (strncmp(argv[i], "-I-", 3) == 0) {
-	// Don't push/pop directories
-	Swig_set_push_dir(0);
-	Swig_mark_arg(i);
+        // Don't push/pop directories
+        Swig_set_push_dir(0);
+        Swig_mark_arg(i);
       } else if (strncmp(argv[i], "-I", 2) == 0) {
-	// Add a new directory search path
-	Swig_add_directory((String_or_char*)(argv[i] + 2));
-	Swig_mark_arg(i);
+        // Add a new directory search path
+        Swig_add_directory((String_or_char*)(argv[i] + 2));
+        Swig_mark_arg(i);
       } else if (strncmp(argv[i], "-D", 2) == 0) {
-	String *d = NewString(argv[i] + 2);
-	if (Replace(d, "=", " ", DOH_REPLACE_FIRST) == 0) {
-	  // Match C preprocessor behaviour whereby -DFOO sets FOO=1.
-	  Append(d, " 1");
-	}
-	// Create a symbol
-	Preprocessor_define(d, 0);
-	Delete(d);
-	Swig_mark_arg(i);
+        String *d = NewString(argv[i] + 2);
+        if (Replace(d, "=", " ", DOH_REPLACE_FIRST) == 0) {
+          // Match C preprocessor behaviour whereby -DFOO sets FOO=1.
+          Append(d, " 1");
+        }
+        // Create a symbol
+        Preprocessor_define(d, 0);
+        Delete(d);
+        Swig_mark_arg(i);
       } else if (strncmp(argv[i], "-U", 2) == 0) {
-	Preprocessor_undef(argv[i] + 2);
-	Swig_mark_arg(i);
+        Preprocessor_undef(argv[i] + 2);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-E") == 0) {
-	cpp_only = 1;
-	Swig_mark_arg(i);
+        cpp_only = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-nopreprocess") == 0) {
-	no_cpp = 1;
-	Swig_mark_arg(i);
+        no_cpp = 1;
+        Swig_mark_arg(i);
       } else if ((strcmp(argv[i], "-verbose") == 0) || (strcmp(argv[i], "-v") == 0)) {
-	Verbose = 1;
-	Swig_mark_arg(i);
+        Verbose = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-c++") == 0) {
-	CPlusPlus = 1;
-	Swig_cparse_cplusplus(1);
-	Swig_mark_arg(i);
+        CPlusPlus = 1;
+        Swig_cparse_cplusplus(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-c++out") == 0) {
-	// Undocumented
-	Swig_cparse_cplusplusout(1);
-	Swig_mark_arg(i);
+        // Undocumented
+        Swig_cparse_cplusplusout(1);
+        Swig_mark_arg(i);
       } else if (strncmp(argv[i], "-std=c", 6) == 0) {
-	const char *std = argv[i] + 6;
-	if (strncmp(std, "++", 2) == 0) {
-	  std += 2;
-	  if (strcmp(std, "98") == 0 || strcmp(std, "03") == 0) {
-	    stdcpp_define = "__cplusplus 199711L";
-	  } else if (strcmp(std, "11") == 0) {
-	    stdcpp_define = "__cplusplus 201103L";
-	  } else if (strcmp(std, "14") == 0) {
-	    stdcpp_define = "__cplusplus 201402L";
-	  } else if (strcmp(std, "17") == 0) {
-	    stdcpp_define = "__cplusplus 201703L";
-	  } else if (strcmp(std, "20") == 0) {
-	    stdcpp_define = "__cplusplus 202002L";
-	  } else if (strcmp(std, "23") == 0) {
-	    stdcpp_define = "__cplusplus 202302L";
-	  } else {
-	    Printf(stderr, "Unrecognised C++ standard version in option '%s'\n", argv[i]);
-	    Exit(EXIT_FAILURE);
-	  }
-	} else {
-	  if (strcmp(std, "89") == 0 || strcmp(std, "90") == 0) {
-	    stdc_define = NULL;
-	  } else if (strcmp(std, "95") == 0) {
-	    stdc_define = "__STDC_VERSION__ 199409L";
-	  } else if (strcmp(std, "99") == 0) {
-	    stdc_define = "__STDC_VERSION__ 199901L";
-	  } else if (strcmp(std, "11") == 0) {
-	    stdc_define = "__STDC_VERSION__ 201112L";
-	  } else if (strcmp(std, "17") == 0 || strcmp(std, "18") == 0) {
-	    // Both GCC and clang accept -std=c18 as well as -std=c17.
-	    stdc_define = "__STDC_VERSION__ 201710L";
-	  } else if (strcmp(std, "23") == 0) {
-	    stdc_define = "__STDC_VERSION__ 202311L";
-	  } else {
-	    Printf(stderr, "Unrecognised C standard version in option '%s'\n", argv[i]);
-	    Exit(EXIT_FAILURE);
-	  }
-	}
-	Swig_mark_arg(i);
+        const char *std = argv[i] + 6;
+        if (strncmp(std, "++", 2) == 0) {
+          std += 2;
+          if (strcmp(std, "98") == 0 || strcmp(std, "03") == 0) {
+            stdcpp_define = "__cplusplus 199711L";
+          } else if (strcmp(std, "11") == 0) {
+            stdcpp_define = "__cplusplus 201103L";
+          } else if (strcmp(std, "14") == 0) {
+            stdcpp_define = "__cplusplus 201402L";
+          } else if (strcmp(std, "17") == 0) {
+            stdcpp_define = "__cplusplus 201703L";
+          } else if (strcmp(std, "20") == 0) {
+            stdcpp_define = "__cplusplus 202002L";
+          } else if (strcmp(std, "23") == 0) {
+            stdcpp_define = "__cplusplus 202302L";
+          } else {
+            Printf(stderr, "Unrecognised C++ standard version in option '%s'\n", argv[i]);
+            Exit(EXIT_FAILURE);
+          }
+        } else {
+          if (strcmp(std, "89") == 0 || strcmp(std, "90") == 0) {
+            stdc_define = NULL;
+          } else if (strcmp(std, "95") == 0) {
+            stdc_define = "__STDC_VERSION__ 199409L";
+          } else if (strcmp(std, "99") == 0) {
+            stdc_define = "__STDC_VERSION__ 199901L";
+          } else if (strcmp(std, "11") == 0) {
+            stdc_define = "__STDC_VERSION__ 201112L";
+          } else if (strcmp(std, "17") == 0 || strcmp(std, "18") == 0) {
+            // Both GCC and clang accept -std=c18 as well as -std=c17.
+            stdc_define = "__STDC_VERSION__ 201710L";
+          } else if (strcmp(std, "23") == 0) {
+            stdc_define = "__STDC_VERSION__ 202311L";
+          } else {
+            Printf(stderr, "Unrecognised C standard version in option '%s'\n", argv[i]);
+            Exit(EXIT_FAILURE);
+          }
+        }
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-fcompact") == 0) {
-	Wrapper_compact_print_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_compact_print_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-fvirtual") == 0) {
-	Wrapper_virtual_elimination_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_virtual_elimination_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-fastdispatch") == 0) {
-	Wrapper_fast_dispatch_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_fast_dispatch_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-nofastdispatch") == 0) {
-	Wrapper_fast_dispatch_mode_set(0);
-	Swig_mark_arg(i);
+        Wrapper_fast_dispatch_mode_set(0);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-naturalvar") == 0) {
-	Wrapper_naturalvar_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_naturalvar_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-directors") == 0) {
-	SWIG_setfeature("feature:director", "1");
-	Wrapper_director_mode_set(1);
-	Swig_mark_arg(i);
+        SWIG_setfeature("feature:director", "1");
+        Wrapper_director_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-dirprot") == 0) {
-	Wrapper_director_protected_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_director_protected_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-nodirprot") == 0) {
-	Wrapper_director_protected_mode_set(0);
-	Swig_mark_arg(i);
+        Wrapper_director_protected_mode_set(0);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-pcreversion") == 0) {
-	String *version = Swig_pcre_version();
-	Printf(stdout, "%s\n", version);
-	Delete(version);
-	Swig_mark_arg(i);
-	Exit(EXIT_SUCCESS);
+        String *version = Swig_pcre_version();
+        Printf(stdout, "%s\n", version);
+        Delete(version);
+        Swig_mark_arg(i);
+        Exit(EXIT_SUCCESS);
       } else if (strcmp(argv[i], "-small") == 0) {
-	Wrapper_compact_print_mode_set(1);
-	Wrapper_virtual_elimination_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_compact_print_mode_set(1);
+        Wrapper_virtual_elimination_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-external-runtime") == 0) {
-	external_runtime = 1;
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  external_runtime_name = NewString(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	  i++;
-	}
+        external_runtime = 1;
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          external_runtime_name = NewString(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+          i++;
+        }
       } else if ((strcmp(argv[i], "-nodefaultctor") == 0)) {
-	SWIG_setfeature("feature:nodefaultctor", "1");
-	Swig_mark_arg(i);
+        SWIG_setfeature("feature:nodefaultctor", "1");
+        Swig_mark_arg(i);
       } else if ((strcmp(argv[i], "-nodefaultdtor") == 0)) {
-	SWIG_setfeature("feature:nodefaultdtor", "1");
-	Swig_mark_arg(i);
+        SWIG_setfeature("feature:nodefaultdtor", "1");
+        Swig_mark_arg(i);
       } else if ((strcmp(argv[i], "-copyctor") == 0)) {
-	SWIG_setfeature("feature:copyctor", "1");
-	Swig_mark_arg(i);
+        SWIG_setfeature("feature:copyctor", "1");
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-noexcept") == 0) {
-	NoExcept = 1;
-	Swig_mark_arg(i);
+        NoExcept = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-addextern") == 0) {
-	AddExtern = 1;
-	Swig_mark_arg(i);
+        AddExtern = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-template") == 0) {
-	Swig_cparse_debug_templates(1);
-	Swig_mark_arg(i);
+        Swig_cparse_debug_templates(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-templatereduce") == 0) {
-	SWIG_cparse_template_reduce(1);
-	Swig_mark_arg(i);
+        SWIG_cparse_template_reduce(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-notemplatereduce") == 0) {
-	SWIG_cparse_template_reduce(0);
-	Swig_mark_arg(i);
+        SWIG_cparse_template_reduce(0);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-macroerrors") == 0) {
-	Swig_cparse_follow_locators(1);
-	Swig_mark_arg(i);
+        Swig_cparse_follow_locators(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-swiglib") == 0) {
-	Printf(stdout, "%s\n", SwigLib);
-	if (SwigLibWinUnix)
-	  Printf(stdout, "%s\n", SwigLibWinUnix);
-	Exit(EXIT_SUCCESS);
+        Printf(stdout, "%s\n", SwigLib);
+        if (SwigLibWinUnix)
+          Printf(stdout, "%s\n", SwigLibWinUnix);
+        Exit(EXIT_SUCCESS);
       } else if (strcmp(argv[i], "-o") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  outfile_name = NewString(argv[i + 1]);
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          outfile_name = NewString(argv[i + 1]);
           Swig_filename_correct(outfile_name);
-	  if (!outfile_name_h || !dependencies_file) {
-	    char *ext = strrchr(Char(outfile_name), '.');
-	    String *basename = ext ? NewStringWithSize(Char(outfile_name), (int)(Char(ext) - Char(outfile_name))) : NewString(outfile_name);
-	    if (!dependencies_file) {
-	      dependencies_file = NewStringf("%s.%s", basename, depends_extension);
-	    }
-	    if (!outfile_name_h) {
-	      Printf(basename, ".%s", hpp_extension);
-	      outfile_name_h = NewString(basename);
-	    }
-	    Delete(basename);
-	  }
-	  Swig_mark_arg(i + 1);
-	  i++;
-	} else {
-	  Swig_arg_error();
-	}
+          if (!outfile_name_h || !dependencies_file) {
+            char *ext = strrchr(Char(outfile_name), '.');
+            String *basename = ext ? NewStringWithSize(Char(outfile_name), (int)(Char(ext) - Char(outfile_name))) : NewString(outfile_name);
+            if (!dependencies_file) {
+              dependencies_file = NewStringf("%s.%s", basename, depends_extension);
+            }
+            if (!outfile_name_h) {
+              Printf(basename, ".%s", hpp_extension);
+              outfile_name_h = NewString(basename);
+            }
+            Delete(basename);
+          }
+          Swig_mark_arg(i + 1);
+          i++;
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-oh") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  outfile_name_h = NewString(argv[i + 1]);
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          outfile_name_h = NewString(argv[i + 1]);
           Swig_filename_correct(outfile_name_h);
-	  Swig_mark_arg(i + 1);
-	  i++;
-	} else {
-	  Swig_arg_error();
-	}
+          Swig_mark_arg(i + 1);
+          i++;
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-fakeversion") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  Swig_set_fakeversion(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	  i++;
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          Swig_set_fakeversion(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+          i++;
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-version") == 0 || strcmp(argv[1], "--version") == 0) {
-	fprintf(stdout, "\nSWIG Version %s\n", Swig_package_version());
-	fprintf(stdout, "\nCompiled with %s [%s]\n", SWIG_CXX, SWIG_PLATFORM);
-	fprintf(stdout, "\nConfigured options: %cpcre\n",
+        fprintf(stdout, "\nSWIG Version %s\n", Swig_package_version());
+        fprintf(stdout, "\nCompiled with %s [%s]\n", SWIG_CXX, SWIG_PLATFORM);
+        fprintf(stdout, "\nConfigured options: %cpcre\n",
 #ifdef HAVE_PCRE
-		'+'
+                '+'
 #else
-		'-'
+                '-'
 #endif
-	    );
-	fprintf(stdout, "\nPlease see %s for reporting bugs and further information\n", PACKAGE_BUGREPORT);
-	Exit(EXIT_SUCCESS);
+            );
+        fprintf(stdout, "\nPlease see %s for reporting bugs and further information\n", PACKAGE_BUGREPORT);
+        Exit(EXIT_SUCCESS);
       } else if (strcmp(argv[i], "-copyright") == 0) {
-	fprintf(stdout, "\nSWIG Version %s\n", Swig_package_version());
-	fprintf(stdout, "Copyright (c) 1995-1998\n");
-	fprintf(stdout, "University of Utah and the Regents of the University of California\n");
-	fprintf(stdout, "Copyright (c) 1998-2005\n");
-	fprintf(stdout, "University of Chicago\n");
-	fprintf(stdout, "Copyright (c) 2005-2006\n");
-	fprintf(stdout, "Arizona Board of Regents (University of Arizona)\n");
-	Exit(EXIT_SUCCESS);
+        fprintf(stdout, "\nSWIG Version %s\n", Swig_package_version());
+        fprintf(stdout, "Copyright (c) 1995-1998\n");
+        fprintf(stdout, "University of Utah and the Regents of the University of California\n");
+        fprintf(stdout, "Copyright (c) 1998-2005\n");
+        fprintf(stdout, "University of Chicago\n");
+        fprintf(stdout, "Copyright (c) 2005-2006\n");
+        fprintf(stdout, "Arizona Board of Regents (University of Arizona)\n");
+        Exit(EXIT_SUCCESS);
       } else if (strncmp(argv[i], "-l", 2) == 0) {
-	// Add a new directory search path
-	Append(libfiles, argv[i] + 2);
-	Swig_mark_arg(i);
+        // Add a new directory search path
+        Append(libfiles, argv[i] + 2);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-co") == 0) {
-	checkout = 1;
-	Swig_mark_arg(i);
+        checkout = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-features") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  SWIG_setfeatures(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          SWIG_setfeatures(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-freeze") == 0) {
-	freeze = 1;
-	Swig_mark_arg(i);
+        freeze = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-includeall") == 0) {
-	Preprocessor_include_all(1);
-	Swig_mark_arg(i);
+        Preprocessor_include_all(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-importall") == 0) {
-	Preprocessor_import_all(1);
-	Swig_mark_arg(i);
+        Preprocessor_import_all(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-ignoremissing") == 0) {
-	Preprocessor_ignore_missing(1);
-	Swig_mark_arg(i);
+        Preprocessor_ignore_missing(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-cpperraswarn") == 0) {
-	Preprocessor_error_as_warning(1);
-	Swig_mark_arg(i);
+        Preprocessor_error_as_warning(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-nocpperraswarn") == 0) {
-	Preprocessor_error_as_warning(0);
-	Swig_mark_arg(i);
+        Preprocessor_error_as_warning(0);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-cppext") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  SWIG_config_cppext(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	  i++;
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          SWIG_config_cppext(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+          i++;
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-debug-typemap") == 0) {
-	tm_debug = 1;
-	Swig_mark_arg(i);
+        tm_debug = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-tmsearch") == 0) {
-	Swig_typemap_search_debug_set();
-	Swig_mark_arg(i);
+        Swig_typemap_search_debug_set();
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-tmused") == 0) {
-	Swig_typemap_used_debug_set();
-	Swig_mark_arg(i);
+        Swig_typemap_used_debug_set();
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-module") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  ModuleName = NewString(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          ModuleName = NewString(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-M") == 0) {
-	depend = 1;
-	depend_only = 1;
-	Swig_mark_arg(i);
+        depend = 1;
+        depend_only = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-MM") == 0) {
-	depend = 2;
-	depend_only = 1;
-	Swig_mark_arg(i);
+        depend = 2;
+        depend_only = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-MF") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  dependencies_file = NewString(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          dependencies_file = NewString(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-MD") == 0) {
-	depend = 1;
-	Swig_mark_arg(i);
+        depend = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-MMD") == 0) {
-	depend = 2;
-	Swig_mark_arg(i);
+        depend = 2;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-MP") == 0) {
-	depend_phony = 1;
-	Swig_mark_arg(i);
+        depend_phony = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-MT") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
           if (!dependencies_target)
             dependencies_target = NewString(argv[i + 1]);
           else
             Printf(dependencies_target, " %s", argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	} else {
-	  Swig_arg_error();
-	}
+          Swig_mark_arg(i + 1);
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-outdir") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  outdir = NewString(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          outdir = NewString(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-outcurrentdir") == 0) {
-	Swig_mark_arg(i);
-	outcurrentdir = 1;
+        Swig_mark_arg(i);
+        outcurrentdir = 1;
       } else if (strcmp(argv[i], "-Wall") == 0) {
-	Swig_mark_arg(i);
-	Swig_warnall();
+        Swig_mark_arg(i);
+        Swig_warnall();
       } else if (strcmp(argv[i], "-Wallkw") == 0) {
-	allkw = 1;
-	Swig_mark_arg(i);
+        allkw = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-Werror") == 0) {
-	werror = 1;
-	Swig_mark_arg(i);
+        werror = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-Wextra") == 0) {
-	Swig_mark_arg(i);
+        Swig_mark_arg(i);
         Swig_warnfilter(EXTRA_WARNINGS, 0);
       } else if (strncmp(argv[i], "-w", 2) == 0) {
-	Swig_mark_arg(i);
-	Swig_warnfilter(argv[i] + 2, 1);
+        Swig_mark_arg(i);
+        Swig_warnfilter(argv[i] + 2, 1);
       } else if (strcmp(argv[i], "-debug-quiet") == 0) {
-	Swig_print_quiet(1);
-	Swig_mark_arg(i);
+        Swig_print_quiet(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-symtabs") == 0) {
-	dump_symtabs = 1;
-	Swig_mark_arg(i);
+        dump_symtabs = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-symbols") == 0) {
-	dump_symbols = 1;
-	Swig_mark_arg(i);
+        dump_symbols = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-csymbols") == 0) {
-	dump_csymbols = 1;
-	Swig_mark_arg(i);
+        dump_csymbols = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-lsymbols") == 0) {
-	dump_lang_symbols = 1;
-	Swig_mark_arg(i);
+        dump_lang_symbols = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-tags") == 0) {
-	dump_tags = 1;
-	Swig_mark_arg(i);
+        dump_tags = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-top") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  String *dump_list = NewString(argv[i + 1]);
-	  dump_top = decode_numbers_list(dump_list);
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          String *dump_list = NewString(argv[i + 1]);
+          dump_top = decode_numbers_list(dump_list);
           if (dump_top < STAGE1 || dump_top >= STAGEOVERFLOW)
             Swig_arg_error();
           else
             Swig_mark_arg(i + 1);
           Delete(dump_list);
-	} else {
-	  Swig_arg_error();
-	}
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-debug-module") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  String *dump_list = NewString(argv[i + 1]);
-	  dump_module = decode_numbers_list(dump_list);
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          String *dump_list = NewString(argv[i + 1]);
+          dump_module = decode_numbers_list(dump_list);
           if (dump_module < STAGE1 || dump_module >= STAGEOVERFLOW)
             Swig_arg_error();
           else
             Swig_mark_arg(i + 1);
           Delete(dump_list);
-	} else {
-	  Swig_arg_error();
-	}
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-xmlout") == 0) {
-	Swig_mark_arg(i);
-	if (argv[i + 1]) {
-	  xmlout = NewString(argv[i + 1]);
-	  Swig_mark_arg(i + 1);
-	} else {
-	  Swig_arg_error();
-	}
+        Swig_mark_arg(i);
+        if (argv[i + 1]) {
+          xmlout = NewString(argv[i + 1]);
+          Swig_mark_arg(i + 1);
+        } else {
+          Swig_arg_error();
+        }
       } else if (strcmp(argv[i], "-nocontract") == 0) {
-	Swig_mark_arg(i);
-	Swig_contract_mode_set(0);
+        Swig_mark_arg(i);
+        Swig_contract_mode_set(0);
       } else if (strcmp(argv[i], "-debug-typedef") == 0) {
-	dump_typedef = 1;
-	Swig_mark_arg(i);
+        dump_typedef = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-classes") == 0) {
-	dump_classes = 1;
-	Swig_mark_arg(i);
+        dump_classes = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-debug-memory") == 0) {
-	memory_debug = 1;
-	Swig_mark_arg(i);
+        memory_debug = 1;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-Fstandard") == 0) {
-	Swig_error_msg_format(EMF_STANDARD);
-	Swig_mark_arg(i);
+        Swig_error_msg_format(EMF_STANDARD);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-Fmicrosoft") == 0) {
-	Swig_error_msg_format(EMF_MICROSOFT);
-	Swig_mark_arg(i);
+        Swig_error_msg_format(EMF_MICROSOFT);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-O") == 0) {
-	Wrapper_virtual_elimination_mode_set(1);
-	Wrapper_fast_dispatch_mode_set(1);
-	Swig_mark_arg(i);
+        Wrapper_virtual_elimination_mode_set(1);
+        Wrapper_fast_dispatch_mode_set(1);
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-help") == 0) {
-	fputs(usage1, stdout);
-	fputs(usage2, stdout);
-	fputs(usage3, stdout);
-	fputs(usage4, stdout);
-	Swig_mark_arg(i);
-	help = 1;
+        fputs(usage1, stdout);
+        fputs(usage2, stdout);
+        fputs(usage3, stdout);
+        fputs(usage4, stdout);
+        Swig_mark_arg(i);
+        help = 1;
       }
     }
   }
@@ -1034,8 +1034,8 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     } else {
       FILE *f = Swig_open(outfile);
       if (f) {
-	fclose(f);
-	Printf(stderr, "File '%s' already exists. Checkout aborted.\n", outfile);
+        fclose(f);
+        Printf(stderr, "File '%s' already exists. Checkout aborted.\n", outfile);
       } else {
         File *f_outfile = NewFile(outfile, "w", SWIG_output_files());
         if (!f_outfile) {
@@ -1059,88 +1059,88 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
       String *fs = NewString("");
       FILE *df = Swig_open(input_file);
       if (!df) {
-	char *cfile = Char(input_file);
-	if (cfile && cfile[0] == '-') {
-	  Printf(stderr, "Unable to find option or file '%s', ", input_file);
-	  Printf(stderr, "Use 'swig -help' for more information.\n");
-	} else {
-	  Printf(stderr, "Unable to find file '%s'.\n", input_file);
-	}
-	Exit(EXIT_FAILURE);
+        char *cfile = Char(input_file);
+        if (cfile && cfile[0] == '-') {
+          Printf(stderr, "Unable to find option or file '%s', ", input_file);
+          Printf(stderr, "Use 'swig -help' for more information.\n");
+        } else {
+          Printf(stderr, "Unable to find file '%s'.\n", input_file);
+        }
+        Exit(EXIT_FAILURE);
       }
 
       if (!tlm) {
-	Printf(stderr, "No target language specified.\n");
-	Printf(stderr, "Use 'swig -help' for more information.\n");
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "No target language specified.\n");
+        Printf(stderr, "Use 'swig -help' for more information.\n");
+        Exit(EXIT_FAILURE);
       }
 
       if (!no_cpp) {
-	fclose(df);
-	Printf(fs, "%%include <swig.swg>\n");
-	if (allkw) {
-	  Printf(fs, "%%include <allkw.swg>\n");
-	}
-	if (lang_config) {
-	  Printf(fs, "\n%%include <%s>\n", lang_config);
-	}
-	Printf(fs, "%%include(maininput=\"%s\") \"%s\"\n", Swig_filename_escape(input_file), Swig_filename_escape(Swig_last_file()));
-	for (i = 0; i < Len(libfiles); i++) {
-	  Printf(fs, "\n%%include \"%s\"\n", Swig_filename_escape(Getitem(libfiles, i)));
-	}
-	Seek(fs, 0, SEEK_SET);
-	cpps = Preprocessor_parse(fs);
-	Delete(fs);
+        fclose(df);
+        Printf(fs, "%%include <swig.swg>\n");
+        if (allkw) {
+          Printf(fs, "%%include <allkw.swg>\n");
+        }
+        if (lang_config) {
+          Printf(fs, "\n%%include <%s>\n", lang_config);
+        }
+        Printf(fs, "%%include(maininput=\"%s\") \"%s\"\n", Swig_filename_escape(input_file), Swig_filename_escape(Swig_last_file()));
+        for (i = 0; i < Len(libfiles); i++) {
+          Printf(fs, "\n%%include \"%s\"\n", Swig_filename_escape(Getitem(libfiles, i)));
+        }
+        Seek(fs, 0, SEEK_SET);
+        cpps = Preprocessor_parse(fs);
+        Delete(fs);
       } else {
-	cpps = Swig_read_file(df);
-	fclose(df);
+        cpps = Swig_read_file(df);
+        fclose(df);
       }
       if (Swig_error_count()) {
-	Exit(EXIT_FAILURE);
+        Exit(EXIT_FAILURE);
       }
       if (cpp_only) {
-	Printf(stdout, "%s", cpps);
-	Exit(EXIT_SUCCESS);
+        Printf(stdout, "%s", cpps);
+        Exit(EXIT_SUCCESS);
       }
       if (depend) {
-	if (!no_cpp) {
-	  String *outfile;
+        if (!no_cpp) {
+          String *outfile;
           File *f_dependencies_file = 0;
 
-	  String *inputfile_filename = outcurrentdir ? Swig_file_filename(input_file): Copy(input_file);
-	  String *basename = Swig_file_basename(inputfile_filename);
-	  if (!outfile_name) {
-	    if (CPlusPlus || lang->cplus_runtime_mode()) {
-	      outfile = NewStringf("%s_wrap.%s", basename, cpp_extension);
-	    } else {
-	      outfile = NewStringf("%s_wrap.c", basename);
-	    }
-	  } else {
-	    outfile = NewString(outfile_name);
-	  }
-	  if (dependencies_file && Len(dependencies_file) != 0) {
-	    f_dependencies_file = NewFile(dependencies_file, "w", SWIG_output_files());
-	    if (!f_dependencies_file) {
-	      FileErrorDisplay(dependencies_file);
-	      Exit(EXIT_FAILURE);
-	    }
-	  } else if (!depend_only) {
-	    String *filename = NewStringf("%s_wrap.%s", basename, depends_extension);
-	    f_dependencies_file = NewFile(filename, "w", SWIG_output_files());
-	    if (!f_dependencies_file) {
-	      FileErrorDisplay(filename);
-	      Exit(EXIT_FAILURE);
-	    }
-	  } else
-	    f_dependencies_file = stdout;
-	  if (dependencies_target) {
-	    Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(dependencies_target));
-	  } else {
-	    Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(outfile));
-	  }
-	  List *files = Preprocessor_depend();
-	  List *phony_targets = NewList();
-	  for (int i = 0; i < Len(files); i++) {
+          String *inputfile_filename = outcurrentdir ? Swig_file_filename(input_file): Copy(input_file);
+          String *basename = Swig_file_basename(inputfile_filename);
+          if (!outfile_name) {
+            if (CPlusPlus || lang->cplus_runtime_mode()) {
+              outfile = NewStringf("%s_wrap.%s", basename, cpp_extension);
+            } else {
+              outfile = NewStringf("%s_wrap.c", basename);
+            }
+          } else {
+            outfile = NewString(outfile_name);
+          }
+          if (dependencies_file && Len(dependencies_file) != 0) {
+            f_dependencies_file = NewFile(dependencies_file, "w", SWIG_output_files());
+            if (!f_dependencies_file) {
+              FileErrorDisplay(dependencies_file);
+              Exit(EXIT_FAILURE);
+            }
+          } else if (!depend_only) {
+            String *filename = NewStringf("%s_wrap.%s", basename, depends_extension);
+            f_dependencies_file = NewFile(filename, "w", SWIG_output_files());
+            if (!f_dependencies_file) {
+              FileErrorDisplay(filename);
+              Exit(EXIT_FAILURE);
+            }
+          } else
+            f_dependencies_file = stdout;
+          if (dependencies_target) {
+            Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(dependencies_target));
+          } else {
+            Printf(f_dependencies_file, "%s: ", Swig_filename_escape_space(outfile));
+          }
+          List *files = Preprocessor_depend();
+          List *phony_targets = NewList();
+          for (int i = 0; i < Len(files); i++) {
             int use_file = 1;
             if (depend == 2) {
               if ((Strncmp(Getitem(files, i), SwigLib, Len(SwigLib)) == 0) || (SwigLibWinUnix && (Strncmp(Getitem(files, i), SwigLibWinUnix, Len(SwigLibWinUnix)) == 0)))
@@ -1151,26 +1151,26 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
               if (depend_phony)
                 Append(phony_targets, Getitem(files, i));
             }
-	  }
-	  Printf(f_dependencies_file, "\n");
-	  if (depend_phony) {
-	    for (int i = 0; i < Len(phony_targets); i++) {
-	      Printf(f_dependencies_file, "\n%s:\n", Swig_filename_escape_space(Getitem(phony_targets, i)));
-	    }
-	  }
+          }
+          Printf(f_dependencies_file, "\n");
+          if (depend_phony) {
+            for (int i = 0; i < Len(phony_targets); i++) {
+              Printf(f_dependencies_file, "\n%s:\n", Swig_filename_escape_space(Getitem(phony_targets, i)));
+            }
+          }
 
-	  if (f_dependencies_file != stdout)
-	    Delete(f_dependencies_file);
-	  if (depend_only)
-	    Exit(EXIT_SUCCESS);
-	  Delete(inputfile_filename);
-	  Delete(basename);
-	  Delete(phony_targets);
-	} else {
-	  Printf(stderr, "Cannot generate dependencies with -nopreprocess\n");
-	  // Actually we could but it would be inefficient when just generating dependencies, as it would be done after Swig_cparse
-	  Exit(EXIT_FAILURE);
-	}
+          if (f_dependencies_file != stdout)
+            Delete(f_dependencies_file);
+          if (depend_only)
+            Exit(EXIT_SUCCESS);
+          Delete(inputfile_filename);
+          Delete(basename);
+          Delete(phony_targets);
+        } else {
+          Printf(stderr, "Cannot generate dependencies with -nopreprocess\n");
+          // Actually we could but it would be inefficient when just generating dependencies, as it would be done after Swig_cparse
+          Exit(EXIT_FAILURE);
+        }
       }
       Seek(cpps, 0, SEEK_SET);
     }
@@ -1196,7 +1196,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     }
     if (!CPlusPlus) {
       if (Verbose)
-	Printf(stdout, "Processing unnamed structs...\n");
+        Printf(stdout, "Processing unnamed structs...\n");
       Swig_nested_name_unnamed_c_structs(top);
     }
     Swig_extend_unused_check();
@@ -1222,7 +1222,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
 
     if (CPlusPlus) {
       if (Verbose)
-	Printf(stdout, "Processing nested classes...\n");
+        Printf(stdout, "Processing nested classes...\n");
       Swig_nested_process_classes(top);
     }
 
@@ -1242,12 +1242,12 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     if (top && dump_classes) {
       Hash *classes = Getattr(top, "classes");
       if (classes) {
-	Printf(stdout, "Classes\n");
-	Printf(stdout, "------------\n");
-	Iterator ki;
-	for (ki = First(classes); ki.key; ki = Next(ki)) {
-	  Printf(stdout, "%s\n", ki.key);
-	}
+        Printf(stdout, "Classes\n");
+        Printf(stdout, "------------\n");
+        Iterator ki;
+        for (ki = First(classes); ki.key; ki = Next(ki)) {
+          Printf(stdout, "%s\n", ki.key);
+        }
       }
     }
 
@@ -1273,59 +1273,59 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     }
     if (top) {
       if (!Getattr(top, "name")) {
-	Printf(stderr, "No module name specified using %%module or -module.\n");
-	Exit(EXIT_FAILURE);
+        Printf(stderr, "No module name specified using %%module or -module.\n");
+        Exit(EXIT_FAILURE);
       } else {
-	/* Set some filename information on the object */
-	String *infile = scanner_get_main_input_file();
-	if (!infile) {
-	  Printf(stderr, "Missing input file in preprocessed output.\n");
-	  Exit(EXIT_FAILURE);
-	}
-	Setattr(top, "infile", infile); // Note: if nopreprocess then infile is the original input file, otherwise input_file
-	Setattr(top, "inputfile", input_file);
+        /* Set some filename information on the object */
+        String *infile = scanner_get_main_input_file();
+        if (!infile) {
+          Printf(stderr, "Missing input file in preprocessed output.\n");
+          Exit(EXIT_FAILURE);
+        }
+        Setattr(top, "infile", infile); // Note: if nopreprocess then infile is the original input file, otherwise input_file
+        Setattr(top, "inputfile", input_file);
 
-	String *infile_filename = outcurrentdir ? Swig_file_filename(infile): Copy(infile);
-	String *basename = Swig_file_basename(infile_filename);
-	if (!outfile_name) {
-	  if (CPlusPlus || lang->cplus_runtime_mode()) {
-	    Setattr(top, "outfile", NewStringf("%s_wrap.%s", basename, cpp_extension));
-	  } else {
-	    Setattr(top, "outfile", NewStringf("%s_wrap.c", basename));
-	  }
-	} else {
-	  Setattr(top, "outfile", outfile_name);
-	}
-	if (!outfile_name_h) {
-	  Setattr(top, "outfile_h", NewStringf("%s_wrap.%s", basename, hpp_extension));
-	} else {
-	  Setattr(top, "outfile_h", outfile_name_h);
-	}
-	configure_outdir(Getattr(top, "outfile"));
-	if (Swig_contract_mode_get()) {
-	  Swig_contracts(top);
-	}
+        String *infile_filename = outcurrentdir ? Swig_file_filename(infile): Copy(infile);
+        String *basename = Swig_file_basename(infile_filename);
+        if (!outfile_name) {
+          if (CPlusPlus || lang->cplus_runtime_mode()) {
+            Setattr(top, "outfile", NewStringf("%s_wrap.%s", basename, cpp_extension));
+          } else {
+            Setattr(top, "outfile", NewStringf("%s_wrap.c", basename));
+          }
+        } else {
+          Setattr(top, "outfile", outfile_name);
+        }
+        if (!outfile_name_h) {
+          Setattr(top, "outfile_h", NewStringf("%s_wrap.%s", basename, hpp_extension));
+        } else {
+          Setattr(top, "outfile_h", outfile_name_h);
+        }
+        configure_outdir(Getattr(top, "outfile"));
+        if (Swig_contract_mode_get()) {
+          Swig_contracts(top);
+        }
 
-	// Check the extension for a c/c++ file.  If so, we're going to declare everything we see as "extern"
-	ForceExtern = check_extension(input_file);
+        // Check the extension for a c/c++ file.  If so, we're going to declare everything we see as "extern"
+        ForceExtern = check_extension(input_file);
 
-	if (tlm->status == Experimental) {
-	  Swig_warning(WARN_LANG_EXPERIMENTAL, "SWIG", 1, "Experimental target language. "
-	    "Target language %s specified by %s is an experimental language. "
-	    "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
-	    tlm->help ? tlm->help : "", tlm->name);
-	} else if (tlm->status == Deprecated) {
-	  Swig_warning(WARN_LANG_DEPRECATED, "SWIG", 1, "Deprecated target language. "
-	    "Target language %s specified by %s is a deprecated target language. "
-	    "It will be removed in the next release of SWIG unless a new maintainer steps forward to bring it up to at least experimental status. "
-	    "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
-	    tlm->help ? tlm->help : "", tlm->name);
-	}
+        if (tlm->status == Experimental) {
+          Swig_warning(WARN_LANG_EXPERIMENTAL, "SWIG", 1, "Experimental target language. "
+            "Target language %s specified by %s is an experimental language. "
+            "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
+            tlm->help ? tlm->help : "", tlm->name);
+        } else if (tlm->status == Deprecated) {
+          Swig_warning(WARN_LANG_DEPRECATED, "SWIG", 1, "Deprecated target language. "
+            "Target language %s specified by %s is a deprecated target language. "
+            "It will be removed in the next release of SWIG unless a new maintainer steps forward to bring it up to at least experimental status. "
+            "See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.\n",
+            tlm->help ? tlm->help : "", tlm->name);
+        }
 
-	lang->top(top);
+        lang->top(top);
 
-	Delete(infile_filename);
-	Delete(basename);
+        Delete(infile_filename);
+        Delete(basename);
       }
     }
     if (dump_lang_symbols) {
@@ -1400,10 +1400,10 @@ static void SWIG_exit_handler(int status) {
     /* Remove all generated files */
     if (all_output_files) {
       for (int i = 0; i < Len(all_output_files); i++) {
-	String *filename = Getitem(all_output_files, i);
-	int removed = remove(Char(filename));
-	if (removed == -1)
-	  fprintf(stderr, "On exit, could not delete file %s: %s\n", Char(filename), strerror(errno));
+        String *filename = Getitem(all_output_files, i);
+        int removed = remove(Char(filename));
+        if (removed == -1)
+          fprintf(stderr, "On exit, could not delete file %s: %s\n", Char(filename), strerror(errno));
       }
     }
   }

--- a/Source/Modules/nested.cxx
+++ b/Source/Modules/nested.cxx
@@ -66,7 +66,7 @@ static void add_symbols_c(Node *n) {
     Swig_features_get(Swig_cparse_features(), 0, name, 0, n);
     if (makename) {
       symname = make_name(n, makename, 0);
-      Delattr(n, "parser:makename");    /* temporary information, don't leave it hanging around */
+      Delattr(n, "parser:makename"); /* temporary information, don't leave it hanging around */
     } else {
       makename = name;
       symname = make_name(n, makename, 0);
@@ -93,7 +93,6 @@ static void add_symbols_c(Node *n) {
 
     Delete(fdecl);
     Delete(fun);
-
   }
   if (!symname)
     return;
@@ -223,7 +222,7 @@ static Node *create_insert(Node *n, bool noTypedef = false) {
   /* Make all SWIG created typedef structs/unions/classes unnamed else
      redefinition errors occur - nasty hack alert. */
   if (!noTypedef) {
-    const char *types_array[3] = { "struct", "union", "class" };
+    const char *types_array[3] = {"struct", "union", "class"};
     for (int i = 0; i < 3; i++) {
       char *code_ptr = Char(ccode);
       while (code_ptr) {
@@ -392,7 +391,7 @@ void Swig_nested_process_classes(Node *n) {
         removeNode(c);
         if (!checkAttribute(c, "access", "public"))
           SetFlag(c, "feature:ignore");
-        else if (Strcmp(nodeType(n),"extend") == 0 && Strcmp(nodeType(parentNode(n)),"class") == 0)
+        else if (Strcmp(nodeType(n), "extend") == 0 && Strcmp(nodeType(parentNode(n)), "class") == 0)
           insertNodeAfter(parentNode(n), c);
         else
           insertNodeAfter(n, c);
@@ -403,4 +402,3 @@ void Swig_nested_process_classes(Node *n) {
   }
   remove_outer_class_reference(n);
 }
-

--- a/Source/Modules/nested.cxx
+++ b/Source/Modules/nested.cxx
@@ -66,7 +66,7 @@ static void add_symbols_c(Node *n) {
     Swig_features_get(Swig_cparse_features(), 0, name, 0, n);
     if (makename) {
       symname = make_name(n, makename, 0);
-      Delattr(n, "parser:makename");	/* temporary information, don't leave it hanging around */
+      Delattr(n, "parser:makename");    /* temporary information, don't leave it hanging around */
     } else {
       makename = name;
       symname = make_name(n, makename, 0);

--- a/Source/Modules/nested.cxx
+++ b/Source/Modules/nested.cxx
@@ -50,17 +50,17 @@ static void add_symbols_c(Node *n) {
     if (iscdecl) {
       String *storage = Getattr(n, "storage");
       if (Cmp(storage, "typedef") == 0) {
-	Setattr(n, "kind", "typedef");
+        Setattr(n, "kind", "typedef");
       } else {
-	SwigType *type = Getattr(n, "type");
-	String *value = Getattr(n, "value");
-	Setattr(n, "kind", "variable");
-	if (value && Len(value)) {
-	  Setattr(n, "hasvalue", "1");
-	}
-	if (!type) {
-	  Printf(stderr, "notype name %s\n", name);
-	}
+        SwigType *type = Getattr(n, "type");
+        String *value = Getattr(n, "value");
+        Setattr(n, "kind", "variable");
+        if (value && Len(value)) {
+          Setattr(n, "hasvalue", "1");
+        }
+        if (!type) {
+          Printf(stderr, "notype name %s\n", name);
+        }
       }
     }
     Swig_features_get(Swig_cparse_features(), 0, name, 0, n);
@@ -114,10 +114,10 @@ static void add_symbols_c(Node *n) {
     if ((wrn) && (Len(wrn))) {
       String *metaname = symname;
       if (!Getmeta(metaname, "already_warned")) {
-	SWIG_WARN_NODE_BEGIN(n);
-	Swig_warning(0, Getfile(n), Getline(n), "%s\n", wrn);
-	SWIG_WARN_NODE_END(n);
-	Setmeta(metaname, "already_warned", "1");
+        SWIG_WARN_NODE_BEGIN(n);
+        Swig_warning(0, Getfile(n), Getline(n), "%s\n", wrn);
+        SWIG_WARN_NODE_END(n);
+        Setmeta(metaname, "already_warned", "1");
       }
     }
     c = Swig_symbol_add(symname, n);
@@ -125,10 +125,10 @@ static void add_symbols_c(Node *n) {
     if (c != n) {
       /* symbol conflict attempting to add in the new symbol */
       if (Getattr(n, "sym:weak")) {
-	Setattr(n, "sym:name", symname);
+        Setattr(n, "sym:name", symname);
       } else {
-	int inclass = 1;
-	Swig_symbol_conflict_warn(n, c, symname, inclass);
+        int inclass = 1;
+        Swig_symbol_conflict_warn(n, c, symname, inclass);
       }
     }
   }
@@ -152,44 +152,44 @@ static void strip_comments(char *string) {
     switch (state) {
     case 0:
       if (*c == '\"')
-	state = 3;
+        state = 3;
       else if (*c == '/')
-	state = 4;
+        state = 4;
       break;
     case 1:
       if (*c == '*')
-	state = 5;
+        state = 5;
       *c = ' ';
       break;
     case 2:
       if (*c == '\n')
-	state = 0;
+        state = 0;
       else
-	*c = ' ';
+        *c = ' ';
       break;
     case 3:
       if (*c == '\"')
-	state = 0;
+        state = 0;
       else if (*c == '\\')
-	state = 6;
+        state = 6;
       break;
     case 4:
       if (*c == '/') {
-	*(c - 1) = ' ';
-	*c = ' ';
-	state = 2;
+        *(c - 1) = ' ';
+        *c = ' ';
+        state = 2;
       } else if (*c == '*') {
-	*(c - 1) = ' ';
-	*c = ' ';
-	state = 1;
+        *(c - 1) = ' ';
+        *c = ' ';
+        state = 1;
       } else
-	state = 0;
+        state = 0;
       break;
     case 5:
       if (*c == '/')
-	state = 0;
+        state = 0;
       else
-	state = 1;
+        state = 1;
       *c = ' ';
       break;
     case 6:
@@ -227,22 +227,22 @@ static Node *create_insert(Node *n, bool noTypedef = false) {
     for (int i = 0; i < 3; i++) {
       char *code_ptr = Char(ccode);
       while (code_ptr) {
-	/* Replace struct name (as in 'struct name {...}' ) with whitespace
-	   name will be between struct and opening brace */
+        /* Replace struct name (as in 'struct name {...}' ) with whitespace
+           name will be between struct and opening brace */
 
-	code_ptr = strstr(code_ptr, types_array[i]);
-	if (code_ptr) {
-	  char *open_bracket_pos;
-	  code_ptr += strlen(types_array[i]);
-	  open_bracket_pos = strchr(code_ptr, '{');
-	  if (open_bracket_pos) {
-	    /* Make sure we don't have something like struct A a; */
-	    char *semi_colon_pos = strchr(code_ptr, ';');
-	    if (!(semi_colon_pos && (semi_colon_pos < open_bracket_pos)))
-	      while (code_ptr < open_bracket_pos)
-		*code_ptr++ = ' ';
-	  }
-	}
+        code_ptr = strstr(code_ptr, types_array[i]);
+        if (code_ptr) {
+          char *open_bracket_pos;
+          code_ptr += strlen(types_array[i]);
+          open_bracket_pos = strchr(code_ptr, '{');
+          if (open_bracket_pos) {
+            /* Make sure we don't have something like struct A a; */
+            char *semi_colon_pos = strchr(code_ptr, ';');
+            if (!(semi_colon_pos && (semi_colon_pos < open_bracket_pos)))
+              while (code_ptr < open_bracket_pos)
+                *code_ptr++ = ' ';
+          }
+        }
       }
     }
   }
@@ -252,11 +252,11 @@ static Node *create_insert(Node *n, bool noTypedef = false) {
     while (code_ptr) {
       code_ptr = strstr(code_ptr, "%constant");
       if (code_ptr) {
-	char *directive_end_pos = strchr(code_ptr, ';');
-	if (directive_end_pos) {
-	  while (code_ptr <= directive_end_pos)
-	    *code_ptr++ = ' ';
-	}
+        char *directive_end_pos = strchr(code_ptr, ';');
+        if (directive_end_pos) {
+          while (code_ptr <= directive_end_pos)
+            *code_ptr++ = ' ';
+        }
       }
     }
   }
@@ -302,68 +302,68 @@ void Swig_nested_name_unnamed_c_structs(Node *n) {
     Node *next = nextSibling(c);
     if (String *declName = Getattr(c, "nested:unnamed")) {
       if (Node *outer = Getattr(c, "nested:outer")) {
-	// generate a name
-	String *name = NewStringf("%s_%s", Getattr(outer, "name"), declName);
-	Delattr(c, "nested:unnamed");
-	// set the name to the class and symbol table
-	Setattr(c, "tdname", name);
-	Setattr(c, "name", name);
-	Swig_symbol_setscope(Getattr(c, "symtab"));
-	Swig_symbol_setscopename(name);
-	// now that we have a name - gather base symbols
-	if (List *publicBases = Getattr(c, "baselist")) {
-	  List *bases = Swig_make_inherit_list(name, publicBases, 0);
-	  Swig_inherit_base_symbols(bases);
-	  Delete(bases);
-	}
-	Setattr(classhash, name, c);
+        // generate a name
+        String *name = NewStringf("%s_%s", Getattr(outer, "name"), declName);
+        Delattr(c, "nested:unnamed");
+        // set the name to the class and symbol table
+        Setattr(c, "tdname", name);
+        Setattr(c, "name", name);
+        Swig_symbol_setscope(Getattr(c, "symtab"));
+        Swig_symbol_setscopename(name);
+        // now that we have a name - gather base symbols
+        if (List *publicBases = Getattr(c, "baselist")) {
+          List *bases = Swig_make_inherit_list(name, publicBases, 0);
+          Swig_inherit_base_symbols(bases);
+          Delete(bases);
+        }
+        Setattr(classhash, name, c);
 
-	// Merge the extension into the symbol table
-	if (Node *am = Getattr(Swig_extend_hash(), name)) {
-	  Swig_extend_merge(c, am);
-	  Swig_extend_append_previous(c, am);
-	  Delattr(Swig_extend_hash(), name);
-	}
-	Swig_symbol_popscope();
+        // Merge the extension into the symbol table
+        if (Node *am = Getattr(Swig_extend_hash(), name)) {
+          Swig_extend_merge(c, am);
+          Swig_extend_append_previous(c, am);
+          Delattr(Swig_extend_hash(), name);
+        }
+        Swig_symbol_popscope();
 
-	// process declarations following this type (assign correct new type)
-	SwigType *ty = Copy(name);
-	Node *decl = nextSibling(c);
-	List *declList = NewList();
-	while (decl && Getattr(decl, "nested:unnamedtype") == c) {
-	  Setattr(decl, "type", ty);
-	  Append(declList, decl);
-	  Delattr(decl, "nested:unnamedtype");
-	  SetFlag(decl, "feature:immutable");
-	  add_symbols_c(decl);
-	  decl = nextSibling(decl);
-	}
-	Delete(ty);
-	Swig_symbol_setscope(Swig_symbol_global_scope());
-	add_symbols_c(c);
+        // process declarations following this type (assign correct new type)
+        SwigType *ty = Copy(name);
+        Node *decl = nextSibling(c);
+        List *declList = NewList();
+        while (decl && Getattr(decl, "nested:unnamedtype") == c) {
+          Setattr(decl, "type", ty);
+          Append(declList, decl);
+          Delattr(decl, "nested:unnamedtype");
+          SetFlag(decl, "feature:immutable");
+          add_symbols_c(decl);
+          decl = nextSibling(decl);
+        }
+        Delete(ty);
+        Swig_symbol_setscope(Swig_symbol_global_scope());
+        add_symbols_c(c);
 
-	Node *ins = create_insert(c);
-	insertNodeAfter(c, ins);
-	removeNode(c);
-	insertNodeAfter(n, c);
-	Delete(ins);
-	Delattr(c, "nested:outer");
+        Node *ins = create_insert(c);
+        insertNodeAfter(c, ins);
+        removeNode(c);
+        insertNodeAfter(n, c);
+        Delete(ins);
+        Delattr(c, "nested:outer");
       } else {
-	// global unnamed struct - ignore it and its instances
-	SetFlag(c, "feature:ignore");
-	while (next && Getattr(next, "nested:unnamedtype") == c) {
-	  SetFlag(next, "feature:ignore");
-	  next = nextSibling(next);
-	}
-	c = next;
-	continue;
+        // global unnamed struct - ignore it and its instances
+        SetFlag(c, "feature:ignore");
+        while (next && Getattr(next, "nested:unnamedtype") == c) {
+          SetFlag(next, "feature:ignore");
+          next = nextSibling(next);
+        }
+        c = next;
+        continue;
       }
     } else if (cparse_cplusplusout) {
       if (Getattr(c, "nested:outer")) {
-	Node *ins = create_insert(c, true);
-	insertNodeAfter(c, ins);
-	Delete(ins);
-	Delattr(c, "nested:outer");
+        Node *ins = create_insert(c, true);
+        insertNodeAfter(c, ins);
+        Delete(ins);
+        Delattr(c, "nested:outer");
       }
     }
     // process children
@@ -389,13 +389,13 @@ void Swig_nested_process_classes(Node *n) {
     Node *next = nextSibling(c);
     if (!Getattr(c, "templatetype")) {
       if (GetFlag(c, "nested") && (GetFlag(c, "feature:flatnested") || Language::instance()->nestedClassesSupport() == Language::NCS_None)) {
-	removeNode(c);
-	if (!checkAttribute(c, "access", "public"))
-	  SetFlag(c, "feature:ignore");
-	else if (Strcmp(nodeType(n),"extend") == 0 && Strcmp(nodeType(parentNode(n)),"class") == 0)
-	  insertNodeAfter(parentNode(n), c);
-	else
-	  insertNodeAfter(n, c);
+        removeNode(c);
+        if (!checkAttribute(c, "access", "public"))
+          SetFlag(c, "feature:ignore");
+        else if (Strcmp(nodeType(n),"extend") == 0 && Strcmp(nodeType(parentNode(n)),"class") == 0)
+          insertNodeAfter(parentNode(n), c);
+        else
+          insertNodeAfter(n, c);
       }
       Swig_nested_process_classes(c);
     }

--- a/Source/Modules/nested.cxx
+++ b/Source/Modules/nested.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -1239,7 +1239,7 @@ public:
     if (const_enum && qtype && symname && !Getattr(seen_enumvalues, symname)) {
       Setattr(seen_enumvalues, symname, "true");
       SetFlag(n, "feature:immutable");
-      Setattr(n, "feature:enumvalue", "1");	// this does not appear to be used
+      Setattr(n, "feature:enumvalue", "1");     // this does not appear to be used
 
       Setattr(n, "qualified:name", SwigType_namestr(qtype));
 

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -65,8 +65,8 @@ public:
   OCAML() {
     director_prot_ctor_code = NewString("");
     Printv(director_prot_ctor_code,
-	   "if ($comparison) { /* subclassed */\n",
-	   "  $director_new\n", "} else {\n", "  caml_failwith(\"accessing abstract class or protected constructor\"); \n", "}\n", NIL);
+           "if ($comparison) { /* subclassed */\n",
+           "  $director_new\n", "} else {\n", "  caml_failwith(\"accessing abstract class or protected constructor\"); \n", "}\n", NIL);
     director_multiple_inheritance = 1;
     directorLanguage();
   }
@@ -95,24 +95,24 @@ public:
     // Look for certain command line options
     for (i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-help") == 0) {
-	  fputs(usage, stdout);
-	} else if (strcmp(argv[i], "-where") == 0) {
-	  PrintIncludeArg();
-	  Exit(EXIT_SUCCESS);
-	} else if (strcmp(argv[i], "-prefix") == 0) {
-	  if (argv[i + 1]) {
-	    prefix = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-oldvarnames") == 0) {
-	  Swig_mark_arg(i);
-	  old_variable_names = true;
-	}
+        if (strcmp(argv[i], "-help") == 0) {
+          fputs(usage, stdout);
+        } else if (strcmp(argv[i], "-where") == 0) {
+          PrintIncludeArg();
+          Exit(EXIT_SUCCESS);
+        } else if (strcmp(argv[i], "-prefix") == 0) {
+          if (argv[i + 1]) {
+            prefix = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-oldvarnames") == 0) {
+          Swig_mark_arg(i);
+          old_variable_names = true;
+        }
       }
     }
 
@@ -120,7 +120,7 @@ public:
     if (prefix) {
       const char *px = Char(prefix);
       if (px[Len(prefix) - 1] != '_')
-	Printf(prefix, "_");
+        Printf(prefix, "_");
     } else
       prefix = NewString("swig_");
 
@@ -190,19 +190,19 @@ public:
     {
       Node *module = Getattr(n, "module");
       if (module) {
-	Node *options = Getattr(module, "options");
-	if (options) {
-	  if (Getattr(options, "directors")) {
-	    allow_directors();
-	  }
-	  if (Getattr(options, "dirprot")) {
-	    allow_dirprot();
-	  }
-	  if (Getattr(options, "sizeof")) {
-	    generate_sizeof = 1;
-	  }
-	  mod_docstring = Getattr(options, "docstring");
-	}
+        Node *options = Getattr(module, "options");
+        if (options) {
+          if (Getattr(options, "directors")) {
+            allow_directors();
+          }
+          if (Getattr(options, "dirprot")) {
+            allow_dirprot();
+          }
+          if (Getattr(options, "sizeof")) {
+            generate_sizeof = 1;
+          }
+          mod_docstring = Getattr(options, "docstring");
+        }
       }
     }
 
@@ -268,11 +268,11 @@ public:
     Printf(f_mlbody, "let module_name = \"%s\"\n", module);
     Printf(f_mlibody, "val module_name : string\n");
     Printf(f_enum_to_int,
-	   "let enum_to_int x (v : c_obj) =\n"
-	   "   match v with\n"
-	   "     C_enum _y ->\n"
-	   "     (let y = _y in match (x : c_enum_type) with\n"
-	   "       `unknown -> " "         (match y with\n" "           `Int x -> (Swig.C_int x)\n" "           | _ -> raise (LabelNotFromThisEnum v))\n");
+           "let enum_to_int x (v : c_obj) =\n"
+           "   match v with\n"
+           "     C_enum _y ->\n"
+           "     (let y = _y in match (x : c_enum_type) with\n"
+           "       `unknown -> " "         (match y with\n" "           `Int x -> (Swig.C_int x)\n" "           | _ -> raise (LabelNotFromThisEnum v))\n");
 
     Printf(f_int_to_enum, "let int_to_enum x y =\n" "    match (x : c_enum_type) with\n" "      `unknown -> C_enum (`Int y)\n");
 
@@ -309,7 +309,7 @@ public:
 
     if (mod_docstring) {
       if (Len(mod_docstring)) {
-	Printv(f_mliout, "(** ", mod_docstring, " *)\n", NIL);
+        Printv(f_mliout, "(** ", mod_docstring, " *)\n", NIL);
       }
       Delete(mod_docstring);
       mod_docstring = NULL;
@@ -473,7 +473,7 @@ public:
     } else {
       if (!addSymbol(iname, n)) {
         DelWrapper(f);
-	return SWIG_ERROR;
+        return SWIG_ERROR;
       }
     }
     if (overname) {
@@ -496,7 +496,7 @@ public:
     } else if (classmode && in_destructor) {
       Printf(f_class_ctors, "    \"~\", %s ;\n", mangled_name);
     } else if (classmode && !in_constructor && !in_destructor && !static_member_function &&
-	    !Getattr(n, "membervariableHandler:sym:name") && expose_func) {
+            !Getattr(n, "membervariableHandler:sym:name") && expose_func) {
       String *opname = Copy(Getattr(n, "memberfunctionHandler:sym:name"));
 
       Replaceall(opname, "operator ", "");
@@ -530,14 +530,14 @@ public:
     numreq = emit_num_required(l);
     if (!isOverloaded) {
       if (numargs > 0) {
-	if (numreq > 0) {
-	  Printf(f->code, "if (caml_list_length(args) < %d || caml_list_length(args) > %d) {\n", numreq, numargs);
-	} else {
-	  Printf(f->code, "if (caml_list_length(args) > %d) {\n", numargs);
-	}
-	Printf(f->code, "caml_invalid_argument(\"Incorrect number of arguments passed to '%s'\");\n}\n", iname);
+        if (numreq > 0) {
+          Printf(f->code, "if (caml_list_length(args) < %d || caml_list_length(args) > %d) {\n", numreq, numargs);
+        } else {
+          Printf(f->code, "if (caml_list_length(args) > %d) {\n", numargs);
+        }
+        Printf(f->code, "caml_invalid_argument(\"Incorrect number of arguments passed to '%s'\");\n}\n", iname);
       } else {
-	Printf(f->code, "if (caml_list_length(args) > 0) caml_invalid_argument(\"'%s' takes no arguments\");\n", iname);
+        Printf(f->code, "if (caml_list_length(args) > 0) caml_invalid_argument(\"'%s' takes no arguments\");\n", iname);
       }
     }
     Printf(f->code, "swig_result = Val_unit;\n");
@@ -547,7 +547,7 @@ public:
     for (i = 0, p = l; i < numargs; i++) {
       /* Skip ignored arguments */
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -562,22 +562,22 @@ public:
       Printv(arg, Getattr(p, "name"), NIL);
 
       if (i >= numreq) {
-	Printf(f->code, "if (caml_list_length(args) > %d) {\n", i);
+        Printf(f->code, "if (caml_list_length(args) > %d) {\n", i);
       }
       // Handle parameter types.
       if ((tm = Getattr(p, "tmap:in"))) {
-	Replaceall(tm, "$input", source);
-	Setattr(p, "emit:input", source);
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:in:next");
+        Replaceall(tm, "$input", source);
+        Setattr(p, "emit:input", source);
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:in:next");
       } else {
-	// no typemap found
-	// check if typedef and resolve
-	throw_unhandled_ocaml_type_error(pt, "in");
-	p = nextSibling(p);
+        // no typemap found
+        // check if typedef and resolve
+        throw_unhandled_ocaml_type_error(pt, "in");
+        p = nextSibling(p);
       }
       if (i >= numreq) {
-	Printf(f->code, "}\n");
+        Printf(f->code, "}\n");
       }
       Delete(source);
     }
@@ -585,10 +585,10 @@ public:
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -596,13 +596,13 @@ public:
 
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Replaceall(tm, "$ntype", normalizeTemplatedClassName(Getattr(p, "type")));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Replaceall(tm, "$ntype", normalizeTemplatedClassName(Getattr(p, "type")));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -611,10 +611,10 @@ public:
     /* Insert cleanup code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -669,7 +669,7 @@ public:
 
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printv(f->code, tm, "\n", NIL);
+        Printv(f->code, tm, "\n", NIL);
       }
     }
 
@@ -700,53 +700,53 @@ public:
 
     if (isOverloaded) {
       if (!Getattr(n, "sym:nextSibling")) {
-	int maxargs;
-	bool check_emitted = false;
-	Wrapper *df = NewWrapper();
-	String *dispatch = Swig_overload_dispatch(n, "free(argv);\n" "CAMLreturn(%s(args));\n", &maxargs, &check_emitted);
+        int maxargs;
+        bool check_emitted = false;
+        Wrapper *df = NewWrapper();
+        String *dispatch = Swig_overload_dispatch(n, "free(argv);\n" "CAMLreturn(%s(args));\n", &maxargs, &check_emitted);
 
-	Wrapper_add_local(df, "argv", "value *argv");
+        Wrapper_add_local(df, "argv", "value *argv");
 
-	/* Undifferentiate name .. this is the dispatch function */
-	wname = Swig_name_wrapper(iname);
-	/* Do this to disambiguate functions emitted from different
-	 * modules */
-	Append(wname, module);
+        /* Undifferentiate name .. this is the dispatch function */
+        wname = Swig_name_wrapper(iname);
+        /* Do this to disambiguate functions emitted from different
+         * modules */
+        Append(wname, module);
 
-	Printv(df->def,
-	       "SWIGEXT value ", wname, "(value args) {\n" "  CAMLparam1(args);\n" "  int i;\n" "  int argc = caml_list_length(args);\n", NIL);
-	Printv(df->code,
-	       "argv = (value *)malloc( argc * sizeof( value ) );\n"
-	       "for( i = 0; i < argc; i++ ) {\n" "  argv[i] = caml_list_nth(args,i);\n" "}\n", NIL);
-	Printv(df->code, dispatch, "\nfree(argv);\n", NIL);
-	Node *sibl = n;
-	while (Getattr(sibl, "sym:previousSibling"))
-	  sibl = Getattr(sibl, "sym:previousSibling");
-	String *protoTypes = NewString("");
-	do {
-	  String *fulldecl = Swig_name_decl(sibl);
-	  Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
-	  Delete(fulldecl);
-	} while ((sibl = Getattr(sibl, "sym:nextSibling")));
-	Printf(df->code, "caml_failwith(\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
-	       "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n", iname, protoTypes);
-	Delete(protoTypes);
-	Printv(df->code, "}\n", NIL);
-	Wrapper_print(df, f_wrappers);
+        Printv(df->def,
+               "SWIGEXT value ", wname, "(value args) {\n" "  CAMLparam1(args);\n" "  int i;\n" "  int argc = caml_list_length(args);\n", NIL);
+        Printv(df->code,
+               "argv = (value *)malloc( argc * sizeof( value ) );\n"
+               "for( i = 0; i < argc; i++ ) {\n" "  argv[i] = caml_list_nth(args,i);\n" "}\n", NIL);
+        Printv(df->code, dispatch, "\nfree(argv);\n", NIL);
+        Node *sibl = n;
+        while (Getattr(sibl, "sym:previousSibling"))
+          sibl = Getattr(sibl, "sym:previousSibling");
+        String *protoTypes = NewString("");
+        do {
+          String *fulldecl = Swig_name_decl(sibl);
+          Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
+          Delete(fulldecl);
+        } while ((sibl = Getattr(sibl, "sym:nextSibling")));
+        Printf(df->code, "caml_failwith(\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
+               "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n", iname, protoTypes);
+        Delete(protoTypes);
+        Printv(df->code, "}\n", NIL);
+        Wrapper_print(df, f_wrappers);
 
-	DelWrapper(df);
-	Delete(dispatch);
+        DelWrapper(df);
+        Delete(dispatch);
       }
     }
 
     if (expose_func) {
       Printf(f_mlbody, "external %s_f : c_obj list -> c_obj list = \"%s\" ;;\n", mangled_name, wname);
       Printf(f_mlbody, "let %s arg = match %s_f (%s(fnhelper arg)) with\n", mangled_name, mangled_name,
-	     in_constructor && Swig_directorclass(getCurrentClass()) ? "director_core_helper " : "");
+             in_constructor && Swig_directorclass(getCurrentClass()) ? "director_core_helper " : "");
       Printf(f_mlbody, "  [] -> C_void\n"
-	     "| [x] -> (if %s then Gc.finalise \n"
-	     "  (fun x -> ignore ((invoke x) \"~\" C_void)) x) ; x\n"
-	     "| lst -> C_list lst ;;\n", newobj ? "true" : "false");
+             "| [x] -> (if %s then Gc.finalise \n"
+             "  (fun x -> ignore ((invoke x) \"~\" C_void)) x) ; x\n"
+             "| lst -> C_list lst ;;\n", newobj ? "true" : "false");
     }
 
     if ((!classmode || in_constructor || in_destructor || static_member_function) && expose_func)
@@ -821,13 +821,13 @@ public:
       /* Check for a setting of the variable value */
       Printf(f->code, "if (args != Val_int(0)) {\n");
       if ((tm = Swig_typemap_lookup("varin", n, name, 0))) {
-	Replaceall(tm, "$input", "args");
-	emit_action_code(n, f->code, tm);
+        Replaceall(tm, "$input", "args");
+        emit_action_code(n, f->code, tm);
       } else if ((tm = Swig_typemap_lookup("in", n, name, 0))) {
-	Replaceall(tm, "$input", "args");
-	emit_action_code(n, f->code, tm);
+        Replaceall(tm, "$input", "args");
+        emit_action_code(n, f->code, tm);
       } else {
-	throw_unhandled_ocaml_type_error(t, "varin/in");
+        throw_unhandled_ocaml_type_error(t, "varin/in");
       }
       Printf(f->code, "}\n");
     }
@@ -855,8 +855,8 @@ public:
       Printf(f_mlbody, "external _%s : c_obj -> Swig.c_obj = \"%s\" \n", mname, var_name);
       Printf(f_mlibody, "val _%s : c_obj -> Swig.c_obj\n", iname);
       if (const_enum) {
-	Printf(f_enum_to_int, " | `%s -> _%s C_void\n", mname, mname);
-	Printf(f_int_to_enum, " if y = (get_int (_%s C_void)) then `%s else\n", mname, mname);
+        Printf(f_enum_to_int, " | `%s -> _%s C_void\n", mname, mname);
+        Printf(f_int_to_enum, " if y = (get_int (_%s C_void)) then `%s else\n", mname, mname);
       }
     } else {
       Printf(f_mlbody, "external _%s : c_obj -> c_obj = \"%s\"\n", mname, var_name);
@@ -967,20 +967,20 @@ public:
       find_marker += strlen("(*Stream:");
 
       if (next) {
-	int num_chars = (int)(next - find_marker);
-	String *stream_name = NewString(find_marker);
-	Delslice(stream_name, num_chars, Len(stream_name));
-	File *fout = Swig_filebyname(stream_name);
-	if (fout) {
-	  next += strlen("*)");
-	  char *following = strstr(next, "(*Stream:");
-	  find_marker = following;
-	  if (!following)
-	    following = next + strlen(next);
-	  String *chunk = NewString(next);
-	  Delslice(chunk, (int)(following - next), Len(chunk));
-	  Printv(fout, chunk, NIL);
-	}
+        int num_chars = (int)(next - find_marker);
+        String *stream_name = NewString(find_marker);
+        Delslice(stream_name, num_chars, Len(stream_name));
+        File *fout = Swig_filebyname(stream_name);
+        if (fout) {
+          next += strlen("*)");
+          char *following = strstr(next, "(*Stream:");
+          find_marker = following;
+          if (!following)
+            following = next + strlen(next);
+          String *chunk = NewString(next);
+          Delslice(chunk, (int)(following - next), Len(chunk));
+          Printv(fout, chunk, NIL);
+        }
       }
     }
   }
@@ -1093,8 +1093,8 @@ public:
 
     if (sizeof_feature) {
       Printf(f_wrappers,
-	     "SWIGEXT value _wrap_%s_sizeof( value args ) {\n"
-	     "    CAMLparam1(args);\n" "    CAMLreturn(Val_int(sizeof(%s)));\n" "}\n", mangled_name, name_normalized);
+             "SWIGEXT value _wrap_%s_sizeof( value args ) {\n"
+             "    CAMLparam1(args);\n" "    CAMLreturn(Val_int(sizeof(%s)));\n" "}\n", mangled_name, name_normalized);
 
       Printf(f_mlbody, "external __%s_sizeof : unit -> int = " "\"_wrap_%s_sizeof\"\n", mangled_name, mangled_name);
     }
@@ -1110,14 +1110,14 @@ public:
       Iterator b;
       b = First(baselist);
       while (b.item) {
-	String *bname = Getattr(b.item, "name");
-	if (bname) {
-	  String *base_create = NewString("");
-	  Printv(base_create, "(create_class \"", bname, "\")", NIL);
-	  Printv(f_class_ctors, "   \"::", bname, "\", (fun args -> ", base_create, " args) ;\n", NIL);
-	  Printv(base_classes, base_create, " ;\n", NIL);
-	}
-	b = Next(b);
+        String *bname = Getattr(b.item, "name");
+        if (bname) {
+          String *base_create = NewString("");
+          Printv(base_create, "(create_class \"", bname, "\")", NIL);
+          Printv(f_class_ctors, "   \"::", bname, "\", (fun args -> ", base_create, " args) ;\n", NIL);
+          Printv(base_classes, base_create, " ;\n", NIL);
+        }
+        b = Next(b);
       }
     }
 
@@ -1147,18 +1147,18 @@ public:
       took_action = false;
 
       if (is_a_pointer(name_normalized)) {
-	SwigType_del_pointer(name_normalized);
-	took_action = true;
+        SwigType_del_pointer(name_normalized);
+        took_action = true;
       }
 
       if (is_a_reference(name_normalized)) {
-	oc_SwigType_del_reference(name_normalized);
-	took_action = true;
+        oc_SwigType_del_reference(name_normalized);
+        took_action = true;
       }
 
       if (is_an_array(name_normalized)) {
-	oc_SwigType_del_array(name_normalized);
-	took_action = true;
+        oc_SwigType_del_array(name_normalized);
+        took_action = true;
       }
     } while (took_action);
 
@@ -1211,13 +1211,13 @@ public:
     while (parent) {
       parent_type = nodeType(parent);
       if (Getattr(parent, "name")) {
-	String *parent_copy = NewStringf("%s::", Getattr(parent, "name"));
-	if (Cmp(parent_type, "class") == 0 || Cmp(parent_type, "namespace") == 0)
-	  Insert(fully_qualified_name, 0, parent_copy);
-	Delete(parent_copy);
+        String *parent_copy = NewStringf("%s::", Getattr(parent, "name"));
+        if (Cmp(parent_type, "class") == 0 || Cmp(parent_type, "namespace") == 0)
+          Insert(fully_qualified_name, 0, parent_copy);
+        Delete(parent_copy);
       }
       if (!Cmp(parent_type, "class"))
-	break;
+        break;
       parent = parentNode(parent);
     }
 
@@ -1374,7 +1374,7 @@ public:
 
     if (Cmp(storage, "virtual") == 0) {
       if (Cmp(value, "0") == 0) {
-	pure_virtual = true;
+        pure_virtual = true;
       }
     }
     Printf(w->locals, "CAMLparam0();\n");
@@ -1411,18 +1411,18 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
-	  String *str = SwigType_str(Getattr(p, "type"), 0);
-	  Append(w->def, str);
-	  Append(declaration, str);
-	  Delete(str);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
+          String *str = SwigType_str(Getattr(p, "type"), 0);
+          Append(w->def, str);
+          Append(declaration, str);
+          Delete(str);
+        }
       }
       Append(w->def, ")");
       Append(declaration, ")");
@@ -1435,31 +1435,31 @@ public:
      */
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	}
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        }
       } else {
-	String *cres = SwigType_lstr(returntype, "c_result");
-	Printf(w->code, "%s;\n", cres);
-	Delete(cres);
+        String *cres = SwigType_lstr(returntype, "c_result");
+        Printf(w->code, "%s;\n", cres);
+        Delete(cres);
       }
     }
 
     if (ignored_method) {
       if (!pure_virtual) {
-	String *super_call = Swig_method_call(super, l);
-	if (is_void)
-	  Printf(w->code, "%s;\n", super_call);
-	else
-	  Printf(w->code, "CAMLreturnT(%s, %s);\n", SwigType_str(returntype, 0), super_call);
-	Delete(super_call);
+        String *super_call = Swig_method_call(super, l);
+        if (is_void)
+          Printf(w->code, "%s;\n", super_call);
+        else
+          Printf(w->code, "CAMLreturnT(%s, %s);\n", SwigType_str(returntype, 0), super_call);
+        Delete(super_call);
       } else {
-	Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	       SwigType_namestr(name));
+        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+               SwigType_namestr(name));
       }
     } else {
       Wrapper_add_local(w, "swig_result", "CAMLlocal2(swig_result, args)");
@@ -1479,86 +1479,86 @@ public:
 
       /* build argument list and type conversion string */
       for (i = 0, idx = 0, p = l; i < num_arguments; i++) {
-	String *pname = Getattr(p, "name");
-	String *ptype = Getattr(p, "type");
+        String *pname = Getattr(p, "name");
+        String *ptype = Getattr(p, "type");
 
-	Putc(',', arglist);
-	if ((tm = Getattr(p, "tmap:directorin")) != 0) {
-	  Setattr(p, "emit:directorinput", pname);
-	  Replaceall(tm, "$input", pname);
-	  Replaceall(tm, "$owner", "0");
-	  if (Len(tm) == 0)
-	    Append(tm, pname);
-	  Printv(wrap_args, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorin:next");
-	  continue;
-	} else if (Cmp(ptype, "void")) {
-	  /* special handling for pointers to other C++ director classes.
-	   * ideally this would be left to a typemap, but there is currently no
-	   * way to selectively apply the dynamic_cast<> to classes that have
-	   * directors.  in other words, the type "SwigDirector_$1_lname" only exists
-	   * for classes with directors.  we avoid the problem here by checking
-	   * module.wrap::directormap, but it's not clear how to get a typemap to
-	   * do something similar.  perhaps a new default typemap (in addition
-	   * to SWIGTYPE) called DIRECTORTYPE?
-	   */
-	  if (SwigType_ispointer(ptype) || SwigType_isreference(ptype)) {
-	    Node *module = Getattr(parent, "module");
-	    Node *target = Swig_directormap(module, ptype);
-	    sprintf(source, "obj%d", idx++);
-	    String *nonconst = 0;
-	    /* strip pointer/reference --- should move to Swig/stype.c */
-	    String *nptype = NewString(Char(ptype) + 2);
-	    /* name as pointer */
-	    String *ppname = Copy(pname);
-	    if (SwigType_isreference(ptype)) {
-	      Insert(ppname, 0, "&");
-	    }
-	    /* if necessary, cast away const since Python doesn't support it! */
-	    if (SwigType_isconst(nptype)) {
-	      nonconst = NewStringf("nc_tmp_%s", pname);
-	      String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
-	      Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
-	      Delete(nonconst_i);
-	      Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
-			   "Target language argument '%s' discards const in director method %s::%s.\n", SwigType_str(ptype, pname),
-			   SwigType_namestr(c_classname), SwigType_namestr(name));
-	    } else {
-	      nonconst = Copy(ppname);
-	    }
-	    Delete(nptype);
-	    Delete(ppname);
-	    String *mangle = SwigType_manglestr(ptype);
-	    if (target) {
-	      String *director = NewStringf("director_%s", mangle);
-	      Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
-	      Wrapper_add_localv(w, source, "value", source, "= Val_unit", NIL);
-	      Printf(wrap_args, "%s = dynamic_cast<Swig::Director *>(%s);\n", director, nonconst);
-	      Printf(wrap_args, "if (!%s) {\n", director);
-	      Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	      Printf(wrap_args, "} else {\n");
-	      Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
-	      Printf(wrap_args, "}\n");
-	      Delete(director);
-	      Printv(arglist, source, NIL);
-	    } else {
-	      Wrapper_add_localv(w, source, "value", source, "= Val_unit", NIL);
-	      Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	      //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
-	      //       source, nonconst, base);
-	      Printv(arglist, source, NIL);
-	    }
-	    Delete(mangle);
-	    Delete(nonconst);
-	  } else {
-	    Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-			 "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-			 SwigType_namestr(c_classname), SwigType_namestr(name));
-	    status = SWIG_NOWRAP;
-	    break;
-	  }
-	}
-	p = nextSibling(p);
+        Putc(',', arglist);
+        if ((tm = Getattr(p, "tmap:directorin")) != 0) {
+          Setattr(p, "emit:directorinput", pname);
+          Replaceall(tm, "$input", pname);
+          Replaceall(tm, "$owner", "0");
+          if (Len(tm) == 0)
+            Append(tm, pname);
+          Printv(wrap_args, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorin:next");
+          continue;
+        } else if (Cmp(ptype, "void")) {
+          /* special handling for pointers to other C++ director classes.
+           * ideally this would be left to a typemap, but there is currently no
+           * way to selectively apply the dynamic_cast<> to classes that have
+           * directors.  in other words, the type "SwigDirector_$1_lname" only exists
+           * for classes with directors.  we avoid the problem here by checking
+           * module.wrap::directormap, but it's not clear how to get a typemap to
+           * do something similar.  perhaps a new default typemap (in addition
+           * to SWIGTYPE) called DIRECTORTYPE?
+           */
+          if (SwigType_ispointer(ptype) || SwigType_isreference(ptype)) {
+            Node *module = Getattr(parent, "module");
+            Node *target = Swig_directormap(module, ptype);
+            sprintf(source, "obj%d", idx++);
+            String *nonconst = 0;
+            /* strip pointer/reference --- should move to Swig/stype.c */
+            String *nptype = NewString(Char(ptype) + 2);
+            /* name as pointer */
+            String *ppname = Copy(pname);
+            if (SwigType_isreference(ptype)) {
+              Insert(ppname, 0, "&");
+            }
+            /* if necessary, cast away const since Python doesn't support it! */
+            if (SwigType_isconst(nptype)) {
+              nonconst = NewStringf("nc_tmp_%s", pname);
+              String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
+              Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
+              Delete(nonconst_i);
+              Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
+                           "Target language argument '%s' discards const in director method %s::%s.\n", SwigType_str(ptype, pname),
+                           SwigType_namestr(c_classname), SwigType_namestr(name));
+            } else {
+              nonconst = Copy(ppname);
+            }
+            Delete(nptype);
+            Delete(ppname);
+            String *mangle = SwigType_manglestr(ptype);
+            if (target) {
+              String *director = NewStringf("director_%s", mangle);
+              Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
+              Wrapper_add_localv(w, source, "value", source, "= Val_unit", NIL);
+              Printf(wrap_args, "%s = dynamic_cast<Swig::Director *>(%s);\n", director, nonconst);
+              Printf(wrap_args, "if (!%s) {\n", director);
+              Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+              Printf(wrap_args, "} else {\n");
+              Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
+              Printf(wrap_args, "}\n");
+              Delete(director);
+              Printv(arglist, source, NIL);
+            } else {
+              Wrapper_add_localv(w, source, "value", source, "= Val_unit", NIL);
+              Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
+              //       source, nonconst, base);
+              Printv(arglist, source, NIL);
+            }
+            Delete(mangle);
+            Delete(nonconst);
+          } else {
+            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
+                         SwigType_namestr(c_classname), SwigType_namestr(name));
+            status = SWIG_NOWRAP;
+            break;
+          }
+        }
+        p = nextSibling(p);
       }
 
       Printv(w->code, "swig_result = Val_unit;\n", 0);
@@ -1569,21 +1569,21 @@ public:
 
       /* pass the method call on to the OCaml object */
       Printv(w->code,
-	     "swig_result = caml_swig_alloc(1,C_list);\n" "Store_field(swig_result,0,args);\n" "args = swig_result;\n" "swig_result = Val_unit;\n", 0);
+             "swig_result = caml_swig_alloc(1,C_list);\n" "Store_field(swig_result,0,args);\n" "args = swig_result;\n" "swig_result = Val_unit;\n", 0);
       Printf(w->code, "static const value *swig_ocaml_func_val = NULL;\n" "if (!swig_ocaml_func_val) {\n");
       Printf(w->code, "  swig_ocaml_func_val = caml_named_value(\"swig_runmethod\");\n  }\n");
       Printf(w->code, "swig_result = caml_callback3(*swig_ocaml_func_val,swig_get_self(),caml_copy_string(\"%s\"),args);\n", Getattr(n, "name"));
       /* exception handling */
       tm = Swig_typemap_lookup("director:except", n, Swig_cresult_name(), 0);
       if (!tm) {
-	tm = Getattr(n, "feature:director:except");
+        tm = Getattr(n, "feature:director:except");
       }
       if ((tm) && Len(tm) && (Strcmp(tm, "1") != 0)) {
-	Printf(w->code, "if (!%s) {\n", Swig_cresult_name());
-	Printf(w->code, "  value error = *caml_named_value(\"director_except\");\n");
-	Replaceall(tm, "$error", "error");
-	Printv(w->code, Str(tm), "\n", NIL);
-	Printf(w->code, "}\n");
+        Printf(w->code, "if (!%s) {\n", Swig_cresult_name());
+        Printf(w->code, "  value error = *caml_named_value(\"director_except\");\n");
+        Replaceall(tm, "$error", "error");
+        Printv(w->code, Str(tm), "\n", NIL);
+        Printf(w->code, "}\n");
       }
 
       /*
@@ -1601,27 +1601,27 @@ public:
 
       tm = Swig_typemap_lookup("directorout", n, "c_result", w);
       if (tm != 0) {
-	Replaceall(tm, "$input", "swig_result");
-	/* TODO check this */
-	if (Getattr(n, "wrap:disown")) {
-	  Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	} else {
-	  Replaceall(tm, "$disown", "0");
-	}
-	Replaceall(tm, "$result", "c_result");
-	Printv(w->code, tm, "\n", NIL);
+        Replaceall(tm, "$input", "swig_result");
+        /* TODO check this */
+        if (Getattr(n, "wrap:disown")) {
+          Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+        } else {
+          Replaceall(tm, "$disown", "0");
+        }
+        Replaceall(tm, "$result", "c_result");
+        Printv(w->code, tm, "\n", NIL);
       }
 
       /* marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
-	  Replaceall(tm, "$result", "swig_result");
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
+          Replaceall(tm, "$result", "swig_result");
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       Delete(arglist);
@@ -1632,13 +1632,13 @@ public:
     /* any existing helper functions to handle this? */
     if (!is_void) {
       if (!(ignored_method && !pure_virtual)) {
-	String *rettype = SwigType_str(returntype, 0);
-	if (!SwigType_isreference(returntype)) {
-	  Printf(w->code, "CAMLreturnT(%s, (%s)c_result);\n", rettype, rettype);
-	} else {
-	  Printf(w->code, "CAMLreturnT(%s, (%s)*c_result);\n", rettype, rettype);
-	}
-	Delete(rettype);
+        String *rettype = SwigType_str(returntype, 0);
+        if (!SwigType_isreference(returntype)) {
+          Printf(w->code, "CAMLreturnT(%s, (%s)c_result);\n", rettype, rettype);
+        } else {
+          Printf(w->code, "CAMLreturnT(%s, (%s)*c_result);\n", rettype, rettype);
+        }
+        Delete(rettype);
       }
     } else {
       Printf(w->code, "CAMLreturn0;\n");
@@ -1654,7 +1654,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -1665,10 +1665,10 @@ public:
     if (status == SWIG_OK) {
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 
@@ -1705,23 +1705,23 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	Wrapper *w = NewWrapper();
-	String *call;
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, classname, parms, 0);
-	call = Swig_csuperclass_call(0, basetype, superparms);
-	Printf(w->def, "%s::%s: %s, Swig::Director(self) { }", classname, target, call);
-	Delete(target);
-	Wrapper_print(w, f_directors);
-	Delete(call);
-	DelWrapper(w);
+        Wrapper *w = NewWrapper();
+        String *call;
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, classname, parms, 0);
+        call = Swig_csuperclass_call(0, basetype, superparms);
+        Printf(w->def, "%s::%s: %s, Swig::Director(self) { }", classname, target, call);
+        Delete(target);
+        Wrapper_print(w, f_directors);
+        Delete(call);
+        DelWrapper(w);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, classname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, classname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -59,14 +59,17 @@ static File *f_class_ctors_end = 0;
 static File *f_enum_to_int = 0;
 static File *f_int_to_enum = 0;
 
-class OCAML:public Language {
+class OCAML : public Language {
 public:
-
   OCAML() {
     director_prot_ctor_code = NewString("");
     Printv(director_prot_ctor_code,
            "if ($comparison) { /* subclassed */\n",
-           "  $director_new\n", "} else {\n", "  caml_failwith(\"accessing abstract class or protected constructor\"); \n", "}\n", NIL);
+           "  $director_new\n",
+           "} else {\n",
+           "  caml_failwith(\"accessing abstract class or protected constructor\"); \n",
+           "}\n",
+           NIL);
     director_multiple_inheritance = 1;
     directorLanguage();
   }
@@ -272,9 +275,15 @@ public:
            "   match v with\n"
            "     C_enum _y ->\n"
            "     (let y = _y in match (x : c_enum_type) with\n"
-           "       `unknown -> " "         (match y with\n" "           `Int x -> (Swig.C_int x)\n" "           | _ -> raise (LabelNotFromThisEnum v))\n");
+           "       `unknown -> "
+           "         (match y with\n"
+           "           `Int x -> (Swig.C_int x)\n"
+           "           | _ -> raise (LabelNotFromThisEnum v))\n");
 
-    Printf(f_int_to_enum, "let int_to_enum x y =\n" "    match (x : c_enum_type) with\n" "      `unknown -> C_enum (`Int y)\n");
+    Printf(f_int_to_enum,
+           "let int_to_enum x y =\n"
+           "    match (x : c_enum_type) with\n"
+           "      `unknown -> C_enum (`Int y)\n");
 
     if (Swig_directors_enabled()) {
       Printf(f_runtime, "#define SWIG_DIRECTORS\n");
@@ -284,7 +293,9 @@ public:
 
     /* Produce the enum_to_int and int_to_enum functions */
 
-    Printf(f_enumtypes_type, "open Swig\n" "type c_enum_type = [ \n  `unknown\n");
+    Printf(f_enumtypes_type,
+           "open Swig\n"
+           "type c_enum_type = [ \n  `unknown\n");
     Printf(f_enumtypes_value, "type c_enum_value = [ \n  `Int of int\n");
     String *mlfile = NewString("");
     String *mlifile = NewString("");
@@ -315,15 +326,28 @@ public:
       mod_docstring = NULL;
     }
 
-    Printf(f_enum_to_int, ") | _ -> (C_int (get_int v))\n" "let _ = Callback.register \"%s_enum_to_int\" enum_to_int\n", module);
+    Printf(f_enum_to_int,
+           ") | _ -> (C_int (get_int v))\n"
+           "let _ = Callback.register \"%s_enum_to_int\" enum_to_int\n",
+           module);
     Printf(f_mlibody, "val enum_to_int : c_enum_type -> c_obj -> Swig.c_obj\n");
 
     Printf(f_int_to_enum, "let _ = Callback.register \"%s_int_to_enum\" int_to_enum\n", module);
     Printf(f_mlibody, "val int_to_enum : c_enum_type -> int -> c_obj\n");
-    Printf(f_init, "#define SWIG_init f_%s_init\n" "%s" "}\n", module, init_func_def);
-    Printf(f_mlbody, "external f_init : unit -> unit = \"f_%s_init\" ;;\n" "let _ = f_init ()\n", module);
+    Printf(f_init,
+           "#define SWIG_init f_%s_init\n"
+           "%s"
+           "}\n",
+           module,
+           init_func_def);
+    Printf(f_mlbody,
+           "external f_init : unit -> unit = \"f_%s_init\" ;;\n"
+           "let _ = f_init ()\n",
+           module);
     Printf(f_enumtypes_type, "]\n");
-    Printf(f_enumtypes_value, "]\n\n" "type c_obj = c_enum_value c_obj_t\n");
+    Printf(f_enumtypes_value,
+           "]\n\n"
+           "type c_obj = c_enum_value c_obj_t\n");
 
     if (Swig_directors_enabled()) {
       // Insert director runtime into the f_runtime file (make it occur before %header section)
@@ -372,8 +396,7 @@ public:
   }
 
   /* Return true iff T is a pointer type */
-  int
-   is_a_pointer(SwigType *t) {
+  int is_a_pointer(SwigType *t) {
     return SwigType_ispointer(SwigType_typedef_resolve_all(t));
   }
 
@@ -401,13 +424,11 @@ public:
    * Return true iff T is a reference type
    */
 
-  int
-   is_a_reference(SwigType *t) {
+  int is_a_reference(SwigType *t) {
     return SwigType_isreference(SwigType_typedef_resolve_all(t));
   }
 
-  int
-   is_an_array(SwigType *t) {
+  int is_an_array(SwigType *t) {
     return SwigType_isarray(SwigType_typedef_resolve_all(t));
   }
 
@@ -424,10 +445,19 @@ public:
       String *setname = Swig_name_set(NSPACE_TODO, mname);
       String *mangled_setname = mangleNameForCaml(setname);
       Delete(setname);
-      Printf(f_class_ctors, "    \"[%s]\", (fun args -> " "if args = (C_list [ raw_ptr ]) then _%s args else _%s args) ;\n", symname, mangled_getname, mangled_setname);
+      Printf(f_class_ctors,
+             "    \"[%s]\", (fun args -> "
+             "if args = (C_list [ raw_ptr ]) then _%s args else _%s args) ;\n",
+             symname,
+             mangled_getname,
+             mangled_setname);
       Delete(mangled_setname);
     } else {
-      Printf(f_class_ctors, "    \"[%s]\", (fun args -> " "if args = (C_list [ raw_ptr ]) then _%s args else C_void) ;\n", symname, mangled_getname);
+      Printf(f_class_ctors,
+             "    \"[%s]\", (fun args -> "
+             "if args = (C_list [ raw_ptr ]) then _%s args else C_void) ;\n",
+             symname,
+             mangled_getname);
     }
     Delete(mangled_getname);
     Delete(mname);
@@ -488,15 +518,14 @@ public:
     Printv(proc_name, "_", iname, NIL);
     String *mangled_name = mangleNameForCaml(proc_name);
 
-    if (classmode && in_constructor && expose_func) { // Emit constructor for object
-      String *mangled_name_nounder = NewString((char *) (Char(mangled_name)) + 1);
+    if (classmode && in_constructor && expose_func) {  // Emit constructor for object
+      String *mangled_name_nounder = NewString((char *)(Char(mangled_name)) + 1);
       Printf(f_class_ctors_end, "let %s clst = _%s clst\n", mangled_name_nounder, mangled_name_nounder);
       Printf(f_mlibody, "val %s : c_obj -> c_obj\n", mangled_name_nounder);
       Delete(mangled_name_nounder);
     } else if (classmode && in_destructor) {
       Printf(f_class_ctors, "    \"~\", %s ;\n", mangled_name);
-    } else if (classmode && !in_constructor && !in_destructor && !static_member_function &&
-            !Getattr(n, "membervariableHandler:sym:name") && expose_func) {
+    } else if (classmode && !in_constructor && !in_destructor && !static_member_function && !Getattr(n, "membervariableHandler:sym:name") && expose_func) {
       String *opname = Copy(Getattr(n, "memberfunctionHandler:sym:name"));
 
       Replaceall(opname, "operator ", "");
@@ -514,7 +543,7 @@ public:
 
     /* Define the scheme name in C. This define is used by several
        macros. */
-    //Printv(f->def, "#define FUNC_NAME \"", mangled_name, "\"", NIL);
+    // Printv(f->def, "#define FUNC_NAME \"", mangled_name, "\"", NIL);
 
     // adds local variables
     Wrapper_add_local(f, "args", "CAMLparam1(args)");
@@ -703,7 +732,11 @@ public:
         int maxargs;
         bool check_emitted = false;
         Wrapper *df = NewWrapper();
-        String *dispatch = Swig_overload_dispatch(n, "free(argv);\n" "CAMLreturn(%s(args));\n", &maxargs, &check_emitted);
+        String *dispatch = Swig_overload_dispatch(n,
+                                                  "free(argv);\n"
+                                                  "CAMLreturn(%s(args));\n",
+                                                  &maxargs,
+                                                  &check_emitted);
 
         Wrapper_add_local(df, "argv", "value *argv");
 
@@ -714,10 +747,19 @@ public:
         Append(wname, module);
 
         Printv(df->def,
-               "SWIGEXT value ", wname, "(value args) {\n" "  CAMLparam1(args);\n" "  int i;\n" "  int argc = caml_list_length(args);\n", NIL);
+               "SWIGEXT value ",
+               wname,
+               "(value args) {\n"
+               "  CAMLparam1(args);\n"
+               "  int i;\n"
+               "  int argc = caml_list_length(args);\n",
+               NIL);
         Printv(df->code,
                "argv = (value *)malloc( argc * sizeof( value ) );\n"
-               "for( i = 0; i < argc; i++ ) {\n" "  argv[i] = caml_list_nth(args,i);\n" "}\n", NIL);
+               "for( i = 0; i < argc; i++ ) {\n"
+               "  argv[i] = caml_list_nth(args,i);\n"
+               "}\n",
+               NIL);
         Printv(df->code, dispatch, "\nfree(argv);\n", NIL);
         Node *sibl = n;
         while (Getattr(sibl, "sym:previousSibling"))
@@ -728,8 +770,11 @@ public:
           Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
           Delete(fulldecl);
         } while ((sibl = Getattr(sibl, "sym:nextSibling")));
-        Printf(df->code, "caml_failwith(\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
-               "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n", iname, protoTypes);
+        Printf(df->code,
+               "caml_failwith(\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
+               "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n",
+               iname,
+               protoTypes);
         Delete(protoTypes);
         Printv(df->code, "}\n", NIL);
         Wrapper_print(df, f_wrappers);
@@ -741,12 +786,17 @@ public:
 
     if (expose_func) {
       Printf(f_mlbody, "external %s_f : c_obj list -> c_obj list = \"%s\" ;;\n", mangled_name, wname);
-      Printf(f_mlbody, "let %s arg = match %s_f (%s(fnhelper arg)) with\n", mangled_name, mangled_name,
+      Printf(f_mlbody,
+             "let %s arg = match %s_f (%s(fnhelper arg)) with\n",
+             mangled_name,
+             mangled_name,
              in_constructor && Swig_directorclass(getCurrentClass()) ? "director_core_helper " : "");
-      Printf(f_mlbody, "  [] -> C_void\n"
+      Printf(f_mlbody,
+             "  [] -> C_void\n"
              "| [x] -> (if %s then Gc.finalise \n"
              "  (fun x -> ignore ((invoke x) \"~\" C_void)) x) ; x\n"
-             "| lst -> C_list lst ;;\n", newobj ? "true" : "false");
+             "| lst -> C_list lst ;;\n",
+             newobj ? "true" : "false");
     }
 
     if ((!classmode || in_constructor || in_destructor || static_member_function) && expose_func)
@@ -952,13 +1002,13 @@ public:
     return ret;
   }
 
-    /**
-     * A simple, somewhat general purpose function for writing to multiple
-     * streams from a source template.  This allows the user to define the
-     * class definition in ways different from the one I have here if they
-     * want to.  It will also make the class definition system easier to
-     * fiddle with when I want to change methods, etc.
-     */
+  /**
+   * A simple, somewhat general purpose function for writing to multiple
+   * streams from a source template.  This allows the user to define the
+   * class definition in ways different from the one I have here if they
+   * want to.  It will also make the class definition system easier to
+   * fiddle with when I want to change methods, etc.
+   */
 
   void Multiwrite(String *s) {
     char *find_marker = strstr(Char(s), "(*Stream:");
@@ -1086,7 +1136,6 @@ public:
     f_class_ctors = NewString("");
     bool sizeof_feature = generate_sizeof && isSimpleType(name);
 
-
     classmode = true;
     int rv = Language::classHandler(n);
     classmode = false;
@@ -1094,11 +1143,18 @@ public:
     if (sizeof_feature) {
       Printf(f_wrappers,
              "SWIGEXT value _wrap_%s_sizeof( value args ) {\n"
-             "    CAMLparam1(args);\n" "    CAMLreturn(Val_int(sizeof(%s)));\n" "}\n", mangled_name, name_normalized);
+             "    CAMLparam1(args);\n"
+             "    CAMLreturn(Val_int(sizeof(%s)));\n"
+             "}\n",
+             mangled_name,
+             name_normalized);
 
-      Printf(f_mlbody, "external __%s_sizeof : unit -> int = " "\"_wrap_%s_sizeof\"\n", mangled_name, mangled_name);
+      Printf(f_mlbody,
+             "external __%s_sizeof : unit -> int = "
+             "\"_wrap_%s_sizeof\"\n",
+             mangled_name,
+             mangled_name);
     }
-
 
     /* Insert sizeof operator for concrete classes */
     if (sizeof_feature) {
@@ -1239,7 +1295,7 @@ public:
     if (const_enum && qtype && symname && !Getattr(seen_enumvalues, symname)) {
       Setattr(seen_enumvalues, symname, "true");
       SetFlag(n, "feature:immutable");
-      Setattr(n, "feature:enumvalue", "1");     // this does not appear to be used
+      Setattr(n, "feature:enumvalue", "1");  // this does not appear to be used
 
       Setattr(n, "qualified:name", SwigType_namestr(qtype));
 
@@ -1309,7 +1365,12 @@ public:
         if (!strncmp(Char(fully_qualified_name), "enum ", 5)) {
           String *fq_noenum = NewString(Char(fully_qualified_name) + 5);
           Printf(f_mlbody,
-                 "let _ = Callback.register \"%s_marker\" (`%s)\n" "let _ = Callback.register \"%s_marker\" (`%s)\n", fq_noenum, oname, fq_noenum, name);
+                 "let _ = Callback.register \"%s_marker\" (`%s)\n"
+                 "let _ = Callback.register \"%s_marker\" (`%s)\n",
+                 fq_noenum,
+                 oname,
+                 fq_noenum,
+                 name);
         }
 
         Printf(f_enumtypes_type, "| `%s\n", oname);
@@ -1322,7 +1383,9 @@ public:
 
     if (const_enum) {
       Printf(f_int_to_enum, "`Int y)\n");
-      Printf(f_enum_to_int, "| `Int x -> Swig.C_int x\n" "| _ -> raise (LabelNotFromThisEnum v))\n");
+      Printf(f_enum_to_int,
+             "| `Int x -> Swig.C_int x\n"
+             "| _ -> raise (LabelNotFromThisEnum v))\n");
     }
 
     const_enum = false;
@@ -1458,7 +1521,9 @@ public:
           Printf(w->code, "CAMLreturnT(%s, %s);\n", SwigType_str(returntype, 0), super_call);
         Delete(super_call);
       } else {
-        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       }
     } else {
@@ -1520,9 +1585,13 @@ public:
               String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
               Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
               Delete(nonconst_i);
-              Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
-                           "Target language argument '%s' discards const in director method %s::%s.\n", SwigType_str(ptype, pname),
-                           SwigType_namestr(c_classname), SwigType_namestr(name));
+              Swig_warning(WARN_LANG_DISCARD_CONST,
+                           input_file,
+                           line_number,
+                           "Target language argument '%s' discards const in director method %s::%s.\n",
+                           SwigType_str(ptype, pname),
+                           SwigType_namestr(c_classname),
+                           SwigType_namestr(name));
             } else {
               nonconst = Copy(ppname);
             }
@@ -1544,16 +1613,20 @@ public:
             } else {
               Wrapper_add_localv(w, source, "value", source, "= Val_unit", NIL);
               Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
-              //       source, nonconst, base);
+              // Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
+              //        source, nonconst, base);
               Printv(arglist, source, NIL);
             }
             Delete(mangle);
             Delete(nonconst);
           } else {
-            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-                         SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                         input_file,
+                         line_number,
+                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                         SwigType_str(ptype, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             status = SWIG_NOWRAP;
             break;
           }
@@ -1569,8 +1642,14 @@ public:
 
       /* pass the method call on to the OCaml object */
       Printv(w->code,
-             "swig_result = caml_swig_alloc(1,C_list);\n" "Store_field(swig_result,0,args);\n" "args = swig_result;\n" "swig_result = Val_unit;\n", 0);
-      Printf(w->code, "static const value *swig_ocaml_func_val = NULL;\n" "if (!swig_ocaml_func_val) {\n");
+             "swig_result = caml_swig_alloc(1,C_list);\n"
+             "Store_field(swig_result,0,args);\n"
+             "args = swig_result;\n"
+             "swig_result = Val_unit;\n",
+             0);
+      Printf(w->code,
+             "static const value *swig_ocaml_func_val = NULL;\n"
+             "if (!swig_ocaml_func_val) {\n");
       Printf(w->code, "  swig_ocaml_func_val = caml_named_value(\"swig_runmethod\");\n  }\n");
       Printf(w->code, "swig_result = caml_callback3(*swig_ocaml_func_val,swig_get_self(),caml_copy_string(\"%s\"),args);\n", Getattr(n, "name"));
       /* exception handling */
@@ -1731,7 +1810,7 @@ public:
     Delete(sub);
     Delete(classname);
     Delete(supername);
-    //Delete(parms);
+    // Delete(parms);
 
     return SWIG_OK;
   }
@@ -1767,7 +1846,11 @@ public:
 
   int classDirectorInit(Node *n) {
     String *declaration = Swig_director_declaration(n);
-    Printf(f_directors_h, "\n" "%s\n" "public:\n", declaration);
+    Printf(f_directors_h,
+           "\n"
+           "%s\n"
+           "public:\n",
+           declaration);
     Delete(declaration);
     return Language::classDirectorInit(n);
   }
@@ -1803,7 +1886,6 @@ public:
       String *name = Getattr(enum_node, "name");
 
       Printf(f_mlbody, "let _ = Callback.register \"%s_marker\" (`%s)\n", Getattr(n, "name"), name);
-
     }
     return SWIG_OK;
   }

--- a/Source/Modules/ocaml.cxx
+++ b/Source/Modules/ocaml.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -70,7 +70,7 @@ public:
     director_multiple_inheritance = 1;
     directorLanguage();
   }
- 
+
   String *Swig_class_name(Node *n) {
     String *name;
     name = Copy(Getattr(n, "sym:name"));
@@ -178,12 +178,12 @@ public:
     /* Set comparison with none for ConstructorToFunction */
     setSubclassInstanceCheck(NewString("caml_list_nth(args,0) != Val_unit"));
 
-    /* check if directors are enabled for this module.  note: this 
+    /* check if directors are enabled for this module.  note: this
      * is a "master" switch, without which no director code will be
      * emitted.  %feature("director") statements are also required
      * to enable directors for individual classes or methods.
      *
-     * use %module(directors="1") modulename at the start of the 
+     * use %module(directors="1") modulename at the start of the
      * interface file to enable director generation.
      */
     String *mod_docstring = NULL;
@@ -397,8 +397,8 @@ public:
     }
   }
 
-  /* 
-   * Return true iff T is a reference type 
+  /*
+   * Return true iff T is a reference type
    */
 
   int
@@ -619,7 +619,7 @@ public:
     }
 
     /* if the object is a director, and the method call originated from its
-     * underlying ocaml object, resolve the call by going up the c++ 
+     * underlying ocaml object, resolve the call by going up the c++
      * inheritance chain.  otherwise try to resolve the method in ocaml.
      * without this check an infinite loop is set up between the director and
      * shadow class method calls.
@@ -772,7 +772,7 @@ public:
    * simply evaluating this variable.  We return the value of the variable
    * in both cases.
    *
-   * symname is the name of the variable with respect to C.  This 
+   * symname is the name of the variable with respect to C.  This
    * may need to differ from the original name in the case of enums.
    * enumvname is the name of the variable with respect to ocaml.  This
    * will vary if the variable has been renamed.
@@ -871,7 +871,7 @@ public:
 
   /* ------------------------------------------------------------
    * staticmemberfunctionHandler --
-   * Overridden to set static_member_function 
+   * Overridden to set static_member_function
    * ------------------------------------------------------------ */
 
   virtual int staticmemberfunctionHandler(Node *n) {
@@ -998,11 +998,11 @@ public:
   }
 
   /* classHandler
-   * 
+   *
    * Create a "class" definition for ocaml.  I thought quite a bit about
    * how I should do this part of it, and arrived here, using a function
    * invocation to select a method, and dispatch.  This can obviously be
-   * done better, but I can't see how, given that I want to support 
+   * done better, but I can't see how, given that I want to support
    * overloaded methods, out parameters, and operators.
    *
    * I needed a system that would do this:
@@ -1060,7 +1060,7 @@ public:
    * classes represented);.
    *
    * I can't think of a more elegant way of converting a C_obj fun to a
-   * pointer than "operator &"... 
+   * pointer than "operator &"...
    *
    * Added a 'sizeof' that will allow you to do the expected thing.
    * This should help users to fill buffer structs and the like (as is
@@ -1166,7 +1166,7 @@ public:
   }
 
   /*
-   * Produce the symbol name that ocaml will use when referring to the 
+   * Produce the symbol name that ocaml will use when referring to the
    * target item.  I wonder if there's a better way to do this:
    * (WF - use Swig_name_mangle_string/Swig_name_mangle_type)
    *
@@ -1302,8 +1302,8 @@ public:
          * typedef name resolution.  My opinion is that SwigType_typedef
          * resolve_all should *always* return the enum tag if one exists,
          * rather than the admittedly friendlier enclosing typedef.
-         * 
-         * This would make one of the cases below unnecessary. 
+         *
+         * This would make one of the cases below unnecessary.
          * * * */
         Printf(f_mlbody, "let _ = Callback.register \"%s_marker\" (`%s)\n", fully_qualified_name, oname);
         if (!strncmp(Char(fully_qualified_name), "enum ", 5)) {
@@ -1346,7 +1346,7 @@ public:
   /* ---------------------------------------------------------------
    * classDirectorMethod()
    *
-   * Emit a virtual director method to pass a method call on to the 
+   * Emit a virtual director method to pass a method call on to the
    * underlying Python object.
    *
    * --------------------------------------------------------------- */
@@ -1429,7 +1429,7 @@ public:
     }
     Append(w->def, " {");
     Append(declaration, ";\n");
-    /* declare method return value 
+    /* declare method return value
      * if the return value is a reference or const reference, a specialized typemap must
      * handle it, including declaration of c_result ($result).
      */
@@ -1544,7 +1544,7 @@ public:
             } else {
               Wrapper_add_localv(w, source, "value", source, "= Val_unit", NIL);
               Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
+              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
               //       source, nonconst, base);
               Printv(arglist, source, NIL);
             }
@@ -1593,7 +1593,7 @@ public:
        * output arguments).
        */
 
-      /* marshal return value and other outputs (if any) from value to C/C++ 
+      /* marshal return value and other outputs (if any) from value to C/C++
        * type */
 
       String *cleanup = NewString("");
@@ -1731,7 +1731,7 @@ public:
     Delete(sub);
     Delete(classname);
     Delete(supername);
-    //Delete(parms);        
+    //Delete(parms);
 
     return SWIG_OK;
   }
@@ -1781,7 +1781,7 @@ public:
    * typedefHandler
    *
    * This is here in order to maintain the correct association between
-   * typedef names and enum names. 
+   * typedef names and enum names.
    *
    * Since I implement enums as polymorphic variant tags, I need to call
    * back into ocaml to evaluate them.  This requires a string that can
@@ -1792,7 +1792,7 @@ public:
    * e_typedef_name
    * for
    * typedef enum e_name_tag { ... } e_typedef_name;
-   * 
+   *
    * Since I need these strings to be consistent, I must maintain a correct
    * association list between typedef and enum names.
    * --------------------------------------------------------------------- */

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -15,7 +15,7 @@
 #include "cparse.h"
 
 static String *global_name = 0;
-static String *op_prefix   = 0;
+static String *op_prefix = 0;
 
 static const char *usage = "\
 Octave Options (available with -octave)\n\
@@ -24,8 +24,7 @@ Octave Options (available with -octave)\n\
      -opprefix <str> - Prefix <str> for global operator functions [default: 'op_']\n\
 \n";
 
-
-class OCTAVE:public Language {
+class OCTAVE : public Language {
 private:
   File *f_begin;
   File *f_runtime;
@@ -50,14 +49,13 @@ private:
     if (dld) {
       String *tname = texinfo_name(n, "std::string()");
       Printf(f, "SWIG_DEFUN( %s, %s, %s ) {", cname, wname, tname);
-    }
-    else {
+    } else {
       Printf(f, "static octave_value_list %s (const octave_value_list& args, int nargout) {", wname);
     }
   }
 
 public:
-  OCTAVE():
+  OCTAVE() :
     f_begin(0),
     f_runtime(0),
     f_header(0),
@@ -73,14 +71,17 @@ public:
     have_constructor(0),
     have_destructor(0),
     constructor_name(0),
-    docs(0)
-  {
+    docs(0) {
     /* Add code to manage protected constructors and directors */
     director_prot_ctor_code = NewString("");
     Printv(director_prot_ctor_code,
            "if ($comparison) { /* subclassed */\n",
            "  $director_new\n",
-           "} else {\n", "  error(\"accessing abstract class or protected constructor\");\n", "  SWIG_fail;\n", "}\n", NIL);
+           "} else {\n",
+           "  error(\"accessing abstract class or protected constructor\");\n",
+           "  SWIG_fail;\n",
+           "}\n",
+           NIL);
 
     enable_cplus_runtime_mode();
     allow_overloading();
@@ -213,12 +214,12 @@ public:
     Printf(f_init, "static bool SWIG_init_user(octave_swig_type* module_ns)\n{\n");
 
     if (!CPlusPlus)
-      Printf(f_header,"extern \"C\" {\n");
+      Printf(f_header, "extern \"C\" {\n");
 
     Language::top(n);
 
     if (!CPlusPlus)
-      Printf(f_header,"}\n");
+      Printf(f_header, "}\n");
 
     if (Len(docs))
       emit_doc_texinfo();
@@ -259,11 +260,11 @@ public:
   }
 
   String *texinfo_escape(String *_s) {
-    const char* s=(const char*)Data(_s);
-    while (*s&&(*s=='\t'||*s=='\r'||*s=='\n'||*s==' '))
+    const char *s = (const char *)Data(_s);
+    while (*s && (*s == '\t' || *s == '\r' || *s == '\n' || *s == ' '))
       ++s;
     String *r = NewString("");
-    for (int j=0;s[j];++j) {
+    for (int j = 0; s[j]; ++j) {
       if (s[j] == '\n') {
         Append(r, "\\n\\\n");
       } else if (s[j] == '\r') {
@@ -294,35 +295,34 @@ public:
       Printv(doc_str, synopsis, decl_info, cdecl_info, args_info, NIL);
       String *escaped_doc_str = texinfo_escape(doc_str);
 
-      if (Len(doc_str)>0) {
-        Printf(f_doc,"static const char* %s_texinfo = ",wrap_name);
-        Printf(f_doc,"\"-*- texinfo -*-\\n\\\n%s", escaped_doc_str);
+      if (Len(doc_str) > 0) {
+        Printf(f_doc, "static const char* %s_texinfo = ", wrap_name);
+        Printf(f_doc, "\"-*- texinfo -*-\\n\\\n%s", escaped_doc_str);
         if (Len(decl_info))
-          Printf(f_doc,"\\n\\\n@end deftypefn");
-        Printf(f_doc,"\";\n");
+          Printf(f_doc, "\\n\\\n@end deftypefn");
+        Printf(f_doc, "\";\n");
       }
 
       Delete(escaped_doc_str);
       Delete(doc_str);
       Delete(wrap_name);
     }
-    Printf(f_doc,"\n");
+    Printf(f_doc, "\n");
   }
-  bool is_empty_doc_node(Node* n) {
+  bool is_empty_doc_node(Node *n) {
     if (!n)
       return true;
     String *synopsis = Getattr(n, "synopsis");
     String *decl_info = Getattr(n, "decl_info");
     String *cdecl_info = Getattr(n, "cdecl_info");
     String *args_info = Getattr(n, "args_info");
-    return !Len(synopsis) && !Len(decl_info) &&
-      !Len(cdecl_info) && !Len(args_info);
+    return !Len(synopsis) && !Len(decl_info) && !Len(cdecl_info) && !Len(args_info);
   }
-  String *texinfo_name(Node* n, const char* defval = "0") {
+  String *texinfo_name(Node *n, const char *defval = "0") {
     String *tname = NewString("");
     String *iname = Getattr(n, "sym:name");
     String *wname = Swig_name_wrapper(iname);
-    Node* d = Getattr(docs, wname);
+    Node *d = Getattr(docs, wname);
 
     if (is_empty_doc_node(d))
       Printf(tname, defval);
@@ -337,7 +337,7 @@ public:
     String *wname = Swig_name_wrapper(iname);
     String *str = Getattr(n, "feature:docstring");
     bool autodoc_enabled = !Cmp(Getattr(n, "feature:autodoc"), "1");
-    Node* d = Getattr(docs, wname);
+    Node *d = Getattr(docs, wname);
     if (!d) {
       d = NewHash();
       Setattr(d, "synopsis", NewString(""));
@@ -417,7 +417,7 @@ public:
    *   The "lname" attribute in each parameter in plist will be contain a parameter name
    * ----------------------------------------------------------------------------- */
 
-  void addMissingParameterNames(Node* n, ParmList *plist, int arg_offset) {
+  void addMissingParameterNames(Node *n, ParmList *plist, int arg_offset) {
     Parm *p = plist;
     int i = arg_offset;
     while (p) {
@@ -438,7 +438,7 @@ public:
     Parm *pnext;
     int arg_num = is_wrapping_class() ? 1 : 0;
 
-    addMissingParameterNames(n, plist, arg_num); // for $1_name substitutions done in Swig_typemap_attach_parms
+    addMissingParameterNames(n, plist, arg_num);  // for $1_name substitutions done in Swig_typemap_attach_parms
 
     Swig_typemap_attach_parms("in", plist, 0);
     Swig_typemap_attach_parms("doc", plist, 0);
@@ -574,8 +574,13 @@ public:
     int varargs = emit_isvarargs(l);
     char source[64];
 
-    Printf(f->code, "if (!SWIG_check_num_args(\"%s\",args.length(),%i,%i,%i)) "
-           "{\n SWIG_fail;\n }\n", iname, num_arguments, num_required, varargs);
+    Printf(f->code,
+           "if (!SWIG_check_num_args(\"%s\",args.length(),%i,%i,%i)) "
+           "{\n SWIG_fail;\n }\n",
+           iname,
+           num_arguments,
+           num_required,
+           varargs);
 
     if (constructor && num_arguments == 1 && num_required == 1) {
       if (Cmp(storage, "explicit") == 0) {
@@ -719,7 +724,9 @@ public:
         Replaceall(tm, "$owner", "0");
 
       Printf(f->code, "%s\n", tm);
-      Printf(f->code, "if (_outv.is_defined()) _outp = " "SWIG_Octave_AppendOutput(_outp, _outv);\n");
+      Printf(f->code,
+             "if (_outv.is_defined()) _outp = "
+             "SWIG_Octave_AppendOutput(_outp, _outv);\n");
       Delete(tm);
     } else {
       Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), iname);
@@ -1072,8 +1079,7 @@ public:
       bool overloaded = !!Getattr(n, "sym:overloaded");
       if (overloaded)
         Delslice(rname, Len(rname) - Len(Getattr(n, "sym:overname")), DOH_END);
-      Printf(s_members_tab, "{\"%s\",%s,0,0,0,%s},\n",
-             realname, rname, tname);
+      Printf(s_members_tab, "{\"%s\",%s,0,0,0,%s},\n", realname, rname, tname);
       Delete(rname);
       Delete(tname);
     }
@@ -1152,8 +1158,7 @@ public:
       bool overloaded = !!Getattr(n, "sym:overloaded");
       if (overloaded)
         Delslice(rname, Len(rname) - Len(Getattr(n, "sym:overname")), DOH_END);
-      Printf(s_members_tab, "{\"%s\",%s,0,0,1,%s},\n",
-             realname, rname, tname);
+      Printf(s_members_tab, "{\"%s\",%s,0,0,1,%s},\n", realname, rname, tname);
       Delete(rname);
       Delete(tname);
     }
@@ -1230,7 +1235,13 @@ public:
         String *basetype = Getattr(parent, "classtype");
         String *target = Swig_method_decl(0, decl, classname, parms, 0);
         call = Swig_csuperclass_call(0, basetype, superparms);
-        Printf(w->def, "%s::%s: %s," "\nSwig::Director(static_cast<%s*>(this)) { \n", classname, target, call, basetype);
+        Printf(w->def,
+               "%s::%s: %s,"
+               "\nSwig::Director(static_cast<%s*>(this)) { \n",
+               classname,
+               target,
+               call,
+               basetype);
         Append(w->def, "}\n");
         Delete(target);
         Wrapper_print(w, f_directors);
@@ -1257,8 +1268,12 @@ public:
     String *classname = Swig_class_name(n);
     {
       Wrapper *w = NewWrapper();
-      Printf(w->def, "SwigDirector_%s::SwigDirector_%s(void* self) :"
-             "\nSwig::Director((octave_swig_type*)self,static_cast<%s*>(this)) { \n", classname, classname, classname);
+      Printf(w->def,
+             "SwigDirector_%s::SwigDirector_%s(void* self) :"
+             "\nSwig::Director((octave_swig_type*)self,static_cast<%s*>(this)) { \n",
+             classname,
+             classname,
+             classname);
       Append(w->def, "}\n");
       Wrapper_print(w, f_directors);
       DelWrapper(w);
@@ -1377,7 +1392,9 @@ public:
         Printf(w->code, "%s;\n", super_call);
         Delete(super_call);
       } else {
-        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       }
     } else {
@@ -1431,9 +1448,13 @@ public:
           p = Getattr(p, "tmap:directorin:next");
           continue;
         } else if (Cmp(ptype, "void")) {
-          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                       SwigType_str(ptype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_NOWRAP;
           break;
         }
@@ -1459,8 +1480,12 @@ public:
       // marshal return value
       if (!is_void) {
         Printf(w->code, "if (out.length()<%d) {\n", outputs);
-        Printf(w->code, "Swig::DirectorTypeMismatchException::raise(\"Octave "
-               "method %s.%s failed to return the required number " "of arguments.\");\n", classname, method_name);
+        Printf(w->code,
+               "Swig::DirectorTypeMismatchException::raise(\"Octave "
+               "method %s.%s failed to return the required number "
+               "of arguments.\");\n",
+               classname,
+               method_name);
         Printf(w->code, "}\n");
 
         tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
@@ -1477,9 +1502,13 @@ public:
           Printv(w->code, tm, "\n", NIL);
           Delete(tm);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
                        "Unable to use return type %s in director method %s::%s (skipping method).\n",
-                       SwigType_str(returntype, 0), SwigType_namestr(c_classname), SwigType_namestr(name));
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_ERROR;
         }
       }

--- a/Source/Modules/octave.cxx
+++ b/Source/Modules/octave.cxx
@@ -113,13 +113,13 @@ public:
           } else {
             Swig_arg_error();
           }
-	} else if (strcmp(argv[i], "-cppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nocppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
-	  Swig_mark_arg(i);
-	  Exit(EXIT_FAILURE);
+        } else if (strcmp(argv[i], "-cppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nocppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
+          Swig_mark_arg(i);
+          Exit(EXIT_FAILURE);
         }
       }
     }
@@ -422,9 +422,9 @@ public:
     int i = arg_offset;
     while (p) {
       if (!Getattr(p, "lname")) {
-	String *name = makeParameterName(n, p, i);
-	Setattr(p, "lname", name);
-	Delete(name);
+        String *name = makeParameterName(n, p, i);
+        Setattr(p, "lname", name);
+        Delete(name);
       }
       i++;
       p = nextSibling(p);
@@ -467,7 +467,7 @@ public:
 
       String *made_name = 0;
       if (!name) {
-	name = made_name = makeParameterName(n, p, arg_num);
+        name = made_name = makeParameterName(n, p, arg_num);
       }
 
       type = type ? type : Getattr(p, "type");
@@ -522,7 +522,7 @@ public:
     }
     if (numval) {
       if (SwigType_type(t) == T_BOOL) {
-	return NewString(*Char(numval) == '0' ? "false" : "true");
+        return NewString(*Char(numval) == '0' ? "false" : "true");
       }
       return numval;
     }
@@ -800,7 +800,7 @@ public:
     if (maxargs > 0 && check_emitted) {
       Printf(tmp, "octave_value_ref argv[%d]={", maxargs);
       for (int j = 0; j < maxargs; ++j)
-	Printf(tmp, "%soctave_value_ref(args,%d)", j ? "," : " ", j);
+        Printf(tmp, "%soctave_value_ref(args,%d)", j ? "," : " ", j);
       Printf(tmp, "}");
       Wrapper_add_local(f, "argv", tmp);
     }
@@ -1355,17 +1355,17 @@ public:
     // handle it, including declaration of c_result ($result).
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	}
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        }
       } else {
-	String *cres = SwigType_lstr(returntype, "c_result");
-	Printf(w->code, "%s;\n", cres);
-	Delete(cres);
+        String *cres = SwigType_lstr(returntype, "c_result");
+        Printf(w->code, "%s;\n", cres);
+        Delete(cres);
       }
     }
 

--- a/Source/Modules/overload.cxx
+++ b/Source/Modules/overload.cxx
@@ -23,11 +23,11 @@ String *argc_template_string;
 
 namespace {
 struct Overloaded {
-  Node *n;			/* Node                               */
-  int argc;			/* Argument count                     */
-  ParmList *parms;		/* Parameters used for overload check */
-  int error;			/* Ambiguity error                    */
-  bool implicitconv_function;	/* For ordering implicitconv functions*/
+  Node *n;                      /* Node                               */
+  int argc;                     /* Argument count                     */
+  ParmList *parms;              /* Parameters used for overload check */
+  int error;                    /* Ambiguity error                    */
+  bool implicitconv_function;   /* For ordering implicitconv functions*/
 };
 }
 
@@ -591,7 +591,7 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
     Printf(sw, Char(lfmt), Getattr(ni, "wrap:name"));
     Printf(sw, "\n");
 
-    Printf(f, "}\n");		/* braces closes "if" for this method */
+    Printf(f, "}\n");           /* braces closes "if" for this method */
     if (fn)
       Printf(f, "check_%d:\n\n", fn);
 
@@ -765,7 +765,7 @@ static String *overload_dispatch_fast(Node *n, const_String_or_char_ptr fmt, int
     String *lfmt = ReplaceFormat(!emitcheck && fmt_fastdispatch ? fmt_fastdispatch : fmt, num_arguments);
     Printf(f, Char(lfmt), Getattr(ni, "wrap:name"));
 
-    Printf(f, "}\n");		/* braces closes "if" for this method */
+    Printf(f, "}\n");           /* braces closes "if" for this method */
     if (fn)
       Printf(f, "check_%d:\n\n", fn);
 
@@ -862,7 +862,7 @@ String *Swig_overload_dispatch(Node *n, const_String_or_char_ptr fmt, int *maxar
     /* close braces */
     for ( /* empty */ ; num_braces > 0; num_braces--)
       Printf(f, "}\n");
-    Printf(f, "}\n");		/* braces closes "if" for this method */
+    Printf(f, "}\n");           /* braces closes "if" for this method */
     if (implicitconvtypecheckoff)
       Delattr(ni, "implicitconvtypecheckoff");
   }

--- a/Source/Modules/overload.cxx
+++ b/Source/Modules/overload.cxx
@@ -23,13 +23,13 @@ String *argc_template_string;
 
 namespace {
 struct Overloaded {
-  Node *n;                      /* Node                               */
-  int argc;                     /* Argument count                     */
-  ParmList *parms;              /* Parameters used for overload check */
-  int error;                    /* Ambiguity error                    */
-  bool implicitconv_function;   /* For ordering implicitconv functions*/
+  Node *n;                    /* Node                               */
+  int argc;                   /* Argument count                     */
+  ParmList *parms;            /* Parameters used for overload check */
+  int error;                  /* Ambiguity error                    */
+  bool implicitconv_function; /* For ordering implicitconv functions*/
 };
-}
+}  // namespace
 
 static int fast_dispatch_mode = 0;
 static int cast_dispatch_mode = 0;
@@ -48,7 +48,7 @@ void Wrapper_cast_dispatch_mode_set(int flag) {
  *
  * Mark function if it contains an implicitconv type in the parameter list
  * ----------------------------------------------------------------------------- */
-static void mark_implicitconv_function(Overloaded& onode) {
+static void mark_implicitconv_function(Overloaded &onode) {
   Parm *parms = onode.parms;
   if (parms) {
     bool is_implicitconv_function = false;
@@ -159,14 +159,20 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
             String *t1 = Getattr(p1, "tmap:typecheck:precedence");
             String *t2 = Getattr(p2, "tmap:typecheck:precedence");
             if ((!t1) && (!nodes[i].error)) {
-              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
+              Swig_warning(WARN_TYPEMAP_TYPECHECK,
+                           Getfile(nodes[i].n),
+                           Getline(nodes[i].n),
                            "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-                           Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
+                           Swig_name_decl(nodes[i].n),
+                           SwigType_str(Getattr(p1, "type"), 0));
               nodes[i].error = 1;
             } else if ((!t2) && (!nodes[j].error)) {
-              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
+              Swig_warning(WARN_TYPEMAP_TYPECHECK,
+                           Getfile(nodes[j].n),
+                           Getline(nodes[j].n),
                            "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-                           Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
+                           Swig_name_decl(nodes[j].n),
+                           SwigType_str(Getattr(p2, "type"), 0));
               nodes[j].error = 1;
             }
             if (t1 && t2) {
@@ -270,16 +276,15 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
                   differ = 1;
                   if (!nodes[j].error) {
                     if (script_lang_wrapping) {
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n), "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
                     } else {
                       if (!Getattr(nodes[j].n, "overload:ignore")) {
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                        Swig_warning(
+                          WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
                       }
                     }
                   }
@@ -288,16 +293,15 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
                   differ = 1;
                   if (!nodes[j].error) {
                     if (script_lang_wrapping) {
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n), "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
                     } else {
                       if (!Getattr(nodes[j].n, "overload:ignore")) {
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                        Swig_warning(
+                          WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
                       }
                     }
                   }
@@ -311,16 +315,17 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
           if (!differ) {
             if (!nodes[j].error) {
               if (script_lang_wrapping) {
-                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
-                             "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
-                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
-                             "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW,
+                             Getfile(nodes[j].n),
+                             Getline(nodes[j].n),
+                             "Overloaded method %s effectively ignored,\n",
+                             Swig_name_decl(nodes[j].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n), "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
               } else {
                 if (!Getattr(nodes[j].n, "overload:ignore")) {
-                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-                               "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-                               "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                  Swig_warning(
+                    WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
                 }
               }
               nodes[j].error = 1;
@@ -339,8 +344,8 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
         Setattr(nodes[i].n, "overload:ignore", "1");
       Append(result, nodes[i].n);
       // Printf(stdout,"[ %d ] %d    %s\n", i, nodes[i].implicitconv_function, ParmList_errorstr(nodes[i].parms));
-      if (i == nnodes-1 || nodes[i].argc != nodes[i+1].argc) {
-        if (argc_changed_index+2 < nnodes && (nodes[argc_changed_index+1].argc == nodes[argc_changed_index+2].argc)) {
+      if (i == nnodes - 1 || nodes[i].argc != nodes[i + 1].argc) {
+        if (argc_changed_index + 2 < nnodes && (nodes[argc_changed_index + 1].argc == nodes[argc_changed_index + 2].argc)) {
           // Add additional implicitconv functions in same order as already ranked.
           // Consider overloaded functions by argument count... only add additional implicitconv functions if
           // the number of functions with the same arg count > 1, ie, only if overloaded by same argument count.
@@ -520,9 +525,9 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
                   Replaceid(tml, Getattr(pl, "lname"), "_v");
                 if (!tml || Cmp(tm, tml))
                   emitcheck = true;
-                //printf("tmap: %s[%d] (%d) => %s\n\n",
-                //       Char(Getattr(nk, "sym:name")),
-                //       l, emitcheck, tml?Char(tml):0);
+                // printf("tmap: %s[%d] (%d) => %s\n\n",
+                //        Char(Getattr(nk, "sym:name")),
+                //        l, emitcheck, tml?Char(tml):0);
               }
               Parm *pl1 = Getattr(pl, "tmap:in:next");
               if (pl1)
@@ -563,11 +568,18 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
         }
         if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
           /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
-          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF,
+                       Getfile(ni),
+                       Getline(ni),
                        "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
-                       Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
-          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-                      "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
+                       Swig_name_decl(n),
+                       j,
+                       SwigType_str(Getattr(pj, "type"), 0));
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF,
+                       Getfile(ni),
+                       Getline(ni),
+                       "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the "
+                       "SWIG documentation.\n");
         }
         Parm *pj1 = Getattr(pj, "tmap:in:next");
         if (pj1)
@@ -579,7 +591,7 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
     }
 
     /* close braces */
-    for ( /* empty */ ; num_braces > 0; num_braces--)
+    for (/* empty */; num_braces > 0; num_braces--)
       Printf(f, "}\n");
 
     Printf(f, "if (!_index || (_ranki < _rank)) {\n");
@@ -591,7 +603,7 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
     Printf(sw, Char(lfmt), Getattr(ni, "wrap:name"));
     Printf(sw, "\n");
 
-    Printf(f, "}\n");           /* braces closes "if" for this method */
+    Printf(f, "}\n"); /* braces closes "if" for this method */
     if (fn)
       Printf(f, "check_%d:\n\n", fn);
 
@@ -702,9 +714,9 @@ static String *overload_dispatch_fast(Node *n, const_String_or_char_ptr fmt, int
                   Replaceid(tml, Getattr(pl, "lname"), "_v");
                 if (!tml || Cmp(tm, tml))
                   emitcheck = true;
-                //printf("tmap: %s[%d] (%d) => %s\n\n",
-                //       Char(Getattr(nk, "sym:name")),
-                //       l, emitcheck, tml?Char(tml):0);
+                // printf("tmap: %s[%d] (%d) => %s\n\n",
+                //        Char(Getattr(nk, "sym:name")),
+                //        l, emitcheck, tml?Char(tml):0);
               }
               Parm *pl1 = Getattr(pl, "tmap:in:next");
               if (pl1)
@@ -742,11 +754,18 @@ static String *overload_dispatch_fast(Node *n, const_String_or_char_ptr fmt, int
         }
         if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
           /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
-          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF,
+                       Getfile(ni),
+                       Getline(ni),
                        "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
-                       Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
-          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-                       "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
+                       Swig_name_decl(n),
+                       j,
+                       SwigType_str(Getattr(pj, "type"), 0));
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF,
+                       Getfile(ni),
+                       Getline(ni),
+                       "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the "
+                       "SWIG documentation.\n");
         }
         Parm *pj1 = Getattr(pj, "tmap:in:next");
         if (pj1)
@@ -758,14 +777,14 @@ static String *overload_dispatch_fast(Node *n, const_String_or_char_ptr fmt, int
     }
 
     /* close braces */
-    for ( /* empty */ ; num_braces > 0; num_braces--)
+    for (/* empty */; num_braces > 0; num_braces--)
       Printf(f, "}\n");
 
     // The language module may want to generate different code for last overloaded function called (with same number of arguments)
     String *lfmt = ReplaceFormat(!emitcheck && fmt_fastdispatch ? fmt_fastdispatch : fmt, num_arguments);
     Printf(f, Char(lfmt), Getattr(ni, "wrap:name"));
 
-    Printf(f, "}\n");           /* braces closes "if" for this method */
+    Printf(f, "}\n"); /* braces closes "if" for this method */
     if (fn)
       Printf(f, "check_%d:\n\n", fn);
 
@@ -843,11 +862,18 @@ String *Swig_overload_dispatch(Node *n, const_String_or_char_ptr fmt, int *maxar
       }
       if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
         /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
-        Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+        Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF,
+                     Getfile(ni),
+                     Getline(ni),
                      "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
-                     Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
-        Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-                     "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
+                     Swig_name_decl(n),
+                     j,
+                     SwigType_str(Getattr(pj, "type"), 0));
+        Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF,
+                     Getfile(ni),
+                     Getline(ni),
+                     "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG "
+                     "documentation.\n");
       }
       Parm *pk = Getattr(pj, "tmap:in:next");
       if (pk)
@@ -860,9 +886,9 @@ String *Swig_overload_dispatch(Node *n, const_String_or_char_ptr fmt, int *maxar
     Printf(f, Char(lfmt), Getattr(ni, "wrap:name"));
     Delete(lfmt);
     /* close braces */
-    for ( /* empty */ ; num_braces > 0; num_braces--)
+    for (/* empty */; num_braces > 0; num_braces--)
       Printf(f, "}\n");
-    Printf(f, "}\n");           /* braces closes "if" for this method */
+    Printf(f, "}\n"); /* braces closes "if" for this method */
     if (implicitconvtypecheckoff)
       Delattr(ni, "implicitconvtypecheckoff");
   }

--- a/Source/Modules/overload.cxx
+++ b/Source/Modules/overload.cxx
@@ -55,12 +55,12 @@ static void mark_implicitconv_function(Overloaded& onode) {
     Parm *p = parms;
     while (p) {
       if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
       if (GetFlag(p, "implicitconv")) {
-	is_implicitconv_function = true;
-	break;
+        is_implicitconv_function = true;
+        break;
       }
       p = nextSibling(p);
     }
@@ -127,11 +127,11 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
     int i, j;
     for (i = 0; i < nnodes; i++) {
       for (j = i + 1; j < nnodes; j++) {
-	if (nodes[i].argc > nodes[j].argc) {
-	  Overloaded t = nodes[i];
-	  nodes[i] = nodes[j];
-	  nodes[j] = t;
-	}
+        if (nodes[i].argc > nodes[j].argc) {
+          Overloaded t = nodes[i];
+          nodes[i] = nodes[j];
+          nodes[j] = t;
+        }
       }
     }
   }
@@ -141,192 +141,192 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
     int i, j;
     for (i = 0; i < nnodes - 1; i++) {
       if (nodes[i].argc == nodes[i + 1].argc) {
-	for (j = i + 1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
-	  Parm *p1 = nodes[i].parms;
-	  Parm *p2 = nodes[j].parms;
-	  int differ = 0;
-	  int num_checked = 0;
-	  while (p1 && p2 && (num_checked < nodes[i].argc)) {
-	    //    Printf(stdout,"p1 = '%s', p2 = '%s'\n", Getattr(p1,"type"), Getattr(p2,"type"));
-	    if (checkAttribute(p1, "tmap:in:numinputs", "0")) {
-	      p1 = Getattr(p1, "tmap:in:next");
-	      continue;
-	    }
-	    if (checkAttribute(p2, "tmap:in:numinputs", "0")) {
-	      p2 = Getattr(p2, "tmap:in:next");
-	      continue;
-	    }
-	    String *t1 = Getattr(p1, "tmap:typecheck:precedence");
-	    String *t2 = Getattr(p2, "tmap:typecheck:precedence");
-	    if ((!t1) && (!nodes[i].error)) {
-	      Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
-			   "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-			   Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
-	      nodes[i].error = 1;
-	    } else if ((!t2) && (!nodes[j].error)) {
-	      Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
-			   "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-			   Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
-	      nodes[j].error = 1;
-	    }
-	    if (t1 && t2) {
-	      int t1v, t2v;
-	      t1v = atoi(Char(t1));
-	      t2v = atoi(Char(t2));
-	      differ = t1v - t2v;
-	    } else if (!t1 && t2)
-	      differ = 1;
-	    else if (t1 && !t2)
-	      differ = -1;
-	    else if (!t1 && !t2)
-	      differ = -1;
-	    num_checked++;
-	    if (differ > 0) {
-	      Overloaded t = nodes[i];
-	      nodes[i] = nodes[j];
-	      nodes[j] = t;
-	      break;
-	    } else if ((differ == 0) && (Strcmp(t1, "0") == 0)) {
-	      t1 = Getattr(p1, "equivtype");
-	      t1 = t1 ? t1 : Getattr(p1, "ltype");
-	      if (!t1) {
-		t1 = SwigType_ltype(Getattr(p1, "type"));
-		if (Getattr(p1, "tmap:typecheck:SWIGTYPE")) {
-		  SwigType_add_pointer(t1);
-		}
-		Setattr(p1, "ltype", t1);
-	      }
-	      t2 = Getattr(p2, "equivtype");
-	      t2 = t2 ? t2 : Getattr(p2, "ltype");
-	      if (!t2) {
-		t2 = SwigType_ltype(Getattr(p2, "type"));
-		if (Getattr(p2, "tmap:typecheck:SWIGTYPE")) {
-		  SwigType_add_pointer(t2);
-		}
-		Setattr(p2, "ltype", t2);
-	      }
+        for (j = i + 1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
+          Parm *p1 = nodes[i].parms;
+          Parm *p2 = nodes[j].parms;
+          int differ = 0;
+          int num_checked = 0;
+          while (p1 && p2 && (num_checked < nodes[i].argc)) {
+            //    Printf(stdout,"p1 = '%s', p2 = '%s'\n", Getattr(p1,"type"), Getattr(p2,"type"));
+            if (checkAttribute(p1, "tmap:in:numinputs", "0")) {
+              p1 = Getattr(p1, "tmap:in:next");
+              continue;
+            }
+            if (checkAttribute(p2, "tmap:in:numinputs", "0")) {
+              p2 = Getattr(p2, "tmap:in:next");
+              continue;
+            }
+            String *t1 = Getattr(p1, "tmap:typecheck:precedence");
+            String *t2 = Getattr(p2, "tmap:typecheck:precedence");
+            if ((!t1) && (!nodes[i].error)) {
+              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
+                           "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
+                           Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
+              nodes[i].error = 1;
+            } else if ((!t2) && (!nodes[j].error)) {
+              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
+                           "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
+                           Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
+              nodes[j].error = 1;
+            }
+            if (t1 && t2) {
+              int t1v, t2v;
+              t1v = atoi(Char(t1));
+              t2v = atoi(Char(t2));
+              differ = t1v - t2v;
+            } else if (!t1 && t2)
+              differ = 1;
+            else if (t1 && !t2)
+              differ = -1;
+            else if (!t1 && !t2)
+              differ = -1;
+            num_checked++;
+            if (differ > 0) {
+              Overloaded t = nodes[i];
+              nodes[i] = nodes[j];
+              nodes[j] = t;
+              break;
+            } else if ((differ == 0) && (Strcmp(t1, "0") == 0)) {
+              t1 = Getattr(p1, "equivtype");
+              t1 = t1 ? t1 : Getattr(p1, "ltype");
+              if (!t1) {
+                t1 = SwigType_ltype(Getattr(p1, "type"));
+                if (Getattr(p1, "tmap:typecheck:SWIGTYPE")) {
+                  SwigType_add_pointer(t1);
+                }
+                Setattr(p1, "ltype", t1);
+              }
+              t2 = Getattr(p2, "equivtype");
+              t2 = t2 ? t2 : Getattr(p2, "ltype");
+              if (!t2) {
+                t2 = SwigType_ltype(Getattr(p2, "type"));
+                if (Getattr(p2, "tmap:typecheck:SWIGTYPE")) {
+                  SwigType_add_pointer(t2);
+                }
+                Setattr(p2, "ltype", t2);
+              }
 
-	      /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
-	         order */
+              /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
+                 order */
 
-	      if (SwigType_issubtype(t2, t1)) {
-		Overloaded t = nodes[i];
-		nodes[i] = nodes[j];
-		nodes[j] = t;
-	      }
+              if (SwigType_issubtype(t2, t1)) {
+                Overloaded t = nodes[i];
+                nodes[i] = nodes[j];
+                nodes[j] = t;
+              }
 
-	      if (Strcmp(t1, t2) != 0) {
-		differ = 1;
-		break;
-	      }
-	    } else if (differ) {
-	      break;
-	    }
-	    if (Getattr(p1, "tmap:in:next")) {
-	      p1 = Getattr(p1, "tmap:in:next");
-	    } else {
-	      p1 = nextSibling(p1);
-	    }
-	    if (Getattr(p2, "tmap:in:next")) {
-	      p2 = Getattr(p2, "tmap:in:next");
-	    } else {
-	      p2 = nextSibling(p2);
-	    }
-	  }
-	  if (!differ) {
-	    /* See if declarations differ by const only */
-	    String *decl1 = Getattr(nodes[i].n, "decl");
-	    String *decl2 = Getattr(nodes[j].n, "decl");
-	    if (decl1 && decl2) {
-	      /* Remove ref-qualifiers. Note that rvalue ref-qualifiers are already ignored and 
-	       * it is illegal to overload a function with and without ref-qualifiers. So with
-	       * all the combinations of ref-qualifiers and cv-qualifiers, we just detect 
-	       * the cv-qualifier (const) overloading. */
-	      String *d1 = Copy(decl1);
-	      String *d2 = Copy(decl2);
-	      if (SwigType_isreference(d1) || SwigType_isrvalue_reference(d1)) {
-		Delete(SwigType_pop(d1));
-	      }
-	      if (SwigType_isreference(d2) || SwigType_isrvalue_reference(d2)) {
-		Delete(SwigType_pop(d2));
-	      }
-	      String *dq1 = Copy(d1);
-	      String *dq2 = Copy(d2);
-	      if (SwigType_isconst(d1)) {
-		Delete(SwigType_pop(dq1));
-	      }
-	      if (SwigType_isconst(d2)) {
-		Delete(SwigType_pop(dq2));
-	      }
-	      if (Strcmp(dq1, dq2) == 0) {
+              if (Strcmp(t1, t2) != 0) {
+                differ = 1;
+                break;
+              }
+            } else if (differ) {
+              break;
+            }
+            if (Getattr(p1, "tmap:in:next")) {
+              p1 = Getattr(p1, "tmap:in:next");
+            } else {
+              p1 = nextSibling(p1);
+            }
+            if (Getattr(p2, "tmap:in:next")) {
+              p2 = Getattr(p2, "tmap:in:next");
+            } else {
+              p2 = nextSibling(p2);
+            }
+          }
+          if (!differ) {
+            /* See if declarations differ by const only */
+            String *decl1 = Getattr(nodes[i].n, "decl");
+            String *decl2 = Getattr(nodes[j].n, "decl");
+            if (decl1 && decl2) {
+              /* Remove ref-qualifiers. Note that rvalue ref-qualifiers are already ignored and 
+               * it is illegal to overload a function with and without ref-qualifiers. So with
+               * all the combinations of ref-qualifiers and cv-qualifiers, we just detect 
+               * the cv-qualifier (const) overloading. */
+              String *d1 = Copy(decl1);
+              String *d2 = Copy(decl2);
+              if (SwigType_isreference(d1) || SwigType_isrvalue_reference(d1)) {
+                Delete(SwigType_pop(d1));
+              }
+              if (SwigType_isreference(d2) || SwigType_isrvalue_reference(d2)) {
+                Delete(SwigType_pop(d2));
+              }
+              String *dq1 = Copy(d1);
+              String *dq2 = Copy(d2);
+              if (SwigType_isconst(d1)) {
+                Delete(SwigType_pop(dq1));
+              }
+              if (SwigType_isconst(d2)) {
+                Delete(SwigType_pop(dq2));
+              }
+              if (Strcmp(dq1, dq2) == 0) {
 
-		if (SwigType_isconst(d1) && !SwigType_isconst(d2)) {
-		  if (script_lang_wrapping) {
-		    // Swap nodes so that the const method gets ignored (shadowed by the non-const method)
-		    Overloaded t = nodes[i];
-		    nodes[i] = nodes[j];
-		    nodes[j] = t;
-		  }
-		  differ = 1;
-		  if (!nodes[j].error) {
-		    if (script_lang_wrapping) {
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-				   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-				   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
-		    } else {
-		      if (!Getattr(nodes[j].n, "overload:ignore")) {
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-				     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-				     "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		      }
-		    }
-		  }
-		  nodes[j].error = 1;
-		} else if (!SwigType_isconst(d1) && SwigType_isconst(d2)) {
-		  differ = 1;
-		  if (!nodes[j].error) {
-		    if (script_lang_wrapping) {
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-				   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-				   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
-		    } else {
-		      if (!Getattr(nodes[j].n, "overload:ignore")) {
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-				     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-				     "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		      }
-		    }
-		  }
-		  nodes[j].error = 1;
-		}
-	      }
-	      Delete(dq1);
-	      Delete(dq2);
-	    }
-	  }
-	  if (!differ) {
-	    if (!nodes[j].error) {
-	      if (script_lang_wrapping) {
-		Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
-			     "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
-		Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
-			     "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
-	      } else {
-		if (!Getattr(nodes[j].n, "overload:ignore")) {
-		  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-			       "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-			       "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		}
-	      }
-	      nodes[j].error = 1;
-	    }
-	  }
-	}
+                if (SwigType_isconst(d1) && !SwigType_isconst(d2)) {
+                  if (script_lang_wrapping) {
+                    // Swap nodes so that the const method gets ignored (shadowed by the non-const method)
+                    Overloaded t = nodes[i];
+                    nodes[i] = nodes[j];
+                    nodes[j] = t;
+                  }
+                  differ = 1;
+                  if (!nodes[j].error) {
+                    if (script_lang_wrapping) {
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                    } else {
+                      if (!Getattr(nodes[j].n, "overload:ignore")) {
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                      }
+                    }
+                  }
+                  nodes[j].error = 1;
+                } else if (!SwigType_isconst(d1) && SwigType_isconst(d2)) {
+                  differ = 1;
+                  if (!nodes[j].error) {
+                    if (script_lang_wrapping) {
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                    } else {
+                      if (!Getattr(nodes[j].n, "overload:ignore")) {
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                      }
+                    }
+                  }
+                  nodes[j].error = 1;
+                }
+              }
+              Delete(dq1);
+              Delete(dq2);
+            }
+          }
+          if (!differ) {
+            if (!nodes[j].error) {
+              if (script_lang_wrapping) {
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
+                             "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
+                             "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
+              } else {
+                if (!Getattr(nodes[j].n, "overload:ignore")) {
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                               "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
+                               "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                }
+              }
+              nodes[j].error = 1;
+            }
+          }
+        }
       }
     }
   }
@@ -336,24 +336,24 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
     int argc_changed_index = -1;
     for (i = 0; i < nnodes; i++) {
       if (nodes[i].error)
-	Setattr(nodes[i].n, "overload:ignore", "1");
+        Setattr(nodes[i].n, "overload:ignore", "1");
       Append(result, nodes[i].n);
       // Printf(stdout,"[ %d ] %d    %s\n", i, nodes[i].implicitconv_function, ParmList_errorstr(nodes[i].parms));
       if (i == nnodes-1 || nodes[i].argc != nodes[i+1].argc) {
-	if (argc_changed_index+2 < nnodes && (nodes[argc_changed_index+1].argc == nodes[argc_changed_index+2].argc)) {
-	  // Add additional implicitconv functions in same order as already ranked.
-	  // Consider overloaded functions by argument count... only add additional implicitconv functions if
-	  // the number of functions with the same arg count > 1, ie, only if overloaded by same argument count.
-	  int j;
-	  for (j = argc_changed_index + 1; j <= i; j++) {
-	    if (nodes[j].implicitconv_function) {
-	      SetFlag(nodes[j].n, "implicitconvtypecheckoff");
-	      Append(result, nodes[j].n);
-	      // Printf(stdout,"[ %d ] %d +  %s\n", j, nodes[j].implicitconv_function, ParmList_errorstr(nodes[j].parms));
-	    }
-	  }
-	}
-	argc_changed_index = i;
+        if (argc_changed_index+2 < nnodes && (nodes[argc_changed_index+1].argc == nodes[argc_changed_index+2].argc)) {
+          // Add additional implicitconv functions in same order as already ranked.
+          // Consider overloaded functions by argument count... only add additional implicitconv functions if
+          // the number of functions with the same arg count > 1, ie, only if overloaded by same argument count.
+          int j;
+          for (j = argc_changed_index + 1; j <= i; j++) {
+            if (nodes[j].implicitconv_function) {
+              SetFlag(nodes[j].n, "implicitconvtypecheckoff");
+              Append(result, nodes[j].n);
+              // Printf(stdout,"[ %d ] %d +  %s\n", j, nodes[j].implicitconv_function, ParmList_errorstr(nodes[j].parms));
+            }
+          }
+        }
+        argc_changed_index = i;
       }
     }
   }
@@ -473,7 +473,7 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
       int nrk = emit_num_required(pk);
       int nak = emit_num_arguments(pk);
       if ((nrk >= num_required && nrk <= num_arguments) || (nak >= num_required && nak <= num_arguments) || (nrk <= num_required && nak >= num_arguments))
-	Append(coll, nk);
+        Append(coll, nk);
     }
 
     // printf("overload: %s coll=%d\n", Char(Getattr(n, "sym:name")), Len(coll));
@@ -485,96 +485,96 @@ String *Swig_overload_dispatch_cast(Node *n, const_String_or_char_ptr fmt, int *
       j = 0;
       Parm *pj = pi;
       while (pj) {
-	if (checkAttribute(pj, "tmap:in:numinputs", "0")) {
-	  pj = Getattr(pj, "tmap:in:next");
-	  continue;
-	}
+        if (checkAttribute(pj, "tmap:in:numinputs", "0")) {
+          pj = Getattr(pj, "tmap:in:next");
+          continue;
+        }
 
-	String *tm = Getattr(pj, "tmap:typecheck");
-	if (tm) {
-	  tm = Copy(tm);
-	  /* normalise for comparison later */
-	  Replaceid(tm, Getattr(pj, "lname"), "_v");
+        String *tm = Getattr(pj, "tmap:typecheck");
+        if (tm) {
+          tm = Copy(tm);
+          /* normalise for comparison later */
+          Replaceid(tm, Getattr(pj, "lname"), "_v");
 
-	  /* if all the wrappers have the same type check on this
-	     argument we can optimize it out */
-	  for (int k = 0; k < Len(coll) && !emitcheck; k++) {
-	    Node *nk = Getitem(coll, k);
-	    Parm *pk = Getattr(nk, "wrap:parms");
-	    int nak = emit_num_arguments(pk);
-	    if (nak <= j)
-	      continue;
-	    int l = 0;
-	    Parm *pl = pk;
-	    /* finds arg j on the collider wrapper */
-	    while (pl && l <= j) {
-	      if (checkAttribute(pl, "tmap:in:numinputs", "0")) {
-		pl = Getattr(pl, "tmap:in:next");
-		continue;
-	      }
-	      if (l == j) {
-		/* we are at arg j, so we compare the tmaps now */
-		String *tml = Getattr(pl, "tmap:typecheck");
-		/* normalise it before comparing */
-		if (tml)
-		  Replaceid(tml, Getattr(pl, "lname"), "_v");
-		if (!tml || Cmp(tm, tml))
-		  emitcheck = true;
-		//printf("tmap: %s[%d] (%d) => %s\n\n",
-		//       Char(Getattr(nk, "sym:name")),
-		//       l, emitcheck, tml?Char(tml):0);
-	      }
-	      Parm *pl1 = Getattr(pl, "tmap:in:next");
-	      if (pl1)
-		pl = pl1;
-	      else
-		pl = nextSibling(pl);
-	      l++;
-	    }
-	  }
+          /* if all the wrappers have the same type check on this
+             argument we can optimize it out */
+          for (int k = 0; k < Len(coll) && !emitcheck; k++) {
+            Node *nk = Getitem(coll, k);
+            Parm *pk = Getattr(nk, "wrap:parms");
+            int nak = emit_num_arguments(pk);
+            if (nak <= j)
+              continue;
+            int l = 0;
+            Parm *pl = pk;
+            /* finds arg j on the collider wrapper */
+            while (pl && l <= j) {
+              if (checkAttribute(pl, "tmap:in:numinputs", "0")) {
+                pl = Getattr(pl, "tmap:in:next");
+                continue;
+              }
+              if (l == j) {
+                /* we are at arg j, so we compare the tmaps now */
+                String *tml = Getattr(pl, "tmap:typecheck");
+                /* normalise it before comparing */
+                if (tml)
+                  Replaceid(tml, Getattr(pl, "lname"), "_v");
+                if (!tml || Cmp(tm, tml))
+                  emitcheck = true;
+                //printf("tmap: %s[%d] (%d) => %s\n\n",
+                //       Char(Getattr(nk, "sym:name")),
+                //       l, emitcheck, tml?Char(tml):0);
+              }
+              Parm *pl1 = Getattr(pl, "tmap:in:next");
+              if (pl1)
+                pl = pl1;
+              else
+                pl = nextSibling(pl);
+              l++;
+            }
+          }
 
-	  if (emitcheck) {
-	    *check_emitted = true;
-	    if (need_v) {
-	      Printf(f, "int _v = 0;\n");
-	      need_v = 0;
-	    }
-	    if (j >= num_required) {
-	      Printf(f, "if (%s > %d) {\n", argc_template_string, j);
-	      num_braces++;
-	    }
-	    String *tmp = NewStringf(argv_template_string, j);
+          if (emitcheck) {
+            *check_emitted = true;
+            if (need_v) {
+              Printf(f, "int _v = 0;\n");
+              need_v = 0;
+            }
+            if (j >= num_required) {
+              Printf(f, "if (%s > %d) {\n", argc_template_string, j);
+              num_braces++;
+            }
+            String *tmp = NewStringf(argv_template_string, j);
 
-	    String *conv = Getattr(pj, "implicitconv");
-	    if (conv && !implicitconvtypecheckoff) {
-	      Replaceall(tm, "$implicitconv", conv);
-	    } else {
-	      Replaceall(tm, "$implicitconv", "0");
-	    }
-	    Replaceall(tm, "$input", tmp);
-	    Printv(f, "{\n", tm, "}\n", NIL);
-	    Delete(tm);
-	    fn = i + 1;
-	    Printf(f, "if (!_v) goto check_%d;\n", fn);
-	    Printf(f, "_ranki += _v*_pi;\n");
-	    Printf(f, "_rankm += _pi;\n");
-	    Printf(f, "_pi *= SWIG_MAXCASTRANK;\n");
-	  }
-	}
-	if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
-	  /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
-	  Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-		       "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
-		       Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
-	  Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-		      "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
-	}
-	Parm *pj1 = Getattr(pj, "tmap:in:next");
-	if (pj1)
-	  pj = pj1;
-	else
-	  pj = nextSibling(pj);
-	j++;
+            String *conv = Getattr(pj, "implicitconv");
+            if (conv && !implicitconvtypecheckoff) {
+              Replaceall(tm, "$implicitconv", conv);
+            } else {
+              Replaceall(tm, "$implicitconv", "0");
+            }
+            Replaceall(tm, "$input", tmp);
+            Printv(f, "{\n", tm, "}\n", NIL);
+            Delete(tm);
+            fn = i + 1;
+            Printf(f, "if (!_v) goto check_%d;\n", fn);
+            Printf(f, "_ranki += _v*_pi;\n");
+            Printf(f, "_rankm += _pi;\n");
+            Printf(f, "_pi *= SWIG_MAXCASTRANK;\n");
+          }
+        }
+        if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
+          /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+                       "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
+                       Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+                      "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
+        }
+        Parm *pj1 = Getattr(pj, "tmap:in:next");
+        if (pj1)
+          pj = pj1;
+        else
+          pj = nextSibling(pj);
+        j++;
       }
     }
 
@@ -653,7 +653,7 @@ static String *overload_dispatch_fast(Node *n, const_String_or_char_ptr fmt, int
       int nrk = emit_num_required(pk);
       int nak = emit_num_arguments(pk);
       if ((nrk >= num_required && nrk <= num_arguments) || (nak >= num_required && nak <= num_arguments) || (nrk <= num_required && nak >= num_arguments))
-	Append(coll, nk);
+        Append(coll, nk);
     }
 
     // printf("overload: %s coll=%d\n", Char(Getattr(n, "sym:name")), Len(coll));
@@ -666,94 +666,94 @@ static String *overload_dispatch_fast(Node *n, const_String_or_char_ptr fmt, int
       j = 0;
       Parm *pj = pi;
       while (pj) {
-	if (checkAttribute(pj, "tmap:in:numinputs", "0")) {
-	  pj = Getattr(pj, "tmap:in:next");
-	  continue;
-	}
+        if (checkAttribute(pj, "tmap:in:numinputs", "0")) {
+          pj = Getattr(pj, "tmap:in:next");
+          continue;
+        }
 
-	String *tm = Getattr(pj, "tmap:typecheck");
-	if (tm) {
-	  tm = Copy(tm);
-	  /* normalise for comparison later */
-	  Replaceid(tm, Getattr(pj, "lname"), "_v");
+        String *tm = Getattr(pj, "tmap:typecheck");
+        if (tm) {
+          tm = Copy(tm);
+          /* normalise for comparison later */
+          Replaceid(tm, Getattr(pj, "lname"), "_v");
 
-	  /* if all the wrappers have the same type check on this
-	     argument we can optimize it out */
-	  emitcheck = false;
-	  for (int k = 0; k < Len(coll) && !emitcheck; k++) {
-	    Node *nk = Getitem(coll, k);
-	    Parm *pk = Getattr(nk, "wrap:parms");
-	    int nak = emit_num_arguments(pk);
-	    if (nak <= j)
-	      continue;
-	    int l = 0;
-	    Parm *pl = pk;
-	    /* finds arg j on the collider wrapper */
-	    while (pl && l <= j) {
-	      if (checkAttribute(pl, "tmap:in:numinputs", "0")) {
-		pl = Getattr(pl, "tmap:in:next");
-		continue;
-	      }
-	      if (l == j) {
-		/* we are at arg j, so we compare the tmaps now */
-		String *tml = Getattr(pl, "tmap:typecheck");
-		/* normalise it before comparing */
-		if (tml)
-		  Replaceid(tml, Getattr(pl, "lname"), "_v");
-		if (!tml || Cmp(tm, tml))
-		  emitcheck = true;
-		//printf("tmap: %s[%d] (%d) => %s\n\n",
-		//       Char(Getattr(nk, "sym:name")),
-		//       l, emitcheck, tml?Char(tml):0);
-	      }
-	      Parm *pl1 = Getattr(pl, "tmap:in:next");
-	      if (pl1)
-		pl = pl1;
-	      else
-		pl = nextSibling(pl);
-	      l++;
-	    }
-	  }
+          /* if all the wrappers have the same type check on this
+             argument we can optimize it out */
+          emitcheck = false;
+          for (int k = 0; k < Len(coll) && !emitcheck; k++) {
+            Node *nk = Getitem(coll, k);
+            Parm *pk = Getattr(nk, "wrap:parms");
+            int nak = emit_num_arguments(pk);
+            if (nak <= j)
+              continue;
+            int l = 0;
+            Parm *pl = pk;
+            /* finds arg j on the collider wrapper */
+            while (pl && l <= j) {
+              if (checkAttribute(pl, "tmap:in:numinputs", "0")) {
+                pl = Getattr(pl, "tmap:in:next");
+                continue;
+              }
+              if (l == j) {
+                /* we are at arg j, so we compare the tmaps now */
+                String *tml = Getattr(pl, "tmap:typecheck");
+                /* normalise it before comparing */
+                if (tml)
+                  Replaceid(tml, Getattr(pl, "lname"), "_v");
+                if (!tml || Cmp(tm, tml))
+                  emitcheck = true;
+                //printf("tmap: %s[%d] (%d) => %s\n\n",
+                //       Char(Getattr(nk, "sym:name")),
+                //       l, emitcheck, tml?Char(tml):0);
+              }
+              Parm *pl1 = Getattr(pl, "tmap:in:next");
+              if (pl1)
+                pl = pl1;
+              else
+                pl = nextSibling(pl);
+              l++;
+            }
+          }
 
-	  if (emitcheck) {
-	    *check_emitted = true;
-	    if (need_v) {
-	      Printf(f, "int _v = 0;\n");
-	      need_v = 0;
-	    }
-	    if (j >= num_required) {
-	      Printf(f, "if (%s > %d) {\n", argc_template_string, j);
-	      num_braces++;
-	    }
-	    String *tmp = NewStringf(argv_template_string, j);
+          if (emitcheck) {
+            *check_emitted = true;
+            if (need_v) {
+              Printf(f, "int _v = 0;\n");
+              need_v = 0;
+            }
+            if (j >= num_required) {
+              Printf(f, "if (%s > %d) {\n", argc_template_string, j);
+              num_braces++;
+            }
+            String *tmp = NewStringf(argv_template_string, j);
 
-	    String *conv = Getattr(pj, "implicitconv");
-	    if (conv && !implicitconvtypecheckoff) {
-	      Replaceall(tm, "$implicitconv", conv);
-	    } else {
-	      Replaceall(tm, "$implicitconv", "0");
-	    }
-	    Replaceall(tm, "$input", tmp);
-	    Printv(f, "{\n", tm, "}\n", NIL);
-	    Delete(tm);
-	    fn = i + 1;
-	    Printf(f, "if (!_v) goto check_%d;\n", fn);
-	  }
-	}
-	if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
-	  /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
-	  Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-		       "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
-		       Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
-	  Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-		       "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
-	}
-	Parm *pj1 = Getattr(pj, "tmap:in:next");
-	if (pj1)
-	  pj = pj1;
-	else
-	  pj = nextSibling(pj);
-	j++;
+            String *conv = Getattr(pj, "implicitconv");
+            if (conv && !implicitconvtypecheckoff) {
+              Replaceall(tm, "$implicitconv", conv);
+            } else {
+              Replaceall(tm, "$implicitconv", "0");
+            }
+            Replaceall(tm, "$input", tmp);
+            Printv(f, "{\n", tm, "}\n", NIL);
+            Delete(tm);
+            fn = i + 1;
+            Printf(f, "if (!_v) goto check_%d;\n", fn);
+          }
+        }
+        if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
+          /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+                       "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
+                       Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
+          Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+                       "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
+        }
+        Parm *pj1 = Getattr(pj, "tmap:in:next");
+        if (pj1)
+          pj = pj1;
+        else
+          pj = nextSibling(pj);
+        j++;
       }
     }
 
@@ -826,34 +826,34 @@ String *Swig_overload_dispatch(Node *n, const_String_or_char_ptr fmt, int *maxar
     Parm *pj = pi;
     while (pj) {
       if (checkAttribute(pj, "tmap:in:numinputs", "0")) {
-	pj = Getattr(pj, "tmap:in:next");
-	continue;
+        pj = Getattr(pj, "tmap:in:next");
+        continue;
       }
       *check_emitted = true;
       if (j >= num_required) {
-	String *lfmt = ReplaceFormat(fmt, num_arguments);
-	Printf(f, "if (%s <= %d) {\n", argc_template_string, j);
-	Printf(f, Char(lfmt), Getattr(ni, "wrap:name"));
-	Printf(f, "}\n");
-	Delete(lfmt);
+        String *lfmt = ReplaceFormat(fmt, num_arguments);
+        Printf(f, "if (%s <= %d) {\n", argc_template_string, j);
+        Printf(f, Char(lfmt), Getattr(ni, "wrap:name"));
+        Printf(f, "}\n");
+        Delete(lfmt);
       }
       if (print_typecheck(f, (GetFlag(n, "wrap:this") ? j + 1 : j), pj, implicitconvtypecheckoff)) {
-	Printf(f, "if (_v) {\n");
-	num_braces++;
+        Printf(f, "if (_v) {\n");
+        num_braces++;
       }
       if (!Getattr(pj, "tmap:in:SWIGTYPE") && Getattr(pj, "tmap:typecheck:SWIGTYPE")) {
-	/* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
-	Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-		     "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
-		     Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
-	Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
-		     "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
+        /* we emit a warning if the argument defines the 'in' typemap, but not the 'typecheck' one */
+        Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+                     "Overloaded method %s with no explicit typecheck typemap for arg %d of type '%s'.\n",
+                     Swig_name_decl(n), j, SwigType_str(Getattr(pj, "type"), 0));
+        Swig_warning(WARN_TYPEMAP_TYPECHECK_UNDEF, Getfile(ni), Getline(ni),
+                     "Dispatching calls to this method may not work correctly, see the 'Typemaps and Overloading' section in the Typemaps chapter of the SWIG documentation.\n");
       }
       Parm *pk = Getattr(pj, "tmap:in:next");
       if (pk)
-	pj = pk;
+        pj = pk;
       else
-	pj = nextSibling(pj);
+        pj = nextSibling(pj);
       j++;
     }
     String *lfmt = ReplaceFormat(fmt, num_arguments);

--- a/Source/Modules/overload.cxx
+++ b/Source/Modules/overload.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -73,10 +73,10 @@ static void mark_implicitconv_function(Overloaded& onode) {
  * Swig_overload_rank()
  *
  * This function takes an overloaded declaration and creates a list that ranks
- * all overloaded methods in an order that can be used to generate a dispatch 
+ * all overloaded methods in an order that can be used to generate a dispatch
  * function.
  * Slight difference in the way this function is used by scripting languages and
- * statically typed languages. The script languages call this method via 
+ * statically typed languages. The script languages call this method via
  * Swig_overload_dispatch() - where wrappers for all overloaded methods are generated,
  * however sometimes the code can never be executed. The non-scripting languages
  * call this method via Swig_overload_check() for each overloaded method in order
@@ -238,9 +238,9 @@ List *Swig_overload_rank(Node *n, bool script_lang_wrapping) {
             String *decl1 = Getattr(nodes[i].n, "decl");
             String *decl2 = Getattr(nodes[j].n, "decl");
             if (decl1 && decl2) {
-              /* Remove ref-qualifiers. Note that rvalue ref-qualifiers are already ignored and 
+              /* Remove ref-qualifiers. Note that rvalue ref-qualifiers are already ignored and
                * it is illegal to overload a function with and without ref-qualifiers. So with
-               * all the combinations of ref-qualifiers and cv-qualifiers, we just detect 
+               * all the combinations of ref-qualifiers and cv-qualifiers, we just detect
                * the cv-qualifier (const) overloading. */
               String *d1 = Copy(decl1);
               String *d2 = Copy(decl2);

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -53,7 +53,7 @@ static String *module = 0;
  *   the same as module, above, unless the %module directive is given
  *   the 'package' option, e.g. %module(package="Foo::Bar") "baz"
  */
-static String       *namespace_module = 0;
+static String *namespace_module = 0;
 
 /*
  * cmodule
@@ -67,7 +67,7 @@ static String *cmodule = 0;
  *   an optional namespace to put all classes into. Specified by using
  *   the %module(package="Foo::Bar") "baz" syntax
  */
-static String       *dest_package = 0;
+static String *dest_package = 0;
 
 static String *command_tab = 0;
 static String *constant_tab = 0;
@@ -82,42 +82,41 @@ static File *f_directors = 0;
 static File *f_directors_h = 0;
 static File *f_init = 0;
 static File *f_pm = 0;
-static String *pm;              /* Package initialization code */
-static String *magic;           /* Magic variable wrappers     */
+static String *pm;    /* Package initialization code */
+static String *magic; /* Magic variable wrappers     */
 
 static int staticoption = 0;
 
 // controlling verbose output
-static int          verbose = 0;
+static int verbose = 0;
 
 /* The following variables are used to manage Perl5 classes */
 
-static int blessed = 1;         /* Enable object oriented features */
-static int do_constants = 0;    /* Constant wrapping */
-static List *classlist = 0;     /* List of classes */
+static int blessed = 1;      /* Enable object oriented features */
+static int do_constants = 0; /* Constant wrapping */
+static List *classlist = 0;  /* List of classes */
 static int have_constructor = 0;
 static int have_destructor = 0;
 static int have_data_members = 0;
-static String *class_name = 0;  /* Name of the class (what Perl thinks it is) */
-static String *real_classname = 0;      /* Real name of C/C++ class */
+static String *class_name = 0;     /* Name of the class (what Perl thinks it is) */
+static String *real_classname = 0; /* Real name of C/C++ class */
 static String *fullclassname = 0;
 
-static String *pcode = 0;       /* Perl code associated with each class */
-                                                  /* static  String   *blessedmembers = 0;     *//* Member data associated with each class */
-static int member_func = 0;     /* Set to 1 when wrapping a member function */
-static String *func_stubs = 0;  /* Function stubs */
-static String *const_stubs = 0; /* Constant stubs */
-static Node *const_stubs_enum_class = 0; /* Node for enum class if we're currently generating one */
-static String *var_stubs = 0;   /* Variable stubs */
-static String *exported = 0;    /* Exported symbols */
+static String *pcode = 0;                       /* Perl code associated with each class */
+/* static  String   *blessedmembers = 0;     */ /* Member data associated with each class */
+static int member_func = 0;                     /* Set to 1 when wrapping a member function */
+static String *func_stubs = 0;                  /* Function stubs */
+static String *const_stubs = 0;                 /* Constant stubs */
+static Node *const_stubs_enum_class = 0;        /* Node for enum class if we're currently generating one */
+static String *var_stubs = 0;                   /* Variable stubs */
+static String *exported = 0;                    /* Exported symbols */
 static String *pragma_include = 0;
-static String *additional_perl_code = 0;        /* Additional Perl code from %perlcode %{ ... %} */
+static String *additional_perl_code = 0; /* Additional Perl code from %perlcode %{ ... %} */
 static Hash *operators = 0;
 static int have_operators = 0;
 
-class PERL5:public Language {
+class PERL5 : public Language {
 public:
-
   PERL5() {
     Clear(argc_template_string);
     Printv(argc_template_string, "items", NIL);
@@ -153,11 +152,15 @@ public:
       if (argv[i]) {
         if (strcmp(argv[i], "-package") == 0) {
           Printv(stderr,
-                 "*** -package is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the manual for details.\n", NIL);
+                 "*** -package is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the "
+                 "manual for details.\n",
+                 NIL);
           Exit(EXIT_FAILURE);
         } else if (strcmp(argv[i], "-interface") == 0) {
           Printv(stderr,
-                 "*** -interface is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the manual for details.\n", NIL);
+                 "*** -interface is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in "
+                 "the manual for details.\n",
+                 NIL);
           Exit(EXIT_FAILURE);
         } else if (strcmp(argv[i], "-exportall") == 0) {
           export_all = 1;
@@ -183,9 +186,9 @@ public:
           i++;
           pmfile = NewString(argv[i]);
           Swig_mark_arg(i);
-        } else if (strcmp(argv[i],"-v") == 0) {
-            Swig_mark_arg(i);
-            verbose++;
+        } else if (strcmp(argv[i], "-v") == 0) {
+          Swig_mark_arg(i);
+          verbose++;
         } else if (strcmp(argv[i], "-compat") == 0) {
           compat = 1;
           Swig_mark_arg(i);
@@ -331,10 +334,10 @@ public:
     // of this module.)
     Node *mod = Getattr(n, "module");
     Node *options = Getattr(mod, "options");
-    module = Copy(Getattr(n,"name"));
+    module = Copy(Getattr(n, "name"));
 
     String *underscore_module = Copy(module);
-    Replaceall(underscore_module,":","_");
+    Replaceall(underscore_module, ":", "_");
 
     if (verbose > 0) {
       fprintf(stdout, "top: using namespace_module: %s\n", Char(namespace_module));
@@ -369,7 +372,7 @@ public:
     if (dest_package) {
       namespace_module = Copy(dest_package);
       if (verbose > 0) {
-        fprintf(stdout, "top: Found package: %s\n",Char(dest_package));
+        fprintf(stdout, "top: Found package: %s\n", Char(dest_package));
       }
     } else {
       namespace_module = Copy(module);
@@ -380,7 +383,7 @@ public:
     /* If we're in blessed mode, change the package name to "packagec" */
 
     if (blessed) {
-      cmodule = NewStringf("%sc",namespace_module);
+      cmodule = NewStringf("%sc", namespace_module);
     } else {
       cmodule = NewString(namespace_module);
     }
@@ -415,9 +418,9 @@ public:
     }
     {
       String *boot_name = NewStringf("boot_%s", underscore_module);
-      Printf(f_header,"#define SWIG_init    %s\n\n", boot_name);
-      Printf(f_header,"#define SWIG_name   \"%s::%s\"\n", cmodule, boot_name);
-      Printf(f_header,"#define SWIG_prefix \"%s::\"\n", cmodule);
+      Printf(f_header, "#define SWIG_init    %s\n\n", boot_name);
+      Printf(f_header, "#define SWIG_name   \"%s::%s\"\n", cmodule, boot_name);
+      Printf(f_header, "#define SWIG_prefix \"%s::\"\n", cmodule);
       Delete(boot_name);
     }
 
@@ -432,11 +435,11 @@ public:
      *   mess with @ISA or require for that package
      */
     if (dest_package) {
-      Printf(f_pm,"use base qw(DynaLoader);\n");
+      Printf(f_pm, "use base qw(DynaLoader);\n");
     } else {
-      Printf(f_pm,"use base qw(Exporter);\n");
+      Printf(f_pm, "use base qw(Exporter);\n");
       if (!staticoption) {
-        Printf(f_pm,"use base qw(DynaLoader);\n");
+        Printf(f_pm, "use base qw(DynaLoader);\n");
       }
     }
 
@@ -481,7 +484,7 @@ public:
         if (pname) {
           SwigType *type = Getattr(cls.item, "classtypeobj");
           if (!type)
-            continue;           /* If unnamed class, no type will be found */
+            continue; /* If unnamed class, no type will be found */
           type = Copy(type);
 
           SwigType_add_pointer(type);
@@ -513,14 +516,13 @@ public:
     Printf(command_tab, "{0,0}\n};\n");
     Printv(f_wrappers, command_tab, NIL);
 
-
     Printf(f_pm, "package %s;\n", cmodule);
 
     if (!staticoption) {
-      Printf(f_pm,"bootstrap %s;\n", module);
+      Printf(f_pm, "bootstrap %s;\n", module);
     } else {
-      Printf(f_pm,"package %s;\n", cmodule);
-      Printf(f_pm,"boot_%s();\n", underscore_module);
+      Printf(f_pm, "package %s;\n", cmodule);
+      Printf(f_pm, "boot_%s();\n", underscore_module);
     }
 
     Printf(f_pm, "package %s;\n", module);
@@ -530,7 +532,7 @@ public:
      *   mess with @EXPORT
      */
     if (!dest_package) {
-      Printf(f_pm,"@EXPORT = qw(%s);\n", exported);
+      Printf(f_pm, "@EXPORT = qw(%s);\n", exported);
     }
 
     Printf(f_pm, "%s", pragma_include);
@@ -546,12 +548,7 @@ public:
 
         /* Write out the TIE method */
 
-        Printv(base,
-               "sub TIEHASH {\n",
-               "    my ($classname,$obj) = @_;\n",
-               "    return bless $obj, $classname;\n",
-               "}\n\n",
-               NIL);
+        Printv(base, "sub TIEHASH {\n", "    my ($classname,$obj) = @_;\n", "    return bless $obj, $classname;\n", "}\n\n", NIL);
 
         /* Output a CLEAR method.   This is just a place-holder, but by providing it we
          * can make declarations such as
@@ -587,12 +584,7 @@ public:
 
         /* Output a 'this' method */
 
-        Printv(base,
-               "sub this {\n",
-               "    my $ptr = shift;\n",
-               "    return tied(%$ptr);\n",
-               "}\n\n",
-               NIL);
+        Printv(base, "sub this {\n", "    my $ptr = shift;\n", "    return tied(%$ptr);\n", "}\n\n", NIL);
 
         Printf(f_pm, "%s", base);
       }
@@ -702,7 +694,11 @@ public:
       Append(wname, overname);
     }
     Setattr(n, "wrap:name", wname);
-    Printv(f->def, "XS(", wname, ") {\n", "{\n",        /* scope to destroy C++ objects before croaking */
+    Printv(f->def,
+           "XS(",
+           wname,
+           ") {\n",
+           "{\n", /* scope to destroy C++ objects before croaking */
            NIL);
 
     emit_parameter_variables(l, f);
@@ -743,7 +739,7 @@ public:
       }
       if ((tm = Getattr(p, "tmap:in"))) {
         Replaceall(tm, "$input", source);
-        Setattr(p, "emit:input", source);       /* Save input location */
+        Setattr(p, "emit:input", source); /* Save input location */
 
         if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
           Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
@@ -904,7 +900,14 @@ public:
       }
     }
 
-    Printv(f->code, "XSRETURN(argvi);\n" "fail:;\n", cleanup, "}\n" "SWIG_croak_null();\n" "}\n", NIL);
+    Printv(f->code,
+           "XSRETURN(argvi);\n"
+           "fail:;\n",
+           cleanup,
+           "}\n"
+           "SWIG_croak_null();\n"
+           "}\n",
+           NIL);
 
     /* Add the dXSARGS last */
 
@@ -962,7 +965,6 @@ public:
       if ((blessed) && (!member_func)) {
         Printv(func_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
-
     }
     Delete(cleanup);
     Delete(outarg);
@@ -1045,7 +1047,6 @@ public:
     }
     Append(getf->code, "}\n");
 
-
     Replaceall(getf->code, "$symname", iname);
     Wrapper_print(getf, magic);
 
@@ -1071,9 +1072,29 @@ public:
     if (blessed) {
       if (is_shadow(t)) {
         Printv(var_stubs,
-               "\nmy %__", iname, "_hash;\n",
-               "tie %__", iname, "_hash,\"", is_shadow(t), "\", $",
-               cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(t), ";\n", NIL);
+               "\nmy %__",
+               iname,
+               "_hash;\n",
+               "tie %__",
+               iname,
+               "_hash,\"",
+               is_shadow(t),
+               "\", $",
+               cmodule,
+               "::",
+               iname,
+               ";\n",
+               "$",
+               iname,
+               "= \\%__",
+               iname,
+               "_hash;\n",
+               "bless $",
+               iname,
+               ", ",
+               is_shadow(t),
+               ";\n",
+               NIL);
       } else {
         Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
@@ -1136,9 +1157,29 @@ public:
     if (blessed) {
       if (is_shadow(type)) {
         Printv(var_stubs,
-               "\nmy %__", iname, "_hash;\n",
-               "tie %__", iname, "_hash,\"", is_shadow(type), "\", $",
-               cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(type), ";\n", NIL);
+               "\nmy %__",
+               iname,
+               "_hash;\n",
+               "tie %__",
+               iname,
+               "_hash,\"",
+               is_shadow(type),
+               "\", $",
+               cmodule,
+               "::",
+               iname,
+               ";\n",
+               "$",
+               iname,
+               "= \\%__",
+               iname,
+               "_hash;\n",
+               "bless $",
+               iname,
+               ", ",
+               is_shadow(type),
+               ";\n",
+               NIL);
       } else if (do_constants) {
         char *dcolon = Strstr(name, "::");
         if (!dcolon) {
@@ -1189,7 +1230,7 @@ public:
     while (p != 0) {
       SwigType *pt = Getattr(p, "type");
       String *pn = Getattr(p, "name");
-      if (!checkAttribute(p,"tmap:in:numinputs","0")) {
+      if (!checkAttribute(p, "tmap:in:numinputs", "0")) {
         /* If parameter has been named, use that.   Otherwise, just print a type  */
         if (SwigType_type(pt) != T_VOID) {
           if (Len(pn) > 0) {
@@ -1201,12 +1242,12 @@ public:
         i++;
         p = nextSibling(p);
         if (p)
-          if (!checkAttribute(p,"tmap:in:numinputs","0"))
+          if (!checkAttribute(p, "tmap:in:numinputs", "0"))
             Putc(',', temp);
       } else {
         p = nextSibling(p);
         if (p)
-          if ((i > 0) && (!checkAttribute(p,"tmap:in:numinputs","0")))
+          if ((i > 0) && (!checkAttribute(p, "tmap:in:numinputs", "0")))
             Putc(',', temp);
       }
     }
@@ -1234,39 +1275,38 @@ public:
     return SWIG_OK;
   }
 
-/* ----------------------------------------------------------------------------
- *                      OBJECT-ORIENTED FEATURES
- *
- * These extensions provide a more object-oriented interface to C++
- * classes and structures.    The code here is based on extensions
- * provided by David Fletcher and Gary Holt.
- *
- * I have generalized these extensions to make them more general purpose
- * and to resolve object-ownership problems.
- *
- * The approach here is very similar to the Python module :
- *       1.   All of the original methods are placed into a single
- *            package like before except that a 'c' is appended to the
- *            package name.
- *
- *       2.   All methods and function calls are wrapped with a new
- *            perl function.   While possibly inefficient this allows
- *            us to catch complex function arguments (which are hard to
- *            track otherwise).
- *
- *       3.   Classes are represented as tied-hashes in a manner similar
- *            to Gary Holt's extension.   This allows us to access
- *            member data.
- *
- *       4.   Stand-alone (global) C functions are modified to take
- *            tied hashes as arguments for complex datatypes (if
- *            appropriate).
- *
- *       5.   Global variables involving a class/struct is encapsulated
- *            in a tied hash.
- *
- * ------------------------------------------------------------------------- */
-
+  /* ----------------------------------------------------------------------------
+   *                      OBJECT-ORIENTED FEATURES
+   *
+   * These extensions provide a more object-oriented interface to C++
+   * classes and structures.    The code here is based on extensions
+   * provided by David Fletcher and Gary Holt.
+   *
+   * I have generalized these extensions to make them more general purpose
+   * and to resolve object-ownership problems.
+   *
+   * The approach here is very similar to the Python module :
+   *       1.   All of the original methods are placed into a single
+   *            package like before except that a 'c' is appended to the
+   *            package name.
+   *
+   *       2.   All methods and function calls are wrapped with a new
+   *            perl function.   While possibly inefficient this allows
+   *            us to catch complex function arguments (which are hard to
+   *            track otherwise).
+   *
+   *       3.   Classes are represented as tied-hashes in a manner similar
+   *            to Gary Holt's extension.   This allows us to access
+   *            member data.
+   *
+   *       4.   Stand-alone (global) C functions are modified to take
+   *            tied hashes as arguments for complex datatypes (if
+   *            appropriate).
+   *
+   *       5.   Global variables involving a class/struct is encapsulated
+   *            in a tied hash.
+   *
+   * ------------------------------------------------------------------------- */
 
   void setclassname(Node *n) {
     String *symname = Getattr(n, "sym:name");
@@ -1290,13 +1330,13 @@ public:
     if (dest_package) {
       fullname = NewStringf("%s::%s", namespace_module, symname);
     } else {
-      actualpackage = Getattr(clsmodule,"name");
+      actualpackage = Getattr(clsmodule, "name");
 
       if (verbose > 0) {
         fprintf(stdout, "setclassname: Found actualpackage: %s\n", Char(actualpackage));
       }
-      if ((!compat) && (!Strchr(symname,':'))) {
-        fullname = NewStringf("%s::%s",actualpackage,symname);
+      if ((!compat) && (!Strchr(symname, ':'))) {
+        fullname = NewStringf("%s::%s", actualpackage, symname);
       } else {
         fullname = NewString(symname);
       }
@@ -1354,7 +1394,6 @@ public:
     /* Emit all of the members */
     Language::classHandler(n);
 
-
     /* Finish the rest of the class */
     if (blessed) {
       /* Generate a client-data entry */
@@ -1372,32 +1411,32 @@ public:
           char *name = Char(ki.key);
           //        fprintf(stderr,"found name: <%s>\n", name);
           if (strstr(name, "__eq__")) {
-            Printv(pm, tab4, "\"==\" => sub { $_[0]->__eq__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"==\" => sub { $_[0]->__eq__($_[1])},\n", NIL);
           } else if (strstr(name, "__ne__")) {
-            Printv(pm, tab4, "\"!=\" => sub { $_[0]->__ne__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"!=\" => sub { $_[0]->__ne__($_[1])},\n", NIL);
             // there are no tests for this in operator_overload_runme.pl
             // it is likely to be broken
             //    } else if (strstr(name, "__assign__")) {
             //      Printv(pm, tab4, "\"=\" => sub { $_[0]->__assign__($_[1])},\n",NIL);
           } else if (strstr(name, "__str__")) {
-            Printv(pm, tab4, "'\"\"' => sub { $_[0]->__str__()},\n",NIL);
+            Printv(pm, tab4, "'\"\"' => sub { $_[0]->__str__()},\n", NIL);
           } else if (strstr(name, "__plusplus__")) {
-            Printv(pm, tab4, "\"++\" => sub { $_[0]->__plusplus__()},\n",NIL);
+            Printv(pm, tab4, "\"++\" => sub { $_[0]->__plusplus__()},\n", NIL);
           } else if (strstr(name, "__minmin__")) {
-            Printv(pm, tab4, "\"--\" => sub { $_[0]->__minmin__()},\n",NIL);
+            Printv(pm, tab4, "\"--\" => sub { $_[0]->__minmin__()},\n", NIL);
           } else if (strstr(name, "__add__")) {
-            Printv(pm, tab4, "\"+\" => sub { $_[0]->__add__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"+\" => sub { $_[0]->__add__($_[1])},\n", NIL);
           } else if (strstr(name, "__sub__")) {
-            Printv(pm, tab4, "\"-\" => sub {  if( not $_[2] ) { $_[0]->__sub__($_[1]) }\n",NIL);
-            Printv(pm, tab8, "elsif( $_[0]->can('__rsub__') ) { $_[0]->__rsub__($_[1]) }\n",NIL);
-            Printv(pm, tab8, "else { die(\"reverse subtraction not supported\") }\n",NIL);
-            Printv(pm, tab8, "},\n",NIL);
+            Printv(pm, tab4, "\"-\" => sub {  if( not $_[2] ) { $_[0]->__sub__($_[1]) }\n", NIL);
+            Printv(pm, tab8, "elsif( $_[0]->can('__rsub__') ) { $_[0]->__rsub__($_[1]) }\n", NIL);
+            Printv(pm, tab8, "else { die(\"reverse subtraction not supported\") }\n", NIL);
+            Printv(pm, tab8, "},\n", NIL);
           } else if (strstr(name, "__mul__")) {
-            Printv(pm, tab4, "\"*\" => sub { $_[0]->__mul__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"*\" => sub { $_[0]->__mul__($_[1])},\n", NIL);
           } else if (strstr(name, "__div__")) {
-            Printv(pm, tab4, "\"/\" => sub { $_[0]->__div__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"/\" => sub { $_[0]->__div__($_[1])},\n", NIL);
           } else if (strstr(name, "__mod__")) {
-            Printv(pm, tab4, "\"%\" => sub { $_[0]->__mod__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"%\" => sub { $_[0]->__mod__($_[1])},\n", NIL);
             // there are no tests for this in operator_overload_runme.pl
             // it is likely to be broken
             //    } else if (strstr(name, "__and__")) {
@@ -1408,27 +1447,26 @@ public:
             //    } else if (strstr(name, "__or__")) {
             //      Printv(pm, tab4, "\"|\" => sub { $_[0]->__or__($_[1])},\n",NIL);
           } else if (strstr(name, "__gt__")) {
-            Printv(pm, tab4, "\">\" => sub { $_[0]->__gt__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\">\" => sub { $_[0]->__gt__($_[1])},\n", NIL);
           } else if (strstr(name, "__ge__")) {
-            Printv(pm, tab4, "\">=\" => sub { $_[0]->__ge__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\">=\" => sub { $_[0]->__ge__($_[1])},\n", NIL);
           } else if (strstr(name, "__not__")) {
-            Printv(pm, tab4, "\"!\" => sub { $_[0]->__not__()},\n",NIL);
+            Printv(pm, tab4, "\"!\" => sub { $_[0]->__not__()},\n", NIL);
           } else if (strstr(name, "__lt__")) {
-            Printv(pm, tab4, "\"<\" => sub { $_[0]->__lt__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"<\" => sub { $_[0]->__lt__($_[1])},\n", NIL);
           } else if (strstr(name, "__le__")) {
-            Printv(pm, tab4, "\"<=\" => sub { $_[0]->__le__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"<=\" => sub { $_[0]->__le__($_[1])},\n", NIL);
           } else if (strstr(name, "__pluseq__")) {
-            Printv(pm, tab4, "\"+=\" => sub { $_[0]->__pluseq__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"+=\" => sub { $_[0]->__pluseq__($_[1])},\n", NIL);
           } else if (strstr(name, "__mineq__")) {
-            Printv(pm, tab4, "\"-=\" => sub { $_[0]->__mineq__($_[1])},\n",NIL);
+            Printv(pm, tab4, "\"-=\" => sub { $_[0]->__mineq__($_[1])},\n", NIL);
           } else if (strstr(name, "__neg__")) {
-            Printv(pm, tab4, "\"neg\" => sub { $_[0]->__neg__()},\n",NIL);
+            Printv(pm, tab4, "\"neg\" => sub { $_[0]->__neg__()},\n", NIL);
           } else {
-            fprintf(stderr,"Unknown operator: %s\n", name);
+            fprintf(stderr, "Unknown operator: %s\n", name);
           }
         }
-        Printv(pm, tab4,
-               "\"=\" => sub { my $class = ref($_[0]); $class->new($_[0]) },\n", NIL);
+        Printv(pm, tab4, "\"=\" => sub { my $class = ref($_[0]); $class->new($_[0]) },\n", NIL);
         Printv(pm, tab4, "\"fallback\" => 1;\n", NIL);
       }
       // make use strict happy
@@ -1514,8 +1552,13 @@ public:
         type = NewString("SV");
         SwigType_add_pointer(type);
         String *action = NewString("");
-        Printv(action, "{\n", "  Swig::Director *director = SWIG_DIRECTOR_CAST(arg1);\n",
-               "  result = sv_newmortal();\n" "  if (director) sv_setsv(result, director->swig_get_self());\n", "}\n", NIL);
+        Printv(action,
+               "{\n",
+               "  Swig::Director *director = SWIG_DIRECTOR_CAST(arg1);\n",
+               "  result = sv_newmortal();\n"
+               "  if (director) sv_setsv(result, director->swig_get_self());\n",
+               "}\n",
+               NIL);
         Setfile(get_attr, Getfile(n));
         Setline(get_attr, Getline(n));
         Setattr(get_attr, "wrap:action", action);
@@ -1536,7 +1579,8 @@ public:
                "sub FETCH {\n",
                "    my ($self,$field) = @_;\n",
                "    my $member_func = \"swig_${field}_get\";\n",
-               "    if (not $self->can($member_func)) {\n", NIL);
+               "    if (not $self->can($member_func)) {\n",
+               NIL);
         Printv(pm, "        my $h = ", cmodule, "::", mrename, "($self);\n", NIL);
         Printv(pm,
                "        return $h->{$field} if $h;\n",
@@ -1550,12 +1594,7 @@ public:
                "    if (not $self->can($member_func)) {\n",
                NIL);
         Printv(pm, "        my $h = ", cmodule, "::", mrename, "($self);\n", NIL);
-        Printv(pm,
-               "        return $h->{$field} = $newval if $h;\n",
-               "    }\n",
-               "    return $self->$member_func($newval);\n",
-               "}\n",
-               NIL);
+        Printv(pm, "        return $h->{$field} = $newval if $h;\n", "    }\n", "    return $self->$member_func($newval);\n", "}\n", NIL);
 
         Delete(mrename);
       }
@@ -1729,8 +1768,11 @@ public:
     String *saved_nc = none_comparison;
     none_comparison = NewStringf("strcmp(SvPV_nolen(ST(0)), \"%s::%s\") != 0", module, class_name);
     String *saved_director_prot_ctor_code = director_prot_ctor_code;
-    director_prot_ctor_code = NewStringf("if ($comparison) { /* subclassed */\n" "  $director_new\n" "} else {\n"
-                                         "SWIG_exception_fail(SWIG_RuntimeError, \"accessing abstract class or protected constructor\");\n" "}\n");
+    director_prot_ctor_code = NewStringf("if ($comparison) { /* subclassed */\n"
+                                         "  $director_new\n"
+                                         "} else {\n"
+                                         "SWIG_exception_fail(SWIG_RuntimeError, \"accessing abstract class or protected constructor\");\n"
+                                         "}\n");
     Language::constructorHandler(n);
     Delete(none_comparison);
     none_comparison = saved_nc;
@@ -1754,10 +1796,19 @@ public:
           Printv(pcode, "sub ", Swig_name_construct(NSPACE_TODO, symname), " {\n", NIL);
         }
 
-        const char *pkg = getCurrentClass() && Swig_directorclass(getCurrentClass())? "$_[0]" : "shift";
+        const char *pkg = getCurrentClass() && Swig_directorclass(getCurrentClass()) ? "$_[0]" : "shift";
         Printv(pcode,
-               "    my $pkg = ", pkg, ";\n",
-               "    my $self = ", cmodule, "::", Swig_name_construct(NSPACE_TODO, symname), "(@_);\n", "    bless $self, $pkg if defined($self);\n", "}\n\n", NIL);
+               "    my $pkg = ",
+               pkg,
+               ";\n",
+               "    my $self = ",
+               cmodule,
+               "::",
+               Swig_name_construct(NSPACE_TODO, symname),
+               "(@_);\n",
+               "    bless $self, $pkg if defined($self);\n",
+               "}\n\n",
+               NIL);
 
         have_constructor = 1;
       }
@@ -1791,11 +1842,7 @@ public:
                "    if (exists $OWNER{$self}) {\n",
                NIL);
         Printv(pcode, tab8, cmodule, "::", Swig_name_destroy(NSPACE_TODO, symname), NIL);
-        Printv(pcode,
-               "($self);\n",
-               "        delete $OWNER{$self};\n",
-               "    }\n}\n\n",
-               NIL);
+        Printv(pcode, "($self);\n", "        delete $OWNER{$self};\n", "    }\n}\n\n", NIL);
         have_destructor = 1;
       }
     }
@@ -2204,7 +2251,9 @@ public:
         Printf(w->code, "%s;\n", super_call);
         Delete(super_call);
       } else {
-        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       }
     } else {
@@ -2300,9 +2349,13 @@ public:
               String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
               Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
               Delete(nonconst_i);
-              Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
+              Swig_warning(WARN_LANG_DISCARD_CONST,
+                           input_file,
+                           line_number,
                            "Target language argument '%s' discards const in director method %s::%s.\n",
-                           SwigType_str(ptype, pname), SwigType_namestr(c_classname), SwigType_namestr(name));
+                           SwigType_str(ptype, pname),
+                           SwigType_namestr(c_classname),
+                           SwigType_namestr(name));
             } else {
               nonconst = Copy(ppname);
             }
@@ -2330,9 +2383,13 @@ public:
             Delete(mangle);
             Delete(nonconst);
           } else {
-            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-                         SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                         input_file,
+                         line_number,
+                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                         SwigType_str(ptype, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             status = SWIG_NOWRAP;
             break;
           }
@@ -2427,9 +2484,13 @@ public:
           Printv(w->code, tm, "\n", NIL);
           Delete(tm);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-                       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
-                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use return type %s in director method %s::%s (skipping method).\n",
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_ERROR;
         }
       }
@@ -2531,11 +2592,9 @@ public:
     SwigType_add_pointer(ptype);
     String *mangle = SwigType_manglestr(ptype);
 
+    Printv(body, "  dSP;\n", "  SV *self = SWIG_NewPointerObj(SWIG_as_voidptr(this), SWIGTYPE", mangle, ", SWIG_SHADOW);\n", NIL);
     Printv(body,
-           "  dSP;\n",
-           "  SV *self = SWIG_NewPointerObj(SWIG_as_voidptr(this), SWIGTYPE", mangle, ", SWIG_SHADOW);\n",
-           NIL);
-    Printv(body, "    \n",
+           "    \n",
            "  sv_bless(self, gv_stashpv(swig_get_class(), 0));\n",
            "  ENTER;\n",
            "  SAVETMPS;\n",

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -103,7 +103,7 @@ static String *real_classname = 0;	/* Real name of C/C++ class */
 static String *fullclassname = 0;
 
 static String *pcode = 0;	/* Perl code associated with each class */
-						  /* static  String   *blessedmembers = 0;     *//* Member data associated with each class */
+                                                  /* static  String   *blessedmembers = 0;     *//* Member data associated with each class */
 static int member_func = 0;	/* Set to 1 when wrapping a member function */
 static String *func_stubs = 0;	/* Function stubs */
 static String *const_stubs = 0;	/* Constant stubs */
@@ -133,7 +133,7 @@ public:
     /*  Printf(stdout,"'%s' --> '%p'\n", t, n); */
     if (n) {
       if (!Getattr(n, "perl5:proxy")) {
-	setclassname(n);
+        setclassname(n);
       }
       return Getattr(n, "perl5:proxy");
     }
@@ -151,54 +151,54 @@ public:
 
     for (i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-package") == 0) {
-	  Printv(stderr,
-		 "*** -package is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the manual for details.\n", NIL);
-	  Exit(EXIT_FAILURE);
-	} else if (strcmp(argv[i], "-interface") == 0) {
-	  Printv(stderr,
-		 "*** -interface is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the manual for details.\n", NIL);
-	  Exit(EXIT_FAILURE);
-	} else if (strcmp(argv[i], "-exportall") == 0) {
-	  export_all = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-static") == 0) {
-	  staticoption = 1;
-	  Swig_mark_arg(i);
-	} else if ((strcmp(argv[i], "-shadow") == 0) || ((strcmp(argv[i], "-proxy") == 0))) {
-	  blessed = 1;
-	  Swig_mark_arg(i);
-	} else if ((strcmp(argv[i], "-noproxy") == 0)) {
-	  blessed = 0;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-const") == 0) {
-	  do_constants = 1;
-	  blessed = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nopm") == 0) {
-	  no_pmfile = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-pm") == 0) {
-	  Swig_mark_arg(i);
-	  i++;
-	  pmfile = NewString(argv[i]);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i],"-v") == 0) {
-	    Swig_mark_arg(i);
-	    verbose++;
-	} else if (strcmp(argv[i], "-compat") == 0) {
-	  compat = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  fputs(usage, stdout);
-	} else if (strcmp(argv[i], "-cppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nocppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
-	  Swig_mark_arg(i);
-	  Exit(EXIT_FAILURE);
-	}
+        if (strcmp(argv[i], "-package") == 0) {
+          Printv(stderr,
+                 "*** -package is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the manual for details.\n", NIL);
+          Exit(EXIT_FAILURE);
+        } else if (strcmp(argv[i], "-interface") == 0) {
+          Printv(stderr,
+                 "*** -interface is no longer supported\n*** use the directive '%module A::B::C' in your interface file instead\n*** see the Perl section in the manual for details.\n", NIL);
+          Exit(EXIT_FAILURE);
+        } else if (strcmp(argv[i], "-exportall") == 0) {
+          export_all = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-static") == 0) {
+          staticoption = 1;
+          Swig_mark_arg(i);
+        } else if ((strcmp(argv[i], "-shadow") == 0) || ((strcmp(argv[i], "-proxy") == 0))) {
+          blessed = 1;
+          Swig_mark_arg(i);
+        } else if ((strcmp(argv[i], "-noproxy") == 0)) {
+          blessed = 0;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-const") == 0) {
+          do_constants = 1;
+          blessed = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nopm") == 0) {
+          no_pmfile = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-pm") == 0) {
+          Swig_mark_arg(i);
+          i++;
+          pmfile = NewString(argv[i]);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i],"-v") == 0) {
+            Swig_mark_arg(i);
+            verbose++;
+        } else if (strcmp(argv[i], "-compat") == 0) {
+          compat = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-help") == 0) {
+          fputs(usage, stdout);
+        } else if (strcmp(argv[i], "-cppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nocppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
+          Swig_mark_arg(i);
+          Exit(EXIT_FAILURE);
+        }
       }
     }
 
@@ -229,42 +229,42 @@ public:
     {
       Node *mod = Getattr(n, "module");
       if (mod) {
-	Node *options = Getattr(mod, "options");
-	if (options) {
-	  int dirprot = 0;
-	  if (Getattr(options, "dirprot"))
-	    dirprot = 1;
-	  if (Getattr(options, "nodirprot"))
-	    dirprot = 0;
-	  if (Getattr(options, "directors")) {
-	    int allow = 1;
-	    if (export_all) {
-	      Printv(stderr, "*** directors are not supported with -exportall\n", NIL);
-	      allow = 0;
-	    }
-	    if (staticoption) {
-	      Printv(stderr, "*** directors are not supported with -static\n", NIL);
-	      allow = 0;
-	    }
-	    if (!blessed) {
-	      Printv(stderr, "*** directors are not supported with -noproxy\n", NIL);
-	      allow = 0;
-	    }
-	    if (no_pmfile) {
-	      Printv(stderr, "*** directors are not supported with -nopm\n", NIL);
-	      allow = 0;
-	    }
-	    if (compat) {
-	      Printv(stderr, "*** directors are not supported with -compat\n", NIL);
-	      allow = 0;
-	    }
-	    if (allow) {
-	      allow_directors();
-	      if (dirprot)
-		allow_dirprot();
-	    }
-	  }
-	}
+        Node *options = Getattr(mod, "options");
+        if (options) {
+          int dirprot = 0;
+          if (Getattr(options, "dirprot"))
+            dirprot = 1;
+          if (Getattr(options, "nodirprot"))
+            dirprot = 0;
+          if (Getattr(options, "directors")) {
+            int allow = 1;
+            if (export_all) {
+              Printv(stderr, "*** directors are not supported with -exportall\n", NIL);
+              allow = 0;
+            }
+            if (staticoption) {
+              Printv(stderr, "*** directors are not supported with -static\n", NIL);
+              allow = 0;
+            }
+            if (!blessed) {
+              Printv(stderr, "*** directors are not supported with -noproxy\n", NIL);
+              allow = 0;
+            }
+            if (no_pmfile) {
+              Printv(stderr, "*** directors are not supported with -nopm\n", NIL);
+              allow = 0;
+            }
+            if (compat) {
+              Printv(stderr, "*** directors are not supported with -compat\n", NIL);
+              allow = 0;
+            }
+            if (allow) {
+              allow_directors();
+              if (dirprot)
+                allow_dirprot();
+            }
+          }
+        }
       }
     }
 
@@ -287,8 +287,8 @@ public:
     if (Swig_directors_enabled()) {
       f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
       if (!f_runtime_h) {
-	FileErrorDisplay(outfile_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -346,8 +346,8 @@ public:
       Printf(f_directors_h, "#ifndef SWIG_%s_WRAP_H_\n", underscore_module);
       Printf(f_directors_h, "#define SWIG_%s_WRAP_H_\n\n", underscore_module);
       if (dirprot_mode()) {
-	Printf(f_directors_h, "#include <map>\n");
-	Printf(f_directors_h, "#include <string>\n\n");
+        Printf(f_directors_h, "#include <map>\n");
+        Printf(f_directors_h, "#include <string>\n\n");
       }
 
       Printf(f_directors, "\n\n");
@@ -355,9 +355,9 @@ public:
       Printf(f_directors, " * C++ director class methods\n");
       Printf(f_directors, " * --------------------------------------------------- */\n\n");
       if (outfile_h) {
-	String *filename = Swig_file_filename(outfile_h);
-	Printf(magic, "#include \"%s\"\n\n", filename);
-	Delete(filename);
+        String *filename = Swig_file_filename(outfile_h);
+        Printf(magic, "#include \"%s\"\n\n", filename);
+        Delete(filename);
       }
     }
 
@@ -369,12 +369,12 @@ public:
     if (dest_package) {
       namespace_module = Copy(dest_package);
       if (verbose > 0) {
-	fprintf(stdout, "top: Found package: %s\n",Char(dest_package));
+        fprintf(stdout, "top: Found package: %s\n",Char(dest_package));
       }
     } else {
       namespace_module = Copy(module);
       if (verbose > 0) {
-	fprintf(stdout, "top: No package found\n");
+        fprintf(stdout, "top: No package found\n");
       }
     }
     /* If we're in blessed mode, change the package name to "packagec" */
@@ -393,20 +393,20 @@ public:
       f_pm = NewString(0);
     } else {
       if (!pmfile) {
-	char *m = Char(module) + Len(module);
-	while (m != Char(module)) {
-	  if (*m == ':') {
-	    m++;
-	    break;
-	  }
-	  m--;
-	}
-	pmfile = NewStringf("%s.pm", m);
+        char *m = Char(module) + Len(module);
+        while (m != Char(module)) {
+          if (*m == ':') {
+            m++;
+            break;
+          }
+          m--;
+        }
+        pmfile = NewStringf("%s.pm", m);
       }
       String *filen = NewStringf("%s%s", SWIG_output_directory(), pmfile);
       if ((f_pm = NewFile(filen, "w", SWIG_output_files())) == 0) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Delete(filen);
       filen = NULL;
@@ -436,7 +436,7 @@ public:
     } else {
       Printf(f_pm,"use base qw(Exporter);\n");
       if (!staticoption) {
-	Printf(f_pm,"use base qw(DynaLoader);\n");
+        Printf(f_pm,"use base qw(DynaLoader);\n");
       }
     }
 
@@ -477,19 +477,19 @@ public:
     if (blessed) {
       Iterator cls;
       for (cls = First(classlist); cls.item; cls = Next(cls)) {
-	String *pname = Getattr(cls.item, "perl5:proxy");
-	if (pname) {
-	  SwigType *type = Getattr(cls.item, "classtypeobj");
-	  if (!type)
-	    continue;		/* If unnamed class, no type will be found */
-	  type = Copy(type);
+        String *pname = Getattr(cls.item, "perl5:proxy");
+        if (pname) {
+          SwigType *type = Getattr(cls.item, "classtypeobj");
+          if (!type)
+            continue;		/* If unnamed class, no type will be found */
+          type = Copy(type);
 
-	  SwigType_add_pointer(type);
-	  String *mangled = SwigType_manglestr(type);
-	  SwigType_remember_mangleddata(mangled, NewStringf("\"%s\"", pname));
-	  Delete(type);
-	  Delete(mangled);
-	}
+          SwigType_add_pointer(type);
+          String *mangled = SwigType_manglestr(type);
+          SwigType_remember_mangleddata(mangled, NewStringf("\"%s\"", pname));
+          Delete(type);
+          Delete(mangled);
+        }
       }
     }
     SwigType_emit_type_table(f_runtime, type_table);
@@ -542,9 +542,9 @@ public:
        *   has been specified, so we do not output them
        */
       if (!dest_package) {
-	Printv(base, "\n# ---------- BASE METHODS -------------\n\n", "package ", namespace_module, ";\n\n", NIL);
+        Printv(base, "\n# ---------- BASE METHODS -------------\n\n", "package ", namespace_module, ";\n\n", NIL);
 
-	/* Write out the TIE method */
+        /* Write out the TIE method */
 
         Printv(base,
                "sub TIEHASH {\n",
@@ -553,39 +553,39 @@ public:
                "}\n\n",
                NIL);
 
-	/* Output a CLEAR method.   This is just a place-holder, but by providing it we
-	 * can make declarations such as
-	 *     %$u = ( x => 2, y=>3, z =>4 );
-	 *
-	 * Where x,y,z are the members of some C/C++ object. */
+        /* Output a CLEAR method.   This is just a place-holder, but by providing it we
+         * can make declarations such as
+         *     %$u = ( x => 2, y=>3, z =>4 );
+         *
+         * Where x,y,z are the members of some C/C++ object. */
 
-	Printf(base, "sub CLEAR { }\n\n");
+        Printf(base, "sub CLEAR { }\n\n");
 
-	/* Output default firstkey/nextkey methods */
+        /* Output default firstkey/nextkey methods */
 
-	Printf(base, "sub FIRSTKEY { }\n\n");
-	Printf(base, "sub NEXTKEY { }\n\n");
+        Printf(base, "sub FIRSTKEY { }\n\n");
+        Printf(base, "sub NEXTKEY { }\n\n");
 
-	/* Output a FETCH method.  This is actually common to all classes */
-	Printv(base,
-	       "sub FETCH {\n",
+        /* Output a FETCH method.  This is actually common to all classes */
+        Printv(base,
+               "sub FETCH {\n",
                "    my ($self,$field) = @_;\n",
                "    my $member_func = \"swig_${field}_get\";\n",
                "    $self->$member_func();\n",
                "}\n\n",
                NIL);
 
-	/* Output a STORE method.   This is also common to all classes (might move to base class) */
+        /* Output a STORE method.   This is also common to all classes (might move to base class) */
 
-	Printv(base,
-	       "sub STORE {\n",
+        Printv(base,
+               "sub STORE {\n",
                "    my ($self,$field,$newval) = @_;\n",
                "    my $member_func = \"swig_${field}_set\";\n",
                "    $self->$member_func($newval);\n",
                "}\n\n",
                NIL);
 
-	/* Output a 'this' method */
+        /* Output a 'this' method */
 
         Printv(base,
                "sub this {\n",
@@ -594,7 +594,7 @@ public:
                "}\n\n",
                NIL);
 
-	Printf(f_pm, "%s", base);
+        Printf(f_pm, "%s", base);
       }
 
       /* Emit function stubs for stand-alone functions */
@@ -606,9 +606,9 @@ public:
       Printf(f_pm, "%s", pm);
 
       if (Len(const_stubs) > 0) {
-	/* Emit constant stubs */
-	Printf(f_pm, "\n# ------- CONSTANT STUBS -------\n\n");
-	Printf(f_pm, "%s", const_stubs);
+        /* Emit constant stubs */
+        Printf(f_pm, "\n# ------- CONSTANT STUBS -------\n\n");
+        Printf(f_pm, "%s", const_stubs);
       }
 
       /* Emit variable stubs */
@@ -658,7 +658,7 @@ public:
     if (blessed) {
       String *modname = Getattr(n, "module");
       if (modname) {
-	Printf(f_pm, "require %s;\n", modname);
+        Printf(f_pm, "require %s;\n", modname);
       }
     }
     return Language::importDirective(n);
@@ -690,7 +690,7 @@ public:
       overname = Getattr(n, "sym:overname");
     } else {
       if (!addSymbol(iname, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     f = NewWrapper();
@@ -703,7 +703,7 @@ public:
     }
     Setattr(n, "wrap:name", wname);
     Printv(f->def, "XS(", wname, ") {\n", "{\n",	/* scope to destroy C++ objects before croaking */
-	   NIL);
+           NIL);
 
     emit_parameter_variables(l, f);
     emit_attach_parmmaps(l, f);
@@ -730,7 +730,7 @@ public:
       /* Skip ignored arguments */
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -739,59 +739,59 @@ public:
       sprintf(source, "ST(%d)", i);
 
       if (i >= num_required) {
-	Printf(f->code, "    if (items > %d) {\n", i);
+        Printf(f->code, "    if (items > %d) {\n", i);
       }
       if ((tm = Getattr(p, "tmap:in"))) {
-	Replaceall(tm, "$input", source);
-	Setattr(p, "emit:input", source);	/* Save input location */
+        Replaceall(tm, "$input", source);
+        Setattr(p, "emit:input", source);	/* Save input location */
 
-	if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
-	  Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	} else {
-	  Replaceall(tm, "$disown", "0");
-	}
+        if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
+          Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+        } else {
+          Replaceall(tm, "$disown", "0");
+        }
 
-	Printf(f->code, "%s\n", tm);
-	p = Getattr(p, "tmap:in:next");
+        Printf(f->code, "%s\n", tm);
+        p = Getattr(p, "tmap:in:next");
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	p = nextSibling(p);
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        p = nextSibling(p);
       }
       if (i >= num_required) {
-	Printf(f->code, "    }\n");
+        Printf(f->code, "    }\n");
       }
     }
 
     if (varargs) {
       if (p && (tm = Getattr(p, "tmap:in"))) {
-	sprintf(source, "ST(%d)", i);
-	Replaceall(tm, "$input", source);
-	Setattr(p, "emit:input", source);
-	Printf(f->code, "if (items >= %d) {\n", i);
-	Printv(f->code, tm, "\n", NIL);
-	Printf(f->code, "}\n");
+        sprintf(source, "ST(%d)", i);
+        Replaceall(tm, "$input", source);
+        Setattr(p, "emit:input", source);
+        Printf(f->code, "if (items >= %d) {\n", i);
+        Printv(f->code, tm, "\n", NIL);
+        Printf(f->code, "}\n");
       }
     }
 
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (i = 0, p = l; p; i++) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -799,26 +799,26 @@ public:
     num_saved = 0;
     for (i = 0, p = l; p; i++) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	SwigType *t = Getattr(p, "type");
-	Replaceall(tm, "$result", "ST(argvi)");
-	if (is_shadow(t)) {
-	  Replaceall(tm, "$shadow", "SWIG_SHADOW");
-	} else {
-	  Replaceall(tm, "$shadow", "0");
-	}
+        SwigType *t = Getattr(p, "type");
+        Replaceall(tm, "$result", "ST(argvi)");
+        if (is_shadow(t)) {
+          Replaceall(tm, "$shadow", "SWIG_SHADOW");
+        } else {
+          Replaceall(tm, "$shadow", "0");
+        }
 
-	String *in = Getattr(p, "emit:input");
-	if (in) {
-	  sprintf(temp, "_saved[%d]", num_saved);
-	  Replaceall(tm, "$arg", temp);
-	  Replaceall(tm, "$input", temp);
-	  Printf(f->code, "_saved[%d] = %s;\n", num_saved, in);
-	  num_saved++;
-	}
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        String *in = Getattr(p, "emit:input");
+        if (in) {
+          sprintf(temp, "_saved[%d]", num_saved);
+          Replaceall(tm, "$arg", temp);
+          Replaceall(tm, "$input", temp);
+          Printf(f->code, "_saved[%d] = %s;\n", num_saved, in);
+          num_saved++;
+        }
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -833,9 +833,9 @@ public:
       Wrapper_add_local(f, "director", "Swig::Director *director = 0");
       Append(f->code, "director = SWIG_DIRECTOR_CAST(arg1);\n");
       if (dirprot_mode() && !is_public(n)) {
-	Printf(f->code, "if (!director || !(director->swig_get_inner(\"%s\"))) {\n", name);
-	Printf(f->code, "SWIG_exception_fail(SWIG_RuntimeError, \"accessing protected member %s\");\n", name);
-	Append(f->code, "}\n");
+        Printf(f->code, "if (!director || !(director->swig_get_inner(\"%s\"))) {\n", name);
+        Printf(f->code, "SWIG_exception_fail(SWIG_RuntimeError, \"accessing protected member %s\");\n", name);
+        Append(f->code, "}\n");
       }
       Wrapper_add_local(f, "upcall", "bool upcall = false");
       Printf(f->code, "upcall = director && SvSTASH(SvRV(ST(0))) == gv_stashpv(director->swig_get_class(), 0);\n");
@@ -862,14 +862,14 @@ public:
       SwigType *t = Getattr(n, "type");
       Replaceall(tm, "$result", "ST(argvi)");
       if (is_shadow(t)) {
-	Replaceall(tm, "$shadow", "SWIG_SHADOW");
+        Replaceall(tm, "$shadow", "SWIG_SHADOW");
       } else {
-	Replaceall(tm, "$shadow", "0");
+        Replaceall(tm, "$shadow", "0");
       }
       if (GetFlag(n, "feature:new")) {
-	Replaceall(tm, "$owner", "SWIG_OWNER");
+        Replaceall(tm, "$owner", "SWIG_OWNER");
       } else {
-	Replaceall(tm, "$owner", "0");
+        Replaceall(tm, "$owner", "0");
       }
       Printf(f->code, "%s\n", tm);
     } else {
@@ -887,7 +887,7 @@ public:
 
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printf(f->code, "%s\n", tm);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -897,10 +897,10 @@ public:
 
     if (director_method) {
       if ((tm = Swig_typemap_lookup("directorfree", n, Swig_cresult_name(), 0))) {
-	Replaceall(tm, "$input", Swig_cresult_name());
-	Replaceall(tm, "$result", "ST(argvi)");
-	Printf(f->code, "%s\n", tm);
-	Delete(tm);
+        Replaceall(tm, "$input", Swig_cresult_name());
+        Replaceall(tm, "$result", "ST(argvi)");
+        Printf(f->code, "%s\n", tm);
+        Delete(tm);
       }
     }
 
@@ -952,7 +952,7 @@ public:
     }
     if (!Getattr(n, "sym:nextSibling")) {
       if (export_all) {
-	Printf(exported, "%s ", iname);
+        Printf(exported, "%s ", iname);
       }
 
       /* --------------------------------------------------------------------
@@ -960,7 +960,7 @@ public:
        * -------------------------------------------------------------------- */
 
       if ((blessed) && (!member_func)) {
-	Printv(func_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
+        Printv(func_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
 
     }
@@ -1002,14 +1002,14 @@ public:
       /* Check for a few typemaps */
       tm = Swig_typemap_lookup("varin", n, name, 0);
       if (tm) {
-	Replaceall(tm, "$input", "sv");
-	/* Printf(setf->code,"%s\n", tm); */
-	emit_action_code(n, setf->code, tm);
+        Replaceall(tm, "$input", "sv");
+        /* Printf(setf->code,"%s\n", tm); */
+        emit_action_code(n, setf->code, tm);
       } else {
-	Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(t, 0));
-	DelWrapper(setf);
-	DelWrapper(getf);
-	return SWIG_NOWRAP;
+        Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(t, 0));
+        DelWrapper(setf);
+        DelWrapper(getf);
+        return SWIG_NOWRAP;
       }
       Printf(setf->code, "fail:\n");
       Printf(setf->code, "    return 1;\n}\n");
@@ -1026,9 +1026,9 @@ public:
     if ((tm = Swig_typemap_lookup("varout", n, name, 0))) {
       Replaceall(tm, "$result", "sv");
       if (is_shadow(t)) {
-	Replaceall(tm, "$shadow", "SWIG_SHADOW");
+        Replaceall(tm, "$shadow", "SWIG_SHADOW");
       } else {
-	Replaceall(tm, "$shadow", "0");
+        Replaceall(tm, "$shadow", "0");
       }
       /* Printf(getf->code,"%s\n", tm); */
       addfail = emit_action_code(n, getf->code, tm);
@@ -1070,12 +1070,12 @@ public:
 
     if (blessed) {
       if (is_shadow(t)) {
-	Printv(var_stubs,
-	       "\nmy %__", iname, "_hash;\n",
-	       "tie %__", iname, "_hash,\"", is_shadow(t), "\", $",
-	       cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(t), ";\n", NIL);
+        Printv(var_stubs,
+               "\nmy %__", iname, "_hash;\n",
+               "tie %__", iname, "_hash,\"", is_shadow(t), "\", $",
+               cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(t), ";\n", NIL);
       } else {
-	Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
+        Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
     }
     if (export_all)
@@ -1115,17 +1115,17 @@ public:
     if ((tm = Swig_typemap_lookup("consttab", n, name, 0))) {
       Replaceall(tm, "$value", value);
       if (is_shadow(type)) {
-	Replaceall(tm, "$shadow", "SWIG_SHADOW");
+        Replaceall(tm, "$shadow", "SWIG_SHADOW");
       } else {
-	Replaceall(tm, "$shadow", "0");
+        Replaceall(tm, "$shadow", "0");
       }
       Printf(constant_tab, "%s,\n", tm);
     } else if ((tm = Swig_typemap_lookup("constcode", n, name, 0))) {
       Replaceall(tm, "$value", value);
       if (is_shadow(type)) {
-	Replaceall(tm, "$shadow", "SWIG_SHADOW");
+        Replaceall(tm, "$shadow", "SWIG_SHADOW");
       } else {
-	Replaceall(tm, "$shadow", "0");
+        Replaceall(tm, "$shadow", "0");
       }
       Printf(f_init, "%s\n", tm);
     } else {
@@ -1135,36 +1135,36 @@ public:
 
     if (blessed) {
       if (is_shadow(type)) {
-	Printv(var_stubs,
-	       "\nmy %__", iname, "_hash;\n",
-	       "tie %__", iname, "_hash,\"", is_shadow(type), "\", $",
-	       cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(type), ";\n", NIL);
+        Printv(var_stubs,
+               "\nmy %__", iname, "_hash;\n",
+               "tie %__", iname, "_hash,\"", is_shadow(type), "\", $",
+               cmodule, "::", iname, ";\n", "$", iname, "= \\%__", iname, "_hash;\n", "bless $", iname, ", ", is_shadow(type), ";\n", NIL);
       } else if (do_constants) {
-	char *dcolon = Strstr(name, "::");
-	if (!dcolon) {
-	  if (Len(const_stubs) == 0 || const_stubs_enum_class != NULL) {
-	    Printf(const_stubs, "package %s;\n", namespace_module);
-	    const_stubs_enum_class = NULL;
-	  }
-	  Printv(const_stubs, "sub ", iname, " () { $", cmodule, "::", iname, " }\n", NIL);
-	} else {
-	  // C++11 strongly-typed enum.
-	  Node *parent = Getattr(n, "parentNode");
-	  if (const_stubs_enum_class != parent) {
-	    Printf(const_stubs, "package %s::%s;\n", namespace_module, Getattr(parent, "sym:name"));
-	    const_stubs_enum_class = parent;
-	  }
-	  Printv(const_stubs, "sub ", Getattr(n, "enumvalueDeclaration:sym:name"), " () { $", cmodule, "::", iname, " }\n", NIL);
-	}
+        char *dcolon = Strstr(name, "::");
+        if (!dcolon) {
+          if (Len(const_stubs) == 0 || const_stubs_enum_class != NULL) {
+            Printf(const_stubs, "package %s;\n", namespace_module);
+            const_stubs_enum_class = NULL;
+          }
+          Printv(const_stubs, "sub ", iname, " () { $", cmodule, "::", iname, " }\n", NIL);
+        } else {
+          // C++11 strongly-typed enum.
+          Node *parent = Getattr(n, "parentNode");
+          if (const_stubs_enum_class != parent) {
+            Printf(const_stubs, "package %s::%s;\n", namespace_module, Getattr(parent, "sym:name"));
+            const_stubs_enum_class = parent;
+          }
+          Printv(const_stubs, "sub ", Getattr(n, "enumvalueDeclaration:sym:name"), " () { $", cmodule, "::", iname, " }\n", NIL);
+        }
       } else {
-	Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
+        Printv(var_stubs, "*", iname, " = *", cmodule, "::", iname, ";\n", NIL);
       }
     }
     if (export_all) {
       if (do_constants && !is_shadow(type)) {
-	Printf(exported, "%s ", name);
+        Printf(exported, "%s ", name);
       } else {
-	Printf(exported, "$%s ", iname);
+        Printf(exported, "$%s ", iname);
       }
     }
     return SWIG_OK;
@@ -1190,24 +1190,24 @@ public:
       SwigType *pt = Getattr(p, "type");
       String *pn = Getattr(p, "name");
       if (!checkAttribute(p,"tmap:in:numinputs","0")) {
-	/* If parameter has been named, use that.   Otherwise, just print a type  */
-	if (SwigType_type(pt) != T_VOID) {
-	  if (Len(pn) > 0) {
-	    Printf(temp, "%s", pn);
-	  } else {
-	    Printf(temp, "%s", SwigType_str(pt, 0));
-	  }
-	}
-	i++;
-	p = nextSibling(p);
-	if (p)
-	  if (!checkAttribute(p,"tmap:in:numinputs","0"))
-	    Putc(',', temp);
+        /* If parameter has been named, use that.   Otherwise, just print a type  */
+        if (SwigType_type(pt) != T_VOID) {
+          if (Len(pn) > 0) {
+            Printf(temp, "%s", pn);
+          } else {
+            Printf(temp, "%s", SwigType_str(pt, 0));
+          }
+        }
+        i++;
+        p = nextSibling(p);
+        if (p)
+          if (!checkAttribute(p,"tmap:in:numinputs","0"))
+            Putc(',', temp);
       } else {
-	p = nextSibling(p);
-	if (p)
-	  if ((i > 0) && (!checkAttribute(p,"tmap:in:numinputs","0")))
-	    Putc(',', temp);
+        p = nextSibling(p);
+        if (p)
+          if ((i > 0) && (!checkAttribute(p,"tmap:in:numinputs","0")))
+            Putc(',', temp);
       }
     }
     Printf(temp, ");");
@@ -1293,12 +1293,12 @@ public:
       actualpackage = Getattr(clsmodule,"name");
 
       if (verbose > 0) {
-	fprintf(stdout, "setclassname: Found actualpackage: %s\n", Char(actualpackage));
+        fprintf(stdout, "setclassname: Found actualpackage: %s\n", Char(actualpackage));
       }
       if ((!compat) && (!Strchr(symname,':'))) {
-	fullname = NewStringf("%s::%s",actualpackage,symname);
+        fullname = NewStringf("%s::%s",actualpackage,symname);
       } else {
-	fullname = NewString(symname);
+        fullname = NewString(symname);
       }
     }
     if (verbose > 0) {
@@ -1314,8 +1314,8 @@ public:
     /* Do some work on the class name */
     if (!Getattr(n, "feature:onlychildren")) {
       if (blessed) {
-	setclassname(n);
-	Append(classlist, n);
+        setclassname(n);
+        Append(classlist, n);
       }
     }
 
@@ -1338,13 +1338,13 @@ public:
       class_name = Getattr(n, "sym:name");
 
       if (!addSymbol(class_name, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
 
       /* Use the fully qualified name of the Perl class */
       if (!compat) {
-	fullclassname = NewStringf("%s::%s", namespace_module, class_name);
+        fullclassname = NewStringf("%s::%s", namespace_module, class_name);
       } else {
-	fullclassname = NewString(class_name);
+        fullclassname = NewString(class_name);
       }
       real_classname = Getattr(n, "name");
       pcode = NewString("");
@@ -1366,70 +1366,70 @@ public:
       Printv(pm, "\n############# Class : ", fullclassname, " ##############\n", "\npackage ", fullclassname, ";\n", NIL);
 
       if (have_operators) {
-	Printf(pm, "use overload\n");
-	Iterator ki;
-	for (ki = First(operators); ki.key; ki = Next(ki)) {
-	  char *name = Char(ki.key);
-	  //        fprintf(stderr,"found name: <%s>\n", name);
-	  if (strstr(name, "__eq__")) {
-	    Printv(pm, tab4, "\"==\" => sub { $_[0]->__eq__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__ne__")) {
-	    Printv(pm, tab4, "\"!=\" => sub { $_[0]->__ne__($_[1])},\n",NIL);
-	    // there are no tests for this in operator_overload_runme.pl
-	    // it is likely to be broken
-	    //	  } else if (strstr(name, "__assign__")) {
-	    //	    Printv(pm, tab4, "\"=\" => sub { $_[0]->__assign__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__str__")) {
-	    Printv(pm, tab4, "'\"\"' => sub { $_[0]->__str__()},\n",NIL);
-	  } else if (strstr(name, "__plusplus__")) {
-	    Printv(pm, tab4, "\"++\" => sub { $_[0]->__plusplus__()},\n",NIL);
-	  } else if (strstr(name, "__minmin__")) {
-	    Printv(pm, tab4, "\"--\" => sub { $_[0]->__minmin__()},\n",NIL);
-	  } else if (strstr(name, "__add__")) {
-	    Printv(pm, tab4, "\"+\" => sub { $_[0]->__add__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__sub__")) {
-	    Printv(pm, tab4, "\"-\" => sub {  if( not $_[2] ) { $_[0]->__sub__($_[1]) }\n",NIL);
-	    Printv(pm, tab8, "elsif( $_[0]->can('__rsub__') ) { $_[0]->__rsub__($_[1]) }\n",NIL);
-	    Printv(pm, tab8, "else { die(\"reverse subtraction not supported\") }\n",NIL);
-	    Printv(pm, tab8, "},\n",NIL);
-	  } else if (strstr(name, "__mul__")) {
-	    Printv(pm, tab4, "\"*\" => sub { $_[0]->__mul__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__div__")) {
-	    Printv(pm, tab4, "\"/\" => sub { $_[0]->__div__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__mod__")) {
-	    Printv(pm, tab4, "\"%\" => sub { $_[0]->__mod__($_[1])},\n",NIL);
-	    // there are no tests for this in operator_overload_runme.pl
-	    // it is likely to be broken
-	    //	  } else if (strstr(name, "__and__")) {
-	    //	    Printv(pm, tab4, "\"&\" => sub { $_[0]->__and__($_[1])},\n",NIL);
+        Printf(pm, "use overload\n");
+        Iterator ki;
+        for (ki = First(operators); ki.key; ki = Next(ki)) {
+          char *name = Char(ki.key);
+          //        fprintf(stderr,"found name: <%s>\n", name);
+          if (strstr(name, "__eq__")) {
+            Printv(pm, tab4, "\"==\" => sub { $_[0]->__eq__($_[1])},\n",NIL);
+          } else if (strstr(name, "__ne__")) {
+            Printv(pm, tab4, "\"!=\" => sub { $_[0]->__ne__($_[1])},\n",NIL);
+            // there are no tests for this in operator_overload_runme.pl
+            // it is likely to be broken
+            //	  } else if (strstr(name, "__assign__")) {
+            //	    Printv(pm, tab4, "\"=\" => sub { $_[0]->__assign__($_[1])},\n",NIL);
+          } else if (strstr(name, "__str__")) {
+            Printv(pm, tab4, "'\"\"' => sub { $_[0]->__str__()},\n",NIL);
+          } else if (strstr(name, "__plusplus__")) {
+            Printv(pm, tab4, "\"++\" => sub { $_[0]->__plusplus__()},\n",NIL);
+          } else if (strstr(name, "__minmin__")) {
+            Printv(pm, tab4, "\"--\" => sub { $_[0]->__minmin__()},\n",NIL);
+          } else if (strstr(name, "__add__")) {
+            Printv(pm, tab4, "\"+\" => sub { $_[0]->__add__($_[1])},\n",NIL);
+          } else if (strstr(name, "__sub__")) {
+            Printv(pm, tab4, "\"-\" => sub {  if( not $_[2] ) { $_[0]->__sub__($_[1]) }\n",NIL);
+            Printv(pm, tab8, "elsif( $_[0]->can('__rsub__') ) { $_[0]->__rsub__($_[1]) }\n",NIL);
+            Printv(pm, tab8, "else { die(\"reverse subtraction not supported\") }\n",NIL);
+            Printv(pm, tab8, "},\n",NIL);
+          } else if (strstr(name, "__mul__")) {
+            Printv(pm, tab4, "\"*\" => sub { $_[0]->__mul__($_[1])},\n",NIL);
+          } else if (strstr(name, "__div__")) {
+            Printv(pm, tab4, "\"/\" => sub { $_[0]->__div__($_[1])},\n",NIL);
+          } else if (strstr(name, "__mod__")) {
+            Printv(pm, tab4, "\"%\" => sub { $_[0]->__mod__($_[1])},\n",NIL);
+            // there are no tests for this in operator_overload_runme.pl
+            // it is likely to be broken
+            //	  } else if (strstr(name, "__and__")) {
+            //	    Printv(pm, tab4, "\"&\" => sub { $_[0]->__and__($_[1])},\n",NIL);
 
-	    // there are no tests for this in operator_overload_runme.pl
-	    // it is likely to be broken
-	    //	  } else if (strstr(name, "__or__")) {
-	    //	    Printv(pm, tab4, "\"|\" => sub { $_[0]->__or__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__gt__")) {
-	    Printv(pm, tab4, "\">\" => sub { $_[0]->__gt__($_[1])},\n",NIL);
+            // there are no tests for this in operator_overload_runme.pl
+            // it is likely to be broken
+            //	  } else if (strstr(name, "__or__")) {
+            //	    Printv(pm, tab4, "\"|\" => sub { $_[0]->__or__($_[1])},\n",NIL);
+          } else if (strstr(name, "__gt__")) {
+            Printv(pm, tab4, "\">\" => sub { $_[0]->__gt__($_[1])},\n",NIL);
           } else if (strstr(name, "__ge__")) {
             Printv(pm, tab4, "\">=\" => sub { $_[0]->__ge__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__not__")) {
-	    Printv(pm, tab4, "\"!\" => sub { $_[0]->__not__()},\n",NIL);
-	  } else if (strstr(name, "__lt__")) {
-	    Printv(pm, tab4, "\"<\" => sub { $_[0]->__lt__($_[1])},\n",NIL);
+          } else if (strstr(name, "__not__")) {
+            Printv(pm, tab4, "\"!\" => sub { $_[0]->__not__()},\n",NIL);
+          } else if (strstr(name, "__lt__")) {
+            Printv(pm, tab4, "\"<\" => sub { $_[0]->__lt__($_[1])},\n",NIL);
           } else if (strstr(name, "__le__")) {
             Printv(pm, tab4, "\"<=\" => sub { $_[0]->__le__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__pluseq__")) {
-	    Printv(pm, tab4, "\"+=\" => sub { $_[0]->__pluseq__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__mineq__")) {
-	    Printv(pm, tab4, "\"-=\" => sub { $_[0]->__mineq__($_[1])},\n",NIL);
-	  } else if (strstr(name, "__neg__")) {
-	    Printv(pm, tab4, "\"neg\" => sub { $_[0]->__neg__()},\n",NIL);
-	  } else {
-	    fprintf(stderr,"Unknown operator: %s\n", name);
-	  }
-	}
-	Printv(pm, tab4,
+          } else if (strstr(name, "__pluseq__")) {
+            Printv(pm, tab4, "\"+=\" => sub { $_[0]->__pluseq__($_[1])},\n",NIL);
+          } else if (strstr(name, "__mineq__")) {
+            Printv(pm, tab4, "\"-=\" => sub { $_[0]->__mineq__($_[1])},\n",NIL);
+          } else if (strstr(name, "__neg__")) {
+            Printv(pm, tab4, "\"neg\" => sub { $_[0]->__neg__()},\n",NIL);
+          } else {
+            fprintf(stderr,"Unknown operator: %s\n", name);
+          }
+        }
+        Printv(pm, tab4,
                "\"=\" => sub { my $class = ref($_[0]); $class->new($_[0]) },\n", NIL);
-	Printv(pm, tab4, "\"fallback\" => 1;\n", NIL);
+        Printv(pm, tab4, "\"fallback\" => 1;\n", NIL);
       }
       // make use strict happy
       Printv(pm, "use vars qw(@ISA %OWNER %ITERATORS %BLESSEDMEMBERS);\n", NIL);
@@ -1441,22 +1441,22 @@ public:
       /* Handle inheritance */
       List *baselist = Getattr(n, "bases");
       if (baselist && Len(baselist)) {
-	Iterator b;
-	b = First(baselist);
-	while (b.item) {
-	  String *bname = Getattr(b.item, "perl5:proxy");
-	  if (!bname) {
-	    b = Next(b);
-	    continue;
-	  }
-	  Printv(pm, " ", bname, NIL);
-	  b = Next(b);
-	}
+        Iterator b;
+        b = First(baselist);
+        while (b.item) {
+          String *bname = Getattr(b.item, "perl5:proxy");
+          if (!bname) {
+            b = Next(b);
+            continue;
+          }
+          Printv(pm, " ", bname, NIL);
+          b = Next(b);
+        }
       }
 
       /* Module comes last */
       if (!compat || Cmp(namespace_module, fullclassname)) {
-	Printv(pm, " ", namespace_module, NIL);
+        Printv(pm, " ", namespace_module, NIL);
       }
 
       Printf(pm, " );\n");
@@ -1464,7 +1464,7 @@ public:
       /* Dump out a hash table containing the pointers that we own */
       Printf(pm, "%%OWNER = ();\n");
       if (have_data_members || have_destructor)
-	Printf(pm, "%%ITERATORS = ();\n");
+        Printf(pm, "%%ITERATORS = ();\n");
 
       /* Dump out the package methods */
 
@@ -1475,9 +1475,9 @@ public:
 
       String *director_disown;
       if (Getattr(n, "perl5:directordisown")) {
-	director_disown = NewStringf("%s%s($self);\n", tab4, Getattr(n, "perl5:directordisown"));
+        director_disown = NewStringf("%s%s($self);\n", tab4, Getattr(n, "perl5:directordisown"));
       } else {
-	director_disown = NewString("");
+        director_disown = NewString("");
       }
       Printv(pm,
              "sub DISOWN {\n",
@@ -1499,38 +1499,38 @@ public:
       Delete(operators);
       operators = 0;
       if (Swig_directorclass(n)) {
-	/* director classes need a way to recover subclass instance attributes */
-	Node *get_attr = NewHash();
-	String *mrename;
-	String *symname = Getattr(n, "sym:name");
-	mrename = Swig_name_disown(NSPACE_TODO, symname);
-	Replaceall(mrename, "disown", "swig_get_attr");
-	String *type = NewString(getClassType());
-	String *name = NewString("self");
-	SwigType_add_pointer(type);
-	Parm *p = NewParm(type, name, n);
-	Delete(name);
-	Delete(type);
-	type = NewString("SV");
-	SwigType_add_pointer(type);
-	String *action = NewString("");
-	Printv(action, "{\n", "  Swig::Director *director = SWIG_DIRECTOR_CAST(arg1);\n",
-	       "  result = sv_newmortal();\n" "  if (director) sv_setsv(result, director->swig_get_self());\n", "}\n", NIL);
-	Setfile(get_attr, Getfile(n));
-	Setline(get_attr, Getline(n));
-	Setattr(get_attr, "wrap:action", action);
-	Setattr(get_attr, "name", mrename);
-	Setattr(get_attr, "sym:name", mrename);
-	Setattr(get_attr, "type", type);
-	Setattr(get_attr, "parms", p);
-	Delete(action);
-	Delete(type);
-	Delete(p);
+        /* director classes need a way to recover subclass instance attributes */
+        Node *get_attr = NewHash();
+        String *mrename;
+        String *symname = Getattr(n, "sym:name");
+        mrename = Swig_name_disown(NSPACE_TODO, symname);
+        Replaceall(mrename, "disown", "swig_get_attr");
+        String *type = NewString(getClassType());
+        String *name = NewString("self");
+        SwigType_add_pointer(type);
+        Parm *p = NewParm(type, name, n);
+        Delete(name);
+        Delete(type);
+        type = NewString("SV");
+        SwigType_add_pointer(type);
+        String *action = NewString("");
+        Printv(action, "{\n", "  Swig::Director *director = SWIG_DIRECTOR_CAST(arg1);\n",
+               "  result = sv_newmortal();\n" "  if (director) sv_setsv(result, director->swig_get_self());\n", "}\n", NIL);
+        Setfile(get_attr, Getfile(n));
+        Setline(get_attr, Getline(n));
+        Setattr(get_attr, "wrap:action", action);
+        Setattr(get_attr, "name", mrename);
+        Setattr(get_attr, "sym:name", mrename);
+        Setattr(get_attr, "type", type);
+        Setattr(get_attr, "parms", p);
+        Delete(action);
+        Delete(type);
+        Delete(p);
 
-	member_func = 1;
-	functionWrapper(get_attr);
-	member_func = 0;
-	Delete(get_attr);
+        member_func = 1;
+        functionWrapper(get_attr);
+        member_func = 0;
+        Delete(get_attr);
 
         Printv(pm,
                "sub FETCH {\n",
@@ -1557,7 +1557,7 @@ public:
                "}\n",
                NIL);
 
-	Delete(mrename);
+        Delete(mrename);
       }
     }
     return SWIG_OK;
@@ -1577,78 +1577,78 @@ public:
     if ((blessed) && (!Getattr(n, "sym:nextSibling"))) {
 
       if (Strstr(symname, "__eq__")) {
-	SetInt(operators, "__eq__", 1);
-	have_operators = 1;
+        SetInt(operators, "__eq__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__ne__")) {
-	SetInt(operators, "__ne__", 1);
-	have_operators = 1;
+        SetInt(operators, "__ne__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__assign__")) {
-	SetInt(operators, "__assign__", 1);
-	have_operators = 1;
+        SetInt(operators, "__assign__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__str__")) {
-	SetInt(operators, "__str__", 1);
-	have_operators = 1;
+        SetInt(operators, "__str__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__add__")) {
-	SetInt(operators, "__add__", 1);
-	have_operators = 1;
+        SetInt(operators, "__add__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__sub__")) {
-	SetInt(operators, "__sub__", 1);
-	have_operators = 1;
+        SetInt(operators, "__sub__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__mul__")) {
-	SetInt(operators, "__mul__", 1);
-	have_operators = 1;
+        SetInt(operators, "__mul__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__div__")) {
-	SetInt(operators, "__div__", 1);
-	have_operators = 1;
+        SetInt(operators, "__div__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__mod__")) {
-	SetInt(operators, "__mod__", 1);
-	have_operators = 1;
+        SetInt(operators, "__mod__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__and__")) {
-	SetInt(operators, "__and__", 1);
-	have_operators = 1;
+        SetInt(operators, "__and__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__or__")) {
-	SetInt(operators, "__or__", 1);
-	have_operators = 1;
+        SetInt(operators, "__or__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__not__")) {
-	SetInt(operators, "__not__", 1);
-	have_operators = 1;
+        SetInt(operators, "__not__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__gt__")) {
-	SetInt(operators, "__gt__", 1);
-	have_operators = 1;
+        SetInt(operators, "__gt__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__ge__")) {
-	SetInt(operators, "__ge__", 1);
-	have_operators = 1;
+        SetInt(operators, "__ge__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__lt__")) {
-	SetInt(operators, "__lt__", 1);
-	have_operators = 1;
+        SetInt(operators, "__lt__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__le__")) {
-	SetInt(operators, "__le__", 1);
-	have_operators = 1;
+        SetInt(operators, "__le__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__neg__")) {
-	SetInt(operators, "__neg__", 1);
-	have_operators = 1;
+        SetInt(operators, "__neg__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__plusplus__")) {
-	SetInt(operators, "__plusplus__", 1);
-	have_operators = 1;
+        SetInt(operators, "__plusplus__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__minmin__")) {
-	SetInt(operators, "__minmin__", 1);
-	have_operators = 1;
+        SetInt(operators, "__minmin__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__mineq__")) {
-	SetInt(operators, "__mineq__", 1);
-	have_operators = 1;
+        SetInt(operators, "__mineq__", 1);
+        have_operators = 1;
       } else if (Strstr(symname, "__pluseq__")) {
-	SetInt(operators, "__pluseq__", 1);
-	have_operators = 1;
+        SetInt(operators, "__pluseq__", 1);
+        have_operators = 1;
       }
 
       if (Getattr(n, "feature:shadow")) {
-	String *plcode = perlcode(Getattr(n, "feature:shadow"), 0);
-	String *plaction = NewStringf("%s::%s", cmodule, Swig_name_member(NSPACE_TODO, class_name, symname));
-	Replaceall(plcode, "$action", plaction);
-	Delete(plaction);
-	Printv(pcode, plcode, NIL);
+        String *plcode = perlcode(Getattr(n, "feature:shadow"), 0);
+        String *plaction = NewStringf("%s::%s", cmodule, Swig_name_member(NSPACE_TODO, class_name, symname));
+        Replaceall(plcode, "$action", plaction);
+        Delete(plaction);
+        Printv(pcode, plcode, NIL);
       } else {
-	Printv(pcode, "*", symname, " = *", cmodule, "::", Swig_name_member(NSPACE_TODO, class_name, symname), ";\n", NIL);
+        Printv(pcode, "*", symname, " = *", cmodule, "::", Swig_name_member(NSPACE_TODO, class_name, symname), ";\n", NIL);
       }
     }
     return SWIG_OK;
@@ -1720,7 +1720,7 @@ public:
       Delete(name);
       Setattr(self, "lname", "O");
       if (parms)
-	set_nextSibling(self, parms);
+        set_nextSibling(self, parms);
       Setattr(n, "parms", self);
       Setattr(n, "hidden", "1");
       Delete(self);
@@ -1730,7 +1730,7 @@ public:
     none_comparison = NewStringf("strcmp(SvPV_nolen(ST(0)), \"%s::%s\") != 0", module, class_name);
     String *saved_director_prot_ctor_code = director_prot_ctor_code;
     director_prot_ctor_code = NewStringf("if ($comparison) { /* subclassed */\n" "  $director_new\n" "} else {\n"
-					 "SWIG_exception_fail(SWIG_RuntimeError, \"accessing abstract class or protected constructor\");\n" "}\n");
+                                         "SWIG_exception_fail(SWIG_RuntimeError, \"accessing abstract class or protected constructor\");\n" "}\n");
     Language::constructorHandler(n);
     Delete(none_comparison);
     none_comparison = saved_nc;
@@ -1740,26 +1740,26 @@ public:
 
     if ((blessed) && (!Getattr(n, "sym:nextSibling"))) {
       if (Getattr(n, "feature:shadow")) {
-	String *plcode = perlcode(Getattr(n, "feature:shadow"), 0);
-	String *plaction = NewStringf("%s::%s", module, Swig_name_member(NSPACE_TODO, class_name, symname));
-	Replaceall(plcode, "$action", plaction);
-	Delete(plaction);
-	Printv(pcode, plcode, NIL);
+        String *plcode = perlcode(Getattr(n, "feature:shadow"), 0);
+        String *plaction = NewStringf("%s::%s", module, Swig_name_member(NSPACE_TODO, class_name, symname));
+        Replaceall(plcode, "$action", plaction);
+        Delete(plaction);
+        Printv(pcode, plcode, NIL);
       } else {
-	if ((Cmp(symname, class_name) == 0)) {
-	  /* Emit a blessed constructor  */
-	  Printf(pcode, "sub new {\n");
-	} else {
-	  /* Constructor doesn't match classname so we'll just use the normal name  */
-	  Printv(pcode, "sub ", Swig_name_construct(NSPACE_TODO, symname), " {\n", NIL);
-	}
+        if ((Cmp(symname, class_name) == 0)) {
+          /* Emit a blessed constructor  */
+          Printf(pcode, "sub new {\n");
+        } else {
+          /* Constructor doesn't match classname so we'll just use the normal name  */
+          Printv(pcode, "sub ", Swig_name_construct(NSPACE_TODO, symname), " {\n", NIL);
+        }
 
-	const char *pkg = getCurrentClass() && Swig_directorclass(getCurrentClass())? "$_[0]" : "shift";
-	Printv(pcode,
-	       "    my $pkg = ", pkg, ";\n",
-	       "    my $self = ", cmodule, "::", Swig_name_construct(NSPACE_TODO, symname), "(@_);\n", "    bless $self, $pkg if defined($self);\n", "}\n\n", NIL);
+        const char *pkg = getCurrentClass() && Swig_directorclass(getCurrentClass())? "$_[0]" : "shift";
+        Printv(pcode,
+               "    my $pkg = ", pkg, ";\n",
+               "    my $self = ", cmodule, "::", Swig_name_construct(NSPACE_TODO, symname), "(@_);\n", "    bless $self, $pkg if defined($self);\n", "}\n\n", NIL);
 
-	have_constructor = 1;
+        have_constructor = 1;
       }
     }
     member_func = 0;
@@ -1776,11 +1776,11 @@ public:
     Language::destructorHandler(n);
     if (blessed) {
       if (Getattr(n, "feature:shadow")) {
-	String *plcode = perlcode(Getattr(n, "feature:shadow"), 0);
-	String *plaction = NewStringf("%s::%s", module, Swig_name_member(NSPACE_TODO, class_name, symname));
-	Replaceall(plcode, "$action", plaction);
-	Delete(plaction);
-	Printv(pcode, plcode, NIL);
+        String *plcode = perlcode(Getattr(n, "feature:shadow"), 0);
+        String *plaction = NewStringf("%s::%s", module, Swig_name_member(NSPACE_TODO, class_name, symname));
+        Replaceall(plcode, "$action", plaction);
+        Delete(plaction);
+        Printv(pcode, plcode, NIL);
       } else {
         Printv(pcode,
                "sub DESTROY {\n",
@@ -1796,7 +1796,7 @@ public:
                "        delete $OWNER{$self};\n",
                "    }\n}\n\n",
                NIL);
-	have_destructor = 1;
+        have_destructor = 1;
       }
     }
     member_func = 0;
@@ -1868,28 +1868,28 @@ public:
       code = Getattr(n, "name");
       value = Getattr(n, "value");
       if (Strcmp(lang, "perl5") == 0) {
-	if (Strcmp(code, "code") == 0) {
-	  /* Dump the value string into the .pm file */
-	  if (value) {
-	    Printf(pragma_include, "%s\n", value);
-	  }
-	} else if (Strcmp(code, "include") == 0) {
-	  /* Include a file into the .pm file */
-	  if (value) {
-	    FILE *f = Swig_include_open(value);
-	    if (!f) {
-	      Swig_error(input_file, line_number, "Unable to locate file %s\n", value);
-	    } else {
-	      char buffer[4096];
-	      while (fgets(buffer, 4095, f)) {
-		Printf(pragma_include, "%s", buffer);
-	      }
-	      fclose(f);
-	    }
-	  }
-	} else {
-	  Swig_error(input_file, line_number, "Unrecognized pragma.\n");
-	}
+        if (Strcmp(code, "code") == 0) {
+          /* Dump the value string into the .pm file */
+          if (value) {
+            Printf(pragma_include, "%s\n", value);
+          }
+        } else if (Strcmp(code, "include") == 0) {
+          /* Include a file into the .pm file */
+          if (value) {
+            FILE *f = Swig_include_open(value);
+            if (!f) {
+              Swig_error(input_file, line_number, "Unable to locate file %s\n", value);
+            } else {
+              char buffer[4096];
+              while (fgets(buffer, 4095, f)) {
+                Printf(pragma_include, "%s", buffer);
+              }
+              fclose(f);
+            }
+          }
+        } else {
+          Swig_error(input_file, line_number, "Unrecognized pragma.\n");
+        }
       }
     }
     return Language::pragmaDirective(n);
@@ -1925,28 +1925,28 @@ public:
     for (si = First(clist); si.item; si = Next(si)) {
       s = si.item;
       if (Len(s)) {
-	char *c = Char(s);
-	while (*c) {
-	  if (!isspace(*c))
-	    break;
-	  initial++;
-	  c++;
-	}
-	if (*c && !isspace(*c))
-	  break;
-	else {
-	  initial = 0;
-	}
+        char *c = Char(s);
+        while (*c) {
+          if (!isspace(*c))
+            break;
+          initial++;
+          c++;
+        }
+        if (*c && !isspace(*c))
+          break;
+        else {
+          initial = 0;
+        }
       }
     }
     while (si.item) {
       s = si.item;
       if (Len(s) > initial) {
-	char *c = Char(s);
-	c += initial;
-	Printv(out, indent, c, "\n", NIL);
+        char *c = Char(s);
+        c += initial;
+        Printv(out, indent, c, "\n", NIL);
       } else {
-	Printv(out, "\n", NIL);
+        Printv(out, "\n", NIL);
       }
       si = Next(si);
     }
@@ -2060,25 +2060,25 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	Wrapper *w = NewWrapper();
-	String *call;
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, classname, parms, 0);
-	call = Swig_csuperclass_call(0, basetype, superparms);
-	Printf(w->def, "%s::%s: %s, Swig::Director(self) { \n", classname, target, call);
-	Printf(w->def, "   SWIG_DIRECTOR_RGTR((%s *)this, this); \n", basetype);
-	Append(w->def, "}\n");
-	Delete(target);
-	Wrapper_print(w, f_directors);
-	Delete(call);
-	DelWrapper(w);
+        Wrapper *w = NewWrapper();
+        String *call;
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, classname, parms, 0);
+        call = Swig_csuperclass_call(0, basetype, superparms);
+        Printf(w->def, "%s::%s: %s, Swig::Director(self) { \n", classname, target, call);
+        Printf(w->def, "   SWIG_DIRECTOR_RGTR((%s *)this, this); \n", basetype);
+        Append(w->def, "}\n");
+        Delete(target);
+        Wrapper_print(w, f_directors);
+        Delete(call);
+        DelWrapper(w);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, classname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, classname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -2112,7 +2112,7 @@ public:
 
     if (Cmp(storage, "virtual") == 0) {
       if (Cmp(value, "0") == 0) {
-	pure_virtual = true;
+        pure_virtual = true;
       }
     }
 
@@ -2149,18 +2149,18 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
-	  String *str = SwigType_str(Getattr(p, "type"), 0);
-	  Append(w->def, str);
-	  Append(declaration, str);
-	  Delete(str);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
+          String *str = SwigType_str(Getattr(p, "type"), 0);
+          Append(w->def, str);
+          Append(declaration, str);
+          Delete(str);
+        }
       }
 
       Append(w->def, ")");
@@ -2176,17 +2176,17 @@ public:
      */
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	}
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        }
       } else {
-	String *cres = SwigType_lstr(returntype, "c_result");
-	Printf(w->code, "%s;\n", cres);
-	Delete(cres);
+        String *cres = SwigType_lstr(returntype, "c_result");
+        Printf(w->code, "%s;\n", cres);
+        Delete(cres);
       }
     }
 
@@ -2198,14 +2198,14 @@ public:
 
     if (ignored_method) {
       if (!pure_virtual) {
-	if (!is_void)
-	  Printf(w->code, "return ");
-	String *super_call = Swig_method_call(super, l);
-	Printf(w->code, "%s;\n", super_call);
-	Delete(super_call);
+        if (!is_void)
+          Printf(w->code, "return ");
+        String *super_call = Swig_method_call(super, l);
+        Printf(w->code, "%s;\n", super_call);
+        Delete(super_call);
       } else {
-	Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	       SwigType_namestr(name));
+        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+               SwigType_namestr(name));
       }
     } else {
       /* attach typemaps to arguments (C/C++ -> Perl) */
@@ -2222,16 +2222,16 @@ public:
       Wrapper_add_local(w, "SP", "dSP");
 
       {
-	String *ptype = Copy(getClassType());
-	SwigType_add_pointer(ptype);
-	String *mangle = SwigType_manglestr(ptype);
+        String *ptype = Copy(getClassType());
+        SwigType_add_pointer(ptype);
+        String *mangle = SwigType_manglestr(ptype);
 
-	Wrapper_add_local(w, "swigself", "SV *swigself");
-	Printf(w->code, "swigself = SWIG_NewPointerObj(SWIG_as_voidptr(this), SWIGTYPE%s, SWIG_SHADOW);\n", mangle);
-	Printf(w->code, "sv_bless(swigself, gv_stashpv(swig_get_class(), 0));\n");
-	Delete(mangle);
-	Delete(ptype);
-	Append(pstack, "XPUSHs(swigself);\n");
+        Wrapper_add_local(w, "swigself", "SV *swigself");
+        Printf(w->code, "swigself = SWIG_NewPointerObj(SWIG_as_voidptr(this), SWIGTYPE%s, SWIG_SHADOW);\n", mangle);
+        Printf(w->code, "sv_bless(swigself, gv_stashpv(swig_get_class(), 0));\n");
+        Delete(mangle);
+        Delete(ptype);
+        Append(pstack, "XPUSHs(swigself);\n");
       }
 
       Parm *p;
@@ -2239,105 +2239,105 @@ public:
 
       int outputs = 0;
       if (!is_void)
-	outputs++;
+        outputs++;
 
       /* build argument list and type conversion string */
       idx = 0;
       p = l;
       while (p) {
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
 
-	if (Getattr(p, "tmap:directorargout") != 0)
-	  outputs++;
+        if (Getattr(p, "tmap:directorargout") != 0)
+          outputs++;
 
-	String *pname = Getattr(p, "name");
-	String *ptype = Getattr(p, "type");
+        String *pname = Getattr(p, "name");
+        String *ptype = Getattr(p, "type");
 
-	if ((tm = Getattr(p, "tmap:directorin")) != 0) {
-	  sprintf(source, "obj%d", idx++);
-	  String *input = NewString(source);
-	  Setattr(p, "emit:directorinput", input);
-	  Replaceall(tm, "$input", input);
-	  Delete(input);
-	  Replaceall(tm, "$owner", "0");
-	  Replaceall(tm, "$shadow", "0");
-	  /* Wrapper_add_localv(w, source, "SV *", source, "= 0", NIL); */
-	  Printv(wrap_args, "SV *", source, ";\n", NIL);
+        if ((tm = Getattr(p, "tmap:directorin")) != 0) {
+          sprintf(source, "obj%d", idx++);
+          String *input = NewString(source);
+          Setattr(p, "emit:directorinput", input);
+          Replaceall(tm, "$input", input);
+          Delete(input);
+          Replaceall(tm, "$owner", "0");
+          Replaceall(tm, "$shadow", "0");
+          /* Wrapper_add_localv(w, source, "SV *", source, "= 0", NIL); */
+          Printv(wrap_args, "SV *", source, ";\n", NIL);
 
-	  Printv(wrap_args, tm, "\n", NIL);
-	  Putc('O', parse_args);
-	  Printv(pstack, "XPUSHs(", source, ");\n", NIL);
-	  p = Getattr(p, "tmap:directorin:next");
-	  continue;
-	} else if (Cmp(ptype, "void")) {
-	  /* special handling for pointers to other C++ director classes.
-	   * ideally this would be left to a typemap, but there is currently no
-	   * way to selectively apply the dynamic_cast<> to classes that have
-	   * directors.  in other words, the type "SwigDirector_$1_lname" only exists
-	   * for classes with directors.  we avoid the problem here by checking
-	   * module.wrap::directormap, but it's not clear how to get a typemap to
-	   * do something similar.  perhaps a new default typemap (in addition
-	   * to SWIGTYPE) called DIRECTORTYPE?
-	   */
-	  if (SwigType_ispointer(ptype) || SwigType_isreference(ptype)) {
-	    Node *module = Getattr(parent, "module");
-	    Node *target = Swig_directormap(module, ptype);
-	    sprintf(source, "obj%d", idx++);
-	    String *nonconst = 0;
-	    /* strip pointer/reference --- should move to Swig/stype.c */
-	    String *nptype = NewString(Char(ptype) + 2);
-	    /* name as pointer */
-	    String *ppname = Copy(pname);
-	    if (SwigType_isreference(ptype)) {
-	      Insert(ppname, 0, "&");
-	    }
-	    /* if necessary, cast away const since Perl doesn't support it! */
-	    if (SwigType_isconst(nptype)) {
-	      nonconst = NewStringf("nc_tmp_%s", pname);
-	      String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
-	      Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
-	      Delete(nonconst_i);
-	      Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
-			   "Target language argument '%s' discards const in director method %s::%s.\n",
-			   SwigType_str(ptype, pname), SwigType_namestr(c_classname), SwigType_namestr(name));
-	    } else {
-	      nonconst = Copy(ppname);
-	    }
-	    Delete(nptype);
-	    Delete(ppname);
-	    String *mangle = SwigType_manglestr(ptype);
-	    if (target) {
-	      String *director = NewStringf("director_%s", mangle);
-	      Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
-	      Wrapper_add_localv(w, source, "SV *", source, "= 0", NIL);
-	      Printf(wrap_args, "%s = SWIG_DIRECTOR_CAST(%s);\n", director, nonconst);
-	      Printf(wrap_args, "if (!%s) {\n", director);
-	      Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	      Append(wrap_args, "} else {\n");
-	      Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
-	      Printf(wrap_args, "SvREFCNT_inc((SV *)%s);\n", source);
-	      Append(wrap_args, "}\n");
-	      Delete(director);
-	    } else {
-	      Wrapper_add_localv(w, source, "SV *", source, "= 0", NIL);
-	      Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	      Printf(pstack, "XPUSHs(sv_2mortal(%s));\n", source);
-	    }
-	    Putc('O', parse_args);
-	    Delete(mangle);
-	    Delete(nonconst);
-	  } else {
-	    Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-			 "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-			 SwigType_namestr(c_classname), SwigType_namestr(name));
-	    status = SWIG_NOWRAP;
-	    break;
-	  }
-	}
-	p = nextSibling(p);
+          Printv(wrap_args, tm, "\n", NIL);
+          Putc('O', parse_args);
+          Printv(pstack, "XPUSHs(", source, ");\n", NIL);
+          p = Getattr(p, "tmap:directorin:next");
+          continue;
+        } else if (Cmp(ptype, "void")) {
+          /* special handling for pointers to other C++ director classes.
+           * ideally this would be left to a typemap, but there is currently no
+           * way to selectively apply the dynamic_cast<> to classes that have
+           * directors.  in other words, the type "SwigDirector_$1_lname" only exists
+           * for classes with directors.  we avoid the problem here by checking
+           * module.wrap::directormap, but it's not clear how to get a typemap to
+           * do something similar.  perhaps a new default typemap (in addition
+           * to SWIGTYPE) called DIRECTORTYPE?
+           */
+          if (SwigType_ispointer(ptype) || SwigType_isreference(ptype)) {
+            Node *module = Getattr(parent, "module");
+            Node *target = Swig_directormap(module, ptype);
+            sprintf(source, "obj%d", idx++);
+            String *nonconst = 0;
+            /* strip pointer/reference --- should move to Swig/stype.c */
+            String *nptype = NewString(Char(ptype) + 2);
+            /* name as pointer */
+            String *ppname = Copy(pname);
+            if (SwigType_isreference(ptype)) {
+              Insert(ppname, 0, "&");
+            }
+            /* if necessary, cast away const since Perl doesn't support it! */
+            if (SwigType_isconst(nptype)) {
+              nonconst = NewStringf("nc_tmp_%s", pname);
+              String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
+              Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
+              Delete(nonconst_i);
+              Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
+                           "Target language argument '%s' discards const in director method %s::%s.\n",
+                           SwigType_str(ptype, pname), SwigType_namestr(c_classname), SwigType_namestr(name));
+            } else {
+              nonconst = Copy(ppname);
+            }
+            Delete(nptype);
+            Delete(ppname);
+            String *mangle = SwigType_manglestr(ptype);
+            if (target) {
+              String *director = NewStringf("director_%s", mangle);
+              Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
+              Wrapper_add_localv(w, source, "SV *", source, "= 0", NIL);
+              Printf(wrap_args, "%s = SWIG_DIRECTOR_CAST(%s);\n", director, nonconst);
+              Printf(wrap_args, "if (!%s) {\n", director);
+              Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+              Append(wrap_args, "} else {\n");
+              Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
+              Printf(wrap_args, "SvREFCNT_inc((SV *)%s);\n", source);
+              Append(wrap_args, "}\n");
+              Delete(director);
+            } else {
+              Wrapper_add_localv(w, source, "SV *", source, "= 0", NIL);
+              Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+              Printf(pstack, "XPUSHs(sv_2mortal(%s));\n", source);
+            }
+            Putc('O', parse_args);
+            Delete(mangle);
+            Delete(nonconst);
+          } else {
+            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
+                         SwigType_namestr(c_classname), SwigType_namestr(name));
+            status = SWIG_NOWRAP;
+            break;
+          }
+        }
+        p = nextSibling(p);
       }
 
       /* add the method name as a PyString */
@@ -2348,7 +2348,7 @@ public:
 
       /* pass the method call on to the Python object */
       if (dirprot_mode() && !is_public(n)) {
-	Printf(w->code, "swig_set_inner(\"%s\", true);\n", name);
+        Printf(w->code, "swig_set_inner(\"%s\", true);\n", name);
       }
 
       Append(w->code, "ENTER;\n");
@@ -2360,22 +2360,22 @@ public:
       Printf(w->code, "call_method(\"%s\", G_EVAL | G_SCALAR);\n", pyname);
 
       if (dirprot_mode() && !is_public(n))
-	Printf(w->code, "swig_set_inner(\"%s\", false);\n", name);
+        Printf(w->code, "swig_set_inner(\"%s\", false);\n", name);
 
       /* exception handling */
       tm = Swig_typemap_lookup("director:except", n, Swig_cresult_name(), 0);
       if (!tm) {
-	tm = Getattr(n, "feature:director:except");
-	if (tm)
-	  tm = Copy(tm);
+        tm = Getattr(n, "feature:director:except");
+        if (tm)
+          tm = Copy(tm);
       }
       Append(w->code, "if (SvTRUE(ERRSV)) {\n");
       Append(w->code, "  PUTBACK;\n  FREETMPS;\n  LEAVE;\n");
       if ((tm) && Len(tm) && (Strcmp(tm, "1") != 0)) {
-	Replaceall(tm, "$error", "ERRSV");
-	Printv(w->code, Str(tm), "\n", NIL);
+        Replaceall(tm, "$error", "ERRSV");
+        Printv(w->code, Str(tm), "\n", NIL);
       } else {
-	Printf(w->code, "  Swig::DirectorMethodException::raise(ERRSV);\n");
+        Printf(w->code, "  Swig::DirectorMethodException::raise(ERRSV);\n");
       }
       Append(w->code, "}\n");
       Delete(tm);
@@ -2393,62 +2393,62 @@ public:
       String *outarg = NewString("");
 
       if (outputs > 1) {
-	Wrapper_add_local(w, "output", "SV *output");
-	Printf(w->code, "if (count != %d) {\n", outputs);
-	Printf(w->code, "  Swig::DirectorTypeMismatchException::raise(\"Perl method %s.%sfailed to return a list.\");\n", classname, pyname);
-	Append(w->code, "}\n");
+        Wrapper_add_local(w, "output", "SV *output");
+        Printf(w->code, "if (count != %d) {\n", outputs);
+        Printf(w->code, "  Swig::DirectorTypeMismatchException::raise(\"Perl method %s.%sfailed to return a list.\");\n", classname, pyname);
+        Append(w->code, "}\n");
       }
 
       idx = 0;
 
       /* marshal return value */
       if (!is_void) {
-	Append(w->code, "SPAGAIN;\n");
-	Printf(w->code, "%s = POPs;\n", Swig_cresult_name());
-	tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
-	if (tm != 0) {
-	  if (outputs > 1) {
-	    Printf(w->code, "output = POPs;\n");
-	    Replaceall(tm, "$input", "output");
-	  } else {
-	    Replaceall(tm, "$input", Swig_cresult_name());
-	  }
-	  char temp[24];
-	  sprintf(temp, "%d", idx);
-	  Replaceall(tm, "$argnum", temp);
+        Append(w->code, "SPAGAIN;\n");
+        Printf(w->code, "%s = POPs;\n", Swig_cresult_name());
+        tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
+        if (tm != 0) {
+          if (outputs > 1) {
+            Printf(w->code, "output = POPs;\n");
+            Replaceall(tm, "$input", "output");
+          } else {
+            Replaceall(tm, "$input", Swig_cresult_name());
+          }
+          char temp[24];
+          sprintf(temp, "%d", idx);
+          Replaceall(tm, "$argnum", temp);
 
-	  /* TODO check this */
-	  if (Getattr(n, "wrap:disown")) {
-	    Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	  } else {
-	    Replaceall(tm, "$disown", "0");
-	  }
-	  Replaceall(tm, "$result", "c_result");
-	  Printv(w->code, tm, "\n", NIL);
-	  Delete(tm);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
-		       SwigType_namestr(c_classname), SwigType_namestr(name));
-	  status = SWIG_ERROR;
-	}
+          /* TODO check this */
+          if (Getattr(n, "wrap:disown")) {
+            Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+          } else {
+            Replaceall(tm, "$disown", "0");
+          }
+          Replaceall(tm, "$result", "c_result");
+          Printv(w->code, tm, "\n", NIL);
+          Delete(tm);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          status = SWIG_ERROR;
+        }
       }
 
       /* marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
-	  if (outputs > 1) {
-	    Printf(w->code, "output = POPs;\n");
-	    Replaceall(tm, "$result", "output");
-	  } else {
-	    Replaceall(tm, "$result", Swig_cresult_name());
-	  }
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
+          if (outputs > 1) {
+            Printf(w->code, "output = POPs;\n");
+            Replaceall(tm, "$result", "output");
+          } else {
+            Replaceall(tm, "$result", Swig_cresult_name());
+          }
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       Delete(parse_args);
@@ -2464,13 +2464,13 @@ public:
 
     if (!is_void) {
       if (!(ignored_method && !pure_virtual)) {
-	String *rettype = SwigType_str(returntype, 0);
-	if (!SwigType_isreference(returntype)) {
-	  Printf(w->code, "return (%s) c_result;\n", rettype);
-	} else {
-	  Printf(w->code, "return (%s) *c_result;\n", rettype);
-	}
-	Delete(rettype);
+        String *rettype = SwigType_str(returntype, 0);
+        if (!SwigType_isreference(returntype)) {
+          Printf(w->code, "return (%s) c_result;\n", rettype);
+        } else {
+          Printf(w->code, "return (%s) *c_result;\n", rettype);
+        }
+        Delete(rettype);
       }
     }
 
@@ -2484,7 +2484,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -2495,10 +2495,10 @@ public:
     if (status == SWIG_OK) {
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -1,5 +1,5 @@
 /* ----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -214,16 +214,16 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int top(Node *n) {
-    /* check if directors are enabled for this module.  note: this 
+    /* check if directors are enabled for this module.  note: this
      * is a "master" switch, without which no director code will be
      * emitted.  %feature("director") statements are also required
      * to enable directors for individual classes or methods.
      *
-     * use %module(directors="1") modulename at the start of the 
+     * use %module(directors="1") modulename at the start of the
      * interface file to enable director generation.
      *
      * TODO: directors are disallowed in conjunction with many command
-     * line options.  Some of them are probably safe, but it will take 
+     * line options.  Some of them are probably safe, but it will take
      * some effort to validate each one.
      */
     {
@@ -426,7 +426,7 @@ public:
 
     Printf(f_pm, "package %s;\n", module);
 
-    /* 
+    /*
      * If the package option has been given we are placing our
      *   symbols into some other packages namespace, so we do not
      *   mess with @ISA or require for that package
@@ -524,7 +524,7 @@ public:
     }
 
     Printf(f_pm, "package %s;\n", module);
-    /* 
+    /*
      * If the package option has been given we are placing our
      *   symbols into some other packages namespace, so we do not
      *   mess with @EXPORT
@@ -538,7 +538,7 @@ public:
     if (blessed) {
 
       /*
-       * These methods will be duplicated if package 
+       * These methods will be duplicated if package
        *   has been specified, so we do not output them
        */
       if (!dest_package) {
@@ -1538,7 +1538,7 @@ public:
                "    my $member_func = \"swig_${field}_get\";\n",
                "    if (not $self->can($member_func)) {\n", NIL);
         Printv(pm, "        my $h = ", cmodule, "::", mrename, "($self);\n", NIL);
-        Printv(pm, 
+        Printv(pm,
                "        return $h->{$field} if $h;\n",
                "    }\n",
                "    return $self->$member_func;\n",
@@ -1766,7 +1766,7 @@ public:
     return SWIG_OK;
   }
 
-  /* ------------------------------------------------------------ 
+  /* ------------------------------------------------------------
    * destructorHandler()
    * ------------------------------------------------------------ */
 
@@ -1956,7 +1956,7 @@ public:
 
   /* ------------------------------------------------------------
    * insertDirective()
-   * 
+   *
    * Hook for %insert directive.
    * ------------------------------------------------------------ */
 
@@ -2170,7 +2170,7 @@ public:
     Append(w->def, " {");
     Append(declaration, ";\n");
 
-    /* declare method return value 
+    /* declare method return value
      * if the return value is a reference or const reference, a specialized typemap must
      * handle it, including declaration of c_result ($result).
      */

--- a/Source/Modules/perl5.cxx
+++ b/Source/Modules/perl5.cxx
@@ -82,8 +82,8 @@ static File *f_directors = 0;
 static File *f_directors_h = 0;
 static File *f_init = 0;
 static File *f_pm = 0;
-static String *pm;		/* Package initialization code */
-static String *magic;		/* Magic variable wrappers     */
+static String *pm;              /* Package initialization code */
+static String *magic;           /* Magic variable wrappers     */
 
 static int staticoption = 0;
 
@@ -92,26 +92,26 @@ static int          verbose = 0;
 
 /* The following variables are used to manage Perl5 classes */
 
-static int blessed = 1;		/* Enable object oriented features */
-static int do_constants = 0;	/* Constant wrapping */
-static List *classlist = 0;	/* List of classes */
+static int blessed = 1;         /* Enable object oriented features */
+static int do_constants = 0;    /* Constant wrapping */
+static List *classlist = 0;     /* List of classes */
 static int have_constructor = 0;
 static int have_destructor = 0;
 static int have_data_members = 0;
-static String *class_name = 0;	/* Name of the class (what Perl thinks it is) */
-static String *real_classname = 0;	/* Real name of C/C++ class */
+static String *class_name = 0;  /* Name of the class (what Perl thinks it is) */
+static String *real_classname = 0;      /* Real name of C/C++ class */
 static String *fullclassname = 0;
 
-static String *pcode = 0;	/* Perl code associated with each class */
+static String *pcode = 0;       /* Perl code associated with each class */
                                                   /* static  String   *blessedmembers = 0;     *//* Member data associated with each class */
-static int member_func = 0;	/* Set to 1 when wrapping a member function */
-static String *func_stubs = 0;	/* Function stubs */
-static String *const_stubs = 0;	/* Constant stubs */
+static int member_func = 0;     /* Set to 1 when wrapping a member function */
+static String *func_stubs = 0;  /* Function stubs */
+static String *const_stubs = 0; /* Constant stubs */
 static Node *const_stubs_enum_class = 0; /* Node for enum class if we're currently generating one */
-static String *var_stubs = 0;	/* Variable stubs */
-static String *exported = 0;	/* Exported symbols */
+static String *var_stubs = 0;   /* Variable stubs */
+static String *exported = 0;    /* Exported symbols */
 static String *pragma_include = 0;
-static String *additional_perl_code = 0;	/* Additional Perl code from %perlcode %{ ... %} */
+static String *additional_perl_code = 0;        /* Additional Perl code from %perlcode %{ ... %} */
 static Hash *operators = 0;
 static int have_operators = 0;
 
@@ -481,7 +481,7 @@ public:
         if (pname) {
           SwigType *type = Getattr(cls.item, "classtypeobj");
           if (!type)
-            continue;		/* If unnamed class, no type will be found */
+            continue;           /* If unnamed class, no type will be found */
           type = Copy(type);
 
           SwigType_add_pointer(type);
@@ -702,7 +702,7 @@ public:
       Append(wname, overname);
     }
     Setattr(n, "wrap:name", wname);
-    Printv(f->def, "XS(", wname, ") {\n", "{\n",	/* scope to destroy C++ objects before croaking */
+    Printv(f->def, "XS(", wname, ") {\n", "{\n",        /* scope to destroy C++ objects before croaking */
            NIL);
 
     emit_parameter_variables(l, f);
@@ -743,7 +743,7 @@ public:
       }
       if ((tm = Getattr(p, "tmap:in"))) {
         Replaceall(tm, "$input", source);
-        Setattr(p, "emit:input", source);	/* Save input location */
+        Setattr(p, "emit:input", source);       /* Save input location */
 
         if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
           Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
@@ -1377,8 +1377,8 @@ public:
             Printv(pm, tab4, "\"!=\" => sub { $_[0]->__ne__($_[1])},\n",NIL);
             // there are no tests for this in operator_overload_runme.pl
             // it is likely to be broken
-            //	  } else if (strstr(name, "__assign__")) {
-            //	    Printv(pm, tab4, "\"=\" => sub { $_[0]->__assign__($_[1])},\n",NIL);
+            //    } else if (strstr(name, "__assign__")) {
+            //      Printv(pm, tab4, "\"=\" => sub { $_[0]->__assign__($_[1])},\n",NIL);
           } else if (strstr(name, "__str__")) {
             Printv(pm, tab4, "'\"\"' => sub { $_[0]->__str__()},\n",NIL);
           } else if (strstr(name, "__plusplus__")) {
@@ -1400,13 +1400,13 @@ public:
             Printv(pm, tab4, "\"%\" => sub { $_[0]->__mod__($_[1])},\n",NIL);
             // there are no tests for this in operator_overload_runme.pl
             // it is likely to be broken
-            //	  } else if (strstr(name, "__and__")) {
-            //	    Printv(pm, tab4, "\"&\" => sub { $_[0]->__and__($_[1])},\n",NIL);
+            //    } else if (strstr(name, "__and__")) {
+            //      Printv(pm, tab4, "\"&\" => sub { $_[0]->__and__($_[1])},\n",NIL);
 
             // there are no tests for this in operator_overload_runme.pl
             // it is likely to be broken
-            //	  } else if (strstr(name, "__or__")) {
-            //	    Printv(pm, tab4, "\"|\" => sub { $_[0]->__or__($_[1])},\n",NIL);
+            //    } else if (strstr(name, "__or__")) {
+            //      Printv(pm, tab4, "\"|\" => sub { $_[0]->__or__($_[1])},\n",NIL);
           } else if (strstr(name, "__gt__")) {
             Printv(pm, tab4, "\">\" => sub { $_[0]->__gt__($_[1])},\n",NIL);
           } else if (strstr(name, "__ge__")) {

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -47,11 +47,11 @@ static File *f_directors_h = 0;
 static String *s_header;
 static String *s_wrappers;
 static String *s_init;
-static String *r_init;          // RINIT user code
-static String *s_shutdown;      // MSHUTDOWN user code
-static String *r_shutdown;      // RSHUTDOWN user code
+static String *r_init;      // RINIT user code
+static String *s_shutdown;  // MSHUTDOWN user code
+static String *r_shutdown;  // RSHUTDOWN user code
 static String *s_vdecl;
-static String *s_cinit;         // consttab initialization code.
+static String *s_cinit;  // consttab initialization code.
 static String *s_oinit;
 static String *s_arginfo;
 static String *s_entry;
@@ -80,7 +80,7 @@ static String *fake_class_name() {
       fake_cs_entry = NewStringf("static const zend_function_entry class_%s_functions[] = {\n", result);
     }
 
-    Printf(s_creation, "static zend_class_entry *SWIG_Php_ce_%s;\n\n",result);
+    Printf(s_creation, "static zend_class_entry *SWIG_Php_ce_%s;\n\n", result);
 
     Printf(s_oinit, "  INIT_CLASS_ENTRY(internal_ce, \"%s\", class_%s_functions);\n", result, result);
     Printf(s_oinit, "  SWIG_Php_ce_%s = zend_register_internal_class(&internal_ce);\n", result);
@@ -122,7 +122,7 @@ static enum {
 } wrapperType = standard;
 
 extern "C" {
-  static void (*r_prevtracefunc) (const SwigType *t, String *mangled, String *clientdata) = 0;
+static void (*r_prevtracefunc)(const SwigType *t, String *mangled, String *clientdata) = 0;
 }
 
 static void SwigPHP_emit_pointer_type_registrations() {
@@ -285,7 +285,8 @@ class PHPTypes {
         }
         String *c = Getattr(php_type_flags, i.item);
         if (c) {
-          if (Len(result) > 0) Append(result, "|");
+          if (Len(result) > 0)
+            Append(result, "|");
           Append(result, c);
         } else {
           SetFlag(classes, i.item);
@@ -312,7 +313,8 @@ class PHPTypes {
 
     List *sorted_classes = SortedKeys(classes, Strcmp);
     for (i = First(sorted_classes); i.item; i = Next(i)) {
-      if (Len(classtypes) > 0) Append(classtypes, "|");
+      if (Len(classtypes) > 0)
+        Append(classtypes, "|");
       Append(classtypes, prefix);
       Append(classtypes, i.item);
     }
@@ -326,10 +328,7 @@ class PHPTypes {
   }
 
 public:
-  PHPTypes(Node *n)
-    : merged_types(NewList()),
-      byref(NULL),
-      num_required(INT_MAX) {
+  PHPTypes(Node *n) : merged_types(NewList()), byref(NULL), num_required(INT_MAX) {
     String *php_type_feature = Getattr(n, "feature:php:type");
     php_type_flag = 0;
     if (php_type_feature != NULL) {
@@ -349,9 +348,13 @@ public:
     Delete(byref);
   }
 
-  void not_all_static() { all_overloads_static = false; }
+  void not_all_static() {
+    all_overloads_static = false;
+  }
 
-  bool get_all_static() const { return all_overloads_static; }
+  bool get_all_static() const {
+    return all_overloads_static;
+  }
 
   void adjust(int num_required_, bool php_constructor) {
     num_required = std::min(num_required, num_required_);
@@ -375,7 +378,7 @@ public:
   // Both merge_list and o_merge_list should be in sorted order.
   static void merge_type_lists(List *merge_list, List *o_merge_list);
 
-  void merge_from(const PHPTypes* o);
+  void merge_from(const PHPTypes *o);
 
   void set_byref(int key) {
     if (!byref) {
@@ -387,7 +390,7 @@ public:
     // If any overload takes a particular parameter by reference then the
     // dispatch function also needs to take that parameter by reference so
     // we can just set unconditionally here.
-    Setitem(byref, key, ""); // Just needs to be something != None.
+    Setitem(byref, key, "");  // Just needs to be something != None.
   }
 
   void emit_arginfo(DOH *item, String *key) {
@@ -405,7 +408,7 @@ public:
         String *k = NewStringf("%s%s", parent, colon_ptr);
         DOH *item = Getattr(all_phptypes, k);
         if (item) {
-          PHPTypes *p = (PHPTypes*)Data(item);
+          PHPTypes *p = (PHPTypes *)Data(item);
           if (!Getmark(item)) {
             p->emit_arginfo(item, k);
           }
@@ -739,7 +742,7 @@ public:
       for (Iterator k = First(sorted_keys); k.item; k = Next(k)) {
         DOH *val = Getattr(all_phptypes, k.item);
         if (!Getmark(val)) {
-          PHPTypes *p = (PHPTypes*)Data(val);
+          PHPTypes *p = (PHPTypes *)Data(val);
           p->emit_arginfo(val, k.item);
         }
       }
@@ -827,10 +830,7 @@ public:
       Printf(f_h, "PHP_RINIT_FUNCTION(%s);\n", module);
 
       Printf(s_init, "PHP_RINIT_FUNCTION(%s)\n{\n", module);
-      Printv(s_init,
-             "/* rinit section */\n",
-             r_init, "\n",
-             NIL);
+      Printv(s_init, "/* rinit section */\n", r_init, "\n", NIL);
 
       Printf(s_init, "  return SUCCESS;\n");
       Printf(s_init, "}\n\n");
@@ -841,12 +841,16 @@ public:
     if (Len(s_shutdown) > 0) {
       Printf(f_h, "PHP_MSHUTDOWN_FUNCTION(%s);\n", module);
 
-      Printv(s_init, "PHP_MSHUTDOWN_FUNCTION(", module, ")\n"
-                     "/* shutdown section */\n"
-                     "{\n",
-                     s_shutdown,
-                     "  return SUCCESS;\n"
-                     "}\n\n", NIL);
+      Printv(s_init,
+             "PHP_MSHUTDOWN_FUNCTION(",
+             module,
+             ")\n"
+             "/* shutdown section */\n"
+             "{\n",
+             s_shutdown,
+             "  return SUCCESS;\n"
+             "}\n\n",
+             NIL);
     }
 
     if (Len(r_shutdown) > 0) {
@@ -899,8 +903,7 @@ public:
       Dump(f_directors, f_begin);
     }
     Printv(f_begin, s_vdecl, s_wrappers, NIL);
-    Printv(f_begin, s_arginfo, "\n\n", all_cs_entry, "\n\n", s_entry,
-        " ZEND_FE_END\n};\n\n", NIL);
+    Printv(f_begin, s_arginfo, "\n\n", all_cs_entry, "\n\n", s_entry, " ZEND_FE_END\n};\n\n", NIL);
     if (fake_cs_entry) {
       Printv(f_begin, fake_cs_entry, " ZEND_FE_END\n};\n\n", NIL);
       Delete(fake_cs_entry);
@@ -952,11 +955,10 @@ public:
     ParmList *l = Getattr(n, "parms");
     if (cname && !Strstr(Getattr(n, "storage"), "friend")) {
       Printf(f_h, "static PHP_METHOD(%s%s,%s);\n", prefix, cname, fname);
-      if (wrapperType != staticmemberfn &&
-          wrapperType != staticmembervar &&
-          !Equal(fname, "__construct")) {
+      if (wrapperType != staticmemberfn && wrapperType != staticmembervar && !Equal(fname, "__construct")) {
         // Skip the first entry in the parameter list which is the this pointer.
-        if (l) l = Getattr(l, "tmap:in:next");
+        if (l)
+          l = Getattr(l, "tmap:in:next");
         // FIXME: does this throw the phptype key value off?
       }
     } else {
@@ -971,7 +973,8 @@ public:
 
     String *arginfo_id = phptypes->get_arginfo_id();
     String *s = cs_entry;
-    if (!s) s = s_entry;
+    if (!s)
+      s = s_entry;
     if (cname && !Strstr(Getattr(n, "storage"), "friend")) {
       Printf(all_cs_entry, " PHP_ME(%s%s,%s,swig_arginfo_%s,%s)\n", prefix, cname, fname, arginfo_id, modes);
     } else {
@@ -1133,10 +1136,14 @@ public:
     Printf(f->code, "\nelse if (strcmp(ZSTR_VAL(arg2),\"thisown\") == 0) {\n");
     Printf(f->code, "arg->newobject = zval_get_long(&args[1]);\n");
     if (Swig_directorclass(class_node)) {
-      Printv(f->code, "if (arg->newobject == 0) {\n",
-                      "  Swig::Director *director = SWIG_DIRECTOR_CAST((", Getattr(class_node, "classtype"), "*)(arg->ptr));\n",
-                      "  if (director) director->swig_disown();\n",
-                      "}\n", NIL);
+      Printv(f->code,
+             "if (arg->newobject == 0) {\n",
+             "  Swig::Director *director = SWIG_DIRECTOR_CAST((",
+             Getattr(class_node, "classtype"),
+             "*)(arg->ptr));\n",
+             "  if (director) director->swig_disown();\n",
+             "}\n",
+             NIL);
     }
     if (swig_base) {
       Printf(f->code, "} else {\nPHP_MN(%s%s___set)(INTERNAL_FUNCTION_PARAM_PASSTHRU);\n", prefix, swig_base);
@@ -1149,10 +1156,9 @@ public:
     Printf(f->code, "return;\n");
     Printf(f->code, "}\n\n\n");
 
-
     Printf(f_h, "PHP_METHOD(%s%s,__get);\n", prefix, class_name);
     Printf(all_cs_entry, " PHP_ME(%s%s,__get,swig_magic_arginfo_get,ZEND_ACC_PUBLIC)\n", prefix, class_name);
-    Printf(f->code, "PHP_METHOD(%s%s,__get) {\n",prefix, class_name);
+    Printf(f->code, "PHP_METHOD(%s%s,__get) {\n", prefix, class_name);
 
     Printf(f->code, "  swig_object_wrapper *arg = SWIG_Z_FETCH_OBJ_P(ZEND_THIS);\n");
     Printf(f->code, "  zval args[1];\n  zend_string *arg2 = 0;\n\n");
@@ -1182,10 +1188,9 @@ public:
     Printf(f->code, "return;\n");
     Printf(f->code, "}\n\n\n");
 
-
     Printf(f_h, "PHP_METHOD(%s%s,__isset);\n", prefix, class_name);
     Printf(all_cs_entry, " PHP_ME(%s%s,__isset,swig_magic_arginfo_isset,ZEND_ACC_PUBLIC)\n", prefix, class_name);
-    Printf(f->code, "PHP_METHOD(%s%s,__isset) {\n",prefix, class_name);
+    Printf(f->code, "PHP_METHOD(%s%s,__isset) {\n", prefix, class_name);
 
     Printf(f->code, "  swig_object_wrapper *arg = SWIG_Z_FETCH_OBJ_P(ZEND_THIS);\n");
     Printf(f->code, "  zval args[1];\n  zend_string *arg2 = 0;\n\n");
@@ -1370,7 +1375,7 @@ public:
         key = NewStringf(":%s", wname);
       }
 
-      PHPTypes *p = (PHPTypes*)GetVoid(all_phptypes, key);
+      PHPTypes *p = (PHPTypes *)GetVoid(all_phptypes, key);
       if (p) {
         // We already have an entry so use it.
         phptypes = p;
@@ -1399,9 +1404,8 @@ public:
           Printv(f->def, "static PHP_METHOD(", prefix, class_name, ",", wname, ") {\n", NIL);
         } else {
           if (wrap_nonclass_global) {
-            Printv(f->def, "static PHP_METHOD(", fake_class_name(), ",", wname, ") {\n",
-                           "  PHP_FN(", wname, ")(INTERNAL_FUNCTION_PARAM_PASSTHRU);\n",
-                           "}\n\n", NIL);
+            Printv(
+              f->def, "static PHP_METHOD(", fake_class_name(), ",", wname, ") {\n", "  PHP_FN(", wname, ")(INTERNAL_FUNCTION_PARAM_PASSTHRU);\n", "}\n\n", NIL);
           }
 
           if (wrap_nonclass_fake_class) {
@@ -1450,7 +1454,7 @@ public:
 
     // NOTE: possible we ignore this_ptr as a param for native constructor
 
-    if (numopt > 0) {           // membervariable wrappers do not have optional args
+    if (numopt > 0) {  // membervariable wrappers do not have optional args
       Wrapper_add_local(f, "arg_count", "int arg_count");
       Printf(f->code, "arg_count = ZEND_NUM_ARGS();\n");
       Printf(f->code, "if(arg_count<%d || arg_count>%d ||\n", num_required, num_arguments);
@@ -1501,7 +1505,8 @@ public:
       }
 
       phptypes->process_phptype(p, i + 1, "tmap:in:phptype");
-      if (GetFlag(p, "tmap:in:byref")) phptypes->set_byref(i + 1);
+      if (GetFlag(p, "tmap:in:byref"))
+        phptypes->set_byref(i + 1);
 
       String *source = NewStringf("args[%d]", i);
       Replaceall(tm, "$input", source);
@@ -1685,8 +1690,8 @@ public:
    * properties on a dummy class) so just let SWIG do its default thing and
    * wrap them as name_get() and name_set().
    */
-  //virtual int globalvariableHandler(Node *n) {
-  //}
+  // virtual int globalvariableHandler(Node *n) {
+  // }
 
   /* ------------------------------------------------------------
    * constantWrapper()
@@ -1806,9 +1811,9 @@ public:
     Printf(all_cs_entry, "static const zend_function_entry class_%s_functions[] = {\n", class_name);
 
     // namespace code to introduce namespaces into wrapper classes.
-    //if (nameSpace != NULL)
-      //Printf(s_oinit, "INIT_CLASS_ENTRY(internal_ce, \"%s\\\\%s\", class_%s_functions);\n", nameSpace, class_name, class_name);
-    //else
+    // if (nameSpace != NULL)
+    // Printf(s_oinit, "INIT_CLASS_ENTRY(internal_ce, \"%s\\\\%s\", class_%s_functions);\n", nameSpace, class_name, class_name);
+    // else
     Printf(s_oinit, "  INIT_CLASS_ENTRY(internal_ce, \"%s%s\", class_%s_functions);\n", prefix, class_name, class_name);
 
     if (shadow) {
@@ -1829,8 +1834,12 @@ public:
               /* Warn about multiple inheritance for additional base class(es) */
               String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
               String *baseclassname = SwigType_str(Getattr(base.item, "name"), 0);
-              Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE, input_file, line_number,
-                           "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n", proxyclassname, baseclassname);
+              Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE,
+                           input_file,
+                           line_number,
+                           "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n",
+                           proxyclassname,
+                           baseclassname);
             }
           }
           base = Next(base);
@@ -1845,8 +1854,12 @@ public:
        */
       if (base_class) {
         String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
-        Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE, input_file, line_number,
-                     "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n", proxyclassname, base_class);
+        Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE,
+                     input_file,
+                     line_number,
+                     "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n",
+                     proxyclassname,
+                     base_class);
       }
       base_class = NewString("Exception");
     }
@@ -1861,7 +1874,9 @@ public:
     } else {
       Printf(s_oinit, "  {\n");
       Printf(s_oinit, "    swig_type_info *type_info = SWIG_MangledTypeQueryModule(swig_module.next, &swig_module, \"_p_%s\");\n", base_class);
-      Printf(s_oinit, "    SWIG_Php_ce_%s = zend_register_internal_class_ex(&internal_ce, (zend_class_entry*)(type_info ? type_info->clientdata : NULL));\n", class_name);
+      Printf(s_oinit,
+             "    SWIG_Php_ce_%s = zend_register_internal_class_ex(&internal_ce, (zend_class_entry*)(type_info ? type_info->clientdata : NULL));\n",
+             class_name);
       Printf(s_oinit, "  }\n");
     }
 
@@ -1896,11 +1911,7 @@ public:
         // variables declared in the PHP C API - these we can use at MINIT
         // time, so we special case them.  This will also be a little faster
         // than looking up by name.
-        Printv(s_header,
-               "#ifdef __cplusplus\n",
-               "extern \"C\" {\n",
-               "#endif\n",
-               NIL);
+        Printv(s_header, "#ifdef __cplusplus\n", "extern \"C\" {\n", "#endif\n", NIL);
 
         String *r_init_prefix = NewStringEmpty();
 
@@ -1911,24 +1922,36 @@ public:
           // We generate conditional code in both minit and rinit - then we or the user
           // just need to define SWIG_PHP_INTERFACE_xxx_CE (and optionally
           // SWIG_PHP_INTERFACE_xxx_HEADER) to handle interface `xxx` at minit-time.
-          Printv(s_header,
-                 "#ifdef SWIG_PHP_INTERFACE_", interface, "_HEADER\n",
-                 "# include SWIG_PHP_INTERFACE_", interface, "_HEADER\n",
-                 "#endif\n",
-                 NIL);
+          Printv(s_header, "#ifdef SWIG_PHP_INTERFACE_", interface, "_HEADER\n", "# include SWIG_PHP_INTERFACE_", interface, "_HEADER\n", "#endif\n", NIL);
           Printv(s_oinit,
-                 "#ifdef SWIG_PHP_INTERFACE_", interface, "_CE\n",
-                 "  zend_do_implement_interface(SWIG_Php_ce_", class_name, ", SWIG_PHP_INTERFACE_", interface, "_CE);\n",
+                 "#ifdef SWIG_PHP_INTERFACE_",
+                 interface,
+                 "_CE\n",
+                 "  zend_do_implement_interface(SWIG_Php_ce_",
+                 class_name,
+                 ", SWIG_PHP_INTERFACE_",
+                 interface,
+                 "_CE);\n",
                  "#endif\n",
                  NIL);
           Printv(r_init_prefix,
-                 "#ifndef SWIG_PHP_INTERFACE_", interface, "_CE\n",
+                 "#ifndef SWIG_PHP_INTERFACE_",
+                 interface,
+                 "_CE\n",
                  "  {\n",
-                 "    zend_class_entry *swig_interface_ce = zend_lookup_class(zend_string_init(\"", interface, "\", sizeof(\"", interface, "\") - 1, 0));\n",
+                 "    zend_class_entry *swig_interface_ce = zend_lookup_class(zend_string_init(\"",
+                 interface,
+                 "\", sizeof(\"",
+                 interface,
+                 "\") - 1, 0));\n",
                  "    if (swig_interface_ce)\n",
-                 "      zend_do_implement_interface(SWIG_Php_ce_", class_name, ", swig_interface_ce);\n",
+                 "      zend_do_implement_interface(SWIG_Php_ce_",
+                 class_name,
+                 ", swig_interface_ce);\n",
                  "    else\n",
-                 "      zend_throw_exception(zend_ce_error, \"Interface \\\"", interface, "\\\" not found\", 0);\n",
+                 "      zend_throw_exception(zend_ce_error, \"Interface \\\"",
+                 interface,
+                 "\\\" not found\", 0);\n",
                  "  }\n",
                  "#endif\n",
                  NIL);
@@ -1940,11 +1963,7 @@ public:
         Insert(r_init, 0, r_init_prefix);
         Delete(r_init_prefix);
 
-        Printv(s_header,
-               "#ifdef __cplusplus\n",
-               "}\n",
-               "#endif\n",
-               NIL);
+        Printv(s_header, "#ifdef __cplusplus\n", "}\n", "#endif\n", NIL);
       }
       Delete(interfaces);
     }
@@ -1976,7 +1995,9 @@ public:
         if (!emitted_common_cdestructor) {
           Printf(s_creation, "static zend_object_handlers Swig_Php_common_c_object_handlers;\n\n");
           Printf(s_creation, "static void SWIG_Php_common_c_free_obj(zend_object *object) {free(SWIG_Php_free_obj(object));}\n\n");
-          Printf(s_creation, "static zend_object *SWIG_Php_common_c_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_common_c_object_handlers);}\n");
+          Printf(s_creation,
+                 "static zend_object *SWIG_Php_common_c_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, "
+                 "&Swig_Php_common_c_object_handlers);}\n");
 
           Printf(s_oinit, "  Swig_Php_common_c_object_handlers = Swig_Php_base_object_handlers;\n");
           Printf(s_oinit, "  Swig_Php_common_c_object_handlers.free_obj = SWIG_Php_common_c_free_obj;\n");
@@ -1987,18 +2008,29 @@ public:
         Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_common_c_create_object;\n", class_name);
       } else {
         Printf(s_creation, "static zend_object_handlers %s_object_handlers;\n", class_name);
-        Printf(s_creation, "static zend_object *SWIG_Php_create_object_%s(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &%s_object_handlers);}\n", class_name, class_name);
+        Printf(s_creation,
+               "static zend_object *SWIG_Php_create_object_%s(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &%s_object_handlers);}\n",
+               class_name,
+               class_name);
 
-        Printf(s_creation, "static void SWIG_Php_free_obj_%s(zend_object *object) {",class_name);
+        Printf(s_creation, "static void SWIG_Php_free_obj_%s(zend_object *object) {", class_name);
         String *type = Getattr(n, "classtype");
         // Special case handling the delete call generated by
         // Swig_cppdestructor_call() and generate simpler code.
         if (destructor_action && !Equal(destructor_action, "delete arg1;")) {
-          Printv(s_creation, "\n"
-                 "  ", type, " *arg1 = (" , type, " *)SWIG_Php_free_obj(object);\n"
+          Printv(s_creation,
+                 "\n"
+                 "  ",
+                 type,
+                 " *arg1 = (",
+                 type,
+                 " *)SWIG_Php_free_obj(object);\n"
                  "  if (arg1) {\n"
-                 "    ", destructor_action, "\n"
-                 "  }\n", NIL);
+                 "    ",
+                 destructor_action,
+                 "\n"
+                 "  }\n",
+                 NIL);
         } else {
           Printf(s_creation, "delete (%s *)SWIG_Php_free_obj(object);", type);
         }
@@ -2012,7 +2044,9 @@ public:
       static bool emitted_destructorless_create_object = false;
       if (!emitted_destructorless_create_object) {
         emitted_destructorless_create_object = true;
-        Printf(s_creation, "static zend_object *SWIG_Php_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_base_object_handlers);}\n", class_name);
+        Printf(s_creation,
+               "static zend_object *SWIG_Php_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_base_object_handlers);}\n",
+               class_name);
       }
 
       Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_create_object;\n", class_name);
@@ -2339,7 +2373,9 @@ public:
         Printf(w->code, "%s;\n", super_call);
         Delete(super_call);
       } else {
-        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       }
     } else {
@@ -2384,9 +2420,13 @@ public:
           p = Getattr(p, "tmap:directorin:next");
           continue;
         } else if (Cmp(ptype, "void")) {
-          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-              "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-              SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                       SwigType_str(ptype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_NOWRAP;
           break;
         }
@@ -2456,9 +2496,13 @@ public:
           Printv(w->code, tm, "\n", NIL);
           Delete(tm);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-                       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
-                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use return type %s in director method %s::%s (skipping method).\n",
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_ERROR;
         }
       }
@@ -2534,7 +2578,7 @@ public:
     wrapperType = standard;
     return result;
   }
-};                              /* class PHP */
+}; /* class PHP */
 
 static PHP *maininstance = 0;
 
@@ -2556,7 +2600,8 @@ List *PHPTypes::process_phptype(Node *n, int key, const String_or_char *attribut
   }
 
   DOH *merge_list = Getitem(merged_types, key);
-  if (merge_list == None) return NULL;
+  if (merge_list == None)
+    return NULL;
 
   List *types = Split(phptype, '|', -1);
   String *first_type = Getitem(types, 0);
@@ -2635,7 +2680,7 @@ handled:
   }
 }
 
-void PHPTypes::merge_from(const PHPTypes* o) {
+void PHPTypes::merge_from(const PHPTypes *o) {
   num_required = std::min(num_required, o->num_required);
 
   if (o->byref) {
@@ -2646,8 +2691,7 @@ void PHPTypes::merge_from(const PHPTypes* o) {
       // Start at 1 because we only want to merge parameter types, and key 0 is
       // the return type.
       for (int key = 1; key < len; ++key) {
-        if (Getitem(byref, key) == None &&
-            Getitem(o->byref, key) != None) {
+        if (Getitem(byref, key) == None && Getitem(o->byref, key) != None) {
           Setitem(byref, key, "");
         }
       }
@@ -2661,7 +2705,8 @@ void PHPTypes::merge_from(const PHPTypes* o) {
   for (int key = 0; key < len; ++key) {
     DOH *merge_list = Getitem(merged_types, key);
     // None trumps anything else in the merge.
-    if (merge_list == None) continue;
+    if (merge_list == None)
+      continue;
     DOH *o_merge_list = Getitem(o->merged_types, key);
     if (o_merge_list == None) {
       Setitem(merged_types, key, None);
@@ -2689,7 +2734,7 @@ static void typetrace(const SwigType *ty, String *mangled, String *clientdata) {
     Setattr(raw_pointer_types, mangled, mangled);
   }
   if (r_prevtracefunc)
-    (*r_prevtracefunc) (ty, mangled, clientdata);
+    (*r_prevtracefunc)(ty, mangled, clientdata);
 }
 }
 

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -272,25 +272,25 @@ class PHPTypes {
     String *result = NewStringEmpty();
     if (more_return_types) {
       if (types != None) {
-	merge_type_lists(types, more_return_types);
+        merge_type_lists(types, more_return_types);
       }
     }
     if (types != None) {
       SortList(types, NULL);
       String *prev = NULL;
       for (Iterator i = First(types); i.item; i = Next(i)) {
-	if (prev && Equal(prev, i.item)) {
-	  // Skip duplicates when merging.
-	  continue;
-	}
-	String *c = Getattr(php_type_flags, i.item);
-	if (c) {
-	  if (Len(result) > 0) Append(result, "|");
-	  Append(result, c);
-	} else {
-	  SetFlag(classes, i.item);
-	}
-	prev = i.item;
+        if (prev && Equal(prev, i.item)) {
+          // Skip duplicates when merging.
+          continue;
+        }
+        String *c = Getattr(php_type_flags, i.item);
+        if (c) {
+          if (Len(result) > 0) Append(result, "|");
+          Append(result, c);
+        } else {
+          SetFlag(classes, i.item);
+        }
+        prev = i.item;
       }
     }
 
@@ -303,10 +303,10 @@ class PHPTypes {
       i = Next(i);
       String *parent = this_class;
       while ((parent = Getattr(php_parent_class, parent)) != NULL) {
-	if (GetFlag(classes, parent)) {
-	  Delattr(classes, this_class);
-	  break;
-	}
+        if (GetFlag(classes, parent)) {
+          Delattr(classes, this_class);
+          break;
+        }
       }
     }
 
@@ -334,9 +334,9 @@ public:
     php_type_flag = 0;
     if (php_type_feature != NULL) {
       if (Equal(php_type_feature, "1")) {
-	php_type_flag = 1;
+        php_type_flag = 1;
       } else if (!Equal(php_type_feature, "0")) {
-	php_type_flag = -1;
+        php_type_flag = -1;
       }
     }
     arginfo_id = Copy(Getattr(n, "sym:name"));
@@ -402,18 +402,18 @@ public:
       String *this_class = NewStringWithSize(Char(key), colon);
       String *parent = this_class;
       while ((parent = Getattr(php_parent_class, parent)) != NULL) {
-	String *k = NewStringf("%s%s", parent, colon_ptr);
-	DOH *item = Getattr(all_phptypes, k);
-	if (item) {
-	  PHPTypes *p = (PHPTypes*)Data(item);
-	  if (!Getmark(item)) {
-	    p->emit_arginfo(item, k);
-	  }
-	  merge_from(p);
-	  Delete(k);
-	  break;
-	}
-	Delete(k);
+        String *k = NewStringf("%s%s", parent, colon_ptr);
+        DOH *item = Getattr(all_phptypes, k);
+        if (item) {
+          PHPTypes *p = (PHPTypes*)Data(item);
+          if (!Getmark(item)) {
+            p->emit_arginfo(item, k);
+          }
+          merge_from(p);
+          Delete(k);
+          break;
+        }
+        Delete(k);
       }
       Delete(this_class);
     }
@@ -450,7 +450,7 @@ public:
     // director_frob.
     if (php_type_flag && (php_type_flag > 0 || !has_director_node)) {
       if (!GetFlag(has_directed_descendent, key)) {
-	out_phptype = get_phptype(0, out_phpclasses, Getattr(parent_class_method_return_type, key));
+        out_phptype = get_phptype(0, out_phpclasses, Getattr(parent_class_method_return_type, key));
       }
     }
 
@@ -458,10 +458,10 @@ public:
     String *arginfo_code = NewStringEmpty();
     if (out_phptype) {
       if (Len(out_phpclasses)) {
-	Replace(out_phpclasses, "\\", "\\\\", DOH_REPLACE_ANY);
-	Printf(arginfo_code, "ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(swig_arginfo_###, 0, %d, %s, %s)\n", num_required, out_phpclasses, out_phptype);
+        Replace(out_phpclasses, "\\", "\\\\", DOH_REPLACE_ANY);
+        Printf(arginfo_code, "ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(swig_arginfo_###, 0, %d, %s, %s)\n", num_required, out_phpclasses, out_phptype);
       } else {
-	Printf(arginfo_code, "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(swig_arginfo_###, 0, %d, %s)\n", num_required, out_phptype);
+        Printf(arginfo_code, "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(swig_arginfo_###, 0, %d, %s)\n", num_required, out_phptype);
       }
     } else {
       Printf(arginfo_code, "ZEND_BEGIN_ARG_INFO_EX(swig_arginfo_###, 0, 0, %d)\n", num_required);
@@ -477,17 +477,17 @@ public:
       // FIXME: Should we be doing byref for return value as well?
 
       if (phptype) {
-	if (Len(phpclasses)) {
-	  // We need to double any backslashes (which are PHP namespace
-	  // separators) in the PHP class names as they get turned into
-	  // C strings by the ZEND_ARG_OBJ_TYPE_MASK macro.
-	  Replace(phpclasses, "\\", "\\\\", DOH_REPLACE_ANY);
-	  Printf(arginfo_code, " ZEND_ARG_OBJ_TYPE_MASK(%d,arg%d,%s,%s,NULL)\n", byref, param_count, phpclasses, phptype);
-	} else {
-	  Printf(arginfo_code, " ZEND_ARG_TYPE_MASK(%d,arg%d,%s,NULL)\n", byref, param_count, phptype);
-	}
+        if (Len(phpclasses)) {
+          // We need to double any backslashes (which are PHP namespace
+          // separators) in the PHP class names as they get turned into
+          // C strings by the ZEND_ARG_OBJ_TYPE_MASK macro.
+          Replace(phpclasses, "\\", "\\\\", DOH_REPLACE_ANY);
+          Printf(arginfo_code, " ZEND_ARG_OBJ_TYPE_MASK(%d,arg%d,%s,%s,NULL)\n", byref, param_count, phpclasses, phptype);
+        } else {
+          Printf(arginfo_code, " ZEND_ARG_TYPE_MASK(%d,arg%d,%s,NULL)\n", byref, param_count, phptype);
+        }
       } else {
-	Printf(arginfo_code, " ZEND_ARG_INFO(%d,arg%d)\n", byref, param_count);
+        Printf(arginfo_code, " ZEND_ARG_INFO(%d,arg%d)\n", byref, param_count);
       }
     }
     Printf(arginfo_code, "ZEND_END_ARG_INFO()\n");
@@ -524,19 +524,19 @@ public:
 
     for (int i = 1; i < argc; i++) {
       if (strcmp(argv[i], "-prefix") == 0) {
-	if (argv[i + 1]) {
-	  prefix = NewString(argv[i + 1]);
-	  Swig_mark_arg(i);
-	  Swig_mark_arg(i + 1);
-	  i++;
-	} else {
-	  Swig_arg_error();
-	}
+        if (argv[i + 1]) {
+          prefix = NewString(argv[i + 1]);
+          Swig_mark_arg(i);
+          Swig_mark_arg(i + 1);
+          i++;
+        } else {
+          Swig_arg_error();
+        }
       } else if ((strcmp(argv[i], "-noshadow") == 0)) {
-	shadow = 0;
-	Swig_mark_arg(i);
+        shadow = 0;
+        Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-help") == 0) {
-	fputs(usage, stdout);
+        fputs(usage, stdout);
       }
     }
 
@@ -559,7 +559,7 @@ public:
     if (mod) {
       Node *options = Getattr(mod, "options");
       if (options && Getattr(options, "directors")) {
-	allow_directors();
+        allow_directors();
       }
     }
 
@@ -597,8 +597,8 @@ public:
     if (Swig_directors_enabled()) {
       f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
       if (!f_runtime_h) {
-	FileErrorDisplay(outfile_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -635,19 +635,19 @@ public:
     // see a good way to only do this within our testsuite, but disabling
     // it globally like this shouldn't be problematic.
     Append(f_runtime,
-	   "\n"
-	   "#if defined __GNUC__ && !defined __cplusplus\n"
-	   "# if __GNUC__ >= 4\n"
-	   "#  pragma GCC diagnostic push\n"
-	   "#  pragma GCC diagnostic ignored \"-Wdeclaration-after-statement\"\n"
-	   "# endif\n"
-	   "#endif\n"
-	   "#include \"php.h\"\n"
-	   "#if defined __GNUC__ && !defined __cplusplus\n"
-	   "# if __GNUC__ >= 4\n"
-	   "#  pragma GCC diagnostic pop\n"
-	   "# endif\n"
-	   "#endif\n\n");
+           "\n"
+           "#if defined __GNUC__ && !defined __cplusplus\n"
+           "# if __GNUC__ >= 4\n"
+           "#  pragma GCC diagnostic push\n"
+           "#  pragma GCC diagnostic ignored \"-Wdeclaration-after-statement\"\n"
+           "# endif\n"
+           "#endif\n"
+           "#include \"php.h\"\n"
+           "#if defined __GNUC__ && !defined __cplusplus\n"
+           "# if __GNUC__ >= 4\n"
+           "#  pragma GCC diagnostic pop\n"
+           "# endif\n"
+           "#endif\n\n");
 
     /* Set the module name */
     module = Copy(Getattr(n, "name"));
@@ -737,11 +737,11 @@ public:
     {
       List *sorted_keys = SortedKeys(all_phptypes, Strcmp);
       for (Iterator k = First(sorted_keys); k.item; k = Next(k)) {
-	DOH *val = Getattr(all_phptypes, k.item);
-	if (!Getmark(val)) {
-	  PHPTypes *p = (PHPTypes*)Data(val);
-	  p->emit_arginfo(val, k.item);
-	}
+        DOH *val = Getattr(all_phptypes, k.item);
+        if (!Getmark(val)) {
+          PHPTypes *p = (PHPTypes*)Data(val);
+          p->emit_arginfo(val, k.item);
+        }
       }
       Delete(sorted_keys);
     }
@@ -761,29 +761,29 @@ public:
       Printf(s_init, "    module_%s_functions,\n", module);
       Printf(s_init, "    PHP_MINIT(%s),\n", module);
       if (Len(s_shutdown) > 0) {
-	Printf(s_init, "    PHP_MSHUTDOWN(%s),\n", module);
+        Printf(s_init, "    PHP_MSHUTDOWN(%s),\n", module);
       } else {
-	Printf(s_init, "    NULL, /* No MSHUTDOWN code */\n");
+        Printf(s_init, "    NULL, /* No MSHUTDOWN code */\n");
       }
       if (Len(r_init) > 0) {
-	Printf(s_init, "    PHP_RINIT(%s),\n", module);
+        Printf(s_init, "    PHP_RINIT(%s),\n", module);
       } else {
-	Printf(s_init, "    NULL, /* No RINIT code */\n");
+        Printf(s_init, "    NULL, /* No RINIT code */\n");
       }
       if (Len(r_shutdown) > 0) {
-	Printf(s_init, "    PHP_RSHUTDOWN(%s),\n", module);
+        Printf(s_init, "    PHP_RSHUTDOWN(%s),\n", module);
       } else {
-	Printf(s_init, "    NULL, /* No RSHUTDOWN code */\n");
+        Printf(s_init, "    NULL, /* No RSHUTDOWN code */\n");
       }
       if (Len(pragma_phpinfo) > 0) {
-	Printf(s_init, "    PHP_MINFO(%s),\n", module);
+        Printf(s_init, "    PHP_MINFO(%s),\n", module);
       } else {
-	Printf(s_init, "    NULL, /* No MINFO code */\n");
+        Printf(s_init, "    NULL, /* No MINFO code */\n");
       }
       if (Len(pragma_version) > 0) {
-	Printf(s_init, "    \"%s\",\n", pragma_version);
+        Printf(s_init, "    \"%s\",\n", pragma_version);
       } else {
-	Printf(s_init, "    NO_VERSION_YET,\n");
+        Printf(s_init, "    NO_VERSION_YET,\n");
       }
       Printf(s_init, "    STANDARD_MODULE_PROPERTIES\n");
       Printf(s_init, "};\n\n");
@@ -828,9 +828,9 @@ public:
 
       Printf(s_init, "PHP_RINIT_FUNCTION(%s)\n{\n", module);
       Printv(s_init,
-	     "/* rinit section */\n",
-	     r_init, "\n",
-	     NIL);
+             "/* rinit section */\n",
+             r_init, "\n",
+             NIL);
 
       Printf(s_init, "  return SUCCESS;\n");
       Printf(s_init, "}\n\n");
@@ -842,11 +842,11 @@ public:
       Printf(f_h, "PHP_MSHUTDOWN_FUNCTION(%s);\n", module);
 
       Printv(s_init, "PHP_MSHUTDOWN_FUNCTION(", module, ")\n"
-		     "/* shutdown section */\n"
-		     "{\n",
-		     s_shutdown,
-		     "  return SUCCESS;\n"
-		     "}\n\n", NIL);
+                     "/* shutdown section */\n"
+                     "{\n",
+                     s_shutdown,
+                     "  return SUCCESS;\n"
+                     "}\n\n", NIL);
     }
 
     if (Len(r_shutdown) > 0) {
@@ -900,7 +900,7 @@ public:
     }
     Printv(f_begin, s_vdecl, s_wrappers, NIL);
     Printv(f_begin, s_arginfo, "\n\n", all_cs_entry, "\n\n", s_entry,
-	" ZEND_FE_END\n};\n\n", NIL);
+        " ZEND_FE_END\n};\n\n", NIL);
     if (fake_cs_entry) {
       Printv(f_begin, fake_cs_entry, " ZEND_FE_END\n};\n\n", NIL);
       Delete(fake_cs_entry);
@@ -925,18 +925,18 @@ public:
 
       File *f_phpcode = NewFile(php_filename, "w", SWIG_output_files());
       if (!f_phpcode) {
-	FileErrorDisplay(php_filename);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(php_filename);
+        Exit(EXIT_FAILURE);
       }
 
       Printf(f_phpcode, "<?php\n\n");
 
       if (Len(pragma_incl) > 0) {
-	Printv(f_phpcode, pragma_incl, "\n", NIL);
+        Printv(f_phpcode, pragma_incl, "\n", NIL);
       }
 
       if (Len(pragma_code) > 0) {
-	Printv(f_phpcode, pragma_code, "\n", NIL);
+        Printv(f_phpcode, pragma_code, "\n", NIL);
       }
 
       Delete(f_phpcode);
@@ -953,17 +953,17 @@ public:
     if (cname && !Strstr(Getattr(n, "storage"), "friend")) {
       Printf(f_h, "static PHP_METHOD(%s%s,%s);\n", prefix, cname, fname);
       if (wrapperType != staticmemberfn &&
-	  wrapperType != staticmembervar &&
-	  !Equal(fname, "__construct")) {
-	// Skip the first entry in the parameter list which is the this pointer.
-	if (l) l = Getattr(l, "tmap:in:next");
-	// FIXME: does this throw the phptype key value off?
+          wrapperType != staticmembervar &&
+          !Equal(fname, "__construct")) {
+        // Skip the first entry in the parameter list which is the this pointer.
+        if (l) l = Getattr(l, "tmap:in:next");
+        // FIXME: does this throw the phptype key value off?
       }
     } else {
       if (dispatch) {
-	Printf(f_h, "static ZEND_NAMED_FUNCTION(%s);\n", fname);
+        Printf(f_h, "static ZEND_NAMED_FUNCTION(%s);\n", fname);
       } else {
-	Printf(f_h, "static PHP_FUNCTION(%s);\n", fname);
+        Printf(f_h, "static PHP_FUNCTION(%s);\n", fname);
       }
     }
 
@@ -976,23 +976,23 @@ public:
       Printf(all_cs_entry, " PHP_ME(%s%s,%s,swig_arginfo_%s,%s)\n", prefix, cname, fname, arginfo_id, modes);
     } else {
       if (dispatch) {
-	if (wrap_nonclass_global) {
-	  Printf(s, " ZEND_NAMED_FE(%(lower)s,%s,swig_arginfo_%s)\n", Getattr(n, "sym:name"), fname, arginfo_id);
-	}
+        if (wrap_nonclass_global) {
+          Printf(s, " ZEND_NAMED_FE(%(lower)s,%s,swig_arginfo_%s)\n", Getattr(n, "sym:name"), fname, arginfo_id);
+        }
 
-	if (wrap_nonclass_fake_class) {
-	  (void)fake_class_name();
-	  Printf(fake_cs_entry, " ZEND_NAMED_ME(%(lower)s,%s,swig_arginfo_%s,ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)\n", Getattr(n, "sym:name"), fname, arginfo_id);
-	}
+        if (wrap_nonclass_fake_class) {
+          (void)fake_class_name();
+          Printf(fake_cs_entry, " ZEND_NAMED_ME(%(lower)s,%s,swig_arginfo_%s,ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)\n", Getattr(n, "sym:name"), fname, arginfo_id);
+        }
       } else {
-	if (wrap_nonclass_global) {
-	  Printf(s, " PHP_FE(%s,swig_arginfo_%s)\n", fname, arginfo_id);
-	}
+        if (wrap_nonclass_global) {
+          Printf(s, " PHP_FE(%s,swig_arginfo_%s)\n", fname, arginfo_id);
+        }
 
-	if (wrap_nonclass_fake_class) {
-	  String *fake_class = fake_class_name();
-	  Printf(fake_cs_entry, " PHP_ME(%s,%s,swig_arginfo_%s,ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)\n", fake_class, fname, arginfo_id);
-	}
+        if (wrap_nonclass_fake_class) {
+          String *fake_class = fake_class_name();
+          Printf(fake_cs_entry, " PHP_ME(%s,%s,swig_arginfo_%s,ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)\n", fake_class, fname, arginfo_id);
+        }
       }
     }
   }
@@ -1018,11 +1018,11 @@ public:
 
     if (constructor) {
       if (!Equal(class_name, Getattr(n, "constructorHandler:sym:name"))) {
-	// Renamed constructor - turn into static factory method
-	constructorRenameOverload = true;
-	wname = Copy(Getattr(n, "constructorHandler:sym:name"));
+        // Renamed constructor - turn into static factory method
+        constructorRenameOverload = true;
+        wname = Copy(Getattr(n, "constructorHandler:sym:name"));
       } else {
-	wname = NewString("__construct");
+        wname = NewString("__construct");
       }
     } else if (class_name) {
       wname = Getattr(n, "wrapper:method:name");
@@ -1033,7 +1033,7 @@ public:
     if (constructor) {
       modes = NewString("ZEND_ACC_PUBLIC | ZEND_ACC_CTOR");
       if (constructorRenameOverload) {
-	Append(modes, " | ZEND_ACC_STATIC");
+        Append(modes, " | ZEND_ACC_STATIC");
       }
     } else if (phptypes->get_all_static()) {
       modes = NewString("ZEND_ACC_PUBLIC | ZEND_ACC_STATIC");
@@ -1095,18 +1095,18 @@ public:
     if (!generated_magic_arginfo) {
       // Create arginfo entries for __get, __set and __isset.
       Append(s_arginfo,
-	     "ZEND_BEGIN_ARG_INFO_EX(swig_magic_arginfo_get, 0, 0, 1)\n"
-	     " ZEND_ARG_TYPE_MASK(0,arg1,MAY_BE_STRING,NULL)\n"
-	     "ZEND_END_ARG_INFO()\n");
+             "ZEND_BEGIN_ARG_INFO_EX(swig_magic_arginfo_get, 0, 0, 1)\n"
+             " ZEND_ARG_TYPE_MASK(0,arg1,MAY_BE_STRING,NULL)\n"
+             "ZEND_END_ARG_INFO()\n");
       Append(s_arginfo,
-	     "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(swig_magic_arginfo_set, 0, 1, MAY_BE_VOID)\n"
-	     " ZEND_ARG_TYPE_MASK(0,arg1,MAY_BE_STRING,NULL)\n"
-	     " ZEND_ARG_INFO(0,arg2)\n"
-	     "ZEND_END_ARG_INFO()\n");
+             "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(swig_magic_arginfo_set, 0, 1, MAY_BE_VOID)\n"
+             " ZEND_ARG_TYPE_MASK(0,arg1,MAY_BE_STRING,NULL)\n"
+             " ZEND_ARG_INFO(0,arg2)\n"
+             "ZEND_END_ARG_INFO()\n");
       Append(s_arginfo,
-	     "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(swig_magic_arginfo_isset, 0, 1, MAY_BE_BOOL)\n"
-	     " ZEND_ARG_TYPE_MASK(0,arg1,MAY_BE_STRING,NULL)\n"
-	     "ZEND_END_ARG_INFO()\n");
+             "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(swig_magic_arginfo_isset, 0, 1, MAY_BE_BOOL)\n"
+             " ZEND_ARG_TYPE_MASK(0,arg1,MAY_BE_STRING,NULL)\n"
+             "ZEND_END_ARG_INFO()\n");
       generated_magic_arginfo = true;
     }
 
@@ -1134,9 +1134,9 @@ public:
     Printf(f->code, "arg->newobject = zval_get_long(&args[1]);\n");
     if (Swig_directorclass(class_node)) {
       Printv(f->code, "if (arg->newobject == 0) {\n",
-		      "  Swig::Director *director = SWIG_DIRECTOR_CAST((", Getattr(class_node, "classtype"), "*)(arg->ptr));\n",
-		      "  if (director) director->swig_disown();\n",
-		      "}\n", NIL);
+                      "  Swig::Director *director = SWIG_DIRECTOR_CAST((", Getattr(class_node, "classtype"), "*)(arg->ptr));\n",
+                      "  if (director) director->swig_disown();\n",
+                      "}\n", NIL);
     }
     if (swig_base) {
       Printf(f->code, "} else {\nPHP_MN(%s%s___set)(INTERNAL_FUNCTION_PARAM_PASSTHRU);\n", prefix, swig_base);
@@ -1241,7 +1241,7 @@ public:
     if (strlen(p) > 4) {
       p += strlen(p) - 4;
       if (strcmp(p, "_set") == 0) {
-	return true;
+        return true;
       }
     }
     return false;
@@ -1252,7 +1252,7 @@ public:
     if (strlen(p) > 4) {
       p += strlen(p) - 4;
       if (strcmp(p, "_get") == 0) {
-	return true;
+        return true;
       }
     }
     return false;
@@ -1301,22 +1301,22 @@ public:
       Printf(overloadwname, "%s", Getattr(n, "sym:overname"));
     } else {
       if (!addSymbol(iname, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     if (constructor) {
       if (!Equal(class_name, Getattr(n, "constructorHandler:sym:name"))) {
-	// Renamed constructor - turn into static factory method
-	wname = Copy(Getattr(n, "constructorHandler:sym:name"));
+        // Renamed constructor - turn into static factory method
+        wname = Copy(Getattr(n, "constructorHandler:sym:name"));
       } else {
-	wname = NewString("__construct");
+        wname = NewString("__construct");
       }
     } else if (wrapperType == membervar) {
       wname = Copy(Getattr(n, "membervariableHandler:sym:name"));
       if (is_setter_method(n)) {
-	Append(wname, "_set");
+        Append(wname, "_set");
       } else if (is_getter_method(n)) {
-	Append(wname, "_get");
+        Append(wname, "_get");
       }
     } else if (wrapperType == memberfn) {
       wname = Getattr(n, "memberfunctionHandler:sym:name");
@@ -1325,28 +1325,28 @@ public:
       wname = Getattr(n, "staticmembervariableHandler:sym:name");
 
       /* We get called twice for getter and setter methods. But to maintain
-	 compatibility, Shape::nshapes() is being used for both setter and
-	 getter methods. So using static_setter and static_getter variables
-	 to generate half of the code each time.
+         compatibility, Shape::nshapes() is being used for both setter and
+         getter methods. So using static_setter and static_getter variables
+         to generate half of the code each time.
        */
       static_setter = is_setter_method(n);
 
       if (is_getter_method(n)) {
-	// This is to overcome types that can't be set and hence no setter.
-	if (!Equal(Getattr(n, "feature:immutable"), "1"))
-	  static_getter = true;
+        // This is to overcome types that can't be set and hence no setter.
+        if (!Equal(Getattr(n, "feature:immutable"), "1"))
+          static_getter = true;
       }
     } else if (wrapperType == staticmemberfn) {
       wname = Getattr(n, "staticmemberfunctionHandler:sym:name");
     } else {
       if (class_name) {
-	if (Strstr(Getattr(n, "storage"), "friend") && Cmp(Getattr(n, "view"), "globalfunctionHandler") == 0) {
-	  wname = iname;
-	} else {
-	  wname = Getattr(n, "destructorHandler:sym:name");
-	}
+        if (Strstr(Getattr(n, "storage"), "friend") && Cmp(Getattr(n, "view"), "globalfunctionHandler") == 0) {
+          wname = iname;
+        } else {
+          wname = Getattr(n, "destructorHandler:sym:name");
+        }
       } else {
-	wname = iname;
+        wname = iname;
       }
     }
 
@@ -1365,22 +1365,22 @@ public:
 
       String *key;
       if (class_name && !Strstr(Getattr(n, "storage"), "friend")) {
-	key = NewStringf("%s:%s", class_name, wname);
+        key = NewStringf("%s:%s", class_name, wname);
       } else {
-	key = NewStringf(":%s", wname);
+        key = NewStringf(":%s", wname);
       }
 
       PHPTypes *p = (PHPTypes*)GetVoid(all_phptypes, key);
       if (p) {
-	// We already have an entry so use it.
-	phptypes = p;
-	Delete(key);
+        // We already have an entry so use it.
+        phptypes = p;
+        Delete(key);
       } else {
-	phptypes = new PHPTypes(n);
-	SetVoid(all_phptypes, key, phptypes);
+        phptypes = new PHPTypes(n);
+        SetVoid(all_phptypes, key, phptypes);
       }
       if (!(wrapperType == staticmemberfn || Cmp(Getattr(n, "storage"), "static") == 0)) {
-	phptypes->not_all_static();
+        phptypes->not_all_static();
       }
     }
 
@@ -1395,19 +1395,19 @@ public:
 
     if (!overloaded) {
       if (!static_getter) {
-	if (class_name && !Strstr(Getattr(n, "storage"), "friend")) {
-	  Printv(f->def, "static PHP_METHOD(", prefix, class_name, ",", wname, ") {\n", NIL);
-	} else {
-	  if (wrap_nonclass_global) {
-	    Printv(f->def, "static PHP_METHOD(", fake_class_name(), ",", wname, ") {\n",
-			   "  PHP_FN(", wname, ")(INTERNAL_FUNCTION_PARAM_PASSTHRU);\n",
-			   "}\n\n", NIL);
-	  }
+        if (class_name && !Strstr(Getattr(n, "storage"), "friend")) {
+          Printv(f->def, "static PHP_METHOD(", prefix, class_name, ",", wname, ") {\n", NIL);
+        } else {
+          if (wrap_nonclass_global) {
+            Printv(f->def, "static PHP_METHOD(", fake_class_name(), ",", wname, ") {\n",
+                           "  PHP_FN(", wname, ")(INTERNAL_FUNCTION_PARAM_PASSTHRU);\n",
+                           "}\n\n", NIL);
+          }
 
-	  if (wrap_nonclass_fake_class) {
-	    Printv(f->def, "static PHP_FUNCTION(", wname, ") {\n", NIL);
-	  }
-	}
+          if (wrap_nonclass_fake_class) {
+            Printv(f->def, "static PHP_FUNCTION(", wname, ") {\n", NIL);
+          }
+        }
       }
     } else {
       Printv(f->def, "static ZEND_NAMED_FUNCTION(", overloadwname, ") {\n", NIL);
@@ -1458,15 +1458,15 @@ public:
       Printf(f->code, "\tWRONG_PARAM_COUNT;\n\n");
     } else if (static_setter || static_getter) {
       if (num_arguments == 0) {
-	Printf(f->code, "if(ZEND_NUM_ARGS() == 0) {\n");
+        Printf(f->code, "if(ZEND_NUM_ARGS() == 0) {\n");
       } else {
-	Printf(f->code, "if(ZEND_NUM_ARGS() == %d && zend_get_parameters_array_ex(%d, args) == SUCCESS) {\n", num_arguments, num_arguments);
+        Printf(f->code, "if(ZEND_NUM_ARGS() == %d && zend_get_parameters_array_ex(%d, args) == SUCCESS) {\n", num_arguments, num_arguments);
       }
     } else {
       if (num_arguments == 0) {
-	Printf(f->code, "if(ZEND_NUM_ARGS() != 0) {\n");
+        Printf(f->code, "if(ZEND_NUM_ARGS() != 0) {\n");
       } else {
-	Printf(f->code, "if(ZEND_NUM_ARGS() != %d || zend_get_parameters_array_ex(%d, args) != SUCCESS) {\n", num_arguments, num_arguments);
+        Printf(f->code, "if(ZEND_NUM_ARGS() != %d || zend_get_parameters_array_ex(%d, args) != SUCCESS) {\n", num_arguments, num_arguments);
       }
       Printf(f->code, "WRONG_PARAM_COUNT;\n}\n\n");
     }
@@ -1484,20 +1484,20 @@ public:
     for (i = 0, p = l; i < num_arguments; i++) {
       /* Skip ignored arguments */
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       /* Check if optional */
       if (i >= num_required) {
-	Printf(f->code, "\tif(arg_count > %d) {\n", i);
+        Printf(f->code, "\tif(arg_count > %d) {\n", i);
       }
 
       tm = Getattr(p, "tmap:in");
       if (!tm) {
-	SwigType *pt = Getattr(p, "type");
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	p = nextSibling(p);
-	continue;
+        SwigType *pt = Getattr(p, "type");
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        p = nextSibling(p);
+        continue;
       }
 
       phptypes->process_phptype(p, i + 1, "tmap:in:phptype");
@@ -1508,14 +1508,14 @@ public:
       Setattr(p, "emit:input", source);
       Printf(f->code, "%s\n", tm);
       if (i == 0 && Getattr(p, "self")) {
-	Printf(f->code, "\tif(!arg1) {\n");
-	Printf(f->code, "\t  zend_throw_exception(zend_ce_type_error, \"this pointer is NULL\", 0);\n");
-	Printf(f->code, "\t  return;\n");
-	Printf(f->code, "\t}\n");
+        Printf(f->code, "\tif(!arg1) {\n");
+        Printf(f->code, "\t  zend_throw_exception(zend_ce_type_error, \"this pointer is NULL\", 0);\n");
+        Printf(f->code, "\t  return;\n");
+        Printf(f->code, "\t}\n");
       }
 
       if (i >= num_required) {
-	Printf(f->code, "}\n");
+        Printf(f->code, "}\n");
       }
 
       p = Getattr(p, "tmap:in:next");
@@ -1535,33 +1535,33 @@ public:
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (i = 0, p = l; p; i++) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	Printv(cleanup, tm, "\n", NIL);
-	p = Getattr(p, "tmap:freearg:next");
+        Printv(cleanup, tm, "\n", NIL);
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert argument output code */
     for (i = 0, p = l; p; i++) {
       if ((tm = Getattr(p, "tmap:argout")) && Len(tm)) {
-	Replaceall(tm, "$result", "return_value");
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        Replaceall(tm, "$result", "return_value");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -1591,27 +1591,27 @@ public:
 
     if (class_name && !Strstr(Getattr(n, "storage"), "friend")) {
       if (is_member_director(n)) {
-	String *parent = class_name;
-	while ((parent = Getattr(php_parent_class, parent)) != NULL) {
-	  // Mark this method name as having no return type declaration for all
-	  // classes we're derived from.
-	  SetFlag(has_directed_descendent, NewStringf("%s:%s", parent, wname));
-	}
+        String *parent = class_name;
+        while ((parent = Getattr(php_parent_class, parent)) != NULL) {
+          // Mark this method name as having no return type declaration for all
+          // classes we're derived from.
+          SetFlag(has_directed_descendent, NewStringf("%s:%s", parent, wname));
+        }
       } else if (return_types) {
-	String *parent = class_name;
-	while ((parent = Getattr(php_parent_class, parent)) != NULL) {
-	  String *key = NewStringf("%s:%s", parent, wname);
-	  // The parent class method needs to have a superset of the possible
-	  // return types of methods with the same name in subclasses.
-	  List *v = Getattr(parent_class_method_return_type, key);
-	  if (!v) {
-	    // New entry.
-	    Setattr(parent_class_method_return_type, key, Copy(return_types));
-	  } else {
-	    // Update existing entry.
-	    PHPTypes::merge_type_lists(v, return_types);
-	  }
-	}
+        String *parent = class_name;
+        while ((parent = Getattr(php_parent_class, parent)) != NULL) {
+          String *key = NewStringf("%s:%s", parent, wname);
+          // The parent class method needs to have a superset of the possible
+          // return types of methods with the same name in subclasses.
+          List *v = Getattr(parent_class_method_return_type, key);
+          if (!v) {
+            // New entry.
+            Setattr(parent_class_method_return_type, key, Copy(return_types));
+          } else {
+            // Update existing entry.
+            PHPTypes::merge_type_lists(v, return_types);
+          }
+        }
       }
     }
 
@@ -1626,8 +1626,8 @@ public:
     /* Look to see if there is any newfree cleanup code */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printf(f->code, "%s\n", tm);
-	Delete(tm);
+        Printf(f->code, "%s\n", tm);
+        Delete(tm);
       }
     }
 
@@ -1665,11 +1665,11 @@ public:
 
     if (overloaded) {
       if (!Getattr(n, "sym:nextSibling")) {
-	dispatchFunction(n, constructor);
+        dispatchFunction(n, constructor);
       }
     } else {
       if (!static_setter) {
-	create_command(class_name, wname, n, false, modes);
+        create_command(class_name, wname, n, false, modes);
       }
     }
 
@@ -1707,26 +1707,26 @@ public:
     String *wrapping_member_constant = Getattr(n, "memberconstantHandler:sym:name");
     if (!wrapping_member_constant) {
       {
-	tm = Swig_typemap_lookup("consttab", n, name, 0);
-	Replaceall(tm, "$value", value);
-	if (Getattr(n, "tmap:consttab:rinit")) {
-	  Printf(r_init, "%s\n", tm);
-	} else {
-	  Printf(s_cinit, "%s\n", tm);
-	}
+        tm = Swig_typemap_lookup("consttab", n, name, 0);
+        Replaceall(tm, "$value", value);
+        if (Getattr(n, "tmap:consttab:rinit")) {
+          Printf(r_init, "%s\n", tm);
+        } else {
+          Printf(s_cinit, "%s\n", tm);
+        }
       }
 
       {
-	tm = Swig_typemap_lookup("classconsttab", n, name, 0);
+        tm = Swig_typemap_lookup("classconsttab", n, name, 0);
 
-	Replaceall(tm, "$class", fake_class_name());
-	Replaceall(tm, "$const_name", iname);
-	Replaceall(tm, "$value", value);
-	if (Getattr(n, "tmap:classconsttab:rinit")) {
-	  Printf(r_init, "%s\n", tm);
-	} else {
-	  Printf(s_cinit, "%s\n", tm);
-	}
+        Replaceall(tm, "$class", fake_class_name());
+        Replaceall(tm, "$const_name", iname);
+        Replaceall(tm, "$value", value);
+        if (Getattr(n, "tmap:classconsttab:rinit")) {
+          Printf(r_init, "%s\n", tm);
+        } else {
+          Printf(s_cinit, "%s\n", tm);
+        }
       }
     } else {
       tm = Swig_typemap_lookup("classconsttab", n, name, 0);
@@ -1734,9 +1734,9 @@ public:
       Replaceall(tm, "$const_name", wrapping_member_constant);
       Replaceall(tm, "$value", value);
       if (Getattr(n, "tmap:classconsttab:rinit")) {
-	Printf(r_init, "%s\n", tm);
+        Printf(r_init, "%s\n", tm);
       } else {
-	Printf(s_cinit, "%s\n", tm);
+        Printf(s_cinit, "%s\n", tm);
       }
     }
 
@@ -1760,25 +1760,25 @@ public:
       String *value = Getattr(n, "value");
 
       if (Strcmp(lang, "php") == 0) {
-	if (Strcmp(type, "code") == 0) {
-	  if (value) {
-	    Printf(pragma_code, "%s\n", value);
-	  }
-	} else if (Strcmp(type, "include") == 0) {
-	  if (value) {
-	    Printf(pragma_incl, "include '%s';\n", value);
-	  }
-	} else if (Strcmp(type, "phpinfo") == 0) {
-	  if (value) {
-	    Printf(pragma_phpinfo, "%s\n", value);
-	  }
-	} else if (Strcmp(type, "version") == 0) {
-	  if (value) {
-	    pragma_version = value;
-	  }
-	} else {
-	  Swig_warning(WARN_PHP_UNKNOWN_PRAGMA, input_file, line_number, "Unrecognized pragma <%s>.\n", type);
-	}
+        if (Strcmp(type, "code") == 0) {
+          if (value) {
+            Printf(pragma_code, "%s\n", value);
+          }
+        } else if (Strcmp(type, "include") == 0) {
+          if (value) {
+            Printf(pragma_incl, "include '%s';\n", value);
+          }
+        } else if (Strcmp(type, "phpinfo") == 0) {
+          if (value) {
+            Printf(pragma_phpinfo, "%s\n", value);
+          }
+        } else if (Strcmp(type, "version") == 0) {
+          if (value) {
+            pragma_version = value;
+          }
+        } else {
+          Swig_warning(WARN_PHP_UNKNOWN_PRAGMA, input_file, line_number, "Unrecognized pragma <%s>.\n", type);
+        }
       }
     }
     return Language::pragmaDirective(n);
@@ -1815,26 +1815,26 @@ public:
       char *rename = GetChar(n, "sym:name");
 
       if (!addSymbol(rename, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
 
       /* Deal with inheritance */
       List *baselist = Getattr(n, "bases");
       if (baselist) {
-	Iterator base = First(baselist);
-	while (base.item) {
-	  if (!GetFlag(base.item, "feature:ignore")) {
-	    if (!base_class) {
-	      base_class = Getattr(base.item, "sym:name");
-	    } else {
-	      /* Warn about multiple inheritance for additional base class(es) */
-	      String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
-	      String *baseclassname = SwigType_str(Getattr(base.item, "name"), 0);
-	      Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE, input_file, line_number,
-			   "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n", proxyclassname, baseclassname);
-	    }
-	  }
-	  base = Next(base);
-	}
+        Iterator base = First(baselist);
+        while (base.item) {
+          if (!GetFlag(base.item, "feature:ignore")) {
+            if (!base_class) {
+              base_class = Getattr(base.item, "sym:name");
+            } else {
+              /* Warn about multiple inheritance for additional base class(es) */
+              String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
+              String *baseclassname = SwigType_str(Getattr(base.item, "name"), 0);
+              Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE, input_file, line_number,
+                           "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n", proxyclassname, baseclassname);
+            }
+          }
+          base = Next(base);
+        }
       }
     }
 
@@ -1844,9 +1844,9 @@ public:
        * explicit base class.
        */
       if (base_class) {
-	String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
-	Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE, input_file, line_number,
-		     "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n", proxyclassname, base_class);
+        String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
+        Swig_warning(WARN_PHP_MULTIPLE_INHERITANCE, input_file, line_number,
+                     "Warning for %s, base %s ignored. Multiple inheritance is not supported in PHP.\n", proxyclassname, base_class);
       }
       base_class = NewString("Exception");
     }
@@ -1888,63 +1888,63 @@ public:
       String *interfaces = Swig_typemap_lookup("phpinterfaces", node, "", 0);
       Replaceall(interfaces, " ", "");
       if (interfaces && Len(interfaces) > 0) {
-	// It seems we need to wait until RINIT time to look up class entries
-	// for interfaces by name.  The downside is that this then happens for
-	// every request.
-	//
-	// Most pre-defined interfaces are accessible via zend_class_entry*
-	// variables declared in the PHP C API - these we can use at MINIT
-	// time, so we special case them.  This will also be a little faster
-	// than looking up by name.
-	Printv(s_header,
-	       "#ifdef __cplusplus\n",
-	       "extern \"C\" {\n",
-	       "#endif\n",
-	       NIL);
+        // It seems we need to wait until RINIT time to look up class entries
+        // for interfaces by name.  The downside is that this then happens for
+        // every request.
+        //
+        // Most pre-defined interfaces are accessible via zend_class_entry*
+        // variables declared in the PHP C API - these we can use at MINIT
+        // time, so we special case them.  This will also be a little faster
+        // than looking up by name.
+        Printv(s_header,
+               "#ifdef __cplusplus\n",
+               "extern \"C\" {\n",
+               "#endif\n",
+               NIL);
 
-	String *r_init_prefix = NewStringEmpty();
+        String *r_init_prefix = NewStringEmpty();
 
-	List *interface_list = Split(interfaces, ',', -1);
-	int num_interfaces = Len(interface_list);
-	for (int i = 0; i < num_interfaces; ++i) {
-	  String *interface = Getitem(interface_list, i);
-	  // We generate conditional code in both minit and rinit - then we or the user
-	  // just need to define SWIG_PHP_INTERFACE_xxx_CE (and optionally
-	  // SWIG_PHP_INTERFACE_xxx_HEADER) to handle interface `xxx` at minit-time.
-	  Printv(s_header,
-		 "#ifdef SWIG_PHP_INTERFACE_", interface, "_HEADER\n",
-		 "# include SWIG_PHP_INTERFACE_", interface, "_HEADER\n",
-		 "#endif\n",
-		 NIL);
-	  Printv(s_oinit,
-		 "#ifdef SWIG_PHP_INTERFACE_", interface, "_CE\n",
-		 "  zend_do_implement_interface(SWIG_Php_ce_", class_name, ", SWIG_PHP_INTERFACE_", interface, "_CE);\n",
-		 "#endif\n",
-		 NIL);
-	  Printv(r_init_prefix,
-		 "#ifndef SWIG_PHP_INTERFACE_", interface, "_CE\n",
-		 "  {\n",
-		 "    zend_class_entry *swig_interface_ce = zend_lookup_class(zend_string_init(\"", interface, "\", sizeof(\"", interface, "\") - 1, 0));\n",
-		 "    if (swig_interface_ce)\n",
-		 "      zend_do_implement_interface(SWIG_Php_ce_", class_name, ", swig_interface_ce);\n",
+        List *interface_list = Split(interfaces, ',', -1);
+        int num_interfaces = Len(interface_list);
+        for (int i = 0; i < num_interfaces; ++i) {
+          String *interface = Getitem(interface_list, i);
+          // We generate conditional code in both minit and rinit - then we or the user
+          // just need to define SWIG_PHP_INTERFACE_xxx_CE (and optionally
+          // SWIG_PHP_INTERFACE_xxx_HEADER) to handle interface `xxx` at minit-time.
+          Printv(s_header,
+                 "#ifdef SWIG_PHP_INTERFACE_", interface, "_HEADER\n",
+                 "# include SWIG_PHP_INTERFACE_", interface, "_HEADER\n",
+                 "#endif\n",
+                 NIL);
+          Printv(s_oinit,
+                 "#ifdef SWIG_PHP_INTERFACE_", interface, "_CE\n",
+                 "  zend_do_implement_interface(SWIG_Php_ce_", class_name, ", SWIG_PHP_INTERFACE_", interface, "_CE);\n",
+                 "#endif\n",
+                 NIL);
+          Printv(r_init_prefix,
+                 "#ifndef SWIG_PHP_INTERFACE_", interface, "_CE\n",
+                 "  {\n",
+                 "    zend_class_entry *swig_interface_ce = zend_lookup_class(zend_string_init(\"", interface, "\", sizeof(\"", interface, "\") - 1, 0));\n",
+                 "    if (swig_interface_ce)\n",
+                 "      zend_do_implement_interface(SWIG_Php_ce_", class_name, ", swig_interface_ce);\n",
                  "    else\n",
                  "      zend_throw_exception(zend_ce_error, \"Interface \\\"", interface, "\\\" not found\", 0);\n",
-		 "  }\n",
-		 "#endif\n",
-		 NIL);
-	}
+                 "  }\n",
+                 "#endif\n",
+                 NIL);
+        }
 
-	// Handle interfaces at the start of rinit so that they're added
-	// before any potential constant objects, etc which might be created
-	// later in rinit.
-	Insert(r_init, 0, r_init_prefix);
-	Delete(r_init_prefix);
+        // Handle interfaces at the start of rinit so that they're added
+        // before any potential constant objects, etc which might be created
+        // later in rinit.
+        Insert(r_init, 0, r_init_prefix);
+        Delete(r_init_prefix);
 
-	Printv(s_header,
-	       "#ifdef __cplusplus\n",
-	       "}\n",
-	       "#endif\n",
-	       NIL);
+        Printv(s_header,
+               "#ifdef __cplusplus\n",
+               "}\n",
+               "#endif\n",
+               NIL);
       }
       Delete(interfaces);
     }
@@ -1968,51 +1968,51 @@ public:
 
     if (Getattr(n, "has_destructor")) {
       if (destructor_action ? Equal(destructor_action, "free((char *) arg1);") : !CPlusPlus) {
-	// We can use a single function if the destructor action calls free()
-	// (either explicitly or as the default in C-mode) since free() doesn't
-	// care about the object's type.  We currently only check for the exact
-	// code that Swig_cdestructor_call() emits.
-	static bool emitted_common_cdestructor = false;
-	if (!emitted_common_cdestructor) {
-	  Printf(s_creation, "static zend_object_handlers Swig_Php_common_c_object_handlers;\n\n");
-	  Printf(s_creation, "static void SWIG_Php_common_c_free_obj(zend_object *object) {free(SWIG_Php_free_obj(object));}\n\n");
-	  Printf(s_creation, "static zend_object *SWIG_Php_common_c_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_common_c_object_handlers);}\n");
+        // We can use a single function if the destructor action calls free()
+        // (either explicitly or as the default in C-mode) since free() doesn't
+        // care about the object's type.  We currently only check for the exact
+        // code that Swig_cdestructor_call() emits.
+        static bool emitted_common_cdestructor = false;
+        if (!emitted_common_cdestructor) {
+          Printf(s_creation, "static zend_object_handlers Swig_Php_common_c_object_handlers;\n\n");
+          Printf(s_creation, "static void SWIG_Php_common_c_free_obj(zend_object *object) {free(SWIG_Php_free_obj(object));}\n\n");
+          Printf(s_creation, "static zend_object *SWIG_Php_common_c_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_common_c_object_handlers);}\n");
 
-	  Printf(s_oinit, "  Swig_Php_common_c_object_handlers = Swig_Php_base_object_handlers;\n");
-	  Printf(s_oinit, "  Swig_Php_common_c_object_handlers.free_obj = SWIG_Php_common_c_free_obj;\n");
+          Printf(s_oinit, "  Swig_Php_common_c_object_handlers = Swig_Php_base_object_handlers;\n");
+          Printf(s_oinit, "  Swig_Php_common_c_object_handlers.free_obj = SWIG_Php_common_c_free_obj;\n");
 
-	  emitted_common_cdestructor = true;
-	}
+          emitted_common_cdestructor = true;
+        }
 
-	Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_common_c_create_object;\n", class_name);
+        Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_common_c_create_object;\n", class_name);
       } else {
-	Printf(s_creation, "static zend_object_handlers %s_object_handlers;\n", class_name);
-	Printf(s_creation, "static zend_object *SWIG_Php_create_object_%s(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &%s_object_handlers);}\n", class_name, class_name);
+        Printf(s_creation, "static zend_object_handlers %s_object_handlers;\n", class_name);
+        Printf(s_creation, "static zend_object *SWIG_Php_create_object_%s(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &%s_object_handlers);}\n", class_name, class_name);
 
-	Printf(s_creation, "static void SWIG_Php_free_obj_%s(zend_object *object) {",class_name);
-	String *type = Getattr(n, "classtype");
-	// Special case handling the delete call generated by
-	// Swig_cppdestructor_call() and generate simpler code.
-	if (destructor_action && !Equal(destructor_action, "delete arg1;")) {
-	  Printv(s_creation, "\n"
-		 "  ", type, " *arg1 = (" , type, " *)SWIG_Php_free_obj(object);\n"
-		 "  if (arg1) {\n"
-		 "    ", destructor_action, "\n"
-		 "  }\n", NIL);
-	} else {
-	  Printf(s_creation, "delete (%s *)SWIG_Php_free_obj(object);", type);
-	}
-	Printf(s_creation, "}\n\n");
+        Printf(s_creation, "static void SWIG_Php_free_obj_%s(zend_object *object) {",class_name);
+        String *type = Getattr(n, "classtype");
+        // Special case handling the delete call generated by
+        // Swig_cppdestructor_call() and generate simpler code.
+        if (destructor_action && !Equal(destructor_action, "delete arg1;")) {
+          Printv(s_creation, "\n"
+                 "  ", type, " *arg1 = (" , type, " *)SWIG_Php_free_obj(object);\n"
+                 "  if (arg1) {\n"
+                 "    ", destructor_action, "\n"
+                 "  }\n", NIL);
+        } else {
+          Printf(s_creation, "delete (%s *)SWIG_Php_free_obj(object);", type);
+        }
+        Printf(s_creation, "}\n\n");
 
-	Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_create_object_%s;\n", class_name, class_name);
-	Printf(s_oinit, "  %s_object_handlers = Swig_Php_base_object_handlers;\n", class_name);
-	Printf(s_oinit, "  %s_object_handlers.free_obj = SWIG_Php_free_obj_%s;\n", class_name, class_name);
+        Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_create_object_%s;\n", class_name, class_name);
+        Printf(s_oinit, "  %s_object_handlers = Swig_Php_base_object_handlers;\n", class_name);
+        Printf(s_oinit, "  %s_object_handlers.free_obj = SWIG_Php_free_obj_%s;\n", class_name, class_name);
       }
     } else {
       static bool emitted_destructorless_create_object = false;
       if (!emitted_destructorless_create_object) {
-	emitted_destructorless_create_object = true;
-	Printf(s_creation, "static zend_object *SWIG_Php_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_base_object_handlers);}\n", class_name);
+        emitted_destructorless_create_object = true;
+        Printf(s_creation, "static zend_object *SWIG_Php_create_object(zend_class_entry *ce) {return SWIG_Php_do_create_object(ce, &Swig_Php_base_object_handlers);}\n", class_name);
       }
 
       Printf(s_oinit, "  SWIG_Php_ce_%s->create_object = SWIG_Php_create_object;\n", class_name);
@@ -2127,8 +2127,8 @@ public:
       Printf(director_prot_ctor_code, "if (Z_OBJCE_P(arg0) == SWIG_Php_ce_%s) { /* not subclassed */\n", class_name);
       Printf(director_ctor_code, "  $nondirector_new\n");
       Printf(director_prot_ctor_code,
-	     "  zend_throw_exception(zend_ce_type_error, \"accessing abstract class or protected constructor\", 0);\n"
-	     "  return;\n");
+             "  zend_throw_exception(zend_ce_type_error, \"accessing abstract class or protected constructor\", 0);\n"
+             "  return;\n");
       Printf(director_ctor_code, "} else {\n  $director_new\n}\n");
       Printf(director_prot_ctor_code, "} else {\n  $director_new\n}\n");
 
@@ -2206,25 +2206,25 @@ public:
 
       /* constructor */
       {
-	Wrapper *w = NewWrapper();
-	String *call;
-	String *basetype = Getattr(parent, "classtype");
+        Wrapper *w = NewWrapper();
+        String *call;
+        String *basetype = Getattr(parent, "classtype");
 
-	String *target = Swig_method_decl(0, decl, classname, parms, 0);
-	call = Swig_csuperclass_call(0, basetype, superparms);
-	Printf(w->def, "%s::%s: %s, Swig::Director(self) {", classname, target, call);
-	Append(w->def, "}");
-	Delete(target);
-	Wrapper_print(w, f_directors);
-	Delete(call);
-	DelWrapper(w);
+        String *target = Swig_method_decl(0, decl, classname, parms, 0);
+        call = Swig_csuperclass_call(0, basetype, superparms);
+        Printf(w->def, "%s::%s: %s, Swig::Director(self) {", classname, target, call);
+        Append(w->def, "}");
+        Delete(target);
+        Wrapper_print(w, f_directors);
+        Delete(call);
+        DelWrapper(w);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, classname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, classname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
     return Language::classDirectorConstructor(n);
@@ -2253,7 +2253,7 @@ public:
 
     if (Cmp(storage, "virtual") == 0) {
       if (Cmp(value, "0") == 0) {
-	pure_virtual = true;
+        pure_virtual = true;
       }
     }
 
@@ -2290,18 +2290,18 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
-	  String *str = SwigType_str(Getattr(p, "type"), 0);
-	  Append(w->def, str);
-	  Append(declaration, str);
-	  Delete(str);
-	}
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
+          String *str = SwigType_str(Getattr(p, "type"), 0);
+          Append(w->def, str);
+          Append(declaration, str);
+          Delete(str);
+        }
       }
 
       Append(w->def, ")");
@@ -2317,30 +2317,30 @@ public:
      */
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	}
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        }
       } else {
-	String *cres = SwigType_lstr(returntype, "c_result");
-	Printf(w->code, "%s;\n", cres);
-	Delete(cres);
+        String *cres = SwigType_lstr(returntype, "c_result");
+        Printf(w->code, "%s;\n", cres);
+        Delete(cres);
       }
     }
 
     if (ignored_method) {
       if (!pure_virtual) {
-	if (!is_void)
-	  Printf(w->code, "return ");
-	String *super_call = Swig_method_call(super, l);
-	Printf(w->code, "%s;\n", super_call);
-	Delete(super_call);
+        if (!is_void)
+          Printf(w->code, "return ");
+        String *super_call = Swig_method_call(super, l);
+        Printf(w->code, "%s;\n", super_call);
+        Delete(super_call);
       } else {
-	Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	       SwigType_namestr(name));
+        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+               SwigType_namestr(name));
       }
     } else {
       /* attach typemaps to arguments (C/C++ -> PHP) */
@@ -2357,46 +2357,46 @@ public:
       idx = 0;
       p = l;
       while (p) {
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
 
-	String *pname = Getattr(p, "name");
-	String *ptype = Getattr(p, "type");
+        String *pname = Getattr(p, "name");
+        String *ptype = Getattr(p, "type");
 
-	if ((tm = Getattr(p, "tmap:directorin")) != 0) {
-	  String *parse = Getattr(p, "tmap:directorin:parse");
-	  if (!parse) {
-	    String *input = NewStringf("&args[%d]", idx++);
-	    Setattr(p, "emit:directorinput", input);
-	    Replaceall(tm, "$input", input);
-	    Delete(input);
-	    Replaceall(tm, "$owner", "0");
-	    Printv(wrap_args, tm, "\n", NIL);
-	  } else {
-	    Setattr(p, "emit:directorinput", pname);
-	    Replaceall(tm, "$input", pname);
-	    Replaceall(tm, "$owner", "0");
-	    if (Len(tm) == 0)
-	      Append(tm, pname);
-	  }
-	  p = Getattr(p, "tmap:directorin:next");
-	  continue;
-	} else if (Cmp(ptype, "void")) {
-	  Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-	      "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-	      SwigType_namestr(c_classname), SwigType_namestr(name));
-	  status = SWIG_NOWRAP;
-	  break;
-	}
-	p = nextSibling(p);
+        if ((tm = Getattr(p, "tmap:directorin")) != 0) {
+          String *parse = Getattr(p, "tmap:directorin:parse");
+          if (!parse) {
+            String *input = NewStringf("&args[%d]", idx++);
+            Setattr(p, "emit:directorinput", input);
+            Replaceall(tm, "$input", input);
+            Delete(input);
+            Replaceall(tm, "$owner", "0");
+            Printv(wrap_args, tm, "\n", NIL);
+          } else {
+            Setattr(p, "emit:directorinput", pname);
+            Replaceall(tm, "$input", pname);
+            Replaceall(tm, "$owner", "0");
+            if (Len(tm) == 0)
+              Append(tm, pname);
+          }
+          p = Getattr(p, "tmap:directorin:next");
+          continue;
+        } else if (Cmp(ptype, "void")) {
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+              "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
+              SwigType_namestr(c_classname), SwigType_namestr(name));
+          status = SWIG_NOWRAP;
+          break;
+        }
+        p = nextSibling(p);
       }
 
       if (!idx) {
-	Printf(w->code, "zval *args = NULL;\n");
+        Printf(w->code, "zval *args = NULL;\n");
       } else {
-	Printf(w->code, "zval args[%d];\n", idx);
+        Printf(w->code, "zval args[%d];\n", idx);
       }
       // typemap_directorout testcase requires that 0 can be assigned to the
       // variable named after the result of Swig_cresult_name(), so that can't
@@ -2417,13 +2417,13 @@ public:
       /* exception handling */
       tm = Swig_typemap_lookup("director:except", n, Swig_cresult_name(), 0);
       if (!tm) {
-	tm = Getattr(n, "feature:director:except");
-	if (tm)
-	  tm = Copy(tm);
+        tm = Getattr(n, "feature:director:except");
+        if (tm)
+          tm = Copy(tm);
       }
       if (!tm || Len(tm) == 0 || Equal(tm, "1")) {
-	// Skip marshalling the return value as there isn't one.
-	tm = NewString("if ($error) SWIG_fail;");
+        // Skip marshalling the return value as there isn't one.
+        tm = NewString("if ($error) SWIG_fail;");
       }
 
       Replaceall(tm, "$error", "EG(exception)");
@@ -2439,40 +2439,40 @@ public:
 
       /* marshal return value */
       if (!is_void) {
-	tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
-	if (tm != 0) {
-	  Replaceall(tm, "$input", Swig_cresult_name());
-	  char temp[24];
-	  sprintf(temp, "%d", idx);
-	  Replaceall(tm, "$argnum", temp);
+        tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
+        if (tm != 0) {
+          Replaceall(tm, "$input", Swig_cresult_name());
+          char temp[24];
+          sprintf(temp, "%d", idx);
+          Replaceall(tm, "$argnum", temp);
 
-	  /* TODO check this */
-	  if (Getattr(n, "wrap:disown")) {
-	    Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	  } else {
-	    Replaceall(tm, "$disown", "0");
-	  }
-	  Replaceall(tm, "$result", "c_result");
-	  Printv(w->code, tm, "\n", NIL);
-	  Delete(tm);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
-		       SwigType_namestr(c_classname), SwigType_namestr(name));
-	  status = SWIG_ERROR;
-	}
+          /* TODO check this */
+          if (Getattr(n, "wrap:disown")) {
+            Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+          } else {
+            Replaceall(tm, "$disown", "0");
+          }
+          Replaceall(tm, "$result", "c_result");
+          Printv(w->code, tm, "\n", NIL);
+          Delete(tm);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          status = SWIG_ERROR;
+        }
       }
 
       /* marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
-	  Replaceall(tm, "$result", Swig_cresult_name());
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
+          Replaceall(tm, "$result", Swig_cresult_name());
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       Append(w->code, "}\n");
@@ -2484,13 +2484,13 @@ public:
     Append(w->code, "fail: SWIGUNUSED;\n");
     if (!is_void) {
       if (!(ignored_method && !pure_virtual)) {
-	String *rettype = SwigType_str(returntype, 0);
-	if (!SwigType_isreference(returntype)) {
-	  Printf(w->code, "return (%s) c_result;\n", rettype);
-	} else {
-	  Printf(w->code, "return (%s) *c_result;\n", rettype);
-	}
-	Delete(rettype);
+        String *rettype = SwigType_str(returntype, 0);
+        if (!SwigType_isreference(returntype)) {
+          Printf(w->code, "return (%s) c_result;\n", rettype);
+        } else {
+          Printf(w->code, "return (%s) *c_result;\n", rettype);
+        }
+        Delete(rettype);
       }
     }
     Append(w->code, "}\n");
@@ -2503,7 +2503,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -2514,10 +2514,10 @@ public:
     if (status == SWIG_OK) {
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 
@@ -2587,25 +2587,25 @@ List *PHPTypes::process_phptype(Node *n, int key, const String_or_char *attribut
       String *type = Getattr(n, "type");
       Node *class_node = maininstance->classLookup(type);
       if (class_node) {
-	// FIXME: Prefix classname with a backslash to prevent collisions
-	// with built-in types?  Or are non of those valid anyway and so will
-	// have been renamed at this point?
-	Append(merge_list, Getattr(class_node, "sym:name"));
+        // FIXME: Prefix classname with a backslash to prevent collisions
+        // with built-in types?  Or are non of those valid anyway and so will
+        // have been renamed at this point?
+        Append(merge_list, Getattr(class_node, "sym:name"));
       } else {
-	// SWIG wraps a pointer to a non-object type as an object in a PHP
-	// class named based on the SWIG-mangled C/C++ type.
-	//
-	// FIXME: We should check this is actually a known pointer to
-	// non-object type so we complain about `phptype="SWIGTYPE"` being
-	// used for PHP types like `int` or `string` (currently this only
-	// fails at runtime and the error isn't very helpful).  We could
-	// check the condition
-	//
-	//   raw_pointer_types && Getattr(raw_pointer_types, SwigType_manglestr(type))
-	//
-	// except that raw_pointer_types may not have been fully filled in when
-	// we are called.
-	Append(merge_list, NewStringf("SWIG\\%s", SwigType_manglestr(type)));
+        // SWIG wraps a pointer to a non-object type as an object in a PHP
+        // class named based on the SWIG-mangled C/C++ type.
+        //
+        // FIXME: We should check this is actually a known pointer to
+        // non-object type so we complain about `phptype="SWIGTYPE"` being
+        // used for PHP types like `int` or `string` (currently this only
+        // fails at runtime and the error isn't very helpful).  We could
+        // check the condition
+        //
+        //   raw_pointer_types && Getattr(raw_pointer_types, SwigType_manglestr(type))
+        //
+        // except that raw_pointer_types may not have been fully filled in when
+        // we are called.
+        Append(merge_list, NewStringf("SWIG\\%s", SwigType_manglestr(type)));
       }
     } else {
       Append(merge_list, i.item);
@@ -2623,9 +2623,9 @@ void PHPTypes::merge_type_lists(List *merge_list, List *o_merge_list) {
     while (i < Len(merge_list)) {
       int cmp = Cmp(Getitem(merge_list, i), candidate);
       if (cmp == 0)
-	goto handled;
+        goto handled;
       if (cmp > 0)
-	break;
+        break;
       ++i;
     }
     Insert(merge_list, i, candidate);
@@ -2646,13 +2646,13 @@ void PHPTypes::merge_from(const PHPTypes* o) {
       // Start at 1 because we only want to merge parameter types, and key 0 is
       // the return type.
       for (int key = 1; key < len; ++key) {
-	if (Getitem(byref, key) == None &&
-	    Getitem(o->byref, key) != None) {
-	  Setitem(byref, key, "");
-	}
+        if (Getitem(byref, key) == None &&
+            Getitem(o->byref, key) != None) {
+          Setitem(byref, key, "");
+        }
       }
       for (int key = len; key < Len(o->byref); ++key) {
-	Append(byref, Getitem(o->byref, key));
+        Append(byref, Getitem(o->byref, key));
       }
     }
   }

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -47,11 +47,11 @@ static File *f_directors_h = 0;
 static String *s_header;
 static String *s_wrappers;
 static String *s_init;
-static String *r_init;		// RINIT user code
-static String *s_shutdown;	// MSHUTDOWN user code
-static String *r_shutdown;	// RSHUTDOWN user code
+static String *r_init;          // RINIT user code
+static String *s_shutdown;      // MSHUTDOWN user code
+static String *r_shutdown;      // RSHUTDOWN user code
 static String *s_vdecl;
-static String *s_cinit;		// consttab initialization code.
+static String *s_cinit;         // consttab initialization code.
 static String *s_oinit;
 static String *s_arginfo;
 static String *s_entry;
@@ -1450,7 +1450,7 @@ public:
 
     // NOTE: possible we ignore this_ptr as a param for native constructor
 
-    if (numopt > 0) {		// membervariable wrappers do not have optional args
+    if (numopt > 0) {           // membervariable wrappers do not have optional args
       Wrapper_add_local(f, "arg_count", "int arg_count");
       Printf(f->code, "arg_count = ZEND_NUM_ARGS();\n");
       Printf(f->code, "if(arg_count<%d || arg_count>%d ||\n", num_required, num_arguments);
@@ -2534,7 +2534,7 @@ public:
     wrapperType = standard;
     return result;
   }
-};				/* class PHP */
+};                              /* class PHP */
 
 static PHP *maininstance = 0;
 

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -19,11 +19,11 @@
 #include <stdint.h>
 #include "pydoc.h"
 
-#define PYSHADOW_MEMBER  0x2
+#define PYSHADOW_MEMBER          0x2
 #define WARN_PYTHON_MULTIPLE_INH 405
 
-#define PYTHON_INT_MAX (2147483647)
-#define PYTHON_INT_MIN (-2147483647-1)
+#define PYTHON_INT_MAX           (2147483647)
+#define PYTHON_INT_MIN           (-2147483647 - 1)
 
 static String *const_code = 0;
 static String *module = 0;
@@ -96,16 +96,7 @@ static int nogil = 0;
 
 /* flags for the make_autodoc function */
 namespace {
-enum autodoc_t {
-  AUTODOC_CLASS,
-  AUTODOC_CTOR,
-  AUTODOC_DTOR,
-  AUTODOC_STATICFUNC,
-  AUTODOC_FUNC,
-  AUTODOC_METHOD,
-  AUTODOC_CONST,
-  AUTODOC_VAR
-};
+enum autodoc_t { AUTODOC_CLASS, AUTODOC_CTOR, AUTODOC_DTOR, AUTODOC_STATICFUNC, AUTODOC_FUNC, AUTODOC_METHOD, AUTODOC_CONST, AUTODOC_VAR };
 }
 
 static const char *usage1 = "\
@@ -220,12 +211,12 @@ static String *getClosure(String *functype, String *wrapper, int funpack = 0) {
 
   const char *c = Char(functype);
   if (funpack) {
-    for (size_t i = 0; i < sizeof(funpack_functypes)/sizeof(FunctionClosure); ++i) {
+    for (size_t i = 0; i < sizeof(funpack_functypes) / sizeof(FunctionClosure); ++i) {
       if (strcmp(c, funpack_functypes[i].function) == 0)
         return NewStringf("%s(%s)", funpack_functypes[i].closure, wrapper);
     }
   } else {
-    for (size_t i = 0; i < sizeof(functypes)/sizeof(FunctionClosure); ++i) {
+    for (size_t i = 0; i < sizeof(functypes) / sizeof(FunctionClosure); ++i) {
       if (strcmp(c, functypes[i].function) == 0)
         return NewStringf("%s(%s)", functypes[i].closure, wrapper);
     }
@@ -233,7 +224,7 @@ static String *getClosure(String *functype, String *wrapper, int funpack = 0) {
   return NULL;
 }
 
-class PYTHON:public Language {
+class PYTHON : public Language {
 public:
   PYTHON() {
     /* Add code to manage protected constructors and directors */
@@ -241,7 +232,11 @@ public:
     Printv(director_prot_ctor_code,
            "if ($comparison) { /* subclassed */\n",
            "  $director_new\n",
-           "} else {\n", "  SWIG_SetErrorMsg(PyExc_RuntimeError,\"accessing abstract class or protected constructor\");\n", "  SWIG_fail;\n", "}\n", NIL);
+           "} else {\n",
+           "  SWIG_SetErrorMsg(PyExc_RuntimeError,\"accessing abstract class or protected constructor\");\n",
+           "  SWIG_fail;\n",
+           "}\n",
+           NIL);
     director_multiple_inheritance = 1;
     directorLanguage();
   }
@@ -314,7 +309,6 @@ public:
       Append(f, "\n}");
     }
   }
-
 
   /* ------------------------------------------------------------
    * main()
@@ -493,7 +487,6 @@ public:
     allow_overloading();
   }
 
-
   /* ------------------------------------------------------------
    * top()
    * ------------------------------------------------------------ */
@@ -665,7 +658,6 @@ public:
     Printf(f_header, "#endif\n");
     Printf(f_header, "#define SWIG_TypeQuery SWIG_Python_TypeQuery\n");
 
-
     /* Set module name */
     module = Copy(Getattr(n, "name"));
     mainmodule = Getattr(n, "name");
@@ -749,12 +741,7 @@ public:
       if (!builtin) {
         /* Need builtins to qualify names like Exception that might also be
            defined in this module (try both Python 3 and Python 2 names) */
-        Printv(f_shadow,
-               "try:\n",
-               "    import builtins as __builtin__\n",
-               "except ImportError:\n",
-               "    import __builtin__\n",
-               NULL);
+        Printv(f_shadow, "try:\n", "    import builtins as __builtin__\n", "except ImportError:\n", "    import __builtin__\n", NULL);
       }
 
       if (!builtin && fastproxy) {
@@ -771,7 +758,8 @@ public:
                "        strthis = \"proxy of \" + self.this.__repr__()\n",
                "    except __builtin__.Exception:\n",
                "        strthis = \"\"\n",
-               "    return \"<%s.%s; %s >\" % (self.__class__.__module__, self.__class__.__name__, strthis,)\n\n", NIL);
+               "    return \"<%s.%s; %s >\" % (self.__class__.__module__, self.__class__.__name__, strthis,)\n\n",
+               NIL);
 
         Printv(f_shadow,
                "\n",
@@ -785,29 +773,36 @@ public:
                "            set(self, name, value)\n",
                "        else:\n",
                "            raise AttributeError(\"You cannot add instance attributes to %s\" % self)\n",
-               "    return set_instance_attr\n\n", NIL);
+               "    return set_instance_attr\n\n",
+               NIL);
 
-        Printv(f_shadow, "\n",
+        Printv(f_shadow,
+               "\n",
                "def _swig_setattr_nondynamic_class_variable(set):\n",
                "    def set_class_attr(cls, name, value):\n",
                "        if hasattr(cls, name) and not isinstance(getattr(cls, name), property):\n",
                "            set(cls, name, value)\n",
                "        else:\n",
                "            raise AttributeError(\"You cannot add class attributes to %s\" % cls)\n",
-               "    return set_class_attr\n\n", NIL);
+               "    return set_class_attr\n\n",
+               NIL);
 
-        Printv(f_shadow, "\n",
+        Printv(f_shadow,
+               "\n",
                "def _swig_add_metaclass(metaclass):\n",
                "    \"\"\"Class decorator for adding a metaclass to a SWIG wrapped class - a slimmed down version of six.add_metaclass\"\"\"\n",
                "    def wrapper(cls):\n",
                "        return metaclass(cls.__name__, cls.__bases__, cls.__dict__.copy())\n",
-               "    return wrapper\n\n", NIL);
+               "    return wrapper\n\n",
+               NIL);
 
-        Printv(f_shadow, "\n",
+        Printv(f_shadow,
+               "\n",
                "class _SwigNonDynamicMeta(type):\n",
                "    \"\"\"Meta class to enforce nondynamic attributes (no new attributes) for a class\"\"\"\n",
                "    __setattr__ = _swig_setattr_nondynamic_class_variable(type.__setattr__)\n",
-               "\n", NIL);
+               "\n",
+               NIL);
 
         Printv(f_shadow, "\n", NIL);
 
@@ -816,8 +811,10 @@ public:
       }
     }
     // Include some information in the code
-    Printf(f_header, "\n/*-----------------------------------------------\n              @(target):= %s.so\n\
-  ------------------------------------------------*/\n", module);
+    Printf(f_header,
+           "\n/*-----------------------------------------------\n              @(target):= %s.so\n\
+  ------------------------------------------------*/\n",
+           module);
 
     Printf(f_header, "#if PY_VERSION_HEX >= 0x03000000\n");
     Printf(f_header, "#  define SWIG_init    PyInit_%s\n\n", module);
@@ -896,7 +893,7 @@ public:
           // follow PEP257 rules: https://www.python.org/dev/peps/pep-0257/
           // reported by pep257: https://github.com/GreenSteam/pep257
           bool multi_line_ds = Strchr(mod_docstring, '\n') != 0;
-          Printv(f_shadow_py, "\n", triple_double, multi_line_ds ? "\n":"", mod_docstring, multi_line_ds ? "\n":"", triple_double, "\n", NIL);
+          Printv(f_shadow_py, "\n", triple_double, multi_line_ds ? "\n" : "", mod_docstring, multi_line_ds ? "\n" : "", triple_double, "\n", NIL);
         }
         Delete(mod_docstring);
         mod_docstring = NULL;
@@ -1118,9 +1115,9 @@ public:
      * NOTE: [1] is necessary for pkg2.foo to be present in the importing module
      */
 
-    String *apkg = 0; // absolute (FQDN) package name of pkg
-    String *rpkg = 0; // relative package name
-    int py3_rlen1 = 0; // length of 1st level sub-package name, used by py3
+    String *apkg = 0;   // absolute (FQDN) package name of pkg
+    String *rpkg = 0;   // relative package name
+    int py3_rlen1 = 0;  // length of 1st level sub-package name, used by py3
     String *out = NewString("");
 
     if (pkg && *Char(pkg)) {
@@ -1191,7 +1188,7 @@ public:
     String *out = NewString("");
     if (pkg && *Char(pkg)) {
       if (mainpkg && *Char(mainpkg)) {
-        if (Strcmp(mainpkg,pkg) != 0 || Strcmp(mainmod, mod) != 0) {
+        if (Strcmp(mainpkg, pkg) != 0 || Strcmp(mainmod, mod) != 0) {
           Printf(out, "%s.%s.", pkg, mod);
         }
       } else {
@@ -1247,9 +1244,9 @@ public:
 
   static String *import_name_string(const String *mainpkg, const String *mainmod, const String *pkg, const String *mod, const String *sym) {
     if (!relativeimport) {
-      return abs_import_name_string(mainpkg,mainmod,pkg,mod,sym);
+      return abs_import_name_string(mainpkg, mainmod, pkg, mod, sym);
     } else {
-      return rel_import_name_string(mainpkg,mainmod,pkg,mod,sym);
+      return rel_import_name_string(mainpkg, mainmod, pkg, mod, sym);
     }
   }
 
@@ -1281,7 +1278,6 @@ public:
           }
           Delete(_import);
         }
-
       }
     }
     return Language::importDirective(n);
@@ -1364,7 +1360,7 @@ public:
     }
 
     // Process remaining lines.
-    for ( ; si.item; si = Next(si), ++py_line) {
+    for (; si.item; si = Next(si), ++py_line) {
       const char *c = Char(si.item);
       // If no prefixed line was found, the above loop should have completed.
       assert(initial);
@@ -1396,7 +1392,11 @@ public:
 
       if (i < Len(initial)) {
         // There's non-whitespace in the initial prefix of this line.
-        Swig_error(file, line, "Line indented less than expected (line %d of %s) as no line should be indented less than the indentation in line 1\n", py_line, directive_name);
+        Swig_error(file,
+                   line,
+                   "Line indented less than expected (line %d of %s) as no line should be indented less than the indentation in line 1\n",
+                   py_line,
+                   directive_name);
         Printv(out, indent, c, "\n", NIL);
       } else {
         if (memcmp(c, Char(initial), Len(initial)) == 0) {
@@ -1405,7 +1405,11 @@ public:
           continue;
         }
         Swig_warning(WARN_PYTHON_INDENT_MISMATCH,
-                     file, line, "Whitespace indentation is inconsistent compared to earlier lines (line %d of %s)\n", py_line, directive_name);
+                     file,
+                     line,
+                     "Whitespace indentation is inconsistent compared to earlier lines (line %d of %s)\n",
+                     py_line,
+                     directive_name);
         // To avoid gratuitously breaking interface files which worked with
         // SWIG <= 3.0.5, we remove a prefix of the same number of bytes for
         // lines which start with different whitespace to the line we got
@@ -1489,21 +1493,20 @@ public:
    * ------------------------------------------------------------ */
 
   enum autodoc_l {
-    NO_AUTODOC = -2,            // no autodoc
-    STRING_AUTODOC = -1,        // use provided string
-    NAMES_AUTODOC = 0,          // only parameter names
-    TYPES_AUTODOC = 1,          // parameter names and types
-    EXTEND_AUTODOC = 2,         // extended documentation and parameter names
-    EXTEND_TYPES_AUTODOC = 3    // extended documentation and parameter types + names
+    NO_AUTODOC = -2,          // no autodoc
+    STRING_AUTODOC = -1,      // use provided string
+    NAMES_AUTODOC = 0,        // only parameter names
+    TYPES_AUTODOC = 1,        // parameter names and types
+    EXTEND_AUTODOC = 2,       // extended documentation and parameter names
+    EXTEND_TYPES_AUTODOC = 3  // extended documentation and parameter types + names
   };
-
 
   autodoc_l autodoc_level(String *autodoc) {
     autodoc_l dlevel = NO_AUTODOC;
     char *c = Char(autodoc);
     if (c) {
       if (isdigit(c[0])) {
-        dlevel = (autodoc_l) atoi(c);
+        dlevel = (autodoc_l)atoi(c);
       } else {
         if (strcmp(c, "extended") == 0) {
           dlevel = EXTEND_AUTODOC;
@@ -1515,7 +1518,6 @@ public:
     return dlevel;
   }
 
-
   /* ------------------------------------------------------------
    * have_docstring()
    *
@@ -1525,10 +1527,8 @@ public:
 
   bool have_docstring(Node *n) {
     String *str = Getattr(n, "feature:docstring");
-    return ((str && Len(str) > 0)
-        || (Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc"))
-        || (doxygen && doxygenTranslator->hasDocumentation(n))
-      );
+    return ((str && Len(str) > 0) || (Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc")) ||
+            (doxygen && doxygenTranslator->hasDocumentation(n)));
   }
 
   /* ------------------------------------------------------------
@@ -1645,7 +1645,7 @@ public:
       Chop(docstr);
       const char *c = Char(docstr);
       if (isspace((int)*c)) {
-        while(isspace((int)*(++c))) {
+        while (isspace((int)*(++c))) {
         }
         String *old_docstr = docstr;
         docstr = NewString(c);
@@ -1772,12 +1772,12 @@ public:
     if (calling)
       func_annotation = false;
 
-    addMissingParameterNames(n, plist, arg_num); // for $1_name substitutions done in Swig_typemap_attach_parms
+    addMissingParameterNames(n, plist, arg_num);  // for $1_name substitutions done in Swig_typemap_attach_parms
     Swig_typemap_attach_parms("in", plist, 0);
     Swig_typemap_attach_parms("doc", plist, 0);
 
     if (Strcmp(ParmList_protostr(plist), "void") == 0) {
-      //No parameters actually
+      // No parameters actually
       return doc;
     }
 
@@ -2127,7 +2127,7 @@ public:
 
     errno = 0;
     double value = strtod(s, &end);
-    (void) value;
+    (void)value;
     if (errno != ERANGE && end != s) {
       // An added complication: at least some versions of strtod() recognize
       // hexadecimal floating point numbers which don't exist in Python, so
@@ -2141,14 +2141,14 @@ public:
 
       // Disregard optional "f" suffix, it can be just dropped in Python as it
       // uses doubles for everything anyhow.
-      for (char * p = end; *p != '\0'; ++p) {
+      for (char *p = end; *p != '\0'; ++p) {
         switch (*p) {
-          case 'f':
-          case 'F':
-            break;
+        case 'f':
+        case 'F':
+          break;
 
-          default:
-            return NIL;
+        default:
+          return NIL;
         }
       }
 
@@ -2176,12 +2176,12 @@ public:
     SwigType *resolved_type = SwigType_typedef_resolve_all(type);
     SwigType *unqualified_type = NIL;
     if (SwigType_isreference(resolved_type)) {
-        SwigType *t = Copy(resolved_type);
-        t = SwigType_del_reference(t);
-        unqualified_type = SwigType_strip_qualifiers(t);
-        Delete(t);
+      SwigType *t = Copy(resolved_type);
+      t = SwigType_del_reference(t);
+      unqualified_type = SwigType_strip_qualifiers(t);
+      Delete(t);
     } else {
-        unqualified_type = SwigType_strip_qualifiers(resolved_type);
+      unqualified_type = SwigType_strip_qualifiers(resolved_type);
     }
     if (numval) {
       if (Equal(unqualified_type, "bool")) {
@@ -2265,7 +2265,6 @@ public:
     return true;
   }
 
-
   /* ------------------------------------------------------------
    * is_real_overloaded()
    *
@@ -2320,7 +2319,8 @@ public:
         4. One of the default argument values can't be represented in Python.
         5. Varargs that haven't been forced to use a fixed number of arguments with %varargs.
      */
-    if (is_real_overloaded(n) || GetFlag(n, "feature:compactdefaultargs") || GetFlag(n, "feature:python:cdefaultargs") || !is_representable_as_pyargs(n) || varargs) {
+    if (is_real_overloaded(n) || GetFlag(n, "feature:compactdefaultargs") || GetFlag(n, "feature:python:cdefaultargs") || !is_representable_as_pyargs(n) ||
+        varargs) {
       String *parms = NewString("");
       if (in_class)
         Printf(parms, "self, ");
@@ -2332,7 +2332,7 @@ public:
 
     bool funcanno = Equal(Getattr(n, "feature:python:annotations"), "c") ? true : false;
     String *params = NewString("");
-    String *_params = make_autodocParmList(n, false, ((in_class || has_self_for_count)? 2 : 1), is_calling, funcanno);
+    String *_params = make_autodocParmList(n, false, ((in_class || has_self_for_count) ? 2 : 1), is_calling, funcanno);
 
     if (in_class) {
       Printf(params, "self");
@@ -2413,7 +2413,6 @@ public:
   bool have_addtofunc(Node *n) {
     return have_pythonappend(n) || have_pythonprepend(n);
   }
-
 
   /* ------------------------------------------------------------
    * returnTypeAnnotation()
@@ -2502,13 +2501,13 @@ public:
       }
     }
 
-    // Below may result in a 2nd definition of the method when -olddefs is used. The Python interpreter will use the second definition as it overwrites the first.
+    // Below may result in a 2nd definition of the method when -olddefs is used. The Python interpreter will use the second definition as it overwrites the
+    // first.
     if (fast) {
       /* If there is no addtofunc directive then just assign from the extension module (for speed up) */
       Printv(f_dest, name, " = ", module, ".", name, "\n", NIL);
     }
   }
-
 
   /* ------------------------------------------------------------
    * check_kwargs()
@@ -2517,18 +2516,15 @@ public:
    * ------------------------------------------------------------ */
 
   int check_kwargs(Node *n) const {
-    return (use_kw || GetFlag(n, "feature:kwargs"))
-        && !GetFlag(n, "memberset") && !GetFlag(n, "memberget");
+    return (use_kw || GetFlag(n, "feature:kwargs")) && !GetFlag(n, "memberset") && !GetFlag(n, "memberget");
   }
-
-
 
   /* ------------------------------------------------------------
    * add_method()
    * ------------------------------------------------------------ */
 
   void add_method(String *name, String *function, int kw, Node *n = 0, int funpack = 0, int num_required = -1, int num_arguments = -1) {
-    String * meth_str = NewString("");
+    String *meth_str = NewString("");
     if (!kw) {
       if (funpack) {
         if (num_required == 0 && num_arguments == 0) {
@@ -2591,7 +2587,8 @@ public:
   /* ------------------------------------------------------------
    * dispatchFunction()
    * ------------------------------------------------------------ */
-  void dispatchFunction(Node *n, String *linkage, int funpack = 0, bool builtin_self = false, bool builtin_ctor = false, bool director_class = false, bool use_static_method = false) {
+  void dispatchFunction(Node *n, String *linkage, int funpack = 0, bool builtin_self = false, bool builtin_ctor = false, bool director_class = false,
+                        bool use_static_method = false) {
     /* Last node in overloaded chain */
 
     bool add_self = builtin_self && (!builtin_ctor || director_class);
@@ -2680,7 +2677,7 @@ public:
     } else {
       Node *sibl = n;
       while (Getattr(sibl, "sym:previousSibling"))
-        sibl = Getattr(sibl, "sym:previousSibling");    // go all the way up
+        sibl = Getattr(sibl, "sym:previousSibling");  // go all the way up
       String *protoTypes = NewString("");
       do {
         String *fulldecl = Swig_name_decl(sibl);
@@ -2688,8 +2685,12 @@ public:
         Delete(fulldecl);
       } while ((sibl = Getattr(sibl, "sym:nextSibling")));
       Append(f->code, "fail:\n");
-      Printf(f->code, "  SWIG_Python_RaiseOrModifyTypeError("
-             "\"Wrong number or type of arguments for overloaded function '%s'.\\n\"" "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n", symname, protoTypes);
+      Printf(f->code,
+             "  SWIG_Python_RaiseOrModifyTypeError("
+             "\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
+             "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n",
+             symname,
+             protoTypes);
       Printf(f->code, "return %s;\n", builtin_ctor ? "-1" : "0");
       Delete(protoTypes);
     }
@@ -2740,7 +2741,6 @@ public:
     return conv ? "SWIG_POINTER_IMPLICIT_CONV" : "0";
   }
 
-
   virtual int functionWrapper(Node *n) {
 
     String *name = Getattr(n, "name");
@@ -2781,8 +2781,7 @@ public:
     /* Only the first constructor is handled as init method. Others
        constructor can be emitted via %rename */
     int handled_as_init = 0;
-    if (!have_constructor && (constructor || Getattr(n, "handled_as_constructor"))
-        && ((shadow & PYSHADOW_MEMBER))) {
+    if (!have_constructor && (constructor || Getattr(n, "handled_as_constructor")) && ((shadow & PYSHADOW_MEMBER))) {
       String *nname = Getattr(n, "sym:name");
       String *sname = Getattr(getCurrentClass(), "sym:name");
       String *cname = Swig_name_construct(NSPACE_TODO, sname);
@@ -2952,7 +2951,7 @@ public:
       if (parse_from_tuple) {
         Printf(arglist, ", ");
         if (i == num_required)
-          Putc('|', parse_args);        /* Optional argument separator */
+          Putc('|', parse_args); /* Optional argument separator */
       }
 
       /* Keyword argument handling */
@@ -2974,7 +2973,7 @@ public:
             Replaceall(tm, "$self", "obj0");
           }
           Replaceall(tm, "$input", source);
-          Setattr(p, "emit:input", source);     /* Save the location of the object */
+          Setattr(p, "emit:input", source); /* Save the location of the object */
 
           if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
             Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
@@ -3058,7 +3057,9 @@ public:
         if (builtin_ctor)
           Printf(parse_args, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", iname);
         if (builtin && in_class && tuple_arguments == 0) {
-          Printf(parse_args, "    if (args && PyTuple_Check(args) && PyTuple_GET_SIZE(args) > 0) SWIG_exception_fail(SWIG_TypeError, \"%s takes no arguments\");\n", iname);
+          Printf(parse_args,
+                 "    if (args && PyTuple_Check(args) && PyTuple_GET_SIZE(args) > 0) SWIG_exception_fail(SWIG_TypeError, \"%s takes no arguments\");\n",
+                 iname);
         } else {
           Printf(parse_args, "if (!PyArg_UnpackTuple(args, \"%s\", %d, %d", iname, num_fixed_arguments, tuple_arguments);
           Printv(parse_args, arglist, ")) SWIG_fail;\n", NIL);
@@ -3481,8 +3482,6 @@ public:
     return SWIG_OK;
   }
 
-
-
   /* ------------------------------------------------------------
    * variableWrapper()
    * ------------------------------------------------------------ */
@@ -3663,7 +3662,6 @@ public:
       have_tm = 1;
     }
 
-
     if (builtin && in_class && Getattr(n, "pybuiltin:symname")) {
       have_builtin_symname = 1;
       Swig_require("builtin_constantWrapper", n, "*sym:name", "pybuiltin:symname", NIL);
@@ -3720,8 +3718,8 @@ public:
 
       if (f_s) {
         if (needs_swigconstant(n)) {
-          Printv(f_s, "\n",NIL);
-          Printv(f_s, module, ".", iname, "_swigconstant(",module,")\n", NIL);
+          Printv(f_s, "\n", NIL);
+          Printv(f_s, module, ".", iname, "_swigconstant(", module, ")\n", NIL);
         }
         Printv(f_s, iname, " = ", module, ".", iname, "\n", NIL);
         if (have_docstring(n))
@@ -3730,7 +3728,6 @@ public:
     }
     return SWIG_OK;
   }
-
 
   /* ------------------------------------------------------------
    * nativeWrapper()
@@ -3749,8 +3746,6 @@ public:
     }
     return SWIG_OK;
   }
-
-
 
   /* ----------------------------------------------------------------------------
    * BEGIN C++ Director Class modifications
@@ -3851,7 +3846,6 @@ public:
     return Language::classDirectorDefaultConstructor(n);
   }
 
-
   /* ------------------------------------------------------------
    * classDirectorInit()
    * ------------------------------------------------------------ */
@@ -3894,7 +3888,6 @@ public:
       Printf(f_directors_h, "    }\n");
       Printf(f_directors_h, "private:\n");
       Printf(f_directors_h, "    mutable std::map<std::string, bool> swig_inner;\n");
-
     }
     if (director_method_index) {
       Printf(f_directors_h, "\n");
@@ -3923,7 +3916,6 @@ public:
     return Language::classDirectorEnd(n);
   }
 
-
   /* ------------------------------------------------------------
    * classDirectorDisown()
    * ------------------------------------------------------------ */
@@ -3943,7 +3935,7 @@ public:
         Delete(rname);
       } else {
         String *symname = Getattr(n, "sym:name");
-        String *mrename = Swig_name_disown(NSPACE_TODO, symname);       //Getattr(n, "name"));
+        String *mrename = Swig_name_disown(NSPACE_TODO, symname);  // Getattr(n, "name"));
         Printv(f_shadow, tab4, "def __disown__(self):\n", NIL);
         Printv(f_shadow, tab8, "self.this.disown()\n", NIL);
         Printv(f_shadow, tab8, module, ".", mrename, "(self)\n", NIL);
@@ -3957,7 +3949,6 @@ public:
   /* ----------------------------------------------------------------------------
    * END of C++ Director Class modifications
    * ------------------------------------------------------------------------- */
-
 
   /* ------------------------------------------------------------
    * classDeclaration()
@@ -4664,7 +4655,7 @@ public:
         }
       }
 
-      shadow_indent = (String *) tab4;
+      shadow_indent = (String *)tab4;
 
       /* Handle inheritance */
       String *base_class = NewString("");
@@ -4677,8 +4668,11 @@ public:
           bool ignore = GetFlag(b.item, "feature:ignore") ? true : false;
           if (!bname || ignore) {
             if (!bname && !ignore) {
-              Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(n), Getline(n),
-                           "Base class '%s' ignored - unknown module name for base. Either import the appropriate module interface file or specify the name of the module in the %%import directive.\n",
+              Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                           Getfile(n),
+                           Getline(n),
+                           "Base class '%s' ignored - unknown module name for base. Either import the appropriate module interface file or specify the name of "
+                           "the module in the %%import directive.\n",
                            SwigType_namestr(Getattr(b.item, "name")));
             }
             b = Next(b);
@@ -4811,8 +4805,8 @@ public:
         Printv(f_wrappers, "  PyObject *obj = NULL;\n", NIL);
         Printv(f_wrappers, "  if (!SWIG_Python_UnpackTuple(args, \"swigregister\", 1, 1, &obj)) return NULL;\n", NIL);
 
-        Printv(f_wrappers,
-               "  SWIG_TypeNewClientData(SWIGTYPE", SwigType_manglestr(ct), ", SWIG_NewClientData(obj));\n", "  return SWIG_Py_Void();\n", "}\n\n", NIL);
+        Printv(
+          f_wrappers, "  SWIG_TypeNewClientData(SWIGTYPE", SwigType_manglestr(ct), ", SWIG_NewClientData(obj));\n", "  return SWIG_Py_Void();\n", "}\n\n", NIL);
         String *cname = NewStringf("%s_swigregister", class_name);
         add_method(cname, cname, 0, 0, 1, 1, 1);
         Delete(cname);
@@ -4821,8 +4815,16 @@ public:
       Delete(realct);
       if (!have_constructor) {
         if (!builtin)
-          Printv(f_shadow_file, "\n", tab4, "def __init__(self, *args, **kwargs):\n", tab8, "raise AttributeError(\"", "No constructor defined",
-                 (Getattr(n, "abstracts") ? " - class is abstract" : ""), "\")\n", NIL);
+          Printv(f_shadow_file,
+                 "\n",
+                 tab4,
+                 "def __init__(self, *args, **kwargs):\n",
+                 tab8,
+                 "raise AttributeError(\"",
+                 "No constructor defined",
+                 (Getattr(n, "abstracts") ? " - class is abstract" : ""),
+                 "\")\n",
+                 NIL);
       } else if (!builtin) {
 
         Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
@@ -4905,7 +4907,7 @@ public:
       Swig_save("builtin_memberfunc", n, "python:argcount", NIL);
 
     /* Create the default member function */
-    oldshadow = shadow;         /* Disable shadowing when wrapping member functions */
+    oldshadow = shadow; /* Disable shadowing when wrapping member functions */
     if (shadow)
       shadow = shadow | PYSHADOW_MEMBER;
     Language::memberfunctionHandler(n);
@@ -4996,7 +4998,6 @@ public:
     return SWIG_OK;
   }
 
-
   /* ------------------------------------------------------------
    * staticmemberfunctionHandler()
    * ------------------------------------------------------------ */
@@ -5014,8 +5015,7 @@ public:
 
     int kw = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
     if (builtin && in_class) {
-      if ((GetFlagAttr(n, "feature:extend") || checkAttribute(n, "access", "public"))
-          && !Getattr(class_members, symname)) {
+      if ((GetFlagAttr(n, "feature:extend") || checkAttribute(n, "access", "public")) && !Getattr(class_members, symname)) {
         String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
         String *wname = Swig_name_wrapper(fullname);
         Setattr(class_members, symname, n);
@@ -5075,10 +5075,10 @@ public:
         }
       }
 
-      // Below may result in a 2nd definition of the method when -olddefs is used. The Python interpreter will use the second definition as it overwrites the first.
+      // Below may result in a 2nd definition of the method when -olddefs is used. The Python interpreter will use the second definition as it overwrites the
+      // first.
       if (fast) {
-        Printv(f_shadow, tab4, symname, " = ", staticfunc_name, "(", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname),
-               ")\n", NIL);
+        Printv(f_shadow, tab4, symname, " = ", staticfunc_name, "(", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname), ")\n", NIL);
       }
       Delete(staticfunc_name);
     }
@@ -5197,10 +5197,14 @@ public:
               if (Node *node_with_doc = find_overload_with_docstring(n))
                 Printv(f_shadow_stubs, tab4, docstring(node_with_doc, AUTODOC_CTOR, tab4), "\n", NIL);
               if (have_pythonprepend(n))
-                Printv(f_shadow_stubs, indent_pythoncode(pythonprepend(n), tab4, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+                Printv(f_shadow_stubs,
+                       indent_pythoncode(pythonprepend(n), tab4, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"),
+                       "\n",
+                       NIL);
               Printv(f_shadow_stubs, tab4, "val = ", funcCall(subfunc, callParms), "\n", NIL);
               if (have_pythonappend(n))
-                Printv(f_shadow_stubs, indent_pythoncode(pythonappend(n), tab4, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
+                Printv(
+                  f_shadow_stubs, indent_pythoncode(pythonappend(n), tab4, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
               Printv(f_shadow_stubs, tab4, "return val\n", NIL);
             }
           } else {
@@ -5232,7 +5236,7 @@ public:
 
     if (shadow)
       shadow = shadow | PYSHADOW_MEMBER;
-    //Setattr(n,"emit:dealloc","1");
+    // Setattr(n,"emit:dealloc","1");
     Language::destructorHandler(n);
     shadow = oldshadow;
 
@@ -5513,7 +5517,6 @@ int PYTHON::classDirectorMethods(Node *n) {
   return Language::classDirectorMethods(n);
 }
 
-
 int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
   int is_void = 0;
   int is_pointer = 0;
@@ -5637,7 +5640,9 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
       Printf(w->code, "%s;\n", super_call);
       Delete(super_call);
     } else {
-      Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+      Printf(w->code,
+             "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+             SwigType_namestr(c_classname),
              SwigType_namestr(name));
     }
   } else {
@@ -5731,9 +5736,13 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
             String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
             Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
             Delete(nonconst_i);
-            Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
+            Swig_warning(WARN_LANG_DISCARD_CONST,
+                         input_file,
+                         line_number,
                          "Target language argument '%s' discards const in director method %s::%s.\n",
-                         SwigType_str(ptype, pname), SwigType_namestr(c_classname), SwigType_namestr(name));
+                         SwigType_str(ptype, pname),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
           } else {
             nonconst = Copy(ppname);
           }
@@ -5756,17 +5765,21 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
           } else {
             Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
             Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-            //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
-            //       source, nonconst, base);
+            // Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
+            //        source, nonconst, base);
             Printv(arglist, source, NIL);
           }
           Putc('O', parse_args);
           Delete(mangle);
           Delete(nonconst);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                       SwigType_str(ptype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_NOWRAP;
           break;
         }
@@ -5792,7 +5805,6 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
       Printf(w->code, "swig_set_inner(\"%s\", true);\n", name);
     }
 
-
     Append(w->code, "if (!swig_get_self()) {\n");
     Printf(w->code, "  Swig::DirectorException::raise(\"'self' uninitialized, maybe you forgot to call %s.__init__.\");\n", classname);
     Append(w->code, "}\n");
@@ -5814,10 +5826,18 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     Append(w->code, "#else\n");
     if (Len(parse_args) > 0) {
       if (use_parse) {
-        Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallMethod(swig_get_self(), (char *)\"%s\", (char *)\"(%s)\" %s);\n", Swig_cresult_name(), pyname, parse_args, arglist);
+        Printf(w->code,
+               "swig::SwigVar_PyObject %s = PyObject_CallMethod(swig_get_self(), (char *)\"%s\", (char *)\"(%s)\" %s);\n",
+               Swig_cresult_name(),
+               pyname,
+               parse_args,
+               arglist);
       } else {
         Printf(w->code, "swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar(\"%s\");\n", pyname);
-        Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name %s, NULL);\n", Swig_cresult_name(), arglist);
+        Printf(w->code,
+               "swig::SwigVar_PyObject %s = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name %s, NULL);\n",
+               Swig_cresult_name(),
+               arglist);
       }
     } else {
       Printf(w->code, "swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar(\"%s\");\n", pyname);
@@ -5896,8 +5916,12 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
         Printv(w->code, tm, "\n", NIL);
         Delete(tm);
       } else {
-        Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-                     "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0), SwigType_namestr(c_classname),
+        Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                     input_file,
+                     line_number,
+                     "Unable to use return type %s in director method %s::%s (skipping method).\n",
+                     SwigType_str(returntype, 0),
+                     SwigType_namestr(c_classname),
                      SwigType_namestr(name));
         status = SWIG_ERROR;
       }

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1015,9 +1015,9 @@ public:
    *  #  base       other         tail
    * --  ----       -----         ----
    *  1  "Foo"      "Foo.Bar" ->  "Bar"
-   *  2	 "Foo"      "Foo."    ->  ""
-   *  3	 "Foo"      "FooB.ar" ->  NULL
-   *  4	 "Foo.Bar"  "Foo.Bar" ->  ""
+   *  2  "Foo"      "Foo."    ->  ""
+   *  3  "Foo"      "FooB.ar" ->  NULL
+   *  4  "Foo.Bar"  "Foo.Bar" ->  ""
    *  5  "Foo.Bar"  "Foo"     ->  NULL
    *  6  "Foo.Bar"  "Foo.Gez" ->  NULL
    *
@@ -1047,9 +1047,9 @@ public:
    *
    * Return a string containing python code to import module.
    *
-   * 	pkg     package name or the module being imported
-   * 	mod     module name of the module being imported
-   * 	pfx     optional prefix to module name
+   *    pkg     package name or the module being imported
+   *    mod     module name of the module being imported
+   *    pfx     optional prefix to module name
    *
    * NOTE: keep this function consistent with abs_import_name_string().
    * ------------------------------------------------------------ */
@@ -1071,10 +1071,10 @@ public:
    * Return a string containing python code to import module that
    * is potentially within a package.
    *
-   * 	mainpkg	package name of the module which imports the other module
-   * 	pkg     package name or the module being imported
-   * 	mod     module name of the module being imported
-   * 	pfx     optional prefix to module name
+   *    mainpkg package name of the module which imports the other module
+   *    pkg     package name or the module being imported
+   *    mod     module name of the module being imported
+   *    pfx     optional prefix to module name
    *
    * NOTE: keep this function consistent with rel_import_name_string().
    * ------------------------------------------------------------ */
@@ -1489,12 +1489,12 @@ public:
    * ------------------------------------------------------------ */
 
   enum autodoc_l {
-    NO_AUTODOC = -2,		// no autodoc
-    STRING_AUTODOC = -1,	// use provided string
-    NAMES_AUTODOC = 0,		// only parameter names
-    TYPES_AUTODOC = 1,		// parameter names and types
-    EXTEND_AUTODOC = 2,		// extended documentation and parameter names
-    EXTEND_TYPES_AUTODOC = 3	// extended documentation and parameter types + names
+    NO_AUTODOC = -2,            // no autodoc
+    STRING_AUTODOC = -1,        // use provided string
+    NAMES_AUTODOC = 0,          // only parameter names
+    TYPES_AUTODOC = 1,          // parameter names and types
+    EXTEND_AUTODOC = 2,         // extended documentation and parameter names
+    EXTEND_TYPES_AUTODOC = 3    // extended documentation and parameter types + names
   };
 
 
@@ -2680,7 +2680,7 @@ public:
     } else {
       Node *sibl = n;
       while (Getattr(sibl, "sym:previousSibling"))
-        sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+        sibl = Getattr(sibl, "sym:previousSibling");    // go all the way up
       String *protoTypes = NewString("");
       do {
         String *fulldecl = Swig_name_decl(sibl);
@@ -2952,7 +2952,7 @@ public:
       if (parse_from_tuple) {
         Printf(arglist, ", ");
         if (i == num_required)
-          Putc('|', parse_args);	/* Optional argument separator */
+          Putc('|', parse_args);        /* Optional argument separator */
       }
 
       /* Keyword argument handling */
@@ -2974,7 +2974,7 @@ public:
             Replaceall(tm, "$self", "obj0");
           }
           Replaceall(tm, "$input", source);
-          Setattr(p, "emit:input", source);	/* Save the location of the object */
+          Setattr(p, "emit:input", source);     /* Save the location of the object */
 
           if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
             Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
@@ -3943,7 +3943,7 @@ public:
         Delete(rname);
       } else {
         String *symname = Getattr(n, "sym:name");
-        String *mrename = Swig_name_disown(NSPACE_TODO, symname);	//Getattr(n, "name"));
+        String *mrename = Swig_name_disown(NSPACE_TODO, symname);       //Getattr(n, "name"));
         Printv(f_shadow, tab4, "def __disown__(self):\n", NIL);
         Printv(f_shadow, tab8, "self.this.disown()\n", NIL);
         Printv(f_shadow, tab8, module, ".", mrename, "(self)\n", NIL);
@@ -4905,7 +4905,7 @@ public:
       Swig_save("builtin_memberfunc", n, "python:argcount", NIL);
 
     /* Create the default member function */
-    oldshadow = shadow;		/* Disable shadowing when wrapping member functions */
+    oldshadow = shadow;         /* Disable shadowing when wrapping member functions */
     if (shadow)
       shadow = shadow | PYSHADOW_MEMBER;
     Language::memberfunctionHandler(n);

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3213,7 +3213,7 @@ public:
         }
       }
 
-      // Unwrap return values that are director classes so that the original Python object is returned instead. 
+      // Unwrap return values that are director classes so that the original Python object is returned instead.
       if (!constructor && Swig_director_can_unwrap(n)) {
         Wrapper_add_local(f, "director", "Swig::Director *director = 0");
         Printf(f->code, "director = SWIG_DIRECTOR_CAST(%s);\n", Swig_cresult_name());

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -239,9 +239,9 @@ public:
     /* Add code to manage protected constructors and directors */
     director_prot_ctor_code = NewString("");
     Printv(director_prot_ctor_code,
-	   "if ($comparison) { /* subclassed */\n",
-	   "  $director_new\n",
-	   "} else {\n", "  SWIG_SetErrorMsg(PyExc_RuntimeError,\"accessing abstract class or protected constructor\");\n", "  SWIG_fail;\n", "}\n", NIL);
+           "if ($comparison) { /* subclassed */\n",
+           "  $director_new\n",
+           "} else {\n", "  SWIG_SetErrorMsg(PyExc_RuntimeError,\"accessing abstract class or protected constructor\");\n", "  SWIG_fail;\n", "}\n", NIL);
     director_multiple_inheritance = 1;
     directorLanguage();
   }
@@ -272,9 +272,9 @@ public:
     if (!GetFlag(n, "feature:nothreadblock")) {
       String *bb = Getattr(n, "feature:threadbeginblock");
       if (bb) {
-	Append(f, bb);
+        Append(f, bb);
       } else {
-	Append(f, "SWIG_PYTHON_THREAD_BEGIN_BLOCK;\n");
+        Append(f, "SWIG_PYTHON_THREAD_BEGIN_BLOCK;\n");
       }
     }
   }
@@ -283,9 +283,9 @@ public:
     if (!GetFlag(n, "feature:nothreadblock")) {
       String *eb = Getattr(n, "feature:threadendblock");
       if (eb) {
-	Append(f, eb);
+        Append(f, eb);
       } else {
-	Append(f, "SWIG_PYTHON_THREAD_END_BLOCK;\n");
+        Append(f, "SWIG_PYTHON_THREAD_END_BLOCK;\n");
       }
     }
   }
@@ -295,9 +295,9 @@ public:
       String *bb = Getattr(n, "feature:threadbeginallow");
       Append(f, "{\n");
       if (bb) {
-	Append(f, bb);
+        Append(f, bb);
       } else {
-	Append(f, "SWIG_PYTHON_THREAD_BEGIN_ALLOW;\n");
+        Append(f, "SWIG_PYTHON_THREAD_BEGIN_ALLOW;\n");
       }
     }
   }
@@ -307,9 +307,9 @@ public:
       String *eb = Getattr(n, "feature:threadendallow");
       Append(f, "\n");
       if (eb) {
-	Append(f, eb);
+        Append(f, eb);
       } else {
-	Append(f, "SWIG_PYTHON_THREAD_END_ALLOW;");
+        Append(f, "SWIG_PYTHON_THREAD_END_ALLOW;");
       }
       Append(f, "\n}");
     }
@@ -328,104 +328,104 @@ public:
 
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-interface") == 0) {
-	  if (argv[i + 1]) {
-	    interface = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-globals") == 0) {
-	  if (argv[i + 1]) {
-	    global_name = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if ((strcmp(argv[i], "-shadow") == 0) || ((strcmp(argv[i], "-proxy") == 0))) {
-	  shadow = 1;
-	  Swig_mark_arg(i);
-	} else if ((strcmp(argv[i], "-noproxy") == 0)) {
-	  shadow = 0;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-keyword") == 0) {
-	  use_kw = 1;
-	  SWIG_cparse_set_compact_default_args(1);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nortti") == 0) {
-	  nortti = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-threads") == 0) {
-	  threads = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nothreads") == 0) {
-	  /* Turn off thread support mode */
-	  nothreads = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-dirvtable") == 0) {
-	  dirvtable = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-doxygen") == 0) {
-	  doxygen = 1;
-	  scan_doxygen_comments = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-debug-doxygen-translator") == 0) {
-	  doxygen_translator_flags |= DoxygenTranslator::debug_translator;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-debug-doxygen-parser") == 0) {
-	  doxygen_translator_flags |= DoxygenTranslator::debug_parser;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nofastunpack") == 0) {
-	  fastunpack = 0;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-fastproxy") == 0) {
-	  fastproxy = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-olddefs") == 0) {
-	  olddefs = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-castmode") == 0) {
-	  castmode = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-extranative") == 0) {
-	  extranative = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-flatstaticmethod") == 0) {
-	  flat_static_method = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-noh") == 0) {
-	  no_header_file = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-newvwm") == 0) {
-	  /* Turn on new value wrapper mode */
-	  /* Undocumented option, did have -help text: New value wrapper mode, use only when everything else fails */
-	  Swig_value_wrapper_mode(1);
-	  no_header_file = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-O") == 0) {
-	  fastproxy = 1;
-	  Wrapper_fast_dispatch_mode_set(1);
-	  Wrapper_virtual_elimination_mode_set(1);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  fputs(usage1, stdout);
-	  fputs(usage2, stdout);
-	  fputs(usage3, stdout);
-	} else if (strcmp(argv[i], "-builtin") == 0) {
-	  builtin = 1;
-	  Preprocessor_define("SWIGPYTHON_BUILTIN", 0);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nogil") == 0) {
-	  nogil = 1;
-	  Preprocessor_define("SWIGPYTHON_NOGIL", 0);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-relativeimport") == 0) {
-	  relativeimport = 1;
-	  Swig_mark_arg(i);
+        if (strcmp(argv[i], "-interface") == 0) {
+          if (argv[i + 1]) {
+            interface = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-globals") == 0) {
+          if (argv[i + 1]) {
+            global_name = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if ((strcmp(argv[i], "-shadow") == 0) || ((strcmp(argv[i], "-proxy") == 0))) {
+          shadow = 1;
+          Swig_mark_arg(i);
+        } else if ((strcmp(argv[i], "-noproxy") == 0)) {
+          shadow = 0;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-keyword") == 0) {
+          use_kw = 1;
+          SWIG_cparse_set_compact_default_args(1);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nortti") == 0) {
+          nortti = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-threads") == 0) {
+          threads = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nothreads") == 0) {
+          /* Turn off thread support mode */
+          nothreads = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-dirvtable") == 0) {
+          dirvtable = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-doxygen") == 0) {
+          doxygen = 1;
+          scan_doxygen_comments = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-debug-doxygen-translator") == 0) {
+          doxygen_translator_flags |= DoxygenTranslator::debug_translator;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-debug-doxygen-parser") == 0) {
+          doxygen_translator_flags |= DoxygenTranslator::debug_parser;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nofastunpack") == 0) {
+          fastunpack = 0;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-fastproxy") == 0) {
+          fastproxy = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-olddefs") == 0) {
+          olddefs = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-castmode") == 0) {
+          castmode = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-extranative") == 0) {
+          extranative = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-flatstaticmethod") == 0) {
+          flat_static_method = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-noh") == 0) {
+          no_header_file = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-newvwm") == 0) {
+          /* Turn on new value wrapper mode */
+          /* Undocumented option, did have -help text: New value wrapper mode, use only when everything else fails */
+          Swig_value_wrapper_mode(1);
+          no_header_file = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-O") == 0) {
+          fastproxy = 1;
+          Wrapper_fast_dispatch_mode_set(1);
+          Wrapper_virtual_elimination_mode_set(1);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-help") == 0) {
+          fputs(usage1, stdout);
+          fputs(usage2, stdout);
+          fputs(usage3, stdout);
+        } else if (strcmp(argv[i], "-builtin") == 0) {
+          builtin = 1;
+          Preprocessor_define("SWIGPYTHON_BUILTIN", 0);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nogil") == 0) {
+          nogil = 1;
+          Preprocessor_define("SWIGPYTHON_NOGIL", 0);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-relativeimport") == 0) {
+          relativeimport = 1;
+          Swig_mark_arg(i);
           // clang-format off
         } else if (strcmp(argv[i], "-cppcast") == 0 ||
                    strcmp(argv[i], "-fastinit") == 0 ||
@@ -512,49 +512,49 @@ public:
     {
       Node *mod = Getattr(n, "module");
       if (mod) {
-	Node *options = Getattr(mod, "options");
-	if (options) {
-	  int dirprot = 0;
-	  if (Getattr(options, "dirprot")) {
-	    dirprot = 1;
-	  }
-	  if (Getattr(options, "nodirprot")) {
-	    dirprot = 0;
-	  }
-	  if (Getattr(options, "directors")) {
-	    allow_directors();
-	    if (dirprot)
-	      allow_dirprot();
-	  }
-	  if (Getattr(options, "threads")) {
-	    threads = 1;
-	  }
-	  if (Getattr(options, "castmode")) {
-	    castmode = 1;
-	  }
-	  if (Getattr(options, "nocastmode")) {
-	    Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "nocastmode");
-	    Exit(EXIT_FAILURE);
-	  }
-	  if (Getattr(options, "extranative")) {
-	    extranative = 1;
-	  }
-	  if (Getattr(options, "noextranative")) {
-	    Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "noextranative");
-	    Exit(EXIT_FAILURE);
-	  }
-	  if (Getattr(options, "outputtuple")) {
-	    Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "outputtuple");
-	    Exit(EXIT_FAILURE);
-	  }
-	  if (Getattr(options, "nooutputtuple")) {
-	    Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "nooutputtuple");
-	    Exit(EXIT_FAILURE);
-	  }
-	  mod_docstring = Getattr(options, "docstring");
-	  package = Getattr(options, "package");
-	  moduleimport = Getattr(options, "moduleimport");
-	}
+        Node *options = Getattr(mod, "options");
+        if (options) {
+          int dirprot = 0;
+          if (Getattr(options, "dirprot")) {
+            dirprot = 1;
+          }
+          if (Getattr(options, "nodirprot")) {
+            dirprot = 0;
+          }
+          if (Getattr(options, "directors")) {
+            allow_directors();
+            if (dirprot)
+              allow_dirprot();
+          }
+          if (Getattr(options, "threads")) {
+            threads = 1;
+          }
+          if (Getattr(options, "castmode")) {
+            castmode = 1;
+          }
+          if (Getattr(options, "nocastmode")) {
+            Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "nocastmode");
+            Exit(EXIT_FAILURE);
+          }
+          if (Getattr(options, "extranative")) {
+            extranative = 1;
+          }
+          if (Getattr(options, "noextranative")) {
+            Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "noextranative");
+            Exit(EXIT_FAILURE);
+          }
+          if (Getattr(options, "outputtuple")) {
+            Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "outputtuple");
+            Exit(EXIT_FAILURE);
+          }
+          if (Getattr(options, "nooutputtuple")) {
+            Printf(stderr, "Deprecated module option: %s. This option is no longer supported.\n", "nooutputtuple");
+            Exit(EXIT_FAILURE);
+          }
+          mod_docstring = Getattr(options, "docstring");
+          package = Getattr(options, "package");
+          moduleimport = Getattr(options, "moduleimport");
+        }
       }
     }
 
@@ -590,13 +590,13 @@ public:
 
     if (Swig_directors_enabled()) {
       if (!no_header_file) {
-	f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
-	if (!f_runtime_h) {
-	  FileErrorDisplay(outfile_h);
-	  Exit(EXIT_FAILURE);
-	}
+        f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
+        if (!f_runtime_h) {
+          FileErrorDisplay(outfile_h);
+          Exit(EXIT_FAILURE);
+        }
       } else {
-	f_runtime_h = f_runtime;
+        f_runtime_h = f_runtime;
       }
     }
 
@@ -676,8 +676,8 @@ public:
       Printf(f_directors_h, "#ifndef SWIG_%s_WRAP_H_\n", module);
       Printf(f_directors_h, "#define SWIG_%s_WRAP_H_\n\n", module);
       if (dirprot_mode()) {
-	Printf(f_directors_h, "#include <map>\n");
-	Printf(f_directors_h, "#include <string>\n\n");
+        Printf(f_directors_h, "#include <map>\n");
+        Printf(f_directors_h, "#include <string>\n\n");
       }
 
       Printf(f_directors, "\n\n");
@@ -685,9 +685,9 @@ public:
       Printf(f_directors, " * C++ director class methods\n");
       Printf(f_directors, " * --------------------------------------------------- */\n\n");
       if (outfile_h) {
-	String *filename = Swig_file_filename(outfile_h);
-	Printf(f_directors, "#include \"%s\"\n\n", filename);
-	Delete(filename);
+        String *filename = Swig_file_filename(outfile_h);
+        Printf(f_directors, "#include \"%s\"\n\n", filename);
+        Delete(filename);
       }
     }
 
@@ -697,12 +697,12 @@ public:
       String *filen = NewStringf("%s%s.py", SWIG_output_directory(), Char(module));
       // If we don't have an interface then change the module name X to _X
       if (interface)
-	module = interface;
+        module = interface;
       else
-	Insert(module, 0, "_");
+        Insert(module, 0, "_");
       if ((f_shadow_py = NewFile(filen, "w", SWIG_output_files())) == 0) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       Delete(filen);
       filen = NULL;
@@ -717,22 +717,22 @@ public:
       Swig_register_filebyname("python", f_shadow);
 
       if (!builtin) {
-	/* Import the low-level C/C++ module.  This should be a relative import,
-	 * since the shadow module may also have been imported by a relative
-	 * import, and there is thus no guarantee that the low-level C/C++ module is on
-	 * sys.path.  Relative imports must be explicitly specified from 2.6.0
-	 * onwards (implicit relative imports raised a DeprecationWarning in 2.6,
-	 * and fail in 2.7 onwards).
-	 *
-	 * First check for __spec__.parent which is available from 3.4 onwards,
-	 * see https://docs.python.org/3/reference/import.html#spec. If not,
-	 * check for __package__, which is available from 2.6 onwards (see PEP366),
-	 * but will no longer be set/used in 3.15.
-	 * Next try determine the shadow wrapper's package based on the __name__ it
-	 * was given by the importer that loaded it.
-	 * If the module is in a package, load the low-level C/C++ module from the
-	 * same package, otherwise load it as a global module.
-	 */
+        /* Import the low-level C/C++ module.  This should be a relative import,
+         * since the shadow module may also have been imported by a relative
+         * import, and there is thus no guarantee that the low-level C/C++ module is on
+         * sys.path.  Relative imports must be explicitly specified from 2.6.0
+         * onwards (implicit relative imports raised a DeprecationWarning in 2.6,
+         * and fail in 2.7 onwards).
+         *
+         * First check for __spec__.parent which is available from 3.4 onwards,
+         * see https://docs.python.org/3/reference/import.html#spec. If not,
+         * check for __package__, which is available from 2.6 onwards (see PEP366),
+         * but will no longer be set/used in 3.15.
+         * Next try determine the shadow wrapper's package based on the __name__ it
+         * was given by the importer that loaded it.
+         * If the module is in a package, load the low-level C/C++ module from the
+         * same package, otherwise load it as a global module.
+         */
         Printv(default_import_code, "# Import the low-level C/C++ module\n", NULL);
         Printv(default_import_code, "if getattr(globals().get(\"__spec__\"), \"parent\", None) or __package__ or \".\" in __name__:\n", NULL);
         Printv(default_import_code, "    from . import ", module, "\n", NULL);
@@ -747,8 +747,8 @@ public:
       }
 
       if (!builtin) {
-	/* Need builtins to qualify names like Exception that might also be
-	   defined in this module (try both Python 3 and Python 2 names) */
+        /* Need builtins to qualify names like Exception that might also be
+           defined in this module (try both Python 3 and Python 2 names) */
         Printv(f_shadow,
                "try:\n",
                "    import builtins as __builtin__\n",
@@ -758,9 +758,9 @@ public:
       }
 
       if (!builtin && fastproxy) {
-	Printf(f_shadow, "\n");
-	Printf(f_shadow, "_swig_new_instance_method = %s.SWIG_PyInstanceMethod_New\n", module);
-	Printf(f_shadow, "_swig_new_static_method = %s.SWIG_PyStaticMethod_New\n", module);
+        Printf(f_shadow, "\n");
+        Printf(f_shadow, "_swig_new_instance_method = %s.SWIG_PyInstanceMethod_New\n", module);
+        Printf(f_shadow, "_swig_new_static_method = %s.SWIG_PyStaticMethod_New\n", module);
       }
 
       if (!builtin) {
@@ -809,10 +809,10 @@ public:
                "    __setattr__ = _swig_setattr_nondynamic_class_variable(type.__setattr__)\n",
                "\n", NIL);
 
-	Printv(f_shadow, "\n", NIL);
+        Printv(f_shadow, "\n", NIL);
 
-	if (Swig_directors_enabled())
-	  Printv(f_shadow, "import weakref\n\n", NIL);
+        if (Swig_directors_enabled())
+          Printv(f_shadow, "import weakref\n\n", NIL);
       }
     }
     // Include some information in the code
@@ -891,36 +891,36 @@ public:
       Swig_banner_target_lang(f_shadow_py, "#");
 
       if (mod_docstring) {
-	if (Len(mod_docstring)) {
-	  const char *triple_double = "\"\"\"";
-	  // follow PEP257 rules: https://www.python.org/dev/peps/pep-0257/
-	  // reported by pep257: https://github.com/GreenSteam/pep257
-	  bool multi_line_ds = Strchr(mod_docstring, '\n') != 0;
-	  Printv(f_shadow_py, "\n", triple_double, multi_line_ds ? "\n":"", mod_docstring, multi_line_ds ? "\n":"", triple_double, "\n", NIL);
-	}
-	Delete(mod_docstring);
-	mod_docstring = NULL;
+        if (Len(mod_docstring)) {
+          const char *triple_double = "\"\"\"";
+          // follow PEP257 rules: https://www.python.org/dev/peps/pep-0257/
+          // reported by pep257: https://github.com/GreenSteam/pep257
+          bool multi_line_ds = Strchr(mod_docstring, '\n') != 0;
+          Printv(f_shadow_py, "\n", triple_double, multi_line_ds ? "\n":"", mod_docstring, multi_line_ds ? "\n":"", triple_double, "\n", NIL);
+        }
+        Delete(mod_docstring);
+        mod_docstring = NULL;
       }
 
       if (Len(f_shadow_begin) > 0)
-	Printv(f_shadow_py, "\n", f_shadow_begin, "\n", NIL);
+        Printv(f_shadow_py, "\n", f_shadow_begin, "\n", NIL);
 
       Printv(f_shadow_py, "\nfrom sys import version_info as _swig_python_version_info\n", NULL);
 
       if (Len(f_shadow_after_begin) > 0)
-	Printv(f_shadow_py, f_shadow_after_begin, "\n", NIL);
+        Printv(f_shadow_py, f_shadow_after_begin, "\n", NIL);
 
       if (moduleimport) {
-	Replaceall(moduleimport, "$module", module);
-	Printv(f_shadow_py, moduleimport, "\n", NIL);
+        Replaceall(moduleimport, "$module", module);
+        Printv(f_shadow_py, moduleimport, "\n", NIL);
       } else {
-	Printv(f_shadow_py, default_import_code, NIL);
+        Printv(f_shadow_py, default_import_code, NIL);
       }
 
       if (Len(f_shadow) > 0)
-	Printv(f_shadow_py, "\n", f_shadow, "\n", NIL);
+        Printv(f_shadow_py, "\n", f_shadow, "\n", NIL);
       if (Len(f_shadow_stubs) > 0)
-	Printv(f_shadow_py, f_shadow_stubs, "\n", NIL);
+        Printv(f_shadow_py, f_shadow_stubs, "\n", NIL);
       Delete(f_shadow_py);
     }
 
@@ -933,7 +933,7 @@ public:
       Printf(f_runtime_h, "\n");
       Printf(f_runtime_h, "#endif\n");
       if (f_runtime_h != f_begin)
-	Delete(f_runtime_h);
+        Delete(f_runtime_h);
       Dump(f_directors, f_begin);
     }
 
@@ -1125,23 +1125,23 @@ public:
 
     if (pkg && *Char(pkg)) {
       if (mainpkg) {
-	String *tail = subpkg_tail(mainpkg, pkg);
-	if (tail) {
-	  if (*Char(tail)) {
-	    rpkg = NewString(tail);
-	    const char *py3_end1 = Strchr(rpkg, '.');
-	    if (!py3_end1)
-	      py3_end1 = (Char(rpkg)) + Len(rpkg);
-	    py3_rlen1 = (int)(py3_end1 - Char(rpkg));
-	  } else {
-	    rpkg = NewString("");
-	  }
-	  Delete(tail);
-	} else {
-	  apkg = NewString(pkg);
-	}
+        String *tail = subpkg_tail(mainpkg, pkg);
+        if (tail) {
+          if (*Char(tail)) {
+            rpkg = NewString(tail);
+            const char *py3_end1 = Strchr(rpkg, '.');
+            if (!py3_end1)
+              py3_end1 = (Char(rpkg)) + Len(rpkg);
+            py3_rlen1 = (int)(py3_end1 - Char(rpkg));
+          } else {
+            rpkg = NewString("");
+          }
+          Delete(tail);
+        } else {
+          apkg = NewString(pkg);
+        }
       } else {
-	apkg = NewString(pkg);
+        apkg = NewString(pkg);
       }
     } else {
       apkg = NewString("");
@@ -1152,7 +1152,7 @@ public:
       Delete(apkg);
     } else {
       if (py3_rlen1)
-	Printf(out, "from . import %.*s\n", py3_rlen1, rpkg);
+        Printf(out, "from . import %.*s\n", py3_rlen1, rpkg);
       Printf(out, "from .%s import %s%s\n", rpkg, pfx, mod);
       Delete(rpkg);
     }
@@ -1262,25 +1262,25 @@ public:
       String *modname = Getattr(n, "module");
 
       if (modname) {
-	// Find the module node for this imported module.  It should be the
-	// first child but search just in case.
-	Node *mod = firstChild(n);
-	while (mod && Strcmp(nodeType(mod), "module") != 0)
-	  mod = nextSibling(mod);
+        // Find the module node for this imported module.  It should be the
+        // first child but search just in case.
+        Node *mod = firstChild(n);
+        while (mod && Strcmp(nodeType(mod), "module") != 0)
+          mod = nextSibling(mod);
 
-	Node *options = Getattr(mod, "options");
-	String *pkg = options ? Getattr(options, "package") : 0;
+        Node *options = Getattr(mod, "options");
+        String *pkg = options ? Getattr(options, "package") : 0;
 
-	if (!options || (!Getattr(options, "noshadow") && !Getattr(options, "noproxy"))) {
-	  String *_import = import_directive_string(package, pkg, modname, "_");
-	  if (!GetFlagAttr(f_shadow_imports, _import)) {
-	    String *import = import_directive_string(package, pkg, modname);
-	    Printf(builtin ? f_shadow_after_begin : f_shadow, "%s", import);
-	    Delete(import);
-	    SetFlag(f_shadow_imports, _import);
-	  }
-	  Delete(_import);
-	}
+        if (!options || (!Getattr(options, "noshadow") && !Getattr(options, "noproxy"))) {
+          String *_import = import_directive_string(package, pkg, modname, "_");
+          if (!GetFlagAttr(f_shadow_imports, _import)) {
+            String *import = import_directive_string(package, pkg, modname);
+            Printf(builtin ? f_shadow_after_begin : f_shadow, "%s", import);
+            Delete(import);
+            SetFlag(f_shadow_imports, _import);
+          }
+          Delete(_import);
+        }
 
       }
     }
@@ -1349,16 +1349,16 @@ public:
       const char *c = Char(si.item);
       int i;
       for (i = 0; isspace((unsigned char)c[i]); i++) {
-	// Scan forward until we find a non-space (which may be a null byte).
+        // Scan forward until we find a non-space (which may be a null byte).
       }
       char ch = c[i];
       if (ch && ch != '#') {
-	// Found a line with actual content.
-	initial = NewStringWithSize(c, i);
-	break;
+        // Found a line with actual content.
+        initial = NewStringWithSize(c, i);
+        break;
       }
       if (ch) {
-	Printv(out, indent, c, NIL);
+        Printv(out, indent, c, NIL);
       }
       Putc('\n', out);
     }
@@ -1371,46 +1371,46 @@ public:
 
       int i;
       for (i = 0; isspace((unsigned char)c[i]); i++) {
-	// Scan forward until we find a non-space (which may be a null byte).
+        // Scan forward until we find a non-space (which may be a null byte).
       }
       char ch = c[i];
       if (!ch) {
-	// Line is just whitespace - emit an empty line.
-	Putc('\n', out);
-	continue;
+        // Line is just whitespace - emit an empty line.
+        Putc('\n', out);
+        continue;
       }
 
       if (ch == '#') {
-	// Comment - the indentation doesn't matter to python, but try to
-	// adjust the whitespace for the benefit of human readers (though SWIG
-	// currently seems to always remove any whitespace before a '#' before
-	// we get here, in which case we'll just leave the comment at the start
-	// of the line).
-	if (i >= Len(initial)) {
-	  Printv(out, indent, NIL);
-	}
+        // Comment - the indentation doesn't matter to python, but try to
+        // adjust the whitespace for the benefit of human readers (though SWIG
+        // currently seems to always remove any whitespace before a '#' before
+        // we get here, in which case we'll just leave the comment at the start
+        // of the line).
+        if (i >= Len(initial)) {
+          Printv(out, indent, NIL);
+        }
 
-	Printv(out, c + i, "\n", NIL);
-	continue;
+        Printv(out, c + i, "\n", NIL);
+        continue;
       }
 
       if (i < Len(initial)) {
-	// There's non-whitespace in the initial prefix of this line.
-	Swig_error(file, line, "Line indented less than expected (line %d of %s) as no line should be indented less than the indentation in line 1\n", py_line, directive_name);
-	Printv(out, indent, c, "\n", NIL);
+        // There's non-whitespace in the initial prefix of this line.
+        Swig_error(file, line, "Line indented less than expected (line %d of %s) as no line should be indented less than the indentation in line 1\n", py_line, directive_name);
+        Printv(out, indent, c, "\n", NIL);
       } else {
-	if (memcmp(c, Char(initial), Len(initial)) == 0) {
-	  // Prefix matches initial, so just remove it.
-	  Printv(out, indent, c + Len(initial), "\n", NIL);
-	  continue;
-	}
-	Swig_warning(WARN_PYTHON_INDENT_MISMATCH,
-		     file, line, "Whitespace indentation is inconsistent compared to earlier lines (line %d of %s)\n", py_line, directive_name);
-	// To avoid gratuitously breaking interface files which worked with
-	// SWIG <= 3.0.5, we remove a prefix of the same number of bytes for
-	// lines which start with different whitespace to the line we got
-	// 'initial' from.
-	Printv(out, indent, c + Len(initial), "\n", NIL);
+        if (memcmp(c, Char(initial), Len(initial)) == 0) {
+          // Prefix matches initial, so just remove it.
+          Printv(out, indent, c + Len(initial), "\n", NIL);
+          continue;
+        }
+        Swig_warning(WARN_PYTHON_INDENT_MISMATCH,
+                     file, line, "Whitespace indentation is inconsistent compared to earlier lines (line %d of %s)\n", py_line, directive_name);
+        // To avoid gratuitously breaking interface files which worked with
+        // SWIG <= 3.0.5, we remove a prefix of the same number of bytes for
+        // lines which start with different whitespace to the line we got
+        // 'initial' from.
+        Printv(out, indent, c + Len(initial), "\n", NIL);
       }
     }
     Delete(clist);
@@ -1451,13 +1451,13 @@ public:
       const char *c = Char(si.item);
       int i;
       for (i = 0; isspace((unsigned char)c[i]); i++) {
-	// Scan forward until we find a non-space (which may be a null byte).
+        // Scan forward until we find a non-space (which may be a null byte).
       }
       char ch = c[i];
       if (ch) {
-	// Found a line which isn't just whitespace
-	if (i < truncate_characters_count)
-	  truncate_characters_count = i;
+        // Found a line which isn't just whitespace
+        if (i < truncate_characters_count)
+          truncate_characters_count = i;
       }
     }
 
@@ -1469,13 +1469,13 @@ public:
 
       int i;
       for (i = 0; isspace((unsigned char)c[i]); i++) {
-	// Scan forward until we find a non-space (which may be a null byte).
+        // Scan forward until we find a non-space (which may be a null byte).
       }
       char ch = c[i];
       if (!ch) {
-	// Line is just whitespace - emit an empty line.
-	Putc('\n', out);
-	continue;
+        // Line is just whitespace - emit an empty line.
+        Putc('\n', out);
+        continue;
       }
 
       Printv(out, indent, c + truncate_characters_count, "\n", NIL);
@@ -1503,13 +1503,13 @@ public:
     char *c = Char(autodoc);
     if (c) {
       if (isdigit(c[0])) {
-	dlevel = (autodoc_l) atoi(c);
+        dlevel = (autodoc_l) atoi(c);
       } else {
-	if (strcmp(c, "extended") == 0) {
-	  dlevel = EXTEND_AUTODOC;
-	} else {
-	  dlevel = STRING_AUTODOC;
-	}
+        if (strcmp(c, "extended") == 0) {
+          dlevel = EXTEND_AUTODOC;
+        } else {
+          dlevel = STRING_AUTODOC;
+        }
       }
     }
     return dlevel;
@@ -1526,8 +1526,8 @@ public:
   bool have_docstring(Node *n) {
     String *str = Getattr(n, "feature:docstring");
     return ((str && Len(str) > 0)
-	|| (Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc"))
-	|| (doxygen && doxygenTranslator->hasDocumentation(n))
+        || (Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc"))
+        || (doxygen && doxygenTranslator->hasDocumentation(n))
       );
   }
 
@@ -1545,7 +1545,7 @@ public:
   Node *find_overload_with_docstring(Node *n) {
     for (Node *node_with_doc = n; node_with_doc; node_with_doc = Getattr(node_with_doc, "sym:previousSibling")) {
       if (have_docstring(node_with_doc))
-	return node_with_doc;
+        return node_with_doc;
     }
 
     return NULL;
@@ -1570,53 +1570,53 @@ public:
     if (docstr) {
       // Simplify the code below by just ignoring empty docstrings.
       if (!Len(docstr))
-	docstr = NULL;
+        docstr = NULL;
       else
-	docstr = Copy(docstr);
+        docstr = Copy(docstr);
     }
 
     if (docstr) {
       char *t = Char(docstr);
       if (*t == '{') {
-	Delitem(docstr, 0);
-	Delitem(docstr, DOH_END);
+        Delitem(docstr, 0);
+        Delitem(docstr, DOH_END);
       }
     }
 
     if (!docstr) {
       if (doxygen && doxygenTranslator->hasDocumentation(n)) {
-	docstr = Getattr(n, "python:docstring");
-	if (!docstr) {
-	  docstr = doxygenTranslator->getDocumentation(n, 0);
+        docstr = Getattr(n, "python:docstring");
+        if (!docstr) {
+          docstr = doxygenTranslator->getDocumentation(n, 0);
 
-	  // Avoid rebuilding it again the next time: notice that we can't do
-	  // this for the combined doc string as autodoc part of it depends on
-	  // the sym:name of the node and it is changed while handling it, so
-	  // the cached results become incorrect. But Doxygen docstring only
-	  // depends on the comment which is not going to change, so we can
-	  // safely cache it.
-	  Setattr(n, "python:docstring", Copy(docstr));
-	} else {
-	  // Must copy here since if the docstring is multi-line, the String*
-	  // here will get Deleted below, which is bad if it is a pointer to
-	  // the cached object!
-	  docstr = Copy(docstr);
-	}
-	add_autodoc = false;
+          // Avoid rebuilding it again the next time: notice that we can't do
+          // this for the combined doc string as autodoc part of it depends on
+          // the sym:name of the node and it is changed while handling it, so
+          // the cached results become incorrect. But Doxygen docstring only
+          // depends on the comment which is not going to change, so we can
+          // safely cache it.
+          Setattr(n, "python:docstring", Copy(docstr));
+        } else {
+          // Must copy here since if the docstring is multi-line, the String*
+          // here will get Deleted below, which is bad if it is a pointer to
+          // the cached object!
+          docstr = Copy(docstr);
+        }
+        add_autodoc = false;
       }
     }
 
     if (add_autodoc && Getattr(n, "feature:autodoc") && !GetFlag(n, "feature:noautodoc")) {
       String *autodoc = make_autodoc(n, ad_type, low_level);
       if (autodoc && Len(autodoc) > 0) {
-	if (docstr) {
-	  Append(autodoc, "\n");
-	  Append(autodoc, docstr);
-	}
+        if (docstr) {
+          Append(autodoc, "\n");
+          Append(autodoc, docstr);
+        }
 
-	String *tmp = autodoc;
-	autodoc = docstr;
-	docstr = tmp;
+        String *tmp = autodoc;
+        autodoc = docstr;
+        docstr = tmp;
       }
 
       Delete(autodoc);
@@ -1645,11 +1645,11 @@ public:
       Chop(docstr);
       const char *c = Char(docstr);
       if (isspace((int)*c)) {
-	while(isspace((int)*(++c))) {
-	}
-	String *old_docstr = docstr;
-	docstr = NewString(c);
-	Delete(old_docstr);
+        while(isspace((int)*(++c))) {
+        }
+        String *old_docstr = docstr;
+        docstr = NewString(c);
+        Delete(old_docstr);
       }
     }
 
@@ -1743,9 +1743,9 @@ public:
     int i = arg_num;
     while (p) {
       if (!Getattr(p, "lname")) {
-	String *name = makeParameterName(n, p, i);
-	Setattr(p, "lname", name);
-	Delete(name);
+        String *name = makeParameterName(n, p, i);
+        Setattr(p, "lname", name);
+        Delete(name);
       }
       i++;
       p = nextSibling(p);
@@ -1784,12 +1784,12 @@ public:
     for (p = plist; p; p = pnext) {
       String *tm = Getattr(p, "tmap:in");
       if (tm) {
-	pnext = Getattr(p, "tmap:in:next");
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  continue;
-	}
+        pnext = Getattr(p, "tmap:in:next");
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          continue;
+        }
       } else {
-	pnext = nextSibling(p);
+        pnext = nextSibling(p);
       }
 
       String *name = 0;
@@ -1797,21 +1797,21 @@ public:
       String *value = 0;
       String *pdoc = Getattr(p, "tmap:doc");
       if (pdoc) {
-	name = Getattr(p, "tmap:doc:name");
-	type = Getattr(p, "tmap:doc:type");
-	value = Getattr(p, "tmap:doc:value");
+        name = Getattr(p, "tmap:doc:name");
+        type = Getattr(p, "tmap:doc:type");
+        value = Getattr(p, "tmap:doc:value");
       }
 
       // Skip the "self" argument - it is added to the parameter list automatically
       // and shouldn't be included in the Parameters block
       if (Getattr(p, "self")) {
-	continue;
+        continue;
       }
 
       // Note: the generated name should be consistent with that in kwnames[]
       String *made_name = 0;
       if (!name) {
-	name = made_name = makeParameterName(n, p, arg_num);
+        name = made_name = makeParameterName(n, p, arg_num);
       }
 
       // Increment the argument number once we are sure this is a real argument to count
@@ -1821,48 +1821,48 @@ public:
       value = value ? value : Getattr(p, "value");
 
       if (SwigType_isvarargs(type)) {
-	Delete(made_name);
-	break;
+        Delete(made_name);
+        break;
       }
 
       if (Len(doc)) {
-	// add a comma to the previous one if any
-	Append(doc, ", ");
+        // add a comma to the previous one if any
+        Append(doc, ", ");
       }
 
       // Do the param type too?
       Node *nn = classLookup(Getattr(p, "type"));
       String *type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
       if (showTypes)
-	Printf(doc, "%s ", type_str);
+        Printf(doc, "%s ", type_str);
 
       Append(doc, name);
       if (pdoc) {
-	if (!pdocs)
-	  // numpydoc style: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
-	  pdocs = NewString("\nParameters\n----------\n");
-	Printf(pdocs, "%s\n", pdoc);
+        if (!pdocs)
+          // numpydoc style: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+          pdocs = NewString("\nParameters\n----------\n");
+        Printf(pdocs, "%s\n", pdoc);
       }
       // Write the function annotation
       if (func_annotation)
-	Printf(doc, ": \"%s\"", type_str);
+        Printf(doc, ": \"%s\"", type_str);
 
       // Write default value
       if (value && !calling) {
-	String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
-	if (new_value) {
-	  value = new_value;
-	} else {
-	  // Even if the value is not representable in the target language, still use it in the documentation, for compatibility with the previous SWIG versions
-	  // and because it can still be useful to see the C++ expression there.
-	  Node *lookup = Swig_symbol_clookup(value, 0);
-	  if (lookup)
-	    value = Getattr(lookup, "sym:name");
-	}
-	Printf(doc, "=%s", value);
+        String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
+        if (new_value) {
+          value = new_value;
+        } else {
+          // Even if the value is not representable in the target language, still use it in the documentation, for compatibility with the previous SWIG versions
+          // and because it can still be useful to see the C++ expression there.
+          Node *lookup = Swig_symbol_clookup(value, 0);
+          if (lookup)
+            value = Getattr(lookup, "sym:name");
+        }
+        Printf(doc, "=%s", value);
 
-	if (new_value)
-	  Delete(new_value);
+        if (new_value)
+          Delete(new_value);
       }
       Delete(type_str);
       Delete(made_name);
@@ -1901,177 +1901,177 @@ public:
       autodoc_l dlevel = autodoc_level(autodoc);
       switch (dlevel) {
       case NO_AUTODOC:
-	break;
+        break;
       case NAMES_AUTODOC:
-	showTypes = false;
-	break;
+        showTypes = false;
+        break;
       case TYPES_AUTODOC:
-	showTypes = true;
-	break;
+        showTypes = true;
+        break;
       case EXTEND_AUTODOC:
-	extended = 1;
-	showTypes = false;
-	break;
+        extended = 1;
+        showTypes = false;
+        break;
       case EXTEND_TYPES_AUTODOC:
-	extended = 1;
-	showTypes = true;
-	break;
+        extended = 1;
+        showTypes = true;
+        break;
       case STRING_AUTODOC:
-	Append(doc, autodoc);
-	skipAuto = true;
-	break;
+        Append(doc, autodoc);
+        skipAuto = true;
+        break;
       }
 
       if (!skipAuto) {
-	/* Check if a documentation name was given for either the low-level C API or high-level Python shadow API */
-	String *symname = Getattr(n, low_level ? "doc:low:name" : "doc:high:name");
-	if (!symname) {
-	  symname = Getattr(n, "sym:name");
-	}
+        /* Check if a documentation name was given for either the low-level C API or high-level Python shadow API */
+        String *symname = Getattr(n, low_level ? "doc:low:name" : "doc:high:name");
+        if (!symname) {
+          symname = Getattr(n, "sym:name");
+        }
 
-	SwigType *type = Getattr(n, "type");
-	String *type_str = NULL;
+        SwigType *type = Getattr(n, "type");
+        String *type_str = NULL;
 
-	// If the function has default arguments, then that documentation covers this version too
-	if (Getattr(n, "defaultargs") != NULL) {
-	  n = Getattr(n, "sym:nextSibling");
-	  continue;
-	}
+        // If the function has default arguments, then that documentation covers this version too
+        if (Getattr(n, "defaultargs") != NULL) {
+          n = Getattr(n, "sym:nextSibling");
+          continue;
+        }
 
-	if (!first_func)
-	  Append(doc, "\n");
+        if (!first_func)
+          Append(doc, "\n");
 
-	if (type) {
-	  if (Strcmp(type, "void") == 0) {
-	    type_str = NULL;
-	  } else {
-	    Node *nn = classLookup(type);
-	    type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
-	  }
-	}
+        if (type) {
+          if (Strcmp(type, "void") == 0) {
+            type_str = NULL;
+          } else {
+            Node *nn = classLookup(type);
+            type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
+          }
+        }
 
-	/* Treat the low-level C API functions for getting/setting variables as methods for documentation purposes */
-	String *kind = Getattr(n, "kind");
-	if (kind && Strcmp(kind, "variable") == 0) {
-	  if (ad_type == AUTODOC_FUNC) {
-	    ad_type = AUTODOC_METHOD;
-	  }
-	}
-	/* Treat destructors as methods for documentation purposes */
-	String *nodeType = Getattr(n, "nodeType");
-	if (nodeType && Strcmp(nodeType, "destructor") == 0) {
-	  if (ad_type == AUTODOC_FUNC) {
-	    ad_type = AUTODOC_METHOD;
-	  }
-	}
+        /* Treat the low-level C API functions for getting/setting variables as methods for documentation purposes */
+        String *kind = Getattr(n, "kind");
+        if (kind && Strcmp(kind, "variable") == 0) {
+          if (ad_type == AUTODOC_FUNC) {
+            ad_type = AUTODOC_METHOD;
+          }
+        }
+        /* Treat destructors as methods for documentation purposes */
+        String *nodeType = Getattr(n, "nodeType");
+        if (nodeType && Strcmp(nodeType, "destructor") == 0) {
+          if (ad_type == AUTODOC_FUNC) {
+            ad_type = AUTODOC_METHOD;
+          }
+        }
 
-	switch (ad_type) {
-	case AUTODOC_CLASS:
-	  {
-	    // Only do the autodoc if there isn't a docstring for the class
-	    String *str = Getattr(n, "feature:docstring");
-	    if (!str || Len(str) == 0) {
-	      if (builtin) {
-		SwigType *name = Getattr(n, "name");
-		SwigType *sname = add_explicit_scope(name);
-		String *rname = SwigType_namestr(sname);
-		Printf(doc, "%s", rname);
-		Delete(sname);
-		Delete(rname);
-	      } else {
-		String *classname_str = SwigType_namestr(real_classname);
-		if (CPlusPlus) {
-		  Printf(doc, "Proxy of C++ %s class.", classname_str);
-		} else {
-		  Printf(doc, "Proxy of C %s struct.", classname_str);
-		}
-		Delete(classname_str);
-	      }
-	    }
-	  }
-	  break;
-	case AUTODOC_CTOR:
-	  if (Strcmp(class_name, symname) == 0) {
-	    String *paramList = make_autodocParmList(n, showTypes, 2);
-	    Printf(doc, "__init__(");
-	    if (showTypes)
-	      Printf(doc, "%s ", class_name);
-	    if (Len(paramList))
-	      Printf(doc, "self, %s) -> %s", paramList, class_name);
-	    else
-	      Printf(doc, "self) -> %s", class_name);
-	  } else
-	    Printf(doc, "%s(%s) -> %s", symname, make_autodocParmList(n, showTypes), class_name);
-	  break;
+        switch (ad_type) {
+        case AUTODOC_CLASS:
+          {
+            // Only do the autodoc if there isn't a docstring for the class
+            String *str = Getattr(n, "feature:docstring");
+            if (!str || Len(str) == 0) {
+              if (builtin) {
+                SwigType *name = Getattr(n, "name");
+                SwigType *sname = add_explicit_scope(name);
+                String *rname = SwigType_namestr(sname);
+                Printf(doc, "%s", rname);
+                Delete(sname);
+                Delete(rname);
+              } else {
+                String *classname_str = SwigType_namestr(real_classname);
+                if (CPlusPlus) {
+                  Printf(doc, "Proxy of C++ %s class.", classname_str);
+                } else {
+                  Printf(doc, "Proxy of C %s struct.", classname_str);
+                }
+                Delete(classname_str);
+              }
+            }
+          }
+          break;
+        case AUTODOC_CTOR:
+          if (Strcmp(class_name, symname) == 0) {
+            String *paramList = make_autodocParmList(n, showTypes, 2);
+            Printf(doc, "__init__(");
+            if (showTypes)
+              Printf(doc, "%s ", class_name);
+            if (Len(paramList))
+              Printf(doc, "self, %s) -> %s", paramList, class_name);
+            else
+              Printf(doc, "self) -> %s", class_name);
+          } else
+            Printf(doc, "%s(%s) -> %s", symname, make_autodocParmList(n, showTypes), class_name);
+          break;
 
-	case AUTODOC_DTOR:
-	  if (showTypes)
-	    Printf(doc, "__del__(%s self)", class_name);
-	  else
-	    Printf(doc, "__del__(self)");
-	  break;
+        case AUTODOC_DTOR:
+          if (showTypes)
+            Printf(doc, "__del__(%s self)", class_name);
+          else
+            Printf(doc, "__del__(self)");
+          break;
 
-	case AUTODOC_STATICFUNC:
-	  Printf(doc, "%s(%s)", symname, make_autodocParmList(n, showTypes));
-	  if (type_str)
-	    Printf(doc, " -> %s", type_str);
-	  break;
+        case AUTODOC_STATICFUNC:
+          Printf(doc, "%s(%s)", symname, make_autodocParmList(n, showTypes));
+          if (type_str)
+            Printf(doc, " -> %s", type_str);
+          break;
 
-	case AUTODOC_FUNC:
-	  Printf(doc, "%s(%s)", symname, make_autodocParmList(n, showTypes));
-	  if (type_str)
-	    Printf(doc, " -> %s", type_str);
-	  break;
+        case AUTODOC_FUNC:
+          Printf(doc, "%s(%s)", symname, make_autodocParmList(n, showTypes));
+          if (type_str)
+            Printf(doc, " -> %s", type_str);
+          break;
 
-	case AUTODOC_METHOD:
-	  {
-	    String *paramList = make_autodocParmList(n, showTypes, 2);
-	    Printf(doc, "%s(", symname);
-	    if (showTypes)
-	      Printf(doc, "%s ", class_name);
-	    if (Len(paramList))
-	      Printf(doc, "self, %s)", paramList);
-	    else
-	      Printf(doc, "self)");
-	    if (type_str)
-	      Printf(doc, " -> %s", type_str);
-	  }
-	  break;
+        case AUTODOC_METHOD:
+          {
+            String *paramList = make_autodocParmList(n, showTypes, 2);
+            Printf(doc, "%s(", symname);
+            if (showTypes)
+              Printf(doc, "%s ", class_name);
+            if (Len(paramList))
+              Printf(doc, "self, %s)", paramList);
+            else
+              Printf(doc, "self)");
+            if (type_str)
+              Printf(doc, " -> %s", type_str);
+          }
+          break;
 
-	case AUTODOC_CONST:
-	  // There is no autodoc support for constants currently, this enum
-	  // element only exists to allow calling docstring() with it.
-	  return NULL;
-	case AUTODOC_VAR:
-	  // Variables can also be documented (e.g. through the property() function in python)
-	  Printf(doc, "%s", symname);
-	  if (showTypes) {
-	    String *type = Getattr(n, "tmap:doc:type");
-	    if (!type)
-	      type = Getattr(n, "membervariableHandler:type");
-	    if (!type)
-	      type = Getattr(n, "type");
-	    Printf(doc, " : %s", type);
-	  }
-	  break;
-	}
-	Delete(type_str);
+        case AUTODOC_CONST:
+          // There is no autodoc support for constants currently, this enum
+          // element only exists to allow calling docstring() with it.
+          return NULL;
+        case AUTODOC_VAR:
+          // Variables can also be documented (e.g. through the property() function in python)
+          Printf(doc, "%s", symname);
+          if (showTypes) {
+            String *type = Getattr(n, "tmap:doc:type");
+            if (!type)
+              type = Getattr(n, "membervariableHandler:type");
+            if (!type)
+              type = Getattr(n, "type");
+            Printf(doc, " : %s", type);
+          }
+          break;
+        }
+        Delete(type_str);
 
-	// Special case: wrapper functions to get a variable should have no parameters.
-	// Because the node is re-used for the setter and getter, the feature:pdocs field will
-	// exist for the getter function, so explicitly avoid printing parameters in this case.
-	bool variable_getter = kind && Strcmp(kind, "variable") == 0 && Getattr(n, "memberget");
-	if (extended && ad_type != AUTODOC_VAR && !variable_getter) {
-	  String *pdocs = Getattr(n, "feature:pdocs");
-	  if (pdocs) {
-	    Printv(doc, "\n", pdocs, NULL);
-	  }
-	}
+        // Special case: wrapper functions to get a variable should have no parameters.
+        // Because the node is re-used for the setter and getter, the feature:pdocs field will
+        // exist for the getter function, so explicitly avoid printing parameters in this case.
+        bool variable_getter = kind && Strcmp(kind, "variable") == 0 && Getattr(n, "memberget");
+        if (extended && ad_type != AUTODOC_VAR && !variable_getter) {
+          String *pdocs = Getattr(n, "feature:pdocs");
+          if (pdocs) {
+            Printv(doc, "\n", pdocs, NULL);
+          }
+        }
       }
       // if it's overloaded then get the next decl and loop around again
       n = Getattr(n, "sym:nextSibling");
       if (n)
-	first_func = false;
+        first_func = false;
     }
 
     return doc;
@@ -2137,19 +2137,19 @@ public:
       // Also don't accept neither "NAN" nor "INFINITY" (both of which
       // conveniently contain "n").
       if (strpbrk(s, "xXnN"))
-	return NIL;
+        return NIL;
 
       // Disregard optional "f" suffix, it can be just dropped in Python as it
       // uses doubles for everything anyhow.
       for (char * p = end; *p != '\0'; ++p) {
-	switch (*p) {
-	  case 'f':
-	  case 'F':
-	    break;
+        switch (*p) {
+          case 'f':
+          case 'F':
+            break;
 
-	  default:
-	    return NIL;
-	}
+          default:
+            return NIL;
+        }
       }
 
       // Avoid unnecessary string allocation in the common case when we don't
@@ -2176,18 +2176,18 @@ public:
     SwigType *resolved_type = SwigType_typedef_resolve_all(type);
     SwigType *unqualified_type = NIL;
     if (SwigType_isreference(resolved_type)) {
-	SwigType *t = Copy(resolved_type);
-	t = SwigType_del_reference(t);
-	unqualified_type = SwigType_strip_qualifiers(t);
-	Delete(t);
+        SwigType *t = Copy(resolved_type);
+        t = SwigType_del_reference(t);
+        unqualified_type = SwigType_strip_qualifiers(t);
+        Delete(t);
     } else {
-	unqualified_type = SwigType_strip_qualifiers(resolved_type);
+        unqualified_type = SwigType_strip_qualifiers(resolved_type);
     }
     if (numval) {
       if (Equal(unqualified_type, "bool")) {
-	Delete(resolved_type);
-	Delete(unqualified_type);
-	return NewString(*Char(numval) == '0' ? "False" : "True");
+        Delete(resolved_type);
+        Delete(unqualified_type);
+        return NewString(*Char(numval) == '0' ? "False" : "True");
       }
       String *result = convertIntegerValue(numval, unqualified_type);
       Delete(resolved_type);
@@ -2198,16 +2198,16 @@ public:
     String *result = convertDoubleValue(v);
     if (!result) {
       if (Strcmp(v, "NULL") == 0 || Strcmp(v, "nullptr") == 0)
-	result = SwigType_ispointer(unqualified_type) ? NewString("None") : NewString("0");
+        result = SwigType_ispointer(unqualified_type) ? NewString("None") : NewString("0");
       // This could also be an enum type, default value of which could be
       // representable in Python if it doesn't include any scope (which could,
       // but currently is not, translated).
       else if (!Strchr(v, ':')) {
-	Node *lookup = Swig_symbol_clookup(v, 0);
-	if (lookup) {
-	  if (Cmp(Getattr(lookup, "nodeType"), "enumitem") == 0)
-	    result = Copy(Getattr(lookup, "sym:name"));
-	}
+        Node *lookup = Swig_symbol_clookup(v, 0);
+        if (lookup) {
+          if (Cmp(Getattr(lookup, "nodeType"), "enumitem") == 0)
+            result = Copy(Getattr(lookup, "sym:name"));
+        }
       }
     }
 
@@ -2237,12 +2237,12 @@ public:
       pnext = nextSibling(p);
       String *tm = Getattr(p, "tmap:in");
       if (tm) {
-	Parm *in_next = Getattr(p, "tmap:in:next");
-	if (in_next)
-	  pnext = in_next;
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  continue;
-	}
+        Parm *in_next = Getattr(p, "tmap:in:next");
+        if (in_next)
+          pnext = in_next;
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          continue;
+        }
       }
 
       // "default" typemap can contain arbitrary C++ code, so while it could, in
@@ -2251,14 +2251,14 @@ public:
       // check if expression can be used in Python, but for now we just
       // pessimistically give up and prefer to handle this at C++ level only.
       if (Getattr(p, "tmap:default"))
-	return false;
+        return false;
 
       String *value = Getattr(p, "value");
       if (value) {
-	String *convertedValue = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
-	if (!convertedValue)
-	  return false;
-	Delete(convertedValue);
+        String *convertedValue = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
+        if (!convertedValue)
+          return false;
+        Delete(convertedValue);
       }
     }
 
@@ -2283,9 +2283,9 @@ public:
     while (i) {
       Node *nn = Getattr(i, "defaultargs");
       if (nn != h) {
-	/* Check if overloaded function has defaultargs and
-	 * pointed to the first overloaded. */
-	return true;
+        /* Check if overloaded function has defaultargs and
+         * pointed to the first overloaded. */
+        return true;
       }
       i = Getattr(i, "sym:nextSibling");
     }
@@ -2314,19 +2314,19 @@ public:
        however in some cases we must replace the real parameters list with just
        the catch all "*args". This happens when:
 
-	1. The function is overloaded as Python doesn't support this.
-	2. We were explicitly asked to use the "compact" arguments form.
-	3. We were explicitly asked to use default args from C via the "python:cdefaultargs" feature.
-	4. One of the default argument values can't be represented in Python.
-	5. Varargs that haven't been forced to use a fixed number of arguments with %varargs.
+        1. The function is overloaded as Python doesn't support this.
+        2. We were explicitly asked to use the "compact" arguments form.
+        3. We were explicitly asked to use default args from C via the "python:cdefaultargs" feature.
+        4. One of the default argument values can't be represented in Python.
+        5. Varargs that haven't been forced to use a fixed number of arguments with %varargs.
      */
     if (is_real_overloaded(n) || GetFlag(n, "feature:compactdefaultargs") || GetFlag(n, "feature:python:cdefaultargs") || !is_representable_as_pyargs(n) || varargs) {
       String *parms = NewString("");
       if (in_class)
-	Printf(parms, "self, ");
+        Printf(parms, "self, ");
       Printf(parms, "*args");
       if (kw)
-	Printf(parms, ", **kwargs");
+        Printf(parms, ", **kwargs");
       return parms;
     }
 
@@ -2337,7 +2337,7 @@ public:
     if (in_class) {
       Printf(params, "self");
       if (Len(_params) > 0)
-	Printf(params, ", ");
+        Printf(params, ", ");
     }
 
     Printv(params, _params, NULL);
@@ -2429,14 +2429,14 @@ public:
      * however the result may not accurate. */
     while (p) {
       if ((tm = Getattr(p, "tmap:argout:match_type"))) {
-	tm = SwigType_str(tm, 0);
-	if (ret)
-	  Printv(ret, ", ", tm, NULL);
-	else
-	  ret = tm;
-	p = Getattr(p, "tmap:argout:next");
+        tm = SwigType_str(tm, 0);
+        if (ret)
+          Printv(ret, ", ", tm, NULL);
+        else
+          ret = tm;
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
     /* If no argout typemap, then get the returning type from
@@ -2444,7 +2444,7 @@ public:
     if (!ret) {
       ret = Getattr(n, "type");
       if (ret)
-	ret = SwigType_str(ret, 0);
+        ret = SwigType_str(ret, 0);
     }
     bool funcanno = Equal(Getattr(n, "feature:python:annotations"), "c") ? true : false;
     return (ret && funcanno) ? NewStringf(" -> \"%s\"", ret) : NewString("");
@@ -2489,16 +2489,16 @@ public:
       // When handling the last overloaded function in an overload set (and we're only called for the last one if the function is overloaded at all), we need to
       // output the docstring if any of the overloads has any documentation, not just this last one.
       if (Node *node_with_doc = find_overload_with_docstring(n))
-	Printv(f_dest, tab4, docstring(node_with_doc, AUTODOC_FUNC, tab4, true), "\n", NIL);
+        Printv(f_dest, tab4, docstring(node_with_doc, AUTODOC_FUNC, tab4, true), "\n", NIL);
 
       if (have_pythonprepend(n))
-	Printv(f_dest, indent_pythoncode(pythonprepend(n), tab4, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+        Printv(f_dest, indent_pythoncode(pythonprepend(n), tab4, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
       if (have_pythonappend(n)) {
-	Printv(f_dest, tab4 "val = ", funcCall(name, callParms), "\n", NIL);
-	Printv(f_dest, indent_pythoncode(pythonappend(n), tab4, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
-	Printv(f_dest, tab4 "return val\n", NIL);
+        Printv(f_dest, tab4 "val = ", funcCall(name, callParms), "\n", NIL);
+        Printv(f_dest, indent_pythoncode(pythonappend(n), tab4, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
+        Printv(f_dest, tab4 "return val\n", NIL);
       } else {
-	Printv(f_dest, tab4 "return ", funcCall(name, callParms), "\n", NIL);
+        Printv(f_dest, tab4 "return ", funcCall(name, callParms), "\n", NIL);
       }
     }
 
@@ -2518,7 +2518,7 @@ public:
 
   int check_kwargs(Node *n) const {
     return (use_kw || GetFlag(n, "feature:kwargs"))
-	&& !GetFlag(n, "memberset") && !GetFlag(n, "memberget");
+        && !GetFlag(n, "memberset") && !GetFlag(n, "memberget");
   }
 
 
@@ -2531,15 +2531,15 @@ public:
     String * meth_str = NewString("");
     if (!kw) {
       if (funpack) {
-	if (num_required == 0 && num_arguments == 0) {
-	  Printf(meth_str, "\t { \"%s\", %s, METH_NOARGS, ", name, function);
-	} else if (num_required == 1 && num_arguments == 1) {
-	  Printf(meth_str, "\t { \"%s\", %s, METH_O, ", name, function);
-	} else {
-	  Printf(meth_str, "\t { \"%s\", %s, METH_VARARGS, ", name, function);
-	}
+        if (num_required == 0 && num_arguments == 0) {
+          Printf(meth_str, "\t { \"%s\", %s, METH_NOARGS, ", name, function);
+        } else if (num_required == 1 && num_arguments == 1) {
+          Printf(meth_str, "\t { \"%s\", %s, METH_O, ", name, function);
+        } else {
+          Printf(meth_str, "\t { \"%s\", %s, METH_VARARGS, ", name, function);
+        }
       } else {
-	Printf(meth_str, "\t { \"%s\", %s, METH_VARARGS, ", name, function);
+        Printf(meth_str, "\t { \"%s\", %s, METH_VARARGS, ", name, function);
       }
     } else {
       // Cast via void(*)(void) to suppress GCC -Wcast-function-type warning.
@@ -2556,29 +2556,29 @@ public:
     if (!n) {
       Append(methods, "NULL");
       if (fastproxy) {
-	Append(methods_proxydocs, "NULL");
+        Append(methods_proxydocs, "NULL");
       }
     } else if (Node *node_with_doc = find_overload_with_docstring(n)) {
       /* Use the low-level docstring here since this is the docstring that will be used for the C API */
       String *ds = cdocstring(node_with_doc, Getattr(n, "memberfunction") ? AUTODOC_METHOD : AUTODOC_FUNC, true);
       Printf(methods, "\"%s\"", ds);
       if (fastproxy) {
-	/* In the fastproxy case, we must also record the high-level docstring for use in the Python shadow API */
-	Delete(ds);
+        /* In the fastproxy case, we must also record the high-level docstring for use in the Python shadow API */
+        Delete(ds);
         ds = cdocstring(node_with_doc, Getattr(n, "memberfunction") ? AUTODOC_METHOD : AUTODOC_FUNC);
-	Printf(methods_proxydocs, "\"%s\"", ds);
+        Printf(methods_proxydocs, "\"%s\"", ds);
       }
       Delete(ds);
     } else if (Getattr(n, "feature:callback")) {
       Printf(methods, "\"swig_ptr: %s\"", Getattr(n, "feature:callback:name"));
       if (fastproxy) {
-	Printf(methods_proxydocs, "\"swig_ptr: %s\"", Getattr(n, "feature:callback:name"));
-	have_fast_proxy_static_member_method_callback = true;
+        Printf(methods_proxydocs, "\"swig_ptr: %s\"", Getattr(n, "feature:callback:name"));
+        have_fast_proxy_static_member_method_callback = true;
       }
     } else {
       Append(methods, "NULL");
       if (fastproxy) {
-	Append(methods_proxydocs, "NULL");
+        Append(methods_proxydocs, "NULL");
       }
     }
 
@@ -2610,12 +2610,12 @@ public:
     } else {
       String *fastdispatch_code;
       if (builtin_ctor)
-	fastdispatch_code = NewStringf("int retval = %s\nif (retval == 0 || !SWIG_Python_TypeErrorOccurred(NULL)) return retval;\nSWIG_fail;", dispatch_call);
+        fastdispatch_code = NewStringf("int retval = %s\nif (retval == 0 || !SWIG_Python_TypeErrorOccurred(NULL)) return retval;\nSWIG_fail;", dispatch_call);
       else
-	fastdispatch_code = NewStringf("PyObject *retobj = %s\nif (!SWIG_Python_TypeErrorOccurred(retobj)) return retobj;\nSWIG_fail;", dispatch_call);
+        fastdispatch_code = NewStringf("PyObject *retobj = %s\nif (!SWIG_Python_TypeErrorOccurred(retobj)) return retobj;\nSWIG_fail;", dispatch_call);
       if (!CPlusPlus) {
-	Insert(fastdispatch_code, 0, "{\n");
-	Append(fastdispatch_code, "\n}");
+        Insert(fastdispatch_code, 0, "{\n");
+        Append(fastdispatch_code, "\n}");
       }
       dispatch = Swig_overload_dispatch(n, dispatch_code, &maxargs, &check_emitted, fastdispatch_code);
       Delete(fastdispatch_code);
@@ -2643,7 +2643,7 @@ public:
       Wrapper_add_local(f, "ii", "Py_ssize_t ii");
 
       if (builtin_ctor)
-	Printf(f->code, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", symname);
+        Printf(f->code, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", symname);
 
       if (maxargs - (add_self ? 1 : 0) > 0) {
         Append(f->code, "if (!PyTuple_Check(args)) SWIG_fail;\n");
@@ -2653,20 +2653,20 @@ public:
       }
 
       if (add_self)
-	Append(f->code, "argv[0] = self;\n");
+        Append(f->code, "argv[0] = self;\n");
       Printf(f->code, "for (ii = 0; (ii < %d) && (ii < argc); ii++) {\n", add_self ? maxargs - 1 : maxargs);
       Printf(f->code, "argv[ii%s] = PyTuple_GET_ITEM(args,ii);\n", add_self ? " + 1" : "");
       Append(f->code, "}\n");
       if (add_self)
-	Append(f->code, "argc++;\n");
+        Append(f->code, "argc++;\n");
     } else {
       if (builtin_ctor)
-	Printf(f->code, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", symname);
+        Printf(f->code, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", symname);
       Printf(f->code, "if (!(argc = SWIG_Python_UnpackTuple(args, \"%s\", 0, %d, argv%s))) SWIG_fail;\n", symname, maxargs, add_self ? "+1" : "");
       if (add_self)
-	Append(f->code, "argv[0] = self;\n");
+        Append(f->code, "argv[0] = self;\n");
       else
-	Append(f->code, "--argc;\n");
+        Append(f->code, "--argc;\n");
     }
 
     Replaceall(dispatch, "$args", "self, args");
@@ -2680,16 +2680,16 @@ public:
     } else {
       Node *sibl = n;
       while (Getattr(sibl, "sym:previousSibling"))
-	sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+        sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
       String *protoTypes = NewString("");
       do {
-	String *fulldecl = Swig_name_decl(sibl);
-	Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
-	Delete(fulldecl);
+        String *fulldecl = Swig_name_decl(sibl);
+        Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
+        Delete(fulldecl);
       } while ((sibl = Getattr(sibl, "sym:nextSibling")));
       Append(f->code, "fail:\n");
       Printf(f->code, "  SWIG_Python_RaiseOrModifyTypeError("
-	     "\"Wrong number or type of arguments for overloaded function '%s'.\\n\"" "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n", symname, protoTypes);
+             "\"Wrong number or type of arguments for overloaded function '%s'.\\n\"" "\n\"  Possible C/C++ prototypes are:\\n\"%s);\n", symname, protoTypes);
       Printf(f->code, "return %s;\n", builtin_ctor ? "-1" : "0");
       Delete(protoTypes);
     }
@@ -2782,7 +2782,7 @@ public:
        constructor can be emitted via %rename */
     int handled_as_init = 0;
     if (!have_constructor && (constructor || Getattr(n, "handled_as_constructor"))
-	&& ((shadow & PYSHADOW_MEMBER))) {
+        && ((shadow & PYSHADOW_MEMBER))) {
       String *nname = Getattr(n, "sym:name");
       String *sname = Getattr(getCurrentClass(), "sym:name");
       String *cname = Swig_name_construct(NSPACE_TODO, sname);
@@ -2795,9 +2795,9 @@ public:
       String *class_mname = Getattr(getCurrentClass(), "sym:name");
       String *mrename = Swig_name_construct(getNSpace(), class_mname);
       if (Cmp(iname, mrename))
-	builtin_self = false;
+        builtin_self = false;
       else
-	builtin_ctor = true;
+        builtin_ctor = true;
       Delete(mrename);
     }
     bool director_class = (getCurrentClass() && Swig_directorclass(getCurrentClass()));
@@ -2812,7 +2812,7 @@ public:
       overname = Getattr(n, "sym:overname");
     } else {
       if (!addSymbol(iname, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     f = NewWrapper();
@@ -2847,7 +2847,7 @@ public:
     // The check below is for zero arguments. Sometimes (eg directors) self is the first argument for a method with zero arguments.
     if (((num_arguments == 0) && (num_required == 0)) || ((num_arguments == 1) && (num_required == 1) && Getattr(l, "self")))
       if (!builtin_ctor)
-	allow_kwargs = 0;
+        allow_kwargs = 0;
     varargs = emit_isvarargs(l);
 
     String *wname = Copy(wrapper_name);
@@ -2858,18 +2858,18 @@ public:
     const char *builtin_kwargs = builtin_ctor ? ", PyObject *kwargs" : "";
     if (!allow_kwargs || overname) {
       if (!varargs) {
-	Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
+        Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
       } else {
-	Printv(f->def, linkage, wrap_return, wname, "__varargs__", "(PyObject *self, PyObject *args, PyObject *varargs", builtin_kwargs, ") {", NIL);
+        Printv(f->def, linkage, wrap_return, wname, "__varargs__", "(PyObject *self, PyObject *args, PyObject *varargs", builtin_kwargs, ") {", NIL);
       }
       if (allow_kwargs) {
-	Swig_warning(WARN_LANG_OVERLOAD_KEYWORD, input_file, line_number, "Can't use keyword arguments with overloaded functions (%s).\n", Swig_name_decl(n));
-	allow_kwargs = 0;
+        Swig_warning(WARN_LANG_OVERLOAD_KEYWORD, input_file, line_number, "Can't use keyword arguments with overloaded functions (%s).\n", Swig_name_decl(n));
+        allow_kwargs = 0;
       }
     } else {
       if (varargs) {
-	Swig_warning(WARN_LANG_VARARGS_KEYWORD, input_file, line_number, "Can't wrap varargs with keyword arguments enabled\n");
-	varargs = 0;
+        Swig_warning(WARN_LANG_VARARGS_KEYWORD, input_file, line_number, "Can't wrap varargs with keyword arguments enabled\n");
+        varargs = 0;
       }
       Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args, PyObject *kwargs) {", NIL);
     }
@@ -2881,10 +2881,10 @@ public:
 
     if (!builtin || !in_class || tuple_arguments > 0 || builtin_ctor) {
       if (!allow_kwargs) {
-	Append(parse_args, "    if (!PyArg_ParseTuple(args, \"");
+        Append(parse_args, "    if (!PyArg_ParseTuple(args, \"");
       } else {
-	Append(parse_args, "    if (!PyArg_ParseTupleAndKeywords(args, kwargs, \"");
-	Append(arglist, ", kwnames");
+        Append(parse_args, "    if (!PyArg_ParseTupleAndKeywords(args, kwargs, \"");
+        Append(arglist, ", kwnames");
       }
     }
 
@@ -2896,9 +2896,9 @@ public:
 
     if (builtin && funpack && !overname && !builtin_ctor) {
       if (!(tuple_arguments > tuple_required || varargs)) {
-	String *argattr = NewStringf("%d", tuple_arguments);
-	Setattr(n, "python:argcount", argattr);
-	Delete(argattr);
+        String *argattr = NewStringf("%d", tuple_arguments);
+        Setattr(n, "python:argcount", argattr);
+        Delete(argattr);
       }
     }
 
@@ -2907,11 +2907,11 @@ public:
 
     if (constructor && num_arguments == 1 && num_required == 1) {
       if (Cmp(storage, "explicit") == 0) {
-	if (GetFlag(parent, "feature:implicitconv")) {
-	  String *desc = NewStringf("SWIGTYPE%s", SwigType_manglestr(Getattr(n, "type")));
-	  Printf(f->code, "if (SWIG_CheckImplicit(%s)) SWIG_fail;\n", desc);
-	  Delete(desc);
-	}
+        if (GetFlag(parent, "feature:implicitconv")) {
+          String *desc = NewStringf("SWIGTYPE%s", SwigType_manglestr(Getattr(n, "type")));
+          Printf(f->code, "if (SWIG_CheckImplicit(%s)) SWIG_fail;\n", desc);
+          Delete(desc);
+        }
       }
     }
 
@@ -2927,94 +2927,94 @@ public:
     Append(kwargs, "{");
     for (i = 0, p = l; i < num_arguments; i++) {
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
       String *ln = Getattr(p, "lname");
       bool parse_from_tuple = (i > 0 || !add_self);
       if (SwigType_type(pt) == T_VARARGS) {
-	parse_from_tuple = false;
-	num_fixed_arguments -= atoi(Char(Getattr(p, "tmap:in:numinputs")));
+        parse_from_tuple = false;
+        num_fixed_arguments -= atoi(Char(Getattr(p, "tmap:in:numinputs")));
       }
       if (!parse_from_tuple)
-	sprintf(source, "self");
+        sprintf(source, "self");
       else if (funpack) {
-	if (!swig_obj_added && !overname) {
-	  sprintf(source, "PyObject *swig_obj[%d]", num_arguments);
-	  Wrapper_add_localv(f, "swig_obj", source, NIL);
-	  swig_obj_added = true;
-	}
-	sprintf(source, "swig_obj[%d]", add_self && !overname ? i - 1 : i);
+        if (!swig_obj_added && !overname) {
+          sprintf(source, "PyObject *swig_obj[%d]", num_arguments);
+          Wrapper_add_localv(f, "swig_obj", source, NIL);
+          swig_obj_added = true;
+        }
+        sprintf(source, "swig_obj[%d]", add_self && !overname ? i - 1 : i);
       } else
-	sprintf(source, "obj%d", builtin_ctor ? i + 1 : i);
+        sprintf(source, "obj%d", builtin_ctor ? i + 1 : i);
 
       if (parse_from_tuple) {
-	Printf(arglist, ", ");
-	if (i == num_required)
-	  Putc('|', parse_args);	/* Optional argument separator */
+        Printf(arglist, ", ");
+        if (i == num_required)
+          Putc('|', parse_args);	/* Optional argument separator */
       }
 
       /* Keyword argument handling */
       if (allow_kwargs && parse_from_tuple) {
-	String *name = makeParameterName(n, p, i + 1);
-	Printf(kwargs, " (char *)\"%s\", ", name);
-	Delete(name);
+        String *name = makeParameterName(n, p, i + 1);
+        Printf(kwargs, " (char *)\"%s\", ", name);
+        Delete(name);
       }
 
       /* Look for an input typemap */
       if ((tm = Getattr(p, "tmap:in"))) {
-	String *parse = Getattr(p, "tmap:in:parse");
-	if (!parse) {
-	  if (builtin_self) {
-	    Replaceall(tm, "$self", "self");
-	  } else if (funpack) {
-	    Replaceall(tm, "$self", "swig_obj[0]");
-	  } else {
-	    Replaceall(tm, "$self", "obj0");
-	  }
-	  Replaceall(tm, "$input", source);
-	  Setattr(p, "emit:input", source);	/* Save the location of the object */
+        String *parse = Getattr(p, "tmap:in:parse");
+        if (!parse) {
+          if (builtin_self) {
+            Replaceall(tm, "$self", "self");
+          } else if (funpack) {
+            Replaceall(tm, "$self", "swig_obj[0]");
+          } else {
+            Replaceall(tm, "$self", "obj0");
+          }
+          Replaceall(tm, "$input", source);
+          Setattr(p, "emit:input", source);	/* Save the location of the object */
 
-	  if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
-	    Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	  } else {
-	    Replaceall(tm, "$disown", "0");
-	  }
+          if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
+            Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+          } else {
+            Replaceall(tm, "$disown", "0");
+          }
 
-	  if (Getattr(p, "tmap:in:implicitconv")) {
-	    const char *convflag = "0";
-	    if (!Getattr(p, "hidden")) {
-	      SwigType *ptype = Getattr(p, "type");
-	      convflag = get_implicitconv_flag(classLookup(ptype));
-	    }
-	    Replaceall(tm, "$implicitconv", convflag);
-	    Setattr(p, "implicitconv", convflag);
-	  }
+          if (Getattr(p, "tmap:in:implicitconv")) {
+            const char *convflag = "0";
+            if (!Getattr(p, "hidden")) {
+              SwigType *ptype = Getattr(p, "type");
+              convflag = get_implicitconv_flag(classLookup(ptype));
+            }
+            Replaceall(tm, "$implicitconv", convflag);
+            Setattr(p, "implicitconv", convflag);
+          }
 
-	  if (parse_from_tuple)
-	    Putc('O', parse_args);
-	  if (!funpack && parse_from_tuple) {
-	    Wrapper_add_localv(f, source, "PyObject *", source, "= 0", NIL);
-	    Printf(arglist, "&%s", source);
-	  }
-	  if (i >= num_required)
-	    Printv(get_pointers, "if (", source, ") {\n", NIL);
-	  Printv(get_pointers, tm, "\n", NIL);
-	  if (i >= num_required)
-	    Printv(get_pointers, "}\n", NIL);
+          if (parse_from_tuple)
+            Putc('O', parse_args);
+          if (!funpack && parse_from_tuple) {
+            Wrapper_add_localv(f, source, "PyObject *", source, "= 0", NIL);
+            Printf(arglist, "&%s", source);
+          }
+          if (i >= num_required)
+            Printv(get_pointers, "if (", source, ") {\n", NIL);
+          Printv(get_pointers, tm, "\n", NIL);
+          if (i >= num_required)
+            Printv(get_pointers, "}\n", NIL);
 
-	} else {
-	  use_parse = 1;
-	  Append(parse_args, parse);
-	  if (parse_from_tuple)
-	    Printf(arglist, "&%s", ln);
-	}
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        } else {
+          use_parse = 1;
+          Append(parse_args, parse);
+          if (parse_from_tuple)
+            Printf(arglist, "&%s", ln);
+        }
+        p = Getattr(p, "tmap:in:next");
+        continue;
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
-	break;
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        break;
       }
     }
 
@@ -3032,37 +3032,37 @@ public:
       Clear(parse_args);
 
       if (funpack) {
-	Clear(f->def);
-	if (overname) {
-	  if (noargs) {
-	    Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, Py_ssize_t nobjs, PyObject **SWIGUNUSEDPARM(swig_obj)) {", NIL);
-	  } else {
-	    Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {", NIL);
-	  }
-	  Printf(parse_args, "if ((nobjs < %d) || (nobjs > %d)) SWIG_fail;\n", num_required, num_arguments);
-	} else {
-	  int is_tp_call = Equal(Getattr(n, "feature:python:slot"), "tp_call");
-	  Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
-	  if (builtin_ctor)
-	    Printf(parse_args, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", iname);
-	  if (onearg && !builtin_ctor && !is_tp_call) {
-	    Printf(parse_args, "if (!args) SWIG_fail;\n");
-	    Append(parse_args, "swig_obj[0] = args;\n");
-	  } else if (!noargs) {
-	    Printf(parse_args, "if (!SWIG_Python_UnpackTuple(args, \"%s\", %d, %d, swig_obj)) SWIG_fail;\n", iname, num_fixed_arguments, tuple_arguments);
-	  } else if (noargs) {
-	    Printf(parse_args, "if (!SWIG_Python_UnpackTuple(args, \"%s\", %d, %d, 0)) SWIG_fail;\n", iname, num_fixed_arguments, tuple_arguments);
-	  }
-	}
+        Clear(f->def);
+        if (overname) {
+          if (noargs) {
+            Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, Py_ssize_t nobjs, PyObject **SWIGUNUSEDPARM(swig_obj)) {", NIL);
+          } else {
+            Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {", NIL);
+          }
+          Printf(parse_args, "if ((nobjs < %d) || (nobjs > %d)) SWIG_fail;\n", num_required, num_arguments);
+        } else {
+          int is_tp_call = Equal(Getattr(n, "feature:python:slot"), "tp_call");
+          Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
+          if (builtin_ctor)
+            Printf(parse_args, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", iname);
+          if (onearg && !builtin_ctor && !is_tp_call) {
+            Printf(parse_args, "if (!args) SWIG_fail;\n");
+            Append(parse_args, "swig_obj[0] = args;\n");
+          } else if (!noargs) {
+            Printf(parse_args, "if (!SWIG_Python_UnpackTuple(args, \"%s\", %d, %d, swig_obj)) SWIG_fail;\n", iname, num_fixed_arguments, tuple_arguments);
+          } else if (noargs) {
+            Printf(parse_args, "if (!SWIG_Python_UnpackTuple(args, \"%s\", %d, %d, 0)) SWIG_fail;\n", iname, num_fixed_arguments, tuple_arguments);
+          }
+        }
       } else {
-	if (builtin_ctor)
-	  Printf(parse_args, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", iname);
-	if (builtin && in_class && tuple_arguments == 0) {
-	  Printf(parse_args, "    if (args && PyTuple_Check(args) && PyTuple_GET_SIZE(args) > 0) SWIG_exception_fail(SWIG_TypeError, \"%s takes no arguments\");\n", iname);
-	} else {
-	  Printf(parse_args, "if (!PyArg_UnpackTuple(args, \"%s\", %d, %d", iname, num_fixed_arguments, tuple_arguments);
-	  Printv(parse_args, arglist, ")) SWIG_fail;\n", NIL);
-	}
+        if (builtin_ctor)
+          Printf(parse_args, "if (!SWIG_Python_CheckNoKeywords(kwargs, \"%s\")) SWIG_fail;\n", iname);
+        if (builtin && in_class && tuple_arguments == 0) {
+          Printf(parse_args, "    if (args && PyTuple_Check(args) && PyTuple_GET_SIZE(args) > 0) SWIG_exception_fail(SWIG_TypeError, \"%s takes no arguments\");\n", iname);
+        } else {
+          Printf(parse_args, "if (!PyArg_UnpackTuple(args, \"%s\", %d, %d", iname, num_fixed_arguments, tuple_arguments);
+          Printv(parse_args, arglist, ")) SWIG_fail;\n", NIL);
+        }
       }
     }
 
@@ -3072,52 +3072,52 @@ public:
     /* Check for trailing varargs */
     if (varargs) {
       if (p && (tm = Getattr(p, "tmap:in"))) {
-	Replaceall(tm, "$input", "varargs");
-	Printv(f->code, tm, "\n", NIL);
+        Replaceall(tm, "$input", "varargs");
+        Printv(f->code, tm, "\n", NIL);
       }
     }
 
     /* Insert constraint checking code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (p = l; p;) {
       if (!Getattr(p, "tmap:in:parse") && (tm = Getattr(p, "tmap:freearg"))) {
-	if (Getattr(p, "tmap:freearg:implicitconv")) {
-	  const char *convflag = "0";
-	  if (!Getattr(p, "hidden")) {
-	    SwigType *ptype = Getattr(p, "type");
-	    convflag = get_implicitconv_flag(classLookup(ptype));
-	  }
-	  if (strcmp(convflag, "0") == 0) {
-	    tm = 0;
-	  }
-	}
-	if (tm && (Len(tm) != 0)) {
-	  Printv(cleanup, tm, "\n", NIL);
-	}
-	p = Getattr(p, "tmap:freearg:next");
+        if (Getattr(p, "tmap:freearg:implicitconv")) {
+          const char *convflag = "0";
+          if (!Getattr(p, "hidden")) {
+            SwigType *ptype = Getattr(p, "type");
+            convflag = get_implicitconv_flag(classLookup(ptype));
+          }
+          if (strcmp(convflag, "0") == 0) {
+            tm = 0;
+          }
+        }
+        if (tm && (Len(tm) != 0)) {
+          Printv(cleanup, tm, "\n", NIL);
+        }
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert argument output code */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -3146,18 +3146,18 @@ public:
       Wrapper_add_local(f, "director", "Swig::Director *director = 0");
       Append(f->code, "director = SWIG_DIRECTOR_CAST(arg1);\n");
       if (dirprot_mode() && !is_public(n)) {
-	Printf(f->code, "if (!director || !(director->swig_get_inner(\"%s\"))) {\n", name);
-	Printf(f->code, "SWIG_SetErrorMsg(PyExc_RuntimeError,\"accessing protected member %s\");\n", name);
-	Append(f->code, "SWIG_fail;\n");
-	Append(f->code, "}\n");
+        Printf(f->code, "if (!director || !(director->swig_get_inner(\"%s\"))) {\n", name);
+        Printf(f->code, "SWIG_SetErrorMsg(PyExc_RuntimeError,\"accessing protected member %s\");\n", name);
+        Append(f->code, "SWIG_fail;\n");
+        Append(f->code, "}\n");
       }
       Wrapper_add_local(f, "upcall", "bool upcall = false");
       if (funpack) {
-	const char *self_parm = builtin_self ? "self" : "swig_obj[0]";
-	Printf(f->code, "upcall = (director && (director->swig_get_self()==%s));\n", self_parm);
+        const char *self_parm = builtin_self ? "self" : "swig_obj[0]";
+        Printf(f->code, "upcall = (director && (director->swig_get_self()==%s));\n", self_parm);
       } else {
-	const char *self_parm = builtin_self ? "self" : "obj0";
-	Printf(f->code, "upcall = (director && (director->swig_get_self()==%s));\n", self_parm);
+        const char *self_parm = builtin_self ? "self" : "obj0";
+        Printf(f->code, "upcall = (director && (director->swig_get_self()==%s));\n", self_parm);
       }
     }
 
@@ -3166,13 +3166,13 @@ public:
       Append(f->code, "try {\n");
     } else {
       if (allow_thread) {
-	String *preaction = NewString("");
-	thread_begin_allow(n, preaction);
-	Setattr(n, "wrap:preaction", preaction);
+        String *preaction = NewString("");
+        thread_begin_allow(n, preaction);
+        Setattr(n, "wrap:preaction", preaction);
 
-	String *postaction = NewString("");
-	thread_end_allow(n, postaction);
-	Setattr(n, "wrap:postaction", postaction);
+        String *postaction = NewString("");
+        thread_end_allow(n, postaction);
+        Setattr(n, "wrap:postaction", postaction);
       }
     }
 
@@ -3194,37 +3194,37 @@ public:
 
     if (tm) {
       if (builtin_self) {
-	Replaceall(tm, "$self", "self");
+        Replaceall(tm, "$self", "self");
       } else if (funpack) {
-	Replaceall(tm, "$self", "swig_obj[0]");
+        Replaceall(tm, "$self", "swig_obj[0]");
       } else {
-	Replaceall(tm, "$self", "obj0");
+        Replaceall(tm, "$self", "obj0");
       }
       Replaceall(tm, "$result", "resultobj");
       if (builtin_ctor) {
-	Replaceall(tm, "$owner", "SWIG_BUILTIN_INIT");
+        Replaceall(tm, "$owner", "SWIG_BUILTIN_INIT");
       } else if (handled_as_init) {
-	Replaceall(tm, "$owner", "SWIG_POINTER_NEW");
+        Replaceall(tm, "$owner", "SWIG_POINTER_NEW");
       } else {
-	if (GetFlag(n, "feature:new")) {
-	  Replaceall(tm, "$owner", "SWIG_POINTER_OWN");
-	} else {
-	  Replaceall(tm, "$owner", "0");
-	}
+        if (GetFlag(n, "feature:new")) {
+          Replaceall(tm, "$owner", "SWIG_POINTER_OWN");
+        } else {
+          Replaceall(tm, "$owner", "0");
+        }
       }
 
       // Unwrap return values that are director classes so that the original Python object is returned instead. 
       if (!constructor && Swig_director_can_unwrap(n)) {
-	Wrapper_add_local(f, "director", "Swig::Director *director = 0");
-	Printf(f->code, "director = SWIG_DIRECTOR_CAST(%s);\n", Swig_cresult_name());
-	Append(f->code, "if (director) {\n");
-	Append(f->code, "  resultobj = director->swig_get_self();\n");
-	Append(f->code, "  SWIG_Py_INCREF(resultobj);\n");
-	Append(f->code, "} else {\n");
-	Printf(f->code, "%s\n", tm);
-	Append(f->code, "}\n");
+        Wrapper_add_local(f, "director", "Swig::Director *director = 0");
+        Printf(f->code, "director = SWIG_DIRECTOR_CAST(%s);\n", Swig_cresult_name());
+        Append(f->code, "if (director) {\n");
+        Append(f->code, "  resultobj = director->swig_get_self();\n");
+        Append(f->code, "  SWIG_Py_INCREF(resultobj);\n");
+        Append(f->code, "} else {\n");
+        Printf(f->code, "%s\n", tm);
+        Append(f->code, "}\n");
       } else {
-	Printf(f->code, "%s\n", tm);
+        Printf(f->code, "%s\n", tm);
       }
 
       Delete(tm);
@@ -3245,8 +3245,8 @@ public:
     /* Look to see if there is any newfree cleanup code */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printf(f->code, "%s\n", tm);
-	Delete(tm);
+        Printf(f->code, "%s\n", tm);
+        Delete(tm);
       }
     }
 
@@ -3258,10 +3258,10 @@ public:
 
     if (director_method) {
       if ((tm = Swig_typemap_lookup("directorfree", n, Swig_cresult_name(), 0))) {
-	Replaceall(tm, "$input", Swig_cresult_name());
-	Replaceall(tm, "$result", "resultobj");
-	Printf(f->code, "%s\n", tm);
-	Delete(tm);
+        Replaceall(tm, "$input", Swig_cresult_name());
+        Replaceall(tm, "$result", "resultobj");
+        Printf(f->code, "%s\n", tm);
+        Delete(tm);
       }
     }
 
@@ -3280,12 +3280,12 @@ public:
       Printv(f->code, "  return -1;\n", NIL);
     } else {
       if (GetFlag(n, "feature:python:maybecall")) {
-	Append(f->code, "  if (PyErr_Occurred() && !PyErr_ExceptionMatches(PyExc_TypeError)) {\n");
-	Append(f->code, "    return NULL;\n");
-	Append(f->code, "  }\n");
-	Append(f->code, "  PyErr_Clear();\n");
-	Append(f->code, "  SWIG_Py_INCREF(Py_NotImplemented);\n");
-	Append(f->code, "  return Py_NotImplemented;\n");
+        Append(f->code, "  if (PyErr_Occurred() && !PyErr_ExceptionMatches(PyExc_TypeError)) {\n");
+        Append(f->code, "    return NULL;\n");
+        Append(f->code, "  }\n");
+        Append(f->code, "  PyErr_Clear();\n");
+        Append(f->code, "  SWIG_Py_INCREF(Py_NotImplemented);\n");
+        Append(f->code, "  return Py_NotImplemented;\n");
       } else {
         Printv(f->code, "  return NULL;\n", NIL);
       }
@@ -3319,29 +3319,29 @@ public:
       DelWrapper(f);
       f = NewWrapper();
       if (funpack) {
-	// Note: funpack is currently always false for varargs
-	Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {", NIL);
+        // Note: funpack is currently always false for varargs
+        Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {", NIL);
       } else {
-	Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
+        Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
       }
       Wrapper_add_local(f, "resultobj", builtin_ctor ? "int resultobj" : "PyObject *resultobj");
       Wrapper_add_local(f, "varargs", "PyObject *varargs");
       Wrapper_add_local(f, "newargs", "PyObject *newargs");
       if (funpack) {
-	Wrapper_add_local(f, "i", "int i");
-	Printf(f->code, "newargs = PyTuple_New(%d);\n", num_fixed_arguments);
-	Printf(f->code, "for (i = 0; i < %d; ++i) {\n", num_fixed_arguments);
-	Printf(f->code, "  PyTuple_SET_ITEM(newargs, i, swig_obj[i]);\n");
-	Printf(f->code, "  SWIG_Py_XINCREF(swig_obj[i]);\n");
-	Printf(f->code, "}\n");
-	Printf(f->code, "varargs = PyTuple_New(nobjs > %d ? nobjs - %d : 0);\n", num_fixed_arguments, num_fixed_arguments);
-	Printf(f->code, "for (i = 0; i < nobjs - %d; ++i) {\n", num_fixed_arguments);
-	Printf(f->code, "  PyTuple_SET_ITEM(newargs, i, swig_obj[i + %d]);\n", num_fixed_arguments);
-	Printf(f->code, "  SWIG_Py_XINCREF(swig_obj[i + %d]);\n", num_fixed_arguments);
-	Printf(f->code, "}\n");
+        Wrapper_add_local(f, "i", "int i");
+        Printf(f->code, "newargs = PyTuple_New(%d);\n", num_fixed_arguments);
+        Printf(f->code, "for (i = 0; i < %d; ++i) {\n", num_fixed_arguments);
+        Printf(f->code, "  PyTuple_SET_ITEM(newargs, i, swig_obj[i]);\n");
+        Printf(f->code, "  SWIG_Py_XINCREF(swig_obj[i]);\n");
+        Printf(f->code, "}\n");
+        Printf(f->code, "varargs = PyTuple_New(nobjs > %d ? nobjs - %d : 0);\n", num_fixed_arguments, num_fixed_arguments);
+        Printf(f->code, "for (i = 0; i < nobjs - %d; ++i) {\n", num_fixed_arguments);
+        Printf(f->code, "  PyTuple_SET_ITEM(newargs, i, swig_obj[i + %d]);\n", num_fixed_arguments);
+        Printf(f->code, "  SWIG_Py_XINCREF(swig_obj[i + %d]);\n", num_fixed_arguments);
+        Printf(f->code, "}\n");
       } else {
-	Printf(f->code, "newargs = PyTuple_GetSlice(args, 0, %d);\n", num_fixed_arguments);
-	Printf(f->code, "varargs = PyTuple_GetSlice(args, %d, PyTuple_Size(args));\n", num_fixed_arguments);
+        Printf(f->code, "newargs = PyTuple_GetSlice(args, 0, %d);\n", num_fixed_arguments);
+        Printf(f->code, "varargs = PyTuple_GetSlice(args, %d, PyTuple_Size(args));\n", num_fixed_arguments);
       }
       Printf(f->code, "resultobj = %s__varargs__(%s, newargs, varargs%s);\n", wname, builtin ? "self" : "NULL", strlen(builtin_kwargs) == 0 ? "" : ", kwargs");
       Append(f->code, "SWIG_Py_XDECREF(newargs);\n");
@@ -3355,25 +3355,25 @@ public:
     /* Now register the function with the interpreter.   */
     if (!Getattr(n, "sym:overloaded")) {
       if (!builtin_self && (use_static_method || !builtin))
-	add_method(iname, wname, allow_kwargs, n, funpack, num_required, num_arguments);
+        add_method(iname, wname, allow_kwargs, n, funpack, num_required, num_arguments);
 
       /* Create a shadow for this function (if enabled and not in a member function) */
       if (!builtin && shadow && !(shadow & PYSHADOW_MEMBER) && use_static_method) {
-	emitFunctionShadowHelper(n, in_class ? f_shadow_stubs : f_shadow, iname, allow_kwargs);
+        emitFunctionShadowHelper(n, in_class ? f_shadow_stubs : f_shadow, iname, allow_kwargs);
       }
 
     } else {
       if (!Getattr(n, "sym:nextSibling")) {
-	dispatchFunction(n, linkage, funpack, builtin_self, builtin_ctor, director_class, use_static_method);
+        dispatchFunction(n, linkage, funpack, builtin_self, builtin_ctor, director_class, use_static_method);
       }
     }
 
     // Put this in tp_init of the PyTypeObject
     if (builtin_ctor) {
       if ((director_method || !is_private(n)) && !Getattr(class_members, iname)) {
-	Setattr(class_members, iname, n);
-	if (!builtin_tp_init)
-	  builtin_tp_init = Swig_name_wrapper(iname);
+        Setattr(class_members, iname, n);
+        if (!builtin_tp_init)
+          builtin_tp_init = Swig_name_wrapper(iname);
       }
     }
 
@@ -3388,46 +3388,46 @@ public:
       }
       Setattr(h, "getter", "SwigPyObject_get___dict__");
       if (!Getattr(h, "doc")) {
-	Setattr(h, "doc", "dictionary for instance variables");
+        Setattr(h, "doc", "dictionary for instance variables");
       }
     }
 
     if (builtin_getter) {
       String *memname = Getattr(n, "membervariableHandler:sym:name");
       if (!memname)
-	memname = iname;
+        memname = iname;
       Hash *h = Getattr(builtin_getset, memname);
       if (!h) {
-	h = NewHash();
-	Setattr(builtin_getset, memname, h);
-	Delete(h);
+        h = NewHash();
+        Setattr(builtin_getset, memname, h);
+        Delete(h);
       }
       Setattr(h, "getter", wrapper_name);
       Delattr(n, "memberget");
       if (!Getattr(h, "doc")) {
-	Setattr(n, "doc:high:name", Getattr(n, "name"));
-	String *ds = cdocstring(n, AUTODOC_VAR);
-	Setattr(h, "doc", ds);
-	Delete(ds);
+        Setattr(n, "doc:high:name", Getattr(n, "name"));
+        String *ds = cdocstring(n, AUTODOC_VAR);
+        Setattr(h, "doc", ds);
+        Delete(ds);
       }
     }
     if (builtin_setter) {
       String *memname = Getattr(n, "membervariableHandler:sym:name");
       if (!memname)
-	memname = iname;
+        memname = iname;
       Hash *h = Getattr(builtin_getset, memname);
       if (!h) {
-	h = NewHash();
-	Setattr(builtin_getset, memname, h);
-	Delete(h);
+        h = NewHash();
+        Setattr(builtin_getset, memname, h);
+        Delete(h);
       }
       Setattr(h, "setter", wrapper_name);
       Delattr(n, "memberset");
       if (!Getattr(h, "doc")) {
-	Setattr(n, "doc:high:name", Getattr(n, "name"));
-	String *ds = cdocstring(n, AUTODOC_VAR);
-	Setattr(h, "doc", ds);
-	Delete(ds);
+        Setattr(n, "doc:high:name", Getattr(n, "name"));
+        String *ds = cdocstring(n, AUTODOC_VAR);
+        Setattr(h, "doc", ds);
+        Delete(ds);
       }
     }
 
@@ -3435,35 +3435,35 @@ public:
       /* Handle operator overloads for builtin types */
       String *slot = Getattr(n, "feature:python:slot");
       if (slot && !isfriend) {
-	String *func_type = Getattr(n, "feature:python:slot:functype");
-	String *closure_decl = getClosure(func_type, wrapper_name, overname ? 0 : funpack);
-	String *feature_name = NewStringf("feature:python:%s", slot);
-	String *closure_name = 0;
-	if (closure_decl) {
-	  closure_name = NewStringf("%s_%s_closure", wrapper_name, func_type);
-	  if (!GetFlag(builtin_closures, closure_name))
-	    Printf(builtin_closures_code, "%s /* defines %s */\n\n", closure_decl, closure_name);
-	  SetFlag(builtin_closures, closure_name);
-	  Delete(closure_decl);
-	} else {
-	  closure_name = Copy(wrapper_name);
-	}
-	if (func_type) {
-	  String *s = NewStringf("%s", closure_name);
-	  Delete(closure_name);
-	  closure_name = s;
-	}
-	Setattr(parent, feature_name, closure_name);
-	Delete(feature_name);
-	Delete(closure_name);
+        String *func_type = Getattr(n, "feature:python:slot:functype");
+        String *closure_decl = getClosure(func_type, wrapper_name, overname ? 0 : funpack);
+        String *feature_name = NewStringf("feature:python:%s", slot);
+        String *closure_name = 0;
+        if (closure_decl) {
+          closure_name = NewStringf("%s_%s_closure", wrapper_name, func_type);
+          if (!GetFlag(builtin_closures, closure_name))
+            Printf(builtin_closures_code, "%s /* defines %s */\n\n", closure_decl, closure_name);
+          SetFlag(builtin_closures, closure_name);
+          Delete(closure_decl);
+        } else {
+          closure_name = Copy(wrapper_name);
+        }
+        if (func_type) {
+          String *s = NewStringf("%s", closure_name);
+          Delete(closure_name);
+          closure_name = s;
+        }
+        Setattr(parent, feature_name, closure_name);
+        Delete(feature_name);
+        Delete(closure_name);
       }
 
       /* Handle comparison operators for builtin types */
       String *compare = Getattr(n, "feature:python:compare");
       if (compare) {
-	Hash *richcompare = Getattr(parent, "python:richcompare");
-	assert(richcompare);
-	Setattr(richcompare, compare, wrapper_name);
+        Hash *richcompare = Getattr(parent, "python:richcompare");
+        assert(richcompare);
+        Setattr(richcompare, compare, wrapper_name);
       }
     }
 
@@ -3513,10 +3513,10 @@ public:
       Printf(f_init, "\t }\n");
       Printf(f_init, "\t PyDict_SetItemString(md, \"%s\", globals);\n", global_name);
       if (builtin)
-	Printf(f_init, "\t SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", global_name);
+        Printf(f_init, "\t SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", global_name);
       have_globals = 1;
       if (!builtin && shadow && !(shadow & PYSHADOW_MEMBER)) {
-	Printf(f_shadow_stubs, "%s = %s.%s\n", global_name, module, global_name);
+        Printf(f_shadow_stubs, "%s = %s.%s\n", global_name, module, global_name);
       }
     }
     int assignable = !is_immutable(n);
@@ -3533,20 +3533,20 @@ public:
     if (assignable) {
       Setattr(n, "wrap:name", varsetname);
       if (builtin && in_class) {
-	String *set_wrapper = Swig_name_wrapper(setname);
-	Setattr(n, "pybuiltin:setter", set_wrapper);
-	Delete(set_wrapper);
+        String *set_wrapper = Swig_name_wrapper(setname);
+        Setattr(n, "pybuiltin:setter", set_wrapper);
+        Delete(set_wrapper);
       }
       Printf(setf->def, "SWIGINTERN int %s(PyObject *_val) {", varsetname);
       if ((tm = Swig_typemap_lookup("varin", n, name, 0))) {
-	Replaceall(tm, "$input", "_val");
-	if (Getattr(n, "tmap:varin:implicitconv")) {
-	  Replaceall(tm, "$implicitconv", get_implicitconv_flag(n));
-	}
-	emit_action_code(n, setf->code, tm);
-	Delete(tm);
+        Replaceall(tm, "$input", "_val");
+        if (Getattr(n, "tmap:varin:implicitconv")) {
+          Replaceall(tm, "$implicitconv", get_implicitconv_flag(n));
+        }
+        emit_action_code(n, setf->code, tm);
+        Delete(tm);
       } else {
-	Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(t, 0));
+        Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(t, 0));
       }
       Printv(setf->code, "  return 0;\n", NULL);
       Append(setf->code, "fail:\n");
@@ -3554,9 +3554,9 @@ public:
     } else {
       /* Is a readonly variable.  Issue an error */
       if (CPlusPlus) {
-	Printf(setf->def, "SWIGINTERN int %s(PyObject *) {", varsetname);
+        Printf(setf->def, "SWIGINTERN int %s(PyObject *) {", varsetname);
       } else {
-	Printf(setf->def, "SWIGINTERN int %s(PyObject *_val SWIGUNUSED) {", varsetname);
+        Printf(setf->def, "SWIGINTERN int %s(PyObject *_val SWIGUNUSED) {", varsetname);
       }
       Printv(setf->code, "  SWIG_Error(SWIG_AttributeError,\"Variable ", iname, " is read-only.\");\n", "  return 1;\n", NIL);
     }
@@ -3673,18 +3673,18 @@ public:
     if ((tm = Swig_typemap_lookup("constcode", n, name, 0))) {
       Replaceall(tm, "$value", value);
       if (needs_swigconstant(n) && !builtin && shadow && !(shadow & PYSHADOW_MEMBER) && (!in_class || !Getattr(n, "feature:python:callback"))) {
-	// Generate `*_swigconstant()` method which registers the new constant.
-	//
-	// *_swigconstant methods are required for constants of class type.
-	// Class types are registered in shadow file (see *_swigregister). The
-	// instances of class must be created (registered) after the type is
-	// registered, so we can't let SWIG_init() to register constants of
-	// class type (the SWIG_init() is called before shadow classes are
-	// defined and registered).
+        // Generate `*_swigconstant()` method which registers the new constant.
+        //
+        // *_swigconstant methods are required for constants of class type.
+        // Class types are registered in shadow file (see *_swigregister). The
+        // instances of class must be created (registered) after the type is
+        // registered, so we can't let SWIG_init() to register constants of
+        // class type (the SWIG_init() is called before shadow classes are
+        // defined and registered).
         Printf(f_wrappers, "SWIGINTERN PyObject *%s_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", iname);
         Printf(f_wrappers, tab2 "PyObject *module = NULL;\n");
         Printf(f_wrappers, tab2 "PyObject *d;\n");
-	Printf(f_wrappers, tab2 "if (!SWIG_Python_UnpackTuple(args, \"swigconstant\", 1, 1, &module)) return NULL;\n");
+        Printf(f_wrappers, tab2 "if (!SWIG_Python_UnpackTuple(args, \"swigconstant\", 1, 1, &module)) return NULL;\n");
         Printf(f_wrappers, tab2 "d = PyModule_GetDict(module);\n");
         Printf(f_wrappers, tab2 "if (!d) return NULL;\n");
         Printf(f_wrappers, tab2 "%s\n", tm);
@@ -3692,9 +3692,9 @@ public:
         Printf(f_wrappers, "}\n\n\n");
 
         // Register the method in SwigMethods array
-	String *cname = NewStringf("%s_swigconstant", iname);
-	add_method(cname, cname, 0, 0, 1, 1, 1);
-	Delete(cname);
+        String *cname = NewStringf("%s_swigconstant", iname);
+        add_method(cname, cname, 0, 0, 1, 1, 1);
+        Delete(cname);
       } else {
         Printf(f_init, "%s\n", tm);
       }
@@ -3713,19 +3713,19 @@ public:
     if (!builtin && shadow && !(shadow & PYSHADOW_MEMBER)) {
       String *f_s;
       if (!in_class) {
-	f_s = f_shadow;
+        f_s = f_shadow;
       } else {
-	f_s = Getattr(n, "feature:python:callback") ? NIL : f_shadow_stubs;
+        f_s = Getattr(n, "feature:python:callback") ? NIL : f_shadow_stubs;
       }
 
       if (f_s) {
-	if (needs_swigconstant(n)) {
-	  Printv(f_s, "\n",NIL);
-	  Printv(f_s, module, ".", iname, "_swigconstant(",module,")\n", NIL);
-	}
-	Printv(f_s, iname, " = ", module, ".", iname, "\n", NIL);
-	if (have_docstring(n))
-	  Printv(f_s, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
+        if (needs_swigconstant(n)) {
+          Printv(f_s, "\n",NIL);
+          Printv(f_s, module, ".", iname, "_swigconstant(",module,")\n", NIL);
+        }
+        Printv(f_s, iname, " = ", module, ".", iname, "\n", NIL);
+        if (have_docstring(n))
+          Printv(f_s, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
       }
     }
     return SWIG_OK;
@@ -3801,25 +3801,25 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	Wrapper *w = NewWrapper();
-	String *call;
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, classname, parms, 0);
-	call = Swig_csuperclass_call(0, basetype, superparms);
-	Printf(w->def, "%s::%s: %s, Swig::Director(self) { \n", classname, target, call);
-	Printf(w->def, "   SWIG_DIRECTOR_RGTR((%s *)this, this); \n", basetype);
-	Append(w->def, "}\n");
-	Delete(target);
-	Wrapper_print(w, f_directors);
-	Delete(call);
-	DelWrapper(w);
+        Wrapper *w = NewWrapper();
+        String *call;
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, classname, parms, 0);
+        call = Swig_csuperclass_call(0, basetype, superparms);
+        Printf(w->def, "%s::%s: %s, Swig::Director(self) { \n", classname, target, call);
+        Printf(w->def, "   SWIG_DIRECTOR_RGTR((%s *)this, this); \n", basetype);
+        Append(w->def, "}\n");
+        Delete(target);
+        Wrapper_print(w, f_directors);
+        Delete(call);
+        DelWrapper(w);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, classname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, classname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -3938,17 +3938,17 @@ public:
     shadow = oldshadow;
     if (shadow) {
       if (builtin) {
-	String *rname = SwigType_namestr(real_classname);
-	Printf(builtin_methods, "  { \"__disown__\", Swig::Director::swig_pyobj_disown< %s >, METH_NOARGS, \"\" },\n", rname);
-	Delete(rname);
+        String *rname = SwigType_namestr(real_classname);
+        Printf(builtin_methods, "  { \"__disown__\", Swig::Director::swig_pyobj_disown< %s >, METH_NOARGS, \"\" },\n", rname);
+        Delete(rname);
       } else {
-	String *symname = Getattr(n, "sym:name");
-	String *mrename = Swig_name_disown(NSPACE_TODO, symname);	//Getattr(n, "name"));
-	Printv(f_shadow, tab4, "def __disown__(self):\n", NIL);
-	Printv(f_shadow, tab8, "self.this.disown()\n", NIL);
-	Printv(f_shadow, tab8, module, ".", mrename, "(self)\n", NIL);
-	Printv(f_shadow, tab8, "return weakref.proxy(self)\n", NIL);
-	Delete(mrename);
+        String *symname = Getattr(n, "sym:name");
+        String *mrename = Swig_name_disown(NSPACE_TODO, symname);	//Getattr(n, "name"));
+        Printv(f_shadow, tab4, "def __disown__(self):\n", NIL);
+        Printv(f_shadow, tab8, "self.this.disown()\n", NIL);
+        Printv(f_shadow, tab8, module, ".", mrename, "(self)\n", NIL);
+        Printv(f_shadow, tab8, "return weakref.proxy(self)\n", NIL);
+        Delete(mrename);
       }
     }
     return result;
@@ -3967,13 +3967,13 @@ public:
     if (shadow && !Getattr(n, "feature:onlychildren")) {
       Node *mod = Getattr(n, "module");
       if (mod) {
-	String *modname = Getattr(mod, "name");
-	Node *options = Getattr(mod, "options");
-	String *pkg = options ? Getattr(options, "package") : 0;
-	String *sym = Getattr(n, "sym:name");
-	String *importname = import_name_string(package, mainmodule, pkg, modname, sym);
-	Setattr(n, "python:proxy", importname);
-	Delete(importname);
+        String *modname = Getattr(mod, "name");
+        Node *options = Getattr(mod, "options");
+        String *pkg = options ? Getattr(options, "package") : 0;
+        String *sym = Getattr(n, "sym:name");
+        String *importname = import_name_string(package, mainmodule, pkg, modname, sym);
+        Setattr(n, "python:proxy", importname);
+        Delete(importname);
       }
     }
     int result = Language::classDeclaration(n);
@@ -4026,25 +4026,25 @@ public:
     if (baselist) {
       int base_count = 0;
       for (Iterator b = First(baselist); b.item; b = Next(b)) {
-	String *bname = Getattr(b.item, "name");
-	if (!bname || GetFlag(b.item, "feature:ignore"))
-	  continue;
-	base_count++;
-	String *base_name = Copy(bname);
-	SwigType_add_pointer(base_name);
-	String *base_mname = SwigType_manglestr(base_name);
-	Printf(f_init, "  builtin_basetype = SWIG_MangledTypeQuery(\"%s\");\n", base_mname);
-	Printv(f_init, "  if (builtin_basetype && builtin_basetype->clientdata && ((SwigPyClientData *) builtin_basetype->clientdata)->pytype) {\n", NIL);
-	Printv(f_init, "    builtin_bases[builtin_base_count++] = ((SwigPyClientData *) builtin_basetype->clientdata)->pytype;\n", NIL);
-	Printv(f_init, "  } else {\n", NIL);
-	Printf(f_init, "    PyErr_SetString(PyExc_TypeError, \"Could not create type '%s' as base '%s' has not been initialized.\\n\");\n", symname, bname);
-	Printv(f_init, "      return -1;\n", NIL);
-	Printv(f_init, "  }\n", NIL);
-	Delete(base_name);
-	Delete(base_mname);
+        String *bname = Getattr(b.item, "name");
+        if (!bname || GetFlag(b.item, "feature:ignore"))
+          continue;
+        base_count++;
+        String *base_name = Copy(bname);
+        SwigType_add_pointer(base_name);
+        String *base_mname = SwigType_manglestr(base_name);
+        Printf(f_init, "  builtin_basetype = SWIG_MangledTypeQuery(\"%s\");\n", base_mname);
+        Printv(f_init, "  if (builtin_basetype && builtin_basetype->clientdata && ((SwigPyClientData *) builtin_basetype->clientdata)->pytype) {\n", NIL);
+        Printv(f_init, "    builtin_bases[builtin_base_count++] = ((SwigPyClientData *) builtin_basetype->clientdata)->pytype;\n", NIL);
+        Printv(f_init, "  } else {\n", NIL);
+        Printf(f_init, "    PyErr_SetString(PyExc_TypeError, \"Could not create type '%s' as base '%s' has not been initialized.\\n\");\n", symname, bname);
+        Printv(f_init, "      return -1;\n", NIL);
+        Printv(f_init, "  }\n", NIL);
+        Delete(base_name);
+        Delete(base_mname);
       }
       if (base_count > max_bases)
-	max_bases = base_count;
+        max_bases = base_count;
     }
     Printv(f_init, "  builtin_bases[builtin_base_count] = NULL;\n", NIL);
     builtin_bases_needed = 1;
@@ -4075,15 +4075,15 @@ public:
       Printf(f, "static SwigPyGetSet %s = { %s, %s };\n", gspair, getter ? getter : "0", setter ? setter : "0");
       String *doc = Getattr(mgetset, "doc");
       if (!doc)
-	doc = NewStringf("%s.%s", name, memname);
+        doc = NewStringf("%s.%s", name, memname);
       String *entry = NewStringf("{ (char *)\"%s\", %s, %s, (char *)\"%s\", &%s }", memname, getter_closure, setter_closure, doc, gspair);
       if (GetFlag(mgetset, "static")) {
-	Printf(f, "static PyGetSetDef %s_def = %s;\n", gspair, entry);
-	Printf(f_init, "static_getset = SwigPyStaticVar_new_getset(metatype, &%s_def);\n", gspair);
-	Printf(f_init, "PyDict_SetItemString(d, static_getset->d_getset->name, (PyObject *)static_getset);\n");
-	Printf(f_init, "SWIG_Py_DECREF((PyObject *)static_getset);\n");
+        Printf(f, "static PyGetSetDef %s_def = %s;\n", gspair, entry);
+        Printf(f_init, "static_getset = SwigPyStaticVar_new_getset(metatype, &%s_def);\n", gspair);
+        Printf(f_init, "PyDict_SetItemString(d, static_getset->d_getset->name, (PyObject *)static_getset);\n");
+        Printf(f_init, "SWIG_Py_DECREF((PyObject *)static_getset);\n");
       } else {
-	Printf(getset_def, "    %s,\n", entry);
+        Printf(getset_def, "    %s,\n", entry);
       }
       Delete(gspair);
       Delete(entry);
@@ -4108,7 +4108,7 @@ public:
     if (rich_iter.item) {
       Printf(f, "  switch (op) {\n");
       for (; rich_iter.item; rich_iter = Next(rich_iter))
-	Printf(f, "    case %s : result = %s(self, %s); break;\n", rich_iter.item, Getattr(richcompare, rich_iter.item), funpack ? "other" : "tuple");
+        Printf(f, "    case %s : result = %s(self, %s); break;\n", rich_iter.item, Getattr(richcompare, rich_iter.item), funpack ? "other" : "tuple");
       Printv(f, "    default : break;\n", NIL);
       Printf(f, "  }\n");
     }
@@ -4140,14 +4140,14 @@ public:
     String *quoted_symname;
     if (package) {
       if (modname)
-	quoted_symname = NewStringf("\"%s.%s.%s\"", package, modname, symname);
+        quoted_symname = NewStringf("\"%s.%s.%s\"", package, modname, symname);
       else
-	quoted_symname = NewStringf("\"%s.%s\"", package, symname);
+        quoted_symname = NewStringf("\"%s.%s\"", package, symname);
     } else {
       if (modname)
-	quoted_symname = NewStringf("\"%s.%s\"", modname, symname);
+        quoted_symname = NewStringf("\"%s.%s\"", modname, symname);
       else
-	quoted_symname = NewStringf("\"%s\"", symname);
+        quoted_symname = NewStringf("\"%s\"", symname);
     }
     String *quoted_tp_doc_str = NewStringf("\"%s\"", getSlot(n, "feature:python:tp_doc"));
     String *tp_init = NewString(builtin_tp_init ? Char(builtin_tp_init) : Swig_directorclass(n) ? "0" : "SwigPyBuiltin_BadInit");
@@ -4565,7 +4565,7 @@ public:
       Printv(f, "#if !defined(Py_LIMITED_API) && PY_VERSION_HEX < 0x03090000\n", NIL);
       Printf(f, "  if (pytype) {\n");
       if (bf_getbuffer)
-	Printf(f, "    pytype->tp_as_buffer->bf_getbuffer = %s;\n", getSlot(n, "feature:python:bf_getbuffer"));
+        Printf(f, "    pytype->tp_as_buffer->bf_getbuffer = %s;\n", getSlot(n, "feature:python:bf_getbuffer"));
       if (bf_releasebuffer)
         Printf(f, "    pytype->tp_as_buffer->bf_releasebuffer = %s;\n", getSlot(n, "feature:python:bf_releasebuffer"));
       Printf(f, "  }\n");
@@ -4654,14 +4654,14 @@ public:
       real_classname = Getattr(n, "name");
 
       if (!addSymbol(class_name, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
 
       if (builtin) {
-	List *baselist = Getattr(n, "bases");
-	if (baselist && Len(baselist) > 0) {
-	  Iterator b = First(baselist);
-	  base_node = b.item;
-	}
+        List *baselist = Getattr(n, "bases");
+        if (baselist && Len(baselist) > 0) {
+          Iterator b = First(baselist);
+          base_node = b.item;
+        }
       }
 
       shadow_indent = (String *) tab4;
@@ -4670,96 +4670,96 @@ public:
       String *base_class = NewString("");
       List *baselist = Getattr(n, "bases");
       if (baselist && Len(baselist)) {
-	Iterator b;
-	b = First(baselist);
-	while (b.item) {
-	  String *bname = Getattr(b.item, "python:proxy");
-	  bool ignore = GetFlag(b.item, "feature:ignore") ? true : false;
-	  if (!bname || ignore) {
-	    if (!bname && !ignore) {
-	      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(n), Getline(n),
-			   "Base class '%s' ignored - unknown module name for base. Either import the appropriate module interface file or specify the name of the module in the %%import directive.\n",
-			   SwigType_namestr(Getattr(b.item, "name")));
-	    }
-	    b = Next(b);
-	    continue;
-	  }
-	  Printv(base_class, bname, NIL);
-	  b = Next(b);
-	  if (b.item) {
+        Iterator b;
+        b = First(baselist);
+        while (b.item) {
+          String *bname = Getattr(b.item, "python:proxy");
+          bool ignore = GetFlag(b.item, "feature:ignore") ? true : false;
+          if (!bname || ignore) {
+            if (!bname && !ignore) {
+              Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(n), Getline(n),
+                           "Base class '%s' ignored - unknown module name for base. Either import the appropriate module interface file or specify the name of the module in the %%import directive.\n",
+                           SwigType_namestr(Getattr(b.item, "name")));
+            }
+            b = Next(b);
+            continue;
+          }
+          Printv(base_class, bname, NIL);
+          b = Next(b);
+          if (b.item) {
             Printv(base_class, ", ", NIL);
-	  }
-	}
+          }
+        }
       }
 
       if (builtin) {
-	Hash *base_richcompare = NULL;
-	Hash *richcompare = NULL;
-	if (base_node)
-	  base_richcompare = Getattr(base_node, "python:richcompare");
-	if (base_richcompare)
-	  richcompare = Copy(base_richcompare);
-	else
-	  richcompare = NewHash();
-	Setattr(n, "python:richcompare", richcompare);
+        Hash *base_richcompare = NULL;
+        Hash *richcompare = NULL;
+        if (base_node)
+          base_richcompare = Getattr(base_node, "python:richcompare");
+        if (base_richcompare)
+          richcompare = Copy(base_richcompare);
+        else
+          richcompare = NewHash();
+        Setattr(n, "python:richcompare", richcompare);
       }
 
       /* dealing with abstract base class */
       String *abcs = Getattr(n, "feature:python:abc");
       if (abcs) {
-	if (Len(base_class) > 0)
-	  Printv(base_class, ", ", NIL);
-	Printv(base_class, abcs, NIL);
+        if (Len(base_class) > 0)
+          Printv(base_class, ", ", NIL);
+        Printv(base_class, abcs, NIL);
       }
 
       if (builtin) {
-	if (have_docstring(n)) {
-	  String *ds = cdocstring(n, AUTODOC_CLASS);
-	  Setattr(n, "feature:python:tp_doc", ds);
-	  Delete(ds);
-	} else {
-	  SwigType *name = Getattr(n, "name");
-	  SwigType *sname = add_explicit_scope(name);
-	  String *rname = SwigType_namestr(sname);
-	  Setattr(n, "feature:python:tp_doc", rname);
-	  Delete(sname);
-	  Delete(rname);
-	}
+        if (have_docstring(n)) {
+          String *ds = cdocstring(n, AUTODOC_CLASS);
+          Setattr(n, "feature:python:tp_doc", ds);
+          Delete(ds);
+        } else {
+          SwigType *name = Getattr(n, "name");
+          SwigType *sname = add_explicit_scope(name);
+          String *rname = SwigType_namestr(sname);
+          Setattr(n, "feature:python:tp_doc", rname);
+          Delete(sname);
+          Delete(rname);
+        }
       } else {
-	if (GetFlag(n, "feature:python:nondynamic"))
-	  Printv(f_shadow, "@_swig_add_metaclass(_SwigNonDynamicMeta)\n", NIL);
-	Printv(f_shadow, "class ", class_name, NIL);
+        if (GetFlag(n, "feature:python:nondynamic"))
+          Printv(f_shadow, "@_swig_add_metaclass(_SwigNonDynamicMeta)\n", NIL);
+        Printv(f_shadow, "class ", class_name, NIL);
 
-	if (Len(base_class)) {
-	  Printf(f_shadow, "(%s)", base_class);
-	} else {
-	  if (GetFlag(n, "feature:exceptionclass")) {
-	    Printf(f_shadow, "(Exception)");
-	  } else {
-	    Printf(f_shadow, "(object");
-	    /* Replace @_swig_add_metaclass above with below when support for python 2.7 is dropped
-	    if (GetFlag(n, "feature:python:nondynamic")) {
-	      Printf(f_shadow, ", metaclass=_SwigNonDynamicMeta");
-	    }
-	    */
-	    Printf(f_shadow, ")");
-	  }
-	}
+        if (Len(base_class)) {
+          Printf(f_shadow, "(%s)", base_class);
+        } else {
+          if (GetFlag(n, "feature:exceptionclass")) {
+            Printf(f_shadow, "(Exception)");
+          } else {
+            Printf(f_shadow, "(object");
+            /* Replace @_swig_add_metaclass above with below when support for python 2.7 is dropped
+            if (GetFlag(n, "feature:python:nondynamic")) {
+              Printf(f_shadow, ", metaclass=_SwigNonDynamicMeta");
+            }
+            */
+            Printf(f_shadow, ")");
+          }
+        }
 
-	Printf(f_shadow, ":\n");
+        Printf(f_shadow, ":\n");
 
-	// write docstrings if requested
-	if (have_docstring(n)) {
-	  String *str = docstring(n, AUTODOC_CLASS, tab4);
-	  if (str && Len(str))
-	    Printv(f_shadow, tab4, str, "\n\n", NIL);
-	}
+        // write docstrings if requested
+        if (have_docstring(n)) {
+          String *str = docstring(n, AUTODOC_CLASS, tab4);
+          if (str && Len(str))
+            Printv(f_shadow, tab4, str, "\n\n", NIL);
+        }
 
-	Printv(f_shadow, tab4, "thisown = property(lambda x: x.this.own(), ", "lambda x, v: x.this.own(v), doc=\"The membership flag\")\n", NIL);
-	/* Add static attribute */
-	if (GetFlag(n, "feature:python:nondynamic")) {
-	  Printv(f_shadow_file, tab4, "__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n", NIL);
-	}
+        Printv(f_shadow, tab4, "thisown = property(lambda x: x.this.own(), ", "lambda x, v: x.this.own(v), doc=\"The membership flag\")\n", NIL);
+        /* Add static attribute */
+        if (GetFlag(n, "feature:python:nondynamic")) {
+          Printv(f_shadow_file, tab4, "__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n", NIL);
+        }
       }
     }
 
@@ -4802,61 +4802,61 @@ public:
       SwigType_add_pointer(realct);
       SwigType_remember(realct);
       if (builtin) {
-	Printv(f_wrappers, builtin_closures_code, NIL);
-	Delete(builtin_closures_code);
-	builtin_closures_code = NewString("");
-	Clear(builtin_closures);
+        Printv(f_wrappers, builtin_closures_code, NIL);
+        Delete(builtin_closures_code);
+        builtin_closures_code = NewString("");
+        Clear(builtin_closures);
       } else {
-	Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
-	Printv(f_wrappers, "  PyObject *obj = NULL;\n", NIL);
-	Printv(f_wrappers, "  if (!SWIG_Python_UnpackTuple(args, \"swigregister\", 1, 1, &obj)) return NULL;\n", NIL);
+        Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
+        Printv(f_wrappers, "  PyObject *obj = NULL;\n", NIL);
+        Printv(f_wrappers, "  if (!SWIG_Python_UnpackTuple(args, \"swigregister\", 1, 1, &obj)) return NULL;\n", NIL);
 
-	Printv(f_wrappers,
-	       "  SWIG_TypeNewClientData(SWIGTYPE", SwigType_manglestr(ct), ", SWIG_NewClientData(obj));\n", "  return SWIG_Py_Void();\n", "}\n\n", NIL);
-	String *cname = NewStringf("%s_swigregister", class_name);
-	add_method(cname, cname, 0, 0, 1, 1, 1);
-	Delete(cname);
+        Printv(f_wrappers,
+               "  SWIG_TypeNewClientData(SWIGTYPE", SwigType_manglestr(ct), ", SWIG_NewClientData(obj));\n", "  return SWIG_Py_Void();\n", "}\n\n", NIL);
+        String *cname = NewStringf("%s_swigregister", class_name);
+        add_method(cname, cname, 0, 0, 1, 1, 1);
+        Delete(cname);
       }
       Delete(ct);
       Delete(realct);
       if (!have_constructor) {
-	if (!builtin)
-	  Printv(f_shadow_file, "\n", tab4, "def __init__(self, *args, **kwargs):\n", tab8, "raise AttributeError(\"", "No constructor defined",
-		 (Getattr(n, "abstracts") ? " - class is abstract" : ""), "\")\n", NIL);
+        if (!builtin)
+          Printv(f_shadow_file, "\n", tab4, "def __init__(self, *args, **kwargs):\n", tab8, "raise AttributeError(\"", "No constructor defined",
+                 (Getattr(n, "abstracts") ? " - class is abstract" : ""), "\")\n", NIL);
       } else if (!builtin) {
 
-	Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
-	Printv(f_wrappers, "  return SWIG_Python_InitShadowInstance(args);\n", "}\n\n", NIL);
-	String *cname = NewStringf("%s_swiginit", class_name);
-	add_method(cname, cname, 0);
-	Delete(cname);
+        Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
+        Printv(f_wrappers, "  return SWIG_Python_InitShadowInstance(args);\n", "}\n\n", NIL);
+        String *cname = NewStringf("%s_swiginit", class_name);
+        add_method(cname, cname, 0);
+        Delete(cname);
       }
       if (!have_repr && !builtin) {
-	/* Supply a repr method for this class  */
-	String *rname = SwigType_namestr(real_classname);
-	Printv(f_shadow_file, tab4, "__repr__ = _swig_repr\n", NIL);
-	Delete(rname);
+        /* Supply a repr method for this class  */
+        String *rname = SwigType_namestr(real_classname);
+        Printv(f_shadow_file, tab4, "__repr__ = _swig_repr\n", NIL);
+        Delete(rname);
       }
 
       if (builtin)
-	builtin_post_decl(f_builtins, n);
+        builtin_post_decl(f_builtins, n);
 
       if (builtin_tp_init) {
-	Delete(builtin_tp_init);
-	builtin_tp_init = 0;
+        Delete(builtin_tp_init);
+        builtin_tp_init = 0;
       }
 
       if (!builtin) {
-	/* Now emit methods */
-	Printv(f_shadow_file, f_shadow, NIL);
-	Printf(f_shadow_file, "\n");
-	Printf(f_shadow_file, "# Register %s in %s:\n", class_name, module);
-	Printf(f_shadow_file, "%s.%s_swigregister(%s)\n", module, class_name, class_name);
+        /* Now emit methods */
+        Printv(f_shadow_file, f_shadow, NIL);
+        Printf(f_shadow_file, "\n");
+        Printf(f_shadow_file, "# Register %s in %s:\n", class_name, module);
+        Printf(f_shadow_file, "%s.%s_swigregister(%s)\n", module, class_name, class_name);
       }
 
       shadow_indent = 0;
       if (Len(f_shadow_stubs) > 0)
-	Printf(f_shadow_file, "%s\n", f_shadow_stubs);
+        Printf(f_shadow_file, "%s\n", f_shadow_stubs);
       Clear(f_shadow_stubs);
     }
 
@@ -4881,13 +4881,13 @@ public:
     String *pcb = GetFlagAttr(n, "feature:python:callback");
     if (pcb) {
       if (Strcmp(pcb, "1") == 0) {
-	SetFlagAttr(n, "feature:callback", "%s_cb_ptr");
+        SetFlagAttr(n, "feature:callback", "%s_cb_ptr");
       } else {
-	SetFlagAttr(n, "feature:callback", pcb);
+        SetFlagAttr(n, "feature:callback", pcb);
       }
       autodoc_l dlevel = autodoc_level(Getattr(n, "feature:autodoc"));
       if (dlevel != NO_AUTODOC && dlevel > TYPES_AUTODOC) {
-	Setattr(n, "feature:autodoc", "1");
+        Setattr(n, "feature:autodoc", "1");
       }
     }
     return Language::functionHandler(n);
@@ -4915,27 +4915,27 @@ public:
       // Can't use checkAttribute(n, "access", "public") because
       // "access" attr isn't set on %extend methods
       if (!checkAttribute(n, "access", "private") && strncmp(Char(symname), "operator ", 9) && !Getattr(class_members, symname)) {
-	String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
-	String *wname = Swig_name_wrapper(fullname);
-	Setattr(class_members, symname, n);
-	int argcount = Getattr(n, "python:argcount") ? atoi(Char(Getattr(n, "python:argcount"))) : 2;
-	String *ds = have_docstring(n) ? cdocstring(n, AUTODOC_METHOD) : NewString("");
-	if (check_kwargs(n)) {
-	  // Cast via void(*)(void) to suppress GCC -Wcast-function-type
-	  // warning.  Python should always call the function correctly, but
-	  // the Python C API requires us to store it in function pointer of a
-	  // different type.
-	  Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, METH_VARARGS|METH_KEYWORDS, \"%s\" },\n", symname, wname, ds);
-	} else if (argcount == 0) {
-	  Printf(builtin_methods, "  { \"%s\", %s, METH_NOARGS, \"%s\" },\n", symname, wname, ds);
-	} else if (argcount == 1) {
-	  Printf(builtin_methods, "  { \"%s\", %s, METH_O, \"%s\" },\n", symname, wname, ds);
-	} else {
-	  Printf(builtin_methods, "  { \"%s\", %s, METH_VARARGS, \"%s\" },\n", symname, wname, ds);
-	}
-	Delete(fullname);
-	Delete(wname);
-	Delete(ds);
+        String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *wname = Swig_name_wrapper(fullname);
+        Setattr(class_members, symname, n);
+        int argcount = Getattr(n, "python:argcount") ? atoi(Char(Getattr(n, "python:argcount"))) : 2;
+        String *ds = have_docstring(n) ? cdocstring(n, AUTODOC_METHOD) : NewString("");
+        if (check_kwargs(n)) {
+          // Cast via void(*)(void) to suppress GCC -Wcast-function-type
+          // warning.  Python should always call the function correctly, but
+          // the Python C API requires us to store it in function pointer of a
+          // different type.
+          Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, METH_VARARGS|METH_KEYWORDS, \"%s\" },\n", symname, wname, ds);
+        } else if (argcount == 0) {
+          Printf(builtin_methods, "  { \"%s\", %s, METH_NOARGS, \"%s\" },\n", symname, wname, ds);
+        } else if (argcount == 1) {
+          Printf(builtin_methods, "  { \"%s\", %s, METH_O, \"%s\" },\n", symname, wname, ds);
+        } else {
+          Printf(builtin_methods, "  { \"%s\", %s, METH_VARARGS, \"%s\" },\n", symname, wname, ds);
+        }
+        Delete(fullname);
+        Delete(wname);
+        Delete(ds);
       }
     }
 
@@ -4944,53 +4944,53 @@ public:
 
     if (!Getattr(n, "sym:nextSibling")) {
       if (shadow && !builtin) {
-	int fproxy = fastproxy;
-	String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
-	if (Strcmp(symname, "__repr__") == 0) {
-	  have_repr = 1;
-	}
-	if (Getattr(n, "feature:shadow")) {
-	  String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
-	  String *pyaction = NewStringf("%s.%s", module, fullname);
-	  Replaceall(pycode, "$action", pyaction);
-	  Delete(pyaction);
-	  Printv(f_shadow, pycode, "\n", NIL);
-	  Delete(pycode);
-	  fproxy = 0;
-	} else {
-	  int allow_kwargs = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
-	  String *parms = make_pyParmList(n, true, false, allow_kwargs);
-	  String *callParms = make_pyParmList(n, true, true, allow_kwargs);
-	  if (!have_addtofunc(n)) {
-	    if (!fastproxy || olddefs) {
-	      Printv(f_shadow, "\n", tab4, "def ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
-	      if (Node *node_with_doc = find_overload_with_docstring(n))
-		Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_METHOD, tab8), "\n", NIL);
-	      Printv(f_shadow, tab8, "return ", funcCall(fullname, callParms), "\n", NIL);
-	    }
-	  } else {
-	    Printv(f_shadow, "\n", tab4, "def ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
-	    if (Node *node_with_doc = find_overload_with_docstring(n))
-	      Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_METHOD, tab8), "\n", NIL);
-	    if (have_pythonprepend(n)) {
-	      fproxy = 0;
-	      Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
-	    }
-	    if (have_pythonappend(n)) {
-	      fproxy = 0;
-	      Printv(f_shadow, tab8, "val = ", funcCall(fullname, callParms), "\n", NIL);
-	      Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
-	      Printv(f_shadow, tab8, "return val\n\n", NIL);
-	    } else {
-	      Printv(f_shadow, tab8, "return ", funcCall(fullname, callParms), "\n\n", NIL);
-	    }
-	  }
-	}
-	if (fproxy) {
-	  Printf(f_shadow, tab4);
-	  Printf(f_shadow, "%s = _swig_new_instance_method(%s.%s)\n", symname, module, Swig_name_member(NSPACE_TODO, class_name, symname));
-	}
-	Delete(fullname);
+        int fproxy = fastproxy;
+        String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        if (Strcmp(symname, "__repr__") == 0) {
+          have_repr = 1;
+        }
+        if (Getattr(n, "feature:shadow")) {
+          String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
+          String *pyaction = NewStringf("%s.%s", module, fullname);
+          Replaceall(pycode, "$action", pyaction);
+          Delete(pyaction);
+          Printv(f_shadow, pycode, "\n", NIL);
+          Delete(pycode);
+          fproxy = 0;
+        } else {
+          int allow_kwargs = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
+          String *parms = make_pyParmList(n, true, false, allow_kwargs);
+          String *callParms = make_pyParmList(n, true, true, allow_kwargs);
+          if (!have_addtofunc(n)) {
+            if (!fastproxy || olddefs) {
+              Printv(f_shadow, "\n", tab4, "def ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
+              if (Node *node_with_doc = find_overload_with_docstring(n))
+                Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_METHOD, tab8), "\n", NIL);
+              Printv(f_shadow, tab8, "return ", funcCall(fullname, callParms), "\n", NIL);
+            }
+          } else {
+            Printv(f_shadow, "\n", tab4, "def ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
+            if (Node *node_with_doc = find_overload_with_docstring(n))
+              Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_METHOD, tab8), "\n", NIL);
+            if (have_pythonprepend(n)) {
+              fproxy = 0;
+              Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+            }
+            if (have_pythonappend(n)) {
+              fproxy = 0;
+              Printv(f_shadow, tab8, "val = ", funcCall(fullname, callParms), "\n", NIL);
+              Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
+              Printv(f_shadow, tab8, "return val\n\n", NIL);
+            } else {
+              Printv(f_shadow, tab8, "return ", funcCall(fullname, callParms), "\n\n", NIL);
+            }
+          }
+        }
+        if (fproxy) {
+          Printf(f_shadow, tab4);
+          Printf(f_shadow, "%s = _swig_new_instance_method(%s.%s)\n", symname, module, Swig_name_member(NSPACE_TODO, class_name, symname));
+        }
+        Delete(fullname);
       }
     }
     return SWIG_OK;
@@ -5015,37 +5015,37 @@ public:
     int kw = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
     if (builtin && in_class) {
       if ((GetFlagAttr(n, "feature:extend") || checkAttribute(n, "access", "public"))
-	  && !Getattr(class_members, symname)) {
-	String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
-	String *wname = Swig_name_wrapper(fullname);
-	Setattr(class_members, symname, n);
-	int funpack = fastunpack && !Getattr(n, "sym:overloaded");
-	String *pyflags = NewString("METH_STATIC|");
-	int argcount = Getattr(n, "python:argcount") ? atoi(Char(Getattr(n, "python:argcount"))) : 2;
-	if (funpack && argcount == 0)
-	  Append(pyflags, "METH_NOARGS");
-	else if (funpack && argcount == 1)
-	  Append(pyflags, "METH_O");
-	else
-	  Append(pyflags, kw ? "METH_VARARGS|METH_KEYWORDS" : "METH_VARARGS");
-	// Cast via void(*)(void) to suppress GCC -Wcast-function-type warning.
-	// Python should always call the function correctly, but the Python C
-	// API requires us to store it in function pointer of a different type.
-	if (have_docstring(n)) {
-	  String *ds = cdocstring(n, AUTODOC_STATICFUNC);
-	  Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, %s, \"%s\" },\n", symname, wname, pyflags, ds);
-	  Delete(ds);
-	} else if (Getattr(n, "feature:callback")) {
-	  String *ds = NewStringf("swig_ptr: %s", Getattr(n, "feature:callback:name"));
-	  Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, %s, \"%s\" },\n", symname, wname, pyflags, ds);
-	  Delete(ds);
-	  have_builtin_static_member_method_callback = true;
-	} else {
-	  Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, %s, \"\" },\n", symname, wname, pyflags);
-	}
-	Delete(fullname);
-	Delete(wname);
-	Delete(pyflags);
+          && !Getattr(class_members, symname)) {
+        String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *wname = Swig_name_wrapper(fullname);
+        Setattr(class_members, symname, n);
+        int funpack = fastunpack && !Getattr(n, "sym:overloaded");
+        String *pyflags = NewString("METH_STATIC|");
+        int argcount = Getattr(n, "python:argcount") ? atoi(Char(Getattr(n, "python:argcount"))) : 2;
+        if (funpack && argcount == 0)
+          Append(pyflags, "METH_NOARGS");
+        else if (funpack && argcount == 1)
+          Append(pyflags, "METH_O");
+        else
+          Append(pyflags, kw ? "METH_VARARGS|METH_KEYWORDS" : "METH_VARARGS");
+        // Cast via void(*)(void) to suppress GCC -Wcast-function-type warning.
+        // Python should always call the function correctly, but the Python C
+        // API requires us to store it in function pointer of a different type.
+        if (have_docstring(n)) {
+          String *ds = cdocstring(n, AUTODOC_STATICFUNC);
+          Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, %s, \"%s\" },\n", symname, wname, pyflags, ds);
+          Delete(ds);
+        } else if (Getattr(n, "feature:callback")) {
+          String *ds = NewStringf("swig_ptr: %s", Getattr(n, "feature:callback:name"));
+          Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, %s, \"%s\" },\n", symname, wname, pyflags, ds);
+          Delete(ds);
+          have_builtin_static_member_method_callback = true;
+        } else {
+          Printf(builtin_methods, "  { \"%s\", (PyCFunction)(void(*)(void))%s, %s, \"\" },\n", symname, wname, pyflags);
+        }
+        Delete(fullname);
+        Delete(wname);
+        Delete(pyflags);
       }
       return SWIG_OK;
     }
@@ -5058,27 +5058,27 @@ public:
       String *staticfunc_name = NewString(fastproxy ? "_swig_new_static_method" : "staticmethod");
       bool fast = (fastproxy && !have_addtofunc(n)) || Getattr(n, "feature:callback");
       if (!fast || olddefs) {
-	String *parms = make_pyParmList(n, false, false, kw);
-	String *callParms = make_pyParmList(n, false, true, kw);
-	Printv(f_shadow, "\n", tab4, "@staticmethod", NIL);
-	Printv(f_shadow, "\n", tab4, "def ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
-	if (Node *node_with_doc = find_overload_with_docstring(n))
-	  Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_STATICFUNC, tab8), "\n", NIL);
-	if (have_pythonprepend(n))
-	  Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
-	if (have_pythonappend(n)) {
-	  Printv(f_shadow, tab8, "val = ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n", NIL);
-	  Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
-	  Printv(f_shadow, tab8, "return val\n", NIL);
-	} else {
-	  Printv(f_shadow, tab8, "return ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n", NIL);
-	}
+        String *parms = make_pyParmList(n, false, false, kw);
+        String *callParms = make_pyParmList(n, false, true, kw);
+        Printv(f_shadow, "\n", tab4, "@staticmethod", NIL);
+        Printv(f_shadow, "\n", tab4, "def ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
+        if (Node *node_with_doc = find_overload_with_docstring(n))
+          Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_STATICFUNC, tab8), "\n", NIL);
+        if (have_pythonprepend(n))
+          Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+        if (have_pythonappend(n)) {
+          Printv(f_shadow, tab8, "val = ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n", NIL);
+          Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
+          Printv(f_shadow, tab8, "return val\n", NIL);
+        } else {
+          Printv(f_shadow, tab8, "return ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n", NIL);
+        }
       }
 
       // Below may result in a 2nd definition of the method when -olddefs is used. The Python interpreter will use the second definition as it overwrites the first.
       if (fast) {
-	Printv(f_shadow, tab4, symname, " = ", staticfunc_name, "(", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname),
-	       ")\n", NIL);
+        Printv(f_shadow, tab4, symname, " = ", staticfunc_name, "(", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname),
+               ")\n", NIL);
       }
       Delete(staticfunc_name);
     }
@@ -5111,7 +5111,7 @@ public:
       Delete(name);
       Setattr(self, "lname", "O");
       if (parms)
-	set_nextSibling(self, parms);
+        set_nextSibling(self, parms);
       Setattr(n, "parms", self);
       Setattr(n, "hidden", "1");
       Delete(self);
@@ -5126,88 +5126,88 @@ public:
 
     if (!Getattr(n, "sym:nextSibling")) {
       if (shadow) {
-	int allow_kwargs = (check_kwargs(n) && (!Getattr(n, "sym:overloaded"))) ? 1 : 0;
-	int handled_as_init = 0;
-	if (!have_constructor) {
-	  String *nname = Getattr(n, "sym:name");
-	  String *sname = Getattr(getCurrentClass(), "sym:name");
-	  String *cname = Swig_name_construct(NSPACE_TODO, sname);
-	  handled_as_init = (Strcmp(nname, sname) == 0) || (Strcmp(nname, cname) == 0);
-	  Delete(cname);
-	}
+        int allow_kwargs = (check_kwargs(n) && (!Getattr(n, "sym:overloaded"))) ? 1 : 0;
+        int handled_as_init = 0;
+        if (!have_constructor) {
+          String *nname = Getattr(n, "sym:name");
+          String *sname = Getattr(getCurrentClass(), "sym:name");
+          String *cname = Swig_name_construct(NSPACE_TODO, sname);
+          handled_as_init = (Strcmp(nname, sname) == 0) || (Strcmp(nname, cname) == 0);
+          Delete(cname);
+        }
 
-	String *subfunc = Swig_name_construct(NSPACE_TODO, symname);
-	if (!have_constructor && handled_as_init) {
-	  if (!builtin) {
-	    if (Getattr(n, "feature:shadow")) {
-	      String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
-	      String *pyaction = NewStringf("%s.%s", module, subfunc);
-	      Replaceall(pycode, "$action", pyaction);
-	      Delete(pyaction);
-	      Printv(f_shadow, pycode, "\n", NIL);
-	      Delete(pycode);
-	    } else {
-	      String *pass_self = NewString("");
-	      Node *parent = Swig_methodclass(n);
-	      String *classname = Swig_class_name(parent);
-	      String *rclassname = Swig_class_name(getCurrentClass());
-	      assert(rclassname);
-	      (void)rclassname;
+        String *subfunc = Swig_name_construct(NSPACE_TODO, symname);
+        if (!have_constructor && handled_as_init) {
+          if (!builtin) {
+            if (Getattr(n, "feature:shadow")) {
+              String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
+              String *pyaction = NewStringf("%s.%s", module, subfunc);
+              Replaceall(pycode, "$action", pyaction);
+              Delete(pyaction);
+              Printv(f_shadow, pycode, "\n", NIL);
+              Delete(pycode);
+            } else {
+              String *pass_self = NewString("");
+              Node *parent = Swig_methodclass(n);
+              String *classname = Swig_class_name(parent);
+              String *rclassname = Swig_class_name(getCurrentClass());
+              assert(rclassname);
+              (void)rclassname;
 
-	      String *parms = make_pyParmList(n, true, false, allow_kwargs);
-	      /* Pass 'self' only if using director */
-	      String *callParms = make_pyParmList(n, false, true, allow_kwargs, true);
+              String *parms = make_pyParmList(n, true, false, allow_kwargs);
+              /* Pass 'self' only if using director */
+              String *callParms = make_pyParmList(n, false, true, allow_kwargs, true);
 
-	      if (use_director) {
-		Insert(callParms, 0, "_self, ");
-		Printv(pass_self, tab8, NIL);
-		Printf(pass_self, "if self.__class__ == %s:\n", classname);
-		Printv(pass_self, tab8, tab4, "_self = None\n", tab8, "else:\n", tab8, tab4, "_self = self\n", NIL);
-	      }
+              if (use_director) {
+                Insert(callParms, 0, "_self, ");
+                Printv(pass_self, tab8, NIL);
+                Printf(pass_self, "if self.__class__ == %s:\n", classname);
+                Printv(pass_self, tab8, tab4, "_self = None\n", tab8, "else:\n", tab8, tab4, "_self = self\n", NIL);
+              }
 
-	      Printv(f_shadow, "\n", tab4, "def __init__(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
-	      if (Node *node_with_doc = find_overload_with_docstring(n))
-		Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_CTOR, tab8), "\n", NIL);
-	      if (have_pythonprepend(n))
-		Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
-	      Printv(f_shadow, pass_self, NIL);
-	      Printv(f_shadow, tab8, module, ".", class_name, "_swiginit(self, ", funcCall(subfunc, callParms), ")\n", NIL);
-	      if (have_pythonappend(n))
-		Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n\n", NIL);
-	      Delete(pass_self);
-	    }
-	    have_constructor = 1;
-	  }
-	} else {
-	  /* Hmmm. We seem to be creating a different constructor.  We're just going to create a
-	     function for it. */
-	  if (!builtin) {
-	    if (Getattr(n, "feature:shadow")) {
-	      String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), "", Getfile(n), Getline(n), "%feature(\"shadow\")");
-	      String *pyaction = NewStringf("%s.%s", module, subfunc);
-	      Replaceall(pycode, "$action", pyaction);
-	      Delete(pyaction);
-	      Printv(f_shadow_stubs, pycode, "\n", NIL);
-	      Delete(pycode);
-	    } else {
-	      String *parms = make_pyParmList(n, false, false, allow_kwargs);
-	      String *callParms = make_pyParmList(n, false, true, allow_kwargs);
+              Printv(f_shadow, "\n", tab4, "def __init__(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
+              if (Node *node_with_doc = find_overload_with_docstring(n))
+                Printv(f_shadow, tab8, docstring(node_with_doc, AUTODOC_CTOR, tab8), "\n", NIL);
+              if (have_pythonprepend(n))
+                Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+              Printv(f_shadow, pass_self, NIL);
+              Printv(f_shadow, tab8, module, ".", class_name, "_swiginit(self, ", funcCall(subfunc, callParms), ")\n", NIL);
+              if (have_pythonappend(n))
+                Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n\n", NIL);
+              Delete(pass_self);
+            }
+            have_constructor = 1;
+          }
+        } else {
+          /* Hmmm. We seem to be creating a different constructor.  We're just going to create a
+             function for it. */
+          if (!builtin) {
+            if (Getattr(n, "feature:shadow")) {
+              String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), "", Getfile(n), Getline(n), "%feature(\"shadow\")");
+              String *pyaction = NewStringf("%s.%s", module, subfunc);
+              Replaceall(pycode, "$action", pyaction);
+              Delete(pyaction);
+              Printv(f_shadow_stubs, pycode, "\n", NIL);
+              Delete(pycode);
+            } else {
+              String *parms = make_pyParmList(n, false, false, allow_kwargs);
+              String *callParms = make_pyParmList(n, false, true, allow_kwargs);
 
-	      Printv(f_shadow_stubs, "\ndef ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
-	      if (Node *node_with_doc = find_overload_with_docstring(n))
-		Printv(f_shadow_stubs, tab4, docstring(node_with_doc, AUTODOC_CTOR, tab4), "\n", NIL);
-	      if (have_pythonprepend(n))
-		Printv(f_shadow_stubs, indent_pythoncode(pythonprepend(n), tab4, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
-	      Printv(f_shadow_stubs, tab4, "val = ", funcCall(subfunc, callParms), "\n", NIL);
-	      if (have_pythonappend(n))
-		Printv(f_shadow_stubs, indent_pythoncode(pythonappend(n), tab4, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
-	      Printv(f_shadow_stubs, tab4, "return val\n", NIL);
-	    }
-	  } else {
-	    Printf(f_shadow_stubs, "%s = %s\n", symname, subfunc);
-	  }
-	}
-	Delete(subfunc);
+              Printv(f_shadow_stubs, "\ndef ", symname, "(", parms, ")", returnTypeAnnotation(n), ":\n", NIL);
+              if (Node *node_with_doc = find_overload_with_docstring(n))
+                Printv(f_shadow_stubs, tab4, docstring(node_with_doc, AUTODOC_CTOR, tab4), "\n", NIL);
+              if (have_pythonprepend(n))
+                Printv(f_shadow_stubs, indent_pythoncode(pythonprepend(n), tab4, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+              Printv(f_shadow_stubs, tab4, "val = ", funcCall(subfunc, callParms), "\n", NIL);
+              if (have_pythonappend(n))
+                Printv(f_shadow_stubs, indent_pythoncode(pythonappend(n), tab4, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
+              Printv(f_shadow_stubs, tab4, "return val\n", NIL);
+            }
+          } else {
+            Printf(f_shadow_stubs, "%s = %s\n", symname, subfunc);
+          }
+        }
+        Delete(subfunc);
       }
     }
     return SWIG_OK;
@@ -5225,8 +5225,8 @@ public:
       Node *cls = Swig_methodclass(n);
       // Use the destructor for the tp_dealloc slot unless a user overrides it with another method
       if (!Getattr(cls, "feature:python:tp_dealloc")) {
-	Setattr(n, "feature:python:slot", "tp_dealloc");
-	Setattr(n, "feature:python:slot:functype", "destructor");
+        Setattr(n, "feature:python:slot", "tp_dealloc");
+        Setattr(n, "feature:python:slot:functype", "destructor");
       }
     }
 
@@ -5238,26 +5238,26 @@ public:
 
     if (shadow) {
       if (Getattr(n, "feature:shadow")) {
-	String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
-	String *pyaction = NewStringf("%s.%s", module, Swig_name_destroy(NSPACE_TODO, symname));
-	Replaceall(pycode, "$action", pyaction);
-	Delete(pyaction);
-	Printv(f_shadow, pycode, "\n", NIL);
-	Delete(pycode);
+        String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
+        String *pyaction = NewStringf("%s.%s", module, Swig_name_destroy(NSPACE_TODO, symname));
+        Replaceall(pycode, "$action", pyaction);
+        Delete(pyaction);
+        Printv(f_shadow, pycode, "\n", NIL);
+        Delete(pycode);
       } else {
-	Printv(f_shadow, tab4, "__swig_destroy__ = ", module, ".", Swig_name_destroy(NSPACE_TODO, symname), "\n", NIL);
-	if (!have_pythonprepend(n) && !have_pythonappend(n)) {
-	  return SWIG_OK;
-	}
-	Printv(f_shadow, tab4, "def __del__(self):\n", NIL);
-	if (have_docstring(n))
-	  Printv(f_shadow, tab8, docstring(n, AUTODOC_DTOR, tab8), "\n", NIL);
-	if (have_pythonprepend(n))
-	  Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
-	if (have_pythonappend(n))
-	  Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
-	Printv(f_shadow, tab8, "pass\n", NIL);
-	Printv(f_shadow, "\n", NIL);
+        Printv(f_shadow, tab4, "__swig_destroy__ = ", module, ".", Swig_name_destroy(NSPACE_TODO, symname), "\n", NIL);
+        if (!have_pythonprepend(n) && !have_pythonappend(n)) {
+          return SWIG_OK;
+        }
+        Printv(f_shadow, tab4, "def __del__(self):\n", NIL);
+        if (have_docstring(n))
+          Printv(f_shadow, tab8, docstring(n, AUTODOC_DTOR, tab8), "\n", NIL);
+        if (have_pythonprepend(n))
+          Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
+        if (have_pythonappend(n))
+          Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
+        Printv(f_shadow, tab8, "pass\n", NIL);
+        Printv(f_shadow, "\n", NIL);
       }
     }
     return SWIG_OK;
@@ -5284,11 +5284,11 @@ public:
       String *variable_annotation = variableAnnotation(n);
       Printv(f_shadow, tab4, symname, variable_annotation, " = property(", module, ".", getname, NIL);
       if (assignable)
-	Printv(f_shadow, ", ", module, ".", setname, NIL);
+        Printv(f_shadow, ", ", module, ".", setname, NIL);
       if (have_docstring(n)) {
-	String *s = docstring(n, AUTODOC_VAR, tab4);
-	if (Len(s))
-	  Printv(f_shadow, ", doc=", s, NIL);
+        String *s = docstring(n, AUTODOC_VAR, tab4);
+        if (Len(s))
+          Printv(f_shadow, ", doc=", s, NIL);
       }
       Printv(f_shadow, ")\n", NIL);
       Delete(variable_annotation);
@@ -5316,77 +5316,77 @@ public:
 
     if (shadow) {
       if (!builtin && GetFlag(n, "hasconsttype")) {
-	String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
-	Printf(f_shadow_stubs, "%s.%s = %s.%s.%s\n", class_name, symname, module, global_name, mname);
-	Delete(mname);
+        String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        Printf(f_shadow_stubs, "%s.%s = %s.%s.%s\n", class_name, symname, module, global_name, mname);
+        Delete(mname);
       } else {
-	String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
-	String *getname = Swig_name_get(NSPACE_TODO, mname);
-	String *wrapgetname = Swig_name_wrapper(getname);
-	String *vargetname = NewStringf("Swig_var_%s", getname);
-	String *setname = Swig_name_set(NSPACE_TODO, mname);
-	String *wrapsetname = Swig_name_wrapper(setname);
-	String *varsetname = NewStringf("Swig_var_%s", setname);
+        String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *getname = Swig_name_get(NSPACE_TODO, mname);
+        String *wrapgetname = Swig_name_wrapper(getname);
+        String *vargetname = NewStringf("Swig_var_%s", getname);
+        String *setname = Swig_name_set(NSPACE_TODO, mname);
+        String *wrapsetname = Swig_name_wrapper(setname);
+        String *varsetname = NewStringf("Swig_var_%s", setname);
 
-	Wrapper *f = NewWrapper();
-	Printv(f->def, "SWIGINTERN PyObject *", wrapgetname, "(PyObject *SWIGUNUSEDPARM(self), PyObject *SWIGUNUSEDPARM(args)) {", NIL);
-	Printv(f->code, "  return ", vargetname, "();\n", NIL);
-	Append(f->code, "}\n");
-	add_method(getname, wrapgetname, 0);
-	Wrapper_print(f, f_wrappers);
-	DelWrapper(f);
-	int assignable = !is_immutable(n);
-	if (assignable) {
-	  int funpack = fastunpack;
-	  Wrapper *f = NewWrapper();
-	  Printv(f->def, "SWIGINTERN PyObject *", wrapsetname, "(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {", NIL);
-	  Wrapper_add_local(f, "res", "int res");
-	  if (!funpack) {
-	    Wrapper_add_local(f, "value", "PyObject *value");
-	    Append(f->code, "if (!PyArg_ParseTuple(args, \"O:set\", &value)) return NULL;\n");
-	  }
-	  Printf(f->code, "res = %s(%s);\n", varsetname, funpack ? "args" : "value");
-	  Append(f->code, "return !res ? SWIG_Py_Void() : NULL;\n");
-	  Append(f->code, "}\n");
-	  Wrapper_print(f, f_wrappers);
-	  add_method(setname, wrapsetname, 0, 0, funpack, 1, 1);
-	  DelWrapper(f);
-	}
-	if (!builtin) {
-	  Printv(f_shadow, tab4, symname, " = property(", module, ".", getname, NIL);
-	  if (assignable)
-	    Printv(f_shadow, ", ", module, ".", setname, NIL);
-	  if (have_docstring(n)) {
-	    String *s = docstring(n, AUTODOC_VAR, tab4);
-	    if (Len(s))
-	      Printv(f_shadow, ", doc=", s, NIL);
-	  }
-	  Printv(f_shadow, ")\n", NIL);
-	}
-	String *getter = Getattr(n, "pybuiltin:getter");
-	String *setter = Getattr(n, "pybuiltin:setter");
-	Hash *h = NULL;
-	if (getter || setter) {
-	  h = Getattr(builtin_getset, symname);
-	  if (!h) {
-	    h = NewHash();
-	    Setattr(h, "static", "1");
-	    Setattr(builtin_getset, symname, h);
-	  }
-	}
-	if (getter)
-	  Setattr(h, "getter", getter);
-	if (setter)
-	  Setattr(h, "setter", setter);
-	if (h)
-	  Delete(h);
-	Delete(mname);
-	Delete(getname);
-	Delete(wrapgetname);
-	Delete(vargetname);
-	Delete(setname);
-	Delete(wrapsetname);
-	Delete(varsetname);
+        Wrapper *f = NewWrapper();
+        Printv(f->def, "SWIGINTERN PyObject *", wrapgetname, "(PyObject *SWIGUNUSEDPARM(self), PyObject *SWIGUNUSEDPARM(args)) {", NIL);
+        Printv(f->code, "  return ", vargetname, "();\n", NIL);
+        Append(f->code, "}\n");
+        add_method(getname, wrapgetname, 0);
+        Wrapper_print(f, f_wrappers);
+        DelWrapper(f);
+        int assignable = !is_immutable(n);
+        if (assignable) {
+          int funpack = fastunpack;
+          Wrapper *f = NewWrapper();
+          Printv(f->def, "SWIGINTERN PyObject *", wrapsetname, "(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {", NIL);
+          Wrapper_add_local(f, "res", "int res");
+          if (!funpack) {
+            Wrapper_add_local(f, "value", "PyObject *value");
+            Append(f->code, "if (!PyArg_ParseTuple(args, \"O:set\", &value)) return NULL;\n");
+          }
+          Printf(f->code, "res = %s(%s);\n", varsetname, funpack ? "args" : "value");
+          Append(f->code, "return !res ? SWIG_Py_Void() : NULL;\n");
+          Append(f->code, "}\n");
+          Wrapper_print(f, f_wrappers);
+          add_method(setname, wrapsetname, 0, 0, funpack, 1, 1);
+          DelWrapper(f);
+        }
+        if (!builtin) {
+          Printv(f_shadow, tab4, symname, " = property(", module, ".", getname, NIL);
+          if (assignable)
+            Printv(f_shadow, ", ", module, ".", setname, NIL);
+          if (have_docstring(n)) {
+            String *s = docstring(n, AUTODOC_VAR, tab4);
+            if (Len(s))
+              Printv(f_shadow, ", doc=", s, NIL);
+          }
+          Printv(f_shadow, ")\n", NIL);
+        }
+        String *getter = Getattr(n, "pybuiltin:getter");
+        String *setter = Getattr(n, "pybuiltin:setter");
+        Hash *h = NULL;
+        if (getter || setter) {
+          h = Getattr(builtin_getset, symname);
+          if (!h) {
+            h = NewHash();
+            Setattr(h, "static", "1");
+            Setattr(builtin_getset, symname, h);
+          }
+        }
+        if (getter)
+          Setattr(h, "getter", getter);
+        if (setter)
+          Setattr(h, "setter", setter);
+        if (h)
+          Delete(h);
+        Delete(mname);
+        Delete(getname);
+        Delete(wrapgetname);
+        Delete(vargetname);
+        Delete(setname);
+        Delete(wrapsetname);
+        Delete(varsetname);
       }
     }
     return SWIG_OK;
@@ -5413,7 +5413,7 @@ public:
     } else if (shadow) {
       Printv(f_shadow, tab4, symname, " = ", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname), "\n", NIL);
       if (have_docstring(n))
-	Printv(f_shadow, tab4, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
+        Printv(f_shadow, tab4, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
     }
     return SWIG_OK;
   }
@@ -5431,15 +5431,15 @@ public:
 
     if (!ImportMode && (Cmp(section, "python") == 0 || Cmp(section, "shadow") == 0)) {
       if (shadow) {
-	String *pycode = indent_pythoncode(code, shadow_indent, Getfile(n), Getline(n), "%pythoncode or %insert(\"python\") block");
-	Printv(f_shadow, pycode, NIL);
-	Delete(pycode);
+        String *pycode = indent_pythoncode(code, shadow_indent, Getfile(n), Getline(n), "%pythoncode or %insert(\"python\") block");
+        Printv(f_shadow, pycode, NIL);
+        Delete(pycode);
       }
     } else if (!ImportMode && (Cmp(section, "pythonbegin") == 0)) {
       if (shadow) {
-	String *pycode = indent_pythoncode(code, "", Getfile(n), Getline(n), "%pythonbegin or %insert(\"pythonbegin\") block");
-	Printv(f_shadow_begin, pycode, NIL);
-	Delete(pycode);
+        String *pycode = indent_pythoncode(code, "", Getfile(n), Getline(n), "%pythonbegin or %insert(\"pythonbegin\") block");
+        Printv(f_shadow_begin, pycode, NIL);
+        Delete(pycode);
       }
     } else {
       Language::insertDirective(n);
@@ -5541,7 +5541,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     for (p = l; p; p = nextSibling(p)) {
       String *arg = Getattr(p, "name");
       if (arg && Cmp(arg, "self") == 0)
-	Delattr(p, "name");
+        Delattr(p, "name");
     }
   }
 
@@ -5586,14 +5586,14 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
       Swig_typemap_attach_parms("throws", throw_parm_list, 0);
     for (p = throw_parm_list; p; p = nextSibling(p)) {
       if (Getattr(p, "tmap:throws")) {
-	if (gencomma++) {
-	  Append(w->def, ", ");
-	  Append(declaration, ", ");
-	}
-	String *str = SwigType_str(Getattr(p, "type"), 0);
-	Append(w->def, str);
-	Append(declaration, str);
-	Delete(str);
+        if (gencomma++) {
+          Append(w->def, ", ");
+          Append(declaration, ", ");
+        }
+        String *str = SwigType_str(Getattr(p, "type"), 0);
+        Append(w->def, str);
+        Append(declaration, str);
+        Delete(str);
       }
     }
 
@@ -5611,11 +5611,11 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
   if (!is_void && (!ignored_method || pure_virtual)) {
     if (!SwigType_isclass(returntype)) {
       if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	Delete(construct_result);
+        String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+        Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+        Delete(construct_result);
       } else {
-	Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
       }
     } else {
       String *cres = SwigType_lstr(returntype, "c_result");
@@ -5632,13 +5632,13 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
   if (ignored_method) {
     if (!pure_virtual) {
       if (!is_void)
-	Printf(w->code, "return ");
+        Printf(w->code, "return ");
       String *super_call = Swig_method_call(super, l);
       Printf(w->code, "%s;\n", super_call);
       Delete(super_call);
     } else {
       Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	     SwigType_namestr(name));
+             SwigType_namestr(name));
     }
   } else {
     /* attach typemaps to arguments (C/C++ -> Python) */
@@ -5665,111 +5665,111 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     int use_parse = 0;
     while (p) {
       if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
-	continue;
+        p = Getattr(p, "tmap:in:next");
+        continue;
       }
 
       if (Getattr(p, "tmap:directorargout") != 0)
-	outputs++;
+        outputs++;
 
       String *pname = Getattr(p, "name");
       String *ptype = Getattr(p, "type");
 
       Putc(',', arglist);
       if ((tm = Getattr(p, "tmap:directorin")) != 0) {
-	String *parse = Getattr(p, "tmap:directorin:parse");
-	if (!parse) {
-	  sprintf(source, "obj%d", idx++);
-	  String *input = NewString(source);
-	  Setattr(p, "emit:directorinput", input);
-	  Replaceall(tm, "$input", input);
-	  Delete(input);
-	  Replaceall(tm, "$owner", "0");
-	  /* Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL); */
-	  Printv(wrap_args, "swig::SwigVar_PyObject ", source, ";\n", NIL);
+        String *parse = Getattr(p, "tmap:directorin:parse");
+        if (!parse) {
+          sprintf(source, "obj%d", idx++);
+          String *input = NewString(source);
+          Setattr(p, "emit:directorinput", input);
+          Replaceall(tm, "$input", input);
+          Delete(input);
+          Replaceall(tm, "$owner", "0");
+          /* Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL); */
+          Printv(wrap_args, "swig::SwigVar_PyObject ", source, ";\n", NIL);
 
-	  Printv(wrap_args, tm, "\n", NIL);
-	  Printv(arglist, "(PyObject *)", source, NIL);
-	  Putc('O', parse_args);
-	} else {
-	  use_parse = 1;
-	  Append(parse_args, parse);
-	  Setattr(p, "emit:directorinput", pname);
-	  Replaceall(tm, "$input", pname);
-	  Replaceall(tm, "$owner", "0");
-	  if (Len(tm) == 0)
-	    Append(tm, pname);
-	  Append(arglist, tm);
-	}
-	p = Getattr(p, "tmap:directorin:next");
-	continue;
+          Printv(wrap_args, tm, "\n", NIL);
+          Printv(arglist, "(PyObject *)", source, NIL);
+          Putc('O', parse_args);
+        } else {
+          use_parse = 1;
+          Append(parse_args, parse);
+          Setattr(p, "emit:directorinput", pname);
+          Replaceall(tm, "$input", pname);
+          Replaceall(tm, "$owner", "0");
+          if (Len(tm) == 0)
+            Append(tm, pname);
+          Append(arglist, tm);
+        }
+        p = Getattr(p, "tmap:directorin:next");
+        continue;
       } else if (Cmp(ptype, "void")) {
-	/* special handling for pointers to other C++ director classes.
-	 * ideally this would be left to a typemap, but there is currently no
-	 * way to selectively apply the dynamic_cast<> to classes that have
-	 * directors.  in other words, the type "SwigDirector_$1_lname" only exists
-	 * for classes with directors.  we avoid the problem here by checking
-	 * module.wrap::directormap, but it's not clear how to get a typemap to
-	 * do something similar.  perhaps a new default typemap (in addition
-	 * to SWIGTYPE) called DIRECTORTYPE?
-	 */
-	if (SwigType_ispointer(ptype) || SwigType_isreference(ptype)) {
-	  Node *module = Getattr(parent, "module");
-	  Node *target = Swig_directormap(module, ptype);
-	  sprintf(source, "obj%d", idx++);
-	  String *nonconst = 0;
-	  /* strip pointer/reference --- should move to Swig/stype.c */
-	  String *nptype = NewString(Char(ptype) + 2);
-	  /* name as pointer */
-	  String *ppname = Copy(pname);
-	  if (SwigType_isreference(ptype)) {
-	    Insert(ppname, 0, "&");
-	  }
-	  /* if necessary, cast away const since Python doesn't support it! */
-	  if (SwigType_isconst(nptype)) {
-	    nonconst = NewStringf("nc_tmp_%s", pname);
-	    String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
-	    Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
-	    Delete(nonconst_i);
-	    Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
-			 "Target language argument '%s' discards const in director method %s::%s.\n",
-			 SwigType_str(ptype, pname), SwigType_namestr(c_classname), SwigType_namestr(name));
-	  } else {
-	    nonconst = Copy(ppname);
-	  }
-	  Delete(nptype);
-	  Delete(ppname);
-	  String *mangle = SwigType_manglestr(ptype);
-	  if (target) {
-	    String *director = NewStringf("director_%s", mangle);
-	    Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
-	    Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
-	    Printf(wrap_args, "%s = SWIG_DIRECTOR_CAST(%s);\n", director, nonconst);
-	    Printf(wrap_args, "if (!%s) {\n", director);
-	    Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	    Append(wrap_args, "} else {\n");
-	    Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
-	    Printf(wrap_args, "SWIG_Py_INCREF((PyObject *)%s);\n", source);
-	    Append(wrap_args, "}\n");
-	    Delete(director);
-	    Printv(arglist, source, NIL);
-	  } else {
-	    Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
-	    Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	    //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
-	    //       source, nonconst, base);
-	    Printv(arglist, source, NIL);
-	  }
-	  Putc('O', parse_args);
-	  Delete(mangle);
-	  Delete(nonconst);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-		       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
-		       SwigType_namestr(c_classname), SwigType_namestr(name));
-	  status = SWIG_NOWRAP;
-	  break;
-	}
+        /* special handling for pointers to other C++ director classes.
+         * ideally this would be left to a typemap, but there is currently no
+         * way to selectively apply the dynamic_cast<> to classes that have
+         * directors.  in other words, the type "SwigDirector_$1_lname" only exists
+         * for classes with directors.  we avoid the problem here by checking
+         * module.wrap::directormap, but it's not clear how to get a typemap to
+         * do something similar.  perhaps a new default typemap (in addition
+         * to SWIGTYPE) called DIRECTORTYPE?
+         */
+        if (SwigType_ispointer(ptype) || SwigType_isreference(ptype)) {
+          Node *module = Getattr(parent, "module");
+          Node *target = Swig_directormap(module, ptype);
+          sprintf(source, "obj%d", idx++);
+          String *nonconst = 0;
+          /* strip pointer/reference --- should move to Swig/stype.c */
+          String *nptype = NewString(Char(ptype) + 2);
+          /* name as pointer */
+          String *ppname = Copy(pname);
+          if (SwigType_isreference(ptype)) {
+            Insert(ppname, 0, "&");
+          }
+          /* if necessary, cast away const since Python doesn't support it! */
+          if (SwigType_isconst(nptype)) {
+            nonconst = NewStringf("nc_tmp_%s", pname);
+            String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(ptype, 0), ppname);
+            Wrapper_add_localv(w, nonconst, SwigType_lstr(ptype, 0), nonconst, nonconst_i, NIL);
+            Delete(nonconst_i);
+            Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
+                         "Target language argument '%s' discards const in director method %s::%s.\n",
+                         SwigType_str(ptype, pname), SwigType_namestr(c_classname), SwigType_namestr(name));
+          } else {
+            nonconst = Copy(ppname);
+          }
+          Delete(nptype);
+          Delete(ppname);
+          String *mangle = SwigType_manglestr(ptype);
+          if (target) {
+            String *director = NewStringf("director_%s", mangle);
+            Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
+            Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
+            Printf(wrap_args, "%s = SWIG_DIRECTOR_CAST(%s);\n", director, nonconst);
+            Printf(wrap_args, "if (!%s) {\n", director);
+            Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+            Append(wrap_args, "} else {\n");
+            Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
+            Printf(wrap_args, "SWIG_Py_INCREF((PyObject *)%s);\n", source);
+            Append(wrap_args, "}\n");
+            Delete(director);
+            Printv(arglist, source, NIL);
+          } else {
+            Wrapper_add_localv(w, source, "swig::SwigVar_PyObject", source, "= 0", NIL);
+            Printf(wrap_args, "%s = SWIG_InternalNewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+            //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
+            //       source, nonconst, base);
+            Printv(arglist, source, NIL);
+          }
+          Putc('O', parse_args);
+          Delete(mangle);
+          Delete(nonconst);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+                       "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(ptype, 0),
+                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          status = SWIG_NOWRAP;
+          break;
+        }
       }
       p = nextSibling(p);
     }
@@ -5803,9 +5803,9 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     Append(w->code, "PyObject *method = swig_get_method(swig_method_index, swig_method_name);\n");
     if (Len(parse_args) > 0) {
       if (use_parse) {
-	Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallFunction(method, (char *)\"(%s)\" %s);\n", Swig_cresult_name(), parse_args, arglist);
+        Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallFunction(method, (char *)\"(%s)\" %s);\n", Swig_cresult_name(), parse_args, arglist);
       } else {
-	Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallFunctionObjArgs(method %s, NULL);\n", Swig_cresult_name(), arglist);
+        Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallFunctionObjArgs(method %s, NULL);\n", Swig_cresult_name(), arglist);
       }
     } else {
       Append(w->code, "swig::SwigVar_PyObject args = PyTuple_New(0);\n");
@@ -5814,10 +5814,10 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     Append(w->code, "#else\n");
     if (Len(parse_args) > 0) {
       if (use_parse) {
-	Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallMethod(swig_get_self(), (char *)\"%s\", (char *)\"(%s)\" %s);\n", Swig_cresult_name(), pyname, parse_args, arglist);
+        Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallMethod(swig_get_self(), (char *)\"%s\", (char *)\"(%s)\" %s);\n", Swig_cresult_name(), pyname, parse_args, arglist);
       } else {
-	Printf(w->code, "swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar(\"%s\");\n", pyname);
-	Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name %s, NULL);\n", Swig_cresult_name(), arglist);
+        Printf(w->code, "swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar(\"%s\");\n", pyname);
+        Printf(w->code, "swig::SwigVar_PyObject %s = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name %s, NULL);\n", Swig_cresult_name(), arglist);
       }
     } else {
       Printf(w->code, "swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar(\"%s\");\n", pyname);
@@ -5833,7 +5833,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     if (!tm) {
       tm = Getattr(n, "feature:director:except");
       if (tm)
-	tm = Copy(tm);
+        tm = Copy(tm);
     }
     Printf(w->code, "if (!%s) {\n", Swig_cresult_name());
     Append(w->code, "  PyObject *error = PyErr_Occurred();\n");
@@ -5873,50 +5873,50 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     if (!is_void) {
       tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
       if (tm != 0) {
-	if (outputs > 1) {
-	  Printf(w->code, "output = PyTuple_GetItem(%s, %d);\n", Swig_cresult_name(), idx++);
-	  Replaceall(tm, "$input", "output");
-	} else {
-	  Replaceall(tm, "$input", Swig_cresult_name());
-	}
-	char temp[24];
-	sprintf(temp, "%d", idx);
-	Replaceall(tm, "$argnum", temp);
+        if (outputs > 1) {
+          Printf(w->code, "output = PyTuple_GetItem(%s, %d);\n", Swig_cresult_name(), idx++);
+          Replaceall(tm, "$input", "output");
+        } else {
+          Replaceall(tm, "$input", Swig_cresult_name());
+        }
+        char temp[24];
+        sprintf(temp, "%d", idx);
+        Replaceall(tm, "$argnum", temp);
 
-	/* TODO check this */
-	if (Getattr(n, "wrap:disown")) {
-	  Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	} else {
-	  Replaceall(tm, "$disown", "0");
-	}
-	if (Getattr(n, "tmap:directorout:implicitconv")) {
-	  Replaceall(tm, "$implicitconv", get_implicitconv_flag(n));
-	}
-	Replaceall(tm, "$result", "c_result");
-	Printv(w->code, tm, "\n", NIL);
-	Delete(tm);
+        /* TODO check this */
+        if (Getattr(n, "wrap:disown")) {
+          Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+        } else {
+          Replaceall(tm, "$disown", "0");
+        }
+        if (Getattr(n, "tmap:directorout:implicitconv")) {
+          Replaceall(tm, "$implicitconv", get_implicitconv_flag(n));
+        }
+        Replaceall(tm, "$result", "c_result");
+        Printv(w->code, tm, "\n", NIL);
+        Delete(tm);
       } else {
-	Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		     "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0), SwigType_namestr(c_classname),
-		     SwigType_namestr(name));
-	status = SWIG_ERROR;
+        Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                     "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0), SwigType_namestr(c_classname),
+                     SwigType_namestr(name));
+        status = SWIG_ERROR;
       }
     }
 
     /* marshal outputs */
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
-	if (outputs > 1) {
-	  Printf(w->code, "output = PyTuple_GetItem(%s, %d);\n", Swig_cresult_name(), idx++);
-	  Replaceall(tm, "$result", "output");
-	} else {
-	  Replaceall(tm, "$result", Swig_cresult_name());
-	}
-	Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	Printv(w->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:directorargout:next");
+        if (outputs > 1) {
+          Printf(w->code, "output = PyTuple_GetItem(%s, %d);\n", Swig_cresult_name(), idx++);
+          Replaceall(tm, "$result", "output");
+        } else {
+          Replaceall(tm, "$result", Swig_cresult_name());
+        }
+        Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+        Printv(w->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:directorargout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -5936,9 +5936,9 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
     if (!(ignored_method && !pure_virtual)) {
       String *rettype = SwigType_str(returntype, 0);
       if (!SwigType_isreference(returntype)) {
-	Printf(w->code, "return (%s) c_result;\n", rettype);
+        Printf(w->code, "return (%s) c_result;\n", rettype);
       } else {
-	Printf(w->code, "return (%s) *c_result;\n", rettype);
+        Printf(w->code, "return (%s) *c_result;\n", rettype);
       }
       Delete(rettype);
     }

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -73,7 +73,7 @@ static String *getRClassName(String *retType, int deRef=0, int upRef=0) {
     if (isreference) {
       SwigType_del_reference(resolved);
     }
-  } 
+  }
   String *tmp = NewString("");
   Insert(tmp, 0, Char(SwigType_manglestr(resolved)));
   return tmp;
@@ -570,7 +570,7 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
       replaceRClass(tm, Getattr(p,"type"));
       Replaceall(tm,"$owner", "0");
       Delete(lstr);
-    } 
+    }
 
     r_tmp_needed = true;
     Printf(setExprElements, "%s\n", tm);
@@ -853,8 +853,8 @@ int R::DumpCode(Node *n) {
 }
 
 
-List *R::filterMemberList(List *class_member_types, 
-                          List *class_member_other, 
+List *R::filterMemberList(List *class_member_types,
+                          List *class_member_other,
                           String *R_MEMBER, bool equal) {
   // filters class_member_other based on whether corresponding elements of
   // class_member_function_types are equal or notequal to R_MEMBER
@@ -862,7 +862,7 @@ List *R::filterMemberList(List *class_member_types,
   Iterator ftype, other;
 
   for (ftype = First(class_member_types), other = First(class_member_other);
-       ftype.item; 
+       ftype.item;
        ftype=Next(ftype), other=Next(other)) {
     // verbose, clean up later if the overall structure works
     if (equal) {
@@ -990,7 +990,7 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
  * out - the stream where we write the code.
  * --------------------------------------------------------------*/
 
-int R::OutputMemberReferenceMethod(String *className, int isSet,  
+int R::OutputMemberReferenceMethod(String *className, int isSet,
                                    List *memberList, List *nameList,
                                    List *typeList, File *out) {
   int numMems = Len(memberList), j;
@@ -1129,7 +1129,7 @@ int R::enumDeclaration(Node *n) {
     String *ename;
 
     String *name = Getattr(n, "name");
-    ename = getRClassName(name); 
+    ename = getRClassName(name);
     if (debugMode) {
       Node *current_class = getCurrentClass();
       String *cl = NewString("");
@@ -1144,7 +1144,7 @@ int R::enumDeclaration(Node *n) {
     enum_values = 0;
     // Emit each enum item
     Language::enumDeclaration(n);
-      
+
     Printf(enum_def_calls, "defineEnumeration(\"%s\",\n .values=c(%s))\n\n", ename, enum_values);
     Delete(enum_values);
     Delete(ename);
@@ -1177,7 +1177,7 @@ int R::enumvalueDeclaration(Node *n) {
     tmpValue = NewString(name);
   // Note that this is used in enumValue() amongst other places
   Setattr(n, "value", tmpValue);
-  
+
   // Deal with enum values that are not int
   int swigtype = SwigType_type(Getattr(n, "type"));
   if (swigtype == T_CHAR) {
@@ -1203,7 +1203,7 @@ int R::enumvalueDeclaration(Node *n) {
       Printf(stdout, "Setting type: %s\n", Copy(typemap_lookup_type));
     }
     Setattr(n, "type", typemap_lookup_type);
-    
+
     // Simple integer constants
     // Note these are always generated for anonymous enums, no matter what enum_feature is specified
     // Code generated is the same for SimpleEnum and TypeunsafeEnum -> the class it is generated into is determined later
@@ -1288,7 +1288,7 @@ void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
   Append(class_member_function_types, methodSetGet);
   Append(class_member_function_names, name);
   Append(class_member_function_membernames, memberName);
-  
+
   String *tmp = NewString("");
   Wrapper_print(wrapper, tmp);
   Append(class_member_function_wrappernames, tmp);
@@ -1995,7 +1995,7 @@ int R::functionWrapper(Node *n) {
   /* Deal with the explicit return value. */
   if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
     SwigType *retType = Getattr(n, "type");
-    
+
     Replaceall(tm,"$1", Swig_cresult_name());
     Replaceall(tm,"$result", "r_ans");
     if (debugMode){
@@ -2092,7 +2092,7 @@ int R::functionWrapper(Node *n) {
     Printv(f->code, "R_ClearExternalPtr(self);\n", NIL);
 
   Printv(f->code, "return r_ans;\n", NIL);
-  
+
   /* Error handling code */
   Printv(f->code, "fail: SWIGUNUSED;\n", NIL);
   if (need_cleanup) {
@@ -2102,7 +2102,7 @@ int R::functionWrapper(Node *n) {
   Printv(f->code, "  Rf_error(\"%s %s\", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);\n", NIL);
   Printv(f->code, "  return R_NilValue;\n", NIL);
   Delete(cleanup);
-  
+
   Printv(f->code, "}\n", NIL);
   Printv(sfun->code, "\n}", NIL);
 
@@ -2329,20 +2329,20 @@ int R::classDeclaration(Node *n) {
   if (class_member_function_types) {
 
     // collect the "set" methods
-    List *class_set_membernames   = filterMemberList(class_member_function_types, 
+    List *class_set_membernames   = filterMemberList(class_member_function_types,
                                                      class_member_function_membernames, R_MEMBER_SET, true);
-    List *class_set_functionnames = filterMemberList(class_member_function_types, 
+    List *class_set_functionnames = filterMemberList(class_member_function_types,
                                                      class_member_function_names, R_MEMBER_SET, true);
     // this one isn't used - collecting to keep code simpler
-    List *class_set_functiontypes = filterMemberList(class_member_function_types, 
+    List *class_set_functiontypes = filterMemberList(class_member_function_types,
                                                      class_member_function_types, R_MEMBER_SET, true);
 
     // collect the others
-    List *class_other_membernames   = filterMemberList(class_member_function_types, 
+    List *class_other_membernames   = filterMemberList(class_member_function_types,
                                                        class_member_function_membernames, R_MEMBER_SET, false);
-    List *class_other_functionnames = filterMemberList(class_member_function_types, 
+    List *class_other_functionnames = filterMemberList(class_member_function_types,
                                                        class_member_function_names, R_MEMBER_SET, false);
-    List *class_other_functiontypes = filterMemberList(class_member_function_types, 
+    List *class_other_functiontypes = filterMemberList(class_member_function_types,
                                                        class_member_function_types, R_MEMBER_SET, false);
 
     if (Len(class_other_membernames) > 0) {
@@ -2415,8 +2415,8 @@ int R::classDeclaration(Node *n) {
       //	    else
       //XXX How can we tell if this is already done.
       //	      SwigType_push(elType, elDecl);
-        
-        
+
+
       // returns ""  tp = processType(elType, c, NULL);
       //	    Printf(stdout, "<classDeclaration> elType %p\n", elType);
       //	    tp = getRClassNameCopyStruct(Getattr(c, "type"), 1);
@@ -2797,7 +2797,7 @@ String * R::processType(SwigType *t, Node *n, int *nargs) {
 
 /* -----------------------------------------------------------------------
  * enumValue()
- * This method will return a string with an enum value to use in from R when 
+ * This method will return a string with an enum value to use in from R when
  * setting up an enum variable
  * ------------------------------------------------------------------------ */
 
@@ -2808,7 +2808,7 @@ String *R::enumValue(Node *n) {
 
   Node *parent = parentNode(n);
   symname = Getattr(n, "sym:name");
-  
+
   // parent enumtype has namespace mangled in
   String *etype = Getattr(parent, "enumtype");
   // we have to directly call the c wrapper function, as the

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -983,7 +983,7 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
  * struct or union (or class).
  * className - the name of the struct or union (e.g. Bar for struct Bar)
  * isSet - a logical value indicating whether the method is for
- *	   modifying ($<-) or accessing ($) the member field.
+ *         modifying ($<-) or accessing ($) the member field.
  * el - a list of length  2 * # accessible member elements  + 1.
  *     The first element is the name of the class.
  *     The other pairs are  member name and the name of the R function to access it.
@@ -2412,14 +2412,14 @@ int R::classDeclaration(Node *n) {
       if (!firstItem) {
         Printf(def, ",\n");
       }
-      //	    else
+      //            else
       //XXX How can we tell if this is already done.
-      //	      SwigType_push(elType, elDecl);
+      //              SwigType_push(elType, elDecl);
 
 
       // returns ""  tp = processType(elType, c, NULL);
-      //	    Printf(stdout, "<classDeclaration> elType %p\n", elType);
-      //	    tp = getRClassNameCopyStruct(Getattr(c, "type"), 1);
+      //            Printf(stdout, "<classDeclaration> elType %p\n", elType);
+      //            tp = getRClassNameCopyStruct(Getattr(c, "type"), 1);
 
       String *elNameT = replaceInitialDash(elName);
       Printf(def, "%s%s = \"%s\"", tab8, elNameT, tp);

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -109,8 +109,8 @@ static String * getRClassNameCopyStruct(String *retType, int addRef) {
   if(addRef) {
     for(int i = 0; i < n; i++) {
       if(Strcmp(Getitem(l, i), "p.") == 0 ||
-	 Strncmp(Getitem(l, i), "a(", 2) == 0)
-	Printf(tmp, "Ref");
+         Strncmp(Getitem(l, i), "a(", 2) == 0)
+        Printf(tmp, "Ref");
     }
   }
 
@@ -130,9 +130,9 @@ static void writeListByLine(List *l, File *out, bool quote = 0) {
   int i, n = Len(l);
   for(i = 0; i < n; i++)
     Printf(out, "%s%s%s%s%s\n", tab8,
-	   quote ? "\"" :"",
-	   Getitem(l, i),
-	   quote ? "\"" :"", i < n-1 ? "," : "");
+           quote ? "\"" :"",
+           Getitem(l, i),
+           quote ? "\"" :"", i < n-1 ? "," : "");
 }
 
 
@@ -220,8 +220,8 @@ public:
   int memberfunctionHandler(Node *n) {
     if (debugMode)
       Printf(stdout, "<memberfunctionHandler> %s %s\n",
-	     Getattr(n, "name"),
-	     Getattr(n, "type"));
+             Getattr(n, "name"),
+             Getattr(n, "type"));
     member_name = Getattr(n, "sym:name");
     processing_class_member_function = 1;
     int status = Language::memberfunctionHandler(n);
@@ -279,25 +279,25 @@ protected:
 
     Setattr(SClassDefs, name, name);
     Printv(s_classes, "setClass('",
-	   name,
-	   "',\n", tab8,
-	   "prototype = list(parameterTypes = c(", s_paramTypes, "),\n",
-	   tab8, tab8, tab8,
-	   "returnType = '", SwigType_manglestr(t), "'),\n", tab8,
-	   "contains = 'CRoutinePointer')\n\n##\n", NIL);
+           name,
+           "',\n", tab8,
+           "prototype = list(parameterTypes = c(", s_paramTypes, "),\n",
+           tab8, tab8, tab8,
+           "returnType = '", SwigType_manglestr(t), "'),\n", tab8,
+           "contains = 'CRoutinePointer')\n\n##\n", NIL);
 
     return SWIG_OK;
   }
 
 
   void addSMethodInfo(String *name,
-		      String *argType, int nargs);
+                      String *argType, int nargs);
   // Simple initialization such as constant strings that can be reused.
   void init();
 
 
   void addAccessor(String *memberName, Wrapper *f,
-		   String *name, String *methodSetGet);
+                   String *name, String *methodSetGet);
 
   static int getFunctionPointerNumArgs(Node *n, SwigType *tt);
 
@@ -558,9 +558,9 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
     if (tm) {
       String *lstr = SwigType_lstr(tt, 0);
       if (SwigType_isreference(tt) || SwigType_isrvalue_reference(tt)) {
-	Printf(f->code, "%s = (%s) &%s;\n", Getattr(p, "lname"), lstr, swig_parm_name);
+        Printf(f->code, "%s = (%s) &%s;\n", Getattr(p, "lname"), lstr, swig_parm_name);
       } else if (!isVoidParm) {
-	Printf(f->code, "%s = (%s) %s;\n", Getattr(p, "lname"), lstr, swig_parm_name);
+        Printf(f->code, "%s = (%s) %s;\n", Getattr(p, "lname"), lstr, swig_parm_name);
       }
       Replaceall(tm, "$1", name);
       Replaceall(tm, "$result", "r_tmp");
@@ -603,20 +603,20 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   Printf(f->code, "%s\n\n", setExprElements);
 
   Printv(f->code, "r_swig_cb_data->retValue = R_tryEval(",
-	 "r_swig_cb_data->expr,",
-	 " R_GlobalEnv,",
-	 " &r_swig_cb_data->errorOccurred",
-	 ");\n",
-	 NIL);
+         "r_swig_cb_data->expr,",
+         " R_GlobalEnv,",
+         " &r_swig_cb_data->errorOccurred",
+         ");\n",
+         NIL);
 
   Printv(f->code, "\n",
-	 "if(r_swig_cb_data->errorOccurred) {\n",
-	 "R_SWIG_popCallbackFunctionData(1);\n",
-	 "Rf_error(\"error in calling R function as a function pointer (",
-	 funName,
-	 ")\");\n",
-	 "}\n",
-	 NIL);
+         "if(r_swig_cb_data->errorOccurred) {\n",
+         "R_SWIG_popCallbackFunctionData(1);\n",
+         "Rf_error(\"error in calling R function as a function pointer (",
+         funName,
+         ")\");\n",
+         "}\n",
+         NIL);
 
 
 
@@ -914,8 +914,8 @@ int R::OutputClassMethodsTable(File *) {
       int nels = Len(els);
       Printf(stdout, "\t");
       for(int j = 0; j < nels; j+=2) {
-	Printf(stdout, "%s%s", Getitem(els, j), j < nels - 1 ? ", " : "");
-	Printf(stdout, "%s\n", Getitem(els, j+1));
+        Printf(stdout, "%s%s", Getitem(els, j), j < nels - 1 ? ", " : "");
+        Printf(stdout, "%s\n", Getitem(els, j+1));
       }
       Printf(stdout, "\n");
     }
@@ -991,8 +991,8 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
  * --------------------------------------------------------------*/
 
 int R::OutputMemberReferenceMethod(String *className, int isSet,  
-				   List *memberList, List *nameList,
-				   List *typeList, File *out) {
+                                   List *memberList, List *nameList,
+                                   List *typeList, File *out) {
   int numMems = Len(memberList), j;
   int varaccessor = 0;
   if (numMems == 0)
@@ -1050,20 +1050,20 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
 
       // Check the type here instead of the name
       if (setgetmethod == R_MEMBER_GET) {
-	Printf(f->code, "%s'%s'", first ? "" : ", ", item);
-	first = false;
+        Printf(f->code, "%s'%s'", first ? "" : ", ", item);
+        first = false;
       }
     }
     Printf(f->code, ");\n");
   }
 
   Printv(f->code, ";", tab8,
-	 "idx = pmatch(name, names(accessorFuns));\n",
-	 tab8,
-	 "if(is.na(idx)) \n",
-	 tab8, tab4, NIL);
+         "idx = pmatch(name, names(accessorFuns));\n",
+         tab8,
+         "if(is.na(idx)) \n",
+         tab8, tab4, NIL);
   Printf(f->code, "return(callNextMethod(x, name%s));\n",
-	 isSet ? ", value" : "");
+         isSet ? ", value" : "");
   Printv(f->code, tab8, "f = accessorFuns[[idx]];\n", NIL);
   if(isSet) {
     Printv(f->code, tab8, "f(x, value);\n", NIL);
@@ -1071,7 +1071,7 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   } else {
     if (varaccessor) {
       Printv(f->code, tab8,
-	     "if (is.na(match(name, vaccessors))) function(...){f(x, ...)} else f(x);\n", NIL);
+             "if (is.na(match(name, vaccessors))) function(...){f(x, ...)} else f(x);\n", NIL);
     } else {
       Printv(f->code, tab8, "function(...){f(x, ...)};\n", NIL);
     }
@@ -1081,14 +1081,14 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   String *classname_str = SwigType_namestr(className);
   Printf(out, "# Start of accessor method for %s\n", classname_str);
   Printf(out, "setMethod('$%s', '_p%s', ",
-	 isSet ? "<-" : "",
-	 getRClassName(className));
+         isSet ? "<-" : "",
+         getRClassName(className));
   Wrapper_print(f, out);
   Printf(out, ");\n");
 
   if(isSet) {
     Printf(out, "setMethod('[[<-', c('_p%s', 'character'),",
-	   getRClassName(className));
+           getRClassName(className));
     Insert(f->code, 2, "name = i;\n");
     Printf(attr->code, "%s", f->code);
     Wrapper_print(attr, out);
@@ -1254,11 +1254,11 @@ int R::variableWrapper(Node *n) {
   } else if(!SwigType_isconst(ty)) {
     Wrapper *f = NewWrapper();
     Printf(f->def, "%s = \nfunction(value%s)\n{\n",
-	   name, addCopyParam ? ", .copy = FALSE" : "");
+           name, addCopyParam ? ", .copy = FALSE" : "");
     Printv(f->code, "if(missing(value)) {\n",
-	   name, "_get(", addCopyParam ? ".copy" : "", ")\n}", NIL);
+           name, "_get(", addCopyParam ? ".copy" : "", ")\n}", NIL);
     Printv(f->code, " else {\n",
-	   name, "_set(value)\n}\n}", NIL);
+           name, "_set(value)\n}\n}", NIL);
 
     Wrapper_print(f, sfile);
     DelWrapper(f);
@@ -1277,7 +1277,7 @@ int R::variableWrapper(Node *n) {
  * --------------------------------------------------------------*/
 
 void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
-		    String *methodSetGet) {
+                    String *methodSetGet) {
 
   if (!class_member_function_names) {
     class_member_function_names = NewList();
@@ -1309,7 +1309,7 @@ struct Overloaded {
 }
 
 List * R::Swig_overload_rank(Node *n,
-	                     bool script_lang_wrapping) {
+                             bool script_lang_wrapping) {
   Overloaded  nodes[MAX_OVERLOAD];
   int         nnodes = 0;
   Node *o = Getattr(n,"sym:overloaded");
@@ -1341,11 +1341,11 @@ List * R::Swig_overload_rank(Node *n,
     int i,j;
     for (i = 0; i < nnodes; i++) {
       for (j = i+1; j < nnodes; j++) {
-	if (nodes[i].argc > nodes[j].argc) {
-	  Overloaded t = nodes[i];
-	  nodes[i] = nodes[j];
-	  nodes[j] = t;
-	}
+        if (nodes[i].argc > nodes[j].argc) {
+          Overloaded t = nodes[i];
+          nodes[i] = nodes[j];
+          nodes[j] = t;
+        }
       }
     }
   }
@@ -1355,181 +1355,181 @@ List * R::Swig_overload_rank(Node *n,
     int i,j;
     for (i = 0; i < nnodes-1; i++) {
       if (nodes[i].argc == nodes[i+1].argc) {
-	for (j = i+1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
-	  Parm *p1 = nodes[i].parms;
-	  Parm *p2 = nodes[j].parms;
-	  int   differ = 0;
-	  int   num_checked = 0;
-	  while (p1 && p2 && (num_checked < nodes[i].argc)) {
-	    if (debugMode) {
-	      Printf(stdout,"p1 = '%s', p2 = '%s'\n", Getattr(p1,"type"), Getattr(p2,"type"));
-	    }
-	    if (checkAttribute(p1,"tmap:in:numinputs","0")) {
-	      p1 = Getattr(p1,"tmap:in:next");
-	      continue;
-	    }
-	    if (checkAttribute(p2,"tmap:in:numinputs","0")) {
-	      p2 = Getattr(p2,"tmap:in:next");
-	      continue;
-	    }
-	    String *t1 = Getattr(p1,"tmap:typecheck:precedence");
-	    String *t2 = Getattr(p2,"tmap:typecheck:precedence");
-	    if (debugMode) {
-	      Printf(stdout,"t1 = '%s', t2 = '%s'\n", t1, t2);
-	    }
-	    if ((!t1) && (!nodes[i].error)) {
-	      Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
-			   "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-			   Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
-	      nodes[i].error = 1;
-	    } else if ((!t2) && (!nodes[j].error)) {
-	      Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
-			   "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-			   Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
-	      nodes[j].error = 1;
-	    }
-	    if (t1 && t2) {
-	      int t1v, t2v;
-	      t1v = atoi(Char(t1));
-	      t2v = atoi(Char(t2));
-	      differ = t1v-t2v;
-	    }
-	    else if (!t1 && t2) differ = 1;
-	    else if (t1 && !t2) differ = -1;
-	    else if (!t1 && !t2) differ = -1;
-	    num_checked++;
-	    if (differ > 0) {
-	      Overloaded t = nodes[i];
-	      nodes[i] = nodes[j];
-	      nodes[j] = t;
-	      break;
-	    } else if ((differ == 0) && (Strcmp(t1,"0") == 0)) {
-	      t1 = Getattr(p1,"ltype");
-	      if (!t1) {
-		t1 = SwigType_ltype(Getattr(p1,"type"));
-		if (Getattr(p1,"tmap:typecheck:SWIGTYPE")) {
-		  SwigType_add_pointer(t1);
-		}
-		Setattr(p1,"ltype",t1);
-	      }
-	      t2 = Getattr(p2,"ltype");
-	      if (!t2) {
-		t2 = SwigType_ltype(Getattr(p2,"type"));
-		if (Getattr(p2,"tmap:typecheck:SWIGTYPE")) {
-		  SwigType_add_pointer(t2);
-		}
-		Setattr(p2,"ltype",t2);
-	      }
+        for (j = i+1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
+          Parm *p1 = nodes[i].parms;
+          Parm *p2 = nodes[j].parms;
+          int   differ = 0;
+          int   num_checked = 0;
+          while (p1 && p2 && (num_checked < nodes[i].argc)) {
+            if (debugMode) {
+              Printf(stdout,"p1 = '%s', p2 = '%s'\n", Getattr(p1,"type"), Getattr(p2,"type"));
+            }
+            if (checkAttribute(p1,"tmap:in:numinputs","0")) {
+              p1 = Getattr(p1,"tmap:in:next");
+              continue;
+            }
+            if (checkAttribute(p2,"tmap:in:numinputs","0")) {
+              p2 = Getattr(p2,"tmap:in:next");
+              continue;
+            }
+            String *t1 = Getattr(p1,"tmap:typecheck:precedence");
+            String *t2 = Getattr(p2,"tmap:typecheck:precedence");
+            if (debugMode) {
+              Printf(stdout,"t1 = '%s', t2 = '%s'\n", t1, t2);
+            }
+            if ((!t1) && (!nodes[i].error)) {
+              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
+                           "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
+                           Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
+              nodes[i].error = 1;
+            } else if ((!t2) && (!nodes[j].error)) {
+              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
+                           "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
+                           Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
+              nodes[j].error = 1;
+            }
+            if (t1 && t2) {
+              int t1v, t2v;
+              t1v = atoi(Char(t1));
+              t2v = atoi(Char(t2));
+              differ = t1v-t2v;
+            }
+            else if (!t1 && t2) differ = 1;
+            else if (t1 && !t2) differ = -1;
+            else if (!t1 && !t2) differ = -1;
+            num_checked++;
+            if (differ > 0) {
+              Overloaded t = nodes[i];
+              nodes[i] = nodes[j];
+              nodes[j] = t;
+              break;
+            } else if ((differ == 0) && (Strcmp(t1,"0") == 0)) {
+              t1 = Getattr(p1,"ltype");
+              if (!t1) {
+                t1 = SwigType_ltype(Getattr(p1,"type"));
+                if (Getattr(p1,"tmap:typecheck:SWIGTYPE")) {
+                  SwigType_add_pointer(t1);
+                }
+                Setattr(p1,"ltype",t1);
+              }
+              t2 = Getattr(p2,"ltype");
+              if (!t2) {
+                t2 = SwigType_ltype(Getattr(p2,"type"));
+                if (Getattr(p2,"tmap:typecheck:SWIGTYPE")) {
+                  SwigType_add_pointer(t2);
+                }
+                Setattr(p2,"ltype",t2);
+              }
 
-	      /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
-	         order */
+              /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
+                 order */
 
-	      if (SwigType_issubtype(t2,t1)) {
-		Overloaded t = nodes[i];
-		nodes[i] = nodes[j];
-		nodes[j] = t;
-	      }
+              if (SwigType_issubtype(t2,t1)) {
+                Overloaded t = nodes[i];
+                nodes[i] = nodes[j];
+                nodes[j] = t;
+              }
 
-	      if (Strcmp(t1,t2) != 0) {
-		differ = 1;
-		break;
-	      }
-	    } else if (differ) {
-	      break;
-	    }
-	    if (Getattr(p1,"tmap:in:next")) {
-	      p1 = Getattr(p1,"tmap:in:next");
-	    } else {
-	      p1 = nextSibling(p1);
-	    }
-	    if (Getattr(p2,"tmap:in:next")) {
-	      p2 = Getattr(p2,"tmap:in:next");
-	    } else {
-	      p2 = nextSibling(p2);
-	    }
-	  }
-	  if (!differ) {
-	    /* See if declarations differ by const only */
-	    String *d1 = Getattr(nodes[i].n, "decl");
-	    String *d2 = Getattr(nodes[j].n, "decl");
-	    if (d1 && d2) {
-	      String *dq1 = Copy(d1);
-	      String *dq2 = Copy(d2);
-	      if (SwigType_isconst(d1)) {
-		Delete(SwigType_pop(dq1));
-	      }
-	      if (SwigType_isconst(d2)) {
-		Delete(SwigType_pop(dq2));
-	      }
-	      if (Strcmp(dq1, dq2) == 0) {
+              if (Strcmp(t1,t2) != 0) {
+                differ = 1;
+                break;
+              }
+            } else if (differ) {
+              break;
+            }
+            if (Getattr(p1,"tmap:in:next")) {
+              p1 = Getattr(p1,"tmap:in:next");
+            } else {
+              p1 = nextSibling(p1);
+            }
+            if (Getattr(p2,"tmap:in:next")) {
+              p2 = Getattr(p2,"tmap:in:next");
+            } else {
+              p2 = nextSibling(p2);
+            }
+          }
+          if (!differ) {
+            /* See if declarations differ by const only */
+            String *d1 = Getattr(nodes[i].n, "decl");
+            String *d2 = Getattr(nodes[j].n, "decl");
+            if (d1 && d2) {
+              String *dq1 = Copy(d1);
+              String *dq2 = Copy(d2);
+              if (SwigType_isconst(d1)) {
+                Delete(SwigType_pop(dq1));
+              }
+              if (SwigType_isconst(d2)) {
+                Delete(SwigType_pop(dq2));
+              }
+              if (Strcmp(dq1, dq2) == 0) {
 
-		if (SwigType_isconst(d1) && !SwigType_isconst(d2)) {
-		  if (script_lang_wrapping) {
-		    // Swap nodes so that the const method gets ignored (shadowed by the non-const method)
-		    Overloaded t = nodes[i];
-		    nodes[i] = nodes[j];
-		    nodes[j] = t;
-		  }
-		  differ = 1;
-		  if (!nodes[j].error) {
-		    if (script_lang_wrapping) {
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-				   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-				   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
-		    } else {
-		      if (!Getattr(nodes[j].n, "overload:ignore")) {
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-				     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-				     "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		      }
-		    }
-		  }
-		  nodes[j].error = 1;
-		} else if (!SwigType_isconst(d1) && SwigType_isconst(d2)) {
-		  differ = 1;
-		  if (!nodes[j].error) {
-		    if (script_lang_wrapping) {
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-				   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-				   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
-		    } else {
-		      if (!Getattr(nodes[j].n, "overload:ignore")) {
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-				     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-			Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-				     "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		      }
-		    }
-		  }
-		  nodes[j].error = 1;
-		}
-	      }
-	      Delete(dq1);
-	      Delete(dq2);
-	    }
-	  }
-	  if (!differ) {
-	    if (!nodes[j].error) {
-	      if (script_lang_wrapping) {
-		Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
-			     "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
-		Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
-			     "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
-	      } else {
-		if (!Getattr(nodes[j].n, "overload:ignore")) {
-		  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-			       "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-		  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-			       "using %s instead.\n", Swig_name_decl(nodes[i].n));
-		}
-	      }
-	      nodes[j].error = 1;
-	    }
-	  }
-	}
+                if (SwigType_isconst(d1) && !SwigType_isconst(d2)) {
+                  if (script_lang_wrapping) {
+                    // Swap nodes so that the const method gets ignored (shadowed by the non-const method)
+                    Overloaded t = nodes[i];
+                    nodes[i] = nodes[j];
+                    nodes[j] = t;
+                  }
+                  differ = 1;
+                  if (!nodes[j].error) {
+                    if (script_lang_wrapping) {
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                    } else {
+                      if (!Getattr(nodes[j].n, "overload:ignore")) {
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                      }
+                    }
+                  }
+                  nodes[j].error = 1;
+                } else if (!SwigType_isconst(d1) && SwigType_isconst(d2)) {
+                  differ = 1;
+                  if (!nodes[j].error) {
+                    if (script_lang_wrapping) {
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                    } else {
+                      if (!Getattr(nodes[j].n, "overload:ignore")) {
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
+                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                      }
+                    }
+                  }
+                  nodes[j].error = 1;
+                }
+              }
+              Delete(dq1);
+              Delete(dq2);
+            }
+          }
+          if (!differ) {
+            if (!nodes[j].error) {
+              if (script_lang_wrapping) {
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
+                             "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
+                             "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
+              } else {
+                if (!Getattr(nodes[j].n, "overload:ignore")) {
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
+                               "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
+                               "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                }
+              }
+              nodes[j].error = 1;
+            }
+          }
+        }
       }
     }
   }
@@ -1538,7 +1538,7 @@ List * R::Swig_overload_rank(Node *n,
     int i;
     for (i = 0; i < nnodes; i++) {
       if (nodes[i].error)
-	Setattr(nodes[i].n, "overload:ignore", "1");
+        Setattr(nodes[i].n, "overload:ignore", "1");
       Append(result,nodes[i].n);
     }
   }
@@ -1557,17 +1557,17 @@ void R::dispatchFunction(Node *n) {
     Replace(sfname, "new_", "", DOH_REPLACE_FIRST);
 
   Printf(f->def,
-	 "`%s` <- function(...) {", sfname);
+         "`%s` <- function(...) {", sfname);
   if (debugMode) {
     Swig_print_node(n);
   }
   List *dispatch = Swig_overload_rank(n, true);
   int   nfunc = Len(dispatch);
   Printv(f->code,
-	 "argtypes <- mapply(class, list(...));\n",
-	 "argv <- list(...);\n",
-	 "argc <- length(argtypes);\n",
-	 "f <- NULL;\n", NIL);
+         "argtypes <- mapply(class, list(...));\n",
+         "argv <- list(...);\n",
+         "argc <- length(argtypes);\n",
+         "f <- NULL;\n", NIL);
 
   Printf(f->code, "# dispatch functions %d\n", nfunc);
   int cur_args = -1;
@@ -1580,7 +1580,7 @@ void R::dispatchFunction(Node *n) {
     String *overname = Getattr(ni,"sym:overname");
     if (cur_args != num_arguments) {
       if (cur_args != -1) {
-	Printv(f->code, "} else ", NIL);
+        Printv(f->code, "} else ", NIL);
       }
       Printf(f->code, "if (argc == %d) {", num_arguments);
       cur_args = num_arguments;
@@ -1590,45 +1590,45 @@ void R::dispatchFunction(Node *n) {
     int j;
     if (num_arguments > 0) {
       if (!first_compare) {
-	Printv(f->code, " else ", NIL);
+        Printv(f->code, " else ", NIL);
       } else {
-	first_compare = false;
+        first_compare = false;
       }
       Printv(f->code, "if (", NIL);
       for (p = pi, j = 0 ; j < num_arguments ; j++) {
-	SwigType *pt = Getattr(p, "type");
-	if (debugMode) {
-	  Swig_print_node(p);
-	}
-	String *tm = Swig_typemap_lookup("rtype", p, "", 0);
-	if (tm) {
-	  replaceRClass(tm, pt);
-	}
+        SwigType *pt = Getattr(p, "type");
+        if (debugMode) {
+          Swig_print_node(p);
+        }
+        String *tm = Swig_typemap_lookup("rtype", p, "", 0);
+        if (tm) {
+          replaceRClass(tm, pt);
+        }
 
-	/* Check if type have a %typemap(rtypecheck) */
-	String *tmcheck = Getattr(p,"tmap:rtypecheck");
-	if (tmcheck) {
-	  tmcheck = Copy(tmcheck);
-	  String *tmp_argtype = NewStringf("argtypes[%d]", j+1);
-	  Replaceall(tmcheck, "$argtype", tmp_argtype);
-	  String *tmp_arg = NewStringf("argv[[%d]]", j+1);
-	  Replaceall(tmcheck, "$arg", tmp_arg);
-	  replaceRClass(tmcheck, pt);
-	  if (debugMode) {
-	    Printf(stdout, "<rtypecheck>%s\n", tmcheck);
-	  }
-	  if (num_arguments == 1) {
-	    Printf(f->code, "%s", tmcheck);
-	  } else {
-	    Printf(f->code, "%s(%s)", j == 0 ? "" : " && ", tmcheck);
-	  }
-	  Delete(tmcheck);
-	  Delete(tmp_arg);
-	  Delete(tmp_argtype);
-	} else {
-	  Swig_warning(WARN_R_TYPEMAP_RTYPECHECK_UNDEF, input_file, line_number, "No rtypecheck typemap defined for %s\n", SwigType_str(pt, 0));
-	}
-	p = Getattr(p, "tmap:in:next");
+        /* Check if type have a %typemap(rtypecheck) */
+        String *tmcheck = Getattr(p,"tmap:rtypecheck");
+        if (tmcheck) {
+          tmcheck = Copy(tmcheck);
+          String *tmp_argtype = NewStringf("argtypes[%d]", j+1);
+          Replaceall(tmcheck, "$argtype", tmp_argtype);
+          String *tmp_arg = NewStringf("argv[[%d]]", j+1);
+          Replaceall(tmcheck, "$arg", tmp_arg);
+          replaceRClass(tmcheck, pt);
+          if (debugMode) {
+            Printf(stdout, "<rtypecheck>%s\n", tmcheck);
+          }
+          if (num_arguments == 1) {
+            Printf(f->code, "%s", tmcheck);
+          } else {
+            Printf(f->code, "%s(%s)", j == 0 ? "" : " && ", tmcheck);
+          }
+          Delete(tmcheck);
+          Delete(tmp_arg);
+          Delete(tmp_argtype);
+        } else {
+          Swig_warning(WARN_R_TYPEMAP_RTYPECHECK_UNDEF, input_file, line_number, "No rtypecheck typemap defined for %s\n", SwigType_str(pt, 0));
+        }
+        p = Getattr(p, "tmap:in:next");
       }
       Printf(f->code, ") { f <- %s%s; }\n", sfname, overname);
     } else {
@@ -1660,7 +1660,7 @@ int R::functionWrapper(Node *n) {
 
   if (debugMode) {
     Printf(stdout,
-	   "<functionWrapper> %s %s %s\n", fname, iname, returntype);
+           "<functionWrapper> %s %s %s\n", fname, iname, returntype);
   }
   String *overname = 0;
   String *nodeType = Getattr(n, "nodeType");
@@ -1679,7 +1679,7 @@ int R::functionWrapper(Node *n) {
 
   if (debugMode)
     Printf(stdout,
-	   "<functionWrapper> processing parameters\n");
+           "<functionWrapper> processing parameters\n");
 
 
   ParmList *l = Getattr(n, "parms");
@@ -1690,14 +1690,14 @@ int R::functionWrapper(Node *n) {
   while(p) {
     SwigType *resultType = Getattr(p, "type");
     if (expandTypedef(resultType) &&
-	SwigType_istypedef(resultType)) {
+        SwigType_istypedef(resultType)) {
       SwigType *resolved =
-	SwigType_typedef_resolve_all(resultType);
+        SwigType_typedef_resolve_all(resultType);
       if (expandTypedef(resolved)) {
         if (debugMode) {
           Printf(stdout, "Setting type: %s\n", resolved);
         }
-	Setattr(p, "type", Copy(resolved));
+        Setattr(p, "type", Copy(resolved));
       }
     }
     p = nextSibling(p);
@@ -1822,13 +1822,13 @@ int R::functionWrapper(Node *n) {
 
     if (name) {
       /* If we have a :: in the parameter name because we are accessing a static member of a class, say, then
-	 we need to remove that prefix. */
+         we need to remove that prefix. */
       while (Strstr(name, "::")) {
-	String *oldname = name;
-	name = NewStringf("%s", Strchr(name, ':') + 2);
-	if (debugMode)
-	  Printf(stdout, "+++  parameter name with :: in it %s\n", name);
-	Delete(oldname);
+        String *oldname = name;
+        name = NewStringf("%s", Strchr(name, ':') + 2);
+        if (debugMode)
+          Printf(stdout, "+++  parameter name with :: in it %s\n", name);
+        Delete(oldname);
       }
     }
 
@@ -1857,28 +1857,28 @@ int R::functionWrapper(Node *n) {
       replaceRClass(tm, Getattr(p, "type"));
 
       if(funcptr_name) {
-	//XXX need to get this to return non-zero
-	if(nargs == -1)
-	  nargs = getFunctionPointerNumArgs(p, tt);
+        //XXX need to get this to return non-zero
+        if(nargs == -1)
+          nargs = getFunctionPointerNumArgs(p, tt);
 
-	String *snargs = NewStringf("%d", nargs);
-	Printv(sfun->code, "if(is.function(", name, ")) {", "\n",
-	       "assert('...' %in% names(formals(", name,
-	       ")) || length(formals(", name, ")) >= ", snargs, ");\n} ", NIL);
-	Delete(snargs);
+        String *snargs = NewStringf("%d", nargs);
+        Printv(sfun->code, "if(is.function(", name, ")) {", "\n",
+               "assert('...' %in% names(formals(", name,
+               ")) || length(formals(", name, ")) >= ", snargs, ");\n} ", NIL);
+        Delete(snargs);
 
-	Printv(sfun->code, "else {\n",
-	       "if(is.character(", name, ")) {\n",
-	       name, " = getNativeSymbolInfo(", name, ");",
-	       "\n};\n",
-	       "if(is(", name, ", \"NativeSymbolInfo\")) {\n",
-	       name, " = ", name, "$address", ";\n};\n",
-	       "if(is(", name, ", \"ExternalReference\")) {\n",
-	       name, " = ", name, "@ref;\n}\n",
-	       "}; \n",
-	       NIL);
+        Printv(sfun->code, "else {\n",
+               "if(is.character(", name, ")) {\n",
+               name, " = getNativeSymbolInfo(", name, ");",
+               "\n};\n",
+               "if(is(", name, ", \"NativeSymbolInfo\")) {\n",
+               name, " = ", name, "$address", ";\n};\n",
+               "if(is(", name, ", \"ExternalReference\")) {\n",
+               name, " = ", name, "@ref;\n}\n",
+               "}; \n",
+               NIL);
       } else {
-	Printf(sfun->code, "%s\n", tm);
+        Printf(sfun->code, "%s\n", tm);
       }
     }
 
@@ -1899,27 +1899,27 @@ int R::functionWrapper(Node *n) {
       Replaceall(tm,"$input", name);
 
       if (Getattr(p,"wrap:disown") || (Getattr(p,"tmap:in:disown"))) {
-	Replaceall(tm,"$disown","SWIG_POINTER_DISOWN");
+        Replaceall(tm,"$disown","SWIG_POINTER_DISOWN");
       } else {
-	Replaceall(tm,"$disown","0");
+        Replaceall(tm,"$disown","0");
       }
 
       if(funcptr_name) {
-	/* have us a function pointer */
-	Printf(f->code, "if(TYPEOF(%s) != CLOSXP) {\n", name);
-	Replaceall(tm,"$R_class", "");
+        /* have us a function pointer */
+        Printf(f->code, "if(TYPEOF(%s) != CLOSXP) {\n", name);
+        Replaceall(tm,"$R_class", "");
       } else {
-	replaceRClass(tm, Getattr(p, "type"));
+        replaceRClass(tm, Getattr(p, "type"));
       }
 
 
       Printf(f->code,"%s\n",tm);
       if(funcptr_name)
-	Printf(f->code, "} else {\n%s = %s;\nR_SWIG_pushCallbackFunctionData(%s, NULL);\n}\n",
-	       lname, funcptr_name, name);
+        Printf(f->code, "} else {\n%s = %s;\nR_SWIG_pushCallbackFunctionData(%s, NULL);\n}\n",
+               lname, funcptr_name, name);
       Printv(f->def, inFirstArg ? "" : ", ", "SEXP ", name, NIL);
       if (Len(name) != 0)
-	inFirstArg = false;
+        inFirstArg = false;
       p = Getattr(p,"tmap:in:next");
 
     } else {
@@ -2013,7 +2013,7 @@ int R::functionWrapper(Node *n) {
 
   } else {
     Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number,
-		 "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), fname);
+                 "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), fname);
   }
 
 
@@ -2025,8 +2025,8 @@ int R::functionWrapper(Node *n) {
       Printf(tmp, "Rf_protect(r_ans);\n");
 
     Printf(tmp, "Rf_protect(R_OutputValues = Rf_allocVector(VECSXP,%d));\nr_nprotect += %d;\n",
-	   numOutArgs + !isVoidReturnType,
-	   isVoidReturnType ? 1 : 2);
+           numOutArgs + !isVoidReturnType,
+           isVoidReturnType ? 1 : 2);
 
     if(!isVoidReturnType)
       Printf(tmp, "SET_VECTOR_ELT(R_OutputValues, 0, r_ans);\n");
@@ -2075,16 +2075,16 @@ int R::functionWrapper(Node *n) {
 
 
   Printv(sfun->code, ";", (Len(tm) ? "ans = " : ""), ".Call('", wname,
-	 "', ", sargs, "PACKAGE='", Rpackage, "');\n", NIL);
+         "', ", sargs, "PACKAGE='", Rpackage, "');\n", NIL);
   if(Len(tm))
     {
       Printf(sfun->code, "%s\n\n", tm);
       if (constructor)
-	{
-	  String *finalizer = NewString(iname);
-	  Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
-	  Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s);\n", finalizer);
-	}
+        {
+          String *finalizer = NewString(iname);
+          Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
+          Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s);\n", finalizer);
+        }
       Printf(sfun->code, "ans\n");
     }
 
@@ -2126,14 +2126,14 @@ int R::functionWrapper(Node *n) {
   }
 
   Printv(sfile, "attr(`", sfname, "`, 'returnType') = '",
-	 isVoidReturnType ? "void" : (tm ? tm : ""),
-	 "'\n", NIL);
+         isVoidReturnType ? "void" : (tm ? tm : ""),
+         "'\n", NIL);
 
   if(nargs > 0)
     Printv(sfile, "attr(`", sfname, "`, \"inputTypes\") = c(",
-	   s_inputTypes, ")\n", NIL);
+           s_inputTypes, ")\n", NIL);
   Printv(sfile, "class(`", sfname, "`) = c(\"SWIGFunction\", class('",
-	 sfname, "'))\n\n", NIL);
+         sfname, "'))\n\n", NIL);
 
   if (memoryProfile) {
     Printv(sfile, "memory.profile()\n", NIL);
@@ -2238,7 +2238,7 @@ int R::outputRegistrationRoutines(File *out) {
     if (inCPlusMode)
       Printv(out, "extern \"C\" ", NIL);
     { /* R allows pckage names to have '.' in the name, which is not allowed in C++ var names
-	 we simply replace all occurrences of '.' with '_' to construct the var name */
+         we simply replace all occurrences of '.' with '_' to construct the var name */
       String * Rpackage_sane = Copy(Rpackage);
       Replace(Rpackage_sane, ".", "_", DOH_REPLACE_ANY);
       Printf(out, "SWIGEXPORT void R_init_%s(DllInfo *dll) {\n", Rpackage_sane);
@@ -2278,16 +2278,16 @@ void R::registerClass(Node *n) {
       base = NewString("");
       List *l = Getattr(n, "bases");
       if(Len(l)) {
-	Printf(base, "c(");
-	for(int i = 0; i < Len(l); i++) {
-	  registerClass(Getitem(l, i));
-	  Printf(base, "'_p%s'%s",
-		 SwigType_manglestr(Getattr(Getitem(l, i), "name")),
-		 i < Len(l)-1 ? ", " : "");
-	}
-	Printf(base, ")");
+        Printf(base, "c(");
+        for(int i = 0; i < Len(l); i++) {
+          registerClass(Getitem(l, i));
+          Printf(base, "'_p%s'%s",
+                 SwigType_manglestr(Getattr(Getitem(l, i), "name")),
+                 i < Len(l)-1 ? ", " : "");
+        }
+        Printf(base, ")");
       } else {
-	base = NewString("'C++Reference'");
+        base = NewString("'C++Reference'");
       }
     } else
       base = NewString("'ExternalReference'");
@@ -2387,36 +2387,36 @@ int R::classDeclaration(Node *n) {
 
       String *elKind = Getattr(c, "kind");
       if (!Equal(elKind, "variable")) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
       if (!Len(elName)) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
       tp = Swig_typemap_lookup("rtype", c, "", 0);
       if(!tp) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
       if (Strstr(tp, "R_class")) {
-	c = nextSibling(c);
-	continue;
+        c = nextSibling(c);
+        continue;
       }
       if (Strcmp(tp, "character") &&
-	  Strstr(Getattr(c, "decl"), "p.")) {
-	c = nextSibling(c);
-	continue;
+          Strstr(Getattr(c, "decl"), "p.")) {
+        c = nextSibling(c);
+        continue;
       }
 
       if (!firstItem) {
-	Printf(def, ",\n");
+        Printf(def, ",\n");
       }
       //	    else
       //XXX How can we tell if this is already done.
       //	      SwigType_push(elType, elDecl);
-	
-	
+        
+        
       // returns ""  tp = processType(elType, c, NULL);
       //	    Printf(stdout, "<classDeclaration> elType %p\n", elType);
       //	    tp = getRClassNameCopyStruct(Getattr(c, "type"), 1);
@@ -2474,9 +2474,9 @@ int R::generateCopyRoutines(Node *n) {
     Printf(stdout, "generateCopyRoutines:  name = %s, %s\n", name, type);
 
   Printf(copyToR->def, "CopyToR%s = function(value, obj = new(\"%s\"))\n{\n",
-	 mangledName, name);
+         mangledName, name);
   Printf(copyToC->def, "CopyToC%s = function(value, obj)\n{\n",
-	 mangledName);
+         mangledName);
 
   Node *c = firstChild(n);
 
@@ -2498,7 +2498,7 @@ int R::generateCopyRoutines(Node *n) {
       continue;
     }
     if (Strcmp(tp, "character") &&
-	Strstr(Getattr(c, "decl"), "p.")) {
+        Strstr(Getattr(c, "decl"), "p.")) {
       continue;
     }
 
@@ -2520,9 +2520,9 @@ int R::generateCopyRoutines(Node *n) {
 
   Printf(sfile, "# Start definition of copy methods for %s\n", rclassName);
   Printf(sfile, "setMethod('copyToR', '_p%s', CopyToR%s);\n", mangledName,
-	 mangledName);
+         mangledName);
   Printf(sfile, "setMethod('copyToC', '%s', CopyToC%s);\n\n", rclassName,
-	 mangledName);
+         mangledName);
 
   Printf(sfile, "# End definition of copy methods for %s\n", rclassName);
   Printf(sfile, "# End definition of copy functions & methods for %s\n", rclassName);
@@ -2565,7 +2565,7 @@ int R::typedefHandler(Node *n) {
     if (debugMode)
       Printf(stdout, "<typedefHandler> Defining S class %s\n", trueName);
     Printf(s_classes, "setClass('_p%s', contains = 'ExternalReference')\n",
-	   SwigType_manglestr(name));
+           SwigType_manglestr(name));
   }
 
   return Language::typedefHandler(n);
@@ -2587,7 +2587,7 @@ int R::membervariableHandler(Node *n) {
   member_name = Getattr(n,"sym:name");
   if (debugMode)
     Printf(stdout, "<membervariableHandler> name = %s, sym:name = %s\n",
-	   Getattr(n, "name"), member_name);
+           Getattr(n, "name"), member_name);
 
   int status(Language::membervariableHandler(n));
 
@@ -2770,7 +2770,7 @@ String * R::processType(SwigType *t, Node *n, int *nargs) {
     String *b = getRTypeName(t, &count);
     if(count && b && !Getattr(SClassDefs, b)) {
       if (debugMode)
-	Printf(stdout, "<processType> Defining class %s\n",  b);
+        Printf(stdout, "<processType> Defining class %s\n",  b);
 
       Printf(s_classes, "setClass('%s', contains = 'ExternalReference')\n", b);
       Setattr(SClassDefs, b, b);
@@ -2785,7 +2785,7 @@ String * R::processType(SwigType *t, Node *n, int *nargs) {
   if(SwigType_isfunctionpointer(t)) {
     if (debugMode)
       Printf(stdout,
-	     "<processType> Defining pointer handler %s\n",  t);
+             "<processType> Defining pointer handler %s\n",  t);
 
     String *tmp = createFunctionPointerHandler(t, n, nargs);
     return tmp;

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -15,8 +15,7 @@
 #include "swigmod.h"
 #include "cparse.h"
 
-static String* replaceInitialDash(const String *name)
-{
+static String *replaceInitialDash(const String *name) {
   String *retval;
   if (!Strncmp(name, "_", 1)) {
     retval = Copy(name);
@@ -27,30 +26,29 @@ static String* replaceInitialDash(const String *name)
   return retval;
 }
 
-static String * getRTypeName(SwigType *t, int *outCount = NULL) {
+static String *getRTypeName(SwigType *t, int *outCount = NULL) {
   String *b = SwigType_base(t);
   List *els = SwigType_split(t);
   int count = 0;
   int i;
 
-  if(Strncmp(b, "struct ", 7) == 0)
+  if (Strncmp(b, "struct ", 7) == 0)
     Replace(b, "struct ", "", DOH_REPLACE_FIRST);
 
-  for(i = 0; i < Len(els); i++) {
+  for (i = 0; i < Len(els); i++) {
     String *el = Getitem(els, i);
-    if(Strcmp(el, "p.") == 0 || Strncmp(el, "a(", 2) == 0) {
+    if (Strcmp(el, "p.") == 0 || Strncmp(el, "a(", 2) == 0) {
       count++;
       Append(b, "Ref");
     }
   }
-  if(outCount)
+  if (outCount)
     *outCount = count;
 
   String *tmp = NewString("");
   char *retName = Char(SwigType_manglestr(t));
   Insert(tmp, 0, retName);
   return tmp;
-
 }
 
 /* --------------------------------------------------------------
@@ -59,7 +57,7 @@ static String * getRTypeName(SwigType *t, int *outCount = NULL) {
  * to request both
  * --------------------------------------------------------------*/
 
-static String *getRClassName(String *retType, int deRef=0, int upRef=0) {
+static String *getRClassName(String *retType, int deRef = 0, int upRef = 0) {
   SwigType *resolved = SwigType_typedef_resolve_all(retType);
   int ispointer = SwigType_ispointer(resolved);
   int isreference = SwigType_isreference(resolved);
@@ -85,38 +83,34 @@ static String *getRClassName(String *retType, int deRef=0, int upRef=0) {
  * Now handles arrays, i.e. struct A[2]
  * --------------------------------------------------------------*/
 
-
-static String * getRClassNameCopyStruct(String *retType, int addRef) {
+static String *getRClassNameCopyStruct(String *retType, int addRef) {
   String *tmp = NewString("");
 
   List *l = SwigType_split(retType);
   int n = Len(l);
-  if(!l || n == 0) {
+  if (!l || n == 0) {
 #ifdef R_SWIG_VERBOSE
     Printf(stdout, "SwigType_split return an empty list for %s\n", retType);
 #endif
     return tmp;
   }
 
-
-  String *el = Getitem(l, n-1);
+  String *el = Getitem(l, n - 1);
   char *ptr = Char(el);
-  if(strncmp(ptr, "struct ", 7) == 0)
+  if (strncmp(ptr, "struct ", 7) == 0)
     ptr += 7;
 
   Printf(tmp, "%s", ptr);
 
-  if(addRef) {
-    for(int i = 0; i < n; i++) {
-      if(Strcmp(Getitem(l, i), "p.") == 0 ||
-         Strncmp(Getitem(l, i), "a(", 2) == 0)
+  if (addRef) {
+    for (int i = 0; i < n; i++) {
+      if (Strcmp(Getitem(l, i), "p.") == 0 || Strncmp(Getitem(l, i), "a(", 2) == 0)
         Printf(tmp, "Ref");
     }
   }
 
   return tmp;
 }
-
 
 /* -------------------------------------------------------------
  * Write the elements of a list to the File*, one element per line.
@@ -125,16 +119,11 @@ static String * getRClassNameCopyStruct(String *retType, int addRef) {
  * a comma after each element, except the last one.
  * --------------------------------------------------------------*/
 
-
 static void writeListByLine(List *l, File *out, bool quote = 0) {
   int i, n = Len(l);
-  for(i = 0; i < n; i++)
-    Printf(out, "%s%s%s%s%s\n", tab8,
-           quote ? "\"" :"",
-           Getitem(l, i),
-           quote ? "\"" :"", i < n-1 ? "," : "");
+  for (i = 0; i < n; i++)
+    Printf(out, "%s%s%s%s%s\n", tab8, quote ? "\"" : "", Getitem(l, i), quote ? "\"" : "", i < n - 1 ? "," : "");
 }
-
 
 static const char *usage = "\
 R Options (available with -r)\n\
@@ -151,8 +140,6 @@ R Options (available with -r)\n\
                         invocations. Default is the module name.\n\
 \n";
 
-
-
 /* -------------------------------------------------------------
  * Display the help for this module on the screen/console.
  * --------------------------------------------------------------*/
@@ -162,13 +149,15 @@ static void showUsage() {
 }
 
 static bool expandTypedef(SwigType *t) {
-  if (SwigType_isenum(t)) return false;
+  if (SwigType_isenum(t))
+    return false;
   String *prefix = SwigType_prefix(t);
-  if (Strncmp(prefix, "f", 1)) return false;
-  if (Strncmp(prefix, "p.f", 3)) return false;
+  if (Strncmp(prefix, "f", 1))
+    return false;
+  if (Strncmp(prefix, "p.f", 3))
+    return false;
   return true;
 }
-
 
 /* -------------------------------------------------------------
  * Determine whether  we should add a .copy argument to the S function
@@ -178,7 +167,7 @@ static bool expandTypedef(SwigType *t) {
 static int addCopyParameter(SwigType *type) {
   int ok = 0;
   ok = Strncmp(type, "struct ", 7) == 0 || Strncmp(type, "p.struct ", 9) == 0;
-  if(!ok) {
+  if (!ok) {
     ok = Strncmp(type, "p.", 2);
   }
 
@@ -192,7 +181,9 @@ static void replaceRClass(String *tm, SwigType *type) {
   Replaceall(tm, "$R_class", tmp);
   Replaceall(tm, "$*R_class", tmp_base);
   Replaceall(tm, "$&R_class", tmp_ref);
-  Delete(tmp); Delete(tmp_base); Delete(tmp_ref);
+  Delete(tmp);
+  Delete(tmp_base);
+  Delete(tmp_ref);
 }
 
 class R : public Language {
@@ -219,9 +210,7 @@ public:
 
   int memberfunctionHandler(Node *n) {
     if (debugMode)
-      Printf(stdout, "<memberfunctionHandler> %s %s\n",
-             Getattr(n, "name"),
-             Getattr(n, "type"));
+      Printf(stdout, "<memberfunctionHandler> %s %s\n", Getattr(n, "name"), Getattr(n, "type"));
     member_name = Getattr(n, "sym:name");
     processing_class_member_function = 1;
     int status = Language::memberfunctionHandler(n);
@@ -231,8 +220,8 @@ public:
 
   /* Grab the name of the current class being processed so that we can
      deal with members of that class. */
-  int classHandler(Node *n){
-    if(!ClassMemberTable)
+  int classHandler(Node *n) {
+    if (!ClassMemberTable)
       ClassMemberTable = NewHash();
 
     class_name = Getattr(n, "name");
@@ -257,53 +246,59 @@ protected:
   int defineArrayAccessors(SwigType *type);
 
   void addNamespaceFunction(String *name) {
-    if(!namespaceFunctions)
+    if (!namespaceFunctions)
       namespaceFunctions = NewList();
     Append(namespaceFunctions, name);
   }
 
   void addNamespaceMethod(String *name) {
-    if(!namespaceMethods)
+    if (!namespaceMethods)
       namespaceMethods = NewList();
     Append(namespaceMethods, name);
   }
 
-  String* processType(SwigType *t, Node *n, int *nargs = NULL);
+  String *processType(SwigType *t, Node *n, int *nargs = NULL);
   String *createFunctionPointerHandler(SwigType *t, Node *n, int *nargs);
   int addFunctionPointerProxy(String *name, Node *n, SwigType *t, String *s_paramTypes) {
     /*XXX Do we need to put the t in there to get the return type later. */
-    if(!functionPointerProxyTable)
+    if (!functionPointerProxyTable)
       functionPointerProxyTable = NewHash();
 
     Setattr(functionPointerProxyTable, name, n);
 
     Setattr(SClassDefs, name, name);
-    Printv(s_classes, "setClass('",
+    Printv(s_classes,
+           "setClass('",
            name,
-           "',\n", tab8,
-           "prototype = list(parameterTypes = c(", s_paramTypes, "),\n",
-           tab8, tab8, tab8,
-           "returnType = '", SwigType_manglestr(t), "'),\n", tab8,
-           "contains = 'CRoutinePointer')\n\n##\n", NIL);
+           "',\n",
+           tab8,
+           "prototype = list(parameterTypes = c(",
+           s_paramTypes,
+           "),\n",
+           tab8,
+           tab8,
+           tab8,
+           "returnType = '",
+           SwigType_manglestr(t),
+           "'),\n",
+           tab8,
+           "contains = 'CRoutinePointer')\n\n##\n",
+           NIL);
 
     return SWIG_OK;
   }
 
-
-  void addSMethodInfo(String *name,
-                      String *argType, int nargs);
+  void addSMethodInfo(String *name, String *argType, int nargs);
   // Simple initialization such as constant strings that can be reused.
   void init();
 
-
-  void addAccessor(String *memberName, Wrapper *f,
-                   String *name, String *methodSetGet);
+  void addAccessor(String *memberName, Wrapper *f, String *name, String *methodSetGet);
 
   static int getFunctionPointerNumArgs(Node *n, SwigType *tt);
 
   // filtering of class member lists by function type. Used in constructing accessors
   // are we allowed to use stl style functors to customise this?
-  List* filterMemberList(List *class_member_function_types, List *class_member_other, String *R_MEMBER, bool equal);
+  List *filterMemberList(List *class_member_function_types, List *class_member_other, String *R_MEMBER, bool equal);
 
 protected:
   bool copyStruct;
@@ -311,7 +306,7 @@ protected:
   bool aggressiveGc;
 
   // Strings into which we cumulate the generated code that is to be written
-  //vto the files.
+  // vto the files.
   String *enum_values;
   String *enum_def_calls;
   String *sfile;
@@ -359,21 +354,20 @@ protected:
 
   List *namespaceFunctions;
   List *namespaceMethods;
-  List *namespaceClasses; // Probably can do this from ClassMemberTable.
-
+  List *namespaceClasses;  // Probably can do this from ClassMemberTable.
 
   // Store a copy of the command line.
   // Need only keep a string that has it formatted.
   char **Argv;
-  int    Argc;
+  int Argc;
   bool inCPlusMode;
 
   // State variables that we remember from the command line settings
   // potentially that govern the code we generate.
   String *DllName;
   String *Rpackage;
-  bool    noInitializationCode;
-  bool    outputNamespaceInfo;
+  bool noInitializationCode;
+  bool outputNamespaceInfo;
 
   String *UnProtectWrapupCode;
 
@@ -433,7 +427,7 @@ R::R() :
 bool R::debugMode = false;
 
 int R::getFunctionPointerNumArgs(Node *n, SwigType *tt) {
-  (void) tt;
+  (void)tt;
   n = Getattr(n, "type");
   if (debugMode)
     Printf(stdout, "type: %s\n", n);
@@ -444,28 +438,28 @@ int R::getFunctionPointerNumArgs(Node *n, SwigType *tt) {
   return ParmList_len(parms);
 }
 
-
 void R::addSMethodInfo(String *name, String *argType, int nargs) {
-  (void) argType;
+  (void)argType;
 
-  if(!SMethodInfo)
+  if (!SMethodInfo)
     SMethodInfo = NewHash();
   if (debugMode)
     Printf(stdout, "[addMethodInfo] %s\n", name);
 
   Hash *tb = Getattr(SMethodInfo, name);
 
-  if(!tb) {
+  if (!tb) {
     tb = NewHash();
     Setattr(SMethodInfo, name, tb);
   }
 
   String *str = Getattr(tb, "max");
   int max = -1;
-  if(str)
+  if (str)
     max = atoi(Char(str));
-  if(max < nargs) {
-    if(str)  Delete(str);
+  if (max < nargs) {
+    if (str)
+      Delete(str);
     str = NewStringf("%d", max);
     Setattr(tb, "max", str);
   }
@@ -475,15 +469,15 @@ void R::addSMethodInfo(String *name, String *argType, int nargs) {
  * Returns the name of the new routine.
  * ------------------------------------------ */
 
-String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
+String *R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   String *funName = SwigType_manglestr(t);
 
   /* See if we have already processed this one. */
-  if(functionPointerProxyTable && Getattr(functionPointerProxyTable, funName))
+  if (functionPointerProxyTable && Getattr(functionPointerProxyTable, funName))
     return funName;
 
   if (debugMode)
-    Printf(stdout, "<createFunctionPointerHandler> Defining %s\n",  t);
+    Printf(stdout, "<createFunctionPointerHandler> Defining %s\n", t);
 
   SwigType *rettype = Copy(Getattr(n, "type"));
   SwigType *funcparams = SwigType_functionpointer_decompose(rettype);
@@ -492,7 +486,6 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   // ParmList *parms = Getattr(n, "parms");
   // memory leak
   ParmList *parms = SwigType_function_parms(SwigType_del_pointer(Copy(t)), n);
-
 
   if (debugMode) {
     Printf(stdout, "Type: %s\n", t);
@@ -512,7 +505,7 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
     String *arg = Getattr(p, "name");
     String *lname;
     if (!arg && Cmp(Getattr(p, "type"), "void")) {
-      lname = NewStringf("arg%d", i+1);
+      lname = NewStringf("arg%d", i + 1);
       Setattr(p, "name", lname);
     } else
       lname = arg;
@@ -537,7 +530,7 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
 
   p = parms;
   int nargs = ParmList_len(parms);
-  if(numArgs) {
+  if (numArgs) {
     *numArgs = nargs;
     if (debugMode)
       Printf(stdout, "Setting number of parameters to %d\n", *numArgs);
@@ -545,7 +538,7 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   String *setExprElements = NewString("");
 
   String *s_paramTypes = NewString("");
-  for(i = 0; p; i++) {
+  for (i = 0; p; i++) {
     SwigType *tt = Getattr(p, "type");
     SwigType *name = Getattr(p, "name");
     SwigType *swig_parm_name = NewStringf("swigarg_%s", name);
@@ -565,10 +558,10 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
       Replaceall(tm, "$1", name);
       Replaceall(tm, "$result", "r_tmp");
       if (debugMode) {
-        Printf(stdout, "Calling Replace A: %s\n", Getattr(p,"type"));
+        Printf(stdout, "Calling Replace A: %s\n", Getattr(p, "type"));
       }
-      replaceRClass(tm, Getattr(p,"type"));
-      Replaceall(tm,"$owner", "0");
+      replaceRClass(tm, Getattr(p, "type"));
+      Replaceall(tm, "$owner", "0");
       Delete(lstr);
     }
 
@@ -580,18 +573,18 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
     Printf(s_paramTypes, "'%s'", SwigType_manglestr(tt));
 
     p = nextSibling(p);
-    if(p) {
+    if (p) {
       Printf(f->def, ", ");
       Printf(s_paramTypes, ", ");
     }
   }
 
-  Printf(f->def,  ") {\n");
+  Printf(f->def, ") {\n");
 
   if (r_tmp_needed)
-    Wrapper_add_local(f, "r_tmp", "SEXP r_tmp"); // for use in converting arguments to R objects for call.
-  Wrapper_add_local(f, "r_nprotect", "int r_nprotect = 0"); // for use in converting arguments to R objects for call.
-  Wrapper_add_local(f, "r_vmax", "char * r_vmax= 0"); // for use in converting arguments to R objects for call.
+    Wrapper_add_local(f, "r_tmp", "SEXP r_tmp");             // for use in converting arguments to R objects for call.
+  Wrapper_add_local(f, "r_nprotect", "int r_nprotect = 0");  // for use in converting arguments to R objects for call.
+  Wrapper_add_local(f, "r_vmax", "char * r_vmax= 0");        // for use in converting arguments to R objects for call.
 
   Printf(f->code, "Rf_protect(%s->expr = Rf_allocVector(LANGSXP, %d));\n", lvar, nargs + 1);
   Printf(f->code, "r_nprotect++;\n");
@@ -602,14 +595,10 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
 
   Printf(f->code, "%s\n\n", setExprElements);
 
-  Printv(f->code, "r_swig_cb_data->retValue = R_tryEval(",
-         "r_swig_cb_data->expr,",
-         " R_GlobalEnv,",
-         " &r_swig_cb_data->errorOccurred",
-         ");\n",
-         NIL);
+  Printv(f->code, "r_swig_cb_data->retValue = R_tryEval(", "r_swig_cb_data->expr,", " R_GlobalEnv,", " &r_swig_cb_data->errorOccurred", ");\n", NIL);
 
-  Printv(f->code, "\n",
+  Printv(f->code,
+         "\n",
          "if(r_swig_cb_data->errorOccurred) {\n",
          "R_SWIG_popCallbackFunctionData(1);\n",
          "Rf_error(\"error in calling R function as a function pointer (",
@@ -618,9 +607,7 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
          "}\n",
          NIL);
 
-
-
-  if(!isVoidType) {
+  if (!isVoidType) {
     /* Need to deal with the return type of the function pointer, not the function pointer itself.
        So build a new node that has the relevant pieces.
        XXX  Have to be a little more clever so that we can deal with struct A * - the * is getting lost.
@@ -628,12 +615,12 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
     */
     Parm *bbase = NewParmNode(rettype, n);
     String *returnTM = Swig_typemap_lookup("in", bbase, Swig_cresult_name(), f);
-    if(returnTM) {
+    if (returnTM) {
       String *tm = returnTM;
-      Replaceall(tm,"$input", "r_swig_cb_data->retValue");
+      Replaceall(tm, "$input", "r_swig_cb_data->retValue");
       replaceRClass(tm, rettype);
-      Replaceall(tm,"$owner", "0");
-      Replaceall(tm,"$disown","0");
+      Replaceall(tm, "$owner", "0");
+      Replaceall(tm, "$disown", "0");
       Printf(f->code, "%s\n", tm);
     }
     Delete(bbase);
@@ -643,11 +630,11 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
   Printv(f->code, "\n", UnProtectWrapupCode, NIL);
 
   if (SwigType_isreference(rettype)) {
-    Printv(f->code,  "return *", Swig_cresult_name(), ";\n", NIL);
+    Printv(f->code, "return *", Swig_cresult_name(), ";\n", NIL);
   } else if (SwigType_isrvalue_reference(rettype)) {
-    Printv(f->code,  "return std::move(*", Swig_cresult_name(), ");\n", NIL);
+    Printv(f->code, "return std::move(*", Swig_cresult_name(), ");\n", NIL);
   } else if (!isVoidType) {
-    Printv(f->code,  "return ", Swig_cresult_name(), ";\n", NIL);
+    Printv(f->code, "return ", Swig_cresult_name(), ";\n", NIL);
   }
 
   Printv(f->code, "\n}\n", NIL);
@@ -678,8 +665,7 @@ String * R::createFunctionPointerHandler(SwigType *t, Node *n, int *numArgs) {
 }
 
 void R::init() {
-  UnProtectWrapupCode =
-    NewStringf("%s", "vmaxset(r_vmax);\nif(r_nprotect)  Rf_unprotect(r_nprotect);\n\n");
+  UnProtectWrapupCode = NewStringf("%s", "vmaxset(r_vmax);\nif(r_nprotect)  Rf_unprotect(r_nprotect);\n\n");
 
   SClassDefs = NewHash();
 
@@ -695,7 +681,6 @@ void R::init() {
   enum_def_calls = NewString("");
 }
 
-
 /* -------------------------------------------------------------
  *  Method from Language that is called to start the entire
  *  processing off, i.e. the generation of the code.
@@ -709,12 +694,12 @@ int R::top(Node *n) {
     Printf(stdout, "<Top> %s\n", module);
   }
 
-  if(!Rpackage)
+  if (!Rpackage)
     Rpackage = Copy(module);
-  if(!DllName)
+  if (!DllName)
     DllName = Copy(module);
 
-  if(outputNamespaceInfo) {
+  if (outputNamespaceInfo) {
     s_namespace = NewString("");
     Swig_register_filebyname("snamespace", s_namespace);
     Printf(s_namespace, "useDynLib(%s)\n", DllName);
@@ -753,17 +738,17 @@ int R::top(Node *n) {
   Printf(f_wrapper, "#endif\n");
 
   String *type_table = NewString("");
-  SwigType_emit_type_table(f_runtime,f_wrapper);
+  SwigType_emit_type_table(f_runtime, f_wrapper);
   Delete(type_table);
 
-  if(ClassMemberTable) {
-    //XXX OutputClassAccessInfo(ClassMemberTable, sfile);
+  if (ClassMemberTable) {
+    // XXX OutputClassAccessInfo(ClassMemberTable, sfile);
     Delete(ClassMemberTable);
     ClassMemberTable = NULL;
   }
 
-  Printf(f_init,"}\n");
-  if(registrationTable)
+  Printf(f_init, "}\n");
+  if (registrationTable)
     outputRegistrationRoutines(f_init);
 
   /* Now arrange to write the 2 files - .S and .c. */
@@ -783,13 +768,11 @@ int R::top(Node *n) {
   return SWIG_OK;
 }
 
-
 /* -------------------------------------------------------------
  * Write the generated code  to the .S and the .c files.
  * ------------------------------------------------------------- */
 int R::DumpCode(Node *n) {
   String *output_filename = NewString("");
-
 
   /* The name of the file in which we will generate the S code. */
   Printf(output_filename, "%s%s.R", SWIG_output_directory(), Rpackage);
@@ -805,15 +788,14 @@ int R::DumpCode(Node *n) {
   }
   Delete(output_filename);
 
-
   Printf(scode, "%s\n\n", s_init);
   Printf(scode, "%s\n\n", s_classes);
   Printf(scode, "%s\n", sfile);
   Printf(scode, "%s\n", enum_def_calls);
 
   Delete(scode);
-  String *outfile = Getattr(n,"outfile");
-  File *runtime = NewFile(outfile,"w", SWIG_output_files());
+  String *outfile = Getattr(n, "outfile");
+  File *runtime = NewFile(outfile, "w", SWIG_output_files());
   if (!runtime) {
     FileErrorDisplay(outfile);
     Exit(EXIT_FAILURE);
@@ -827,7 +809,7 @@ int R::DumpCode(Node *n) {
 
   Delete(runtime);
 
-  if(outputNamespaceInfo) {
+  if (outputNamespaceInfo) {
     output_filename = NewString("");
     Printf(output_filename, "%sNAMESPACE", SWIG_output_directory());
     File *ns = NewFile(output_filename, "w", SWIG_output_files());
@@ -852,18 +834,13 @@ int R::DumpCode(Node *n) {
   return SWIG_OK;
 }
 
-
-List *R::filterMemberList(List *class_member_types,
-                          List *class_member_other,
-                          String *R_MEMBER, bool equal) {
+List *R::filterMemberList(List *class_member_types, List *class_member_other, String *R_MEMBER, bool equal) {
   // filters class_member_other based on whether corresponding elements of
   // class_member_function_types are equal or notequal to R_MEMBER
   List *CM = NewList();
   Iterator ftype, other;
 
-  for (ftype = First(class_member_types), other = First(class_member_other);
-       ftype.item;
-       ftype=Next(ftype), other=Next(other)) {
+  for (ftype = First(class_member_types), other = First(class_member_other); ftype.item; ftype = Next(ftype), other = Next(other)) {
     // verbose, clean up later if the overall structure works
     if (equal) {
       if (ftype.item == R_MEMBER) {
@@ -878,7 +855,7 @@ List *R::filterMemberList(List *class_member_types,
   return CM;
 }
 
-# if 0
+#if 0
 // not called
 /* -------------------------------------------------------------
  * We may need to do more.... so this is left as a
@@ -990,9 +967,7 @@ int R::OutputClassMemberTable(Hash *tb, File *out) {
  * out - the stream where we write the code.
  * --------------------------------------------------------------*/
 
-int R::OutputMemberReferenceMethod(String *className, int isSet,
-                                   List *memberList, List *nameList,
-                                   List *typeList, File *out) {
+int R::OutputMemberReferenceMethod(String *className, int isSet, List *memberList, List *nameList, List *typeList, File *out) {
   int numMems = Len(memberList), j;
   int varaccessor = 0;
   if (numMems == 0)
@@ -1008,7 +983,7 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
 
   Node *itemList = NewHash();
   bool has_prev = false;
-  for(j = 0; j < numMems; j++) {
+  for (j = 0; j < numMems; j++) {
     String *item = Getitem(memberList, j);
     String *dup = Getitem(nameList, j);
     String *setgetmethod = Getitem(typeList, j);
@@ -1044,7 +1019,7 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
   if (!isSet && varaccessor > 0) {
     Printf(f->code, "%svaccessors = c(", tab8);
     bool first = true;
-    for(j = 0; j < numMems; j++) {
+    for (j = 0; j < numMems; j++) {
       String *item = Getitem(memberList, j);
       String *setgetmethod = Getitem(typeList, j);
 
@@ -1057,21 +1032,15 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
     Printf(f->code, ");\n");
   }
 
-  Printv(f->code, ";", tab8,
-         "idx = pmatch(name, names(accessorFuns));\n",
-         tab8,
-         "if(is.na(idx)) \n",
-         tab8, tab4, NIL);
-  Printf(f->code, "return(callNextMethod(x, name%s));\n",
-         isSet ? ", value" : "");
+  Printv(f->code, ";", tab8, "idx = pmatch(name, names(accessorFuns));\n", tab8, "if(is.na(idx)) \n", tab8, tab4, NIL);
+  Printf(f->code, "return(callNextMethod(x, name%s));\n", isSet ? ", value" : "");
   Printv(f->code, tab8, "f = accessorFuns[[idx]];\n", NIL);
-  if(isSet) {
+  if (isSet) {
     Printv(f->code, tab8, "f(x, value);\n", NIL);
-    Printv(f->code, tab8, "x;\n", NIL); // make certain to return the S value.
+    Printv(f->code, tab8, "x;\n", NIL);  // make certain to return the S value.
   } else {
     if (varaccessor) {
-      Printv(f->code, tab8,
-             "if (is.na(match(name, vaccessors))) function(...){f(x, ...)} else f(x);\n", NIL);
+      Printv(f->code, tab8, "if (is.na(match(name, vaccessors))) function(...){f(x, ...)} else f(x);\n", NIL);
     } else {
       Printv(f->code, tab8, "function(...){f(x, ...)};\n", NIL);
     }
@@ -1080,15 +1049,12 @@ int R::OutputMemberReferenceMethod(String *className, int isSet,
 
   String *classname_str = SwigType_namestr(className);
   Printf(out, "# Start of accessor method for %s\n", classname_str);
-  Printf(out, "setMethod('$%s', '_p%s', ",
-         isSet ? "<-" : "",
-         getRClassName(className));
+  Printf(out, "setMethod('$%s', '_p%s', ", isSet ? "<-" : "", getRClassName(className));
   Wrapper_print(f, out);
   Printf(out, ");\n");
 
-  if(isSet) {
-    Printf(out, "setMethod('[[<-', c('_p%s', 'character'),",
-           getRClassName(className));
+  if (isSet) {
+    Printf(out, "setMethod('[[<-', c('_p%s', 'character'),", getRClassName(className));
     Insert(f->code, 2, "name = i;\n");
     Printf(attr->code, "%s", f->code);
     Wrapper_print(attr, out);
@@ -1125,7 +1091,7 @@ int R::enumDeclaration(Node *n) {
     // create mangled name for the enum
     // This will have content if the %nspace feature is set on
     // the input file
-    String *nspace = Getattr(n, "sym:nspace"); // NSpace/getNSpace() only works during Language::enumDeclaration call
+    String *nspace = Getattr(n, "sym:nspace");  // NSpace/getNSpace() only works during Language::enumDeclaration call
     String *ename;
 
     String *name = Getattr(n, "name");
@@ -1153,7 +1119,7 @@ int R::enumDeclaration(Node *n) {
 }
 
 /* -------------------------------------------------------------
-* --------------------------------------------------------------*/
+ * --------------------------------------------------------------*/
 
 int R::enumvalueDeclaration(Node *n) {
   if (getCurrentClass() && (cplus_mode != PUBLIC)) {
@@ -1188,7 +1154,8 @@ int R::enumvalueDeclaration(Node *n) {
     }
   } else {
     String *numval = Getattr(n, "enumnumval");
-    if (numval) Setattr(n, "enumvalue", numval);
+    if (numval)
+      Setattr(n, "enumvalue", numval);
   }
 
   if (GetFlag(parent, "scopedenum")) {
@@ -1222,7 +1189,6 @@ int R::enumvalueDeclaration(Node *n) {
   return SWIG_OK;
 }
 
-
 /* -------------------------------------------------------------
  * Create accessor functions for variables.
  * Does not create equivalent wrappers for enumerations,
@@ -1235,15 +1201,14 @@ int R::variableWrapper(Node *n) {
     Printf(stdout, "variableWrapper %s\n", n);
   }
   processing_variable = 1;
-  Language::variableWrapper(n); // Force the emission of the _set and _get function wrappers.
+  Language::variableWrapper(n);  // Force the emission of the _set and _get function wrappers.
   processing_variable = 0;
-
 
   SwigType *ty = Getattr(n, "type");
   String *nodeType = nodeType(n);
   int addCopyParam = addCopyParameter(ty);
 
-  //XXX
+  // XXX
   processType(ty, n);
 
   if (nodeType && !Strcmp(nodeType, "enumitem")) {
@@ -1251,14 +1216,11 @@ int R::variableWrapper(Node *n) {
     if (debugMode) {
       Printf(stdout, "variableWrapper enum branch\n");
     }
-  } else if(!SwigType_isconst(ty)) {
+  } else if (!SwigType_isconst(ty)) {
     Wrapper *f = NewWrapper();
-    Printf(f->def, "%s = \nfunction(value%s)\n{\n",
-           name, addCopyParam ? ", .copy = FALSE" : "");
-    Printv(f->code, "if(missing(value)) {\n",
-           name, "_get(", addCopyParam ? ".copy" : "", ")\n}", NIL);
-    Printv(f->code, " else {\n",
-           name, "_set(value)\n}\n}", NIL);
+    Printf(f->def, "%s = \nfunction(value%s)\n{\n", name, addCopyParam ? ", .copy = FALSE" : "");
+    Printv(f->code, "if(missing(value)) {\n", name, "_get(", addCopyParam ? ".copy" : "", ")\n}", NIL);
+    Printv(f->code, " else {\n", name, "_set(value)\n}\n}", NIL);
 
     Wrapper_print(f, sfile);
     DelWrapper(f);
@@ -1276,8 +1238,7 @@ int R::variableWrapper(Node *n) {
  * to be replaced.
  * --------------------------------------------------------------*/
 
-void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
-                    String *methodSetGet) {
+void R::addAccessor(String *memberName, Wrapper *wrapper, String *name, String *methodSetGet) {
 
   if (!class_member_function_names) {
     class_member_function_names = NewList();
@@ -1301,46 +1262,45 @@ void R::addAccessor(String *memberName, Wrapper *wrapper, String *name,
 
 namespace {
 struct Overloaded {
-  Node      *n;          /* Node                               */
-  int        argc;       /* Argument count                     */
-  ParmList  *parms;      /* Parameters used for overload check */
-  int        error;      /* Ambiguity error                    */
+  Node *n;         /* Node                               */
+  int argc;        /* Argument count                     */
+  ParmList *parms; /* Parameters used for overload check */
+  int error;       /* Ambiguity error                    */
 };
-}
+}  // namespace
 
-List * R::Swig_overload_rank(Node *n,
-                             bool script_lang_wrapping) {
-  Overloaded  nodes[MAX_OVERLOAD];
-  int         nnodes = 0;
-  Node *o = Getattr(n,"sym:overloaded");
+List *R::Swig_overload_rank(Node *n, bool script_lang_wrapping) {
+  Overloaded nodes[MAX_OVERLOAD];
+  int nnodes = 0;
+  Node *o = Getattr(n, "sym:overloaded");
 
-
-  if (!o) return 0;
+  if (!o)
+    return 0;
 
   Node *c = o;
   while (c) {
-    if (Getattr(c,"error")) {
-      c = Getattr(c,"sym:nextSibling");
+    if (Getattr(c, "error")) {
+      c = Getattr(c, "sym:nextSibling");
       continue;
     }
     /* Make a list of all the declarations (methods) that are overloaded with
      * this one particular method name */
 
-    if (Getattr(c,"wrap:name")) {
+    if (Getattr(c, "wrap:name")) {
       nodes[nnodes].n = c;
-      nodes[nnodes].parms = Getattr(c,"wrap:parms");
+      nodes[nnodes].parms = Getattr(c, "wrap:parms");
       nodes[nnodes].argc = emit_num_required(nodes[nnodes].parms);
       nodes[nnodes].error = 0;
       nnodes++;
     }
-    c = Getattr(c,"sym:nextSibling");
+    c = Getattr(c, "sym:nextSibling");
   }
 
   /* Sort the declarations by required argument count */
   {
-    int i,j;
+    int i, j;
     for (i = 0; i < nnodes; i++) {
-      for (j = i+1; j < nnodes; j++) {
+      for (j = i + 1; j < nnodes; j++) {
         if (nodes[i].argc > nodes[j].argc) {
           Overloaded t = nodes[i];
           nodes[i] = nodes[j];
@@ -1352,98 +1312,106 @@ List * R::Swig_overload_rank(Node *n,
 
   /* Sort the declarations by argument types */
   {
-    int i,j;
-    for (i = 0; i < nnodes-1; i++) {
-      if (nodes[i].argc == nodes[i+1].argc) {
-        for (j = i+1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
+    int i, j;
+    for (i = 0; i < nnodes - 1; i++) {
+      if (nodes[i].argc == nodes[i + 1].argc) {
+        for (j = i + 1; (j < nnodes) && (nodes[j].argc == nodes[i].argc); j++) {
           Parm *p1 = nodes[i].parms;
           Parm *p2 = nodes[j].parms;
-          int   differ = 0;
-          int   num_checked = 0;
+          int differ = 0;
+          int num_checked = 0;
           while (p1 && p2 && (num_checked < nodes[i].argc)) {
             if (debugMode) {
-              Printf(stdout,"p1 = '%s', p2 = '%s'\n", Getattr(p1,"type"), Getattr(p2,"type"));
+              Printf(stdout, "p1 = '%s', p2 = '%s'\n", Getattr(p1, "type"), Getattr(p2, "type"));
             }
-            if (checkAttribute(p1,"tmap:in:numinputs","0")) {
-              p1 = Getattr(p1,"tmap:in:next");
+            if (checkAttribute(p1, "tmap:in:numinputs", "0")) {
+              p1 = Getattr(p1, "tmap:in:next");
               continue;
             }
-            if (checkAttribute(p2,"tmap:in:numinputs","0")) {
-              p2 = Getattr(p2,"tmap:in:next");
+            if (checkAttribute(p2, "tmap:in:numinputs", "0")) {
+              p2 = Getattr(p2, "tmap:in:next");
               continue;
             }
-            String *t1 = Getattr(p1,"tmap:typecheck:precedence");
-            String *t2 = Getattr(p2,"tmap:typecheck:precedence");
+            String *t1 = Getattr(p1, "tmap:typecheck:precedence");
+            String *t2 = Getattr(p2, "tmap:typecheck:precedence");
             if (debugMode) {
-              Printf(stdout,"t1 = '%s', t2 = '%s'\n", t1, t2);
+              Printf(stdout, "t1 = '%s', t2 = '%s'\n", t1, t2);
             }
             if ((!t1) && (!nodes[i].error)) {
-              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[i].n), Getline(nodes[i].n),
+              Swig_warning(WARN_TYPEMAP_TYPECHECK,
+                           Getfile(nodes[i].n),
+                           Getline(nodes[i].n),
                            "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-                           Swig_name_decl(nodes[i].n), SwigType_str(Getattr(p1, "type"), 0));
+                           Swig_name_decl(nodes[i].n),
+                           SwigType_str(Getattr(p1, "type"), 0));
               nodes[i].error = 1;
             } else if ((!t2) && (!nodes[j].error)) {
-              Swig_warning(WARN_TYPEMAP_TYPECHECK, Getfile(nodes[j].n), Getline(nodes[j].n),
+              Swig_warning(WARN_TYPEMAP_TYPECHECK,
+                           Getfile(nodes[j].n),
+                           Getline(nodes[j].n),
                            "Overloaded method %s not supported (incomplete type checking rule - no precedence level in typecheck typemap for '%s').\n",
-                           Swig_name_decl(nodes[j].n), SwigType_str(Getattr(p2, "type"), 0));
+                           Swig_name_decl(nodes[j].n),
+                           SwigType_str(Getattr(p2, "type"), 0));
               nodes[j].error = 1;
             }
             if (t1 && t2) {
               int t1v, t2v;
               t1v = atoi(Char(t1));
               t2v = atoi(Char(t2));
-              differ = t1v-t2v;
-            }
-            else if (!t1 && t2) differ = 1;
-            else if (t1 && !t2) differ = -1;
-            else if (!t1 && !t2) differ = -1;
+              differ = t1v - t2v;
+            } else if (!t1 && t2)
+              differ = 1;
+            else if (t1 && !t2)
+              differ = -1;
+            else if (!t1 && !t2)
+              differ = -1;
             num_checked++;
             if (differ > 0) {
               Overloaded t = nodes[i];
               nodes[i] = nodes[j];
               nodes[j] = t;
               break;
-            } else if ((differ == 0) && (Strcmp(t1,"0") == 0)) {
-              t1 = Getattr(p1,"ltype");
+            } else if ((differ == 0) && (Strcmp(t1, "0") == 0)) {
+              t1 = Getattr(p1, "ltype");
               if (!t1) {
-                t1 = SwigType_ltype(Getattr(p1,"type"));
-                if (Getattr(p1,"tmap:typecheck:SWIGTYPE")) {
+                t1 = SwigType_ltype(Getattr(p1, "type"));
+                if (Getattr(p1, "tmap:typecheck:SWIGTYPE")) {
                   SwigType_add_pointer(t1);
                 }
-                Setattr(p1,"ltype",t1);
+                Setattr(p1, "ltype", t1);
               }
-              t2 = Getattr(p2,"ltype");
+              t2 = Getattr(p2, "ltype");
               if (!t2) {
-                t2 = SwigType_ltype(Getattr(p2,"type"));
-                if (Getattr(p2,"tmap:typecheck:SWIGTYPE")) {
+                t2 = SwigType_ltype(Getattr(p2, "type"));
+                if (Getattr(p2, "tmap:typecheck:SWIGTYPE")) {
                   SwigType_add_pointer(t2);
                 }
-                Setattr(p2,"ltype",t2);
+                Setattr(p2, "ltype", t2);
               }
 
               /* Need subtype check here.  If t2 is a subtype of t1, then we need to change the
                  order */
 
-              if (SwigType_issubtype(t2,t1)) {
+              if (SwigType_issubtype(t2, t1)) {
                 Overloaded t = nodes[i];
                 nodes[i] = nodes[j];
                 nodes[j] = t;
               }
 
-              if (Strcmp(t1,t2) != 0) {
+              if (Strcmp(t1, t2) != 0) {
                 differ = 1;
                 break;
               }
             } else if (differ) {
               break;
             }
-            if (Getattr(p1,"tmap:in:next")) {
-              p1 = Getattr(p1,"tmap:in:next");
+            if (Getattr(p1, "tmap:in:next")) {
+              p1 = Getattr(p1, "tmap:in:next");
             } else {
               p1 = nextSibling(p1);
             }
-            if (Getattr(p2,"tmap:in:next")) {
-              p2 = Getattr(p2,"tmap:in:next");
+            if (Getattr(p2, "tmap:in:next")) {
+              p2 = Getattr(p2, "tmap:in:next");
             } else {
               p2 = nextSibling(p2);
             }
@@ -1473,16 +1441,15 @@ List * R::Swig_overload_rank(Node *n,
                   differ = 1;
                   if (!nodes[j].error) {
                     if (script_lang_wrapping) {
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n), "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
                     } else {
                       if (!Getattr(nodes[j].n, "overload:ignore")) {
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                        Swig_warning(
+                          WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
                       }
                     }
                   }
@@ -1491,16 +1458,15 @@ List * R::Swig_overload_rank(Node *n,
                   differ = 1;
                   if (!nodes[j].error) {
                     if (script_lang_wrapping) {
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                   "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                      Swig_warning(WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                   "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                      Swig_warning(
+                        WARN_LANG_OVERLOAD_CONST, Getfile(nodes[i].n), Getline(nodes[i].n), "using non-const method %s instead.\n", Swig_name_decl(nodes[i].n));
                     } else {
                       if (!Getattr(nodes[j].n, "overload:ignore")) {
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-                                     "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-                                     "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                        Swig_warning(
+                          WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                        Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
                       }
                     }
                   }
@@ -1514,16 +1480,17 @@ List * R::Swig_overload_rank(Node *n,
           if (!differ) {
             if (!nodes[j].error) {
               if (script_lang_wrapping) {
-                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[j].n), Getline(nodes[j].n),
-                             "Overloaded method %s effectively ignored,\n", Swig_name_decl(nodes[j].n));
-                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n),
-                             "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW,
+                             Getfile(nodes[j].n),
+                             Getline(nodes[j].n),
+                             "Overloaded method %s effectively ignored,\n",
+                             Swig_name_decl(nodes[j].n));
+                Swig_warning(WARN_LANG_OVERLOAD_SHADOW, Getfile(nodes[i].n), Getline(nodes[i].n), "as it is shadowed by %s.\n", Swig_name_decl(nodes[i].n));
               } else {
                 if (!Getattr(nodes[j].n, "overload:ignore")) {
-                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n),
-                               "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
-                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n),
-                               "using %s instead.\n", Swig_name_decl(nodes[i].n));
+                  Swig_warning(
+                    WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[j].n), Getline(nodes[j].n), "Overloaded method %s ignored,\n", Swig_name_decl(nodes[j].n));
+                  Swig_warning(WARN_LANG_OVERLOAD_IGNORED, Getfile(nodes[i].n), Getline(nodes[i].n), "using %s instead.\n", Swig_name_decl(nodes[i].n));
                 }
               }
               nodes[j].error = 1;
@@ -1539,7 +1506,7 @@ List * R::Swig_overload_rank(Node *n,
     for (i = 0; i < nnodes; i++) {
       if (nodes[i].error)
         Setattr(nodes[i].n, "overload:ignore", "1");
-      Append(result,nodes[i].n);
+      Append(result, nodes[i].n);
     }
   }
   return result;
@@ -1556,28 +1523,23 @@ void R::dispatchFunction(Node *n) {
   if (constructor)
     Replace(sfname, "new_", "", DOH_REPLACE_FIRST);
 
-  Printf(f->def,
-         "`%s` <- function(...) {", sfname);
+  Printf(f->def, "`%s` <- function(...) {", sfname);
   if (debugMode) {
     Swig_print_node(n);
   }
   List *dispatch = Swig_overload_rank(n, true);
-  int   nfunc = Len(dispatch);
-  Printv(f->code,
-         "argtypes <- mapply(class, list(...));\n",
-         "argv <- list(...);\n",
-         "argc <- length(argtypes);\n",
-         "f <- NULL;\n", NIL);
+  int nfunc = Len(dispatch);
+  Printv(f->code, "argtypes <- mapply(class, list(...));\n", "argv <- list(...);\n", "argc <- length(argtypes);\n", "f <- NULL;\n", NIL);
 
   Printf(f->code, "# dispatch functions %d\n", nfunc);
   int cur_args = -1;
   bool first_compare = true;
-  for (int i=0; i < nfunc; i++) {
-    Node *ni = Getitem(dispatch,i);
-    Parm *pi = Getattr(ni,"wrap:parms");
+  for (int i = 0; i < nfunc; i++) {
+    Node *ni = Getitem(dispatch, i);
+    Parm *pi = Getattr(ni, "wrap:parms");
     int num_arguments = emit_num_arguments(pi);
 
-    String *overname = Getattr(ni,"sym:overname");
+    String *overname = Getattr(ni, "sym:overname");
     if (cur_args != num_arguments) {
       if (cur_args != -1) {
         Printv(f->code, "} else ", NIL);
@@ -1595,7 +1557,7 @@ void R::dispatchFunction(Node *n) {
         first_compare = false;
       }
       Printv(f->code, "if (", NIL);
-      for (p = pi, j = 0 ; j < num_arguments ; j++) {
+      for (p = pi, j = 0; j < num_arguments; j++) {
         SwigType *pt = Getattr(p, "type");
         if (debugMode) {
           Swig_print_node(p);
@@ -1606,12 +1568,12 @@ void R::dispatchFunction(Node *n) {
         }
 
         /* Check if type have a %typemap(rtypecheck) */
-        String *tmcheck = Getattr(p,"tmap:rtypecheck");
+        String *tmcheck = Getattr(p, "tmap:rtypecheck");
         if (tmcheck) {
           tmcheck = Copy(tmcheck);
-          String *tmp_argtype = NewStringf("argtypes[%d]", j+1);
+          String *tmp_argtype = NewStringf("argtypes[%d]", j + 1);
           Replaceall(tmcheck, "$argtype", tmp_argtype);
-          String *tmp_arg = NewStringf("argv[[%d]]", j+1);
+          String *tmp_arg = NewStringf("argv[[%d]]", j + 1);
           Replaceall(tmcheck, "$arg", tmp_arg);
           replaceRClass(tmcheck, pt);
           if (debugMode) {
@@ -1638,10 +1600,12 @@ void R::dispatchFunction(Node *n) {
   if (cur_args != -1) {
     Printf(f->code, "};\n");
   }
-  Printf(f->code, "if (is.null(f)) {\n"
-      "stop(\"cannot find overloaded function for %s with argtypes (\","
-      "toString(argtypes),\")\");\n"
-      "}", sfname);
+  Printf(f->code,
+         "if (is.null(f)) {\n"
+         "stop(\"cannot find overloaded function for %s with argtypes (\","
+         "toString(argtypes),\")\");\n"
+         "}",
+         sfname);
   Printv(f->code, ";\nf(...)", NIL);
   Printv(f->code, ";\n}", NIL);
   Wrapper_print(f, sfile);
@@ -1659,8 +1623,7 @@ int R::functionWrapper(Node *n) {
   String *returntype = Getattr(n, "type");
 
   if (debugMode) {
-    Printf(stdout,
-           "<functionWrapper> %s %s %s\n", fname, iname, returntype);
+    Printf(stdout, "<functionWrapper> %s %s %s\n", fname, iname, returntype);
   }
   String *overname = 0;
   String *nodeType = Getattr(n, "nodeType");
@@ -1672,27 +1635,23 @@ int R::functionWrapper(Node *n) {
   if (constructor)
     Replace(sfname, "new_", "", DOH_REPLACE_FIRST);
 
-  if (Getattr(n,"sym:overloaded")) {
-    overname = Getattr(n,"sym:overname");
+  if (Getattr(n, "sym:overloaded")) {
+    overname = Getattr(n, "sym:overname");
     Append(sfname, overname);
   }
 
   if (debugMode)
-    Printf(stdout,
-           "<functionWrapper> processing parameters\n");
-
+    Printf(stdout, "<functionWrapper> processing parameters\n");
 
   ParmList *l = Getattr(n, "parms");
   Parm *p;
   String *tm;
 
   p = l;
-  while(p) {
+  while (p) {
     SwigType *resultType = Getattr(p, "type");
-    if (expandTypedef(resultType) &&
-        SwigType_istypedef(resultType)) {
-      SwigType *resolved =
-        SwigType_typedef_resolve_all(resultType);
+    if (expandTypedef(resultType) && SwigType_istypedef(resultType)) {
+      SwigType *resolved = SwigType_typedef_resolve_all(resultType);
       if (expandTypedef(resolved)) {
         if (debugMode) {
           Printf(stdout, "Setting type: %s\n", resolved);
@@ -1715,13 +1674,12 @@ int R::functionWrapper(Node *n) {
   }
   if (debugMode)
     Printf(stdout, "<functionWrapper> unresolved_return_type %s\n", unresolved_return_type);
-  if(processing_member_access_function) {
+  if (processing_member_access_function) {
     if (debugMode)
       Printf(stdout, "<functionWrapper memberAccess> '%s' '%s' '%s' '%s'\n", fname, iname, member_name, class_name);
 
-    if(opaqueClassDeclaration)
+    if (opaqueClassDeclaration)
       return SWIG_OK;
-
 
     /* Add the name of this member to a list for this class_name.
        We will dump all these at the end. */
@@ -1731,7 +1689,7 @@ int R::functionWrapper(Node *n) {
     String *tmp = NewString(isSet ? Swig_name_set(NSPACE_TODO, class_name) : Swig_name_get(NSPACE_TODO, class_name));
 
     List *memList = Getattr(ClassMemberTable, tmp);
-    if(!memList) {
+    if (!memList) {
       memList = NewList();
       Append(memList, class_name);
       Setattr(ClassMemberTable, tmp, memList);
@@ -1746,9 +1704,9 @@ int R::functionWrapper(Node *n) {
 
   String *wname = Swig_name_wrapper(iname);
 
-  if(overname)
+  if (overname)
     Append(wname, overname);
-  Setattr(n,"wrap:name", wname);
+  Setattr(n, "wrap:name", wname);
 
   Wrapper *f = NewWrapper();
   Wrapper *sfun = NewWrapper();
@@ -1762,7 +1720,7 @@ int R::functionWrapper(Node *n) {
   SwigType *rtype = Getattr(n, "type");
   int addCopyParam = 0;
 
-  if(!isVoidReturnType)
+  if (!isVoidReturnType)
     addCopyParam = addCopyParameter(rtype);
 
   if (debugMode)
@@ -1773,7 +1731,7 @@ int R::functionWrapper(Node *n) {
   Printf(sfun->def, "# Start of %s\n", iname);
   Printv(sfun->def, "\n`", sfname, "` = function(", NIL);
 
-  if(outputNamespaceInfo) {//XXX Need to be a little more discriminating
+  if (outputNamespaceInfo) {  // XXX Need to be a little more discriminating
     if (constructor) {
       String *niname = Copy(iname);
       Replace(niname, "new_", "", DOH_REPLACE_FIRST);
@@ -1790,8 +1748,8 @@ int R::functionWrapper(Node *n) {
   Swig_typemap_attach_parms("rtypecheck", l, f);
 
   emit_parameter_variables(l, f);
-  emit_attach_parmmaps(l,f);
-  Setattr(n,"wrap:parms",l);
+  emit_attach_parmmaps(l, f);
+  Setattr(n, "wrap:parms", l);
 
   nargs = emit_num_arguments(l);
 
@@ -1801,13 +1759,12 @@ int R::functionWrapper(Node *n) {
 
   String *sargs = NewString("");
 
-
   String *s_inputTypes = NewString("");
   String *s_inputMap = NewString("");
   bool inFirstArg = true;
   bool inFirstType = true;
   Parm *curP;
-  for (p =l, i = 0 ; i < nargs ; i++) {
+  for (p = l, i = 0; i < nargs; i++) {
 
     while (checkAttribute(p, "tmap:in:numinputs", "0")) {
       p = Getattr(p, "tmap:in:next");
@@ -1817,7 +1774,7 @@ int R::functionWrapper(Node *n) {
     int nargs = -1;
     String *funcptr_name = processType(tt, p, &nargs);
 
-    String *name = makeParameterName(n, p, i+1, false);
+    String *name = makeParameterName(n, p, i + 1, false);
     String *lname = Getattr(p, "lname");
 
     if (name) {
@@ -1839,12 +1796,12 @@ int R::functionWrapper(Node *n) {
       Insert(name, 0, "s_");
     }
 
-    if(processing_variable) {
+    if (processing_variable) {
       name = Copy(name);
       Insert(name, 0, "s_");
     }
 
-    if(!Strcmp(name, fname)) {
+    if (!Strcmp(name, fname)) {
       name = Copy(name);
       Insert(name, 0, "s_");
     }
@@ -1852,29 +1809,56 @@ int R::functionWrapper(Node *n) {
     Printf(sargs, "%s, ", name);
 
     String *tm;
-    if((tm = Getattr(p, "tmap:scoercein"))) {
+    if ((tm = Getattr(p, "tmap:scoercein"))) {
       Replaceall(tm, "$input", name);
       replaceRClass(tm, Getattr(p, "type"));
 
-      if(funcptr_name) {
-        //XXX need to get this to return non-zero
-        if(nargs == -1)
+      if (funcptr_name) {
+        // XXX need to get this to return non-zero
+        if (nargs == -1)
           nargs = getFunctionPointerNumArgs(p, tt);
 
         String *snargs = NewStringf("%d", nargs);
-        Printv(sfun->code, "if(is.function(", name, ")) {", "\n",
-               "assert('...' %in% names(formals(", name,
-               ")) || length(formals(", name, ")) >= ", snargs, ");\n} ", NIL);
+        Printv(sfun->code,
+               "if(is.function(",
+               name,
+               ")) {",
+               "\n",
+               "assert('...' %in% names(formals(",
+               name,
+               ")) || length(formals(",
+               name,
+               ")) >= ",
+               snargs,
+               ");\n} ",
+               NIL);
         Delete(snargs);
 
-        Printv(sfun->code, "else {\n",
-               "if(is.character(", name, ")) {\n",
-               name, " = getNativeSymbolInfo(", name, ");",
+        Printv(sfun->code,
+               "else {\n",
+               "if(is.character(",
+               name,
+               ")) {\n",
+               name,
+               " = getNativeSymbolInfo(",
+               name,
+               ");",
                "\n};\n",
-               "if(is(", name, ", \"NativeSymbolInfo\")) {\n",
-               name, " = ", name, "$address", ";\n};\n",
-               "if(is(", name, ", \"ExternalReference\")) {\n",
-               name, " = ", name, "@ref;\n}\n",
+               "if(is(",
+               name,
+               ", \"NativeSymbolInfo\")) {\n",
+               name,
+               " = ",
+               name,
+               "$address",
+               ";\n};\n",
+               "if(is(",
+               name,
+               ", \"ExternalReference\")) {\n",
+               name,
+               " = ",
+               name,
+               "@ref;\n}\n",
                "}; \n",
                NIL);
       } else {
@@ -1884,62 +1868,57 @@ int R::functionWrapper(Node *n) {
 
     Printv(sfun->def, inFirstArg ? "" : ", ", name, NIL);
 
-    if ((tm = Getattr(p,"tmap:scheck"))) {
+    if ((tm = Getattr(p, "tmap:scheck"))) {
 
-      Replaceall(tm,"$input", name);
+      Replaceall(tm, "$input", name);
       replaceRClass(tm, Getattr(p, "type"));
-      Printf(sfun->code,"%s\n",tm);
+      Printf(sfun->code, "%s\n", tm);
     }
 
-
-
     curP = p;
-    if ((tm = Getattr(p,"tmap:in"))) {
+    if ((tm = Getattr(p, "tmap:in"))) {
 
-      Replaceall(tm,"$input", name);
+      Replaceall(tm, "$input", name);
 
-      if (Getattr(p,"wrap:disown") || (Getattr(p,"tmap:in:disown"))) {
-        Replaceall(tm,"$disown","SWIG_POINTER_DISOWN");
+      if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
+        Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
       } else {
-        Replaceall(tm,"$disown","0");
+        Replaceall(tm, "$disown", "0");
       }
 
-      if(funcptr_name) {
+      if (funcptr_name) {
         /* have us a function pointer */
         Printf(f->code, "if(TYPEOF(%s) != CLOSXP) {\n", name);
-        Replaceall(tm,"$R_class", "");
+        Replaceall(tm, "$R_class", "");
       } else {
         replaceRClass(tm, Getattr(p, "type"));
       }
 
-
-      Printf(f->code,"%s\n",tm);
-      if(funcptr_name)
-        Printf(f->code, "} else {\n%s = %s;\nR_SWIG_pushCallbackFunctionData(%s, NULL);\n}\n",
-               lname, funcptr_name, name);
+      Printf(f->code, "%s\n", tm);
+      if (funcptr_name)
+        Printf(f->code, "} else {\n%s = %s;\nR_SWIG_pushCallbackFunctionData(%s, NULL);\n}\n", lname, funcptr_name, name);
       Printv(f->def, inFirstArg ? "" : ", ", "SEXP ", name, NIL);
       if (Len(name) != 0)
         inFirstArg = false;
-      p = Getattr(p,"tmap:in:next");
+      p = Getattr(p, "tmap:in:next");
 
     } else {
       p = nextSibling(p);
     }
 
-
     tm = Swig_typemap_lookup("rtype", curP, "", 0);
-    if(tm) {
+    if (tm) {
       replaceRClass(tm, Getattr(curP, "type"));
     }
     Printf(s_inputTypes, "%s'%s'", inFirstType ? "" : ", ", tm);
     Printf(s_inputMap, "%s%s='%s'", inFirstType ? "" : ", ", name, tm);
     inFirstType = false;
 
-    if(funcptr_name)
+    if (funcptr_name)
       Delete(funcptr_name);
   } /* end of looping over parameters. */
 
-  if(addCopyParam) {
+  if (addCopyParam) {
     Printf(sfun->def, "%s.copy = FALSE", nargs > 0 ? ", " : "");
     Printf(f->def, "%sSEXP s_swig_copy", nargs > 0 ? ", " : "");
 
@@ -1952,10 +1931,10 @@ int R::functionWrapper(Node *n) {
   // get run.  To avoid this happening, we wrap almost everything in the
   // function in a block, and end that right before Rf_error() at which
   // point those destructors will get called.
-  if (CPlusPlus) Append(f->def, "{\n");
+  if (CPlusPlus)
+    Append(f->def, "{\n");
 
   Printv(sfun->def, ")\n{\n", NIL);
-
 
   /* Insert cleanup code */
   String *cleanup = NewString("");
@@ -1972,20 +1951,19 @@ int R::functionWrapper(Node *n) {
 
   String *outargs = NewString("");
   int numOutArgs = isVoidReturnType ? -1 : 0;
-  for(p = l, i = 0; p; i++) {
-    if((tm = Getattr(p, "tmap:argout"))) {
+  for (p = l, i = 0; p; i++) {
+    if ((tm = Getattr(p, "tmap:argout"))) {
       //       String *lname =  Getattr(p, "lname");
       numOutArgs++;
       String *pos = NewStringf("%d", numOutArgs);
-      Replaceall(tm,"$result", "r_ans");
-      Replaceall(tm,"$n", pos); // The position into which to store the answer.
-      Replaceall(tm,"$arg", Getattr(p, "emit:input"));
-      Replaceall(tm,"$input", Getattr(p, "emit:input"));
-      Replaceall(tm,"$owner", "0");
-
+      Replaceall(tm, "$result", "r_ans");
+      Replaceall(tm, "$n", pos);  // The position into which to store the answer.
+      Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+      Replaceall(tm, "$input", Getattr(p, "emit:input"));
+      Replaceall(tm, "$owner", "0");
 
       Printf(outargs, "%s\n", tm);
-      p = Getattr(p,"tmap:argout:next");
+      p = Getattr(p, "tmap:argout:next");
     } else
       p = nextSibling(p);
   }
@@ -1996,50 +1974,43 @@ int R::functionWrapper(Node *n) {
   if ((tm = Swig_typemap_lookup_out("out", n, Swig_cresult_name(), f, actioncode))) {
     SwigType *retType = Getattr(n, "type");
 
-    Replaceall(tm,"$1", Swig_cresult_name());
-    Replaceall(tm,"$result", "r_ans");
-    if (debugMode){
+    Replaceall(tm, "$1", Swig_cresult_name());
+    Replaceall(tm, "$result", "r_ans");
+    if (debugMode) {
       Printf(stdout, "Calling replace D: %s, %s, %s\n", retType, n, tm);
     }
     replaceRClass(tm, retType);
 
-    if (GetFlag(n,"feature:new")) {
+    if (GetFlag(n, "feature:new")) {
       Replaceall(tm, "$owner", "SWIG_POINTER_OWN");
     } else {
-      Replaceall(tm,"$owner", "0");
+      Replaceall(tm, "$owner", "0");
     }
 
     Printf(f->code, "%s\n", tm);
 
   } else {
-    Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number,
-                 "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), fname);
+    Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(returntype, 0), fname);
   }
 
-
-  if(Len(outargs)) {
+  if (Len(outargs)) {
     Wrapper_add_local(f, "R_OutputValues", "SEXP R_OutputValues");
 
     String *tmp = NewString("");
-    if(!isVoidReturnType)
+    if (!isVoidReturnType)
       Printf(tmp, "Rf_protect(r_ans);\n");
 
-    Printf(tmp, "Rf_protect(R_OutputValues = Rf_allocVector(VECSXP,%d));\nr_nprotect += %d;\n",
-           numOutArgs + !isVoidReturnType,
-           isVoidReturnType ? 1 : 2);
+    Printf(tmp, "Rf_protect(R_OutputValues = Rf_allocVector(VECSXP,%d));\nr_nprotect += %d;\n", numOutArgs + !isVoidReturnType, isVoidReturnType ? 1 : 2);
 
-    if(!isVoidReturnType)
+    if (!isVoidReturnType)
       Printf(tmp, "SET_VECTOR_ELT(R_OutputValues, 0, r_ans);\n");
     Printf(tmp, "r_ans = R_OutputValues;\n");
 
     Insert(outargs, 0, tmp);
     Delete(tmp);
 
-
-
     Printv(f->code, outargs, NIL);
     Delete(outargs);
-
   }
 
   /* Output cleanup code */
@@ -2065,7 +2036,7 @@ int R::functionWrapper(Node *n) {
 
   /*If the user gave us something to convert the result in  */
   if ((tm = Swig_typemap_lookup("scoerceout", n, Swig_cresult_name(), sfun))) {
-    Replaceall(tm,"$result","ans");
+    Replaceall(tm, "$result", "ans");
     if (debugMode) {
       Printf(stdout, "Calling replace B: %s, %s, %s\n", Getattr(n, "type"), Getattr(n, "sym:name"), getNSpace());
     }
@@ -2073,20 +2044,16 @@ int R::functionWrapper(Node *n) {
     Chop(tm);
   }
 
-
-  Printv(sfun->code, ";", (Len(tm) ? "ans = " : ""), ".Call('", wname,
-         "', ", sargs, "PACKAGE='", Rpackage, "');\n", NIL);
-  if(Len(tm))
-    {
-      Printf(sfun->code, "%s\n\n", tm);
-      if (constructor)
-        {
-          String *finalizer = NewString(iname);
-          Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
-          Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s);\n", finalizer);
-        }
-      Printf(sfun->code, "ans\n");
+  Printv(sfun->code, ";", (Len(tm) ? "ans = " : ""), ".Call('", wname, "', ", sargs, "PACKAGE='", Rpackage, "');\n", NIL);
+  if (Len(tm)) {
+    Printf(sfun->code, "%s\n\n", tm);
+    if (constructor) {
+      String *finalizer = NewString(iname);
+      Replace(finalizer, "new_", "", DOH_REPLACE_FIRST);
+      Printf(sfun->code, "reg.finalizer(ans@ref, delete_%s);\n", finalizer);
     }
+    Printf(sfun->code, "ans\n");
+  }
 
   if (destructor)
     Printv(f->code, "R_ClearExternalPtr(self);\n", NIL);
@@ -2098,7 +2065,8 @@ int R::functionWrapper(Node *n) {
   if (need_cleanup) {
     Printv(f->code, cleanup, NIL);
   }
-  if (CPlusPlus) Append(f->code, "}\n");
+  if (CPlusPlus)
+    Append(f->code, "}\n");
   Printv(f->code, "  Rf_error(\"%s %s\", SWIG_ErrorType(SWIG_lasterror_code), SWIG_lasterror_msg);\n", NIL);
   Printv(f->code, "  return R_NilValue;\n", NIL);
   Delete(cleanup);
@@ -2110,14 +2078,14 @@ int R::functionWrapper(Node *n) {
   Replaceall(f->code, "$isvoid", isvoid ? "1" : "0");
 
   /* Substitute the function name */
-  Replaceall(f->code,"$symname",iname);
+  Replaceall(f->code, "$symname", iname);
 
   Wrapper_print(f, f_wrapper);
   Wrapper_print(sfun, sfile);
 
   Printf(sfun->code, "\n# End of %s\n", iname);
   tm = Swig_typemap_lookup("rtype", n, "", 0);
-  if(tm) {
+  if (tm) {
     SwigType *retType = Getattr(n, "type");
     if (debugMode) {
       Printf(stdout, "Calling replace C: %s\n", Copy(retType));
@@ -2125,15 +2093,11 @@ int R::functionWrapper(Node *n) {
     replaceRClass(tm, retType);
   }
 
-  Printv(sfile, "attr(`", sfname, "`, 'returnType') = '",
-         isVoidReturnType ? "void" : (tm ? tm : ""),
-         "'\n", NIL);
+  Printv(sfile, "attr(`", sfname, "`, 'returnType') = '", isVoidReturnType ? "void" : (tm ? tm : ""), "'\n", NIL);
 
-  if(nargs > 0)
-    Printv(sfile, "attr(`", sfname, "`, \"inputTypes\") = c(",
-           s_inputTypes, ")\n", NIL);
-  Printv(sfile, "class(`", sfname, "`) = c(\"SWIGFunction\", class('",
-         sfname, "'))\n\n", NIL);
+  if (nargs > 0)
+    Printv(sfile, "attr(`", sfname, "`, \"inputTypes\") = c(", s_inputTypes, ")\n", NIL);
+  Printv(sfile, "class(`", sfname, "`) = c(\"SWIGFunction\", class('", sfname, "'))\n\n", NIL);
 
   if (memoryProfile) {
     Printv(sfile, "memory.profile()\n", NIL);
@@ -2144,14 +2108,12 @@ int R::functionWrapper(Node *n) {
 
   // Printv(sfile, "setMethod('", name, "', '", name, "', ", iname, ")\n\n\n");
 
-
-
   /* If we are dealing with a method in an C++ class, then
      add the name of the R function and its definition.
      XXX need to figure out how to store the Wrapper if possible in the hash/list.
      Would like to be able to do this so that we can potentially insert
   */
-  if(processing_member_access_function || processing_class_member_function) {
+  if (processing_member_access_function || processing_class_member_function) {
     String *method_type = R_MEMBER_NORMAL;
     if (GetFlag(n, "memberset")) {
       method_type = R_MEMBER_SET;
@@ -2161,12 +2123,11 @@ int R::functionWrapper(Node *n) {
     addAccessor(member_name, sfun, iname, method_type);
   }
 
-  if (Getattr(n, "sym:overloaded") &&
-      !Getattr(n, "sym:nextSibling")) {
+  if (Getattr(n, "sym:overloaded") && !Getattr(n, "sym:nextSibling")) {
     dispatchFunction(n);
   }
 
-  addRegistrationRoutine(wname, addCopyParam ? nargs +1 : nargs);
+  addRegistrationRoutine(wname, addCopyParam ? nargs + 1 : nargs);
 
   DelWrapper(f);
   DelWrapper(sfun);
@@ -2181,7 +2142,7 @@ int R::functionWrapper(Node *n) {
  * ---------------------------------------------------------------------- */
 
 int R::constantWrapper(Node *n) {
-  (void) n;
+  (void)n;
   // TODO
   return SWIG_OK;
 }
@@ -2197,11 +2158,10 @@ int R::constantWrapper(Node *n) {
  * --------------------------------------------------------------*/
 
 int R::addRegistrationRoutine(String *rname, int nargs) {
-  if(!registrationTable)
+  if (!registrationTable)
     registrationTable = NewHash();
 
-  String *el =
-    NewStringf("{\"%s\", (DL_FUNC) &%s, %d}", rname, rname, nargs);
+  String *el = NewStringf("{\"%s\", (DL_FUNC) &%s, %d}", rname, rname, nargs);
 
   Setattr(registrationTable, rname, el);
 
@@ -2216,36 +2176,36 @@ int R::addRegistrationRoutine(String *rname, int nargs) {
 
 int R::outputRegistrationRoutines(File *out) {
   int i, n;
-  if(!registrationTable)
+  if (!registrationTable)
     return 0;
-  if(inCPlusMode)
+  if (inCPlusMode)
     Printf(out, "#ifdef __cplusplus\nextern \"C\" {\n#endif\n\n");
 
   Printf(out, "#include <R_ext/Rdynload.h>\n\n");
-  if(inCPlusMode)
+  if (inCPlusMode)
     Printf(out, "#ifdef __cplusplus\n}\n#endif\n\n");
 
   Printf(out, "SWIGINTERN R_CallMethodDef CallEntries[] = {\n");
 
   List *keys = Keys(registrationTable);
   n = Len(keys);
-  for(i = 0; i < n; i++)
+  for (i = 0; i < n; i++)
     Printf(out, "   %s,\n", Getattr(registrationTable, Getitem(keys, i)));
 
   Printf(out, "   {NULL, NULL, 0}\n};\n\n");
 
-  if(!noInitializationCode) {
+  if (!noInitializationCode) {
     if (inCPlusMode)
       Printv(out, "extern \"C\" ", NIL);
     { /* R allows pckage names to have '.' in the name, which is not allowed in C++ var names
          we simply replace all occurrences of '.' with '_' to construct the var name */
-      String * Rpackage_sane = Copy(Rpackage);
+      String *Rpackage_sane = Copy(Rpackage);
       Replace(Rpackage_sane, ".", "_", DOH_REPLACE_ANY);
       Printf(out, "SWIGEXPORT void R_init_%s(DllInfo *dll) {\n", Rpackage_sane);
       Delete(Rpackage_sane);
     }
     Printf(out, "%sR_registerRoutines(dll, NULL, CallEntries, NULL, NULL);\n", tab4);
-    if(Len(s_init_routine)) {
+    if (Len(s_init_routine)) {
       Printf(out, "\n%s\n", s_init_routine);
     }
     Printf(out, "}\n");
@@ -2254,15 +2214,13 @@ int R::outputRegistrationRoutines(File *out) {
   return n;
 }
 
-
-
 /* -------------------------------------------------------------
  * Process a struct, union or class declaration in the source code,
  * or an anonymous typedef struct
  * --------------------------------------------------------------*/
 
-//XXX What do we need to do here -
-// Define an S4 class to refer to this.
+// XXX What do we need to do here -
+//  Define an S4 class to refer to this.
 
 void R::registerClass(Node *n) {
   String *name = Getattr(n, "name");
@@ -2270,20 +2228,18 @@ void R::registerClass(Node *n) {
   if (debugMode)
     Swig_print_node(n);
   String *sname = NewStringf("_p%s", SwigType_manglestr(name));
-  if(!Getattr(SClassDefs, sname)) {
+  if (!Getattr(SClassDefs, sname)) {
     Setattr(SClassDefs, sname, sname);
     String *base;
 
     if (CPlusPlus && (Strcmp(nodeType(n), "class") == 0)) {
       base = NewString("");
       List *l = Getattr(n, "bases");
-      if(Len(l)) {
+      if (Len(l)) {
         Printf(base, "c(");
-        for(int i = 0; i < Len(l); i++) {
+        for (int i = 0; i < Len(l); i++) {
           registerClass(Getitem(l, i));
-          Printf(base, "'_p%s'%s",
-                 SwigType_manglestr(Getattr(Getitem(l, i), "name")),
-                 i < Len(l)-1 ? ", " : "");
+          Printf(base, "'_p%s'%s", SwigType_manglestr(Getattr(Getitem(l, i), "name")), i < Len(l) - 1 ? ", " : "");
         }
         Printf(base, ")");
       } else {
@@ -2306,11 +2262,10 @@ int R::classDeclaration(Node *n) {
     Swig_print_node(n);
   registerClass(n);
 
-
   /* If we have a typedef union { ... } U, then we never get to see the typedef
      via a regular call to typedefHandler. Instead, */
-  if(Getattr(n, "unnamed") && Getattr(n, "storage") && Strcmp(Getattr(n, "storage"), "typedef") == 0
-     && Getattr(n, "tdname") && Strcmp(Getattr(n, "tdname"), name) == 0) {
+  if (Getattr(n, "unnamed") && Getattr(n, "storage") && Strcmp(Getattr(n, "storage"), "typedef") == 0 && Getattr(n, "tdname") &&
+      Strcmp(Getattr(n, "tdname"), name) == 0) {
     if (debugMode)
       Printf(stdout, "Typedef in the class declaration for %s\n", name);
     //        typedefHandler(n);
@@ -2318,32 +2273,25 @@ int R::classDeclaration(Node *n) {
 
   bool opaque = GetFlag(n, "feature:opaque") ? true : false;
 
-  if(opaque)
+  if (opaque)
     opaqueClassDeclaration = name;
 
   int status = Language::classDeclaration(n);
 
   opaqueClassDeclaration = NULL;
 
-
   if (class_member_function_types) {
 
     // collect the "set" methods
-    List *class_set_membernames   = filterMemberList(class_member_function_types,
-                                                     class_member_function_membernames, R_MEMBER_SET, true);
-    List *class_set_functionnames = filterMemberList(class_member_function_types,
-                                                     class_member_function_names, R_MEMBER_SET, true);
+    List *class_set_membernames = filterMemberList(class_member_function_types, class_member_function_membernames, R_MEMBER_SET, true);
+    List *class_set_functionnames = filterMemberList(class_member_function_types, class_member_function_names, R_MEMBER_SET, true);
     // this one isn't used - collecting to keep code simpler
-    List *class_set_functiontypes = filterMemberList(class_member_function_types,
-                                                     class_member_function_types, R_MEMBER_SET, true);
+    List *class_set_functiontypes = filterMemberList(class_member_function_types, class_member_function_types, R_MEMBER_SET, true);
 
     // collect the others
-    List *class_other_membernames   = filterMemberList(class_member_function_types,
-                                                       class_member_function_membernames, R_MEMBER_SET, false);
-    List *class_other_functionnames = filterMemberList(class_member_function_types,
-                                                       class_member_function_names, R_MEMBER_SET, false);
-    List *class_other_functiontypes = filterMemberList(class_member_function_types,
-                                                       class_member_function_types, R_MEMBER_SET, false);
+    List *class_other_membernames = filterMemberList(class_member_function_types, class_member_function_membernames, R_MEMBER_SET, false);
+    List *class_other_functionnames = filterMemberList(class_member_function_types, class_member_function_names, R_MEMBER_SET, false);
+    List *class_other_functiontypes = filterMemberList(class_member_function_types, class_member_function_types, R_MEMBER_SET, false);
 
     if (Len(class_other_membernames) > 0) {
       OutputMemberReferenceMethod(name, 0, class_other_membernames, class_other_functionnames, class_other_functiontypes, sfile);
@@ -2357,7 +2305,7 @@ int R::classDeclaration(Node *n) {
     Delete(class_other_membernames);
     Delete(class_other_functionnames);
     Delete(class_other_functiontypes);
- }
+  }
 
   if (class_member_function_types) {
     Delete(class_member_function_types);
@@ -2368,18 +2316,16 @@ int R::classDeclaration(Node *n) {
     class_member_function_membernames = NULL;
     Delete(class_member_function_wrappernames);
     class_member_function_wrappernames = NULL;
-   }
+  }
   if (Getattr(n, "has_destructor")) {
     Printf(sfile, "setMethod('delete', '_p%s', function(obj) {delete%s(obj)})\n", getRClassName(name), getRClassName(name));
-
   }
-  if(!opaque && !Strcmp(kind, "struct") && copyStruct) {
+  if (!opaque && !Strcmp(kind, "struct") && copyStruct) {
 
-    String *def =
-      NewStringf("setClass(\"%s\",\n%srepresentation(\n", name, tab4);
+    String *def = NewStringf("setClass(\"%s\",\n%srepresentation(\n", name, tab4);
     bool firstItem = true;
 
-    for(Node *c = firstChild(n); c; ) {
+    for (Node *c = firstChild(n); c;) {
       String *elName;
       String *tp;
 
@@ -2395,7 +2341,7 @@ int R::classDeclaration(Node *n) {
         continue;
       }
       tp = Swig_typemap_lookup("rtype", c, "", 0);
-      if(!tp) {
+      if (!tp) {
         c = nextSibling(c);
         continue;
       }
@@ -2403,8 +2349,7 @@ int R::classDeclaration(Node *n) {
         c = nextSibling(c);
         continue;
       }
-      if (Strcmp(tp, "character") &&
-          Strstr(Getattr(c, "decl"), "p.")) {
+      if (Strcmp(tp, "character") && Strstr(Getattr(c, "decl"), "p.")) {
         c = nextSibling(c);
         continue;
       }
@@ -2413,9 +2358,8 @@ int R::classDeclaration(Node *n) {
         Printf(def, ",\n");
       }
       //            else
-      //XXX How can we tell if this is already done.
+      // XXX How can we tell if this is already done.
       //              SwigType_push(elType, elDecl);
-
 
       // returns ""  tp = processType(elType, c, NULL);
       //            Printf(stdout, "<classDeclaration> elType %p\n", elType);
@@ -2439,8 +2383,6 @@ int R::classDeclaration(Node *n) {
   return status;
 }
 
-
-
 /* -------------------------------------------------------------
  * Create the C routines that copy an S object of the class given
  * by the given struct definition in Node *n to the C value
@@ -2462,7 +2404,7 @@ int R::generateCopyRoutines(Node *n) {
   String *kind = Getattr(n, "kind");
   String *type;
 
-  if(Len(tdname)) {
+  if (Len(tdname)) {
     type = Copy(tdname);
   } else {
     type = NewStringf("%s %s", kind, name);
@@ -2473,14 +2415,12 @@ int R::generateCopyRoutines(Node *n) {
   if (debugMode)
     Printf(stdout, "generateCopyRoutines:  name = %s, %s\n", name, type);
 
-  Printf(copyToR->def, "CopyToR%s = function(value, obj = new(\"%s\"))\n{\n",
-         mangledName, name);
-  Printf(copyToC->def, "CopyToC%s = function(value, obj)\n{\n",
-         mangledName);
+  Printf(copyToR->def, "CopyToR%s = function(value, obj = new(\"%s\"))\n{\n", mangledName, name);
+  Printf(copyToC->def, "CopyToC%s = function(value, obj)\n{\n", mangledName);
 
   Node *c = firstChild(n);
 
-  for(; c; c = nextSibling(c)) {
+  for (; c; c = nextSibling(c)) {
     String *elName = Getattr(c, "name");
     if (!Len(elName)) {
       continue;
@@ -2491,17 +2431,15 @@ int R::generateCopyRoutines(Node *n) {
     }
 
     String *tp = Swig_typemap_lookup("rtype", c, "", 0);
-    if(!tp) {
+    if (!tp) {
       continue;
     }
     if (Strstr(tp, "R_class")) {
       continue;
     }
-    if (Strcmp(tp, "character") &&
-        Strstr(Getattr(c, "decl"), "p.")) {
+    if (Strcmp(tp, "character") && Strstr(Getattr(c, "decl"), "p.")) {
       continue;
     }
-
 
     /* The S functions to get and set the member value. */
     String *elNameT = replaceInitialDash(elName);
@@ -2510,26 +2448,24 @@ int R::generateCopyRoutines(Node *n) {
     Delete(elNameT);
   }
   Printf(copyToR->code, "obj;\n}\n\n");
-  String *rclassName = getRClassNameCopyStruct(type, 0); // without the Ref.
+  String *rclassName = getRClassNameCopyStruct(type, 0);  // without the Ref.
   Printf(sfile, "# Start definition of copy functions & methods for %s\n", rclassName);
 
   Wrapper_print(copyToR, sfile);
   Printf(copyToC->code, "obj\n}\n\n");
   Wrapper_print(copyToC, sfile);
 
-
   Printf(sfile, "# Start definition of copy methods for %s\n", rclassName);
-  Printf(sfile, "setMethod('copyToR', '_p%s', CopyToR%s);\n", mangledName,
-         mangledName);
-  Printf(sfile, "setMethod('copyToC', '%s', CopyToC%s);\n\n", rclassName,
-         mangledName);
+  Printf(sfile, "setMethod('copyToR', '_p%s', CopyToR%s);\n", mangledName, mangledName);
+  Printf(sfile, "setMethod('copyToC', '%s', CopyToC%s);\n\n", rclassName, mangledName);
 
   Printf(sfile, "# End definition of copy methods for %s\n", rclassName);
   Printf(sfile, "# End definition of copy functions & methods for %s\n", rclassName);
 
   String *m = NewStringf("%sCopyToR", name);
   addNamespaceMethod(m);
-  char *tt = Char(m);  tt[Len(m)-1] = 'C';
+  char *tt = Char(m);
+  tt[Len(m) - 1] = 'C';
   addNamespaceMethod(m);
   Delete(m);
   Delete(rclassName);
@@ -2539,8 +2475,6 @@ int R::generateCopyRoutines(Node *n) {
 
   return SWIG_OK;
 }
-
-
 
 /* -------------------------------------------------------------
  *  Called when there is a typedef to be invoked.
@@ -2558,20 +2492,17 @@ int R::typedefHandler(Node *n) {
 
   processType(tp, n);
 
-  if(Strncmp(type, "struct ", 7) == 0) {
+  if (Strncmp(type, "struct ", 7) == 0) {
     String *name = Getattr(n, "name");
     char *trueName = Char(type);
     trueName += 7;
     if (debugMode)
       Printf(stdout, "<typedefHandler> Defining S class %s\n", trueName);
-    Printf(s_classes, "setClass('_p%s', contains = 'ExternalReference')\n",
-           SwigType_manglestr(name));
+    Printf(s_classes, "setClass('_p%s', contains = 'ExternalReference')\n", SwigType_manglestr(name));
   }
 
   return Language::typedefHandler(n);
 }
-
-
 
 /* --------------------------------------------------------------
  * Called when processing a field in a "class", i.e. struct, union or
@@ -2584,14 +2515,13 @@ int R::membervariableHandler(Node *n) {
   SwigType *t = Getattr(n, "type");
   processType(t, n, NULL);
   processing_member_access_function = 1;
-  member_name = Getattr(n,"sym:name");
+  member_name = Getattr(n, "sym:name");
   if (debugMode)
-    Printf(stdout, "<membervariableHandler> name = %s, sym:name = %s\n",
-           Getattr(n, "name"), member_name);
+    Printf(stdout, "<membervariableHandler> name = %s, sym:name = %s\n", Getattr(n, "name"), member_name);
 
   int status(Language::membervariableHandler(n));
 
-  if(!opaqueClassDeclaration && debugMode)
+  if (!opaqueClassDeclaration && debugMode)
     Printf(stdout, "<membervariableHandler> %s %s\n", Getattr(n, "name"), Getattr(n, "type"));
 
   processing_member_access_function = 0;
@@ -2600,11 +2530,10 @@ int R::membervariableHandler(Node *n) {
   return status;
 }
 
-
 /*
   This doesn't seem to get used so leave it out for the moment.
 */
-String * R::runtimeCode() {
+String *R::runtimeCode() {
   String *s = Swig_include_sys("rrun.swg");
   if (!s) {
     Printf(stdout, "*** Unable to open 'rrun.swg'\n");
@@ -2622,7 +2551,6 @@ void R::replaceSpecialVariables(String *method, String *tm, Parm *parm) {
   SwigType *type = Getattr(parm, "type");
   replaceRClass(tm, type);
 }
-
 
 /* -----------------------------------------------------------------------
  * Called when SWIG wants to initialize this
@@ -2648,35 +2576,35 @@ void R::main(int argc, char *argv[]) {
   this->Argc = argc;
   this->Argv = argv;
 
-  allow_overloading();// can we support this?
+  allow_overloading();  // can we support this?
 
-  for(int i = 0; i < argc; i++) {
-    if(strcmp(argv[i], "-package") == 0) {
+  for (int i = 0; i < argc; i++) {
+    if (strcmp(argv[i], "-package") == 0) {
       Swig_mark_arg(i);
       i++;
       Swig_mark_arg(i);
       Rpackage = argv[i];
-    } else if(strcmp(argv[i], "-dll") == 0) {
+    } else if (strcmp(argv[i], "-dll") == 0) {
       Swig_mark_arg(i);
       i++;
       Swig_mark_arg(i);
       DllName = argv[i];
-    } else if(strcmp(argv[i], "-help") == 0) {
+    } else if (strcmp(argv[i], "-help") == 0) {
       showUsage();
-    } else if(strcmp(argv[i], "-namespace") == 0) {
+    } else if (strcmp(argv[i], "-namespace") == 0) {
       outputNamespaceInfo = true;
       Swig_mark_arg(i);
-    } else if(!strcmp(argv[i], "-no-init-code")) {
+    } else if (!strcmp(argv[i], "-no-init-code")) {
       noInitializationCode = true;
       Swig_mark_arg(i);
-    } else if(!strcmp(argv[i], "-c++")) {
+    } else if (!strcmp(argv[i], "-c++")) {
       inCPlusMode = true;
       Swig_mark_arg(i);
       Printf(s_classes, "setClass('C++Reference', contains = 'ExternalReference')\n");
-    } else if(!strcmp(argv[i], "-debug")) {
+    } else if (!strcmp(argv[i], "-debug")) {
       debugMode = true;
       Swig_mark_arg(i);
-    } else if (!strcmp(argv[i],"-copystruct")) {
+    } else if (!strcmp(argv[i], "-copystruct")) {
       copyStruct = true;
       Swig_mark_arg(i);
     } else if (!strcmp(argv[i], "-nocopystruct")) {
@@ -2710,7 +2638,6 @@ void R::main(int argc, char *argv[]) {
       Swig_file_debug_set();
     }
     /// copyToR copyToC functions.
-
   }
 }
 
@@ -2718,13 +2645,12 @@ void R::main(int argc, char *argv[]) {
  * Could make this work for String or File and then just store the resulting string
  * rather than the collection of arguments and argc.
  * ----------------------------------------------------------------------- */
-int R::outputCommandLineArguments(File *out)
-{
-  if(Argc < 1 || !Argv || !Argv[0])
+int R::outputCommandLineArguments(File *out) {
+  if (Argc < 1 || !Argv || !Argv[0])
     return -1;
 
   Printf(out, "\n##   Generated via the command line invocation:\n##\t");
-  for(int i = 0; i < Argc ; i++) {
+  for (int i = 0; i < Argc; i++) {
     Printf(out, " %s", Argv[i]);
   }
   Printf(out, "\n\n\n");
@@ -2732,68 +2658,56 @@ int R::outputCommandLineArguments(File *out)
   return Argc;
 }
 
-
-
 /* How SWIG instantiates an object from this module.
    See swigmain.cxx */
-extern "C"
-Language *swig_r(void) {
+extern "C" Language *swig_r(void) {
   return new R();
 }
-
-
-
 
 /* -----------------------------------------------------------------------
  * Needs to be reworked.
  *----------------------------------------------------------------------- */
-String * R::processType(SwigType *t, Node *n, int *nargs) {
-  //XXX Need to handle typedefs, e.g.
-  //  a type which is a typedef to a function pointer.
+String *R::processType(SwigType *t, Node *n, int *nargs) {
+  // XXX Need to handle typedefs, e.g.
+  //   a type which is a typedef to a function pointer.
 
   SwigType *tmp = Getattr(n, "tdname");
   if (debugMode)
     Printf(stdout, "processType %s (tdname = %s)(SwigType = %s)\n", Getattr(n, "name"), tmp, Copy(t));
 
   SwigType *td = t;
-  if (expandTypedef(t) &&
-      SwigType_istypedef(t)) {
-    SwigType *resolved =
-      SwigType_typedef_resolve_all(t);
+  if (expandTypedef(t) && SwigType_istypedef(t)) {
+    SwigType *resolved = SwigType_typedef_resolve_all(t);
     if (expandTypedef(resolved)) {
       td = Copy(resolved);
     }
   }
 
-  if(!td) {
+  if (!td) {
     int count = 0;
     String *b = getRTypeName(t, &count);
-    if(count && b && !Getattr(SClassDefs, b)) {
+    if (count && b && !Getattr(SClassDefs, b)) {
       if (debugMode)
-        Printf(stdout, "<processType> Defining class %s\n",  b);
+        Printf(stdout, "<processType> Defining class %s\n", b);
 
       Printf(s_classes, "setClass('%s', contains = 'ExternalReference')\n", b);
       Setattr(SClassDefs, b, b);
     }
-
   }
 
-
-  if(td)
+  if (td)
     t = td;
 
-  if(SwigType_isfunctionpointer(t)) {
+  if (SwigType_isfunctionpointer(t)) {
     if (debugMode)
-      Printf(stdout,
-             "<processType> Defining pointer handler %s\n",  t);
+      Printf(stdout, "<processType> Defining pointer handler %s\n", t);
 
     String *tmp = createFunctionPointerHandler(t, n, nargs);
     return tmp;
   }
 
-    return NULL;
+  return NULL;
 }
-
 
 /* -----------------------------------------------------------------------
  * enumValue()
@@ -2841,7 +2755,7 @@ String *R::enumValue(Node *n) {
   value = Swig_name_wrapper(value);
   Replace(value, "_wrap", "R_swig", DOH_REPLACE_FIRST);
 
-  String *valuecall=NewString("");
+  String *valuecall = NewString("");
   Printv(valuecall, ".Call('", value, "',FALSE, PACKAGE='", Rpackage, "')", NIL);
   Delete(value);
   return valuecall;

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -15,7 +15,7 @@
 #include "cparse.h"
 #include <ctype.h>
 #include <string.h>
-#include <limits.h>             /* for INT_MAX */
+#include <limits.h> /* for INT_MAX */
 
 #define SWIG_PROTECTED_TARGET_METHODS 1
 
@@ -24,9 +24,9 @@ private:
   String *temp;
 
 public:
-  String *name;                 /* class name (renamed) */
-  String *cname;                /* original C class/struct name */
-  String *mname;                /* Mangled name */
+  String *name;  /* class name (renamed) */
+  String *cname; /* original C class/struct name */
+  String *mname; /* Mangled name */
 
   /**
    * The C variable name used in the SWIG-generated wrapper code to refer to
@@ -48,11 +48,10 @@ public:
   String *prefix;
   String *init;
 
-
   int constructor_defined;
   int destructor_defined;
 
-   RClass() {
+  RClass() {
     temp = NewString("");
     name = NewString("");
     cname = NewString("");
@@ -115,20 +114,9 @@ public:
   }
 };
 
-
 /* flags for the make_autodoc function */
 namespace {
-enum autodoc_t {
-  AUTODOC_CLASS,
-  AUTODOC_CTOR,
-  AUTODOC_DTOR,
-  AUTODOC_STATICFUNC,
-  AUTODOC_FUNC,
-  AUTODOC_METHOD,
-  AUTODOC_GETTER,
-  AUTODOC_SETTER,
-  AUTODOC_NONE
-};
+enum autodoc_t { AUTODOC_CLASS, AUTODOC_CTOR, AUTODOC_DTOR, AUTODOC_STATICFUNC, AUTODOC_FUNC, AUTODOC_METHOD, AUTODOC_GETTER, AUTODOC_SETTER, AUTODOC_NONE };
 }
 
 static const char *usage = "\
@@ -141,22 +129,19 @@ Ruby Options (available with -ruby)\n\
      -prefix <name>  - Set a prefix <name> to be prepended to all names\n\
 \n";
 
-
-#define RCLASS(hash, name) (RClass*)(Getattr(hash, name) ? Data(Getattr(hash, name)) : 0)
+#define RCLASS(hash, name)            (RClass *)(Getattr(hash, name) ? Data(Getattr(hash, name)) : 0)
 #define SET_RCLASS(hash, name, klass) Setattr(hash, name, NewVoid(klass, 0))
 
-
-class RUBY:public Language {
+class RUBY : public Language {
 private:
-
   String *module;
   String *modvar;
   String *feature;
   String *prefix;
   int current;
-  Hash *classes;                /* key=cname val=RClass */
-  RClass *klass;                /* Currently processing class */
-  Hash *special_methods;        /* Python style special method name table */
+  Hash *classes;         /* key=cname val=RClass */
+  RClass *klass;         /* Currently processing class */
+  Hash *special_methods; /* Python style special method name table */
 
   File *f_directors;
   File *f_directors_h;
@@ -173,40 +158,30 @@ private:
   bool multipleInheritance;
 
   // Wrap modes
-  enum WrapperMode {
-    NO_CPP,
-    MEMBER_FUNC,
-    CONSTRUCTOR_ALLOCATE,
-    CONSTRUCTOR_INITIALIZE,
-    DESTRUCTOR,
-    MEMBER_VAR,
-    CLASS_CONST,
-    STATIC_FUNC,
-    STATIC_VAR
-  };
+  enum WrapperMode { NO_CPP, MEMBER_FUNC, CONSTRUCTOR_ALLOCATE, CONSTRUCTOR_INITIALIZE, DESTRUCTOR, MEMBER_VAR, CLASS_CONST, STATIC_FUNC, STATIC_VAR };
 
   /* ------------------------------------------------------------
    * autodoc level declarations
    * ------------------------------------------------------------ */
 
   enum autodoc_l {
-    NO_AUTODOC = -2,            // no autodoc
-    STRING_AUTODOC = -1,        // use provided string
-    NAMES_AUTODOC = 0,          // only parameter names
-    TYPES_AUTODOC = 1,          // parameter names and types
-    EXTEND_AUTODOC = 2,         // extended documentation and parameter names
-    EXTEND_TYPES_AUTODOC = 3    // extended documentation and parameter types + names
+    NO_AUTODOC = -2,          // no autodoc
+    STRING_AUTODOC = -1,      // use provided string
+    NAMES_AUTODOC = 0,        // only parameter names
+    TYPES_AUTODOC = 1,        // parameter names and types
+    EXTEND_AUTODOC = 2,       // extended documentation and parameter names
+    EXTEND_TYPES_AUTODOC = 3  // extended documentation and parameter types + names
   };
 
   autodoc_t last_mode;
-  String*   last_autodoc;
+  String *last_autodoc;
 
   autodoc_l autodoc_level(String *autodoc) {
     autodoc_l dlevel = NO_AUTODOC;
     char *c = Char(autodoc);
     if (c) {
       if (isdigit(c[0])) {
-        dlevel = (autodoc_l) atoi(c);
+        dlevel = (autodoc_l)atoi(c);
       } else {
         if (strcmp(c, "extended") == 0) {
           dlevel = EXTEND_AUTODOC;
@@ -217,8 +192,6 @@ private:
     }
     return dlevel;
   }
-
-
 
   /* ------------------------------------------------------------
    * have_docstring()
@@ -262,11 +235,11 @@ private:
     if (have_auto || have_ds)
       doc = NewString("/*");
 
-    if (have_auto && have_ds) { // Both autodoc and docstring are present
+    if (have_auto && have_ds) {  // Both autodoc and docstring are present
       Printv(doc, "\n", autodoc, "\n", str, "\n", NIL);
-    } else if (!have_auto && have_ds) { // only docstring
+    } else if (!have_auto && have_ds) {  // only docstring
       Printv(doc, str, NIL);
-    } else if (have_auto && !have_ds) { // only autodoc
+    } else if (have_auto && !have_ds) {  // only autodoc
       Printv(doc, "\n", autodoc, "\n", NIL);
     } else {
       doc = NewString("");
@@ -293,7 +266,7 @@ private:
    *   The "lname" attribute in each parameter in plist will be contain a parameter name
    * ----------------------------------------------------------------------------- */
 
-  void addMissingParameterNames(Node* n, ParmList *plist, int arg_offset) {
+  void addMissingParameterNames(Node *n, ParmList *plist, int arg_offset) {
     Parm *p = plist;
     int i = arg_offset;
     while (p) {
@@ -322,13 +295,13 @@ private:
     int arg_num = is_wrapping_class() ? 1 : 0;
     const int maxwidth = 80;
 
-    addMissingParameterNames(n, plist, arg_num); // for $1_name substitutions done in Swig_typemap_attach_parms
+    addMissingParameterNames(n, plist, arg_num);  // for $1_name substitutions done in Swig_typemap_attach_parms
 
     Swig_typemap_attach_parms("in", plist, 0);
     Swig_typemap_attach_parms("doc", plist, 0);
 
     if (Strcmp(ParmList_protostr(plist), "void") == 0) {
-      //No parameters actually
+      // No parameters actually
       return doc;
     }
 
@@ -367,11 +340,11 @@ private:
         break;
 
       // Skip the 'self' parameter which in ruby is implicit
-      if ( Cmp(name, "self") == 0 )
+      if (Cmp(name, "self") == 0)
         continue;
 
       // Make __p parameters just p (as used in STL)
-      Replace( name, "__", "", DOH_REPLACE_FIRST );
+      Replace(name, "__", "", DOH_REPLACE_FIRST);
 
       if (Len(doc)) {
         // add a comma to the previous one if any
@@ -439,10 +412,10 @@ private:
       n = Getattr(n, "sym:previousSibling");
 
     Node *pn = Swig_methodclass(n);
-    String* super_names = NewString("");
-    String* class_name = Getattr(pn, "sym:name") ;
+    String *super_names = NewString("");
+    String *class_name = Getattr(pn, "sym:name");
 
-    if ( !class_name ) {
+    if (!class_name) {
       class_name = NewString("");
     } else {
       class_name = Copy(class_name);
@@ -454,23 +427,23 @@ private:
         }
 
         int count = 0;
-        for ( ;base.item; ++count) {
-          if ( count ) Append(super_names, ", ");
+        for (; base.item; ++count) {
+          if (count)
+            Append(super_names, ", ");
           String *basename = Getattr(base.item, "sym:name");
 
-          String* basenamestr = NewString(basename);
-          Node* parent = parentNode(base.item);
-          while (parent)
-          {
-            String *parent_name = Copy( Getattr(parent, "sym:name") );
-            if ( !parent_name ) {
-              Node* mod = Getattr(parent, "module");
-              if ( mod )
-                parent_name = Copy( Getattr(mod, "name") );
-              if ( parent_name )
+          String *basenamestr = NewString(basename);
+          Node *parent = parentNode(base.item);
+          while (parent) {
+            String *parent_name = Copy(Getattr(parent, "sym:name"));
+            if (!parent_name) {
+              Node *mod = Getattr(parent, "module");
+              if (mod)
+                parent_name = Copy(Getattr(mod, "name"));
+              if (parent_name)
                 (Char(parent_name))[0] = (char)toupper((Char(parent_name))[0]);
             }
-            if ( parent_name ) {
+            if (parent_name) {
               Insert(basenamestr, 0, "::");
               Insert(basenamestr, 0, parent_name);
               Delete(parent_name);
@@ -478,35 +451,33 @@ private:
             parent = parentNode(parent);
           }
 
-          Append(super_names, basenamestr );
+          Append(super_names, basenamestr);
           Delete(basenamestr);
           base = Next(base);
         }
       }
     }
-    String* full_name;
-    if ( module ) {
+    String *full_name;
+    if (module) {
       full_name = NewString(module);
       if (Len(class_name) > 0)
         Append(full_name, "::");
-    }
-    else
+    } else
       full_name = NewString("");
     Append(full_name, class_name);
 
-    String* symname = Getattr(n, "sym:name");
-    if ( Getattr( special_methods, symname ) )
-      symname = Getattr( special_methods, symname );
+    String *symname = Getattr(n, "sym:name");
+    if (Getattr(special_methods, symname))
+      symname = Getattr(special_methods, symname);
 
-    String* methodName = NewString(full_name);
+    String *methodName = NewString(full_name);
     Append(methodName, symname);
-
 
     // Each overloaded function will try to get documented,
     // so we keep the name of the last overloaded function and its type.
     // Documenting just from functionWrapper() is not possible as
     // sym:name has already been changed to include the class name
-    if ( last_mode == ad_type && Cmp(methodName, last_autodoc) == 0 ) {
+    if (last_mode == ad_type && Cmp(methodName, last_autodoc) == 0) {
       Delete(full_name);
       Delete(class_name);
       Delete(super_names);
@@ -514,15 +485,14 @@ private:
       return NewString("");
     }
 
-
-    last_mode    = ad_type;
+    last_mode = ad_type;
     last_autodoc = Copy(methodName);
 
     String *doc = NewString("");
     int counter = 0;
     bool skipAuto = false;
-    Node* on = n;
-    for ( ; n; ++counter ) {
+    Node *on = n;
+    for (; n; ++counter) {
       String *type_str = NULL;
       skipAuto = false;
       bool showTypes = false;
@@ -570,8 +540,8 @@ private:
         switch (ad_type) {
         case AUTODOC_CLASS:
           Printf(doc, "  Document-class: %s", full_name);
-          if ( Len(super_names) > 0 )
-            Printf( doc, " < %s", super_names);
+          if (Len(super_names) > 0)
+            Printf(doc, " < %s", super_names);
           Append(doc, "\n\n");
           break;
         case AUTODOC_CTOR:
@@ -599,33 +569,33 @@ private:
       }
 
       if (skipAuto) {
-        if ( counter == 0 ) Printf(doc, "  call-seq:\n");
-        switch( ad_type )
+        if (counter == 0)
+          Printf(doc, "  call-seq:\n");
+        switch (ad_type) {
+        case AUTODOC_STATICFUNC:
+        case AUTODOC_FUNC:
+        case AUTODOC_METHOD:
+        case AUTODOC_GETTER:
           {
-          case AUTODOC_STATICFUNC:
-          case AUTODOC_FUNC:
-          case AUTODOC_METHOD:
-          case AUTODOC_GETTER:
-            {
-              String *paramList = make_autodocParmList(n, showTypes);
-              if (Len(paramList))
-                Printf(doc, "    %s(%s)", symname, paramList);
-              else
-                Printf(doc, "    %s", symname);
-              if (type_str)
-                Printf(doc, " -> %s", type_str);
-              break;
-            }
-          case AUTODOC_SETTER:
-            {
-              Printf(doc, "    %s=(x)", symname);
-              if (type_str)
-                Printf(doc, " -> %s", type_str);
-              break;
-            }
-          default:
+            String *paramList = make_autodocParmList(n, showTypes);
+            if (Len(paramList))
+              Printf(doc, "    %s(%s)", symname, paramList);
+            else
+              Printf(doc, "    %s", symname);
+            if (type_str)
+              Printf(doc, " -> %s", type_str);
             break;
           }
+        case AUTODOC_SETTER:
+          {
+            Printf(doc, "    %s=(x)", symname);
+            if (type_str)
+              Printf(doc, " -> %s", type_str);
+            break;
+          }
+        default:
+          break;
+        }
       } else {
         switch (ad_type) {
         case AUTODOC_CLASS:
@@ -723,9 +693,8 @@ private:
       }
     }
 
-
     n = on;
-    while ( n ) {
+    while (n) {
       String *autodoc = Getattr(n, "feature:autodoc");
       autodoc_l dlevel = autodoc_level(autodoc);
 
@@ -737,7 +706,7 @@ private:
         break;
       case STRING_AUTODOC:
         extended = 2;
-        Replaceall( autodoc, "$class", class_name );
+        Replaceall(autodoc, "$class", class_name);
         Printv(doc, autodoc, ".", NIL);
         break;
       case EXTEND_AUTODOC:
@@ -746,14 +715,14 @@ private:
         break;
       }
 
-
       if (extended) {
         String *pdocs = Getattr(n, "feature:pdocs");
         if (pdocs) {
           Printv(doc, "\n\n", pdocs, NULL);
           break;
         }
-        if ( extended == 2 ) break;
+        if (extended == 2)
+          break;
       }
       n = Getattr(n, "sym:nextSibling");
     }
@@ -779,12 +748,12 @@ private:
       SwigType *resolved_type = SwigType_typedef_resolve_all(type);
       SwigType *unqualified_type = NIL;
       if (SwigType_isreference(resolved_type)) {
-          SwigType *t = Copy(resolved_type);
-          t = SwigType_del_reference(t);
-          unqualified_type = SwigType_strip_qualifiers(t);
-          Delete(t);
+        SwigType *t = Copy(resolved_type);
+        t = SwigType_del_reference(t);
+        unqualified_type = SwigType_strip_qualifiers(t);
+        Delete(t);
       } else {
-          unqualified_type = SwigType_strip_qualifiers(resolved_type);
+        unqualified_type = SwigType_strip_qualifiers(resolved_type);
       }
       if (Equal(unqualified_type, "bool")) {
         Delete(resolved_type);
@@ -805,7 +774,6 @@ private:
   }
 
 public:
-
   /* ---------------------------------------------------------------------
    * RUBY()
    *
@@ -834,15 +802,19 @@ public:
     multipleInheritance(false),
     last_mode(AUTODOC_NONE),
     last_autodoc(NewString("")) {
-      current = NO_CPP;
-      director_prot_ctor_code = NewString("");
-      Printv(director_prot_ctor_code,
-          "if ($comparison) { /* subclassed */\n",
-          "  $director_new\n",
-          "} else {\n", "  rb_raise(rb_eRuntimeError,\"accessing abstract class or protected constructor\");\n", "  return Qnil;\n", "}\n", NIL);
-      director_multiple_inheritance = 0;
-      directorLanguage();
-    }
+    current = NO_CPP;
+    director_prot_ctor_code = NewString("");
+    Printv(director_prot_ctor_code,
+           "if ($comparison) { /* subclassed */\n",
+           "  $director_new\n",
+           "} else {\n",
+           "  rb_raise(rb_eRuntimeError,\"accessing abstract class or protected constructor\");\n",
+           "  return Qnil;\n",
+           "}\n",
+           NIL);
+    director_multiple_inheritance = 0;
+    directorLanguage();
+  }
 
   /* ---------------------------------------------------------------------
    * main()
@@ -908,7 +880,7 @@ public:
 
     if (autorename) {
       /* Turn on the autorename mode */
-      Preprocessor_define((DOH *) "SWIG_RUBY_AUTORENAME", 0);
+      Preprocessor_define((DOH *)"SWIG_RUBY_AUTORENAME", 0);
     }
 
     /* Add a symbol to the parser for conditional compilation */
@@ -1027,7 +999,6 @@ public:
     }
 
     /* Set comparison with none for ConstructorToFunction */
-
 
     setSubclassInstanceCheck(NewStringf("strcmp(rb_obj_classname(self), classname) != 0"));
     // setSubclassInstanceCheck(NewString("CLASS_OF(self) != cFoo.klass"));
@@ -1150,8 +1121,8 @@ public:
       Printf(f_header, "static VALUE %s;\n", modvar);
 
     /* Start generating the initialization function */
-    String* docs = docstring(n, AUTODOC_CLASS);
-    Printf(f_init, "/*\n%s\n*/", docs );
+    String *docs = docstring(n, AUTODOC_CLASS);
+    Printf(f_init, "/*\n%s\n*/", docs);
     Printv(f_init, "\n", "#ifdef __cplusplus\n", "extern \"C\"\n", "#endif\n", "SWIGEXPORT void Init_", feature, "(void) {\n", "size_t i;\n", "\n", NIL);
 
     Printv(f_init, tab4, "SWIG_InitRuntime();\n", NIL);
@@ -1416,7 +1387,7 @@ public:
     case CLASS_CONST:
     case STATIC_VAR:
     default:
-      assert(false);            // Should not have gotten here for these types
+      assert(false);  // Should not have gotten here for these types
     }
 
     defineAliases(n, iname);
@@ -1511,7 +1482,7 @@ public:
         Printf(source, "argv[%d]", i - start);
       }
 
-      if (i >= (numreq)) {      /* Check if parsing an optional argument */
+      if (i >= (numreq)) { /* Check if parsing an optional argument */
         Printf(f->code, "    if (argc > %d) {\n", i - start);
       }
 
@@ -1532,8 +1503,8 @@ public:
     /* Finish argument marshalling */
     Printf(kwargs, " NULL }");
     if (allow_kwargs) {
-// kwarg support not implemented
-//      Printv(f->locals, tab4, "const char *kwnames[] = ", kwargs, ";\n", NIL);
+      // kwarg support not implemented
+      //      Printv(f->locals, tab4, "const char *kwnames[] = ", kwargs, ";\n", NIL);
     }
 
     /* Trailing varargs */
@@ -1750,12 +1721,11 @@ public:
       Printf(f->code, "{rb_raise(rb_eArgError, \"wrong # of arguments(%%d for %d)\",argc); SWIG_fail;}\n", numreq - start);
     } else {
 
-      if ( current == NO_CPP )
-        {
-          String* docs = docstring(n, AUTODOC_FUNC);
-          Printf(f_wrappers, "%s", docs);
-          Delete(docs);
-        }
+      if (current == NO_CPP) {
+        String *docs = docstring(n, AUTODOC_FUNC);
+        Printf(f_wrappers, "%s", docs);
+        Delete(docs);
+      }
 
       Printv(f->def, "SWIGINTERN VALUE\n", wname, "(int argc, VALUE *argv, VALUE self) {", NIL);
       if (!varargs) {
@@ -1916,20 +1886,18 @@ public:
       Delete(psmart);
     } else if (current == CONSTRUCTOR_INITIALIZE) {
       need_result = 1;
-    }
-    else
-      {
-        if ( need_result > 1 ) {
-          if ( SwigType_type(returntype) == T_VOID )
-            Printf(f->code, "vresult = rb_ary_new();\n");
-          else
-            {
-              Printf(f->code, "if (vresult == Qnil) vresult = rb_ary_new();\n");
-              Printf(f->code, "else vresult = SWIG_Ruby_AppendOutput( "
-                     "rb_ary_new(), vresult);\n");
-            }
+    } else {
+      if (need_result > 1) {
+        if (SwigType_type(returntype) == T_VOID)
+          Printf(f->code, "vresult = rb_ary_new();\n");
+        else {
+          Printf(f->code, "if (vresult == Qnil) vresult = rb_ary_new();\n");
+          Printf(f->code,
+                 "else vresult = SWIG_Ruby_AppendOutput( "
+                 "rb_ary_new(), vresult);\n");
         }
       }
+    }
 
     /* Dump argument output code; */
     Printv(f->code, outarg, NIL);
@@ -1939,7 +1907,6 @@ public:
     if (need_cleanup) {
       Printv(f->code, cleanup, NIL);
     }
-
 
     /* Look for any remaining cleanup.  This processes the %newobject directive */
     if (current != CONSTRUCTOR_ALLOCATE && GetFlag(n, "feature:new")) {
@@ -1964,7 +1931,6 @@ public:
         Printf(f->code, "%s\n", tm);
       }
     }
-
 
     /* Wrap things up (in a manner of speaking) */
     if (need_result) {
@@ -2079,13 +2045,11 @@ public:
     Replaceall(dispatch, "$args", "nargs, args, self");
     Printv(f->code, dispatch, "\n", NIL);
 
-
-
     // Generate prototype list, go to first node
     Node *sibl = n;
 
     while (Getattr(sibl, "sym:previousSibling"))
-      sibl = Getattr(sibl, "sym:previousSibling");      // go all the way up
+      sibl = Getattr(sibl, "sym:previousSibling");  // go all the way up
 
     // Constructors will be treated specially
     String *siblNodeType = Getattr(sibl, "nodeType");
@@ -2093,45 +2057,44 @@ public:
     const bool isMethod = (Equal(siblNodeType, "cdecl") && GetFlag(sibl, "ismember") && !isCtor);
 
     // Construct real method name
-    String* methodName = NewString("");
-    if ( isMethod ) {
+    String *methodName = NewString("");
+    if (isMethod) {
       // Sometimes a method node has no parent (SF#3034054).
       // This value is used in an exception message, so just skip the class
       // name in this case so at least we don't segfault.  This is probably
       // just working around a problem elsewhere though.
       Node *parent_node = parentNode(sibl);
       if (parent_node)
-        Printv( methodName, Getattr(parent_node,"sym:name"), ".", NIL );
+        Printv(methodName, Getattr(parent_node, "sym:name"), ".", NIL);
     }
-    Append( methodName, Getattr(sibl,"sym:name" ) );
-    if ( isCtor ) Append( methodName, ".new" );
+    Append(methodName, Getattr(sibl, "sym:name"));
+    if (isCtor)
+      Append(methodName, ".new");
 
     // Generate prototype list
     String *protoTypes = NewString("");
     do {
-      Append( protoTypes, "\n\"    ");
+      Append(protoTypes, "\n\"    ");
       if (!isCtor && !Equal(siblNodeType, "using")) {
         SwigType *type = SwigType_str(Getattr(sibl, "type"), NULL);
         Printv(protoTypes, type, " ", NIL);
         Delete(type);
       }
-      Printv(protoTypes, methodName, NIL );
-      Parm* p = Getattr(sibl, "wrap:parms");
-      if (p && (current == MEMBER_FUNC || current == MEMBER_VAR ||
-                ctor_director) )
-        p = nextSibling(p); // skip self
-      Append( protoTypes, "(" );
-      while(p)
-        {
-          Append( protoTypes, SwigType_str(Getattr(p,"type"), Getattr(p,"name")) );
-          if ( ( p = nextSibling(p)) ) Append(protoTypes, ", ");
-        }
-      Append( protoTypes, ")\\n\"" );
+      Printv(protoTypes, methodName, NIL);
+      Parm *p = Getattr(sibl, "wrap:parms");
+      if (p && (current == MEMBER_FUNC || current == MEMBER_VAR || ctor_director))
+        p = nextSibling(p);  // skip self
+      Append(protoTypes, "(");
+      while (p) {
+        Append(protoTypes, SwigType_str(Getattr(p, "type"), Getattr(p, "name")));
+        if ((p = nextSibling(p)))
+          Append(protoTypes, ", ");
+      }
+      Append(protoTypes, ")\\n\"");
     } while ((sibl = Getattr(sibl, "sym:nextSibling")));
 
     Append(f->code, "fail:\n");
-    Printf(f->code, "Ruby_Format_OverloadedError( argc, %d, \"%s\", %s);\n",
-           maxargs, methodName, protoTypes);
+    Printf(f->code, "Ruby_Format_OverloadedError( argc, %d, \"%s\", %s);\n", maxargs, methodName, protoTypes);
     Append(f->code, "\nreturn Qnil;\n");
 
     Delete(methodName);
@@ -2152,10 +2115,9 @@ public:
    * --------------------------------------------------------------------- */
 
   virtual int variableWrapper(Node *n) {
-    String* docs = docstring(n, AUTODOC_GETTER);
+    String *docs = docstring(n, AUTODOC_GETTER);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
-
 
     char *name = GetChar(n, "name");
     char *iname = GetChar(n, "sym:name");
@@ -2204,7 +2166,7 @@ public:
       setfname = NewString("(rb_gvar_setter_t *)NULL");
     } else {
       /* create setter */
-      String* docs = docstring(n, AUTODOC_SETTER);
+      String *docs = docstring(n, AUTODOC_SETTER);
       Printf(f_wrappers, "%s", docs);
       Delete(docs);
 
@@ -2277,7 +2239,6 @@ public:
     DelWrapper(getf);
     return SWIG_OK;
   }
-
 
   /* ---------------------------------------------------------------------
    * validate_const_name(char *name)
@@ -2451,8 +2412,12 @@ public:
             }
             String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
             String *baseclassname = SwigType_str(Getattr(base.item, "name"), 0);
-            Swig_warning(WARN_RUBY_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-                         "Warning for %s, base %s ignored. Multiple inheritance is not supported in Ruby.\n", proxyclassname, baseclassname);
+            Swig_warning(WARN_RUBY_MULTIPLE_INHERITANCE,
+                         Getfile(n),
+                         Getline(n),
+                         "Warning for %s, base %s ignored. Multiple inheritance is not supported in Ruby.\n",
+                         proxyclassname,
+                         baseclassname);
             base = Next(base);
           }
         }
@@ -2503,13 +2468,13 @@ public:
    * ---------------------------------------------------------------------- */
 
   virtual int classHandler(Node *n) {
-    String* docs = docstring(n, AUTODOC_CLASS);
+    String *docs = docstring(n, AUTODOC_CLASS);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
     String *name = Getattr(n, "name");
     String *symname = Getattr(n, "sym:name");
-    String *namestr = SwigType_namestr(name);   // does template expansion
+    String *namestr = SwigType_namestr(name);  // does template expansion
 
     klass = RCLASS(classes, Char(namestr));
     assert(klass != 0);
@@ -2525,8 +2490,7 @@ public:
     if (!useGlobalModule) {
       Printv(klass->init, klass->vname, " = rb_define_class_under(", modvar, ", \"", klass->name, "\", $super);\n", NIL);
     } else {
-      Printv(klass->init, klass->vname, " = rb_define_class(\"", klass->name,
-             "\", $super);\n", NIL);
+      Printv(klass->init, klass->vname, " = rb_define_class(\"", klass->name, "\", $super);\n", NIL);
     }
 
     if (multipleInheritance) {
@@ -2602,7 +2566,7 @@ public:
   virtual int memberfunctionHandler(Node *n) {
     current = MEMBER_FUNC;
 
-    String* docs = docstring(n, AUTODOC_METHOD);
+    String *docs = docstring(n, AUTODOC_METHOD);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
@@ -2630,7 +2594,11 @@ public:
     Printv(director_prot_ctor_code,
            "if ($comparison) { /* subclassed */\n",
            "  $director_new\n",
-           "} else {\n", "  rb_raise(rb_eNameError,\"accessing abstract class or protected constructor\");\n", "  return Qnil;\n", "}\n", NIL);
+           "} else {\n",
+           "  rb_raise(rb_eNameError,\"accessing abstract class or protected constructor\");\n",
+           "  return Qnil;\n",
+           "}\n",
+           NIL);
     Delete(director_ctor_code);
     director_ctor_code = NewString("");
     Printv(director_ctor_code, "if ($comparison) { /* subclassed */\n", "  $director_new\n", "} else {\n", "  $nondirector_new\n", "}\n", NIL);
@@ -2649,7 +2617,7 @@ public:
 
     Language::constructorHandler(n);
 
-    String* docs = docstring(n, AUTODOC_CTOR);
+    String *docs = docstring(n, AUTODOC_CTOR);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
@@ -2702,7 +2670,6 @@ public:
     return Language::copyconstructorHandler(n);
   }
 
-
   /* ---------------------------------------------------------------------
    * destructorHandler()
    * -------------------------------------------------------------------- */
@@ -2712,7 +2679,8 @@ public:
     /* Do no spit free function if user defined his own for this class */
     Node *pn = Swig_methodclass(n);
     String *freefunc = Getattr(pn, "feature:freefunc");
-    if (freefunc) return SWIG_OK;
+    if (freefunc)
+      return SWIG_OK;
 
     current = DESTRUCTOR;
     Language::destructorHandler(n);
@@ -2772,12 +2740,12 @@ public:
    * -------------------------------------------------------------------- */
 
   virtual int membervariableHandler(Node *n) {
-    String* docs = docstring(n, AUTODOC_GETTER);
+    String *docs = docstring(n, AUTODOC_GETTER);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
     if (!is_immutable(n)) {
-      String* docs = docstring(n, AUTODOC_SETTER);
+      String *docs = docstring(n, AUTODOC_SETTER);
       Printf(f_wrappers, "%s", docs);
       Delete(docs);
     }
@@ -2795,7 +2763,7 @@ public:
    * ---------------------------------------------------------------------- */
 
   virtual int staticmemberfunctionHandler(Node *n) {
-    String* docs = docstring(n, AUTODOC_STATICFUNC);
+    String *docs = docstring(n, AUTODOC_STATICFUNC);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
@@ -2812,7 +2780,7 @@ public:
    * --------------------------------------------------------------------- */
 
   virtual int memberconstantHandler(Node *n) {
-    String* docs = docstring(n, AUTODOC_STATICFUNC);
+    String *docs = docstring(n, AUTODOC_STATICFUNC);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
@@ -2827,12 +2795,12 @@ public:
    * --------------------------------------------------------------------- */
 
   virtual int staticmembervariableHandler(Node *n) {
-    String* docs = docstring(n, AUTODOC_GETTER);
+    String *docs = docstring(n, AUTODOC_GETTER);
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
     if (!is_immutable(n)) {
-      String* docs = docstring(n, AUTODOC_SETTER);
+      String *docs = docstring(n, AUTODOC_SETTER);
       Printf(f_wrappers, "%s", docs);
       Delete(docs);
     }
@@ -2996,7 +2964,8 @@ public:
         Printv(w->code, "args.argv = 0;\n", NIL);
       }
       Printf(w->code, "%s = rb_protect(PROTECTFUNC(%s), reinterpret_cast<VALUE>(&args), &status);\n", Swig_cresult_name(), bodyName);
-      if ( initstack ) Printf(w->code, "SWIG_RELEASE_STACK;\n");
+      if (initstack)
+        Printf(w->code, "SWIG_RELEASE_STACK;\n");
       Printf(w->code, "if (status) {\n");
       Printf(w->code, "VALUE lastErr = rb_gv_get(\"$!\");\n");
       Printf(w->code, "%s(reinterpret_cast<VALUE>(&args), lastErr);\n", rescueName);
@@ -3013,7 +2982,8 @@ public:
       } else {
         Printf(w->code, "%s = rb_funcall(swig_get_self(), rb_intern(\"%s\"), 0, Qnil);\n", Swig_cresult_name(), methodName);
       }
-      if ( initstack ) Printf(w->code, "SWIG_RELEASE_STACK;\n");
+      if (initstack)
+        Printf(w->code, "SWIG_RELEASE_STACK;\n");
     }
 
     // Clean up
@@ -3045,8 +3015,8 @@ public:
     int status = SWIG_OK;
     int idx;
     bool ignored_method = GetFlag(n, "feature:ignore") ? true : false;
-    bool asvoid = checkAttribute( n, "feature:numoutputs", "0") ? true : false;
-    bool initstack = checkAttribute( n, "feature:initstack", "1") ? true : false;
+    bool asvoid = checkAttribute(n, "feature:numoutputs", "0") ? true : false;
+    bool initstack = checkAttribute(n, "feature:initstack", "1") ? true : false;
 
     if (Cmp(storage, "virtual") == 0) {
       if (Cmp(value, "0") == 0) {
@@ -3143,7 +3113,9 @@ public:
         Printf(w->code, "%s;\n", super_call);
         Delete(super_call);
       } else {
-        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+        Printf(w->code,
+               "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n",
+               SwigType_namestr(c_classname),
                SwigType_namestr(name));
       }
     } else {
@@ -3163,12 +3135,13 @@ public:
         outputs++;
 
       /* build argument list and type conversion string */
-      idx = 0; p = l;
-      while ( p ) {
+      idx = 0;
+      p = l;
+      while (p) {
         if (Getattr(p, "tmap:directorargout") != 0)
           outputs++;
 
-        if ( checkAttribute( p, "tmap:in:numinputs", "0") ) {
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
           p = Getattr(p, "tmap:in:next");
           continue;
         }
@@ -3218,9 +3191,13 @@ public:
               String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(parameterType, 0), ppname);
               Wrapper_add_localv(w, nonconst, SwigType_lstr(parameterType, 0), nonconst, nonconst_i, NIL);
               Delete(nonconst_i);
-              Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
-                           "Target language argument '%s' discards const in director method %s::%s.\n", SwigType_str(parameterType, parameterName),
-                           SwigType_namestr(c_classname), SwigType_namestr(name));
+              Swig_warning(WARN_LANG_DISCARD_CONST,
+                           input_file,
+                           line_number,
+                           "Target language argument '%s' discards const in director method %s::%s.\n",
+                           SwigType_str(parameterType, parameterName),
+                           SwigType_namestr(c_classname),
+                           SwigType_namestr(name));
             } else {
               nonconst = Copy(ppname);
             }
@@ -3242,16 +3219,20 @@ public:
             } else {
               Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
               Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
-              //       source, nonconst, base);
+              // Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
+              //        source, nonconst, base);
               Printv(arglist, source, NIL);
             }
             Delete(mangle);
             Delete(nonconst);
           } else {
-            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(parameterType, 0),
-                         SwigType_namestr(c_classname), SwigType_namestr(name));
+            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF,
+                         input_file,
+                         line_number,
+                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n",
+                         SwigType_str(parameterType, 0),
+                         SwigType_namestr(c_classname),
+                         SwigType_namestr(name));
             status = SWIG_NOWRAP;
             break;
           }
@@ -3294,7 +3275,7 @@ public:
       if (!is_void) {
         tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
         if (tm != 0) {
-          if (outputs > 1 && !asvoid ) {
+          if (outputs > 1 && !asvoid) {
             Printf(w->code, "output = rb_ary_entry(%s, %d);\n", Swig_cresult_name(), idx++);
             Replaceall(tm, "$input", "output");
           } else {
@@ -3309,9 +3290,13 @@ public:
           Replaceall(tm, "$result", "c_result");
           Printv(w->code, tm, "\n", NIL);
         } else {
-          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-                       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
-                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF,
+                       input_file,
+                       line_number,
+                       "Unable to use return type %s in director method %s::%s (skipping method).\n",
+                       SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname),
+                       SwigType_namestr(name));
           status = SWIG_ERROR;
         }
       }
@@ -3450,7 +3435,7 @@ public:
     // kwargs support isn't actually implemented, but changing to return false may break something now as it turns on compactdefaultargs
     return true;
   }
-};                              /* class RUBY */
+}; /* class RUBY */
 
 /* -----------------------------------------------------------------------------
  * swig_ruby()    - Instantiate module
@@ -3462,7 +3447,6 @@ static Language *new_swig_ruby() {
 extern "C" Language *swig_ruby(void) {
   return new_swig_ruby();
 }
-
 
 /*
  * Local Variables:

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -206,13 +206,13 @@ private:
     char *c = Char(autodoc);
     if (c) {
       if (isdigit(c[0])) {
-	dlevel = (autodoc_l) atoi(c);
+        dlevel = (autodoc_l) atoi(c);
       } else {
-	if (strcmp(c, "extended") == 0) {
-	  dlevel = EXTEND_AUTODOC;
-	} else {
-	  dlevel = STRING_AUTODOC;
-	}
+        if (strcmp(c, "extended") == 0) {
+          dlevel = EXTEND_AUTODOC;
+        } else {
+          dlevel = STRING_AUTODOC;
+        }
       }
     }
     return dlevel;
@@ -249,8 +249,8 @@ private:
     if (have_ds) {
       char *t = Char(str);
       if (*t == '{') {
-	Delitem(str, 0);
-	Delitem(str, DOH_END);
+        Delitem(str, 0);
+        Delitem(str, DOH_END);
       }
     }
 
@@ -298,9 +298,9 @@ private:
     int i = arg_offset;
     while (p) {
       if (!Getattr(p, "lname")) {
-	String *name = makeParameterName(n, p, i);
-	Setattr(p, "lname", name);
-	Delete(name);
+        String *name = makeParameterName(n, p, i);
+        Setattr(p, "lname", name);
+        Delete(name);
       }
       i++;
       p = nextSibling(p);
@@ -336,12 +336,12 @@ private:
 
       String *tm = Getattr(p, "tmap:in");
       if (tm) {
-	pnext = Getattr(p, "tmap:in:next");
-	if (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	  continue;
-	}
+        pnext = Getattr(p, "tmap:in:next");
+        if (checkAttribute(p, "tmap:in:numinputs", "0")) {
+          continue;
+        }
       } else {
-	pnext = nextSibling(p);
+        pnext = nextSibling(p);
       }
 
       String *name = 0;
@@ -349,67 +349,67 @@ private:
       String *value = 0;
       String *pdoc = Getattr(p, "tmap:doc");
       if (pdoc) {
-	name = Getattr(p, "tmap:doc:name");
-	type = Getattr(p, "tmap:doc:type");
-	value = Getattr(p, "tmap:doc:value");
+        name = Getattr(p, "tmap:doc:name");
+        type = Getattr(p, "tmap:doc:type");
+        value = Getattr(p, "tmap:doc:value");
       }
 
       // Note: the generated name should be consistent with that in kwnames[]
       String *made_name = 0;
       if (!name) {
-	name = made_name = makeParameterName(n, p, arg_num);
+        name = made_name = makeParameterName(n, p, arg_num);
       }
 
       type = type ? type : Getattr(p, "type");
       value = value ? value : Getattr(p, "value");
 
       if (SwigType_isvarargs(type))
-	break;
+        break;
 
       // Skip the 'self' parameter which in ruby is implicit
       if ( Cmp(name, "self") == 0 )
-	continue;
+        continue;
 
       // Make __p parameters just p (as used in STL)
       Replace( name, "__", "", DOH_REPLACE_FIRST );
 
       if (Len(doc)) {
-	// add a comma to the previous one if any
-	Append(doc, ", ");
+        // add a comma to the previous one if any
+        Append(doc, ", ");
 
-	// Do we need to wrap a long line?
-	if ((Len(doc) - lines * maxwidth) > maxwidth) {
-	  Printf(doc, "\n%s", tab4);
-	  lines += 1;
-	}
+        // Do we need to wrap a long line?
+        if ((Len(doc) - lines * maxwidth) > maxwidth) {
+          Printf(doc, "\n%s", tab4);
+          lines += 1;
+        }
       }
 
       // Do the param type too?
       Node *nn = classLookup(Getattr(p, "type"));
       String *type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
       if (showTypes)
-	Printf(doc, "%s ", type_str);
+        Printf(doc, "%s ", type_str);
 
       Append(doc, name);
       if (pdoc) {
-	if (!pdocs)
-	  pdocs = NewString("Parameters:\n");
-	Printf(pdocs, "    %s.\n", pdoc);
+        if (!pdocs)
+          pdocs = NewString("Parameters:\n");
+        Printf(pdocs, "    %s.\n", pdoc);
       }
 
       if (value) {
-	String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
-	if (new_value) {
-	  value = new_value;
-	} else {
-	  Node *lookup = Swig_symbol_clookup(value, 0);
-	  if (lookup)
-	    value = Getattr(lookup, "sym:name");
-	}
-	Printf(doc, "=%s", value);
+        String *new_value = convertValue(value, Getattr(p, "numval"), Getattr(p, "stringval"), Getattr(p, "type"));
+        if (new_value) {
+          value = new_value;
+        } else {
+          Node *lookup = Swig_symbol_clookup(value, 0);
+          if (lookup)
+            value = Getattr(lookup, "sym:name");
+        }
+        Printf(doc, "=%s", value);
 
-	if (new_value)
-	  Delete(new_value);
+        if (new_value)
+          Delete(new_value);
       }
       Delete(type_str);
       Delete(made_name);
@@ -448,47 +448,47 @@ private:
       class_name = Copy(class_name);
       List *baselist = Getattr(pn, "bases");
       if (baselist && Len(baselist)) {
-	Iterator base = First(baselist);
-	while (base.item && GetFlag(base.item, "feature:ignore")) {
-	  base = Next(base);
-	}
+        Iterator base = First(baselist);
+        while (base.item && GetFlag(base.item, "feature:ignore")) {
+          base = Next(base);
+        }
 
-	int count = 0;
-	for ( ;base.item; ++count) {
-	  if ( count ) Append(super_names, ", ");
-	  String *basename = Getattr(base.item, "sym:name");
+        int count = 0;
+        for ( ;base.item; ++count) {
+          if ( count ) Append(super_names, ", ");
+          String *basename = Getattr(base.item, "sym:name");
 
-	  String* basenamestr = NewString(basename);
-	  Node* parent = parentNode(base.item);
-	  while (parent)
-	  {
-	    String *parent_name = Copy( Getattr(parent, "sym:name") );
-	    if ( !parent_name ) {
-	      Node* mod = Getattr(parent, "module");
-	      if ( mod )
-		parent_name = Copy( Getattr(mod, "name") );
-	      if ( parent_name )
-		(Char(parent_name))[0] = (char)toupper((Char(parent_name))[0]);
-	    }
-	    if ( parent_name ) {
-	      Insert(basenamestr, 0, "::");
-	      Insert(basenamestr, 0, parent_name);
-	      Delete(parent_name);
-	    }
-	    parent = parentNode(parent);
-	  }
+          String* basenamestr = NewString(basename);
+          Node* parent = parentNode(base.item);
+          while (parent)
+          {
+            String *parent_name = Copy( Getattr(parent, "sym:name") );
+            if ( !parent_name ) {
+              Node* mod = Getattr(parent, "module");
+              if ( mod )
+                parent_name = Copy( Getattr(mod, "name") );
+              if ( parent_name )
+                (Char(parent_name))[0] = (char)toupper((Char(parent_name))[0]);
+            }
+            if ( parent_name ) {
+              Insert(basenamestr, 0, "::");
+              Insert(basenamestr, 0, parent_name);
+              Delete(parent_name);
+            }
+            parent = parentNode(parent);
+          }
 
-	  Append(super_names, basenamestr );
-	  Delete(basenamestr);
-	  base = Next(base);
-	}
+          Append(super_names, basenamestr );
+          Delete(basenamestr);
+          base = Next(base);
+        }
       }
     }
     String* full_name;
     if ( module ) {
       full_name = NewString(module);
       if (Len(class_name) > 0)
-       	Append(full_name, "::");
+        Append(full_name, "::");
     }
     else
       full_name = NewString("");
@@ -530,167 +530,167 @@ private:
       autodoc_l dlevel = autodoc_level(autodoc);
       switch (dlevel) {
       case NO_AUTODOC:
-	break;
+        break;
       case NAMES_AUTODOC:
-	showTypes = false;
-	break;
+        showTypes = false;
+        break;
       case TYPES_AUTODOC:
-	showTypes = true;
-	break;
+        showTypes = true;
+        break;
       case EXTEND_AUTODOC:
-	extended = 1;
-	showTypes = false;
-	break;
+        extended = 1;
+        showTypes = false;
+        break;
       case EXTEND_TYPES_AUTODOC:
-	extended = 1;
-	showTypes = true;
-	break;
+        extended = 1;
+        showTypes = true;
+        break;
       case STRING_AUTODOC:
-	skipAuto = true;
-	break;
+        skipAuto = true;
+        break;
       }
 
       SwigType *type = Getattr(n, "type");
 
       if (type) {
-	if (Strcmp(type, "void") == 0) {
-	  type_str = NULL;
-	} else {
-	  SwigType *qt = SwigType_typedef_resolve_all(type);
-	  if (SwigType_isenum(qt)) {
-	    type_str = NewString("int");
-	  } else {
-	    Node *nn = classLookup(type);
-	    type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
-	  }
-	}
+        if (Strcmp(type, "void") == 0) {
+          type_str = NULL;
+        } else {
+          SwigType *qt = SwigType_typedef_resolve_all(type);
+          if (SwigType_isenum(qt)) {
+            type_str = NewString("int");
+          } else {
+            Node *nn = classLookup(type);
+            type_str = nn ? Copy(Getattr(nn, "sym:name")) : SwigType_str(type, 0);
+          }
+        }
       }
 
       if (counter == 0) {
-	switch (ad_type) {
-	case AUTODOC_CLASS:
-	  Printf(doc, "  Document-class: %s", full_name);
-	  if ( Len(super_names) > 0 )
-	    Printf( doc, " < %s", super_names);
-	  Append(doc, "\n\n");
-	  break;
-	case AUTODOC_CTOR:
- 	  Printf(doc, "  Document-method: %s.new\n\n", full_name);
-	  break;
+        switch (ad_type) {
+        case AUTODOC_CLASS:
+          Printf(doc, "  Document-class: %s", full_name);
+          if ( Len(super_names) > 0 )
+            Printf( doc, " < %s", super_names);
+          Append(doc, "\n\n");
+          break;
+        case AUTODOC_CTOR:
+          Printf(doc, "  Document-method: %s.new\n\n", full_name);
+          break;
 
-	case AUTODOC_DTOR:
-	  break;
+        case AUTODOC_DTOR:
+          break;
 
-	case AUTODOC_STATICFUNC:
- 	  Printf(doc, "  Document-method: %s.%s\n\n", full_name, symname);
-	  break;
+        case AUTODOC_STATICFUNC:
+          Printf(doc, "  Document-method: %s.%s\n\n", full_name, symname);
+          break;
 
-	case AUTODOC_FUNC:
-	case AUTODOC_METHOD:
-	case AUTODOC_GETTER:
- 	  Printf(doc, "  Document-method: %s.%s\n\n", full_name, symname);
-	  break;
-	case AUTODOC_SETTER:
- 	  Printf(doc, "  Document-method: %s.%s=\n\n", full_name, symname);
-	  break;
-	case AUTODOC_NONE:
-	  break;
-	}
+        case AUTODOC_FUNC:
+        case AUTODOC_METHOD:
+        case AUTODOC_GETTER:
+          Printf(doc, "  Document-method: %s.%s\n\n", full_name, symname);
+          break;
+        case AUTODOC_SETTER:
+          Printf(doc, "  Document-method: %s.%s=\n\n", full_name, symname);
+          break;
+        case AUTODOC_NONE:
+          break;
+        }
       }
 
       if (skipAuto) {
-	if ( counter == 0 ) Printf(doc, "  call-seq:\n");
-	switch( ad_type )
-	  {
-	  case AUTODOC_STATICFUNC:
-	  case AUTODOC_FUNC:
-	  case AUTODOC_METHOD:
-	  case AUTODOC_GETTER:
-	    {
-	      String *paramList = make_autodocParmList(n, showTypes);
-	      if (Len(paramList))
-		Printf(doc, "    %s(%s)", symname, paramList);
-	      else
-		Printf(doc, "    %s", symname);
-	      if (type_str)
-		Printf(doc, " -> %s", type_str);
-	      break;
-	    }
-	  case AUTODOC_SETTER:
-	    {
-	      Printf(doc, "    %s=(x)", symname);
-	      if (type_str)
-	       	Printf(doc, " -> %s", type_str);
-	      break;
-	    }
-	  default:
-	    break;
-	  }
+        if ( counter == 0 ) Printf(doc, "  call-seq:\n");
+        switch( ad_type )
+          {
+          case AUTODOC_STATICFUNC:
+          case AUTODOC_FUNC:
+          case AUTODOC_METHOD:
+          case AUTODOC_GETTER:
+            {
+              String *paramList = make_autodocParmList(n, showTypes);
+              if (Len(paramList))
+                Printf(doc, "    %s(%s)", symname, paramList);
+              else
+                Printf(doc, "    %s", symname);
+              if (type_str)
+                Printf(doc, " -> %s", type_str);
+              break;
+            }
+          case AUTODOC_SETTER:
+            {
+              Printf(doc, "    %s=(x)", symname);
+              if (type_str)
+                Printf(doc, " -> %s", type_str);
+              break;
+            }
+          default:
+            break;
+          }
       } else {
-	switch (ad_type) {
-	case AUTODOC_CLASS:
-	  {
-	    // Only do the autodoc if there isn't a docstring for the class
-	    String *str = Getattr(n, "feature:docstring");
-	    if (counter == 0 && (str == 0 || Len(str) == 0)) {
-	      if (CPlusPlus) {
-		Printf(doc, "  Proxy of C++ %s class", full_name);
-	      } else {
-		Printf(doc, "  Proxy of C %s struct", full_name);
-	      }
-	    }
-	  }
-	  break;
-	case AUTODOC_CTOR:
-	  if (counter == 0)
-	    Printf(doc, "  call-seq:\n");
-	  if (Strcmp(class_name, symname) == 0) {
-	    String *paramList = make_autodocParmList(n, showTypes);
-	    if (Len(paramList))
-	      Printf(doc, "    %s.new(%s)", class_name, paramList);
-	    else
-	      Printf(doc, "    %s.new", class_name);
-	  } else {
-	    Printf(doc, "    %s.new(%s)", class_name, make_autodocParmList(n, showTypes));
-	  }
-	  break;
+        switch (ad_type) {
+        case AUTODOC_CLASS:
+          {
+            // Only do the autodoc if there isn't a docstring for the class
+            String *str = Getattr(n, "feature:docstring");
+            if (counter == 0 && (str == 0 || Len(str) == 0)) {
+              if (CPlusPlus) {
+                Printf(doc, "  Proxy of C++ %s class", full_name);
+              } else {
+                Printf(doc, "  Proxy of C %s struct", full_name);
+              }
+            }
+          }
+          break;
+        case AUTODOC_CTOR:
+          if (counter == 0)
+            Printf(doc, "  call-seq:\n");
+          if (Strcmp(class_name, symname) == 0) {
+            String *paramList = make_autodocParmList(n, showTypes);
+            if (Len(paramList))
+              Printf(doc, "    %s.new(%s)", class_name, paramList);
+            else
+              Printf(doc, "    %s.new", class_name);
+          } else {
+            Printf(doc, "    %s.new(%s)", class_name, make_autodocParmList(n, showTypes));
+          }
+          break;
 
-	case AUTODOC_DTOR:
-	  break;
+        case AUTODOC_DTOR:
+          break;
 
-	case AUTODOC_STATICFUNC:
-	case AUTODOC_FUNC:
-	case AUTODOC_METHOD:
-	case AUTODOC_GETTER:
-	  {
-	    if (counter == 0)
-	      Printf(doc, "  call-seq:\n");
-	    String *paramList = make_autodocParmList(n, showTypes);
-	    if (Len(paramList))
-	      Printf(doc, "    %s(%s)", symname, paramList);
-	    else
-	      Printf(doc, "    %s", symname);
-	    if (type_str)
-	      Printf(doc, " -> %s", type_str);
-	    break;
-	  }
-	case AUTODOC_SETTER:
-	  {
-	    Printf(doc, "  call-seq:\n");
-	    Printf(doc, "    %s=(x)", symname);
-	    if (type_str)
-	      Printf(doc, " -> %s", type_str);
-	    break;
-	  }
-	case AUTODOC_NONE:
-	  break;
-	}
+        case AUTODOC_STATICFUNC:
+        case AUTODOC_FUNC:
+        case AUTODOC_METHOD:
+        case AUTODOC_GETTER:
+          {
+            if (counter == 0)
+              Printf(doc, "  call-seq:\n");
+            String *paramList = make_autodocParmList(n, showTypes);
+            if (Len(paramList))
+              Printf(doc, "    %s(%s)", symname, paramList);
+            else
+              Printf(doc, "    %s", symname);
+            if (type_str)
+              Printf(doc, " -> %s", type_str);
+            break;
+          }
+        case AUTODOC_SETTER:
+          {
+            Printf(doc, "  call-seq:\n");
+            Printf(doc, "    %s=(x)", symname);
+            if (type_str)
+              Printf(doc, " -> %s", type_str);
+            break;
+          }
+        case AUTODOC_NONE:
+          break;
+        }
       }
 
       // if it's overloaded then get the next decl and loop around again
       n = Getattr(n, "sym:nextSibling");
       if (n)
-	Append(doc, "\n");
+        Append(doc, "\n");
       Delete(type_str);
     }
 
@@ -699,27 +699,27 @@ private:
       switch (ad_type) {
       case AUTODOC_CLASS:
       case AUTODOC_DTOR:
-	break;
+        break;
       case AUTODOC_CTOR:
-	Printf(doc, "Class constructor.\n");
-	break;
+        Printf(doc, "Class constructor.\n");
+        break;
       case AUTODOC_STATICFUNC:
-	Printf(doc, "A class method.\n");
-	break;
+        Printf(doc, "A class method.\n");
+        break;
       case AUTODOC_FUNC:
-	Printf(doc, "A module function.\n");
-	break;
+        Printf(doc, "A module function.\n");
+        break;
       case AUTODOC_METHOD:
-	Printf(doc, "An instance method.\n");
-	break;
+        Printf(doc, "An instance method.\n");
+        break;
       case AUTODOC_GETTER:
-	Printf(doc, "Get value of attribute.\n");
-	break;
+        Printf(doc, "Get value of attribute.\n");
+        break;
       case AUTODOC_SETTER:
-	Printf(doc, "Set new value for attribute.\n");
-	break;
+        Printf(doc, "Set new value for attribute.\n");
+        break;
       case AUTODOC_NONE:
-	break;
+        break;
       }
     }
 
@@ -733,27 +733,27 @@ private:
       case NO_AUTODOC:
       case NAMES_AUTODOC:
       case TYPES_AUTODOC:
-	extended = 0;
-	break;
+        extended = 0;
+        break;
       case STRING_AUTODOC:
-	extended = 2;
-	Replaceall( autodoc, "$class", class_name );
-	Printv(doc, autodoc, ".", NIL);
-	break;
+        extended = 2;
+        Replaceall( autodoc, "$class", class_name );
+        Printv(doc, autodoc, ".", NIL);
+        break;
       case EXTEND_AUTODOC:
       case EXTEND_TYPES_AUTODOC:
-	extended = 1;
-	break;
+        extended = 1;
+        break;
       }
 
 
       if (extended) {
-	String *pdocs = Getattr(n, "feature:pdocs");
-	if (pdocs) {
-	  Printv(doc, "\n\n", pdocs, NULL);
-	  break;
-	}
-	if ( extended == 2 ) break;
+        String *pdocs = Getattr(n, "feature:pdocs");
+        if (pdocs) {
+          Printv(doc, "\n\n", pdocs, NULL);
+          break;
+        }
+        if ( extended == 2 ) break;
       }
       n = Getattr(n, "sym:nextSibling");
     }
@@ -779,27 +779,27 @@ private:
       SwigType *resolved_type = SwigType_typedef_resolve_all(type);
       SwigType *unqualified_type = NIL;
       if (SwigType_isreference(resolved_type)) {
-	  SwigType *t = Copy(resolved_type);
-	  t = SwigType_del_reference(t);
-	  unqualified_type = SwigType_strip_qualifiers(t);
-	  Delete(t);
+          SwigType *t = Copy(resolved_type);
+          t = SwigType_del_reference(t);
+          unqualified_type = SwigType_strip_qualifiers(t);
+          Delete(t);
       } else {
-	  unqualified_type = SwigType_strip_qualifiers(resolved_type);
+          unqualified_type = SwigType_strip_qualifiers(resolved_type);
       }
       if (Equal(unqualified_type, "bool")) {
-	Delete(resolved_type);
-	Delete(unqualified_type);
-	return NewString(*Char(numval) == '0' ? "false" : "true");
+        Delete(resolved_type);
+        Delete(unqualified_type);
+        return NewString(*Char(numval) == '0' ? "false" : "true");
       }
       Delete(resolved_type);
       Delete(unqualified_type);
       if (SwigType_ispointer(type) && Equal(v, "0"))
-	return NewString("None");
+        return NewString("None");
       return Copy(v);
     }
     if (v && Len(v) > 0) {
       if (Equal(v, "NULL") || Equal(v, "nullptr"))
-	return SwigType_ispointer(type) ? NewString("nil") : NewString("0");
+        return SwigType_ispointer(type) ? NewString("nil") : NewString("0");
     }
     return 0;
   }
@@ -860,49 +860,49 @@ public:
     /* Look for certain command line options */
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-initname") == 0) {
-	  if (argv[i + 1]) {
-	    char *name = argv[i + 1];
-	    feature = NewString(name);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-globalmodule") == 0) {
-	  useGlobalModule = true;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-minherit") == 0) {
-	  multipleInheritance = true;
-	  director_multiple_inheritance = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-autorename") == 0) {
-	  autorename = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-noautorename") == 0) {
-	  autorename = 0;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-prefix") == 0) {
-	  if (argv[i + 1]) {
-	    char *name = argv[i + 1];
-	    prefix = NewString(name);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else {
-	    Swig_arg_error();
-	  }
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  Printf(stdout, "%s", usage);
-	} else if (strcmp(argv[i], "-cppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nocppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
-	  Swig_mark_arg(i);
-	  Exit(EXIT_FAILURE);
-	}
+        if (strcmp(argv[i], "-initname") == 0) {
+          if (argv[i + 1]) {
+            char *name = argv[i + 1];
+            feature = NewString(name);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-globalmodule") == 0) {
+          useGlobalModule = true;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-minherit") == 0) {
+          multipleInheritance = true;
+          director_multiple_inheritance = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-autorename") == 0) {
+          autorename = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-noautorename") == 0) {
+          autorename = 0;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-prefix") == 0) {
+          if (argv[i + 1]) {
+            char *name = argv[i + 1];
+            prefix = NewString(name);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else {
+            Swig_arg_error();
+          }
+        } else if (strcmp(argv[i], "-help") == 0) {
+          Printf(stdout, "%s", usage);
+        } else if (strcmp(argv[i], "-cppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nocppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
+          Swig_mark_arg(i);
+          Exit(EXIT_FAILURE);
+        }
       }
     }
 
@@ -929,15 +929,15 @@ public:
       Iterator m;
       m = First(modules);
       while (m.item) {
-	if (Len(m.item) > 0) {
-	  if (mv != 0) {
-	    Printv(f_init, tab4, modvar, " = rb_define_module_under(", modvar, ", \"", m.item, "\");\n", NIL);
-	  } else {
-	    Printv(f_init, tab4, modvar, " = rb_define_module(\"", m.item, "\");\n", NIL);
-	    mv = NewString(modvar);
-	  }
-	}
-	m = Next(m);
+        if (Len(m.item) > 0) {
+          if (mv != 0) {
+            Printv(f_init, tab4, modvar, " = rb_define_module_under(", modvar, ", \"", m.item, "\");\n", NIL);
+          } else {
+            Printv(f_init, tab4, modvar, " = rb_define_module(\"", m.item, "\");\n", NIL);
+            mv = NewString(modvar);
+          }
+        }
+        m = Next(m);
       }
       Delete(mv);
       Delete(modules);
@@ -1009,20 +1009,20 @@ public:
     if (swigModule) {
       Node *options = Getattr(swigModule, "options");
       if (options) {
-	if (Getattr(options, "directors")) {
-	  allow_directors();
-	}
-	if (Getattr(options, "dirprot")) {
-	  allow_dirprot();
-	}
-	if (Getattr(options, "ruby_globalmodule")) {
-	  useGlobalModule = true;
-	}
-	if (Getattr(options, "ruby_minherit")) {
-	  multipleInheritance = true;
-	  director_multiple_inheritance = 1;
-	}
-	mod_docstring = Getattr(options, "docstring");
+        if (Getattr(options, "directors")) {
+          allow_directors();
+        }
+        if (Getattr(options, "dirprot")) {
+          allow_dirprot();
+        }
+        if (Getattr(options, "ruby_globalmodule")) {
+          useGlobalModule = true;
+        }
+        if (Getattr(options, "ruby_minherit")) {
+          multipleInheritance = true;
+          director_multiple_inheritance = 1;
+        }
+        mod_docstring = Getattr(options, "docstring");
       }
     }
 
@@ -1063,8 +1063,8 @@ public:
       }
       f_runtime_h = NewFile(outfile_h, "w", SWIG_output_files());
       if (!f_runtime_h) {
-	FileErrorDisplay(outfile_h);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile_h);
+        Exit(EXIT_FAILURE);
       }
     }
 
@@ -1127,9 +1127,9 @@ public:
       Printf(f_directors, " * C++ director class methods\n");
       Printf(f_directors, " * --------------------------------------------------- */\n\n");
       if (outfile_h) {
-	String *filename = Swig_file_filename(outfile_h);
-	Printf(f_directors, "#include \"%s\"\n\n", filename);
-	Delete(filename);
+        String *filename = Swig_file_filename(outfile_h);
+        Printf(f_directors, "#include \"%s\"\n\n", filename);
+        Delete(filename);
       }
 
       Delete(module_macro);
@@ -1140,7 +1140,7 @@ public:
 
     if (mod_docstring) {
       if (Len(mod_docstring)) {
-	Printf(f_header, "/*\n  Document-module: %s\n\n%s\n*/\n", module, mod_docstring);
+        Printf(f_header, "/*\n  Document-module: %s\n\n%s\n*/\n", module, mod_docstring);
       }
       Delete(mod_docstring);
       mod_docstring = NULL;
@@ -1213,26 +1213,26 @@ public:
     String *modname = Getattr(n, "module");
     if (modname) {
       if (prefix) {
-	Insert(modname, 0, prefix);
+        Insert(modname, 0, prefix);
       }
 
       List *modules = Split(modname, ':', INT_MAX);
       if (modules && Len(modules) > 0) {
-	modname = NewString("");
-	String *last = NULL;
-	Iterator m = First(modules);
-	while (m.item) {
-	  if (Len(m.item) > 0) {
-	    if (last) {
-	      Append(modname, "/");
-	    }
-	    Append(modname, m.item);
-	    last = m.item;
-	  }
-	  m = Next(m);
-	}
-	Printf(f_init, "rb_require(\"%s\");\n", modname);
-	Delete(modname);
+        modname = NewString("");
+        String *last = NULL;
+        Iterator m = First(modules);
+        while (m.item) {
+          if (Len(m.item) > 0) {
+            if (last) {
+              Append(modname, "/");
+            }
+            Append(modname, m.item);
+            last = m.item;
+          }
+          m = Next(m);
+        }
+        Printf(f_init, "rb_require(\"%s\");\n", modname);
+        Delete(modname);
       }
       Delete(modules);
     }
@@ -1253,33 +1253,33 @@ public:
       module = NewString("");
 
       if (prefix) {
-	Insert(mod_name, 0, prefix);
+        Insert(mod_name, 0, prefix);
       }
 
       /* Account for nested modules */
       List *modules = Split(mod_name, ':', INT_MAX);
       if (modules != 0 && Len(modules) > 0) {
-	String *last = 0;
-	Iterator m = First(modules);
-	while (m.item) {
-	  if (Len(m.item) > 0) {
-	    String *cap = NewString(m.item);
-	    (Char(cap))[0] = (char)toupper((Char(cap))[0]);
-	    if (last != 0) {
-	      Append(module, "::");
-	    }
-	    Append(module, cap);
-	    last = m.item;
-	  }
-	  m = Next(m);
-	}
-	if (last) {
-	  if (feature == 0) {
-	    feature = Copy(last);
-	  }
-	  (Char(last))[0] = (char)toupper((Char(last))[0]);
-	  modvar = NewStringf("m%s", last);
-	}
+        String *last = 0;
+        Iterator m = First(modules);
+        while (m.item) {
+          if (Len(m.item) > 0) {
+            String *cap = NewString(m.item);
+            (Char(cap))[0] = (char)toupper((Char(cap))[0]);
+            if (last != 0) {
+              Append(module, "::");
+            }
+            Append(module, cap);
+            last = m.item;
+          }
+          m = Next(m);
+        }
+        if (last) {
+          if (feature == 0) {
+            feature = Copy(last);
+          }
+          (Char(last))[0] = (char)toupper((Char(last))[0]);
+          modvar = NewStringf("m%s", last);
+        }
       }
       Delete(modules);
     }
@@ -1303,23 +1303,23 @@ public:
     if (aliasv) {
       List *aliases = Split(aliasv, ',', INT_MAX);
       if (aliases && Len(aliases) > 0) {
-	Iterator alias = First(aliases);
-	while (alias.item) {
-	  if (Len(alias.item) > 0) {
-	    if (current == NO_CPP) {
-	      if (useGlobalModule) {
-	        Printv(f_init, tab4, "rb_define_alias(rb_cObject, \"", alias.item, "\", \"", iname, "\");\n", NIL);
-	      } else {
-	        Printv(f_init, tab4, "rb_define_alias(rb_singleton_class(", modvar, "), \"", alias.item, "\", \"", iname, "\");\n", NIL);
-	      }
-	    } else if (multipleInheritance) {
-	      Printv(klass->init, tab4, "rb_define_alias(", klass->mImpl, ", \"", alias.item, "\", \"", iname, "\");\n", NIL);
-	    } else {
-	      Printv(klass->init, tab4, "rb_define_alias(", klass->vname, ", \"", alias.item, "\", \"", iname, "\");\n", NIL);
-	    }
-	  }
-	  alias = Next(alias);
-	}
+        Iterator alias = First(aliases);
+        while (alias.item) {
+          if (Len(alias.item) > 0) {
+            if (current == NO_CPP) {
+              if (useGlobalModule) {
+                Printv(f_init, tab4, "rb_define_alias(rb_cObject, \"", alias.item, "\", \"", iname, "\");\n", NIL);
+              } else {
+                Printv(f_init, tab4, "rb_define_alias(rb_singleton_class(", modvar, "), \"", alias.item, "\", \"", iname, "\");\n", NIL);
+              }
+            } else if (multipleInheritance) {
+              Printv(klass->init, tab4, "rb_define_alias(", klass->mImpl, ", \"", alias.item, "\", \"", iname, "\");\n", NIL);
+            } else {
+              Printv(klass->init, tab4, "rb_define_alias(", klass->vname, ", \"", alias.item, "\", \"", iname, "\");\n", NIL);
+            }
+          }
+          alias = Next(alias);
+        }
       }
       Delete(aliases);
     }
@@ -1367,11 +1367,11 @@ public:
     switch (current) {
     case MEMBER_FUNC:
       {
-	if (multipleInheritance) {
-	  Printv(klass->init, tab4, rb_define_method, "(", klass->mImpl, ", \"", iname, "\", ", wname, ", -1);\n", NIL);
-	} else {
-	  Printv(klass->init, tab4, rb_define_method, "(", klass->vname, ", \"", iname, "\", ", wname, ", -1);\n", NIL);
-	}
+        if (multipleInheritance) {
+          Printv(klass->init, tab4, rb_define_method, "(", klass->mImpl, ", \"", iname, "\", ", wname, ", -1);\n", NIL);
+        } else {
+          Printv(klass->init, tab4, rb_define_method, "(", klass->vname, ", \"", iname, "\", ", wname, ", -1);\n", NIL);
+        }
       }
       break;
     case CONSTRUCTOR_ALLOCATE:
@@ -1386,18 +1386,18 @@ public:
       Append(temp, iname);
       /* Check for _set or _get at the end of the name. */
       if (Len(temp) > 4) {
-	const char *p = Char(temp) + (Len(temp) - 4);
-	if (strcmp(p, "_set") == 0) {
-	  Delslice(temp, Len(temp) - 4, DOH_END);
-	  Append(temp, "=");
-	} else if (strcmp(p, "_get") == 0) {
-	  Delslice(temp, Len(temp) - 4, DOH_END);
-	}
+        const char *p = Char(temp) + (Len(temp) - 4);
+        if (strcmp(p, "_set") == 0) {
+          Delslice(temp, Len(temp) - 4, DOH_END);
+          Append(temp, "=");
+        } else if (strcmp(p, "_get") == 0) {
+          Delslice(temp, Len(temp) - 4, DOH_END);
+        }
       }
       if (multipleInheritance) {
-	Printv(klass->init, tab4, "rb_define_method(", klass->mImpl, ", \"", temp, "\", ", wname, ", -1);\n", NIL);
+        Printv(klass->init, tab4, "rb_define_method(", klass->mImpl, ", \"", temp, "\", ", wname, ", -1);\n", NIL);
       } else {
-	Printv(klass->init, tab4, "rb_define_method(", klass->vname, ", \"", temp, "\", ", wname, ", -1);\n", NIL);
+        Printv(klass->init, tab4, "rb_define_method(", klass->vname, ", \"", temp, "\", ", wname, ", -1);\n", NIL);
       }
       break;
     case STATIC_FUNC:
@@ -1405,11 +1405,11 @@ public:
       break;
     case NO_CPP:
       if (!useGlobalModule) {
-	Printv(s, tab4, "rb_define_module_function(", modvar, ", \"", iname, "\", ", wname, ", -1);\n", NIL);
-	Printv(f_init, s, NIL);
+        Printv(s, tab4, "rb_define_module_function(", modvar, ", \"", iname, "\", ", wname, ", -1);\n", NIL);
+        Printv(f_init, s, NIL);
       } else {
-	Printv(s, tab4, "rb_define_global_function(\"", iname, "\", ", wname, ", -1);\n", NIL);
-	Printv(f_init, s, NIL);
+        Printv(s, tab4, "rb_define_global_function(\"", iname, "\", ", wname, ", -1);\n", NIL);
+        Printv(f_init, s, NIL);
       }
       break;
     case DESTRUCTOR:
@@ -1443,9 +1443,9 @@ public:
       Replaceall(tm, "$symname", symname);
 
       if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
-	Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+        Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
       } else {
-	Replaceall(tm, "$disown", "0");
+        Replaceall(tm, "$disown", "0");
       }
 
       Setattr(p, "emit:input", Copy(source));
@@ -1506,26 +1506,26 @@ public:
 
       /* First argument is a special case */
       if (i == 0) {
-	Printv(source, (start == 0) ? "argv[0]" : "self", NIL);
+        Printv(source, (start == 0) ? "argv[0]" : "self", NIL);
       } else {
-	Printf(source, "argv[%d]", i - start);
+        Printf(source, "argv[%d]", i - start);
       }
 
       if (i >= (numreq)) {	/* Check if parsing an optional argument */
-	Printf(f->code, "    if (argc > %d) {\n", i - start);
+        Printf(f->code, "    if (argc > %d) {\n", i - start);
       }
 
       /* Record argument name for keyword argument handling */
       if (Len(pn)) {
-	Printf(kwargs, "\"%s\",", pn);
+        Printf(kwargs, "\"%s\",", pn);
       } else {
-	Printf(kwargs, "\"arg%d\",", i + 1);
+        Printf(kwargs, "\"arg%d\",", i + 1);
       }
 
       /* Look for an input typemap */
       p = applyInputTypemap(p, source, f, Getattr(n, "name"));
       if (i >= numreq) {
-	Printf(f->code, "}\n");
+        Printf(f->code, "}\n");
       }
     }
 
@@ -1539,13 +1539,13 @@ public:
     /* Trailing varargs */
     if (varargs) {
       if (p && (tm = Getattr(p, "tmap:in"))) {
-	Clear(source);
-	Printf(source, "argv[%d]", i - start);
-	Replaceall(tm, "$input", source);
-	Setattr(p, "emit:input", Copy(source));
-	Printf(f->code, "if (argc > %d) {\n", i - start);
-	Printv(f->code, tm, "\n", NIL);
-	Printf(f->code, "}\n");
+        Clear(source);
+        Printf(source, "argv[%d]", i - start);
+        Replaceall(tm, "$input", source);
+        Setattr(p, "emit:input", Copy(source));
+        Printf(f->code, "if (argc > %d) {\n", i - start);
+        Printv(f->code, tm, "\n", NIL);
+        Printf(f->code, "}\n");
       }
     }
 
@@ -1565,10 +1565,10 @@ public:
     String *tm;
     for (p = l; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -1585,12 +1585,12 @@ public:
     String *tm;
     for (Parm *p = l; p;) {
       if ((tm = Getattr(p, "tmap:freearg"))) {
-	if (Len(tm) != 0) {
-	  Printv(cleanup, tm, "\n", NIL);
-	}
-	p = Getattr(p, "tmap:freearg:next");
+        if (Len(tm) != 0) {
+          Printv(cleanup, tm, "\n", NIL);
+        }
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -1607,15 +1607,15 @@ public:
     String *tm;
     for (Parm *p = l; p;) {
       if ((tm = Getattr(p, "tmap:argout"))) {
-	Replaceall(tm, "$result", "vresult");
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Replaceall(tm, "$result", "vresult");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
 
-	Printv(outarg, tm, "\n", NIL);
-	need_result += 1;
-	p = Getattr(p, "tmap:argout:next");
+        Printv(outarg, tm, "\n", NIL);
+        need_result += 1;
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
   }
@@ -1642,7 +1642,7 @@ public:
     char *c = Char(s);
     while (*c) {
       if (!(isalnum(*c) || (*c == '_') || (*c == '?') || (*c == '!') || (*c == '=')))
-	return 0;
+        return 0;
       c++;
     }
     return 1;
@@ -1687,7 +1687,7 @@ public:
       overname = Getattr(n, "sym:overname");
     } else {
       if (!addSymbol(symname, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     String *cleanup = NewString("");
@@ -1743,25 +1743,25 @@ public:
     } else if (current == CONSTRUCTOR_INITIALIZE) {
       Printv(f->def, "SWIGINTERN VALUE\n", wname, "(int argc, VALUE *argv, VALUE self) {", NIL);
       if (!varargs) {
-	Printf(f->code, "if ((argc < %d) || (argc > %d)) ", numreq - start, numarg - start);
+        Printf(f->code, "if ((argc < %d) || (argc > %d)) ", numreq - start, numarg - start);
       } else {
-	Printf(f->code, "if (argc < %d) ", numreq - start);
+        Printf(f->code, "if (argc < %d) ", numreq - start);
       }
       Printf(f->code, "{rb_raise(rb_eArgError, \"wrong # of arguments(%%d for %d)\",argc); SWIG_fail;}\n", numreq - start);
     } else {
 
       if ( current == NO_CPP )
-	{
-	  String* docs = docstring(n, AUTODOC_FUNC);
-	  Printf(f_wrappers, "%s", docs);
-	  Delete(docs);
-	}
+        {
+          String* docs = docstring(n, AUTODOC_FUNC);
+          Printf(f_wrappers, "%s", docs);
+          Delete(docs);
+        }
 
       Printv(f->def, "SWIGINTERN VALUE\n", wname, "(int argc, VALUE *argv, VALUE self) {", NIL);
       if (!varargs) {
-	Printf(f->code, "if ((argc < %d) || (argc > %d)) ", numreq - start, numarg - start);
+        Printf(f->code, "if ((argc < %d) || (argc > %d)) ", numreq - start, numarg - start);
       } else {
-	Printf(f->code, "if (argc < %d) ", numreq - start);
+        Printf(f->code, "if (argc < %d) ", numreq - start);
       }
       Printf(f->code, "{rb_raise(rb_eArgError, \"wrong # of arguments(%%d for %d)\",argc); SWIG_fail;}\n", numreq - start);
     }
@@ -1817,32 +1817,32 @@ public:
     /* Now write code to make the function call */
     if (current != CONSTRUCTOR_ALLOCATE) {
       if (current == CONSTRUCTOR_INITIALIZE) {
-	Node *pn = Swig_methodclass(n);
-	String *symname = Getattr(pn, "sym:name");
-	String *action = Getattr(n, "wrap:action");
-	if (Swig_directors_enabled()) {
-	  String *classname = NewStringf("const char *classname SWIGUNUSED = \"%s::%s\"", module, symname);
-	  Wrapper_add_local(f, "classname", classname);
-	}
-	if (action) {
-	  SwigType *smart = Getattr(pn, "smart");
-	  String *result_name = NewStringf("%s%s", smart ? "smart" : "", Swig_cresult_name());
-	  if (smart) {
-	    String *result_var = NewStringf("%s *%s = 0", SwigType_namestr(smart), result_name);
-	    Wrapper_add_local(f, result_name, result_var);
-	    Printf(action, "\n%s = new %s(%s);", result_name, SwigType_namestr(smart), Swig_cresult_name());
-	  }
-	  Printf(action, "\nDATA_PTR(self) = %s;", result_name);
-	  if (GetFlag(pn, "feature:trackobjects")) {
-	    Printf(action, "\nSWIG_RubyAddTracking(%s, self);", result_name);
-	  }
-	  Delete(result_name);
-	}
+        Node *pn = Swig_methodclass(n);
+        String *symname = Getattr(pn, "sym:name");
+        String *action = Getattr(n, "wrap:action");
+        if (Swig_directors_enabled()) {
+          String *classname = NewStringf("const char *classname SWIGUNUSED = \"%s::%s\"", module, symname);
+          Wrapper_add_local(f, "classname", classname);
+        }
+        if (action) {
+          SwigType *smart = Getattr(pn, "smart");
+          String *result_name = NewStringf("%s%s", smart ? "smart" : "", Swig_cresult_name());
+          if (smart) {
+            String *result_var = NewStringf("%s *%s = 0", SwigType_namestr(smart), result_name);
+            Wrapper_add_local(f, result_name, result_var);
+            Printf(action, "\n%s = new %s(%s);", result_name, SwigType_namestr(smart), Swig_cresult_name());
+          }
+          Printf(action, "\nDATA_PTR(self) = %s;", result_name);
+          if (GetFlag(pn, "feature:trackobjects")) {
+            Printf(action, "\nSWIG_RubyAddTracking(%s, self);", result_name);
+          }
+          Delete(result_name);
+        }
       }
 
       /* Emit the function call */
       if (director_method) {
-	Printf(f->code, "try {\n");
+        Printf(f->code, "try {\n");
       }
 
       Setattr(n, "wrap:name", wname);
@@ -1851,10 +1851,10 @@ public:
       String *actioncode = emit_action(n);
 
       if (director_method) {
-	Printf(actioncode, "} catch (Swig::DirectorException& e) {\n");
-	Printf(actioncode, "  rb_exc_raise(e.getError());\n");
-	Printf(actioncode, "  SWIG_fail;\n");
-	Printf(actioncode, "}\n");
+        Printf(actioncode, "} catch (Swig::DirectorException& e) {\n");
+        Printf(actioncode, "  rb_exc_raise(e.getError());\n");
+        Printf(actioncode, "  SWIG_fail;\n");
+        Printf(actioncode, "}\n");
       }
 
       /* Return value if necessary */
@@ -1906,7 +1906,7 @@ public:
       SwigType *smart = Getattr(pn, "smart");
       SwigType *psmart = smart ? Copy(smart) : 0;
       if (psmart)
-	SwigType_add_pointer(psmart);
+        SwigType_add_pointer(psmart);
       SwigType *classtype = psmart ? psmart : returntype;
       need_result = 1;
       Printf(f->code, "VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE%s);\n", Char(SwigType_manglestr(classtype)));
@@ -1919,16 +1919,16 @@ public:
     }
     else
       {
-	if ( need_result > 1 ) {
-	  if ( SwigType_type(returntype) == T_VOID )
-	    Printf(f->code, "vresult = rb_ary_new();\n");
-	  else
-	    {
-	      Printf(f->code, "if (vresult == Qnil) vresult = rb_ary_new();\n");
-	      Printf(f->code, "else vresult = SWIG_Ruby_AppendOutput( "
-		     "rb_ary_new(), vresult);\n");
-	    }
-	}
+        if ( need_result > 1 ) {
+          if ( SwigType_type(returntype) == T_VOID )
+            Printf(f->code, "vresult = rb_ary_new();\n");
+          else
+            {
+              Printf(f->code, "if (vresult == Qnil) vresult = rb_ary_new();\n");
+              Printf(f->code, "else vresult = SWIG_Ruby_AppendOutput( "
+                     "rb_ary_new(), vresult);\n");
+            }
+        }
       }
 
     /* Dump argument output code; */
@@ -1945,8 +1945,8 @@ public:
     if (current != CONSTRUCTOR_ALLOCATE && GetFlag(n, "feature:new")) {
       tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0);
       if (tm) {
-	Printv(f->code, tm, "\n", NIL);
-	Delete(tm);
+        Printv(f->code, tm, "\n", NIL);
+        Delete(tm);
       }
     }
 
@@ -1959,9 +1959,9 @@ public:
 
     if (director_method) {
       if ((tm = Swig_typemap_lookup("directorfree", n, Swig_cresult_name(), 0))) {
-	Replaceall(tm, "$input", Swig_cresult_name());
-	Replaceall(tm, "$result", "vresult");
-	Printf(f->code, "%s\n", tm);
+        Replaceall(tm, "$input", Swig_cresult_name());
+        Replaceall(tm, "$result", "vresult");
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -1969,28 +1969,28 @@ public:
     /* Wrap things up (in a manner of speaking) */
     if (need_result) {
       if (current == CONSTRUCTOR_ALLOCATE) {
-	Printv(f->code, tab4, "return vresult;\n", NIL);
+        Printv(f->code, tab4, "return vresult;\n", NIL);
       } else if (current == CONSTRUCTOR_INITIALIZE) {
-	Printv(f->code, tab4, "return self;\n", NIL);
-	Printv(f->code, "fail:\n", NIL);
-	if (need_cleanup) {
-	  Printv(f->code, cleanup, NIL);
-	}
-	Printv(f->code, tab4, "return Qnil;\n", NIL);
+        Printv(f->code, tab4, "return self;\n", NIL);
+        Printv(f->code, "fail:\n", NIL);
+        if (need_cleanup) {
+          Printv(f->code, cleanup, NIL);
+        }
+        Printv(f->code, tab4, "return Qnil;\n", NIL);
       } else {
-	Wrapper_add_local(f, "vresult", "VALUE vresult = Qnil");
-	Printv(f->code, tab4, "return vresult;\n", NIL);
-	Printv(f->code, "fail:\n", NIL);
-	if (need_cleanup) {
-	  Printv(f->code, cleanup, NIL);
-	}
-	Printv(f->code, tab4, "return Qnil;\n", NIL);
+        Wrapper_add_local(f, "vresult", "VALUE vresult = Qnil");
+        Printv(f->code, tab4, "return vresult;\n", NIL);
+        Printv(f->code, "fail:\n", NIL);
+        if (need_cleanup) {
+          Printv(f->code, cleanup, NIL);
+        }
+        Printv(f->code, tab4, "return Qnil;\n", NIL);
       }
     } else {
       Printv(f->code, tab4, "return Qnil;\n", NIL);
       Printv(f->code, "fail:\n", NIL);
       if (need_cleanup) {
-	Printv(f->code, cleanup, NIL);
+        Printv(f->code, cleanup, NIL);
       }
       Printv(f->code, tab4, "return Qnil;\n", NIL);
     }
@@ -2014,10 +2014,10 @@ public:
       create_command(n, symname);
     } else {
       if (current == CONSTRUCTOR_ALLOCATE) {
-	create_command(n, symname);
+        create_command(n, symname);
       } else {
-	if (!Getattr(n, "sym:nextSibling"))
-	  dispatchFunction(n);
+        if (!Getattr(n, "sym:nextSibling"))
+          dispatchFunction(n);
       }
     }
 
@@ -2101,7 +2101,7 @@ public:
       // just working around a problem elsewhere though.
       Node *parent_node = parentNode(sibl);
       if (parent_node)
-	Printv( methodName, Getattr(parent_node,"sym:name"), ".", NIL );
+        Printv( methodName, Getattr(parent_node,"sym:name"), ".", NIL );
     }
     Append( methodName, Getattr(sibl,"sym:name" ) );
     if ( isCtor ) Append( methodName, ".new" ); 
@@ -2111,27 +2111,27 @@ public:
     do {
       Append( protoTypes, "\n\"    ");
       if (!isCtor && !Equal(siblNodeType, "using")) {
-	SwigType *type = SwigType_str(Getattr(sibl, "type"), NULL);
-	Printv(protoTypes, type, " ", NIL);
-	Delete(type);
+        SwigType *type = SwigType_str(Getattr(sibl, "type"), NULL);
+        Printv(protoTypes, type, " ", NIL);
+        Delete(type);
       }
       Printv(protoTypes, methodName, NIL );
       Parm* p = Getattr(sibl, "wrap:parms");
       if (p && (current == MEMBER_FUNC || current == MEMBER_VAR || 
-		ctor_director) )
-	p = nextSibling(p); // skip self
+                ctor_director) )
+        p = nextSibling(p); // skip self
       Append( protoTypes, "(" );
       while(p)
-	{
- 	  Append( protoTypes, SwigType_str(Getattr(p,"type"), Getattr(p,"name")) );
-	  if ( ( p = nextSibling(p)) ) Append(protoTypes, ", ");
-	}
+        {
+          Append( protoTypes, SwigType_str(Getattr(p,"type"), Getattr(p,"name")) );
+          if ( ( p = nextSibling(p)) ) Append(protoTypes, ", ");
+        }
       Append( protoTypes, ")\\n\"" );
     } while ((sibl = Getattr(sibl, "sym:nextSibling")));
 
     Append(f->code, "fail:\n");
     Printf(f->code, "Ruby_Format_OverloadedError( argc, %d, \"%s\", %s);\n", 
-	   maxargs, methodName, protoTypes);
+           maxargs, methodName, protoTypes);
     Append(f->code, "\nreturn Qnil;\n");
 
     Delete(methodName);
@@ -2219,11 +2219,11 @@ public:
       }
       tm = Swig_typemap_lookup("varin", n, name, 0);
       if (tm) {
-	Replaceall(tm, "$input", "_val");
-	/* Printv(setf->code,tm,"\n",NIL); */
-	emit_action_code(n, setf->code, tm);
+        Replaceall(tm, "$input", "_val");
+        /* Printv(setf->code,tm,"\n",NIL); */
+        emit_action_code(n, setf->code, tm);
       } else {
-	Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s\n", SwigType_str(t, 0));
+        Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s\n", SwigType_str(t, 0));
       }
       if (use_virtual_var) {
         Printf(setf->code, "fail:\n");
@@ -2250,7 +2250,7 @@ public:
       /* C++ class variable */
       Printv(s, tab4, "rb_define_singleton_method(", klass->vname, ", \"", klass->strip(iname), "\", ", getfname, ", 0);\n", NIL);
       if (assignable) {
-	Printv(s, tab4, "rb_define_singleton_method(", klass->vname, ", \"", klass->strip(iname), "=\", ", setfname, ", 1);\n", NIL);
+        Printv(s, tab4, "rb_define_singleton_method(", klass->vname, ", \"", klass->strip(iname), "=\", ", setfname, ", 1);\n", NIL);
       }
       Printv(klass->init, s, NIL);
       break;
@@ -2259,12 +2259,12 @@ public:
       /* wrapped in Ruby module attribute */
       assert(current == NO_CPP);
       if (!useGlobalModule) {
-	Printv(s, tab4, "rb_define_singleton_method(", modvar, ", \"", iname, "\", ", getfname, ", 0);\n", NIL);
-	if (assignable) {
-	  Printv(s, tab4, "rb_define_singleton_method(", modvar, ", \"", iname, "=\", ", setfname, ", 1);\n", NIL);
-	}
+        Printv(s, tab4, "rb_define_singleton_method(", modvar, ", \"", iname, "\", ", getfname, ", 0);\n", NIL);
+        if (assignable) {
+          Printv(s, tab4, "rb_define_singleton_method(", modvar, ", \"", iname, "=\", ", setfname, ", 1);\n", NIL);
+        }
       } else {
-	Printv(s, tab4, "rb_define_virtual_variable(\"$", iname, "\", ", getfname, ", ", setfname, ");\n", NIL);
+        Printv(s, tab4, "rb_define_virtual_variable(\"$", iname, "\", ", getfname, ", ", setfname, ");\n", NIL);
       }
       Printv(f_init, s, NIL);
       Delete(s);
@@ -2333,20 +2333,20 @@ public:
       Replaceall(tm, "$symname", iname);
       Replaceall(tm, "$value", value);
       if (current == CLASS_CONST) {
-	if (multipleInheritance) {
-	  Replaceall(tm, "$module", klass->mImpl);
-	  Printv(klass->init, tm, "\n", NIL);
-	} else {
-	  Replaceall(tm, "$module", klass->vname);
-	  Printv(klass->init, tm, "\n", NIL);
-	}
+        if (multipleInheritance) {
+          Replaceall(tm, "$module", klass->mImpl);
+          Printv(klass->init, tm, "\n", NIL);
+        } else {
+          Replaceall(tm, "$module", klass->vname);
+          Printv(klass->init, tm, "\n", NIL);
+        }
       } else {
-	if (!useGlobalModule) {
-	  Replaceall(tm, "$module", modvar);
-	} else {
-	  Replaceall(tm, "$module", "rb_cObject");
-	}
-	Printf(f_init, "%s\n", tm);
+        if (!useGlobalModule) {
+          Replaceall(tm, "$module", modvar);
+        } else {
+          Replaceall(tm, "$module", "rb_cObject");
+        }
+        Printf(f_init, "%s\n", tm);
       }
     } else {
       Swig_warning(WARN_TYPEMAP_CONST_UNDEF, input_file, line_number, "Unsupported constant value %s = %s\n", SwigType_str(type, 0), value);
@@ -2370,12 +2370,12 @@ public:
       String *namestr = SwigType_namestr(name);
       klass = RCLASS(classes, Char(namestr));
       if (!klass) {
-	klass = new RClass();
-	String *valid_name = NewString(symname ? symname : namestr);
-	validate_const_name(Char(valid_name), "class");
-	klass->set_name(namestr, symname, valid_name);
-	SET_RCLASS(classes, Char(namestr), klass);
-	Delete(valid_name);
+        klass = new RClass();
+        String *valid_name = NewString(symname ? symname : namestr);
+        validate_const_name(Char(valid_name), "class");
+        klass->set_name(namestr, symname, valid_name);
+        SET_RCLASS(classes, Char(namestr), klass);
+        Delete(valid_name);
       }
       Delete(namestr);
     }
@@ -2390,13 +2390,13 @@ public:
     if (mixin) {
       List *modules = Split(mixin, ',', INT_MAX);
       if (modules && Len(modules) > 0) {
-	Iterator mod = First(modules);
-	while (mod.item) {
-	  if (Len(mod.item) > 0) {
-	    Printf(klass->init, "rb_include_module(%s, rb_eval_string(\"%s\"));\n", klass->vname, mod.item);
-	  }
-	  mod = Next(mod);
-	}
+        Iterator mod = First(modules);
+        while (mod.item) {
+          if (Len(mod.item) > 0) {
+            Printf(klass->init, "rb_include_module(%s, rb_eval_string(\"%s\"));\n", klass->vname, mod.item);
+          }
+          mod = Next(mod);
+        }
       }
       Delete(modules);
     }
@@ -2407,55 +2407,55 @@ public:
     if (baselist && Len(baselist)) {
       Iterator base = First(baselist);
       while (base.item && GetFlag(base.item, "feature:ignore")) {
-	base = Next(base);
+        base = Next(base);
       }
       while (base.item) {
-	String *basename = Getattr(base.item, "name");
-	String *basenamestr = SwigType_namestr(basename);
-	RClass *super = RCLASS(classes, Char(basenamestr));
-	Delete(basenamestr);
-	if (super) {
-	  SwigType *btype = NewString(basename);
-	  SwigType_add_pointer(btype);
-	  SwigType_remember(btype);
-	  SwigType *smart = Getattr(base.item, "smart");
-	  SwigType *psmart = smart ? Copy(smart) : 0;
-	  if (psmart) {
-	    SwigType_add_pointer(psmart);
-	    SwigType_remember(psmart);
-	  }
-	  String *bmangle = SwigType_manglestr(psmart ? psmart : btype);
-	  if (multipleInheritance) {
-	    Insert(bmangle, 0, "((swig_class *) SWIGTYPE");
-	    Append(bmangle, "->clientdata)->mImpl");
-	    Printv(klass->init, "rb_include_module(", klass->mImpl, ", ", bmangle, ");\n", NIL);
-	  } else {
-	    Insert(bmangle, 0, "((swig_class *) SWIGTYPE");
-	    Append(bmangle, "->clientdata)->klass");
-	    Replaceall(klass->init, "$super", bmangle);
-	  }
-	  Delete(bmangle);
-	  Delete(psmart);
-	  Delete(btype);
-	}
-	base = Next(base);
-	while (base.item && GetFlag(base.item, "feature:ignore")) {
-	  base = Next(base);
-	}
-	if (!multipleInheritance) {
-	  /* Warn about multiple inheritance for additional base class(es) */
-	  while (base.item) {
-	    if (GetFlag(base.item, "feature:ignore")) {
-	      base = Next(base);
-	      continue;
-	    }
-	    String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
-	    String *baseclassname = SwigType_str(Getattr(base.item, "name"), 0);
-	    Swig_warning(WARN_RUBY_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
-			 "Warning for %s, base %s ignored. Multiple inheritance is not supported in Ruby.\n", proxyclassname, baseclassname);
-	    base = Next(base);
-	  }
-	}
+        String *basename = Getattr(base.item, "name");
+        String *basenamestr = SwigType_namestr(basename);
+        RClass *super = RCLASS(classes, Char(basenamestr));
+        Delete(basenamestr);
+        if (super) {
+          SwigType *btype = NewString(basename);
+          SwigType_add_pointer(btype);
+          SwigType_remember(btype);
+          SwigType *smart = Getattr(base.item, "smart");
+          SwigType *psmart = smart ? Copy(smart) : 0;
+          if (psmart) {
+            SwigType_add_pointer(psmart);
+            SwigType_remember(psmart);
+          }
+          String *bmangle = SwigType_manglestr(psmart ? psmart : btype);
+          if (multipleInheritance) {
+            Insert(bmangle, 0, "((swig_class *) SWIGTYPE");
+            Append(bmangle, "->clientdata)->mImpl");
+            Printv(klass->init, "rb_include_module(", klass->mImpl, ", ", bmangle, ");\n", NIL);
+          } else {
+            Insert(bmangle, 0, "((swig_class *) SWIGTYPE");
+            Append(bmangle, "->clientdata)->klass");
+            Replaceall(klass->init, "$super", bmangle);
+          }
+          Delete(bmangle);
+          Delete(psmart);
+          Delete(btype);
+        }
+        base = Next(base);
+        while (base.item && GetFlag(base.item, "feature:ignore")) {
+          base = Next(base);
+        }
+        if (!multipleInheritance) {
+          /* Warn about multiple inheritance for additional base class(es) */
+          while (base.item) {
+            if (GetFlag(base.item, "feature:ignore")) {
+              base = Next(base);
+              continue;
+            }
+            String *proxyclassname = SwigType_str(Getattr(n, "classtypeobj"), 0);
+            String *baseclassname = SwigType_str(Getattr(base.item, "name"), 0);
+            Swig_warning(WARN_RUBY_MULTIPLE_INHERITANCE, Getfile(n), Getline(n),
+                         "Warning for %s, base %s ignored. Multiple inheritance is not supported in Ruby.\n", proxyclassname, baseclassname);
+            base = Next(base);
+          }
+        }
       }
     }
   }
@@ -2481,7 +2481,7 @@ public:
       Printf(klass->init, "SwigClass%s.destroy = (void (*)(void *)) %s;\n", klass->name, freefunc);
     } else {
       if (klass->destructor_defined) {
-	Printf(klass->init, "SwigClass%s.destroy = (void (*)(void *)) free_%s;\n", klass->name, klass->mname);
+        Printf(klass->init, "SwigClass%s.destroy = (void (*)(void *)) free_%s;\n", klass->name, klass->mname);
       }
     }
   }
@@ -2526,7 +2526,7 @@ public:
       Printv(klass->init, klass->vname, " = rb_define_class_under(", modvar, ", \"", klass->name, "\", $super);\n", NIL);
     } else {
       Printv(klass->init, klass->vname, " = rb_define_class(\"", klass->name, 
-	     "\", $super);\n", NIL);
+             "\", $super);\n", NIL);
     }
 
     if (multipleInheritance) {
@@ -2628,9 +2628,9 @@ public:
     if (cname)
       cname[0] = (char)toupper(cname[0]);
     Printv(director_prot_ctor_code,
-	   "if ($comparison) { /* subclassed */\n",
-	   "  $director_new\n",
-	   "} else {\n", "  rb_raise(rb_eNameError,\"accessing abstract class or protected constructor\");\n", "  return Qnil;\n", "}\n", NIL);
+           "if ($comparison) { /* subclassed */\n",
+           "  $director_new\n",
+           "} else {\n", "  rb_raise(rb_eNameError,\"accessing abstract class or protected constructor\");\n", "  return Qnil;\n", "}\n", NIL);
     Delete(director_ctor_code);
     director_ctor_code = NewString("");
     Printv(director_ctor_code, "if ($comparison) { /* subclassed */\n", "  $director_new\n", "} else {\n", "  $nondirector_new\n", "}\n", NIL);
@@ -2669,7 +2669,7 @@ public:
       Delete(name);
       Setattr(self, "lname", "Qnil");
       if (parms)
-	set_nextSibling(self, parms);
+        set_nextSibling(self, parms);
       Setattr(n, "parms", self);
       Delete(self);
     }
@@ -2736,20 +2736,20 @@ public:
     if (Extend) {
       String *wrap = Getattr(n, "wrap:code");
       if (wrap) {
-	Printv(f_wrappers, wrap, NIL);
+        Printv(f_wrappers, wrap, NIL);
       }
       /*    Printv(freebody, Swig_name_destroy(name), "(", pname0, ")", NIL); */
       Printv(freebody, Getattr(n, "wrap:action"), "\n", NIL);
     } else {
       String *action = Getattr(n, "wrap:action");
       if (action) {
-	Printv(freebody, action, "\n", NIL);
+        Printv(freebody, action, "\n", NIL);
       } else {
-	/* In the case swig emits no destroy function. */
-	if (CPlusPlus)
-	  Printf(freebody, "delete %s;\n", pname0);
-	else
-	  Printf(freebody, "free((char*) %s);\n", pname0);
+        /* In the case swig emits no destroy function. */
+        if (CPlusPlus)
+          Printf(freebody, "delete %s;\n", pname0);
+        else
+          Printf(freebody, "free((char*) %s);\n", pname0);
       }
     }
 
@@ -2887,23 +2887,23 @@ public:
     if (!Getattr(n, "defaultargs")) {
       /* constructor */
       {
-	Wrapper *w = NewWrapper();
-	String *call;
-	String *basetype = Getattr(parent, "classtype");
-	String *target = Swig_method_decl(0, decl, classname, parms, 0);
-	call = Swig_csuperclass_call(0, basetype, superparms);
-	Printf(w->def, "%s::%s: %s, Swig::Director(self) { }", classname, target, call);
-	Delete(target);
-	Wrapper_print(w, f_directors);
-	Delete(call);
-	DelWrapper(w);
+        Wrapper *w = NewWrapper();
+        String *call;
+        String *basetype = Getattr(parent, "classtype");
+        String *target = Swig_method_decl(0, decl, classname, parms, 0);
+        call = Swig_csuperclass_call(0, basetype, superparms);
+        Printf(w->def, "%s::%s: %s, Swig::Director(self) { }", classname, target, call);
+        Delete(target);
+        Wrapper_print(w, f_directors);
+        Delete(call);
+        DelWrapper(w);
       }
 
       /* constructor header */
       {
-	String *target = Swig_method_decl(0, decl, classname, parms, 1);
-	Printf(f_directors_h, "    %s;\n", target);
-	Delete(target);
+        String *target = Swig_method_decl(0, decl, classname, parms, 1);
+        Printf(f_directors_h, "    %s;\n", target);
+        Delete(target);
       }
     }
 
@@ -2958,27 +2958,27 @@ public:
     if ((tm != 0) && (Len(tm) > 0) && (Strcmp(tm, "1") != 0)) {
       // Declare a global to hold the depth count
       if (!Getattr(n, "sym:nextSibling")) {
-	Printf(body->def, "static int %s = 0;\n", depthCountName);
+        Printf(body->def, "static int %s = 0;\n", depthCountName);
 
-	// Function body
-	Printf(body->def, "VALUE %s(VALUE data) {\n", bodyName);
-	Wrapper_add_localv(body, "args", "Swig::body_args *", "args", "= reinterpret_cast<Swig::body_args *>(data)", NIL);
-	Wrapper_add_localv(body, Swig_cresult_name(), "VALUE", Swig_cresult_name(), "= Qnil", NIL);
-	Printf(body->code, "%s++;\n", depthCountName);
-	Printv(body->code, Swig_cresult_name(), " = rb_funcall2(args->recv, args->id, args->argc, args->argv);\n", NIL);
-	Printf(body->code, "%s--;\n", depthCountName);
-	Printv(body->code, "return ", Swig_cresult_name(), ";\n", NIL);
-	Printv(body->code, "}", NIL);
+        // Function body
+        Printf(body->def, "VALUE %s(VALUE data) {\n", bodyName);
+        Wrapper_add_localv(body, "args", "Swig::body_args *", "args", "= reinterpret_cast<Swig::body_args *>(data)", NIL);
+        Wrapper_add_localv(body, Swig_cresult_name(), "VALUE", Swig_cresult_name(), "= Qnil", NIL);
+        Printf(body->code, "%s++;\n", depthCountName);
+        Printv(body->code, Swig_cresult_name(), " = rb_funcall2(args->recv, args->id, args->argc, args->argv);\n", NIL);
+        Printf(body->code, "%s--;\n", depthCountName);
+        Printv(body->code, "return ", Swig_cresult_name(), ";\n", NIL);
+        Printv(body->code, "}", NIL);
 
-	// Exception handler
-	Printf(rescue->def, "VALUE %s(VALUE args, VALUE error) {\n", rescueName);
-	Replaceall(tm, "$error", "error");
-	Printf(rescue->code, "%s--;\n", depthCountName);
-	Printf(rescue->code, "if (%s == 0) ", depthCountName);
-	Printv(rescue->code, Str(tm), "\n", NIL);
-	Printv(rescue->code, "rb_exc_raise(error);\n", NIL);
-	Printv(rescue->code, "return Qnil;\n", NIL);
-	Printv(rescue->code, "}", NIL);
+        // Exception handler
+        Printf(rescue->def, "VALUE %s(VALUE args, VALUE error) {\n", rescueName);
+        Replaceall(tm, "$error", "error");
+        Printf(rescue->code, "%s--;\n", depthCountName);
+        Printf(rescue->code, "if (%s == 0) ", depthCountName);
+        Printv(rescue->code, Str(tm), "\n", NIL);
+        Printv(rescue->code, "rb_exc_raise(error);\n", NIL);
+        Printv(rescue->code, "return Qnil;\n", NIL);
+        Printv(rescue->code, "}", NIL);
       }
 
       // Main code
@@ -2988,12 +2988,12 @@ public:
       Printf(w->code, "args.id = rb_intern(\"%s\");\n", methodName);
       Printf(w->code, "args.argc = %d;\n", argc);
       if (argc > 0) {
-	Printf(w->code, "args.argv = new VALUE[%d];\n", argc);
-	for (int i = 0; i < argc; i++) {
-	  Printf(w->code, "args.argv[%d] = obj%d;\n", i, i);
-	}
+        Printf(w->code, "args.argv = new VALUE[%d];\n", argc);
+        for (int i = 0; i < argc; i++) {
+          Printf(w->code, "args.argv[%d] = obj%d;\n", i, i);
+        }
       } else {
-	Printv(w->code, "args.argv = 0;\n", NIL);
+        Printv(w->code, "args.argv = 0;\n", NIL);
       }
       Printf(w->code, "%s = rb_protect(PROTECTFUNC(%s), reinterpret_cast<VALUE>(&args), &status);\n", Swig_cresult_name(), bodyName);
       if ( initstack ) Printf(w->code, "SWIG_RELEASE_STACK;\n");
@@ -3002,16 +3002,16 @@ public:
       Printf(w->code, "%s(reinterpret_cast<VALUE>(&args), lastErr);\n", rescueName);
       Printf(w->code, "}\n");
       if (argc > 0) {
-	Printv(w->code, "delete [] args.argv;\n", NIL);
+        Printv(w->code, "delete [] args.argv;\n", NIL);
       }
       // Dump wrapper code
       Wrapper_print(body, f_directors_helpers);
       Wrapper_print(rescue, f_directors_helpers);
     } else {
       if (argc > 0) {
-	Printf(w->code, "%s = rb_funcall(swig_get_self(), rb_intern(\"%s\"), %d%s);\n", Swig_cresult_name(), methodName, argc, args);
+        Printf(w->code, "%s = rb_funcall(swig_get_self(), rb_intern(\"%s\"), %d%s);\n", Swig_cresult_name(), methodName, argc, args);
       } else {
-	Printf(w->code, "%s = rb_funcall(swig_get_self(), rb_intern(\"%s\"), 0, Qnil);\n", Swig_cresult_name(), methodName);
+        Printf(w->code, "%s = rb_funcall(swig_get_self(), rb_intern(\"%s\"), 0, Qnil);\n", Swig_cresult_name(), methodName);
       }
       if ( initstack ) Printf(w->code, "SWIG_RELEASE_STACK;\n");
     }
@@ -3050,7 +3050,7 @@ public:
 
     if (Cmp(storage, "virtual") == 0) {
       if (Cmp(value, "0") == 0) {
-	pure_virtual = true;
+        pure_virtual = true;
       }
     }
     String *overnametmp = NewString(Getattr(n, "sym:name"));
@@ -3091,17 +3091,17 @@ public:
       Append(declaration, " throw(");
 
       if (throw_parm_list)
-	Swig_typemap_attach_parms("throws", throw_parm_list, 0);
+        Swig_typemap_attach_parms("throws", throw_parm_list, 0);
       for (p = throw_parm_list; p; p = nextSibling(p)) {
-	if (Getattr(p, "tmap:throws")) {
-	  if (gencomma++) {
-	    Append(w->def, ", ");
-	    Append(declaration, ", ");
-	  }
+        if (Getattr(p, "tmap:throws")) {
+          if (gencomma++) {
+            Append(w->def, ", ");
+            Append(declaration, ", ");
+          }
 
-	  Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
-	  Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
-	}
+          Printf(w->def, "%s", SwigType_str(Getattr(p, "type"), 0));
+          Printf(declaration, "%s", SwigType_str(Getattr(p, "type"), 0));
+        }
       }
 
       Append(w->def, ")");
@@ -3121,30 +3121,30 @@ public:
      */
     if (!is_void && (!ignored_method || pure_virtual)) {
       if (!SwigType_isclass(returntype)) {
-	if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
-	  String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
-	  Delete(construct_result);
-	} else {
-	  Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
-	}
+        if (!(SwigType_ispointer(returntype) || SwigType_isreference(returntype))) {
+          String *construct_result = NewStringf("= SwigValueInit< %s >()", SwigType_lstr(returntype, 0));
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), construct_result, NIL);
+          Delete(construct_result);
+        } else {
+          Wrapper_add_localv(w, "c_result", SwigType_lstr(returntype, "c_result"), "= 0", NIL);
+        }
       } else {
-	String *cres = SwigType_lstr(returntype, "c_result");
-	Printf(w->code, "%s;\n", cres);
-	Delete(cres);
+        String *cres = SwigType_lstr(returntype, "c_result");
+        Printf(w->code, "%s;\n", cres);
+        Delete(cres);
       }
     }
 
     if (ignored_method) {
       if (!pure_virtual) {
-	if (!is_void)
-	  Printf(w->code, "return ");
-	String *super_call = Swig_method_call(super, l);
-	Printf(w->code, "%s;\n", super_call);
-	Delete(super_call);
+        if (!is_void)
+          Printf(w->code, "return ");
+        String *super_call = Swig_method_call(super, l);
+        Printf(w->code, "%s;\n", super_call);
+        Delete(super_call);
       } else {
-	Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
-	       SwigType_namestr(name));
+        Printf(w->code, "Swig::DirectorPureVirtualException::raise(\"Attempted to invoke pure virtual method %s::%s\");\n", SwigType_namestr(c_classname),
+               SwigType_namestr(name));
       }
     } else {
       /* attach typemaps to arguments (C/C++ -> Ruby) */
@@ -3160,103 +3160,103 @@ public:
 
       int outputs = 0;
       if (!is_void && !asvoid)
-	outputs++;
+        outputs++;
 
       /* build argument list and type conversion string */
       idx = 0; p = l;
       while ( p ) {
-	if (Getattr(p, "tmap:directorargout") != 0)
-	  outputs++;
+        if (Getattr(p, "tmap:directorargout") != 0)
+          outputs++;
 
-	if ( checkAttribute( p, "tmap:in:numinputs", "0") ) {
-	  p = Getattr(p, "tmap:in:next");
-	  continue;
-	}
+        if ( checkAttribute( p, "tmap:in:numinputs", "0") ) {
+          p = Getattr(p, "tmap:in:next");
+          continue;
+        }
 
-	String *parameterName = Getattr(p, "name");
-	String *parameterType = Getattr(p, "type");
+        String *parameterName = Getattr(p, "name");
+        String *parameterType = Getattr(p, "type");
 
-	Putc(',', arglist);
-	if ((tm = Getattr(p, "tmap:directorin")) != 0) {
-	  sprintf(source, "obj%d", idx++);
-	  String *input = NewString(source);
-	  Setattr(p, "emit:directorinput", input);
-	  Replaceall(tm, "$input", input);
-	  Replaceall(tm, "$owner", "0");
-	  Delete(input);
-	  Printv(wrap_args, tm, "\n", NIL);
-	  Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
-	  Printv(arglist, source, NIL);
-	  p = Getattr(p, "tmap:directorin:next");
-	  continue;
-	} else if (Cmp(parameterType, "void")) {
-	  /**
-	   * Special handling for pointers to other C++ director classes.
-	   * Ideally this would be left to a typemap, but there is currently no
-	   * way to selectively apply the dynamic_cast<> to classes that have
-	   * directors.  In other words, the type "SwigDirector_$1_lname" only exists
-	   * for classes with directors.  We avoid the problem here by checking
-	   * module.wrap::directormap, but it's not clear how to get a typemap to
-	   * do something similar.  Perhaps a new default typemap (in addition
-	   * to SWIGTYPE) called DIRECTORTYPE?
-	   */
-	  if (SwigType_ispointer(parameterType) || SwigType_isreference(parameterType)) {
-	    Node *modname = Getattr(parent, "module");
-	    Node *target = Swig_directormap(modname, parameterType);
-	    sprintf(source, "obj%d", idx++);
-	    String *nonconst = 0;
-	    /* strip pointer/reference --- should move to Swig/stype.c */
-	    String *nptype = NewString(Char(parameterType) + 2);
-	    /* name as pointer */
-	    String *ppname = Copy(parameterName);
-	    if (SwigType_isreference(parameterType)) {
-	      Insert(ppname, 0, "&");
-	    }
-	    /* if necessary, cast away const since Ruby doesn't support it! */
-	    if (SwigType_isconst(nptype)) {
-	      nonconst = NewStringf("nc_tmp_%s", parameterName);
-	      String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(parameterType, 0), ppname);
-	      Wrapper_add_localv(w, nonconst, SwigType_lstr(parameterType, 0), nonconst, nonconst_i, NIL);
-	      Delete(nonconst_i);
-	      Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
-			   "Target language argument '%s' discards const in director method %s::%s.\n", SwigType_str(parameterType, parameterName),
-			   SwigType_namestr(c_classname), SwigType_namestr(name));
-	    } else {
-	      nonconst = Copy(ppname);
-	    }
-	    Delete(nptype);
-	    Delete(ppname);
-	    String *mangle = SwigType_manglestr(parameterType);
-	    if (target) {
-	      String *director = NewStringf("director_%s", mangle);
-	      Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
-	      Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
-	      Printf(wrap_args, "%s = dynamic_cast<Swig::Director *>(%s);\n", director, nonconst);
-	      Printf(wrap_args, "if (!%s) {\n", director);
-	      Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	      Printf(wrap_args, "} else {\n");
-	      Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
-	      Printf(wrap_args, "}\n");
-	      Delete(director);
-	      Printv(arglist, source, NIL);
-	    } else {
-	      Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
-	      Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-	      //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
-	      //       source, nonconst, base);
-	      Printv(arglist, source, NIL);
-	    }
-	    Delete(mangle);
-	    Delete(nonconst);
-	  } else {
-	    Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
-			 "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(parameterType, 0),
-			 SwigType_namestr(c_classname), SwigType_namestr(name));
-	    status = SWIG_NOWRAP;
-	    break;
-	  }
-	}
-	p = nextSibling(p);
+        Putc(',', arglist);
+        if ((tm = Getattr(p, "tmap:directorin")) != 0) {
+          sprintf(source, "obj%d", idx++);
+          String *input = NewString(source);
+          Setattr(p, "emit:directorinput", input);
+          Replaceall(tm, "$input", input);
+          Replaceall(tm, "$owner", "0");
+          Delete(input);
+          Printv(wrap_args, tm, "\n", NIL);
+          Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
+          Printv(arglist, source, NIL);
+          p = Getattr(p, "tmap:directorin:next");
+          continue;
+        } else if (Cmp(parameterType, "void")) {
+          /**
+           * Special handling for pointers to other C++ director classes.
+           * Ideally this would be left to a typemap, but there is currently no
+           * way to selectively apply the dynamic_cast<> to classes that have
+           * directors.  In other words, the type "SwigDirector_$1_lname" only exists
+           * for classes with directors.  We avoid the problem here by checking
+           * module.wrap::directormap, but it's not clear how to get a typemap to
+           * do something similar.  Perhaps a new default typemap (in addition
+           * to SWIGTYPE) called DIRECTORTYPE?
+           */
+          if (SwigType_ispointer(parameterType) || SwigType_isreference(parameterType)) {
+            Node *modname = Getattr(parent, "module");
+            Node *target = Swig_directormap(modname, parameterType);
+            sprintf(source, "obj%d", idx++);
+            String *nonconst = 0;
+            /* strip pointer/reference --- should move to Swig/stype.c */
+            String *nptype = NewString(Char(parameterType) + 2);
+            /* name as pointer */
+            String *ppname = Copy(parameterName);
+            if (SwigType_isreference(parameterType)) {
+              Insert(ppname, 0, "&");
+            }
+            /* if necessary, cast away const since Ruby doesn't support it! */
+            if (SwigType_isconst(nptype)) {
+              nonconst = NewStringf("nc_tmp_%s", parameterName);
+              String *nonconst_i = NewStringf("= const_cast< %s >(%s)", SwigType_lstr(parameterType, 0), ppname);
+              Wrapper_add_localv(w, nonconst, SwigType_lstr(parameterType, 0), nonconst, nonconst_i, NIL);
+              Delete(nonconst_i);
+              Swig_warning(WARN_LANG_DISCARD_CONST, input_file, line_number,
+                           "Target language argument '%s' discards const in director method %s::%s.\n", SwigType_str(parameterType, parameterName),
+                           SwigType_namestr(c_classname), SwigType_namestr(name));
+            } else {
+              nonconst = Copy(ppname);
+            }
+            Delete(nptype);
+            Delete(ppname);
+            String *mangle = SwigType_manglestr(parameterType);
+            if (target) {
+              String *director = NewStringf("director_%s", mangle);
+              Wrapper_add_localv(w, director, "Swig::Director *", director, "= 0", NIL);
+              Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
+              Printf(wrap_args, "%s = dynamic_cast<Swig::Director *>(%s);\n", director, nonconst);
+              Printf(wrap_args, "if (!%s) {\n", director);
+              Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+              Printf(wrap_args, "} else {\n");
+              Printf(wrap_args, "%s = %s->swig_get_self();\n", source, director);
+              Printf(wrap_args, "}\n");
+              Delete(director);
+              Printv(arglist, source, NIL);
+            } else {
+              Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
+              Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
+              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
+              //       source, nonconst, base);
+              Printv(arglist, source, NIL);
+            }
+            Delete(mangle);
+            Delete(nonconst);
+          } else {
+            Swig_warning(WARN_TYPEMAP_DIRECTORIN_UNDEF, input_file, line_number,
+                         "Unable to use type %s as a function argument in director method %s::%s (skipping method).\n", SwigType_str(parameterType, 0),
+                         SwigType_namestr(c_classname), SwigType_namestr(name));
+            status = SWIG_NOWRAP;
+            break;
+          }
+        }
+        p = nextSibling(p);
       }
 
       /* declare Ruby return value */
@@ -3282,55 +3282,55 @@ public:
       String *outarg = NewString("");
 
       if (outputs > 1) {
-	Wrapper_add_local(w, "output", "VALUE output");
-	Printf(w->code, "if (TYPE(%s) != T_ARRAY) {\n", Swig_cresult_name());
-	Printf(w->code, "Ruby_DirectorTypeMismatchException(\"Ruby method failed to return an array.\");\n");
-	Printf(w->code, "}\n");
+        Wrapper_add_local(w, "output", "VALUE output");
+        Printf(w->code, "if (TYPE(%s) != T_ARRAY) {\n", Swig_cresult_name());
+        Printf(w->code, "Ruby_DirectorTypeMismatchException(\"Ruby method failed to return an array.\");\n");
+        Printf(w->code, "}\n");
       }
 
       idx = 0;
 
       /* Marshal return value */
       if (!is_void) {
-	tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
-	if (tm != 0) {
-	  if (outputs > 1 && !asvoid ) {
-	    Printf(w->code, "output = rb_ary_entry(%s, %d);\n", Swig_cresult_name(), idx++);
-	    Replaceall(tm, "$input", "output");
-	  } else {
-	    Replaceall(tm, "$input", Swig_cresult_name());
-	  }
-	  /* TODO check this */
-	  if (Getattr(n, "wrap:disown")) {
-	    Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	  } else {
-	    Replaceall(tm, "$disown", "0");
-	  }
-	  Replaceall(tm, "$result", "c_result");
-	  Printv(w->code, tm, "\n", NIL);
-	} else {
-	  Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
-		       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
-		       SwigType_namestr(c_classname), SwigType_namestr(name));
-	  status = SWIG_ERROR;
-	}
+        tm = Swig_typemap_lookup("directorout", n, Swig_cresult_name(), w);
+        if (tm != 0) {
+          if (outputs > 1 && !asvoid ) {
+            Printf(w->code, "output = rb_ary_entry(%s, %d);\n", Swig_cresult_name(), idx++);
+            Replaceall(tm, "$input", "output");
+          } else {
+            Replaceall(tm, "$input", Swig_cresult_name());
+          }
+          /* TODO check this */
+          if (Getattr(n, "wrap:disown")) {
+            Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+          } else {
+            Replaceall(tm, "$disown", "0");
+          }
+          Replaceall(tm, "$result", "c_result");
+          Printv(w->code, tm, "\n", NIL);
+        } else {
+          Swig_warning(WARN_TYPEMAP_DIRECTOROUT_UNDEF, input_file, line_number,
+                       "Unable to use return type %s in director method %s::%s (skipping method).\n", SwigType_str(returntype, 0),
+                       SwigType_namestr(c_classname), SwigType_namestr(name));
+          status = SWIG_ERROR;
+        }
       }
 
       /* Marshal outputs */
       for (p = l; p;) {
-	if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
-	  if (outputs > 1) {
-	    Printf(w->code, "output = rb_ary_entry(%s, %d);\n", Swig_cresult_name(), idx++);
-	    Replaceall(tm, "$result", "output");
-	  } else {
-	    Replaceall(tm, "$result", Swig_cresult_name());
-	  }
-	  Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
-	  Printv(w->code, tm, "\n", NIL);
-	  p = Getattr(p, "tmap:directorargout:next");
-	} else {
-	  p = nextSibling(p);
-	}
+        if ((tm = Getattr(p, "tmap:directorargout")) != 0) {
+          if (outputs > 1) {
+            Printf(w->code, "output = rb_ary_entry(%s, %d);\n", Swig_cresult_name(), idx++);
+            Replaceall(tm, "$result", "output");
+          } else {
+            Replaceall(tm, "$result", Swig_cresult_name());
+          }
+          Replaceall(tm, "$input", Getattr(p, "emit:directorinput"));
+          Printv(w->code, tm, "\n", NIL);
+          p = Getattr(p, "tmap:directorargout:next");
+        } else {
+          p = nextSibling(p);
+        }
       }
 
       Delete(arglist);
@@ -3341,13 +3341,13 @@ public:
     /* any existing helper functions to handle this? */
     if (!is_void) {
       if (!(ignored_method && !pure_virtual)) {
-	String *rettype = SwigType_str(returntype, 0);
-	if (!SwigType_isreference(returntype)) {
-	  Printf(w->code, "return (%s) c_result;\n", rettype);
-	} else {
-	  Printf(w->code, "return (%s) *c_result;\n", rettype);
-	}
-	Delete(rettype);
+        String *rettype = SwigType_str(returntype, 0);
+        if (!SwigType_isreference(returntype)) {
+          Printf(w->code, "return (%s) c_result;\n", rettype);
+        } else {
+          Printf(w->code, "return (%s) *c_result;\n", rettype);
+        }
+        Delete(rettype);
       }
     }
 
@@ -3361,7 +3361,7 @@ public:
       Replaceall(inline_extra_method, name, extra_method_name);
       Replaceall(inline_extra_method, ";\n", " {\n      ");
       if (!is_void)
-	Printf(inline_extra_method, "return ");
+        Printf(inline_extra_method, "return ");
       String *methodcall = Swig_method_call(super, l);
       Printv(inline_extra_method, methodcall, ";\n    }\n", NIL);
       Delete(methodcall);
@@ -3372,10 +3372,10 @@ public:
     if (status == SWIG_OK) {
       Replaceall(w->code, "$isvoid", is_void ? "1" : "0");
       if (!Getattr(n, "defaultargs")) {
-	Replaceall(w->code, "$symname", symname);
-	Wrapper_print(w, f_directors);
-	Printv(f_directors_h, declaration, NIL);
-	Printv(f_directors_h, inline_extra_method, NIL);
+        Replaceall(w->code, "$symname", symname);
+        Wrapper_print(w, f_directors);
+        Printv(f_directors_h, declaration, NIL);
+        Printv(f_directors_h, inline_extra_method, NIL);
       }
     }
 

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -65,7 +65,7 @@ public:
     constructor_defined = 0;
     destructor_defined = 0;
   }
-  
+
   ~RClass() {
     Delete(name);
     Delete(cname);
@@ -286,7 +286,7 @@ private:
    * addMissingParameterNames()
    *  For functions that have not had nameless parameters set in the Language class.
    *
-   * Inputs: 
+   * Inputs:
    *   plist - entire parameter list
    *   arg_offset - argument number for first parameter
    * Side effects:
@@ -439,8 +439,8 @@ private:
       n = Getattr(n, "sym:previousSibling");
 
     Node *pn = Swig_methodclass(n);
-    String* super_names = NewString(""); 
-    String* class_name = Getattr(pn, "sym:name") ; 
+    String* super_names = NewString("");
+    String* class_name = Getattr(pn, "sym:name") ;
 
     if ( !class_name ) {
       class_name = NewString("");
@@ -849,7 +849,7 @@ public:
    *
    * Parse command line options and initializes variables.
    * --------------------------------------------------------------------- */
-  
+
   virtual void main(int argc, char *argv[]) {
 
     int autorename = 0;
@@ -1787,7 +1787,7 @@ public:
     insertArgOutputCode(l, outarg, need_result);
 
     /* if the object is a director, and the method call originated from its
-     * underlying Ruby object, resolve the call by going up the c++ 
+     * underlying Ruby object, resolve the call by going up the c++
      * inheritance chain.  otherwise try to resolve the method in Ruby.
      * without this check an infinite loop is set up between the director and
      * shadow class method calls.
@@ -1873,7 +1873,7 @@ public:
             else
               Replaceall(tm, "$owner", "0");
 
-            // Unwrap return values that are director classes so that the original Ruby object is returned instead. 
+            // Unwrap return values that are director classes so that the original Ruby object is returned instead.
             if (Swig_director_can_unwrap(n)) {
               Wrapper_add_local(f, "director", "Swig::Director *director = 0");
               Printf(f->code, "director = dynamic_cast<Swig::Director *>(%s);\n", Swig_cresult_name());
@@ -2080,7 +2080,7 @@ public:
     Printv(f->code, dispatch, "\n", NIL);
 
 
-    
+
     // Generate prototype list, go to first node
     Node *sibl = n;
 
@@ -2104,7 +2104,7 @@ public:
         Printv( methodName, Getattr(parent_node,"sym:name"), ".", NIL );
     }
     Append( methodName, Getattr(sibl,"sym:name" ) );
-    if ( isCtor ) Append( methodName, ".new" ); 
+    if ( isCtor ) Append( methodName, ".new" );
 
     // Generate prototype list
     String *protoTypes = NewString("");
@@ -2117,7 +2117,7 @@ public:
       }
       Printv(protoTypes, methodName, NIL );
       Parm* p = Getattr(sibl, "wrap:parms");
-      if (p && (current == MEMBER_FUNC || current == MEMBER_VAR || 
+      if (p && (current == MEMBER_FUNC || current == MEMBER_VAR ||
                 ctor_director) )
         p = nextSibling(p); // skip self
       Append( protoTypes, "(" );
@@ -2130,7 +2130,7 @@ public:
     } while ((sibl = Getattr(sibl, "sym:nextSibling")));
 
     Append(f->code, "fail:\n");
-    Printf(f->code, "Ruby_Format_OverloadedError( argc, %d, \"%s\", %s);\n", 
+    Printf(f->code, "Ruby_Format_OverloadedError( argc, %d, \"%s\", %s);\n",
            maxargs, methodName, protoTypes);
     Append(f->code, "\nreturn Qnil;\n");
 
@@ -2356,7 +2356,7 @@ public:
   }
 
   /* -----------------------------------------------------------------------------
-   * classDeclaration() 
+   * classDeclaration()
    *
    * Records information about classes---even classes that might be defined in
    * other modules referenced by %import.
@@ -2525,7 +2525,7 @@ public:
     if (!useGlobalModule) {
       Printv(klass->init, klass->vname, " = rb_define_class_under(", modvar, ", \"", klass->name, "\", $super);\n", NIL);
     } else {
-      Printv(klass->init, klass->vname, " = rb_define_class(\"", klass->name, 
+      Printv(klass->init, klass->vname, " = rb_define_class(\"", klass->name,
              "\", $super);\n", NIL);
     }
 
@@ -2653,7 +2653,7 @@ public:
     Printf(f_wrappers, "%s", docs);
     Delete(docs);
 
-    /* 
+    /*
      * If we're wrapping the constructor of a C++ director class, prepend a new parameter
      * to receive the scripting language object (e.g. 'self')
      *
@@ -2934,7 +2934,7 @@ public:
   /* ---------------------------------------------------------------
    * exceptionSafeMethodCall()
    *
-   * Emit a virtual director method to pass a method call on to the 
+   * Emit a virtual director method to pass a method call on to the
    * underlying Ruby instance.
    *
    * --------------------------------------------------------------- */
@@ -3115,7 +3115,7 @@ public:
       Append(w->def, "\nSWIG_INIT_STACK;\n");
     }
 
-    /* declare method return value 
+    /* declare method return value
      * if the return value is a reference or const reference, a specialized typemap must
      * handle it, including declaration of c_result ($result).
      */
@@ -3242,7 +3242,7 @@ public:
             } else {
               Wrapper_add_localv(w, source, "VALUE", source, "= Qnil", NIL);
               Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE%s, 0);\n", source, nonconst, mangle);
-              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n", 
+              //Printf(wrap_args, "%s = SWIG_NewPointerObj(%s, SWIGTYPE_p_%s, 0);\n",
               //       source, nonconst, base);
               Printv(arglist, source, NIL);
             }

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -15,7 +15,7 @@
 #include "cparse.h"
 #include <ctype.h>
 #include <string.h>
-#include <limits.h>		/* for INT_MAX */
+#include <limits.h>             /* for INT_MAX */
 
 #define SWIG_PROTECTED_TARGET_METHODS 1
 
@@ -24,9 +24,9 @@ private:
   String *temp;
 
 public:
-  String *name;			/* class name (renamed) */
-  String *cname;		/* original C class/struct name */
-  String *mname;		/* Mangled name */
+  String *name;                 /* class name (renamed) */
+  String *cname;                /* original C class/struct name */
+  String *mname;                /* Mangled name */
 
   /**
    * The C variable name used in the SWIG-generated wrapper code to refer to
@@ -154,9 +154,9 @@ private:
   String *feature;
   String *prefix;
   int current;
-  Hash *classes;		/* key=cname val=RClass */
-  RClass *klass;		/* Currently processing class */
-  Hash *special_methods;	/* Python style special method name table */
+  Hash *classes;                /* key=cname val=RClass */
+  RClass *klass;                /* Currently processing class */
+  Hash *special_methods;        /* Python style special method name table */
 
   File *f_directors;
   File *f_directors_h;
@@ -190,12 +190,12 @@ private:
    * ------------------------------------------------------------ */
 
   enum autodoc_l {
-    NO_AUTODOC = -2,		// no autodoc
-    STRING_AUTODOC = -1,	// use provided string
-    NAMES_AUTODOC = 0,		// only parameter names
-    TYPES_AUTODOC = 1,		// parameter names and types
-    EXTEND_AUTODOC = 2,		// extended documentation and parameter names
-    EXTEND_TYPES_AUTODOC = 3	// extended documentation and parameter types + names
+    NO_AUTODOC = -2,            // no autodoc
+    STRING_AUTODOC = -1,        // use provided string
+    NAMES_AUTODOC = 0,          // only parameter names
+    TYPES_AUTODOC = 1,          // parameter names and types
+    EXTEND_AUTODOC = 2,         // extended documentation and parameter names
+    EXTEND_TYPES_AUTODOC = 3    // extended documentation and parameter types + names
   };
 
   autodoc_t last_mode;
@@ -262,11 +262,11 @@ private:
     if (have_auto || have_ds)
       doc = NewString("/*");
 
-    if (have_auto && have_ds) {	// Both autodoc and docstring are present
+    if (have_auto && have_ds) { // Both autodoc and docstring are present
       Printv(doc, "\n", autodoc, "\n", str, "\n", NIL);
-    } else if (!have_auto && have_ds) {	// only docstring
+    } else if (!have_auto && have_ds) { // only docstring
       Printv(doc, str, NIL);
-    } else if (have_auto && !have_ds) {	// only autodoc
+    } else if (have_auto && !have_ds) { // only autodoc
       Printv(doc, "\n", autodoc, "\n", NIL);
     } else {
       doc = NewString("");
@@ -1416,7 +1416,7 @@ public:
     case CLASS_CONST:
     case STATIC_VAR:
     default:
-      assert(false);		// Should not have gotten here for these types
+      assert(false);            // Should not have gotten here for these types
     }
 
     defineAliases(n, iname);
@@ -1511,7 +1511,7 @@ public:
         Printf(source, "argv[%d]", i - start);
       }
 
-      if (i >= (numreq)) {	/* Check if parsing an optional argument */
+      if (i >= (numreq)) {      /* Check if parsing an optional argument */
         Printf(f->code, "    if (argc > %d) {\n", i - start);
       }
 
@@ -2085,7 +2085,7 @@ public:
     Node *sibl = n;
 
     while (Getattr(sibl, "sym:previousSibling"))
-      sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+      sibl = Getattr(sibl, "sym:previousSibling");      // go all the way up
 
     // Constructors will be treated specially
     String *siblNodeType = Getattr(sibl, "nodeType");
@@ -2509,7 +2509,7 @@ public:
 
     String *name = Getattr(n, "name");
     String *symname = Getattr(n, "sym:name");
-    String *namestr = SwigType_namestr(name);	// does template expansion
+    String *namestr = SwigType_namestr(name);   // does template expansion
 
     klass = RCLASS(classes, Char(namestr));
     assert(klass != 0);
@@ -3450,7 +3450,7 @@ public:
     // kwargs support isn't actually implemented, but changing to return false may break something now as it turns on compactdefaultargs
     return true;
   }
-};				/* class RUBY */
+};                              /* class RUBY */
 
 /* -----------------------------------------------------------------------------
  * swig_ruby()    - Instantiate module

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -1213,7 +1213,7 @@ public:
 
       return smallName;
     }
-    
+
     return name;
   }
 

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -109,23 +109,23 @@ public:
     /* Manage command line arguments */
     for (int argIndex = 1; argIndex < argc; argIndex++) {
       if (argv[argIndex] != NULL) {
-	if (strcmp(argv[argIndex], "-help") == 0) {
-	  Printf(stdout, "%s", usage);
-	} else if (strcmp(argv[argIndex], "-builder") == 0) {
-	  Swig_mark_arg(argIndex);
-	  generateBuilder = true;
-	  createLoader = false;
-	} else if (strcmp(argv[argIndex], "-buildersources") == 0) {
-	  if (argv[argIndex + 1] != NULL) {
-	    Swig_mark_arg(argIndex);
-	    char *sourceFile = strtok(argv[argIndex + 1], ",");
-	    while (sourceFile != NULL) {
-	      Insert(sourceFileList, Len(sourceFileList), sourceFile);
-	      sourceFile = strtok(NULL, ",");
-	    }
-	    Swig_mark_arg(argIndex + 1);
-	  }
-	} else if (strcmp(argv[argIndex], "-buildercflags") == 0) {
+        if (strcmp(argv[argIndex], "-help") == 0) {
+          Printf(stdout, "%s", usage);
+        } else if (strcmp(argv[argIndex], "-builder") == 0) {
+          Swig_mark_arg(argIndex);
+          generateBuilder = true;
+          createLoader = false;
+        } else if (strcmp(argv[argIndex], "-buildersources") == 0) {
+          if (argv[argIndex + 1] != NULL) {
+            Swig_mark_arg(argIndex);
+            char *sourceFile = strtok(argv[argIndex + 1], ",");
+            while (sourceFile != NULL) {
+              Insert(sourceFileList, Len(sourceFileList), sourceFile);
+              sourceFile = strtok(NULL, ",");
+            }
+            Swig_mark_arg(argIndex + 1);
+          }
+        } else if (strcmp(argv[argIndex], "-buildercflags") == 0) {
           Swig_mark_arg(argIndex);
           if (argv[argIndex + 1] != NULL) {
             Insert(cflags, Len(cflags), argv[argIndex + 1]);
@@ -396,34 +396,34 @@ public:
     for (paramIndex = 0, param = functionParamsList; paramIndex < maxInputArguments; ++paramIndex) {
       // Ignore parameter if the typemap specifies numinputs=0
       while (checkAttribute(param, "tmap:in:numinputs", "0")) {
-	param = Getattr(param, "tmap:in:next");
+        param = Getattr(param, "tmap:in:next");
       }
 
       SwigType *paramType = Getattr(param, "type");
       String *paramTypemap = Getattr(param, "tmap:in");
 
       if (paramTypemap) {
-	// Replace $input by the position on Scilab stack
-	String *source = NewString("");
-	Printf(source, "%d", paramIndex + 1);
-	Setattr(param, "emit:input", source);
-	Replaceall(paramTypemap, "$input", Getattr(param, "emit:input"));
+        // Replace $input by the position on Scilab stack
+        String *source = NewString("");
+        Printf(source, "%d", paramIndex + 1);
+        Setattr(param, "emit:input", source);
+        Replaceall(paramTypemap, "$input", Getattr(param, "emit:input"));
 
-	if (Getattr(param, "wrap:disown") || (Getattr(param, "tmap:in:disown"))) {
-	  Replaceall(paramTypemap, "$disown", "SWIG_POINTER_DISOWN");
-	} else {
-	  Replaceall(paramTypemap, "$disown", "0");
-	}
+        if (Getattr(param, "wrap:disown") || (Getattr(param, "tmap:in:disown"))) {
+          Replaceall(paramTypemap, "$disown", "SWIG_POINTER_DISOWN");
+        } else {
+          Replaceall(paramTypemap, "$disown", "0");
+        }
 
-	if (paramIndex >= minInputArguments) {	/* Optional input argument management */
-	  Printf(wrapper->code, "if (SWIG_NbInputArgument(pvApiCtx) > %d) {\n%s\n}\n", paramIndex, paramTypemap);
-	} else {
-	  Printf(wrapper->code, "%s\n", paramTypemap);
-	}
-	param = Getattr(param, "tmap:in:next");
+        if (paramIndex >= minInputArguments) {	/* Optional input argument management */
+          Printf(wrapper->code, "if (SWIG_NbInputArgument(pvApiCtx) > %d) {\n%s\n}\n", paramIndex, paramTypemap);
+        } else {
+          Printf(wrapper->code, "%s\n", paramTypemap);
+        }
+        param = Getattr(param, "tmap:in:next");
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(paramType, 0));
-	break;
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(paramType, 0));
+        break;
       }
     }
 
@@ -443,57 +443,57 @@ public:
     if (functionReturnTypemap) {
       // Result is actually the position of output value on stack
       if (Len(functionReturnTypemap) > 0) {
-	Printf(wrapper->code, "SWIG_Scilab_SetOutputPosition(%d);\n", 1);
+        Printf(wrapper->code, "SWIG_Scilab_SetOutputPosition(%d);\n", 1);
       }
       Replaceall(functionReturnTypemap, "$result", "1");
 
       if (GetFlag(node, "feature:new")) {
-	Replaceall(functionReturnTypemap, "$owner", "1");
+        Replaceall(functionReturnTypemap, "$owner", "1");
       } else {
-	Replaceall(functionReturnTypemap, "$owner", "0");
+        Replaceall(functionReturnTypemap, "$owner", "0");
       }
 
       Printf(wrapper->code, "%s\n", functionReturnTypemap);
 
       /* If the typemap is not empty, the function return one more argument than the typemaps gives */
       if (Len(functionReturnTypemap) > 0) {
-	minOutputArguments++;
-	maxOutputArguments++;
+        minOutputArguments++;
+        maxOutputArguments++;
       }
       Delete(functionReturnTypemap);
 
     } else {
       Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(functionReturnType, 0),
-		   functionName);
+                   functionName);
     }
 
     /* Write typemaps(out) */
     for (param = functionParamsList; param;) {
       String *paramTypemap = Getattr(param, "tmap:argout");
       if (paramTypemap) {
-	minOutputArguments++;
-	maxOutputArguments++;
-	Printf(wrapper->code, "SWIG_Scilab_SetOutputPosition(%d);\n", minOutputArguments);
-	String *result = NewString("");
-	Printf(result, "%d", minOutputArguments);
-	Replaceall(paramTypemap, "$result", result);
-	Printf(wrapper->code, "%s\n", paramTypemap);
-	Delete(paramTypemap);
-	param = Getattr(param, "tmap:argout:next");
+        minOutputArguments++;
+        maxOutputArguments++;
+        Printf(wrapper->code, "SWIG_Scilab_SetOutputPosition(%d);\n", minOutputArguments);
+        String *result = NewString("");
+        Printf(result, "%d", minOutputArguments);
+        Replaceall(paramTypemap, "$result", result);
+        Printf(wrapper->code, "%s\n", paramTypemap);
+        Delete(paramTypemap);
+        param = Getattr(param, "tmap:argout:next");
       } else {
-	param = nextSibling(param);
+        param = nextSibling(param);
       }
     }
     /* Add cleanup code */
     for (param = functionParamsList; param;) {
       String *tm;
       if ((tm = Getattr(param, "tmap:freearg"))) {
-	if (tm && (Len(tm) != 0)) {
-	  Printf(wrapper->code, "%s\n", tm);
-	}
-	param = Getattr(param, "tmap:freearg:next");
+        if (tm && (Len(tm) != 0)) {
+          Printf(wrapper->code, "%s\n", tm);
+        }
+        param = Getattr(param, "tmap:freearg:next");
       } else {
-	param = nextSibling(param);
+        param = nextSibling(param);
       }
     }
 
@@ -660,9 +660,9 @@ public:
 
       String *varinTypemap = Swig_typemap_lookup("varin", node, origVariableName, 0);
       if (varinTypemap != NULL) {
-	Replaceall(varinTypemap, "$input", "1");
-	emit_action_code(node, setFunctionWrapper->code, varinTypemap);
-	Delete(varinTypemap);
+        Replaceall(varinTypemap, "$input", "1");
+        emit_action_code(node, setFunctionWrapper->code, varinTypemap);
+        Delete(varinTypemap);
       }
       Append(setFunctionWrapper->code, "return SWIG_OK;\n");
       Append(setFunctionWrapper->code, "}\n");
@@ -697,22 +697,22 @@ public:
       bool isEnum = (Cmp(nodeType(node), "enumitem") == 0);
 
       if (isConstant || isEnum) {
-	if (isEnum) {
-	  Setattr(node, "type", "double");
-	  constantValue = Getattr(node, "value");
-	}
+        if (isEnum) {
+          Setattr(node, "type", "double");
+          constantValue = Getattr(node, "value");
+        }
 
-	constantTypemap = Swig_typemap_lookup("scilabconstcode", node, nodeName, 0);
-	if (constantTypemap != NULL) {
+        constantTypemap = Swig_typemap_lookup("scilabconstcode", node, nodeName, 0);
+        if (constantTypemap != NULL) {
 
-	  Setattr(node, "wrap:name", constantName);
-	  Replaceall(constantTypemap, "$result", constantName);
-	  Replaceall(constantTypemap, "$value", constantValue);
+          Setattr(node, "wrap:name", constantName);
+          Replaceall(constantTypemap, "$result", constantName);
+          Replaceall(constantTypemap, "$value", constantValue);
 
-	  emit_action_code(node, variablesCode, constantTypemap);
-	  Delete(constantTypemap);
-	  return SWIG_OK;
-	}
+          emit_action_code(node, variablesCode, constantTypemap);
+          Delete(constantTypemap);
+          return SWIG_OK;
+        }
       }
     }
 
@@ -779,22 +779,22 @@ public:
       // First enum value ?
       String *firstenumitem = Getattr(node, "firstenumitem");
       if (firstenumitem) {
-	if (enumValue) {
-	  // Value is in 'enumvalue'
-	  iPreviousEnumValue = atoi(Char(enumValue));
-	} else if (enumValueEx) {
-	  // Or value is in 'enumValueEx'
-	  iPreviousEnumValue = atoi(Char(enumValueEx));
+        if (enumValue) {
+          // Value is in 'enumvalue'
+          iPreviousEnumValue = atoi(Char(enumValue));
+        } else if (enumValueEx) {
+          // Or value is in 'enumValueEx'
+          iPreviousEnumValue = atoi(Char(enumValueEx));
 
-	  enumValue = NewString("");
-	  Printf(enumValue, "%d", iPreviousEnumValue);
-	  Setattr(node, "enumvalue", enumValue);
-	}
+          enumValue = NewString("");
+          Printf(enumValue, "%d", iPreviousEnumValue);
+          Setattr(node, "enumvalue", enumValue);
+        }
       } else if (!enumValue && enumValueEx) {
-	// Value is not specified, set it by incrementing last value
-	enumValue = NewString("");
-	Printf(enumValue, "%d", ++iPreviousEnumValue);
-	Setattr(node, "enumvalue", enumValue);
+        // Value is not specified, set it by incrementing last value
+        enumValue = NewString("");
+        Printf(enumValue, "%d", ++iPreviousEnumValue);
+        Setattr(node, "enumvalue", enumValue);
       }
       // Enums in Scilab are mapped to double
       Setattr(node, "type", "double");
@@ -877,12 +877,12 @@ public:
 
     if (Len(ldflags) > 0) {
       for (int i = 0; i < Len(ldflags); i++) {
-	String *ldflag = Getitem(ldflags, i);
-	if (i == 0) {
-	  Printf(builderCode, "ldflags = \"%s\";\n", ldflag);
-	} else {
-	  Printf(builderCode, "ldflags = ldflags + \" %s\";\n", ldflag);
-	}
+        String *ldflag = Getitem(ldflags, i);
+        if (i == 0) {
+          Printf(builderCode, "ldflags = \"%s\";\n", ldflag);
+        } else {
+          Printf(builderCode, "ldflags = ldflags + \" %s\";\n", ldflag);
+        }
       }
     } else {
       Printf(builderCode, "ldflags = \"\";\n");
@@ -899,9 +899,9 @@ public:
     for (int i = 0; i < Len(sourceFileList); i++) {
       String *sourceFile = Getitem(sourceFileList, i);
       if (i == 0) {
-	Printf(builderCode, "files = \"%s\";\n", sourceFile);
+        Printf(builderCode, "files = \"%s\";\n", sourceFile);
       } else {
-	Printf(builderCode, "files($ + 1) = \"%s\";\n", sourceFile);
+        Printf(builderCode, "files($ + 1) = \"%s\";\n", sourceFile);
       }
     }
 

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -274,7 +274,7 @@ public:
     Replaceall(initSection, "<module>", gatewayName);
 
     /* Write all to the wrapper file */
-    SwigType_emit_type_table(runtimeSection, wrappersSection);	// Declare pointer types, ... (Ex: SWIGTYPE_p_p_double)
+    SwigType_emit_type_table(runtimeSection, wrappersSection);  // Declare pointer types, ... (Ex: SWIGTYPE_p_p_double)
 
     // Gateway header source merged with wrapper source in nobuilder mode
     if (!generateBuilder) {
@@ -336,8 +336,8 @@ public:
     SwigType *functionReturnType = Getattr(node, "type");
     ParmList *functionParamsList = Getattr(node, "parms");
 
-    int paramIndex = 0;		// Used for loops over ParmsList
-    Parm *param = NULL;		// Used for loops over ParamsList
+    int paramIndex = 0;         // Used for loops over ParmsList
+    Parm *param = NULL;         // Used for loops over ParamsList
 
     /* Create the wrapper object */
     Wrapper *wrapper = NewWrapper();
@@ -415,7 +415,7 @@ public:
           Replaceall(paramTypemap, "$disown", "0");
         }
 
-        if (paramIndex >= minInputArguments) {	/* Optional input argument management */
+        if (paramIndex >= minInputArguments) {  /* Optional input argument management */
           Printf(wrapper->code, "if (SWIG_NbInputArgument(pvApiCtx) > %d) {\n%s\n}\n", paramIndex, paramTypemap);
         } else {
           Printf(wrapper->code, "%s\n", paramTypemap);
@@ -610,8 +610,8 @@ public:
   virtual int variableWrapper(Node *node) {
 
     /* Get information about variable */
-    String *origVariableName = Getattr(node, "name");	// Ex: Shape::nshapes
-    String *variableName = Getattr(node, "sym:name");	// Ex; Shape_nshapes (can be used for function names, ...)
+    String *origVariableName = Getattr(node, "name");   // Ex: Shape::nshapes
+    String *variableName = Getattr(node, "sym:name");   // Ex; Shape_nshapes (can be used for function names, ...)
     String *smallVariableName = createSmallIdentifierName(variableName, SCILAB_IDENTIFIER_NAME_CHAR_MAX - 4);
 
     /* Manage GET function */
@@ -857,7 +857,7 @@ public:
     builderCode5 = NewString("");
     builderCode6 = NewString("");
     Printf(builderCode, "mode(-1);\n");
-    Printf(builderCode, "lines(0);\n");	/* Useful for automatic tests */
+    Printf(builderCode, "lines(0);\n"); /* Useful for automatic tests */
 
     // Scilab needs to be in the build directory
     Printf(builderCode, "originaldir = pwd();\n");

--- a/Source/Modules/scilab.cxx
+++ b/Source/Modules/scilab.cxx
@@ -29,8 +29,7 @@ Scilab options (available with -scilab)\n\
      -gatewayxml6                   - Generate gateway xml for Scilab 6\n\
 \n";
 
-
-class SCILAB:public Language {
+class SCILAB : public Language {
 protected:
   /* General objects used for holding the strings */
   File *beginSection;
@@ -75,8 +74,8 @@ protected:
   String *loaderScript5;
   String *loaderScript6;
   int loaderFunctionCount;
-public:
 
+public:
   /* ------------------------------------------------------------------------
    * main()
    * ----------------------------------------------------------------------*/
@@ -336,8 +335,8 @@ public:
     SwigType *functionReturnType = Getattr(node, "type");
     ParmList *functionParamsList = Getattr(node, "parms");
 
-    int paramIndex = 0;         // Used for loops over ParmsList
-    Parm *param = NULL;         // Used for loops over ParamsList
+    int paramIndex = 0;  // Used for loops over ParmsList
+    Parm *param = NULL;  // Used for loops over ParamsList
 
     /* Create the wrapper object */
     Wrapper *wrapper = NewWrapper();
@@ -348,7 +347,7 @@ public:
     /* Deal with overloading */
     String *overloadedName = Copy(wrapperName);
     /* Determine whether the function is overloaded or not */
-    bool isOverloaded = ! !Getattr(node, "sym:overloaded");
+    bool isOverloaded = !!Getattr(node, "sym:overloaded");
     /* Determine whether the function is the last overloaded */
     bool isLastOverloaded = isOverloaded && !Getattr(node, "sym:nextSibling");
 
@@ -381,8 +380,7 @@ public:
 
     if (!emit_isvarargs(functionParamsList)) {
       Printf(wrapper->code, "SWIG_CheckInputArgument(pvApiCtx, $mininputarguments, $maxinputarguments);\n");
-    }
-    else {
+    } else {
       Printf(wrapper->code, "SWIG_CheckInputArgumentAtLeast(pvApiCtx, $mininputarguments-1);\n");
     }
     Printf(wrapper->code, "SWIG_CheckOutputArgument(pvApiCtx, $minoutputarguments, $maxoutputarguments);\n");
@@ -415,7 +413,7 @@ public:
           Replaceall(paramTypemap, "$disown", "0");
         }
 
-        if (paramIndex >= minInputArguments) {  /* Optional input argument management */
+        if (paramIndex >= minInputArguments) { /* Optional input argument management */
           Printf(wrapper->code, "if (SWIG_NbInputArgument(pvApiCtx) > %d) {\n%s\n}\n", paramIndex, paramTypemap);
         } else {
           Printf(wrapper->code, "%s\n", paramTypemap);
@@ -463,8 +461,8 @@ public:
       Delete(functionReturnTypemap);
 
     } else {
-      Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(functionReturnType, 0),
-                   functionName);
+      Swig_warning(
+        WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(functionReturnType, 0), functionName);
     }
 
     /* Write typemaps(out) */
@@ -610,8 +608,8 @@ public:
   virtual int variableWrapper(Node *node) {
 
     /* Get information about variable */
-    String *origVariableName = Getattr(node, "name");   // Ex: Shape::nshapes
-    String *variableName = Getattr(node, "sym:name");   // Ex; Shape_nshapes (can be used for function names, ...)
+    String *origVariableName = Getattr(node, "name");  // Ex: Shape::nshapes
+    String *variableName = Getattr(node, "sym:name");  // Ex; Shape_nshapes (can be used for function names, ...)
     String *smallVariableName = createSmallIdentifierName(variableName, SCILAB_IDENTIFIER_NAME_CHAR_MAX - 4);
 
     /* Manage GET function */
@@ -817,7 +815,8 @@ public:
    * Declare a wrapped function in Scilab (builder, gateway, XML, ...)
    * ----------------------------------------------------------------------- */
 
-  void addFunctionToScilab(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName, const_String_or_char_ptr wrapperFunctionName) {
+  void addFunctionToScilab(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName,
+                           const_String_or_char_ptr wrapperFunctionName) {
     if (!generateBuilder)
       addFunctionInGatewayHeader(scilabFunctionName, scilabSmallFunctionName, wrapperFunctionName);
 
@@ -837,7 +836,6 @@ public:
       Printf(gatewayXMLV6, "<gateway name=\"%s\" function=\"%s\" type=\"0\"/>\n", scilabFunctionName, scilabFunctionName);
     }
   }
-
 
   /* -----------------------------------------------------------------------
    * createBuilderCode()
@@ -914,7 +912,8 @@ public:
    * Add a function wrapper in the function table of generated builder script
    * ----------------------------------------------------------------------- */
 
-  void addFunctionInScriptTable(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName, const_String_or_char_ptr wrapperFunctionName, String *scriptCode5, String *scriptCode6) {
+  void addFunctionInScriptTable(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName,
+                                const_String_or_char_ptr wrapperFunctionName, String *scriptCode5, String *scriptCode6) {
     if (++builderFunctionCount % 10 == 0) {
       Printf(scriptCode5, "];\ntable = [table; ..\n");
       Printf(scriptCode6, "];\ntable = [table; ..\n");
@@ -1062,7 +1061,8 @@ public:
    * Add a function in the gateway header
    * ----------------------------------------------------------------------- */
 
-  void addFunctionInGatewayHeader(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName, const_String_or_char_ptr wrapperFunctionName) {
+  void addFunctionInGatewayHeader(const_String_or_char_ptr scilabFunctionName, const_String_or_char_ptr scilabSmallFunctionName,
+                                  const_String_or_char_ptr wrapperFunctionName) {
     if (gatewayHeaderV5 == NULL) {
       gatewayHeaderV5 = NewString("");
       Printf(gatewayHeaderV5, "static GenericTable Tab[] = {\n");
@@ -1070,7 +1070,11 @@ public:
       Printf(gatewayHeaderV5, ",\n");
     Printf(gatewayHeaderV5, " {(Myinterfun)sci_gateway, (GT)%s, (char *)\"%s\"}", wrapperFunctionName, scilabSmallFunctionName);
 
-    Printf(gatewayHeaderV6, "if (wcscmp(pwstFuncName, L\"%s\") == 0) { addCStackFunction((wchar_t *)L\"%s\", &%s, (wchar_t *)MODULE_NAME); }\n", scilabFunctionName, scilabFunctionName, wrapperFunctionName);
+    Printf(gatewayHeaderV6,
+           "if (wcscmp(pwstFuncName, L\"%s\") == 0) { addCStackFunction((wchar_t *)L\"%s\", &%s, (wchar_t *)MODULE_NAME); }\n",
+           scilabFunctionName,
+           scilabFunctionName,
+           wrapperFunctionName);
   }
 
   /* -----------------------------------------------------------------------
@@ -1109,7 +1113,6 @@ public:
     Printv(gatewayHeader, gatewayHeaderV6, NIL);
     Printf(gatewayHeader, "#endif\n");
   }
-
 
   /* -----------------------------------------------------------------------
    * createLoaderScriptFile()
@@ -1194,19 +1197,19 @@ public:
    * Create a Scilab small identifier to be used by Scilab 5
    * ----------------------------------------------------------------------- */
 
-  String* createSmallIdentifierName(String* name, int outputLen = SCILAB_IDENTIFIER_NAME_CHAR_MAX) {
-    char* s = Char(name);
+  String *createSmallIdentifierName(String *name, int outputLen = SCILAB_IDENTIFIER_NAME_CHAR_MAX) {
+    char *s = Char(name);
     int nameLen = Len(s);
 
     // truncate and preserve common suffix
     if (outputLen > 4 && nameLen > outputLen) {
-      String* smallName = NewStringWithSize(name, outputLen);
-      char* smallNameStr = (char*) Data(smallName);
+      String *smallName = NewStringWithSize(name, outputLen);
+      char *smallNameStr = (char *)Data(smallName);
 
-      if (s[nameLen-4] == '_' && s[nameLen - 3] == 'g' && s[nameLen - 2] == 'e' && s[nameLen - 1] == 't') {
+      if (s[nameLen - 4] == '_' && s[nameLen - 3] == 'g' && s[nameLen - 2] == 'e' && s[nameLen - 1] == 't') {
         // get
         memcpy(&smallNameStr[outputLen - 4], &s[nameLen - 4], 4);
-      } else if (s[nameLen-4] == '_' && s[nameLen - 3] == 's' && s[nameLen - 2] == 'e' && s[nameLen - 1] == 't') {
+      } else if (s[nameLen - 4] == '_' && s[nameLen - 3] == 's' && s[nameLen - 2] == 'e' && s[nameLen - 1] == 't') {
         // set
         memcpy(&smallNameStr[outputLen - 4], &s[nameLen - 4], 4);
       }
@@ -1216,7 +1219,6 @@ public:
 
     return name;
   }
-
 };
 
 extern "C" Language *swig_scilab(void) {

--- a/Source/Modules/swigmain.cxx
+++ b/Source/Modules/swigmain.cxx
@@ -26,24 +26,24 @@
    can be dynamically loaded in future versions. */
 
 extern "C" {
-  Language *swig_c(void);
-  Language *swig_csharp(void);
-  Language *swig_d(void);
-  Language *swig_go(void);
-  Language *swig_guile(void);
-  Language *swig_java(void);
-  Language *swig_javascript(void);
-  Language *swig_lua(void);
-  Language *swig_ocaml(void);
-  Language *swig_octave(void);
-  Language *swig_perl5(void);
-  Language *swig_php(void);
-  Language *swig_python(void);
-  Language *swig_r(void);
-  Language *swig_ruby(void);
-  Language *swig_scilab(void);
-  Language *swig_tcl(void);
-  Language *swig_xml(void);
+Language *swig_c(void);
+Language *swig_csharp(void);
+Language *swig_d(void);
+Language *swig_go(void);
+Language *swig_guile(void);
+Language *swig_java(void);
+Language *swig_javascript(void);
+Language *swig_lua(void);
+Language *swig_ocaml(void);
+Language *swig_octave(void);
+Language *swig_perl5(void);
+Language *swig_php(void);
+Language *swig_python(void);
+Language *swig_r(void);
+Language *swig_ruby(void);
+Language *swig_scilab(void);
+Language *swig_tcl(void);
+Language *swig_xml(void);
 }
 
 /* Association of command line options to language modules.
@@ -51,36 +51,36 @@ extern "C" {
    list sorted alphabetically. */
 
 static TargetLanguageModule modules[] = {
-  {"-allegrocl", NULL, "ALLEGROCL", Disabled},
-  {"-c", swig_c, "C", Experimental},
-  {"-chicken", NULL, "CHICKEN", Disabled},
-  {"-clisp", NULL, "CLISP", Disabled},
-  {"-csharp", swig_csharp, "C#", Supported},
-  {"-d", swig_d, "D", Supported},
-  {"-go", swig_go, "Go", Supported},
-  {"-guile", swig_guile, "Guile", Supported},
-  {"-java", swig_java, "Java", Supported},
-  {"-javascript", swig_javascript, "Javascript", Supported},
-  {"-lua", swig_lua, "Lua", Supported},
-  {"-modula3", NULL, "Modula 3", Disabled},
-  {"-ocaml", swig_ocaml, "OCaml", Experimental},
-  {"-octave", swig_octave, "Octave", Supported},
-  {"-perl", swig_perl5, NULL, Supported},
-  {"-perl5", swig_perl5, "Perl 5", Supported},
-  {"-php", swig_php, NULL, Supported},
-  {"-php5", NULL, "PHP 5", Disabled},
-  {"-php7", swig_php, "PHP 8 or later", Supported},
-  {"-pike", NULL, "Pike", Disabled},
-  {"-python", swig_python, "Python", Supported},
-  {"-r", swig_r, "R (aka GNU S)", Supported},
-  {"-ruby", swig_ruby, "Ruby", Supported},
-  {"-scilab", swig_scilab, "Scilab", Supported},
-  {"-sexp", NULL, "Lisp S-Expressions", Disabled},
-  {"-tcl", swig_tcl, NULL, Supported},
-  {"-tcl8", swig_tcl, "Tcl 8", Supported},
-  {"-uffi", NULL, "Common Lisp / UFFI", Disabled},
-  {"-xml", swig_xml, "XML", Supported},
-  {NULL, NULL, NULL, Disabled}
+  {"-allegrocl",  NULL,            "ALLEGROCL",          Disabled    },
+  {"-c",          swig_c,          "C",                  Experimental},
+  {"-chicken",    NULL,            "CHICKEN",            Disabled    },
+  {"-clisp",      NULL,            "CLISP",              Disabled    },
+  {"-csharp",     swig_csharp,     "C#",                 Supported   },
+  {"-d",          swig_d,          "D",                  Supported   },
+  {"-go",         swig_go,         "Go",                 Supported   },
+  {"-guile",      swig_guile,      "Guile",              Supported   },
+  {"-java",       swig_java,       "Java",               Supported   },
+  {"-javascript", swig_javascript, "Javascript",         Supported   },
+  {"-lua",        swig_lua,        "Lua",                Supported   },
+  {"-modula3",    NULL,            "Modula 3",           Disabled    },
+  {"-ocaml",      swig_ocaml,      "OCaml",              Experimental},
+  {"-octave",     swig_octave,     "Octave",             Supported   },
+  {"-perl",       swig_perl5,      NULL,                 Supported   },
+  {"-perl5",      swig_perl5,      "Perl 5",             Supported   },
+  {"-php",        swig_php,        NULL,                 Supported   },
+  {"-php5",       NULL,            "PHP 5",              Disabled    },
+  {"-php7",       swig_php,        "PHP 8 or later",     Supported   },
+  {"-pike",       NULL,            "Pike",               Disabled    },
+  {"-python",     swig_python,     "Python",             Supported   },
+  {"-r",          swig_r,          "R (aka GNU S)",      Supported   },
+  {"-ruby",       swig_ruby,       "Ruby",               Supported   },
+  {"-scilab",     swig_scilab,     "Scilab",             Supported   },
+  {"-sexp",       NULL,            "Lisp S-Expressions", Disabled    },
+  {"-tcl",        swig_tcl,        NULL,                 Supported   },
+  {"-tcl8",       swig_tcl,        "Tcl 8",              Supported   },
+  {"-uffi",       NULL,            "Common Lisp / UFFI", Disabled    },
+  {"-xml",        swig_xml,        "XML",                Supported   },
+  {NULL,          NULL,            NULL,                 Disabled    }
 };
 
 //-----------------------------------------------------------------
@@ -99,8 +99,8 @@ static void SWIG_merge_envopt(const char *env, int oargc, char *oargv[], int *na
 
   int argc = 1;
   int arge = oargc + 1024;
-  char **argv = (char **) Malloc(sizeof(char *) * (arge + 1));
-  char *buffer = (char *) Malloc(2048);
+  char **argv = (char **)Malloc(sizeof(char *) * (arge + 1));
+  char *buffer = (char *)Malloc(2048);
   char *b = buffer;
   char *be = b + 1023;
   const char *c = env;
@@ -252,18 +252,18 @@ int main(int margc, char **margv) {
         for (int j = 0; modules[j].name; j++) {
           if (modules[j].help) {
             switch (modules[j].status) {
-              case Supported:
-                Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
-                break;
-              case Experimental:
-                ++experimental_count;
-                break;
-              case Deprecated:
-                ++deprecated_count;
-                break;
-              case Disabled:
-                // Avoids -Wswitch GCC warning.
-                break;
+            case Supported:
+              Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
+              break;
+            case Experimental:
+              ++experimental_count;
+              break;
+            case Deprecated:
+              ++deprecated_count;
+              break;
+            case Disabled:
+              // Avoids -Wswitch GCC warning.
+              break;
             }
           }
         }

--- a/Source/Modules/swigmain.cxx
+++ b/Source/Modules/swigmain.cxx
@@ -225,65 +225,65 @@ int main(int margc, char **margv) {
     if (argv[i]) {
       bool is_target_language_module = false;
       for (int j = 0; modules[j].name; j++) {
-	if (strcmp(modules[j].name, argv[i]) == 0) {
-	  if (!language_module) {
-	    language_module = &modules[j];
-	    is_target_language_module = true;
-	  } else {
-	    Printf(stderr, "Only one target language can be supported at a time (both %s and %s were specified).\n", language_module->name, argv[i]);
-	    Exit(EXIT_FAILURE);
-	  }
-	}
+        if (strcmp(modules[j].name, argv[i]) == 0) {
+          if (!language_module) {
+            language_module = &modules[j];
+            is_target_language_module = true;
+          } else {
+            Printf(stderr, "Only one target language can be supported at a time (both %s and %s were specified).\n", language_module->name, argv[i]);
+            Exit(EXIT_FAILURE);
+          }
+        }
       }
       if (is_target_language_module) {
-	Swig_mark_arg(i);
-	if (language_module->status == Disabled) {
-	  if (language_module->help)
-	    Printf(stderr, "Target language option %s (%s) is no longer supported.\n", language_module->name, language_module->help);
-	  else
-	    Printf(stderr, "Target language option %s is no longer supported.\n", language_module->name);
-	  Exit(EXIT_FAILURE);
-	}
+        Swig_mark_arg(i);
+        if (language_module->status == Disabled) {
+          if (language_module->help)
+            Printf(stderr, "Target language option %s (%s) is no longer supported.\n", language_module->name, language_module->help);
+          else
+            Printf(stderr, "Target language option %s is no longer supported.\n", language_module->name);
+          Exit(EXIT_FAILURE);
+        }
       } else if ((strcmp(argv[i], "-help") == 0) || (strcmp(argv[i], "--help") == 0)) {
-	if (strcmp(argv[i], "--help") == 0)
-	  strcpy(argv[i], "-help");
-	Printf(stdout, "Supported Target Language Options\n");
-	int experimental_count = 0, deprecated_count = 0;
-	for (int j = 0; modules[j].name; j++) {
-	  if (modules[j].help) {
-	    switch (modules[j].status) {
-	      case Supported:
-		Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
-		break;
-	      case Experimental:
-		++experimental_count;
-		break;
-	      case Deprecated:
-		++deprecated_count;
-		break;
-	      case Disabled:
-		// Avoids -Wswitch GCC warning.
-		break;
-	    }
-	  }
-	}
-	if (experimental_count) {
-	  Printf(stdout, "\nExperimental Target Language Options\n");
-	  for (int j = 0; modules[j].name; j++) {
-	    if (modules[j].help && modules[j].status == Experimental) {
-	      Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
-	    }
-	  }
-	}
-	if (deprecated_count) {
-	  Printf(stdout, "\nDeprecated Target Language Options\n");
-	  for (int j = 0; modules[j].name; j++) {
-	    if (modules[j].help && modules[j].status == Deprecated) {
-	      Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
-	    }
-	  }
-	}
-	// Swig_mark_arg not called as the general -help options also need to be displayed later on
+        if (strcmp(argv[i], "--help") == 0)
+          strcpy(argv[i], "-help");
+        Printf(stdout, "Supported Target Language Options\n");
+        int experimental_count = 0, deprecated_count = 0;
+        for (int j = 0; modules[j].name; j++) {
+          if (modules[j].help) {
+            switch (modules[j].status) {
+              case Supported:
+                Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
+                break;
+              case Experimental:
+                ++experimental_count;
+                break;
+              case Deprecated:
+                ++deprecated_count;
+                break;
+              case Disabled:
+                // Avoids -Wswitch GCC warning.
+                break;
+            }
+          }
+        }
+        if (experimental_count) {
+          Printf(stdout, "\nExperimental Target Language Options\n");
+          for (int j = 0; modules[j].name; j++) {
+            if (modules[j].help && modules[j].status == Experimental) {
+              Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
+            }
+          }
+        }
+        if (deprecated_count) {
+          Printf(stdout, "\nDeprecated Target Language Options\n");
+          for (int j = 0; modules[j].name; j++) {
+            if (modules[j].help && modules[j].status == Deprecated) {
+              Printf(stdout, "     %-15s - Generate %s wrappers\n", modules[j].name, modules[j].help);
+            }
+          }
+        }
+        // Swig_mark_arg not called as the general -help options also need to be displayed later on
       }
     }
   }

--- a/Source/Modules/swigmain.cxx
+++ b/Source/Modules/swigmain.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -25,14 +25,14 @@
 extern String *input_file;
 extern int line_number;
 extern int start_line;
-extern int CPlusPlus;		// C++ mode
-extern int Extend;		// Extend mode
+extern int CPlusPlus;           // C++ mode
+extern int Extend;              // Extend mode
 extern int Verbose;
 extern int IsVirtual;
 extern int ImportMode;
-extern int NoExcept;		// -no_except option
-extern int Abstract;		// abstract base class
-extern int SmartPointer;	// smart pointer methods being emitted
+extern int NoExcept;            // -no_except option
+extern int Abstract;            // abstract base class
+extern int SmartPointer;        // smart pointer methods being emitted
 
 /* Overload "argc" and "argv" */
 extern String *argv_template_string;
@@ -99,7 +99,7 @@ public:
 protected:
   AccessMode cplus_mode;
   AccessMode accessModeFromString(String *access);
-  int abstractClassTest(Node *n);	/* Is class really abstract? */
+  int abstractClassTest(Node *n);       /* Is class really abstract? */
 };
 
 /* ----------------------------------------------------------------------------
@@ -207,8 +207,8 @@ public:
   virtual int classDirectorDisown(Node *n);
 
   /* Miscellaneous */
-  virtual int validIdentifier(String *s);	/* valid identifier? */
-  virtual int addSymbol(const String *s, const Node *n, const_String_or_char_ptr scope = "");	/* Add symbol        */
+  virtual int validIdentifier(String *s);       /* valid identifier? */
+  virtual int addSymbol(const String *s, const Node *n, const_String_or_char_ptr scope = "");   /* Add symbol        */
   virtual int addInterfaceSymbol(const String *interface_name, Node *n, const_String_or_char_ptr scope = "");
   virtual void dumpSymbols();
   virtual Node *symbolLookup(const String *s, const_String_or_char_ptr scope = ""); /* Symbol lookup */
@@ -216,10 +216,10 @@ public:
   virtual Hash* symbolScopeLookup(const_String_or_char_ptr scope);
   virtual Hash* symbolScopePseudoSymbolLookup(const_String_or_char_ptr scope);
   static Node *classLookup(const SwigType *s); /* Class lookup      */
-  static Node *enumLookup(SwigType *s);	/* Enum lookup       */
-  virtual int is_immutable(Node *n);	/* Is variable assignable? */
-  virtual String *runtimeCode();	/* returns the language specific runtime code */
-  virtual String *defaultExternalRuntimeFilename();	/* the default filename for the external runtime */
+  static Node *enumLookup(SwigType *s); /* Enum lookup       */
+  virtual int is_immutable(Node *n);    /* Is variable assignable? */
+  virtual String *runtimeCode();        /* returns the language specific runtime code */
+  virtual String *defaultExternalRuntimeFilename();     /* the default filename for the external runtime */
   virtual void replaceSpecialVariables(String *method, String *tm, Parm *parm); /* Language specific special variable substitutions for $typemap() */
 
   /* Runtime is C++ based, so extern "C" header section */

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -307,11 +307,11 @@ public:
     NCS_Full, // Target language does have an equivalent to nested classes and is fully implemented
     NCS_Unknown // Target language may or may not have an equivalent to nested classes. If it does, it has not been implemented yet.
   };
-  /* Does target language support nested classes? Default is NCS_Unknown. 
-    If NCS_Unknown is returned, then the nested classes will be ignored unless 
+  /* Does target language support nested classes? Default is NCS_Unknown.
+    If NCS_Unknown is returned, then the nested classes will be ignored unless
     %feature "flatnested" is applied to them, in which case they will appear in global space.
     If the target language does not support the notion of class
-    nesting, the language module should return NCS_None from this function, and 
+    nesting, the language module should return NCS_None from this function, and
     the nested classes will be moved to the global scope (like implicit global %feature "flatnested").
   */
   virtual NestedClassSupport nestedClassesSupport() const;

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -18,21 +18,21 @@
 #include "preprocessor.h"
 #include "swigwarn.h"
 
-#define NOT_VIRTUAL     0
-#define PLAIN_VIRTUAL   1
-#define PURE_VIRTUAL    2
+#define NOT_VIRTUAL   0
+#define PLAIN_VIRTUAL 1
+#define PURE_VIRTUAL  2
 
 extern String *input_file;
 extern int line_number;
 extern int start_line;
-extern int CPlusPlus;           // C++ mode
-extern int Extend;              // Extend mode
+extern int CPlusPlus;  // C++ mode
+extern int Extend;     // Extend mode
 extern int Verbose;
 extern int IsVirtual;
 extern int ImportMode;
-extern int NoExcept;            // -no_except option
-extern int Abstract;            // abstract base class
-extern int SmartPointer;        // smart pointer methods being emitted
+extern int NoExcept;      // -no_except option
+extern int Abstract;      // abstract base class
+extern int SmartPointer;  // smart pointer methods being emitted
 
 /* Overload "argc" and "argv" */
 extern String *argv_template_string;
@@ -40,16 +40,15 @@ extern String *argc_template_string;
 
 /* Miscellaneous stuff */
 
-#define  tab2   "  "
-#define  tab4   "    "
-#define  tab8   "        "
+#define tab2 "  "
+#define tab4 "    "
+#define tab8 "        "
 
 class Dispatcher {
 public:
-
-  Dispatcher ():cplus_mode(PUBLIC) {
+  Dispatcher() : cplus_mode(PUBLIC) {
   }
-  virtual ~ Dispatcher () {
+  virtual ~Dispatcher() {
   }
 
   virtual int emit_one(Node *n);
@@ -99,7 +98,7 @@ public:
 protected:
   AccessMode cplus_mode;
   AccessMode accessModeFromString(String *access);
-  int abstractClassTest(Node *n);       /* Is class really abstract? */
+  int abstractClassTest(Node *n); /* Is class really abstract? */
 };
 
 /* ----------------------------------------------------------------------------
@@ -110,7 +109,7 @@ protected:
  * functions to output different types of code for different languages.
  * ------------------------------------------------------------------------- */
 
-class Language:public Dispatcher {
+class Language : public Dispatcher {
 public:
   Language();
   virtual ~Language();
@@ -127,7 +126,6 @@ public:
   virtual int top(Node *n);
 
   /* SWIG directives */
-
 
   virtual int applyDirective(Node *n);
   virtual int clearDirective(Node *n);
@@ -207,19 +205,19 @@ public:
   virtual int classDirectorDisown(Node *n);
 
   /* Miscellaneous */
-  virtual int validIdentifier(String *s);       /* valid identifier? */
-  virtual int addSymbol(const String *s, const Node *n, const_String_or_char_ptr scope = "");   /* Add symbol        */
+  virtual int validIdentifier(String *s);                                                     /* valid identifier? */
+  virtual int addSymbol(const String *s, const Node *n, const_String_or_char_ptr scope = ""); /* Add symbol        */
   virtual int addInterfaceSymbol(const String *interface_name, Node *n, const_String_or_char_ptr scope = "");
   virtual void dumpSymbols();
   virtual Node *symbolLookup(const String *s, const_String_or_char_ptr scope = ""); /* Symbol lookup */
-  virtual Hash* symbolAddScope(const_String_or_char_ptr scope/*, Node *n = 0*/);
-  virtual Hash* symbolScopeLookup(const_String_or_char_ptr scope);
-  virtual Hash* symbolScopePseudoSymbolLookup(const_String_or_char_ptr scope);
-  static Node *classLookup(const SwigType *s); /* Class lookup      */
-  static Node *enumLookup(SwigType *s); /* Enum lookup       */
-  virtual int is_immutable(Node *n);    /* Is variable assignable? */
-  virtual String *runtimeCode();        /* returns the language specific runtime code */
-  virtual String *defaultExternalRuntimeFilename();     /* the default filename for the external runtime */
+  virtual Hash *symbolAddScope(const_String_or_char_ptr scope /*, Node *n = 0*/);
+  virtual Hash *symbolScopeLookup(const_String_or_char_ptr scope);
+  virtual Hash *symbolScopePseudoSymbolLookup(const_String_or_char_ptr scope);
+  static Node *classLookup(const SwigType *s);                                  /* Class lookup      */
+  static Node *enumLookup(SwigType *s);                                         /* Enum lookup       */
+  virtual int is_immutable(Node *n);                                            /* Is variable assignable? */
+  virtual String *runtimeCode();                                                /* returns the language specific runtime code */
+  virtual String *defaultExternalRuntimeFilename();                             /* the default filename for the external runtime */
   virtual void replaceSpecialVariables(String *method, String *tm, Parm *parm); /* Language specific special variable substitutions for $typemap() */
 
   /* Runtime is C++ based, so extern "C" header section */
@@ -256,7 +254,7 @@ public:
   void setOverloadResolutionTemplates(String *argc, String *argv);
 
   /* Language instance is a singleton - get instance */
-  static Language* instance();
+  static Language *instance();
 
 protected:
   /* Allow multiple-input typemaps */
@@ -303,9 +301,9 @@ protected:
 
 public:
   enum NestedClassSupport {
-    NCS_None, // Target language does not have an equivalent to nested classes
-    NCS_Full, // Target language does have an equivalent to nested classes and is fully implemented
-    NCS_Unknown // Target language may or may not have an equivalent to nested classes. If it does, it has not been implemented yet.
+    NCS_None,    // Target language does not have an equivalent to nested classes
+    NCS_Full,    // Target language does have an equivalent to nested classes and is fully implemented
+    NCS_Unknown  // Target language may or may not have an equivalent to nested classes. If it does, it has not been implemented yet.
   };
   /* Does target language support nested classes? Default is NCS_Unknown.
     If NCS_Unknown is returned, then the nested classes will be ignored unless
@@ -354,10 +352,10 @@ private:
 };
 
 extern "C" {
-  typedef Language *(*ModuleFactory) (void);
+typedef Language *(*ModuleFactory)(void);
 }
 
-enum Status {Disabled, Deprecated, Experimental, Supported};
+enum Status { Disabled, Deprecated, Experimental, Supported };
 
 struct TargetLanguageModule {
   const char *name;
@@ -369,7 +367,7 @@ struct TargetLanguageModule {
 int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm);
 void emit_parameter_variables(ParmList *l, Wrapper *f);
 void emit_return_variable(Node *n, SwigType *rt, Wrapper *f);
-void SWIG_config_file(const_String_or_char_ptr );
+void SWIG_config_file(const_String_or_char_ptr);
 const String *SWIG_output_directory();
 void SWIG_config_cppext(const char *ext);
 void Swig_print_xml(Node *obj, String *filename);
@@ -422,10 +420,10 @@ void Wrapper_naturalvar_mode_set(int);
 void clean_overloaded(Node *n);
 
 extern "C" {
-  const char *Swig_to_string(DOH *object, int count = -1);
-  const char *Swig_to_string_with_location(DOH *object, int count = -1);
-  void Swig_print(DOH *object, int count = -1);
-  void Swig_print_with_location(DOH *object, int count = -1);
+const char *Swig_to_string(DOH *object, int count = -1);
+const char *Swig_to_string_with_location(DOH *object, int count = -1);
+void Swig_print(DOH *object, int count = -1);
+void Swig_print_with_location(DOH *object, int count = -1);
 }
 
 void Swig_default_allocators(Node *n);
@@ -445,16 +443,22 @@ void Swig_interface_feature_enable();
 void Swig_interface_propagate_methods(Node *n);
 
 /* Miscellaneous */
-template <class T> class save_value {
+template <class T>
+class save_value {
   T _value;
-  T& _value_ptr;
-  save_value(const save_value&);
-  save_value& operator=(const save_value&);
+  T &_value_ptr;
+  save_value(const save_value &);
+  save_value &operator=(const save_value &);
 
 public:
-  save_value(T& value) : _value(value), _value_ptr(value) {}
-  save_value(T& value, T new_val) : _value(value), _value_ptr(value) { value = new_val; }
-  ~save_value() { _value_ptr = _value; }
+  save_value(T &value) : _value(value), _value_ptr(value) {
+  }
+  save_value(T &value, T new_val) : _value(value), _value_ptr(value) {
+    value = new_val;
+  }
+  ~save_value() {
+    _value_ptr = _value;
+  }
 };
 
 #endif

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -1144,7 +1144,7 @@ public:
         // inheritance hierarchy.
         // In the former case, we need to call the C++ constructor, in the
         // latter we don't, or we end up with two C++ objects.
-        // Check to see if we are instantiating a 'realname' or something 
+        // Check to see if we are instantiating a 'realname' or something
         // derived from it.
         //
         Printv(constructor, "    if { [string equal -nocase \"", realname, "\" \"[namespace tail [info class]]\" ] } {\n", NIL);

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -23,11 +23,11 @@ Tcl 8 Options (available with -tcl8)\n\
      -pkgversion     - Set package version\n\
 \n";
 
-static String *cmd_tab = 0;	/* Table of command names    */
-static String *var_tab = 0;	/* Table of global variables */
-static String *const_tab = 0;	/* Constant table            */
-static String *methods_tab = 0;	/* Methods table             */
-static String *attr_tab = 0;	/* Attribute table           */
+static String *cmd_tab = 0;     /* Table of command names    */
+static String *var_tab = 0;     /* Table of global variables */
+static String *const_tab = 0;   /* Constant table            */
+static String *methods_tab = 0; /* Methods table             */
+static String *attr_tab = 0;    /* Attribute table           */
 static String *prefix = 0;
 static String *module = 0;
 static int namespace_option = 0;
@@ -259,7 +259,7 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int functionWrapper(Node *n) {
-    String *name = Getattr(n, "name");	/* Like to get rid of this */
+    String *name = Getattr(n, "name");  /* Like to get rid of this */
     String *iname = Getattr(n, "sym:name");
     SwigType *returntype = Getattr(n, "type");
     ParmList *parms = Getattr(n, "parms");
@@ -515,7 +515,7 @@ public:
         Printv(df->code, dispatch, "\n", NIL);
         Node *sibl = n;
         while (Getattr(sibl, "sym:previousSibling"))
-          sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+          sibl = Getattr(sibl, "sym:previousSibling");  // go all the way up
         String *protoTypes = NewString("");
         do {
           String *fulldecl = Swig_name_decl(sibl);

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -38,7 +38,7 @@ static String *constructor_name;
 static int have_destructor;
 static int have_base_classes;
 static String *destructor_action = 0;
-static String *version = (String *) "0.0";
+static String *version = (String *)"0.0";
 static String *class_name = 0;
 
 static int have_attributes;
@@ -50,7 +50,6 @@ static File *f_wrappers = 0;
 static File *f_init = 0;
 static File *f_begin = 0;
 static File *f_runtime = 0;
-
 
 //  Itcl support
 static int itcl = 0;
@@ -67,18 +66,15 @@ static String *attributes = 0;
 static String *attribute_traces = 0;
 static String *iattribute_traces = 0;
 
-
-
-class TCL8:public Language {
+class TCL8 : public Language {
 public:
-
   /* ------------------------------------------------------------
    * TCL8::main()
    * ------------------------------------------------------------ */
 
   virtual void main(int argc, char *argv[]) {
 
-     SWIG_library_directory("tcl");
+    SWIG_library_directory("tcl");
 
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
@@ -89,7 +85,7 @@ public:
             Swig_mark_arg(i + 1);
             i++;
           } else
-             Swig_arg_error();
+            Swig_arg_error();
         } else if (strcmp(argv[i], "-pkgversion") == 0) {
           if (argv[i + 1]) {
             version = NewString(argv[i + 1]);
@@ -171,7 +167,6 @@ public:
     ns_name = prefix ? Copy(prefix) : Copy(module);
     if (prefix)
       Append(prefix, "_");
-
 
     /* If shadow classing is enabled, we're going to change the module name to "_module" */
     if (itcl) {
@@ -259,7 +254,7 @@ public:
    * ------------------------------------------------------------ */
 
   virtual int functionWrapper(Node *n) {
-    String *name = Getattr(n, "name");  /* Like to get rid of this */
+    String *name = Getattr(n, "name"); /* Like to get rid of this */
     String *iname = Getattr(n, "sym:name");
     SwigType *returntype = Getattr(n, "type");
     ParmList *parms = Getattr(n, "parms");
@@ -294,7 +289,6 @@ public:
 #ifdef SWIG_USE_RESULTOBJ
     Wrapper_add_local(f, "resultobj", "Tcl_Obj *resultobj = NULL");
 #endif
-
 
     String *wname = Swig_name_wrapper(iname);
     if (overname) {
@@ -408,8 +402,7 @@ public:
 
     /* Insert cleanup code */
     for (i = 0, p = parms; p; i++) {
-      if (!checkAttribute(p, "tmap:in:numinputs", "0")
-          && !Getattr(p, "tmap:in:parse") && (tm = Getattr(p, "tmap:freearg"))) {
+      if (!checkAttribute(p, "tmap:in:numinputs", "0") && !Getattr(p, "tmap:in:parse") && (tm = Getattr(p, "tmap:freearg"))) {
         if (Len(tm) != 0) {
           Printv(cleanup, tm, "\n", NIL);
         }
@@ -522,9 +515,12 @@ public:
           Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
           Delete(fulldecl);
         } while ((sibl = Getattr(sibl, "sym:nextSibling")));
-        Printf(df->code, "Tcl_SetResult(interp,(char *) "
+        Printf(df->code,
+               "Tcl_SetResult(interp,(char *) "
                "\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
-               "\n\"  Possible C/C++ prototypes are:\\n\"%s, TCL_STATIC);\n", iname, protoTypes);
+               "\n\"  Possible C/C++ prototypes are:\\n\"%s, TCL_STATIC);\n",
+               iname,
+               protoTypes);
         Delete(protoTypes);
         Printf(df->code, "return TCL_ERROR;\n");
         Printv(df->code, "}\n", NIL);
@@ -570,7 +566,8 @@ public:
     String *getname = Swig_name_get(NSPACE_TODO, iname);
     String *getfname = Swig_name_wrapper(getname);
     Setattr(n, "wrap:name", getfname);
-    Printv(getf->def, "SWIGINTERN const char *", getfname, "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, char *name1, char *name2, int flags) {", NIL);
+    Printv(
+      getf->def, "SWIGINTERN const char *", getfname, "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, char *name1, char *name2, int flags) {", NIL);
     Wrapper_add_local(getf, "value", "Tcl_Obj *value = 0");
     if ((tm = Swig_typemap_lookup("varout", n, name, 0))) {
       Replaceall(tm, "$result", "value");
@@ -601,8 +598,11 @@ public:
       setfname = Swig_name_wrapper(setname);
       Setattr(n, "wrap:name", setfname);
       if (setf) {
-        Printv(setf->def, "SWIGINTERN const char *", setfname,
-             "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, char *name1, char *name2 SWIGUNUSED, int flags) {", NIL);
+        Printv(setf->def,
+               "SWIGINTERN const char *",
+               setfname,
+               "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, char *name1, char *name2 SWIGUNUSED, int flags) {",
+               NIL);
         Wrapper_add_local(setf, "value", "Tcl_Obj *value = 0");
         Wrapper_add_local(setf, "name1o", "Tcl_Obj *name1o = 0");
 
@@ -629,14 +629,14 @@ public:
       readonly = 1;
     }
 
-
     Printv(var_tab, tab4, "{ SWIG_prefix \"", iname, "\", 0, (swig_variable_func) ", getfname, ",", NIL);
     if (readonly) {
       static int readonlywrap = 0;
       if (!readonlywrap) {
         Wrapper *ro = NewWrapper();
         Printf(ro->def,
-               "SWIGINTERN const char *swig_readonly(ClientData clientData SWIGUNUSED, Tcl_Interp *interp SWIGUNUSED, char *name1 SWIGUNUSED, char *name2 SWIGUNUSED, int flags SWIGUNUSED) {");
+               "SWIGINTERN const char *swig_readonly(ClientData clientData SWIGUNUSED, Tcl_Interp *interp SWIGUNUSED, char *name1 SWIGUNUSED, char *name2 "
+               "SWIGUNUSED, int flags SWIGUNUSED) {");
         Printv(ro->code, "return \"Variable is read-only\";\n", "}\n", NIL);
         Wrapper_print(ro, f_wrappers);
         readonlywrap = 1;
@@ -704,8 +704,8 @@ public:
     if (!addSymbol(funcname, n))
       return SWIG_ERROR;
 
-    Printf(f_init, "\t Tcl_CreateObjCommand(interp, SWIG_prefix \"%s\", (swig_wrapper_func) %s, (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);\n", name,
-           funcname);
+    Printf(
+      f_init, "\t Tcl_CreateObjCommand(interp, SWIG_prefix \"%s\", (swig_wrapper_func) %s, (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);\n", name, funcname);
     return SWIG_OK;
   }
 
@@ -827,8 +827,8 @@ public:
         Printf(base_class_names, "\"%s *\",", SwigType_namestr(bname));
         /* Put code to register base classes in init function */
 
-        //Printf(f_init,"/* Register base : %s */\n", bmangle);
-        //Printf(f_init,"swig_%s_bases[%d] = (swig_class *) SWIG_TypeQuery(\"%s *\")->clientdata;\n",  mangled_classname, index, SwigType_namestr(bname));
+        // Printf(f_init,"/* Register base : %s */\n", bmangle);
+        // Printf(f_init,"swig_%s_bases[%d] = (swig_class *) SWIG_TypeQuery(\"%s *\")->clientdata;\n",  mangled_classname, index, SwigType_namestr(bname));
         (void)index;
         b = Next(b);
         index++;
@@ -859,14 +859,34 @@ public:
 
           Printv(ptrclass,
                  "    switch -exact -- $op {\n",
-                 "      r {set $var [", ns_name, "::", class_name, "_[set var]_get $swigobj]}\n",
-                 "      w {", ns_name, "::", class_name, "_${var}_set $swigobj [set $var]}\n", "    }\n", "  }\n", NIL);
+                 "      r {set $var [",
+                 ns_name,
+                 "::",
+                 class_name,
+                 "_[set var]_get $swigobj]}\n",
+                 "      w {",
+                 ns_name,
+                 "::",
+                 class_name,
+                 "_${var}_set $swigobj [set $var]}\n",
+                 "    }\n",
+                 "  }\n",
+                 NIL);
         } else {
           Printv(ptrclass,
-                 "  protected method ", class_name, "_swig_getset {var name1 name2 op} {\n",
+                 "  protected method ",
+                 class_name,
+                 "_swig_getset {var name1 name2 op} {\n",
                  "    switch -exact -- $op {\n",
-                 "      r {set $var [", class_name, "_[set var]_get $swigobj]}\n",
-                 "      w {", class_name, "_${var}_set $swigobj [set $var]}\n", "    }\n", "  }\n", NIL);
+                 "      r {set $var [",
+                 class_name,
+                 "_[set var]_get $swigobj]}\n",
+                 "      w {",
+                 class_name,
+                 "_${var}_set $swigobj [set $var]}\n",
+                 "    }\n",
+                 "  }\n",
+                 NIL);
         }
       }
       //  Add the constructor, which may include
@@ -885,11 +905,17 @@ public:
       }
       Printv(ptrclass, "  }\n", NIL);
 
-
       //  Add destructor
-      Printv(ptrclass, "  destructor {\n",
-             "    set d_func delete_", class_name, "\n",
-             "    if { $thisown && ([info command $d_func] != \"\") } {\n" "      $d_func $swigobj\n", "    }\n", "  }\n", NIL);
+      Printv(ptrclass,
+             "  destructor {\n",
+             "    set d_func delete_",
+             class_name,
+             "\n",
+             "    if { $thisown && ([info command $d_func] != \"\") } {\n"
+             "      $d_func $swigobj\n",
+             "    }\n",
+             "  }\n",
+             NIL);
 
       //  Add methods
       if (have_methods) {
@@ -900,7 +926,6 @@ public:
       Printv(ptrclass, "}\n\n", NIL);
       Printv(f_shadow, ptrclass, NIL);
       // pointer class end
-
 
       //  Create the "real" class.
       Printv(f_shadow, "itcl::class ", class_name, " {\n", NIL);
@@ -946,19 +971,34 @@ public:
     } else {
       Printf(f_wrappers, ",0");
     }
-    Printv(f_wrappers, ", swig_", mangled_classname, "_methods, swig_", mangled_classname, "_attributes, swig_", mangled_classname, "_bases,",
-           "swig_", mangled_classname, "_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };\n", NIL);
+    Printv(f_wrappers,
+           ", swig_",
+           mangled_classname,
+           "_methods, swig_",
+           mangled_classname,
+           "_attributes, swig_",
+           mangled_classname,
+           "_bases,",
+           "swig_",
+           mangled_classname,
+           "_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };\n",
+           NIL);
 
     if (!itcl) {
-      Printv(cmd_tab, tab4, "{ SWIG_prefix \"", class_name, "\", (swig_wrapper_func) SWIG_ObjectConstructor, (ClientData)&_wrap_class_", mangled_classname,
-             "},\n", NIL);
+      Printv(cmd_tab,
+             tab4,
+             "{ SWIG_prefix \"",
+             class_name,
+             "\", (swig_wrapper_func) SWIG_ObjectConstructor, (ClientData)&_wrap_class_",
+             mangled_classname,
+             "},\n",
+             NIL);
     }
 
     Delete(t);
     Delete(mangled_classname);
     return SWIG_OK;
   }
-
 
   /* ------------------------------------------------------------
    * memberfunctionHandler()

--- a/Source/Modules/tcl8.cxx
+++ b/Source/Modules/tcl8.cxx
@@ -82,40 +82,40 @@ public:
 
     for (int i = 1; i < argc; i++) {
       if (argv[i]) {
-	if (strcmp(argv[i], "-prefix") == 0) {
-	  if (argv[i + 1]) {
-	    prefix = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  } else
-	     Swig_arg_error();
-	} else if (strcmp(argv[i], "-pkgversion") == 0) {
-	  if (argv[i + 1]) {
-	    version = NewString(argv[i + 1]);
-	    Swig_mark_arg(i);
-	    Swig_mark_arg(i + 1);
-	    i++;
-	  }
-	} else if (strcmp(argv[i], "-namespace") == 0) {
-	  namespace_option = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-itcl") == 0) {
-	  itcl = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nosafe") == 0) {
-	  nosafe = 1;
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-help") == 0) {
-	  fputs(usage, stdout);
-	} else if (strcmp(argv[i], "-cppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
-	  Swig_mark_arg(i);
-	} else if (strcmp(argv[i], "-nocppcast") == 0) {
-	  Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
-	  Swig_mark_arg(i);
-	  Exit(EXIT_FAILURE);
-	}
+        if (strcmp(argv[i], "-prefix") == 0) {
+          if (argv[i + 1]) {
+            prefix = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          } else
+             Swig_arg_error();
+        } else if (strcmp(argv[i], "-pkgversion") == 0) {
+          if (argv[i + 1]) {
+            version = NewString(argv[i + 1]);
+            Swig_mark_arg(i);
+            Swig_mark_arg(i + 1);
+            i++;
+          }
+        } else if (strcmp(argv[i], "-namespace") == 0) {
+          namespace_option = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-itcl") == 0) {
+          itcl = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nosafe") == 0) {
+          nosafe = 1;
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-help") == 0) {
+          fputs(usage, stdout);
+        } else if (strcmp(argv[i], "-cppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is now always on.\n", argv[i]);
+          Swig_mark_arg(i);
+        } else if (strcmp(argv[i], "-nocppcast") == 0) {
+          Printf(stderr, "Deprecated command line option: %s. This option is no longer supported.\n", argv[i]);
+          Swig_mark_arg(i);
+          Exit(EXIT_FAILURE);
+        }
       }
     }
 
@@ -181,8 +181,8 @@ public:
       Insert(module, 0, "_");
 
       if ((f_shadow = NewFile(filen, "w", SWIG_output_files())) == 0) {
-	FileErrorDisplay(filen);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(filen);
+        Exit(EXIT_FAILURE);
       }
       f_shadow_stubs = NewString("");
 
@@ -280,7 +280,7 @@ public:
       overname = Getattr(n, "sym:overname");
     } else {
       if (!addSymbol(iname, n))
-	return SWIG_ERROR;
+        return SWIG_ERROR;
     }
 
     incode = NewString("");
@@ -322,7 +322,7 @@ public:
       /* Skip ignored arguments */
 
       while (checkAttribute(p, "tmap:in:numinputs", "0")) {
-	p = Getattr(p, "tmap:in:next");
+        p = Getattr(p, "tmap:in:next");
       }
 
       SwigType *pt = Getattr(p, "type");
@@ -332,46 +332,46 @@ public:
       sprintf(source, "objv[%d]", i + 1);
 
       if (i == num_required)
-	Putc('|', argstr);
+        Putc('|', argstr);
       if ((tm = Getattr(p, "tmap:in"))) {
-	String *parse = Getattr(p, "tmap:in:parse");
-	if (!parse) {
-	  Replaceall(tm, "$input", source);
-	  Setattr(p, "emit:input", source);
+        String *parse = Getattr(p, "tmap:in:parse");
+        if (!parse) {
+          Replaceall(tm, "$input", source);
+          Setattr(p, "emit:input", source);
 
-	  if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
-	    Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
-	  } else {
-	    Replaceall(tm, "$disown", "0");
-	  }
+          if (Getattr(p, "wrap:disown") || (Getattr(p, "tmap:in:disown"))) {
+            Replaceall(tm, "$disown", "SWIG_POINTER_DISOWN");
+          } else {
+            Replaceall(tm, "$disown", "0");
+          }
 
-	  Putc('o', argstr);
-	  Printf(args, ",(void *)0");
-	  if (i >= num_required) {
-	    Printf(incode, "if (objc > %d) {\n", i + 1);
-	  }
-	  Printf(incode, "%s\n", tm);
-	  if (i >= num_required) {
-	    Printf(incode, "}\n");
-	  }
-	} else {
-	  Printf(argstr, "%s", parse);
-	  Printf(args, ",&%s", ln);
-	  if (Strcmp(parse, "p") == 0) {
-	    SwigType *lt = SwigType_ltype(pt);
-	    SwigType_remember(pt);
-	    if (Cmp(lt, "p.void") == 0) {
-	      Printf(args, ",(void *)0");
-	    } else {
-	      Printf(args, ",SWIGTYPE%s", SwigType_manglestr(pt));
-	    }
-	    Delete(lt);
-	  }
-	}
-	p = Getattr(p, "tmap:in:next");
-	continue;
+          Putc('o', argstr);
+          Printf(args, ",(void *)0");
+          if (i >= num_required) {
+            Printf(incode, "if (objc > %d) {\n", i + 1);
+          }
+          Printf(incode, "%s\n", tm);
+          if (i >= num_required) {
+            Printf(incode, "}\n");
+          }
+        } else {
+          Printf(argstr, "%s", parse);
+          Printf(args, ",&%s", ln);
+          if (Strcmp(parse, "p") == 0) {
+            SwigType *lt = SwigType_ltype(pt);
+            SwigType_remember(pt);
+            if (Cmp(lt, "p.void") == 0) {
+              Printf(args, ",(void *)0");
+            } else {
+              Printf(args, ",SWIGTYPE%s", SwigType_manglestr(pt));
+            }
+            Delete(lt);
+          }
+        }
+        p = Getattr(p, "tmap:in:next");
+        continue;
       } else {
-	Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
+        Swig_warning(WARN_TYPEMAP_IN_UNDEF, input_file, line_number, "Unable to use type %s as a function argument.\n", SwigType_str(pt, 0));
       }
       p = nextSibling(p);
     }
@@ -382,11 +382,11 @@ public:
       Putc(';', argstr);
       /* If variable length arguments we need to emit the in typemap here */
       if (p && (tm = Getattr(p, "tmap:in"))) {
-	sprintf(source, "objv[%d]", i + 1);
-	Printf(incode, "if (objc > %d) {\n", i);
-	Replaceall(tm, "$input", source);
-	Printv(incode, tm, "\n", NIL);
-	Printf(incode, "}\n");
+        sprintf(source, "objv[%d]", i + 1);
+        Printf(incode, "if (objc > %d) {\n", i);
+        Replaceall(tm, "$input", source);
+        Printv(incode, tm, "\n", NIL);
+        Printf(incode, "}\n");
       }
     }
 
@@ -399,23 +399,23 @@ public:
     /* Insert constraint checking code */
     for (p = parms; p;) {
       if ((tm = Getattr(p, "tmap:check"))) {
-	Printv(f->code, tm, "\n", NIL);
-	p = Getattr(p, "tmap:check:next");
+        Printv(f->code, tm, "\n", NIL);
+        p = Getattr(p, "tmap:check:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
     /* Insert cleanup code */
     for (i = 0, p = parms; p; i++) {
       if (!checkAttribute(p, "tmap:in:numinputs", "0")
-	  && !Getattr(p, "tmap:in:parse") && (tm = Getattr(p, "tmap:freearg"))) {
-	if (Len(tm) != 0) {
-	  Printv(cleanup, tm, "\n", NIL);
-	}
-	p = Getattr(p, "tmap:freearg:next");
+          && !Getattr(p, "tmap:in:parse") && (tm = Getattr(p, "tmap:freearg"))) {
+        if (Len(tm) != 0) {
+          Printv(cleanup, tm, "\n", NIL);
+        }
+        p = Getattr(p, "tmap:freearg:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -423,16 +423,16 @@ public:
     for (i = 0, p = parms; p; i++) {
       if ((tm = Getattr(p, "tmap:argout"))) {
 #ifdef SWIG_USE_RESULTOBJ
-	Replaceall(tm, "$result", "resultobj");
+        Replaceall(tm, "$result", "resultobj");
 #else
-	Replaceall(tm, "$result", "(Tcl_GetObjResult(interp))");
+        Replaceall(tm, "$result", "(Tcl_GetObjResult(interp))");
 #endif
-	Replaceall(tm, "$arg", Getattr(p, "emit:input"));
-	Replaceall(tm, "$input", Getattr(p, "emit:input"));
-	Printv(outarg, tm, "\n", NIL);
-	p = Getattr(p, "tmap:argout:next");
+        Replaceall(tm, "$arg", Getattr(p, "emit:input"));
+        Replaceall(tm, "$input", Getattr(p, "emit:input"));
+        Printv(outarg, tm, "\n", NIL);
+        p = Getattr(p, "tmap:argout:next");
       } else {
-	p = nextSibling(p);
+        p = nextSibling(p);
       }
     }
 
@@ -449,9 +449,9 @@ public:
       Replaceall(tm, "$result", "(Tcl_GetObjResult(interp))");
 #endif
       if (GetFlag(n, "feature:new")) {
-	Replaceall(tm, "$owner", "SWIG_POINTER_OWN");
+        Replaceall(tm, "$owner", "SWIG_POINTER_OWN");
       } else {
-	Replaceall(tm, "$owner", "0");
+        Replaceall(tm, "$owner", "0");
       }
       Printf(f->code, "%s\n", tm);
     } else {
@@ -468,7 +468,7 @@ public:
     /* Look for any remaining cleanup */
     if (GetFlag(n, "feature:new")) {
       if ((tm = Swig_typemap_lookup("newfree", n, Swig_cresult_name(), 0))) {
-	Printf(f->code, "%s\n", tm);
+        Printf(f->code, "%s\n", tm);
       }
     }
 
@@ -498,41 +498,41 @@ public:
       Printv(cmd_tab, tab4, "{ SWIG_prefix \"", iname, "\", (swig_wrapper_func) ", Swig_name_wrapper(iname), ", NULL},\n", NIL);
     } else {
       if (!Getattr(n, "sym:nextSibling")) {
-	/* Emit overloading dispatch function */
+        /* Emit overloading dispatch function */
 
-	int maxargs;
-	bool check_emitted = false;
-	String *dispatch = Swig_overload_dispatch(n, "return %s(clientData, interp, objc, argv - 1);", &maxargs, &check_emitted);
+        int maxargs;
+        bool check_emitted = false;
+        String *dispatch = Swig_overload_dispatch(n, "return %s(clientData, interp, objc, argv - 1);", &maxargs, &check_emitted);
 
-	/* Generate a dispatch wrapper for all overloaded functions */
+        /* Generate a dispatch wrapper for all overloaded functions */
 
-	Wrapper *df = NewWrapper();
-	String *dname = Swig_name_wrapper(iname);
+        Wrapper *df = NewWrapper();
+        String *dname = Swig_name_wrapper(iname);
 
-	Printv(df->def, "SWIGINTERN int\n", dname, "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {", NIL);
-	Printf(df->code, "Tcl_Obj *const *argv = objv+1;\n");
-	Printf(df->code, "int argc = objc-1;\n");
-	Printv(df->code, dispatch, "\n", NIL);
-	Node *sibl = n;
-	while (Getattr(sibl, "sym:previousSibling"))
-	  sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
-	String *protoTypes = NewString("");
-	do {
-	  String *fulldecl = Swig_name_decl(sibl);
-	  Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
-	  Delete(fulldecl);
-	} while ((sibl = Getattr(sibl, "sym:nextSibling")));
-	Printf(df->code, "Tcl_SetResult(interp,(char *) "
-	       "\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
-	       "\n\"  Possible C/C++ prototypes are:\\n\"%s, TCL_STATIC);\n", iname, protoTypes);
-	Delete(protoTypes);
-	Printf(df->code, "return TCL_ERROR;\n");
-	Printv(df->code, "}\n", NIL);
-	Wrapper_print(df, f_wrappers);
-	Printv(cmd_tab, tab4, "{ SWIG_prefix \"", iname, "\", (swig_wrapper_func) ", dname, ", NULL},\n", NIL);
-	DelWrapper(df);
-	Delete(dispatch);
-	Delete(dname);
+        Printv(df->def, "SWIGINTERN int\n", dname, "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {", NIL);
+        Printf(df->code, "Tcl_Obj *const *argv = objv+1;\n");
+        Printf(df->code, "int argc = objc-1;\n");
+        Printv(df->code, dispatch, "\n", NIL);
+        Node *sibl = n;
+        while (Getattr(sibl, "sym:previousSibling"))
+          sibl = Getattr(sibl, "sym:previousSibling");	// go all the way up
+        String *protoTypes = NewString("");
+        do {
+          String *fulldecl = Swig_name_decl(sibl);
+          Printf(protoTypes, "\n\"    %s\\n\"", fulldecl);
+          Delete(fulldecl);
+        } while ((sibl = Getattr(sibl, "sym:nextSibling")));
+        Printf(df->code, "Tcl_SetResult(interp,(char *) "
+               "\"Wrong number or type of arguments for overloaded function '%s'.\\n\""
+               "\n\"  Possible C/C++ prototypes are:\\n\"%s, TCL_STATIC);\n", iname, protoTypes);
+        Delete(protoTypes);
+        Printf(df->code, "return TCL_ERROR;\n");
+        Printv(df->code, "}\n", NIL);
+        Wrapper_print(df, f_wrappers);
+        Printv(cmd_tab, tab4, "{ SWIG_prefix \"", iname, "\", (swig_wrapper_func) ", dname, ", NULL},\n", NIL);
+        DelWrapper(df);
+        Delete(dispatch);
+        Delete(dname);
       }
     }
 
@@ -582,8 +582,8 @@ public:
       Printf(getf->code, "}\n");
       Printf(getf->code, "return NULL;\n");
       if (addfail) {
-	Append(getf->code, "fail:\n");
-	Printf(getf->code, "return \"%s\";\n", iname);
+        Append(getf->code, "fail:\n");
+        Printf(getf->code, "return \"%s\";\n", iname);
       }
       Printf(getf->code, "}\n");
       Wrapper_print(getf, f_wrappers);
@@ -602,26 +602,26 @@ public:
       Setattr(n, "wrap:name", setfname);
       if (setf) {
         Printv(setf->def, "SWIGINTERN const char *", setfname,
-	     "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, char *name1, char *name2 SWIGUNUSED, int flags) {", NIL);
+             "(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, char *name1, char *name2 SWIGUNUSED, int flags) {", NIL);
         Wrapper_add_local(setf, "value", "Tcl_Obj *value = 0");
         Wrapper_add_local(setf, "name1o", "Tcl_Obj *name1o = 0");
 
         if ((tm = Swig_typemap_lookup("varin", n, name, 0))) {
-	  Replaceall(tm, "$input", "value");
-	  Printf(setf->code, "name1o = Tcl_NewStringObj(name1,-1);\n");
-	  Printf(setf->code, "value = Tcl_ObjGetVar2(interp, name1o, 0, flags);\n");
-	  Printf(setf->code, "Tcl_DecrRefCount(name1o);\n");
-	  Printf(setf->code, "if (!value) SWIG_fail;\n");
-	  /* Printf(setf->code,"%s\n", tm); */
-	  emit_action_code(n, setf->code, tm);
-	  Printf(setf->code, "return NULL;\n");
-	  Printf(setf->code, "fail:\n");
-	  Printf(setf->code, "return \"%s\";\n", iname);
-	  Printf(setf->code, "}\n");
-	  Wrapper_print(setf, f_wrappers);
+          Replaceall(tm, "$input", "value");
+          Printf(setf->code, "name1o = Tcl_NewStringObj(name1,-1);\n");
+          Printf(setf->code, "value = Tcl_ObjGetVar2(interp, name1o, 0, flags);\n");
+          Printf(setf->code, "Tcl_DecrRefCount(name1o);\n");
+          Printf(setf->code, "if (!value) SWIG_fail;\n");
+          /* Printf(setf->code,"%s\n", tm); */
+          emit_action_code(n, setf->code, tm);
+          Printf(setf->code, "return NULL;\n");
+          Printf(setf->code, "fail:\n");
+          Printf(setf->code, "return \"%s\";\n", iname);
+          Printf(setf->code, "}\n");
+          Wrapper_print(setf, f_wrappers);
         } else {
-	  Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(t, 0));
-	  readonly = 1;
+          Swig_warning(WARN_TYPEMAP_VARIN_UNDEF, input_file, line_number, "Unable to set variable of type %s.\n", SwigType_str(t, 0));
+          readonly = 1;
         }
       }
       DelWrapper(setf);
@@ -634,13 +634,13 @@ public:
     if (readonly) {
       static int readonlywrap = 0;
       if (!readonlywrap) {
-	Wrapper *ro = NewWrapper();
-	Printf(ro->def,
-	       "SWIGINTERN const char *swig_readonly(ClientData clientData SWIGUNUSED, Tcl_Interp *interp SWIGUNUSED, char *name1 SWIGUNUSED, char *name2 SWIGUNUSED, int flags SWIGUNUSED) {");
-	Printv(ro->code, "return \"Variable is read-only\";\n", "}\n", NIL);
-	Wrapper_print(ro, f_wrappers);
-	readonlywrap = 1;
-	DelWrapper(ro);
+        Wrapper *ro = NewWrapper();
+        Printf(ro->def,
+               "SWIGINTERN const char *swig_readonly(ClientData clientData SWIGUNUSED, Tcl_Interp *interp SWIGUNUSED, char *name1 SWIGUNUSED, char *name2 SWIGUNUSED, int flags SWIGUNUSED) {");
+        Printv(ro->code, "return \"Variable is read-only\";\n", "}\n", NIL);
+        Wrapper_print(ro, f_wrappers);
+        readonlywrap = 1;
+        DelWrapper(ro);
       }
       Printf(var_tab, "(swig_variable_func) swig_readonly},\n");
     } else {
@@ -705,7 +705,7 @@ public:
       return SWIG_ERROR;
 
     Printf(f_init, "\t Tcl_CreateObjCommand(interp, SWIG_prefix \"%s\", (swig_wrapper_func) %s, (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);\n", name,
-	   funcname);
+           funcname);
     return SWIG_OK;
   }
 
@@ -777,14 +777,14 @@ public:
     if (have_destructor) {
       Printv(f_wrappers, "SWIGINTERN void swig_delete_", class_name, "(void *obj) {\n", NIL);
       if (destructor_action) {
-	Printv(f_wrappers, SwigType_str(rt, "arg1"), " = (", SwigType_str(rt, 0), ") obj;\n", NIL);
-	Printv(f_wrappers, destructor_action, "\n", NIL);
+        Printv(f_wrappers, SwigType_str(rt, "arg1"), " = (", SwigType_str(rt, 0), ") obj;\n", NIL);
+        Printv(f_wrappers, destructor_action, "\n", NIL);
       } else {
-	if (CPlusPlus) {
-	  Printv(f_wrappers, "    delete (", SwigType_str(rt, 0), ") obj;\n", NIL);
-	} else {
-	  Printv(f_wrappers, "    free((char *) obj);\n", NIL);
-	}
+        if (CPlusPlus) {
+          Printv(f_wrappers, "    delete (", SwigType_str(rt, 0), ") obj;\n", NIL);
+        } else {
+          Printv(f_wrappers, "    free((char *) obj);\n", NIL);
+        }
       }
       Printf(f_wrappers, "}\n");
     }
@@ -810,30 +810,30 @@ public:
       int index = 0;
       b = First(baselist);
       while (b.item) {
-	SwigType *bname = Getattr(b.item, "name");
-	if ((!bname) || GetFlag(b.item, "feature:ignore") || (!Getattr(b.item, "module"))) {
-	  b = Next(b);
-	  continue;
-	}
-	if (itcl) {
-	  have_base_classes = 1;
-	  Printv(base_classes, bname, " ", NIL);
-	  Printv(base_class_init, "    ", bname, "Ptr::constructor $ptr\n", NIL);
-	}
-	String *bmangle = Swig_name_mangle_type(bname);
-	//      Printv(f_wrappers,"extern swig_class _wrap_class_", bmangle, ";\n", NIL);
-	//      Printf(base_class,"&_wrap_class_%s",bmangle);
-	Printf(base_class, "0");
-	Printf(base_class_names, "\"%s *\",", SwigType_namestr(bname));
-	/* Put code to register base classes in init function */
+        SwigType *bname = Getattr(b.item, "name");
+        if ((!bname) || GetFlag(b.item, "feature:ignore") || (!Getattr(b.item, "module"))) {
+          b = Next(b);
+          continue;
+        }
+        if (itcl) {
+          have_base_classes = 1;
+          Printv(base_classes, bname, " ", NIL);
+          Printv(base_class_init, "    ", bname, "Ptr::constructor $ptr\n", NIL);
+        }
+        String *bmangle = Swig_name_mangle_type(bname);
+        //      Printv(f_wrappers,"extern swig_class _wrap_class_", bmangle, ";\n", NIL);
+        //      Printf(base_class,"&_wrap_class_%s",bmangle);
+        Printf(base_class, "0");
+        Printf(base_class_names, "\"%s *\",", SwigType_namestr(bname));
+        /* Put code to register base classes in init function */
 
-	//Printf(f_init,"/* Register base : %s */\n", bmangle);
-	//Printf(f_init,"swig_%s_bases[%d] = (swig_class *) SWIG_TypeQuery(\"%s *\")->clientdata;\n",  mangled_classname, index, SwigType_namestr(bname));
-	(void)index;
-	b = Next(b);
-	index++;
-	Putc(',', base_class);
-	Delete(bmangle);
+        //Printf(f_init,"/* Register base : %s */\n", bmangle);
+        //Printf(f_init,"swig_%s_bases[%d] = (swig_class *) SWIG_TypeQuery(\"%s *\")->clientdata;\n",  mangled_classname, index, SwigType_namestr(bname));
+        (void)index;
+        b = Next(b);
+        index++;
+        Putc(',', base_class);
+        Delete(bmangle);
       }
     }
 
@@ -843,57 +843,57 @@ public:
       // First, build the pointer base class
       Printv(ptrclass, "itcl::class ", class_name, "Ptr {\n", NIL);
       if (have_base_classes)
-	Printv(ptrclass, "  inherit ", base_classes, "\n", NIL);
+        Printv(ptrclass, "  inherit ", base_classes, "\n", NIL);
 
       //  Define protected variables for SWIG object pointer
       Printv(ptrclass, "  protected variable swigobj\n", "  protected variable thisown\n", NIL);
 
       //  Define public variables
       if (have_attributes) {
-	Printv(ptrclass, attributes, NIL);
+        Printv(ptrclass, attributes, NIL);
 
-	// base class swig_getset was being called for complex inheritance trees
-	if (namespace_option) {
+        // base class swig_getset was being called for complex inheritance trees
+        if (namespace_option) {
 
-	  Printv(ptrclass, "  protected method ", class_name, "_swig_getset {var name1 name2 op} {\n", NIL);
+          Printv(ptrclass, "  protected method ", class_name, "_swig_getset {var name1 name2 op} {\n", NIL);
 
-	  Printv(ptrclass,
-		 "    switch -exact -- $op {\n",
-		 "      r {set $var [", ns_name, "::", class_name, "_[set var]_get $swigobj]}\n",
-		 "      w {", ns_name, "::", class_name, "_${var}_set $swigobj [set $var]}\n", "    }\n", "  }\n", NIL);
-	} else {
-	  Printv(ptrclass,
-		 "  protected method ", class_name, "_swig_getset {var name1 name2 op} {\n",
-		 "    switch -exact -- $op {\n",
-		 "      r {set $var [", class_name, "_[set var]_get $swigobj]}\n",
-		 "      w {", class_name, "_${var}_set $swigobj [set $var]}\n", "    }\n", "  }\n", NIL);
-	}
+          Printv(ptrclass,
+                 "    switch -exact -- $op {\n",
+                 "      r {set $var [", ns_name, "::", class_name, "_[set var]_get $swigobj]}\n",
+                 "      w {", ns_name, "::", class_name, "_${var}_set $swigobj [set $var]}\n", "    }\n", "  }\n", NIL);
+        } else {
+          Printv(ptrclass,
+                 "  protected method ", class_name, "_swig_getset {var name1 name2 op} {\n",
+                 "    switch -exact -- $op {\n",
+                 "      r {set $var [", class_name, "_[set var]_get $swigobj]}\n",
+                 "      w {", class_name, "_${var}_set $swigobj [set $var]}\n", "    }\n", "  }\n", NIL);
+        }
       }
       //  Add the constructor, which may include
       //  calls to base class class constructors
 
       Printv(ptrclass, "  constructor { ptr } {\n", NIL);
       if (have_base_classes) {
-	Printv(ptrclass, base_class_init, NIL);
-	Printv(ptrclass, "  } {\n", NIL);
+        Printv(ptrclass, base_class_init, NIL);
+        Printv(ptrclass, "  } {\n", NIL);
       }
 
       Printv(ptrclass, "    set swigobj $ptr\n", "    set thisown 0\n", NIL);
 
       if (have_attributes) {
-	Printv(ptrclass, attribute_traces, NIL);
+        Printv(ptrclass, attribute_traces, NIL);
       }
       Printv(ptrclass, "  }\n", NIL);
 
 
       //  Add destructor
       Printv(ptrclass, "  destructor {\n",
-	     "    set d_func delete_", class_name, "\n",
-	     "    if { $thisown && ([info command $d_func] != \"\") } {\n" "      $d_func $swigobj\n", "    }\n", "  }\n", NIL);
+             "    set d_func delete_", class_name, "\n",
+             "    if { $thisown && ([info command $d_func] != \"\") } {\n" "      $d_func $swigobj\n", "    }\n", "  }\n", NIL);
 
       //  Add methods
       if (have_methods) {
-	Printv(ptrclass, imethods, NIL);
+        Printv(ptrclass, imethods, NIL);
       }
 
       //  Close out the pointer class
@@ -914,14 +914,14 @@ public:
       //  calling the ptrclass constructor.
 
       if (have_constructor) {
-	Printv(f_shadow, constructor, NIL);
+        Printv(f_shadow, constructor, NIL);
       } else {
-	Printv(f_shadow, "  constructor { } {\n", NIL);
-	Printv(f_shadow, "    # This constructor will fail if called directly\n", NIL);
-	Printv(f_shadow, "    if { [info class] == \"::", class_name, "\" } {\n", NIL);
-	Printv(f_shadow, "      error \"No constructor for class ", class_name, (Getattr(n, "abstracts") ? " - class is abstract" : ""), "\"\n", NIL);
-	Printv(f_shadow, "    }\n", NIL);
-	Printv(f_shadow, "  }\n", NIL);
+        Printv(f_shadow, "  constructor { } {\n", NIL);
+        Printv(f_shadow, "    # This constructor will fail if called directly\n", NIL);
+        Printv(f_shadow, "    if { [info class] == \"::", class_name, "\" } {\n", NIL);
+        Printv(f_shadow, "      error \"No constructor for class ", class_name, (Getattr(n, "abstracts") ? " - class is abstract" : ""), "\"\n", NIL);
+        Printv(f_shadow, "    }\n", NIL);
+        Printv(f_shadow, "  }\n", NIL);
       }
 
       Printv(f_shadow, "}\n\n", NIL);
@@ -947,11 +947,11 @@ public:
       Printf(f_wrappers, ",0");
     }
     Printv(f_wrappers, ", swig_", mangled_classname, "_methods, swig_", mangled_classname, "_attributes, swig_", mangled_classname, "_bases,",
-	   "swig_", mangled_classname, "_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };\n", NIL);
+           "swig_", mangled_classname, "_base_names, &swig_module, SWIG_TCL_HASHTABLE_INIT };\n", NIL);
 
     if (!itcl) {
       Printv(cmd_tab, tab4, "{ SWIG_prefix \"", class_name, "\", (swig_wrapper_func) SWIG_ObjectConstructor, (ClientData)&_wrap_class_", mangled_classname,
-	     "},\n", NIL);
+             "},\n", NIL);
     }
 
     Delete(t);
@@ -989,64 +989,64 @@ public:
       int pnum = 0;
       for (p = l; p; p = nextSibling(p)) {
 
-	String *pn = Getattr(p, "name");
-	String *dv = Getattr(p, "value");
-	SwigType *pt = Getattr(p, "type");
+        String *pn = Getattr(p, "name");
+        String *dv = Getattr(p, "value");
+        SwigType *pt = Getattr(p, "type");
 
-	Printv(pname, ",(", pt, ")", NIL);
-	Clear(pname);
+        Printv(pname, ",(", pt, ")", NIL);
+        Clear(pname);
 
-	/* Only print an argument if not void */
-	if (Cmp(pt, "void") != 0) {
-	  if (Len(pn) > 0) {
-	    Printv(pname, pn, NIL);
-	  } else {
-	    Printf(pname, "p%d", pnum);
-	  }
+        /* Only print an argument if not void */
+        if (Cmp(pt, "void") != 0) {
+          if (Len(pn) > 0) {
+            Printv(pname, pn, NIL);
+          } else {
+            Printf(pname, "p%d", pnum);
+          }
 
-	  if (Len(dv) > 0) {
-	    String *defval = NewString(dv);
-	    if (namespace_option) {
-	      Insert(defval, 0, "::");
-	      Insert(defval, 0, ns_name);
-	    }
-	    if (Strncmp(dv, "(", 1) == 0) {
-	      Insert(defval, 0, "$");
-	      Replaceall(defval, "(", "");
-	      Replaceall(defval, ")", "");
-	    }
-	    Printv(imethods, "[list ", pname, " ", defval, "] ", NIL);
-	  } else {
-	    Printv(imethods, pname, " ", NIL);
-	  }
-	}
-	++pnum;
+          if (Len(dv) > 0) {
+            String *defval = NewString(dv);
+            if (namespace_option) {
+              Insert(defval, 0, "::");
+              Insert(defval, 0, ns_name);
+            }
+            if (Strncmp(dv, "(", 1) == 0) {
+              Insert(defval, 0, "$");
+              Replaceall(defval, "(", "");
+              Replaceall(defval, ")", "");
+            }
+            Printv(imethods, "[list ", pname, " ", defval, "] ", NIL);
+          } else {
+            Printv(imethods, pname, " ", NIL);
+          }
+        }
+        ++pnum;
       }
       Printv(imethods, "] ", NIL);
 
       if (namespace_option) {
-	Printv(imethods, "{ ", ns_name, "::", class_name, "_", realname, " $swigobj", NIL);
+        Printv(imethods, "{ ", ns_name, "::", class_name, "_", realname, " $swigobj", NIL);
       } else {
-	Printv(imethods, "{ ", class_name, "_", realname, " $swigobj", NIL);
+        Printv(imethods, "{ ", class_name, "_", realname, " $swigobj", NIL);
       }
 
       pnum = 0;
       for (p = l; p; p = nextSibling(p)) {
 
-	String *pn = Getattr(p, "name");
-	SwigType *pt = Getattr(p, "type");
-	Clear(pname);
+        String *pn = Getattr(p, "name");
+        SwigType *pt = Getattr(p, "type");
+        Clear(pname);
 
-	/* Only print an argument if not void */
-	if (Cmp(pt, "void") != 0) {
-	  if (Len(pn) > 0) {
-	    Printv(pname, pn, NIL);
-	  } else {
-	    Printf(pname, "p%d", pnum);
-	  }
-	  Printv(imethods, " $", pname, NIL);
-	}
-	++pnum;
+        /* Only print an argument if not void */
+        if (Cmp(pt, "void") != 0) {
+          if (Len(pn) > 0) {
+            Printv(pname, pn, NIL);
+          } else {
+            Printf(pname, "p%d", pnum);
+          }
+          Printv(imethods, " $", pname, NIL);
+        }
+        ++pnum;
       }
       Printv(imethods, " }\n", NIL);
       have_methods = 1;
@@ -1109,75 +1109,75 @@ public:
       realname = iname ? iname : name;
 
       if (!have_constructor) {
-	// Add this member to our class handler function
-	Printf(constructor, "  constructor { ");
+        // Add this member to our class handler function
+        Printf(constructor, "  constructor { ");
 
-	//  Add parameter list
-	int pnum = 0;
-	for (p = l; p; p = nextSibling(p)) {
+        //  Add parameter list
+        int pnum = 0;
+        for (p = l; p; p = nextSibling(p)) {
 
-	  SwigType *pt = Getattr(p, "type");
-	  String *pn = Getattr(p, "name");
-	  String *dv = Getattr(p, "value");
-	  Clear(pname);
+          SwigType *pt = Getattr(p, "type");
+          String *pn = Getattr(p, "name");
+          String *dv = Getattr(p, "value");
+          Clear(pname);
 
-	  /* Only print an argument if not void */
-	  if (Cmp(pt, "void") != 0) {
-	    if (Len(pn) > 0) {
-	      Printv(pname, pn, NIL);
-	    } else {
-	      Printf(pname, "p%d", pnum);
-	    }
+          /* Only print an argument if not void */
+          if (Cmp(pt, "void") != 0) {
+            if (Len(pn) > 0) {
+              Printv(pname, pn, NIL);
+            } else {
+              Printf(pname, "p%d", pnum);
+            }
 
-	    if (Len(dv) > 0) {
-	      Printv(constructor, "{", pname, " {", dv, "} } ", NIL);
-	    } else {
-	      Printv(constructor, pname, " ", NIL);
-	    }
-	  }
-	  ++pnum;
-	}
-	Printf(constructor, "} { \n");
+            if (Len(dv) > 0) {
+              Printv(constructor, "{", pname, " {", dv, "} } ", NIL);
+            } else {
+              Printv(constructor, pname, " ", NIL);
+            }
+          }
+          ++pnum;
+        }
+        Printf(constructor, "} { \n");
 
-	// [BRE] 08/17/00 Added test to see if we are instantiating this object
-	// type, or, if this constructor is being called as part of the itcl
-	// inheritance hierarchy.
-	// In the former case, we need to call the C++ constructor, in the
-	// latter we don't, or we end up with two C++ objects.
-	// Check to see if we are instantiating a 'realname' or something 
-	// derived from it.
-	//
-	Printv(constructor, "    if { [string equal -nocase \"", realname, "\" \"[namespace tail [info class]]\" ] } {\n", NIL);
+        // [BRE] 08/17/00 Added test to see if we are instantiating this object
+        // type, or, if this constructor is being called as part of the itcl
+        // inheritance hierarchy.
+        // In the former case, we need to call the C++ constructor, in the
+        // latter we don't, or we end up with two C++ objects.
+        // Check to see if we are instantiating a 'realname' or something 
+        // derived from it.
+        //
+        Printv(constructor, "    if { [string equal -nocase \"", realname, "\" \"[namespace tail [info class]]\" ] } {\n", NIL);
 
-	// Call to constructor wrapper and parent Ptr class
-	// [BRE] add -namespace/-prefix support
+        // Call to constructor wrapper and parent Ptr class
+        // [BRE] add -namespace/-prefix support
 
-	if (namespace_option) {
-	  Printv(constructor, "      ", realname, "Ptr::constructor [", ns_name, "::new_", realname, NIL);
-	} else {
-	  Printv(constructor, "      ", realname, "Ptr::constructor [new_", realname, NIL);
-	}
+        if (namespace_option) {
+          Printv(constructor, "      ", realname, "Ptr::constructor [", ns_name, "::new_", realname, NIL);
+        } else {
+          Printv(constructor, "      ", realname, "Ptr::constructor [new_", realname, NIL);
+        }
 
-	pnum = 0;
-	for (p = l; p; p = nextSibling(p)) {
+        pnum = 0;
+        for (p = l; p; p = nextSibling(p)) {
 
-	  SwigType *pt = Getattr(p, "type");
-	  String *pn = Getattr(p, "name");
-	  Clear(pname);
+          SwigType *pt = Getattr(p, "type");
+          String *pn = Getattr(p, "name");
+          Clear(pname);
 
-	  /* Only print an argument if not void */
-	  if (Cmp(pt, "void") != 0) {
-	    if (Len(pn) > 0) {
-	      Printv(pname, pn, NIL);
-	    } else {
-	      Printf(pname, "p%d", pnum);
-	    }
-	    Printv(constructor, " $", pname, NIL);
-	  }
-	  ++pnum;
-	}
+          /* Only print an argument if not void */
+          if (Cmp(pt, "void") != 0) {
+            if (Len(pn) > 0) {
+              Printv(pname, pn, NIL);
+            } else {
+              Printf(pname, "p%d", pnum);
+            }
+            Printv(constructor, " $", pname, NIL);
+          }
+          ++pnum;
+        }
 
-	Printv(constructor, "]\n", "    }\n", "  } {\n", "    set thisown 1\n", "  }\n", NIL);
+        Printv(constructor, "]\n", "    }\n", "  } {\n", "    set thisown 1\n", "  }\n", NIL);
       }
     }
 
@@ -1235,17 +1235,17 @@ public:
       String *pn = Getattr(p, "name");
       /* Only print an argument if not ignored */
       if (!checkAttribute(p, "tmap:in:numinputs", "0")) {
-	if (i >= (pcount - numopt))
-	  Putc('?', temp);
-	if (Len(pn) > 0) {
-	  Printf(temp, "%s", pn);
-	} else {
-	  Printf(temp, "%s", SwigType_str(pt, 0));
-	}
-	if (i >= (pcount - numopt))
-	  Putc('?', temp);
-	Putc(' ', temp);
-	i++;
+        if (i >= (pcount - numopt))
+          Putc('?', temp);
+        if (Len(pn) > 0) {
+          Printf(temp, "%s", pn);
+        } else {
+          Printf(temp, "%s", SwigType_str(pt, 0));
+        }
+        if (i >= (pcount - numopt))
+          Putc('?', temp);
+        Putc(' ', temp);
+        i++;
       }
     }
     return Char(temp);

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -176,7 +176,7 @@ class TypePass:private Dispatcher {
           String *sname = bname;
           String *tname = 0;
 
-          /* Try to locate the base class.   We look in the symbol table and we chase 
+          /* Try to locate the base class.   We look in the symbol table and we chase
              typedef declarations to get to the base class if necessary */
           Symtab *st = Getattr(cls, "sym:symtab");
 
@@ -607,7 +607,7 @@ class TypePass:private Dispatcher {
     }
 
     /* Inherit type definitions into the class */
-    if (name && !(GetFlag(n, "nested") && !checkAttribute(n, "access", "public") && 
+    if (name && !(GetFlag(n, "nested") && !checkAttribute(n, "access", "public") &&
       (GetFlag(n, "feature:flatnested") || Language::instance()->nestedClassesSupport() == Language::NCS_None))) {
       cplus_inherit_types(n, 0, nname ? nname : (fname ? fname : name));
     }
@@ -622,7 +622,7 @@ class TypePass:private Dispatcher {
     Delete(ts);
     Setattr(n, "module", module);
 
-    // When a fully qualified templated type with default parameters is used in the parsed code, 
+    // When a fully qualified templated type with default parameters is used in the parsed code,
     // the following additional symbols and scopes are needed for successful lookups
     if (template_default_expanded) {
       Swig_symbol_alias(template_default_expanded, Getattr(n, "symtab"));

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -61,15 +61,15 @@ class TypePass:private Dispatcher {
 
     if (SwigType_isfunction(decl)) {
       if ((ParmList_len(parms) == 1) && (SwigType_type(Getattr(parms, "type")) == T_VOID)) {
-	String *qualifiers = SwigType_pop_function_qualifiers(decl);
-	String *func = SwigType_pop_function(decl);
-	SwigType_add_function(decl, 0);
-	SwigType_push(decl, qualifiers);
+        String *qualifiers = SwigType_pop_function_qualifiers(decl);
+        String *func = SwigType_pop_function(decl);
+        SwigType_add_function(decl, 0);
+        SwigType_push(decl, qualifiers);
 
-	Delattr(n, "parms");
+        Delattr(n, "parms");
 
-	Delete(func);
-	Delete(qualifiers);
+        Delete(func);
+        Delete(qualifiers);
       }
     }
   }
@@ -98,29 +98,29 @@ class TypePass:private Dispatcher {
       normalize_type(ty);
       /* This is a check for a function type */
       {
-	SwigType *qty = SwigType_typedef_resolve_all(ty);
-	if (SwigType_isfunction(qty)) {
-	  SwigType_add_pointer(ty);
-	}
-	Delete(qty);
+        SwigType *qty = SwigType_typedef_resolve_all(ty);
+        if (SwigType_isfunction(qty)) {
+          SwigType_add_pointer(ty);
+        }
+        Delete(qty);
       }
 
       String *value = Getattr(p, "value");
       if (value) {
-	Node *n = Swig_symbol_clookup(value, 0);
-	if (n) {
-	  String *q = Swig_symbol_qualified(n);
-	  if (q && Len(q)) {
-	    String *vb = Swig_scopename_last(value);
-	    Clear(value);
-	    Printf(value, "%s::%s", SwigType_namestr(q), vb);
-	    Delete(q);
-	  }
-	}
+        Node *n = Swig_symbol_clookup(value, 0);
+        if (n) {
+          String *q = Swig_symbol_qualified(n);
+          if (q && Len(q)) {
+            String *vb = Swig_scopename_last(value);
+            Clear(value);
+            Printf(value, "%s::%s", SwigType_namestr(q), vb);
+            Delete(q);
+          }
+        }
       }
       if (value && SwigType_istemplate(value)) {
-	String *nv = SwigType_namestr(value);
-	Setattr(p, "value", nv);
+        String *nv = SwigType_namestr(value);
+        Setattr(p, "value", nv);
       }
       p = nextSibling(p);
     }
@@ -145,7 +145,7 @@ class TypePass:private Dispatcher {
       SwigType_set_scope(nn->typescope);
       Iterator t;
       for (t = First(nn->normallist); t.item; t = Next(t)) {
-	normalize_type(t.item);
+        normalize_type(t.item);
       }
       Delete(nn->normallist);
       np = nn->next;
@@ -167,108 +167,108 @@ class TypePass:private Dispatcher {
     if (!ilist) {
       List *nlist = Getattr(cls, baselist);
       if (nlist) {
-	int len = Len(nlist);
-	int i;
-	for (i = 0; i < len; i++) {
-	  Node *bcls = 0;
-	  int clsforward = 0;
-	  String *bname = Getitem(nlist, i);
-	  String *sname = bname;
-	  String *tname = 0;
+        int len = Len(nlist);
+        int i;
+        for (i = 0; i < len; i++) {
+          Node *bcls = 0;
+          int clsforward = 0;
+          String *bname = Getitem(nlist, i);
+          String *sname = bname;
+          String *tname = 0;
 
-	  /* Try to locate the base class.   We look in the symbol table and we chase 
-	     typedef declarations to get to the base class if necessary */
-	  Symtab *st = Getattr(cls, "sym:symtab");
+          /* Try to locate the base class.   We look in the symbol table and we chase 
+             typedef declarations to get to the base class if necessary */
+          Symtab *st = Getattr(cls, "sym:symtab");
 
-	  if (SwigType_istemplate(bname)) {
-	    tname = SwigType_typedef_resolve_all(bname);
-	    sname = tname;
-	  }
-	  while (1) {
-	    String *qsname = SwigType_typedef_qualified(sname);
-	    bcls = Swig_symbol_clookup(qsname, st);
-	    Delete(qsname);
-	    if (bcls) {
-	      if (Strcmp(nodeType(bcls), "class") != 0) {
-		/* Not a class.   The symbol could be a typedef. */
-		if (checkAttribute(bcls, "storage", "typedef")) {
-		  SwigType *decl = Getattr(bcls, "decl");
-		  if (!decl || !(Len(decl))) {
-		    sname = Getattr(bcls, "type");
-		    st = Getattr(bcls, "sym:symtab");
-		    if (SwigType_istemplate(sname)) {
-		      if (tname)
-			Delete(tname);
-		      tname = SwigType_typedef_resolve_all(sname);
-		      sname = tname;
-		    }
-		    continue;
-		  }
-		  // A case when both outer and nested classes inherit from the same parent. Constructor may be found instead of the class itself.
-		} else if (GetFlag(cls, "nested") && checkAttribute(bcls, "nodeType", "constructor")) {
-		  bcls = Getattr(bcls, "parentNode");
-		  if (Getattr(bcls, "typepass:visit")) {
-		    if (!Getattr(bcls, "feature:onlychildren")) {
-		      if (!ilist)
-			ilist = alist = NewList();
-		      Append(ilist, bcls);
-		    } else {
-		      if (!GetFlag(bcls, "feature:ignore")) {
-			Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n", SwigType_namestr(bname));
-			Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n", SwigType_namestr(bname));
-		      }
-		    }
-		  }
-		  break;
-		}
-		if (Strcmp(nodeType(bcls), "classforward") != 0) {
-		  Swig_error(Getfile(bname), Getline(bname), "'%s' is not a valid base class.\n", SwigType_namestr(bname));
-		  Swig_error(Getfile(bcls), Getline(bcls), "See definition of '%s'.\n", SwigType_namestr(bname));
-		} else {
-		  Swig_warning(WARN_TYPE_INCOMPLETE, Getfile(bname), Getline(bname), "Base class '%s' is incomplete.\n", SwigType_namestr(bname));
-		  Swig_warning(WARN_TYPE_INCOMPLETE, Getfile(bcls), Getline(bcls), "Only forward declaration '%s' was found.\n", SwigType_namestr(bname));
-		  clsforward = 1;
-		}
-		bcls = 0;
-	      } else {
-		if (Getattr(bcls, "typepass:visit")) {
-		  if (!Getattr(bcls, "feature:onlychildren")) {
-		    if (!ilist)
-		      ilist = alist = NewList();
-		    Append(ilist, bcls);
-		  } else {
-		    if (!GetFlag(bcls, "feature:ignore")) {
-		      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n", SwigType_namestr(bname));
-		      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n", SwigType_namestr(bname));
-		    }
-		  }
-		} else {
-		  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' undefined.\n", SwigType_namestr(bname));
-		  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "'%s' must be defined before it is used as a base class.\n", SwigType_namestr(bname));
-		}
-	      }
-	    }
-	    break;
-	  }
+          if (SwigType_istemplate(bname)) {
+            tname = SwigType_typedef_resolve_all(bname);
+            sname = tname;
+          }
+          while (1) {
+            String *qsname = SwigType_typedef_qualified(sname);
+            bcls = Swig_symbol_clookup(qsname, st);
+            Delete(qsname);
+            if (bcls) {
+              if (Strcmp(nodeType(bcls), "class") != 0) {
+                /* Not a class.   The symbol could be a typedef. */
+                if (checkAttribute(bcls, "storage", "typedef")) {
+                  SwigType *decl = Getattr(bcls, "decl");
+                  if (!decl || !(Len(decl))) {
+                    sname = Getattr(bcls, "type");
+                    st = Getattr(bcls, "sym:symtab");
+                    if (SwigType_istemplate(sname)) {
+                      if (tname)
+                        Delete(tname);
+                      tname = SwigType_typedef_resolve_all(sname);
+                      sname = tname;
+                    }
+                    continue;
+                  }
+                  // A case when both outer and nested classes inherit from the same parent. Constructor may be found instead of the class itself.
+                } else if (GetFlag(cls, "nested") && checkAttribute(bcls, "nodeType", "constructor")) {
+                  bcls = Getattr(bcls, "parentNode");
+                  if (Getattr(bcls, "typepass:visit")) {
+                    if (!Getattr(bcls, "feature:onlychildren")) {
+                      if (!ilist)
+                        ilist = alist = NewList();
+                      Append(ilist, bcls);
+                    } else {
+                      if (!GetFlag(bcls, "feature:ignore")) {
+                        Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n", SwigType_namestr(bname));
+                        Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n", SwigType_namestr(bname));
+                      }
+                    }
+                  }
+                  break;
+                }
+                if (Strcmp(nodeType(bcls), "classforward") != 0) {
+                  Swig_error(Getfile(bname), Getline(bname), "'%s' is not a valid base class.\n", SwigType_namestr(bname));
+                  Swig_error(Getfile(bcls), Getline(bcls), "See definition of '%s'.\n", SwigType_namestr(bname));
+                } else {
+                  Swig_warning(WARN_TYPE_INCOMPLETE, Getfile(bname), Getline(bname), "Base class '%s' is incomplete.\n", SwigType_namestr(bname));
+                  Swig_warning(WARN_TYPE_INCOMPLETE, Getfile(bcls), Getline(bcls), "Only forward declaration '%s' was found.\n", SwigType_namestr(bname));
+                  clsforward = 1;
+                }
+                bcls = 0;
+              } else {
+                if (Getattr(bcls, "typepass:visit")) {
+                  if (!Getattr(bcls, "feature:onlychildren")) {
+                    if (!ilist)
+                      ilist = alist = NewList();
+                    Append(ilist, bcls);
+                  } else {
+                    if (!GetFlag(bcls, "feature:ignore")) {
+                      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n", SwigType_namestr(bname));
+                      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n", SwigType_namestr(bname));
+                    }
+                  }
+                } else {
+                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' undefined.\n", SwigType_namestr(bname));
+                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "'%s' must be defined before it is used as a base class.\n", SwigType_namestr(bname));
+                }
+              }
+            }
+            break;
+          }
 
-	  if (tname)
-	    Delete(tname);
-	  if (!bcls) {
-	    if (!clsforward && !GetFlag(cls, "feature:ignore")) {
-	      if (ispublic && !Getmeta(bname, "already_warned")) {
-		Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Nothing known about base class '%s'. Ignored.\n", SwigType_namestr(bname));
-		if (Strchr(bname, '<')) {
-		  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Maybe you forgot to instantiate '%s' using %%template.\n", SwigType_namestr(bname));
-		}
-		Setmeta(bname, "already_warned", "1");
-	      }
-	    }
-	    SwigType_inherit(clsname, bname, cast, 0);
-	  }
-	}
+          if (tname)
+            Delete(tname);
+          if (!bcls) {
+            if (!clsforward && !GetFlag(cls, "feature:ignore")) {
+              if (ispublic && !Getmeta(bname, "already_warned")) {
+                Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Nothing known about base class '%s'. Ignored.\n", SwigType_namestr(bname));
+                if (Strchr(bname, '<')) {
+                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Maybe you forgot to instantiate '%s' using %%template.\n", SwigType_namestr(bname));
+                }
+                Setmeta(bname, "already_warned", "1");
+              }
+            }
+            SwigType_inherit(clsname, bname, cast, 0);
+          }
+        }
       }
       if (ilist) {
-	Setattr(cls, bases, ilist);
+        Setattr(cls, bases, ilist);
       }
     }
     if (alist)
@@ -284,49 +284,49 @@ class TypePass:private Dispatcher {
       Hash *scopes = Getattr(bclass, "typescope");
       SwigType_inherit(clsname, bname, cast, 0);
       if (ispublic && !GetFlag(bclass, "feature:ignore")) {
-	String *smart = Getattr(first, "smart");
-	if (smart) {
-	  /* Record a (fake) inheritance relationship between smart pointer
-	     and smart pointer to base class, so that smart pointer upcasts
-	     are automatically generated. */
-	  SwigType *bsmart = Getattr(bclass, "smart");
-	  if (bsmart) {
-	    String *smartnamestr = SwigType_namestr(smart);
-	    String *bsmartnamestr = SwigType_namestr(bsmart);
+        String *smart = Getattr(first, "smart");
+        if (smart) {
+          /* Record a (fake) inheritance relationship between smart pointer
+             and smart pointer to base class, so that smart pointer upcasts
+             are automatically generated. */
+          SwigType *bsmart = Getattr(bclass, "smart");
+          if (bsmart) {
+            String *smartnamestr = SwigType_namestr(smart);
+            String *bsmartnamestr = SwigType_namestr(bsmart);
 
-	    /* construct casting code */
-	    String *convcode = NewStringf("\n    *newmemory = SWIG_CAST_NEW_MEMORY;\n    return (void *) new %s(*(%s *)$from);\n", bsmartnamestr, smartnamestr);
+            /* construct casting code */
+            String *convcode = NewStringf("\n    *newmemory = SWIG_CAST_NEW_MEMORY;\n    return (void *) new %s(*(%s *)$from);\n", bsmartnamestr, smartnamestr);
 
-	    /* setup inheritance relationship between smart pointer templates */
-	    SwigType_inherit(smart, bsmart, 0, convcode);
+            /* setup inheritance relationship between smart pointer templates */
+            SwigType_inherit(smart, bsmart, 0, convcode);
 
-	    Delete(bsmartnamestr);
-	    Delete(smartnamestr);
-	    Delete(convcode);
-	  } else {
-	    Swig_warning(WARN_LANG_SMARTPTR_MISSING, Getfile(first), Getline(first), "Base class '%s' of '%s' is not similarly marked as a smart pointer.\n", SwigType_namestr(Getattr(bclass, "name")), SwigType_namestr(Getattr(first, "name")));
-	  }
-	} else {
-	  if (GetFlag(bclass, "smart"))
-	    if (!GetFlag(first, "feature:ignore"))
-	      Swig_warning(WARN_LANG_SMARTPTR_MISSING, Getfile(first), Getline(first), "Derived class '%s' of '%s' is not similarly marked as a smart pointer.\n", SwigType_namestr(Getattr(first, "name")), SwigType_namestr(Getattr(bclass, "name")));
-	}
+            Delete(bsmartnamestr);
+            Delete(smartnamestr);
+            Delete(convcode);
+          } else {
+            Swig_warning(WARN_LANG_SMARTPTR_MISSING, Getfile(first), Getline(first), "Base class '%s' of '%s' is not similarly marked as a smart pointer.\n", SwigType_namestr(Getattr(bclass, "name")), SwigType_namestr(Getattr(first, "name")));
+          }
+        } else {
+          if (GetFlag(bclass, "smart"))
+            if (!GetFlag(first, "feature:ignore"))
+              Swig_warning(WARN_LANG_SMARTPTR_MISSING, Getfile(first), Getline(first), "Derived class '%s' of '%s' is not similarly marked as a smart pointer.\n", SwigType_namestr(Getattr(first, "name")), SwigType_namestr(Getattr(bclass, "name")));
+        }
       }
       if (!importmode) {
-	String *btype = Copy(bname);
-	SwigType_add_pointer(btype);
-	SwigType_remember(btype);
-	Delete(btype);
+        String *btype = Copy(bname);
+        SwigType_add_pointer(btype);
+        SwigType_remember(btype);
+        Delete(btype);
       }
       if (scopes) {
-	SwigType_inherit_scope(scopes);
+        SwigType_inherit_scope(scopes);
       }
       /* Set up inheritance in the symbol table */
       Symtab *st = Getattr(cls, "symtab");
       Symtab *bst = Getattr(bclass, "symtab");
       if (st == bst) {
-	Swig_warning(WARN_PARSE_REC_INHERITANCE, Getfile(cls), Getline(cls), "Recursive scope inheritance of '%s'.\n", SwigType_namestr(Getattr(cls, "name")));
-	continue;
+        Swig_warning(WARN_PARSE_REC_INHERITANCE, Getfile(cls), Getline(cls), "Recursive scope inheritance of '%s'.\n", SwigType_namestr(Getattr(cls, "name")));
+        continue;
       }
       Symtab *s = Swig_symbol_current();
       Swig_symbol_setscope(st);
@@ -345,7 +345,7 @@ class TypePass:private Dispatcher {
   void append_list(List *lb, List *la) {
     if (la && lb) {
       for (Iterator bi = First(la); bi.item; bi = Next(bi)) {
-	Append(lb, bi.item);
+        Append(lb, bi.item);
       }
     }
   }
@@ -386,8 +386,8 @@ class TypePass:private Dispatcher {
     int valid = 1;
     while(c && *c) {
       if (*(c++) == ':' && *(c++) != ':') {
-	valid = 0;
-	break;
+        valid = 0;
+        break;
       }
     }
 
@@ -399,36 +399,36 @@ class TypePass:private Dispatcher {
     Replaceall(nspace, "::", ".");
     if (valid) {
       if (outer) {
-	// Nested class or enum in a class
-	String *outer_nspace = Getattr(outer, "sym:nspace");
-	String *nspace_attribute = Getattr(n, "feature:nspace");
-	bool warn = false;
-	if (outer_nspace) {
-	  if (Equal(nspace_attribute, "0")) {
-	    warn = true;
-	  } else if (nspace && !(Equal(nspace, "1") || Equal(nspace, outer_nspace))) {
-	    warn = true;
-	  }
-	} else if (nspace) {
-	  warn = true;
-	}
-	if (warn) {
-	  String *outer_nspace_feature = Copy(outer_nspace);
-	  Replaceall(outer_nspace_feature, ".", "::");
-	  Swig_warning(WARN_TYPE_NSPACE_SETTING, Getfile(n), Getline(n), "Ignoring nspace setting (%s) for '%s',\n", nspace_attribute, Swig_name_decl(n));
-	  Swig_warning(WARN_TYPE_NSPACE_SETTING, Getfile(outer), Getline(outer), "as it conflicts with the nspace setting (%s) for outer class '%s'.\n", outer_nspace_feature, Swig_name_decl(outer));
-	}
-	Setattr(n, "sym:nspace", outer_nspace);
+        // Nested class or enum in a class
+        String *outer_nspace = Getattr(outer, "sym:nspace");
+        String *nspace_attribute = Getattr(n, "feature:nspace");
+        bool warn = false;
+        if (outer_nspace) {
+          if (Equal(nspace_attribute, "0")) {
+            warn = true;
+          } else if (nspace && !(Equal(nspace, "1") || Equal(nspace, outer_nspace))) {
+            warn = true;
+          }
+        } else if (nspace) {
+          warn = true;
+        }
+        if (warn) {
+          String *outer_nspace_feature = Copy(outer_nspace);
+          Replaceall(outer_nspace_feature, ".", "::");
+          Swig_warning(WARN_TYPE_NSPACE_SETTING, Getfile(n), Getline(n), "Ignoring nspace setting (%s) for '%s',\n", nspace_attribute, Swig_name_decl(n));
+          Swig_warning(WARN_TYPE_NSPACE_SETTING, Getfile(outer), Getline(outer), "as it conflicts with the nspace setting (%s) for outer class '%s'.\n", outer_nspace_feature, Swig_name_decl(outer));
+        }
+        Setattr(n, "sym:nspace", outer_nspace);
       } else {
-	if (nspace) {
-	  if (Equal(nspace, "1")) {
-	    if (nssymname)
-	      Setattr(n, "sym:nspace", nssymname);
-	  } else {
-	    Setattr(n, "sym:nspace", nspace);
-	    nssymname_new = nspace;
-	  }
-	}
+        if (nspace) {
+          if (Equal(nspace, "1")) {
+            if (nssymname)
+              Setattr(n, "sym:nspace", nssymname);
+          } else {
+            Setattr(n, "sym:nspace", nspace);
+            nssymname_new = nspace;
+          }
+        }
       }
     } else {
       Swig_error(Getfile(n), Getline(n), "'%s' is not a valid identifier for nspace.\n", feature_nspace);
@@ -520,44 +520,44 @@ class TypePass:private Dispatcher {
 
     if (name) {
       if (SwigType_istemplate(name)) {
-	// We need to fully resolve the name and expand default template parameters to make templates work correctly */
-	Node *cn;
-	SwigType *resolved_name = SwigType_typedef_resolve_all(name);
-	SwigType *deftype_name = Swig_symbol_template_deftype(resolved_name, 0);
-	fname = Copy(resolved_name);
-	if (!Equal(resolved_name, deftype_name))
-	  template_default_expanded = Copy(deftype_name);
-	if (!Equal(fname, name) && (cn = Swig_symbol_clookup_local(fname, 0))) {
-	  if ((n == cn)
-	      || (Strcmp(nodeType(cn), "template") == 0)
-	      || (Getattr(cn, "feature:onlychildren") != 0)
-	      || (Getattr(n, "feature:onlychildren") != 0)) {
-	    Swig_symbol_cadd(fname, n);
-	    if (template_default_expanded)
-	      Swig_symbol_cadd(template_default_expanded, n);
-	    SwigType_typedef_class(fname);
-	    scopename = Copy(fname);
-	  } else {
-	    // Arguably the parser should instead ignore these duplicate template instantiations, in particular for ensuring the first parsed instantiation is used
-	    SetFlag(n, "feature:ignore");
-	    Swig_warning(WARN_TYPE_REDEFINED, Getfile(n), Getline(n), "Duplicate template instantiation of '%s' with name '%s' ignored,\n", SwigType_namestr(name), Getattr(n, "sym:name"));
-	    Swig_warning(WARN_TYPE_REDEFINED, Getfile(cn), Getline(cn), "previous instantiation of '%s' with name '%s'.\n", SwigType_namestr(Getattr(cn, "name")), Getattr(cn, "sym:name"));
-	    scopename = 0;
-	  }
-	} else {
-	  Swig_symbol_cadd(fname, n);
-	  SwigType_typedef_class(fname);
-	  scopename = Copy(fname);
-	}
-	Delete(deftype_name);
-	Delete(resolved_name);
+        // We need to fully resolve the name and expand default template parameters to make templates work correctly */
+        Node *cn;
+        SwigType *resolved_name = SwigType_typedef_resolve_all(name);
+        SwigType *deftype_name = Swig_symbol_template_deftype(resolved_name, 0);
+        fname = Copy(resolved_name);
+        if (!Equal(resolved_name, deftype_name))
+          template_default_expanded = Copy(deftype_name);
+        if (!Equal(fname, name) && (cn = Swig_symbol_clookup_local(fname, 0))) {
+          if ((n == cn)
+              || (Strcmp(nodeType(cn), "template") == 0)
+              || (Getattr(cn, "feature:onlychildren") != 0)
+              || (Getattr(n, "feature:onlychildren") != 0)) {
+            Swig_symbol_cadd(fname, n);
+            if (template_default_expanded)
+              Swig_symbol_cadd(template_default_expanded, n);
+            SwigType_typedef_class(fname);
+            scopename = Copy(fname);
+          } else {
+            // Arguably the parser should instead ignore these duplicate template instantiations, in particular for ensuring the first parsed instantiation is used
+            SetFlag(n, "feature:ignore");
+            Swig_warning(WARN_TYPE_REDEFINED, Getfile(n), Getline(n), "Duplicate template instantiation of '%s' with name '%s' ignored,\n", SwigType_namestr(name), Getattr(n, "sym:name"));
+            Swig_warning(WARN_TYPE_REDEFINED, Getfile(cn), Getline(cn), "previous instantiation of '%s' with name '%s'.\n", SwigType_namestr(Getattr(cn, "name")), Getattr(cn, "sym:name"));
+            scopename = 0;
+          }
+        } else {
+          Swig_symbol_cadd(fname, n);
+          SwigType_typedef_class(fname);
+          scopename = Copy(fname);
+        }
+        Delete(deftype_name);
+        Delete(resolved_name);
       } else {
-	if ((CPlusPlus) || (unnamed)) {
-	  SwigType_typedef_class(name);
-	} else {
-	  SwigType_typedef_class(NewStringf("%s %s", kind, name));
-	}
-	scopename = Copy(name);
+        if ((CPlusPlus) || (unnamed)) {
+          SwigType_typedef_class(name);
+        } else {
+          SwigType_typedef_class(NewStringf("%s %s", kind, name));
+        }
+        scopename = Copy(name);
       }
     } else {
       scopename = 0;
@@ -576,8 +576,8 @@ class TypePass:private Dispatcher {
       name = NewStringf("%s::%s", outerName, name);
       Setattr(n, "name", name);
       if (tdname) {
-	tdname = NewStringf("%s::%s", outerName, tdname);
-	Setattr(n, "tdname", tdname);
+        tdname = NewStringf("%s::%s", outerName, tdname);
+        Setattr(n, "tdname", tdname);
       }
     }
 
@@ -585,8 +585,8 @@ class TypePass:private Dispatcher {
       nname = NewStringf("%s::%s", nsname, name);
       String *tdname = Getattr(n, "tdname");
       if (tdname) {
-	tdname = NewStringf("%s::%s", nsname, tdname);
-	Setattr(n, "tdname", tdname);
+        tdname = NewStringf("%s::%s", nsname, tdname);
+        Setattr(n, "tdname", tdname);
       }
     }
 
@@ -599,10 +599,10 @@ class TypePass:private Dispatcher {
     if (!GetFlag(n, "feature:ignore")) {
       SwigType *smart = Swig_cparse_smartptr(n);
       if (smart) {
-	// Resolve the type in 'feature:smartptr' in the scope of the class it is attached to
-	normalize_type(smart);
-	Setattr(n, "smart", smart);
-	Delete(smart);
+        // Resolve the type in 'feature:smartptr' in the scope of the class it is attached to
+        normalize_type(smart);
+        Setattr(n, "smart", smart);
+        Delete(smart);
       }
     }
 
@@ -711,26 +711,26 @@ class TypePass:private Dispatcher {
     if (alias) {
       Typetab *ts = Getattr(n, "typescope");
       if (!ts) {
-	/* Create an empty scope for the alias */
-	Node *ns = Getattr(n, "namespace");
-	SwigType_scope_alias(name, Getattr(ns, "typescope"));
-	ts = Getattr(ns, "typescope");
-	Setattr(n, "typescope", ts);
+        /* Create an empty scope for the alias */
+        Node *ns = Getattr(n, "namespace");
+        SwigType_scope_alias(name, Getattr(ns, "typescope"));
+        ts = Getattr(ns, "typescope");
+        Setattr(n, "typescope", ts);
       }
       /* Namespace alias */
       return SWIG_OK;
     } else {
       if (name) {
-	Node *nn = Swig_symbol_clookup(name, n);
-	Hash *ts = 0;
-	if (nn)
-	  ts = Getattr(nn, "typescope");
-	if (!ts) {
-	  SwigType_new_scope(name);
-	  SwigType_attach_symtab(Getattr(n, "symtab"));
-	} else {
-	  SwigType_set_scope(ts);
-	}
+        Node *nn = Swig_symbol_clookup(name, n);
+        Hash *ts = 0;
+        if (nn)
+          ts = Getattr(nn, "typescope");
+        if (!ts) {
+          SwigType_new_scope(name);
+          SwigType_attach_symtab(Getattr(n, "symtab"));
+        } else {
+          SwigType_set_scope(ts);
+        }
       }
       String *oldnsname = nsname;
       String *oldnssymname = nssymname;
@@ -741,19 +741,19 @@ class TypePass:private Dispatcher {
       Swig_symbol_setscope(symtab);
 
       if (name) {
-	Hash *ts = SwigType_pop_scope();
-	Setattr(n, "typescope", ts);
-	Delete(ts);
+        Hash *ts = SwigType_pop_scope();
+        Setattr(n, "typescope", ts);
+        Delete(ts);
       }
 
       /* Normalize deferred types */
       {
-	normal_node *nn = new normal_node();
-	nn->normallist = normalize;
-	nn->symtab = Getattr(n, "symtab");
-	nn->next = patch_list;
-	nn->typescope = Getattr(n, "typescope");
-	patch_list = nn;
+        normal_node *nn = new normal_node();
+        nn->normallist = normalize;
+        nn->symtab = Getattr(n, "symtab");
+        nn->next = patch_list;
+        nn->typescope = Getattr(n, "typescope");
+        patch_list = nn;
       }
       normalize = olist;
 
@@ -804,24 +804,24 @@ class TypePass:private Dispatcher {
       decl = Getattr(n, "decl");
       SwigType *t = Copy(ty);
       {
-	/* If the typename is qualified, make sure the scopename is fully qualified when making a typedef */
-	if (Swig_scopename_check(t) && strncmp(Char(t), "::", 2)) {
-	  String *base, *prefix, *qprefix;
-	  base = Swig_scopename_last(t);
-	  prefix = Swig_scopename_prefix(t);
-	  qprefix = SwigType_typedef_qualified(prefix);
-	  Delete(t);
-	  t = NewStringf("%s::%s", qprefix, base);
-	  Delete(base);
-	  Delete(prefix);
-	  Delete(qprefix);
-	}
+        /* If the typename is qualified, make sure the scopename is fully qualified when making a typedef */
+        if (Swig_scopename_check(t) && strncmp(Char(t), "::", 2)) {
+          String *base, *prefix, *qprefix;
+          base = Swig_scopename_last(t);
+          prefix = Swig_scopename_prefix(t);
+          qprefix = SwigType_typedef_qualified(prefix);
+          Delete(t);
+          t = NewStringf("%s::%s", qprefix, base);
+          Delete(base);
+          Delete(prefix);
+          Delete(qprefix);
+        }
       }
       SwigType_push(t, decl);
       if (CPlusPlus) {
-	Replaceall(t, "struct ", "");
-	Replaceall(t, "union ", "");
-	Replaceall(t, "class ", "");
+        Replaceall(t, "struct ", "");
+        Replaceall(t, "union ", "");
+        Replaceall(t, "class ", "");
       }
       SwigType_typedef(t, name);
     }
@@ -829,9 +829,9 @@ class TypePass:private Dispatcher {
     if (nsname && !inclass) {
       String *name = Getattr(n, "name");
       if (name) {
-	String *nname = NewStringf("%s::%s", nsname, name);
-	Setattr(n, "name", nname);
-	Delete(nname);
+        String *nname = NewStringf("%s::%s", nsname, name);
+        Setattr(n, "name", nname);
+        Delete(nname);
       }
     }
     clean_overloaded(n);
@@ -893,29 +893,29 @@ class TypePass:private Dispatcher {
       // Add a typedef to the type table so that we can use 'enum Name' as well as just 'Name'
       if (nsname || inclass) {
 
-	// But first correct the name and tdname to contain the fully qualified scopename
-	if (nsname && inclass) {
-	  scope = NewStringf("%s::%s", nsname, Getattr(inclass, "name"));
-	} else if (nsname) {
-	  scope = NewStringf("%s", nsname);
-	} else if (inclass) {
-	  scope = NewStringf("%s", Getattr(inclass, "name"));
-	}
+        // But first correct the name and tdname to contain the fully qualified scopename
+        if (nsname && inclass) {
+          scope = NewStringf("%s::%s", nsname, Getattr(inclass, "name"));
+        } else if (nsname) {
+          scope = NewStringf("%s", nsname);
+        } else if (inclass) {
+          scope = NewStringf("%s", Getattr(inclass, "name"));
+        }
 
-	String *nname = NewStringf("%s::%s", scope, name);
-	Setattr(n, "name", nname);
+        String *nname = NewStringf("%s::%s", scope, name);
+        Setattr(n, "name", nname);
 
-	String *tdname = Getattr(n, "tdname");
-	if (tdname) {
-	  tdname = NewStringf("%s::%s", scope, tdname);
-	  Setattr(n, "tdname", tdname);
-	}
+        String *tdname = Getattr(n, "tdname");
+        if (tdname) {
+          tdname = NewStringf("%s::%s", scope, tdname);
+          Setattr(n, "tdname", tdname);
+        }
 
-	SwigType *t = NewStringf("enum %s", nname);
-	SwigType_typedef(t, name);
+        SwigType *t = NewStringf("enum %s", nname);
+        SwigType_typedef(t, name);
       } else {
-	SwigType *t = NewStringf("enum %s", name);
-	SwigType_typedef(t, name);
+        SwigType *t = NewStringf("enum %s", name);
+        SwigType_typedef(t, name);
       }
       Delete(scope);
     }
@@ -952,34 +952,34 @@ class TypePass:private Dispatcher {
       bool previous_ignored = false;
       bool firstenumitem = false;
       for (c = firstChild(n); c; c = nextSibling(c)) {
-	assert(strcmp(Char(nodeType(c)), "enumitem") == 0);
+        assert(strcmp(Char(nodeType(c)), "enumitem") == 0);
 
-	bool reset;
-	String *enumvalue = Getattr(c, "enumvalue");
-	if (GetFlag(c, "feature:ignore") || !Getattr(c, "sym:name")) {
-	  reset = enumvalue ? true : false;
-	  previous_ignored = true;
-	} else {
-	  if (!enumvalue && previous_ignored) {
-	    if (previous)
-	      Setattr(c, "enumvalue", NewStringf("(%s) + %d", previous, count+1));
-	    else
-	      Setattr(c, "enumvalue", NewStringf("%d", count));
-	    SetFlag(c, "virtenumvalue"); // identify enumvalue as virtual, ie not from the parsed source
-	  }
-	  if (!firstenumitem) {
-	    SetFlag(c, "firstenumitem");
-	    firstenumitem = true;
-	  }
-	  reset = true;
-	  previous_ignored = false;
-	}
-	if (reset) {
-	  previous = enumvalue ? enumvalue : Getattr(c, "name");
-	  count = 0;
-	} else {
-	  count++;
-	}
+        bool reset;
+        String *enumvalue = Getattr(c, "enumvalue");
+        if (GetFlag(c, "feature:ignore") || !Getattr(c, "sym:name")) {
+          reset = enumvalue ? true : false;
+          previous_ignored = true;
+        } else {
+          if (!enumvalue && previous_ignored) {
+            if (previous)
+              Setattr(c, "enumvalue", NewStringf("(%s) + %d", previous, count+1));
+            else
+              Setattr(c, "enumvalue", NewStringf("%d", count));
+            SetFlag(c, "virtenumvalue"); // identify enumvalue as virtual, ie not from the parsed source
+          }
+          if (!firstenumitem) {
+            SetFlag(c, "firstenumitem");
+            firstenumitem = true;
+          }
+          reset = true;
+          previous_ignored = false;
+        }
+        if (reset) {
+          previous = enumvalue ? enumvalue : Getattr(c, "name");
+          count = 0;
+        } else {
+          count++;
+        }
       }
     }
 
@@ -1002,13 +1002,13 @@ class TypePass:private Dispatcher {
     if (Strcmp(value, name) == 0) {
       String *new_value;
       if ((nsname || inclass || scopedenum) && cparse_cplusplus) {
-	new_value = NewStringf("%s::%s", SwigType_namestr(Swig_symbol_qualified(n)), value);
+        new_value = NewStringf("%s::%s", SwigType_namestr(Swig_symbol_qualified(n)), value);
       } else {
-	new_value = NewString(value);
+        new_value = NewString(value);
       }
       if ((nsname || inclass || scopedenum) && !cparse_cplusplus) {
-	String *cppvalue = NewStringf("%s::%s", SwigType_namestr(Swig_symbol_qualified(n)), value);
-	Setattr(n, "cppvalue", cppvalue); /* for target languages that always generate C++ code even when wrapping C code */
+        String *cppvalue = NewStringf("%s::%s", SwigType_namestr(Swig_symbol_qualified(n)), value);
+        Setattr(n, "cppvalue", cppvalue); /* for target languages that always generate C++ code even when wrapping C code */
       }
       Setattr(n, "value", new_value);
       Delete(new_value);
@@ -1018,10 +1018,10 @@ class TypePass:private Dispatcher {
     // Make up an enumvalue if one was not specified in the parsed code (not designed to be used on enum items and %ignore - enumvalue will be set instead)
     if (!GetFlag(n, "feature:ignore")) {
       if (Getattr(n, "_last") && !Getattr(n, "enumvalue")) {	// Only the first enum item has _last set (Note: first non-ignored enum item has firstenumitem set)
-	Setattr(n, "enumvalueex", "0");
+        Setattr(n, "enumvalueex", "0");
       }
       if (next && !Getattr(next, "enumvalue")) {
-	Setattr(next, "enumvalueex", NewStringf("%s + 1", Getattr(n, "sym:name")));
+        Setattr(next, "enumvalueex", NewStringf("%s + 1", Getattr(n, "sym:name")));
       }
     }
 
@@ -1045,9 +1045,9 @@ class TypePass:private Dispatcher {
 
       String *nodetype = nn ? nodeType(nn) : 0;
       if (nodetype) {
-	if (Equal(nodetype, "enumforward")) {
-	  SetFlag(nn, "enumMissing");
-	} // if a real enum was declared this would be an "enum" node type
+        if (Equal(nodetype, "enumforward")) {
+          SetFlag(nn, "enumMissing");
+        } // if a real enum was declared this would be an "enum" node type
       }
       Delete(ty);
     }
@@ -1094,10 +1094,10 @@ class TypePass:private Dispatcher {
       /* For a namespace import.   We set up inheritance in the type system */
       Node *ns = Getattr(n, "node");
       if (ns) {
-	Typetab *ts = Getattr(ns, "typescope");
-	if (ts) {
-	  SwigType_using_scope(ts);
-	}
+        Typetab *ts = Getattr(ns, "typescope");
+        if (ts) {
+          SwigType_using_scope(ts);
+        }
       }
       return SWIG_OK;
     } else {
@@ -1105,39 +1105,39 @@ class TypePass:private Dispatcher {
       /* using id */
       Symtab *stab = Getattr(n, "sym:symtab");
       if (stab) {
-	String *uname = Getattr(n, "uname");
-	ns = Swig_symbol_clookup(uname, stab);
-	if (!ns && SwigType_istemplate(uname)) {
-	  String *tmp = Swig_symbol_template_deftype(uname, 0);
-	  if (!Equal(tmp, uname)) {
-	    ns = Swig_symbol_clookup(tmp, stab);
-	  }
-	  Delete(tmp);
-	}
+        String *uname = Getattr(n, "uname");
+        ns = Swig_symbol_clookup(uname, stab);
+        if (!ns && SwigType_istemplate(uname)) {
+          String *tmp = Swig_symbol_template_deftype(uname, 0);
+          if (!Equal(tmp, uname)) {
+            ns = Swig_symbol_clookup(tmp, stab);
+          }
+          Delete(tmp);
+        }
       } else {
-	ns = 0;
+        ns = 0;
       }
       // Note that Allocate::usingDeclaration will warn when using member is not found (when ns is zero)
       if (ns) {
-	/* Only a single symbol is being used.  There are only a few symbols that
-	   we actually care about.  These are typedef, class declarations, and enum */
-	String *ntype = nodeType(ns);
-	if (Equal(ntype, "cdecl") || Equal(ntype, "constructor")) {
-	  if (checkAttribute(ns, "storage", "typedef")) {
-	    /* A typedef declaration */
-	    String *uname = Getattr(n, "uname");
-	    SwigType_typedef_using(uname);
-	  }
-	} else if ((Strcmp(ntype, "class") == 0) || ((Strcmp(ntype, "classforward") == 0))) {
-	  /* We install the using class name as kind of a typedef back to the original class */
-	  String *uname = Getattr(n, "uname");
-	  /* Import into current type scope */
-	  SwigType_typedef_using(uname);
-	} else if (Strcmp(ntype, "enum") == 0) {
-	  SwigType_typedef_using(Getattr(n, "uname"));
-	} else if (Strcmp(ntype, "template") == 0) {
-	  SwigType_typedef_using(Getattr(n, "uname"));
-	}
+        /* Only a single symbol is being used.  There are only a few symbols that
+           we actually care about.  These are typedef, class declarations, and enum */
+        String *ntype = nodeType(ns);
+        if (Equal(ntype, "cdecl") || Equal(ntype, "constructor")) {
+          if (checkAttribute(ns, "storage", "typedef")) {
+            /* A typedef declaration */
+            String *uname = Getattr(n, "uname");
+            SwigType_typedef_using(uname);
+          }
+        } else if ((Strcmp(ntype, "class") == 0) || ((Strcmp(ntype, "classforward") == 0))) {
+          /* We install the using class name as kind of a typedef back to the original class */
+          String *uname = Getattr(n, "uname");
+          /* Import into current type scope */
+          SwigType_typedef_using(uname);
+        } else if (Strcmp(ntype, "enum") == 0) {
+          SwigType_typedef_using(Getattr(n, "uname"));
+        } else if (Strcmp(ntype, "template") == 0) {
+          SwigType_typedef_using(Getattr(n, "uname"));
+        }
       }
     }
     return SWIG_OK;
@@ -1151,11 +1151,11 @@ class TypePass:private Dispatcher {
     if (inclass || nsname) {
       Node *items = firstChild(n);
       while (items) {
-	Parm *pattern = Getattr(items, "pattern");
-	Parm *parms = Getattr(items, "parms");
-	normalize_later(pattern);
-	normalize_later(parms);
-	items = nextSibling(items);
+        Parm *pattern = Getattr(items, "pattern");
+        Parm *parms = Getattr(items, "parms");
+        normalize_later(pattern);
+        normalize_later(parms);
+        items = nextSibling(items);
       }
     }
     return SWIG_OK;
@@ -1172,9 +1172,9 @@ class TypePass:private Dispatcher {
       ParmList *pattern = Getattr(n, "pattern");
       normalize_later(pattern);
       while (items) {
-	ParmList *npattern = Getattr(items, "pattern");
-	normalize_later(npattern);
-	items = nextSibling(items);
+        ParmList *npattern = Getattr(items, "pattern");
+        normalize_later(npattern);
+        items = nextSibling(items);
       }
     }
     return SWIG_OK;
@@ -1190,9 +1190,9 @@ class TypePass:private Dispatcher {
       normalize_later(pattern);
       Node *items = firstChild(n);
       while (items) {
-	Parm *apattern = Getattr(items, "pattern");
-	normalize_later(apattern);
-	items = nextSibling(items);
+        Parm *apattern = Getattr(items, "pattern");
+        normalize_later(apattern);
+        items = nextSibling(items);
       }
     }
     return SWIG_OK;
@@ -1206,8 +1206,8 @@ class TypePass:private Dispatcher {
     if (inclass || nsname) {
       Node *p;
       for (p = firstChild(n); p; p = nextSibling(p)) {
-	ParmList *pattern = Getattr(p, "pattern");
-	normalize_later(pattern);
+        ParmList *pattern = Getattr(p, "pattern");
+        normalize_later(pattern);
       }
     }
     return SWIG_OK;

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -29,7 +29,7 @@ struct normal_node {
 static normal_node *patch_list = 0;
 
 /* Singleton class - all non-static methods in this class are private */
-class TypePass:private Dispatcher {
+class TypePass : private Dispatcher {
   Node *inclass;
   Node *module;
   int importmode;
@@ -38,14 +38,7 @@ class TypePass:private Dispatcher {
   Hash *classhash;
   List *normalize;
 
-  TypePass() :
-    inclass(0),
-    module(0),
-    importmode(0),
-    nsname(0),
-    nssymname(0),
-    classhash(0),
-    normalize(0) {
+  TypePass() : inclass(0), module(0), importmode(0), nsname(0), nssymname(0), classhash(0), normalize(0) {
   }
 
   /* -----------------------------------------------------------------------------
@@ -149,7 +142,7 @@ class TypePass:private Dispatcher {
       }
       Delete(nn->normallist);
       np = nn->next;
-      delete(nn);
+      delete (nn);
       nn = np;
     }
     Swig_symbol_setscope(currentsym);
@@ -159,7 +152,7 @@ class TypePass:private Dispatcher {
   void cplus_inherit_types_impl(Node *first, Node *cls, String *clsname, const char *bases, const char *baselist, int ispublic, String *cast = 0) {
 
     if (first == cls)
-      return;                   /* The Marcelo check */
+      return; /* The Marcelo check */
     if (!cls)
       cls = first;
     List *alist = 0;
@@ -214,8 +207,16 @@ class TypePass:private Dispatcher {
                       Append(ilist, bcls);
                     } else {
                       if (!GetFlag(bcls, "feature:ignore")) {
-                        Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n", SwigType_namestr(bname));
-                        Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n", SwigType_namestr(bname));
+                        Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                                     Getfile(bname),
+                                     Getline(bname),
+                                     "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n",
+                                     SwigType_namestr(bname));
+                        Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                                     Getfile(bcls),
+                                     Getline(bcls),
+                                     "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n",
+                                     SwigType_namestr(bname));
                       }
                     }
                   }
@@ -238,13 +239,25 @@ class TypePass:private Dispatcher {
                     Append(ilist, bcls);
                   } else {
                     if (!GetFlag(bcls, "feature:ignore")) {
-                      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n", SwigType_namestr(bname));
-                      Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n", SwigType_namestr(bname));
+                      Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                                   Getfile(bname),
+                                   Getline(bname),
+                                   "Base class '%s' has no name as it is an empty template instantiated with '%%template()'. Ignored.\n",
+                                   SwigType_namestr(bname));
+                      Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                                   Getfile(bcls),
+                                   Getline(bcls),
+                                   "The %%template directive must be written before '%s' is used as a base class and be declared with a name.\n",
+                                   SwigType_namestr(bname));
                     }
                   }
                 } else {
                   Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Base class '%s' undefined.\n", SwigType_namestr(bname));
-                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bcls), Getline(bcls), "'%s' must be defined before it is used as a base class.\n", SwigType_namestr(bname));
+                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                               Getfile(bcls),
+                               Getline(bcls),
+                               "'%s' must be defined before it is used as a base class.\n",
+                               SwigType_namestr(bname));
                 }
               }
             }
@@ -256,9 +269,14 @@ class TypePass:private Dispatcher {
           if (!bcls) {
             if (!clsforward && !GetFlag(cls, "feature:ignore")) {
               if (ispublic && !Getmeta(bname, "already_warned")) {
-                Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Nothing known about base class '%s'. Ignored.\n", SwigType_namestr(bname));
+                Swig_warning(
+                  WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Nothing known about base class '%s'. Ignored.\n", SwigType_namestr(bname));
                 if (Strchr(bname, '<')) {
-                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS, Getfile(bname), Getline(bname), "Maybe you forgot to instantiate '%s' using %%template.\n", SwigType_namestr(bname));
+                  Swig_warning(WARN_TYPE_UNDEFINED_CLASS,
+                               Getfile(bname),
+                               Getline(bname),
+                               "Maybe you forgot to instantiate '%s' using %%template.\n",
+                               SwigType_namestr(bname));
                 }
                 Setmeta(bname, "already_warned", "1");
               }
@@ -304,12 +322,22 @@ class TypePass:private Dispatcher {
             Delete(smartnamestr);
             Delete(convcode);
           } else {
-            Swig_warning(WARN_LANG_SMARTPTR_MISSING, Getfile(first), Getline(first), "Base class '%s' of '%s' is not similarly marked as a smart pointer.\n", SwigType_namestr(Getattr(bclass, "name")), SwigType_namestr(Getattr(first, "name")));
+            Swig_warning(WARN_LANG_SMARTPTR_MISSING,
+                         Getfile(first),
+                         Getline(first),
+                         "Base class '%s' of '%s' is not similarly marked as a smart pointer.\n",
+                         SwigType_namestr(Getattr(bclass, "name")),
+                         SwigType_namestr(Getattr(first, "name")));
           }
         } else {
           if (GetFlag(bclass, "smart"))
             if (!GetFlag(first, "feature:ignore"))
-              Swig_warning(WARN_LANG_SMARTPTR_MISSING, Getfile(first), Getline(first), "Derived class '%s' of '%s' is not similarly marked as a smart pointer.\n", SwigType_namestr(Getattr(first, "name")), SwigType_namestr(Getattr(bclass, "name")));
+              Swig_warning(WARN_LANG_SMARTPTR_MISSING,
+                           Getfile(first),
+                           Getline(first),
+                           "Derived class '%s' of '%s' is not similarly marked as a smart pointer.\n",
+                           SwigType_namestr(Getattr(first, "name")),
+                           SwigType_namestr(Getattr(bclass, "name")));
         }
       }
       if (!importmode) {
@@ -384,7 +412,7 @@ class TypePass:private Dispatcher {
     // Check validity - single colons not allowed
     const char *c = Char(feature_nspace);
     int valid = 1;
-    while(c && *c) {
+    while (c && *c) {
       if (*(c++) == ':' && *(c++) != ':') {
         valid = 0;
         break;
@@ -416,7 +444,12 @@ class TypePass:private Dispatcher {
           String *outer_nspace_feature = Copy(outer_nspace);
           Replaceall(outer_nspace_feature, ".", "::");
           Swig_warning(WARN_TYPE_NSPACE_SETTING, Getfile(n), Getline(n), "Ignoring nspace setting (%s) for '%s',\n", nspace_attribute, Swig_name_decl(n));
-          Swig_warning(WARN_TYPE_NSPACE_SETTING, Getfile(outer), Getline(outer), "as it conflicts with the nspace setting (%s) for outer class '%s'.\n", outer_nspace_feature, Swig_name_decl(outer));
+          Swig_warning(WARN_TYPE_NSPACE_SETTING,
+                       Getfile(outer),
+                       Getline(outer),
+                       "as it conflicts with the nspace setting (%s) for outer class '%s'.\n",
+                       outer_nspace_feature,
+                       Swig_name_decl(outer));
         }
         Setattr(n, "sym:nspace", outer_nspace);
       } else {
@@ -454,7 +487,6 @@ class TypePass:private Dispatcher {
     SwigType_set_scope(0);
     return SWIG_OK;
   }
-
 
   /* ------------------------------------------------------------
    * moduleDirective()
@@ -508,7 +540,7 @@ class TypePass:private Dispatcher {
     String *unnamed = Getattr(n, "unnamed");
     String *storage = Getattr(n, "storage");
     String *kind = Getattr(n, "kind");
-    save_value<Node*> oldinclass(inclass);
+    save_value<Node *> oldinclass(inclass);
     List *olist = normalize;
     Symtab *symtab;
     String *nname = 0;
@@ -528,20 +560,28 @@ class TypePass:private Dispatcher {
         if (!Equal(resolved_name, deftype_name))
           template_default_expanded = Copy(deftype_name);
         if (!Equal(fname, name) && (cn = Swig_symbol_clookup_local(fname, 0))) {
-          if ((n == cn)
-              || (Strcmp(nodeType(cn), "template") == 0)
-              || (Getattr(cn, "feature:onlychildren") != 0)
-              || (Getattr(n, "feature:onlychildren") != 0)) {
+          if ((n == cn) || (Strcmp(nodeType(cn), "template") == 0) || (Getattr(cn, "feature:onlychildren") != 0) || (Getattr(n, "feature:onlychildren") != 0)) {
             Swig_symbol_cadd(fname, n);
             if (template_default_expanded)
               Swig_symbol_cadd(template_default_expanded, n);
             SwigType_typedef_class(fname);
             scopename = Copy(fname);
           } else {
-            // Arguably the parser should instead ignore these duplicate template instantiations, in particular for ensuring the first parsed instantiation is used
+            // Arguably the parser should instead ignore these duplicate template instantiations, in particular for ensuring the first parsed instantiation is
+            // used
             SetFlag(n, "feature:ignore");
-            Swig_warning(WARN_TYPE_REDEFINED, Getfile(n), Getline(n), "Duplicate template instantiation of '%s' with name '%s' ignored,\n", SwigType_namestr(name), Getattr(n, "sym:name"));
-            Swig_warning(WARN_TYPE_REDEFINED, Getfile(cn), Getline(cn), "previous instantiation of '%s' with name '%s'.\n", SwigType_namestr(Getattr(cn, "name")), Getattr(cn, "sym:name"));
+            Swig_warning(WARN_TYPE_REDEFINED,
+                         Getfile(n),
+                         Getline(n),
+                         "Duplicate template instantiation of '%s' with name '%s' ignored,\n",
+                         SwigType_namestr(name),
+                         Getattr(n, "sym:name"));
+            Swig_warning(WARN_TYPE_REDEFINED,
+                         Getfile(cn),
+                         Getline(cn),
+                         "previous instantiation of '%s' with name '%s'.\n",
+                         SwigType_namestr(Getattr(cn, "name")),
+                         Getattr(cn, "sym:name"));
             scopename = 0;
           }
         } else {
@@ -608,7 +648,7 @@ class TypePass:private Dispatcher {
 
     /* Inherit type definitions into the class */
     if (name && !(GetFlag(n, "nested") && !checkAttribute(n, "access", "public") &&
-      (GetFlag(n, "feature:flatnested") || Language::instance()->nestedClassesSupport() == Language::NCS_None))) {
+                  (GetFlag(n, "feature:flatnested") || Language::instance()->nestedClassesSupport() == Language::NCS_None))) {
       cplus_inherit_types(n, 0, nname ? nname : (fname ? fname : name));
     }
 
@@ -838,7 +878,6 @@ class TypePass:private Dispatcher {
     return SWIG_OK;
   }
 
-
   /* ------------------------------------------------------------
    * constructorDeclaration()
    * ------------------------------------------------------------ */
@@ -878,7 +917,6 @@ class TypePass:private Dispatcher {
     }
     return SWIG_OK;
   }
-
 
   /* ------------------------------------------------------------
    * enumDeclaration()
@@ -962,10 +1000,10 @@ class TypePass:private Dispatcher {
         } else {
           if (!enumvalue && previous_ignored) {
             if (previous)
-              Setattr(c, "enumvalue", NewStringf("(%s) + %d", previous, count+1));
+              Setattr(c, "enumvalue", NewStringf("(%s) + %d", previous, count + 1));
             else
               Setattr(c, "enumvalue", NewStringf("%d", count));
-            SetFlag(c, "virtenumvalue"); // identify enumvalue as virtual, ie not from the parsed source
+            SetFlag(c, "virtenumvalue");  // identify enumvalue as virtual, ie not from the parsed source
           }
           if (!firstenumitem) {
             SetFlag(c, "firstenumitem");
@@ -1017,7 +1055,8 @@ class TypePass:private Dispatcher {
 
     // Make up an enumvalue if one was not specified in the parsed code (not designed to be used on enum items and %ignore - enumvalue will be set instead)
     if (!GetFlag(n, "feature:ignore")) {
-      if (Getattr(n, "_last") && !Getattr(n, "enumvalue")) {    // Only the first enum item has _last set (Note: first non-ignored enum item has firstenumitem set)
+      if (Getattr(n, "_last") &&
+          !Getattr(n, "enumvalue")) {  // Only the first enum item has _last set (Note: first non-ignored enum item has firstenumitem set)
         Setattr(n, "enumvalueex", "0");
       }
       if (next && !Getattr(next, "enumvalue")) {
@@ -1047,7 +1086,7 @@ class TypePass:private Dispatcher {
       if (nodetype) {
         if (Equal(nodetype, "enumforward")) {
           SetFlag(nn, "enumMissing");
-        } // if a real enum was declared this would be an "enum" node type
+        }  // if a real enum was declared this would be an "enum" node type
       }
       Delete(ty);
     }
@@ -1071,7 +1110,13 @@ class TypePass:private Dispatcher {
       }
 
       String *decl = Strcmp(nodeType(c), "using") == 0 ? NewString("------") : Getattr(c, "decl");
-      Printf(stdout, "  show_overloaded %s::%s(%s)          [%s] nodeType:%s\n", parentNode(c) ? Getattr(parentNode(c), "name") : "NOPARENT", Getattr(c, "name"), decl, Getattr(c, "sym:overname"), nodeType(c));
+      Printf(stdout,
+             "  show_overloaded %s::%s(%s)          [%s] nodeType:%s\n",
+             parentNode(c) ? Getattr(parentNode(c), "name") : "NOPARENT",
+             Getattr(c, "name"),
+             decl,
+             Getattr(c, "sym:overname"),
+             nodeType(c));
       if (!Getattr(c, "sym:overloaded")) {
         Printf(stdout, "sym:overloaded error.....%p\n", c);
         Swig_print_node(c);
@@ -1161,7 +1206,6 @@ class TypePass:private Dispatcher {
     return SWIG_OK;
   }
 
-
   /* ------------------------------------------------------------
    * typemapcopyDirective()
    * ------------------------------------------------------------ */
@@ -1225,4 +1269,3 @@ void Swig_process_types(Node *n) {
     return;
   TypePass::pass(n);
 }
-

--- a/Source/Modules/typepass.cxx
+++ b/Source/Modules/typepass.cxx
@@ -159,7 +159,7 @@ class TypePass:private Dispatcher {
   void cplus_inherit_types_impl(Node *first, Node *cls, String *clsname, const char *bases, const char *baselist, int ispublic, String *cast = 0) {
 
     if (first == cls)
-      return;			/* The Marcelo check */
+      return;                   /* The Marcelo check */
     if (!cls)
       cls = first;
     List *alist = 0;
@@ -1017,7 +1017,7 @@ class TypePass:private Dispatcher {
 
     // Make up an enumvalue if one was not specified in the parsed code (not designed to be used on enum items and %ignore - enumvalue will be set instead)
     if (!GetFlag(n, "feature:ignore")) {
-      if (Getattr(n, "_last") && !Getattr(n, "enumvalue")) {	// Only the first enum item has _last set (Note: first non-ignored enum item has firstenumitem set)
+      if (Getattr(n, "_last") && !Getattr(n, "enumvalue")) {    // Only the first enum item has _last set (Note: first non-ignored enum item has firstenumitem set)
         Setattr(n, "enumvalueex", "0");
       }
       if (next && !Getattr(next, "enumvalue")) {

--- a/Source/Modules/utils.cxx
+++ b/Source/Modules/utils.cxx
@@ -77,9 +77,7 @@ void clean_overloaded(Node *n) {
   Node *first = 0;
   while (nn) {
     String *ntype = nodeType(nn);
-    if ((GetFlag(nn, "feature:ignore")) ||
-        (Getattr(nn, "error")) ||
-        (Strcmp(ntype, "template") == 0) ||
+    if ((GetFlag(nn, "feature:ignore")) || (Getattr(nn, "error")) || (Strcmp(ntype, "template") == 0) ||
         ((Strcmp(ntype, "cdecl") == 0) && is_protected(nn) && !is_member_director(nn) && !is_non_virtual_protected_access(n))) {
       /* Remove from overloaded list */
       Node *ps = Getattr(nn, "sym:previousSibling");
@@ -121,7 +119,6 @@ void clean_overloaded(Node *n) {
 void Swig_set_max_hash_expand(int count) {
   SetMaxHashExpand(count);
 }
-
 
 extern "C" {
 
@@ -222,5 +219,4 @@ void Swig_print_with_location(DOH *object, int count) {
   Delete(output);
 }
 
-} // extern "C"
-
+}  // extern "C"

--- a/Source/Modules/utils.cxx
+++ b/Source/Modules/utils.cxx
@@ -78,17 +78,17 @@ void clean_overloaded(Node *n) {
   while (nn) {
     String *ntype = nodeType(nn);
     if ((GetFlag(nn, "feature:ignore")) ||
-	(Getattr(nn, "error")) ||
-	(Strcmp(ntype, "template") == 0) ||
-	((Strcmp(ntype, "cdecl") == 0) && is_protected(nn) && !is_member_director(nn) && !is_non_virtual_protected_access(n))) {
+        (Getattr(nn, "error")) ||
+        (Strcmp(ntype, "template") == 0) ||
+        ((Strcmp(ntype, "cdecl") == 0) && is_protected(nn) && !is_member_director(nn) && !is_non_virtual_protected_access(n))) {
       /* Remove from overloaded list */
       Node *ps = Getattr(nn, "sym:previousSibling");
       Node *ns = Getattr(nn, "sym:nextSibling");
       if (ps) {
-	Setattr(ps, "sym:nextSibling", ns);
+        Setattr(ps, "sym:nextSibling", ns);
       }
       if (ns) {
-	Setattr(ns, "sym:previousSibling", ps);
+        Setattr(ns, "sym:previousSibling", ps);
       }
       Delattr(nn, "sym:previousSibling");
       Delattr(nn, "sym:nextSibling");
@@ -98,7 +98,7 @@ void clean_overloaded(Node *n) {
       continue;
     } else {
       if (!first)
-	first = nn;
+        first = nn;
       Setattr(nn, "sym:overloaded", first);
     }
     nn = Getattr(nn, "sym:nextSibling");

--- a/Source/Modules/utils.cxx
+++ b/Source/Modules/utils.cxx
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Modules/xml.cxx
+++ b/Source/Modules/xml.cxx
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -30,7 +30,7 @@ public:
 
   XML() :indent_level(0) , id(0) {
   }
-  
+
   ~XML() {
   }
 

--- a/Source/Modules/xml.cxx
+++ b/Source/Modules/xml.cxx
@@ -37,11 +37,11 @@ public:
   virtual void main(int argc, char *argv[]) {
     for (int iX = 0; iX < argc; iX++) {
       if (strcmp(argv[iX], "-help") == 0) {
-	fputs(usage, stdout);
+        fputs(usage, stdout);
       }
       if (strcmp(argv[iX], "-xmllite") == 0) {
-	Swig_mark_arg(iX);
-	xmllite = 1;
+        Swig_mark_arg(iX);
+        xmllite = 1;
       }
     }
 
@@ -61,8 +61,8 @@ public:
       Append(outfile, ".xml");
       out = NewFile(outfile, "w", SWIG_output_files());
       if (!out) {
-	FileErrorDisplay(outfile);
-	Exit(EXIT_FAILURE);
+        FileErrorDisplay(outfile);
+        Exit(EXIT_FAILURE);
       }
     }
     Printf(out, "<?xml version=\"1.0\" ?> \n");
@@ -98,51 +98,51 @@ public:
     while (ki.key) {
       k = ki.key;
       if ((Cmp(k, "nodeType") == 0)
-	  || (Cmp(k, "firstChild") == 0)
-	  || (Cmp(k, "lastChild") == 0)
-	  || (Cmp(k, "parentNode") == 0)
-	  || (Cmp(k, "nextSibling") == 0)
-	  || (Cmp(k, "previousSibling") == 0)
-	  || (*(Char(k)) == '$')) {
-	/* Do nothing */
+          || (Cmp(k, "firstChild") == 0)
+          || (Cmp(k, "lastChild") == 0)
+          || (Cmp(k, "parentNode") == 0)
+          || (Cmp(k, "nextSibling") == 0)
+          || (Cmp(k, "previousSibling") == 0)
+          || (*(Char(k)) == '$')) {
+        /* Do nothing */
       } else if (Cmp(k, "module") == 0) {
-	Xml_print_module(Getattr(obj, k));
+        Xml_print_module(Getattr(obj, k));
       } else if (Cmp(k, "baselist") == 0) {
-	Xml_print_baselist(Getattr(obj, k));
+        Xml_print_baselist(Getattr(obj, k));
       } else if (!xmllite && Cmp(k, "typescope") == 0) {
-	Xml_print_typescope(Getattr(obj, k));
+        Xml_print_typescope(Getattr(obj, k));
       } else if (!xmllite && Cmp(k, "typetab") == 0) {
-	Xml_print_typetab(Getattr(obj, k));
+        Xml_print_typetab(Getattr(obj, k));
       } else if (Cmp(k, "kwargs") == 0) {
-	Xml_print_kwargs(Getattr(obj, k));
+        Xml_print_kwargs(Getattr(obj, k));
       } else if (Cmp(k, "parms") == 0 || Cmp(k, "pattern") == 0) {
-	Xml_print_parmlist(Getattr(obj, k));
+        Xml_print_parmlist(Getattr(obj, k));
       } else if (Cmp(k, "catchlist") == 0 || Cmp(k, "templateparms") == 0) {
-	Xml_print_parmlist(Getattr(obj, k), Char(k));
+        Xml_print_parmlist(Getattr(obj, k), Char(k));
       } else {
-	DOH *o;
-	print_indent(0);
-	if (DohIsString(Getattr(obj, k))) {
-	  String *ck = NewString(k);
-	  o = Str(Getattr(obj, k));
-	  Replaceall(ck, ":", "_");
-	  Replaceall(ck, "<", "&lt;");
-	  /* Do first to avoid aliasing errors. */
-	  Replaceall(o, "&", "&amp;");
-	  Replaceall(o, "<", "&lt;");
-	  Replaceall(o, "\"", "&quot;");
-	  Replaceall(o, "\\", "\\\\");
-	  Replaceall(o, "\n", "&#10;");
-	  Printf(out, "<attribute name=\"%s\" value=\"%s\" id=\"%ld\" addr=\"%p\" />\n", ck, o, ++id, o);
-	  Delete(o);
-	  Delete(ck);
-	} else {
-	  o = Getattr(obj, k);
-	  String *ck = NewString(k);
-	  Replaceall(ck, ":", "_");
-	  Printf(out, "<attribute name=\"%s\" value=\"%p\" id=\"%ld\" addr=\"%p\" />\n", ck, o, ++id, o);
-	  Delete(ck);
-	}
+        DOH *o;
+        print_indent(0);
+        if (DohIsString(Getattr(obj, k))) {
+          String *ck = NewString(k);
+          o = Str(Getattr(obj, k));
+          Replaceall(ck, ":", "_");
+          Replaceall(ck, "<", "&lt;");
+          /* Do first to avoid aliasing errors. */
+          Replaceall(o, "&", "&amp;");
+          Replaceall(o, "<", "&lt;");
+          Replaceall(o, "\"", "&quot;");
+          Replaceall(o, "\\", "\\\\");
+          Replaceall(o, "\n", "&#10;");
+          Printf(out, "<attribute name=\"%s\" value=\"%s\" id=\"%ld\" addr=\"%p\" />\n", ck, o, ++id, o);
+          Delete(o);
+          Delete(ck);
+        } else {
+          o = Getattr(obj, k);
+          String *ck = NewString(k);
+          Replaceall(ck, ":", "_");
+          Printf(out, "<attribute name=\"%s\" value=\"%p\" id=\"%ld\" addr=\"%p\" />\n", ck, o, ++id, o);
+          Delete(ck);
+        }
       }
       ki = Next(ki);
     }

--- a/Source/Modules/xml.cxx
+++ b/Source/Modules/xml.cxx
@@ -21,14 +21,12 @@ XML Options (available with -xml)\n\
 static File *out = 0;
 static int xmllite = 0;
 
-
-class XML:public Language {
+class XML : public Language {
 public:
-
   int indent_level;
   long id;
 
-  XML() :indent_level(0) , id(0) {
+  XML() : indent_level(0), id(0) {
   }
 
   ~XML() {
@@ -97,13 +95,8 @@ public:
     ki = First(obj);
     while (ki.key) {
       k = ki.key;
-      if ((Cmp(k, "nodeType") == 0)
-          || (Cmp(k, "firstChild") == 0)
-          || (Cmp(k, "lastChild") == 0)
-          || (Cmp(k, "parentNode") == 0)
-          || (Cmp(k, "nextSibling") == 0)
-          || (Cmp(k, "previousSibling") == 0)
-          || (*(Char(k)) == '$')) {
+      if ((Cmp(k, "nodeType") == 0) || (Cmp(k, "firstChild") == 0) || (Cmp(k, "lastChild") == 0) || (Cmp(k, "parentNode") == 0) ||
+          (Cmp(k, "nextSibling") == 0) || (Cmp(k, "previousSibling") == 0) || (*(Char(k)) == '$')) {
         /* Do nothing */
       } else if (Cmp(k, "module") == 0) {
         Xml_print_module(Getattr(obj, k));
@@ -172,8 +165,7 @@ public:
     Printf(out, "</%s>\n", nodeType(obj));
   }
 
-
-  void Xml_print_parmlist(ParmList *p, const char* markup = "parmlist") {
+  void Xml_print_parmlist(ParmList *p, const char *markup = "parmlist") {
 
     print_indent(0);
     Printf(out, "<%s id=\"%ld\" addr=\"%p\">\n", markup, ++id, p);
@@ -240,7 +232,6 @@ public:
 
     Xml_print_hash(p, "typetab");
   }
-
 
   void Xml_print_hash(Hash *p, const char *markup) {
 

--- a/Source/Preprocessor/cpp.c
+++ b/Source/Preprocessor/cpp.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -1027,7 +1027,7 @@ static String *expand_macro(String *name, List *args, String *line_file) {
         Replace(ns, temp, rep, DOH_REPLACE_ANY);
       }
 
-      /* Non-standard mangle expansions.  
+      /* Non-standard mangle expansions.
          The #@Name is replaced by mangle_arg(Name). */
       if (strchr(Char(ns), '\004')) {
         String *marg = Swig_name_mangle_string(arg);

--- a/Source/Preprocessor/cpp.c
+++ b/Source/Preprocessor/cpp.c
@@ -67,7 +67,7 @@ static int skip_tochar(String *s, int ch, String *out) {
     if (c == '\\') {
       c = Getc(s);
       if ((c != EOF) && (out))
-	Putc(c, out);
+        Putc(c, out);
     }
   }
   if (c == EOF)
@@ -80,8 +80,8 @@ static int skip_tochar_or_eol(String *s, int ch, String *out) {
   int c;
   while ((c = Getc(s)) != EOF) {
     if (c == '\n') {
-	Ungetc(c, s);
-	break;
+        Ungetc(c, s);
+        break;
     }
     if (out)
       Putc(c, out);
@@ -90,7 +90,7 @@ static int skip_tochar_or_eol(String *s, int ch, String *out) {
     if (c == '\\') {
       c = Getc(s);
       if ((c != EOF) && (out))
-	Putc(c, out);
+        Putc(c, out);
     }
   }
   if (c == EOF)
@@ -368,14 +368,14 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
       copy_location(str, argstr);
       /* It is a macro.  Go extract its argument string */
       while ((c = Getc(str)) != EOF) {
-	if (c == ')')
-	  break;
-	else
-	  Putc(c, argstr);
+        if (c == ')')
+          break;
+        else
+          Putc(c, argstr);
       }
       if (c != ')') {
-	Swig_error(Getfile(argstr), Getline(argstr), "Missing \')\' in macro parameters\n");
-	goto macro_error;
+        Swig_error(Getfile(argstr), Getline(argstr), "Missing \')\' in macro parameters\n");
+        goto macro_error;
       }
       break;
     } else if (isidchar(c) || (c == '%')) {
@@ -385,9 +385,9 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
     } else if (c == '\\') {
       c = Getc(str);
       if (c != '\n') {
-	Ungetc(c, str);
-	Ungetc('\\', str);
-	break;
+        Ungetc(c, str);
+        Ungetc('\\', str);
+        break;
       }
     } else {
       Ungetc(c, str);
@@ -410,32 +410,32 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
     argname = NewStringEmpty();
     while ((c = Getc(argstr)) != EOF) {
       if (c == ',') {
-	varargname = Macro_vararg_name(argname, argstr);
-	if (varargname) {
-	  Delete(varargname);
-	  Swig_error(Getfile(argstr), Getline(argstr), "Variable length macro argument must be last parameter\n");
-	} else {
-	  Append(arglist, argname);
-	}
-	Delete(argname);
-	argname = NewStringEmpty();
+        varargname = Macro_vararg_name(argname, argstr);
+        if (varargname) {
+          Delete(varargname);
+          Swig_error(Getfile(argstr), Getline(argstr), "Variable length macro argument must be last parameter\n");
+        } else {
+          Append(arglist, argname);
+        }
+        Delete(argname);
+        argname = NewStringEmpty();
       } else if (isidchar(c) || (c == '.')) {
-	Putc(c, argname);
+        Putc(c, argname);
       } else if (!(isspace(c) || (c == '\\'))) {
-	Delete(argname);
-	Swig_error(Getfile(argstr), Getline(argstr), "Illegal character in macro argument name\n");
-	goto macro_error;
+        Delete(argname);
+        Swig_error(Getfile(argstr), Getline(argstr), "Illegal character in macro argument name\n");
+        goto macro_error;
       }
     }
     if (Len(argname)) {
       /* Check for varargs */
       varargname = Macro_vararg_name(argname, argstr);
       if (varargname) {
-	Append(arglist, varargname);
-	Delete(varargname);
-	varargs = 1;
+        Append(arglist, varargname);
+        Delete(varargname);
+        varargs = 1;
       } else {
-	Append(arglist, argname);
+        Append(arglist, argname);
       }
     }
     Delete(argname);
@@ -454,59 +454,59 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
     while (*cc) {
       switch (state) {
       case 0:
-	if (*cc == '#')
-	  *cc = '\001';
-	else if (*cc == '/')
-	  state = 10;
-	else if (*cc == '\'')
-	  state = 20;
-	else if (*cc == '\"')
-	  state = 30;
-	break;
+        if (*cc == '#')
+          *cc = '\001';
+        else if (*cc == '/')
+          state = 10;
+        else if (*cc == '\'')
+          state = 20;
+        else if (*cc == '\"')
+          state = 30;
+        break;
       case 10:
-	if (*cc == '*')
-	  state = 11;
-	else if (*cc == '/')
-	  state = 15;
-	else {
-	  state = 0;
-	  cc--;
-	}
-	break;
+        if (*cc == '*')
+          state = 11;
+        else if (*cc == '/')
+          state = 15;
+        else {
+          state = 0;
+          cc--;
+        }
+        break;
       case 11:
-	if (*cc == '*')
-	  state = 12;
-	break;
+        if (*cc == '*')
+          state = 12;
+        break;
       case 12:
-	if (*cc == '/')
-	  state = 0;
-	else if (*cc != '*')
-	  state = 11;
-	break;
+        if (*cc == '/')
+          state = 0;
+        else if (*cc != '*')
+          state = 11;
+        break;
       case 15:
-	if (*cc == '\n')
-	  state = 0;
-	break;
+        if (*cc == '\n')
+          state = 0;
+        break;
       case 20:
-	if (*cc == '\'')
-	  state = 0;
-	if (*cc == '\\')
-	  state = 21;
-	break;
+        if (*cc == '\'')
+          state = 0;
+        if (*cc == '\\')
+          state = 21;
+        break;
       case 21:
-	state = 20;
-	break;
+        state = 20;
+        break;
       case 30:
-	if (*cc == '\"')
-	  state = 0;
-	if (*cc == '\\')
-	  state = 31;
-	break;
+        if (*cc == '\"')
+          state = 0;
+        if (*cc == '\\')
+          state = 31;
+        break;
       case 31:
-	state = 30;
-	break;
+        state = 30;
+        break;
       default:
-	break;
+        break;
       }
       cc++;
     }
@@ -637,15 +637,15 @@ static List *find_args(String *s, int ismacro, String *macro_name) {
     level = 0;
     while (c != EOF) {
       if (c == '\"') {
-	Putc(c, str);
-	skip_tochar(s, '\"', str);
-	c = Getc(s);
-	continue;
+        Putc(c, str);
+        skip_tochar(s, '\"', str);
+        c = Getc(s);
+        continue;
       } else if (c == '\'') {
-	Putc(c, str);
-	skip_tochar(s, '\'', str);
-	c = Getc(s);
-	continue;
+        Putc(c, str);
+        skip_tochar(s, '\'', str);
+        c = Getc(s);
+        continue;
       } else if (c == '/') {
         /* Ensure comments are ignored by eating up the characters */
         c = Getc(s);
@@ -657,7 +657,7 @@ another_star:
               c = Getc(s);
               if (c == '/' || c == EOF)
                 break;
-	      if (c == '*') goto another_star;
+              if (c == '*') goto another_star;
             }
           }
           c = Getc(s);
@@ -678,14 +678,14 @@ another_star:
         c = '/';
       }
       if ((c == ',') && (level == 0))
-	break;
+        break;
       if ((c == ')') && (level == 0))
-	break;
+        break;
       Putc(c, str);
       if (c == '(')
-	level++;
+        level++;
       if (c == ')')
-	level--;
+        level--;
       c = Getc(s);
     }
     if (level > 0) {
@@ -744,11 +744,11 @@ static String *get_filename(String *str, int *sysfile) {
     c = Getc(preprocessed_str);
     if (c == '\"') {
       while (((c = Getc(preprocessed_str)) != EOF) && (c != '\"'))
-	Putc(c, fn);
+        Putc(c, fn);
     } else if (c == '<') {
       *sysfile = 1;
       while (((c = Getc(preprocessed_str)) != EOF) && (c != '>'))
-	Putc(c, fn);
+        Putc(c, fn);
     } else {
       fn = Copy(preprocessed_str);
     }
@@ -770,31 +770,31 @@ static String *get_options(String *str) {
     while (((c = Getc(str)) != EOF)) {
       Putc(c, opt);
       switch (c) {
-	case ')':
-	  level--;
-	  if (!level)
-	    return opt;
-	  break;
-	case '(':
-	  level++;
-	  break;
-	case '"':
-	  /* Skip over quoted strings */
-	  while (1) {
-	    c = Getc(str);
-	    if (c == EOF)
-	      goto bad;
-	    Putc(c, opt);
-	    if (c == '"')
-	      break;
-	    if (c == '\\') {
-	      c = Getc(str);
-	      if (c == EOF)
-		goto bad;
-	      Putc(c, opt);
-	    }
-	  }
-	  break;
+        case ')':
+          level--;
+          if (!level)
+            return opt;
+          break;
+        case '(':
+          level++;
+          break;
+        case '"':
+          /* Skip over quoted strings */
+          while (1) {
+            c = Getc(str);
+            if (c == EOF)
+              goto bad;
+            Putc(c, opt);
+            if (c == '"')
+              break;
+            if (c == '\\') {
+              c = Getc(str);
+              if (c == EOF)
+                goto bad;
+              Putc(c, opt);
+            }
+          }
+          break;
       }
     }
 bad:
@@ -844,14 +844,14 @@ static String *expand_macro(String *name, List *args, String *line_file) {
     if (args) {
       int lenargs = Len(args);
       if (lenargs)
-	Putc('(', ns);
+        Putc('(', ns);
       for (i = 0; i < lenargs; i++) {
-	Append(ns, Getitem(args, i));
-	if (i < (lenargs - 1))
-	  Putc(',', ns);
+        Append(ns, Getitem(args, i));
+        if (i < (lenargs - 1))
+          Putc(',', ns);
       }
       if (i)
-	Putc(')', ns);
+        Putc(')', ns);
     }
     macro_level--;
     return ns;
@@ -872,14 +872,14 @@ static String *expand_macro(String *name, List *args, String *line_file) {
       vi = Len(margs) - 1;
       na = Len(args);
       for (i = vi; i < na; i++) {
-	Append(vararg, Getitem(args, i));
-	if ((i + 1) < na) {
-	  Append(vararg, ",");
-	}
+        Append(vararg, Getitem(args, i));
+        if ((i + 1) < na) {
+          Append(vararg, ",");
+        }
       }
       /* Remove arguments */
       for (i = vi; i < na; i++) {
-	Delitem(args, vi);
+        Delitem(args, vi);
       }
       Append(args, vararg);
       Delete(vararg);
@@ -934,77 +934,77 @@ static String *expand_macro(String *name, List *args, String *line_file) {
       reparg = Preprocessor_replace(arg, NULL);
       aname = Getitem(margs, i);	/* Get macro argument name */
       if (strchr(Char(ns), '\001')) {
-	/* Try to replace a quoted version of the argument */
-	Clear(temp);
-	Clear(tempa);
-	Printf(temp, "\001%s", aname);
-	Printf(tempa, "\"%s\"", arg);
-	Replace(ns, temp, tempa, DOH_REPLACE_ID_END);
+        /* Try to replace a quoted version of the argument */
+        Clear(temp);
+        Clear(tempa);
+        Printf(temp, "\001%s", aname);
+        Printf(tempa, "\"%s\"", arg);
+        Replace(ns, temp, tempa, DOH_REPLACE_ID_END);
       }
       if (isvarargs && i == l - 1) {
-	char *s = Char(ns);
-	char *a = s;
-	while ((a = strchr(a, '\006')) != NULL) {
-	  *a = ' ';
-	  while (isspace((unsigned char)*++a)) { }
-	  if (*a == '(') {
-	    char *e = a;
-	    int depth = 1;
-	    while (*++e) {
-	      if (*e == ')') {
-		if (--depth == 0) break;
-	      } else if (*e == '(') {
-		++depth;
-	      }
-	    }
-	    if (*e) {
-	      if (Len(arg) == 0) {
-		// Empty varargs so replace ( and ) and everything between with
-		// spaces.
-		memset(a, ' ', e - a + 1);
-	      } else {
-		// Non-empty varargs so replace ( and ) with spaces.
-		*a = ' ';
-		*e = ' ';
-	      }
-	    }
-	    a = e + 1;
-	  }
-	}
+        char *s = Char(ns);
+        char *a = s;
+        while ((a = strchr(a, '\006')) != NULL) {
+          *a = ' ';
+          while (isspace((unsigned char)*++a)) { }
+          if (*a == '(') {
+            char *e = a;
+            int depth = 1;
+            while (*++e) {
+              if (*e == ')') {
+                if (--depth == 0) break;
+              } else if (*e == '(') {
+                ++depth;
+              }
+            }
+            if (*e) {
+              if (Len(arg) == 0) {
+                // Empty varargs so replace ( and ) and everything between with
+                // spaces.
+                memset(a, ' ', e - a + 1);
+              } else {
+                // Non-empty varargs so replace ( and ) with spaces.
+                *a = ' ';
+                *e = ' ';
+              }
+            }
+            a = e + 1;
+          }
+        }
       }
 
       if (strchr(Char(ns), '\002')) {
-	/* Look for concatenation tokens */
-	Clear(temp);
-	Clear(tempa);
-	Printf(temp, "\002%s", aname);
-	Append(tempa, "\002\003");
-	Replace(ns, temp, tempa, DOH_REPLACE_ID_END);
-	if (isvarargs && i == l - 1 && Len(arg) == 0) {
-	  // ## followed by a zero length varargs macro argument - if preceded
-	  // by a comma (possibly with whitespace in between) we nuke the
-	  // comma.
-	  char *s = Char(ns);
-	  char *a = s + 1;
-	  while ((a = strstr(a, "\002\003")) != NULL) {
-	    char *t = a;
-	    while (--t >= s) {
-	      if (!isspace((unsigned char)*t)) {
-		if (*t == ',') *t = ' ';
-		break;
-	      }
-	    }
-	    // Advance 3 since we're only interested in \002\003 when it could
-	    // be preceded by a comma.
-	    a += 3;
-	  }
-	}
+        /* Look for concatenation tokens */
+        Clear(temp);
+        Clear(tempa);
+        Printf(temp, "\002%s", aname);
+        Append(tempa, "\002\003");
+        Replace(ns, temp, tempa, DOH_REPLACE_ID_END);
+        if (isvarargs && i == l - 1 && Len(arg) == 0) {
+          // ## followed by a zero length varargs macro argument - if preceded
+          // by a comma (possibly with whitespace in between) we nuke the
+          // comma.
+          char *s = Char(ns);
+          char *a = s + 1;
+          while ((a = strstr(a, "\002\003")) != NULL) {
+            char *t = a;
+            while (--t >= s) {
+              if (!isspace((unsigned char)*t)) {
+                if (*t == ',') *t = ' ';
+                break;
+              }
+            }
+            // Advance 3 since we're only interested in \002\003 when it could
+            // be preceded by a comma.
+            a += 3;
+          }
+        }
 
-	Clear(temp);
-	Clear(tempa);
-	Printf(temp, "%s\002", aname);
-	Append(tempa, "\003\002");
-	Replace(ns, temp, tempa, DOH_REPLACE_ID_BEGIN);
+        Clear(temp);
+        Clear(tempa);
+        Printf(temp, "%s\002", aname);
+        Append(tempa, "\003\002");
+        Replace(ns, temp, tempa, DOH_REPLACE_ID_BEGIN);
       }
 
       /* Non-standard macro expansion.   The value `x` is replaced by a quoted
@@ -1012,38 +1012,38 @@ static String *expand_macro(String *name, List *args, String *line_file) {
          nothing happens */
 
       if (strchr(Char(ns), '`')) {
-	String *rep;
-	char *c;
-	Clear(temp);
-	Printf(temp, "`%s`", aname);
-	c = Char(arg);
-	if (*c == '"') {
-	  rep = arg;
-	} else {
-	  Clear(tempa);
-	  Printf(tempa, "\"%s\"", arg);
-	  rep = tempa;
-	}
-	Replace(ns, temp, rep, DOH_REPLACE_ANY);
+        String *rep;
+        char *c;
+        Clear(temp);
+        Printf(temp, "`%s`", aname);
+        c = Char(arg);
+        if (*c == '"') {
+          rep = arg;
+        } else {
+          Clear(tempa);
+          Printf(tempa, "\"%s\"", arg);
+          rep = tempa;
+        }
+        Replace(ns, temp, rep, DOH_REPLACE_ANY);
       }
 
       /* Non-standard mangle expansions.  
          The #@Name is replaced by mangle_arg(Name). */
       if (strchr(Char(ns), '\004')) {
-	String *marg = Swig_name_mangle_string(arg);
-	Clear(temp);
-	Printf(temp, "\004%s", aname);
-	Replace(ns, temp, marg, DOH_REPLACE_ID_END);
-	Delete(marg);
+        String *marg = Swig_name_mangle_string(arg);
+        Clear(temp);
+        Printf(temp, "\004%s", aname);
+        Replace(ns, temp, marg, DOH_REPLACE_ID_END);
+        Delete(marg);
       }
       if (strchr(Char(ns), '\005')) {
-	String *marg = Swig_name_mangle_string(arg);
-	Clear(temp);
-	Clear(tempa);
-	Printf(temp, "\005%s", aname);
-	Printf(tempa, "\"%s\"", marg);
-	Replace(ns, temp, tempa, DOH_REPLACE_ID_END);
-	Delete(marg);
+        String *marg = Swig_name_mangle_string(arg);
+        Clear(temp);
+        Clear(tempa);
+        Printf(temp, "\005%s", aname);
+        Printf(tempa, "\"%s\"", marg);
+        Replace(ns, temp, tempa, DOH_REPLACE_ID_END);
+        Delete(marg);
       }
 
       /*      Replace(ns, aname, arg, DOH_REPLACE_ID); */
@@ -1124,192 +1124,192 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
     switch (state) {
     case 0:
       if (isidentifier(c)) {
-	Clear(id);
-	Putc(c, id);
-	state = 4;
+        Clear(id);
+        Putc(c, id);
+        state = 4;
       } else if (c == '%') {
-	Clear(id);
-	Putc(c, id);
-	state = 2;
+        Clear(id);
+        Putc(c, id);
+        state = 2;
       } else if (c == '#') {
-	Clear(id);
-	Putc(c, id);
-	state = 4;
+        Clear(id);
+        Putc(c, id);
+        state = 4;
       } else if (c == '\"') {
-	Putc(c, ns);
-	skip_tochar(s, '\"', ns);
+        Putc(c, ns);
+        skip_tochar(s, '\"', ns);
       } else if (c == '\'') {
-	Putc(c, ns);
-	skip_tochar(s, '\'', ns);
+        Putc(c, ns);
+        skip_tochar(s, '\'', ns);
       } else if (c == '/') {
-	Putc(c, ns);
-	state = 10;
+        Putc(c, ns);
+        state = 10;
       } else if (c == '\\') {
-	Putc(c, ns);
-	c = Getc(s);
-	if (c == '\n') {
-	  Putc(c, ns);
-	} else {
-	  Ungetc(c, s);
-	}
+        Putc(c, ns);
+        c = Getc(s);
+        if (c == '\n') {
+          Putc(c, ns);
+        } else {
+          Ungetc(c, s);
+        }
       } else if (c == '\n') {
-	Putc(c, ns);
-	expand_defined_operator = 0;
+        Putc(c, ns);
+        expand_defined_operator = 0;
       } else {
-	Putc(c, ns);
+        Putc(c, ns);
       }
       break;
     case 2:
       /* Found '%#' */
       if (c == '#') {
-	Putc(c, id);
-	state = 4;
+        Putc(c, id);
+        state = 4;
       } else {
-	Ungetc(c, s);
-	state = 4;
+        Ungetc(c, s);
+        state = 4;
       }
       break;
     case 4:			/* An identifier */
       if (isidchar(c)) {
-	Putc(c, id);
-	state = 4;
+        Putc(c, id);
+        state = 4;
       } else {
-	/* We found the end of a valid identifier */
-	Ungetc(c, s);
-	/* See if this is the special "defined" operator */
-       	if (Equal(kpp_defined, id)) {
-	  if (expand_defined_operator) {
-	    int lenargs = 0;
-	    DOH *args = 0;
-	    /* See whether or not a parenthesis has been used */
-	    skip_whitespace(s, 0);
-	    c = Getc(s);
-	    if (c == '(') {
-	      Ungetc(c, s);
-	      args = find_args(s, 0, kpp_defined);
-	    } else if (isidchar(c)) {
-	      DOH *arg = NewStringEmpty();
-	      args = NewList();
-	      Putc(c, arg);
-	      while (((c = Getc(s)) != EOF)) {
-		if (!isidchar(c)) {
-		  Ungetc(c, s);
-		  break;
-		}
-		Putc(c, arg);
-	      }
-	      if (Len(arg))
-		Append(args, arg);
-	      Delete(arg);
-	    } else {
-	      Seek(s, -1, SEEK_CUR);
-	    }
-	    lenargs = Len(args);
-	    if ((!args) || (!lenargs)) {
-	      /* This is not a defined() operator. */
-	      Append(ns, id);
-	      state = 0;
-	      break;
-	    }
-	    for (i = 0; i < lenargs; i++) {
-	      DOH *o = Getitem(args, i);
-	      if (!Getattr(symbols, o)) {
-		break;
-	      }
-	    }
-	    if (i < lenargs)
-	      Putc('0', ns);
-	    else
-	      Putc('1', ns);
-	    Delete(args);
-	  } else {
-	    Append(ns, id);
-	  }
-	  state = 0;
-	  break;
-	} else if (Equal(kpp_LINE, id)) {
-	  Printf(ns, "%d", macro_level > 0 ? macro_start_line : Getline(s));
-	  state = 0;
-	  break;
-	} else if (Equal(kpp_FILE, id)) {
-	  String *fn = Copy(macro_level > 0 ? macro_start_file : Getfile(s));
-	  Replaceall(fn, "\\", "\\\\");
-	  Printf(ns, "\"%s\"", fn);
-	  Delete(fn);
-	  state = 0;
-	  break;
-	} else if (Equal(kpp_hash_if, id) || Equal(kpp_hash_elif, id)) {
-	  expand_defined_operator = 1;
-	  Append(ns, id);
-	} else if (Equal("#ifdef", id) || Equal("#ifndef", id)) {
-	  /* Evaluate the defined-ness check and substitute `#if 0` or `#if 1`. */
-	  int allow = 0;
-	  skip_whitespace(s, 0);
-	  c = Getc(s);
-	  if (isidchar(c)) {
-	    DOH *arg = NewStringEmpty();
-	    Putc(c, arg);
-	    while (((c = Getc(s)) != EOF)) {
-	      if (!isidchar(c)) {
-		Ungetc(c, s);
-		break;
-	      }
-	      Putc(c, arg);
-	    }
-	    if (Equal("#ifdef", id)) {
-	      if (Getattr(symbols, arg)) allow = 1;
-	    } else {
-	      if (!Getattr(symbols, arg)) allow = 1;
-	    }
-	    Delete(arg);
-	  } else {
-	    Ungetc(c, s);
-	    Swig_error(Getfile(s), Getline(s), "Missing identifier for %s.\n", id);
-	  }
-	  if (allow) {
-	    Append(ns, "#if 1");
-	  } else {
-	    Append(ns, "#if 0");
-	  }
-	} else if ((m = Getattr(symbols, id))) {
-	  /* See if the macro is defined in the preprocessor symbol table */
-	  DOH *args = 0;
-	  DOH *e;
-	  int macro_additional_lines = 0;
-	  /* See if the macro expects arguments */
-	  if (Getattr(m, kpp_args)) {
-	    /* Yep.  We need to go find the arguments and do a substitution */
-	    int line = Getline(s);
-	    args = find_args(s, 1, id);
-	    macro_additional_lines = Getline(s) - line;
-	    assert(macro_additional_lines >= 0);
-	  } else {
-	    args = 0;
-	  }
-	  e = expand_macro(id, args, s);
-	  if (e) {
-	    Append(ns, e);
-	  }
-	  while (macro_additional_lines--) {
-	    Putc('\n', ns);
-	  }
-	  Delete(e);
-	  Delete(args);
-	} else {
-	  Append(ns, id);
-	}
-	state = 0;
+        /* We found the end of a valid identifier */
+        Ungetc(c, s);
+        /* See if this is the special "defined" operator */
+        if (Equal(kpp_defined, id)) {
+          if (expand_defined_operator) {
+            int lenargs = 0;
+            DOH *args = 0;
+            /* See whether or not a parenthesis has been used */
+            skip_whitespace(s, 0);
+            c = Getc(s);
+            if (c == '(') {
+              Ungetc(c, s);
+              args = find_args(s, 0, kpp_defined);
+            } else if (isidchar(c)) {
+              DOH *arg = NewStringEmpty();
+              args = NewList();
+              Putc(c, arg);
+              while (((c = Getc(s)) != EOF)) {
+                if (!isidchar(c)) {
+                  Ungetc(c, s);
+                  break;
+                }
+                Putc(c, arg);
+              }
+              if (Len(arg))
+                Append(args, arg);
+              Delete(arg);
+            } else {
+              Seek(s, -1, SEEK_CUR);
+            }
+            lenargs = Len(args);
+            if ((!args) || (!lenargs)) {
+              /* This is not a defined() operator. */
+              Append(ns, id);
+              state = 0;
+              break;
+            }
+            for (i = 0; i < lenargs; i++) {
+              DOH *o = Getitem(args, i);
+              if (!Getattr(symbols, o)) {
+                break;
+              }
+            }
+            if (i < lenargs)
+              Putc('0', ns);
+            else
+              Putc('1', ns);
+            Delete(args);
+          } else {
+            Append(ns, id);
+          }
+          state = 0;
+          break;
+        } else if (Equal(kpp_LINE, id)) {
+          Printf(ns, "%d", macro_level > 0 ? macro_start_line : Getline(s));
+          state = 0;
+          break;
+        } else if (Equal(kpp_FILE, id)) {
+          String *fn = Copy(macro_level > 0 ? macro_start_file : Getfile(s));
+          Replaceall(fn, "\\", "\\\\");
+          Printf(ns, "\"%s\"", fn);
+          Delete(fn);
+          state = 0;
+          break;
+        } else if (Equal(kpp_hash_if, id) || Equal(kpp_hash_elif, id)) {
+          expand_defined_operator = 1;
+          Append(ns, id);
+        } else if (Equal("#ifdef", id) || Equal("#ifndef", id)) {
+          /* Evaluate the defined-ness check and substitute `#if 0` or `#if 1`. */
+          int allow = 0;
+          skip_whitespace(s, 0);
+          c = Getc(s);
+          if (isidchar(c)) {
+            DOH *arg = NewStringEmpty();
+            Putc(c, arg);
+            while (((c = Getc(s)) != EOF)) {
+              if (!isidchar(c)) {
+                Ungetc(c, s);
+                break;
+              }
+              Putc(c, arg);
+            }
+            if (Equal("#ifdef", id)) {
+              if (Getattr(symbols, arg)) allow = 1;
+            } else {
+              if (!Getattr(symbols, arg)) allow = 1;
+            }
+            Delete(arg);
+          } else {
+            Ungetc(c, s);
+            Swig_error(Getfile(s), Getline(s), "Missing identifier for %s.\n", id);
+          }
+          if (allow) {
+            Append(ns, "#if 1");
+          } else {
+            Append(ns, "#if 0");
+          }
+        } else if ((m = Getattr(symbols, id))) {
+          /* See if the macro is defined in the preprocessor symbol table */
+          DOH *args = 0;
+          DOH *e;
+          int macro_additional_lines = 0;
+          /* See if the macro expects arguments */
+          if (Getattr(m, kpp_args)) {
+            /* Yep.  We need to go find the arguments and do a substitution */
+            int line = Getline(s);
+            args = find_args(s, 1, id);
+            macro_additional_lines = Getline(s) - line;
+            assert(macro_additional_lines >= 0);
+          } else {
+            args = 0;
+          }
+          e = expand_macro(id, args, s);
+          if (e) {
+            Append(ns, e);
+          }
+          while (macro_additional_lines--) {
+            Putc('\n', ns);
+          }
+          Delete(e);
+          Delete(args);
+        } else {
+          Append(ns, id);
+        }
+        state = 0;
       }
       break;
     case 10:
       if (c == '/')
-	state = 11;
+        state = 11;
       else if (c == '*')
-	state = 12;
+        state = 12;
       else {
-	Ungetc(c, s);
-	state = 0;
-	break;
+        Ungetc(c, s);
+        state = 0;
+        break;
       }
       Putc(c, ns);
       break;
@@ -1317,22 +1317,22 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
       /* in C++ comment */
       Putc(c, ns);
       if (c == '\n') {
-	expand_defined_operator = 0;
-	state = 0;
+        expand_defined_operator = 0;
+        state = 0;
       }
       break;
     case 12:
       /* in C comment */
       Putc(c, ns);
       if (c == '*')
-	state = 13;
+        state = 13;
       break;
     case 13:
       Putc(c, ns);
       if (c == '/')
-	state = 0;
+        state = 0;
       else if (c != '*')
-	state = 12;
+        state = 12;
       break;
     default:
       state = 0;
@@ -1370,10 +1370,10 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
       }
       e = expand_macro(id, args, s);
       if (e) {
-	Append(ns, e);
+        Append(ns, e);
       }
       while (macro_additional_lines--) {
-	Putc('\n', ns);
+        Putc('\n', ns);
       }
       Delete(e);
       Delete(args);
@@ -1422,7 +1422,7 @@ static void addline(DOH *s1, DOH *s2, int allow) {
     int len = Len(s2);
     for (int i = 0; i < len; ++i) {
       if (Char(s2)[i] == '\n')
-	Putc('\n', s1);
+        Putc('\n', s1);
     }
   }
 }
@@ -1508,115 +1508,115 @@ String *Preprocessor_parse(String *s) {
     case 0:			/* Initial state - in first column */
       /* Look for C preprocessor directives.   Otherwise, go directly to state 1 */
       if (c == '#') {
-	copy_location(s, chunk);
-	add_chunk(ns, chunk, allow);
-	cpp_lines = 1;
-	state = 40;
+        copy_location(s, chunk);
+        add_chunk(ns, chunk, allow);
+        cpp_lines = 1;
+        state = 40;
       } else if (isspace(c)) {
-	Putc(c, chunk);
-	skip_whitespace(s, chunk);
+        Putc(c, chunk);
+        skip_whitespace(s, chunk);
       } else {
-	state = 1;
-	Ungetc(c, s);
+        state = 1;
+        Ungetc(c, s);
       }
       break;
     case 1: {			/* Non-preprocessor directive */
       /* Look for SWIG directives */
 state1:
       if (c == '%') {
-	state = 100;
-	break;
+        state = 100;
+        break;
       }
       Putc(c, chunk);
       if (c == '\n')
-	state = 0;
+        state = 0;
       else if (c == '\"') {
-	start_line = Getline(s);
-	if (skip_tochar(s, '\"', chunk) < 0) {
-	  Swig_error(Getfile(s), start_line, "Unterminated string constant\n");
-	}
+        start_line = Getline(s);
+        if (skip_tochar(s, '\"', chunk) < 0) {
+          Swig_error(Getfile(s), start_line, "Unterminated string constant\n");
+        }
       } else if (c == '\'') {
-	start_line = Getline(s);
-	if (skip_tochar(s, '\'', chunk) < 0) {
-	  Swig_error(Getfile(s), start_line, "Unterminated character constant\n");
-	}
+        start_line = Getline(s);
+        if (skip_tochar(s, '\'', chunk) < 0) {
+          Swig_error(Getfile(s), start_line, "Unterminated character constant\n");
+        }
       } else if (c == '/')
-	state = 30;		/* Comment */
+        state = 30;		/* Comment */
       break;
     }
 
     case 30:			/* Possibly a comment string of some sort */
       start_line = Getline(s);
       if (c == '/')
-	state = 31;
+        state = 31;
       else if (c == '*')
-	state = 32;
+        state = 32;
       else {
-	state = 1;
-	goto state1; /* Process this character the same as if it wasn't preceded by a `/`. */
+        state = 1;
+        goto state1; /* Process this character the same as if it wasn't preceded by a `/`. */
       }
       Putc(c, chunk);
       break;
     case 31:
       Putc(c, chunk);
       if (c == '\n')
-	state = 0;
+        state = 0;
       break;
     case 32:
       Putc(c, chunk);
       if (c == '*')
-	state = 33;
+        state = 33;
       break;
     case 33:
       Putc(c, chunk);
       if (c == '/')
-	state = 1;
+        state = 1;
       else if (c != '*')
-	state = 32;
+        state = 32;
       break;
 
     case 40:			/* Start of a C preprocessor directive */
       if (c == '\n') {
-	Putc('\n', chunk);
-	state = 0;
+        Putc('\n', chunk);
+        state = 0;
       } else if (isspace(c)) {
-	state = 40;
+        state = 40;
       } else {
-	/* Got the start of a preprocessor directive */
-	Ungetc(c, s);
-	Clear(id);
-	copy_location(s, id);
-	state = 41;
+        /* Got the start of a preprocessor directive */
+        Ungetc(c, s);
+        Clear(id);
+        copy_location(s, id);
+        state = 41;
       }
       break;
 
     case 41:			/* Build up the name of the preprocessor directive */
       if ((isspace(c) || (!isidchar(c)))) {
-	Clear(value);
-	Clear(comment);
-	if (c == '\n') {
-	  Ungetc(c, s);
-	  state = 50;
-	} else {
-	  state = 42;
-	  if (!isspace(c)) {
-	    Ungetc(c, s);
-	  }
-	}
+        Clear(value);
+        Clear(comment);
+        if (c == '\n') {
+          Ungetc(c, s);
+          state = 50;
+        } else {
+          state = 42;
+          if (!isspace(c)) {
+            Ungetc(c, s);
+          }
+        }
 
-	copy_location(s, value);
-	break;
+        copy_location(s, value);
+        break;
       }
       Putc(c, id);
       break;
 
     case 42:			/* Strip any leading space after the preprocessor directive (before preprocessor value) */
       if (isspace(c)) {
-	if (c == '\n') {
-	  Ungetc(c, s);
-	  state = 50;
-	}
-	break;
+        if (c == '\n') {
+          Ungetc(c, s);
+          state = 50;
+        }
+        break;
       }
       state = 43;
       /* FALL THRU */
@@ -1624,29 +1624,29 @@ state1:
     case 43:
       /* Get preprocessor value */
       if (c == '\n') {
-	Ungetc(c, s);
-	state = 50;
+        Ungetc(c, s);
+        state = 50;
       } else if (c == '/') {
-	state = 45;
+        state = 45;
       } else if (c == '\"') {
-	Putc(c, value);
-	skip_tochar_or_eol(s, '\"', value);
+        Putc(c, value);
+        skip_tochar_or_eol(s, '\"', value);
       } else if (c == '\'') {
-	Putc(c, value);
-	skip_tochar_or_eol(s, '\'', value);
+        Putc(c, value);
+        skip_tochar_or_eol(s, '\'', value);
       } else {
-	Putc(c, value);
-	if (c == '\\')
-	  state = 44;
+        Putc(c, value);
+        if (c == '\\')
+          state = 44;
       }
       break;
 
     case 44:
       if (c == '\n') {
-	Putc(c, value);
-	cpp_lines++;
+        Putc(c, value);
+        cpp_lines++;
       } else {
-	Ungetc(c, s);
+        Ungetc(c, s);
       }
       state = 43;
       break;
@@ -1656,290 +1656,290 @@ state1:
 
     case 45:
       if (c == '/')
-	state = 46;
+        state = 46;
       else if (c == '*')
-	state = 47;
+        state = 47;
       else if (c == '\n') {
-	Putc('/', value);
-	Ungetc(c, s);
-	state = 50;
+        Putc('/', value);
+        Ungetc(c, s);
+        state = 50;
       } else {
-	Putc('/', value);
-	Putc(c, value);
-	state = 43;
+        Putc('/', value);
+        Putc(c, value);
+        state = 43;
       }
       break;
     case 46: /* in C++ comment */
       if (c == '\n') {
-	Ungetc(c, s);
-	state = 50;
+        Ungetc(c, s);
+        state = 50;
       } else
-	Putc(c, comment);
+        Putc(c, comment);
       break;
     case 47: /* in C comment */
       if (c == '*')
-	state = 48;
+        state = 48;
       else
-	Putc(c, comment);
+        Putc(c, comment);
       break;
     case 48:
       if (c == '/')
-	state = 43;
+        state = 43;
       else if (c == '*')
-	Putc(c, comment);
+        Putc(c, comment);
       else {
-	Putc('*', comment);
-	Putc(c, comment);
-	state = 47;
+        Putc('*', comment);
+        Putc(c, comment);
+        state = 47;
       }
       break;
     case 50:
       /* Check for various preprocessor directives */
       Chop(value);
       if (Equal(id, kpp_define)) {
-	if (allow) {
-	  DOH *m, *v, *v1;
-	  Seek(value, 0, SEEK_SET);
-	  m = Preprocessor_define(value, 0);
-	  if ((m) && !(Getattr(m, kpp_args))) {
-	    v = Copy(Getattr(m, kpp_value));
-	    copy_location(m, v);
-	    if (Len(v)) {
-	      Swig_error_silent(1);
-	      v1 = Preprocessor_replace(v, NULL);
-	      Swig_error_silent(0);
-	      /*              Printf(stdout,"checking '%s'\n", v1); */
-	      if (!checkpp_id(v1)) {
-		if (Len(comment) == 0)
-		  Printf(ns, "%%constant %s = %s;\n", Getattr(m, kpp_name), v1);
-		else
-		  Printf(ns, "%%constant %s = %s; /*%s*/\n", Getattr(m, kpp_name), v1, comment);
-		cpp_lines--;
-	      }
-	      Delete(v1);
-	    }
-	    Delete(v);
-	  }
-	}
+        if (allow) {
+          DOH *m, *v, *v1;
+          Seek(value, 0, SEEK_SET);
+          m = Preprocessor_define(value, 0);
+          if ((m) && !(Getattr(m, kpp_args))) {
+            v = Copy(Getattr(m, kpp_value));
+            copy_location(m, v);
+            if (Len(v)) {
+              Swig_error_silent(1);
+              v1 = Preprocessor_replace(v, NULL);
+              Swig_error_silent(0);
+              /*              Printf(stdout,"checking '%s'\n", v1); */
+              if (!checkpp_id(v1)) {
+                if (Len(comment) == 0)
+                  Printf(ns, "%%constant %s = %s;\n", Getattr(m, kpp_name), v1);
+                else
+                  Printf(ns, "%%constant %s = %s; /*%s*/\n", Getattr(m, kpp_name), v1, comment);
+                cpp_lines--;
+              }
+              Delete(v1);
+            }
+            Delete(v);
+          }
+        }
       } else if (Equal(id, kpp_undef)) {
-	if (allow)
-	  Preprocessor_undef(value);
+        if (allow)
+          Preprocessor_undef(value);
       } else if (Equal(id, kpp_ifdef)) {
-	cond_lines[level] = Getline(id);
-	level++;
-	if (allow) {
-	  start_level = level;
-	  if (Len(value) > 0) {
-	    /* See if the identifier is in the hash table */
-	    if (!Getattr(symbols, value))
-	      allow = 0;
-	  } else {
-	    Swig_error(Getfile(s), Getline(id), "Missing identifier for #ifdef.\n");
-	    allow = 0;
-	  }
-	  mask = 1;
-	}
+        cond_lines[level] = Getline(id);
+        level++;
+        if (allow) {
+          start_level = level;
+          if (Len(value) > 0) {
+            /* See if the identifier is in the hash table */
+            if (!Getattr(symbols, value))
+              allow = 0;
+          } else {
+            Swig_error(Getfile(s), Getline(id), "Missing identifier for #ifdef.\n");
+            allow = 0;
+          }
+          mask = 1;
+        }
       } else if (Equal(id, kpp_ifndef)) {
-	cond_lines[level] = Getline(id);
-	level++;
-	if (allow) {
-	  start_level = level;
-	  if (Len(value) > 0) {
-	    /* See if the identifier is in the hash table */
-	    if (Getattr(symbols, value))
-	      allow = 0;
-	  } else {
-	    Swig_error(Getfile(s), Getline(id), "Missing identifier for #ifndef.\n");
-	    allow = 0;
-	  }
-	  mask = 1;
-	}
+        cond_lines[level] = Getline(id);
+        level++;
+        if (allow) {
+          start_level = level;
+          if (Len(value) > 0) {
+            /* See if the identifier is in the hash table */
+            if (Getattr(symbols, value))
+              allow = 0;
+          } else {
+            Swig_error(Getfile(s), Getline(id), "Missing identifier for #ifndef.\n");
+            allow = 0;
+          }
+          mask = 1;
+        }
       } else if (Equal(id, kpp_else)) {
-	if (level <= 0) {
-	  Swig_error(Getfile(s), Getline(id), "Misplaced #else.\n");
-	} else {
-	  cond_lines[level - 1] = Getline(id);
-	  if (Len(value) != 0)
-	    Swig_warning(WARN_PP_UNEXPECTED_TOKENS, Getfile(s), Getline(id), "Unexpected tokens after #else directive.\n");
-	  if (allow) {
-	    allow = 0;
-	    mask = 0;
-	  } else if (level == start_level) {
-	    allow = 1 * mask;
-	  }
-	}
+        if (level <= 0) {
+          Swig_error(Getfile(s), Getline(id), "Misplaced #else.\n");
+        } else {
+          cond_lines[level - 1] = Getline(id);
+          if (Len(value) != 0)
+            Swig_warning(WARN_PP_UNEXPECTED_TOKENS, Getfile(s), Getline(id), "Unexpected tokens after #else directive.\n");
+          if (allow) {
+            allow = 0;
+            mask = 0;
+          } else if (level == start_level) {
+            allow = 1 * mask;
+          }
+        }
       } else if (Equal(id, kpp_endif)) {
-	level--;
-	if (level < 0) {
-	  Swig_error(Getfile(id), Getline(id), "Extraneous #endif.\n");
-	  level = 0;
-	} else {
-	  if (level < start_level) {
-	    if (Len(value) != 0)
-	      Swig_warning(WARN_PP_UNEXPECTED_TOKENS, Getfile(s), Getline(id), "Unexpected tokens after #endif directive.\n");
-	    allow = 1;
-	    start_level--;
-	  }
-	}
+        level--;
+        if (level < 0) {
+          Swig_error(Getfile(id), Getline(id), "Extraneous #endif.\n");
+          level = 0;
+        } else {
+          if (level < start_level) {
+            if (Len(value) != 0)
+              Swig_warning(WARN_PP_UNEXPECTED_TOKENS, Getfile(s), Getline(id), "Unexpected tokens after #endif directive.\n");
+            allow = 1;
+            start_level--;
+          }
+        }
       } else if (Equal(id, kpp_if)) {
-	cond_lines[level] = Getline(id);
-	level++;
-	if (allow) {
-	  int val;
-	  String *sval;
-	  expand_defined_operator = 1;
-	  sval = Preprocessor_replace(value, NULL);
-	  start_level = level;
-	  Seek(sval, 0, SEEK_SET);
-	  /*      Printf(stdout,"Evaluating '%s'\n", sval); */
-	  if (Len(sval) > 0) {
-	    val = Preprocessor_expr(sval, &e);
-	    if (e) {
-	      const char *msg = Preprocessor_expr_error();
-	      Seek(value, 0, SEEK_SET);
-	      Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "Could not evaluate expression '%s'\n", value);
-	      if (msg)
-		Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "%s\n", msg);
-	      allow = 0;
-	    } else {
-	      if (val == 0)
-		allow = 0;
-	    }
-	  } else {
-	    Swig_error(Getfile(s), Getline(id), "Missing expression for #if.\n");
-	    allow = 0;
-	  }
-	  expand_defined_operator = 0;
-	  mask = 1;
-	}
+        cond_lines[level] = Getline(id);
+        level++;
+        if (allow) {
+          int val;
+          String *sval;
+          expand_defined_operator = 1;
+          sval = Preprocessor_replace(value, NULL);
+          start_level = level;
+          Seek(sval, 0, SEEK_SET);
+          /*      Printf(stdout,"Evaluating '%s'\n", sval); */
+          if (Len(sval) > 0) {
+            val = Preprocessor_expr(sval, &e);
+            if (e) {
+              const char *msg = Preprocessor_expr_error();
+              Seek(value, 0, SEEK_SET);
+              Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "Could not evaluate expression '%s'\n", value);
+              if (msg)
+                Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "%s\n", msg);
+              allow = 0;
+            } else {
+              if (val == 0)
+                allow = 0;
+            }
+          } else {
+            Swig_error(Getfile(s), Getline(id), "Missing expression for #if.\n");
+            allow = 0;
+          }
+          expand_defined_operator = 0;
+          mask = 1;
+        }
       } else if (Equal(id, kpp_elif)) {
-	if (level == 0) {
-	  Swig_error(Getfile(s), Getline(id), "Misplaced #elif.\n");
-	} else {
-	  cond_lines[level - 1] = Getline(id);
-	  if (allow) {
-	    allow = 0;
-	    mask = 0;
-	  } else if (level == start_level) {
-	    int val;
-	    String *sval;
-	    expand_defined_operator = 1;
-	    sval = Preprocessor_replace(value, NULL);
-	    Seek(sval, 0, SEEK_SET);
-	    if (Len(sval) > 0) {
-	      val = Preprocessor_expr(sval, &e);
-	      if (e) {
-		const char *msg = Preprocessor_expr_error();
-		Seek(value, 0, SEEK_SET);
-		Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "Could not evaluate expression '%s'\n", value);
-		if (msg)
-		  Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "%s\n", msg);
-		allow = 0;
-	      } else {
-		if (val)
-		  allow = 1 * mask;
-		else
-		  allow = 0;
-	      }
-	    } else {
-	      Swig_error(Getfile(s), Getline(id), "Missing expression for #elif.\n");
-	      allow = 0;
-	    }
-	    expand_defined_operator = 0;
-	  }
-	}
+        if (level == 0) {
+          Swig_error(Getfile(s), Getline(id), "Misplaced #elif.\n");
+        } else {
+          cond_lines[level - 1] = Getline(id);
+          if (allow) {
+            allow = 0;
+            mask = 0;
+          } else if (level == start_level) {
+            int val;
+            String *sval;
+            expand_defined_operator = 1;
+            sval = Preprocessor_replace(value, NULL);
+            Seek(sval, 0, SEEK_SET);
+            if (Len(sval) > 0) {
+              val = Preprocessor_expr(sval, &e);
+              if (e) {
+                const char *msg = Preprocessor_expr_error();
+                Seek(value, 0, SEEK_SET);
+                Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "Could not evaluate expression '%s'\n", value);
+                if (msg)
+                  Swig_warning(WARN_PP_EVALUATION, Getfile(value), Getline(value), "%s\n", msg);
+                allow = 0;
+              } else {
+                if (val)
+                  allow = 1 * mask;
+                else
+                  allow = 0;
+              }
+            } else {
+              Swig_error(Getfile(s), Getline(id), "Missing expression for #elif.\n");
+              allow = 0;
+            }
+            expand_defined_operator = 0;
+          }
+        }
       } else if (Equal(id, kpp_warning)) {
-	if (allow) {
-	  Swig_warning(WARN_PP_CPP_WARNING, Getfile(s), Getline(id), "CPP #warning, \"%s\".\n", value);
-	}
+        if (allow) {
+          Swig_warning(WARN_PP_CPP_WARNING, Getfile(s), Getline(id), "CPP #warning, \"%s\".\n", value);
+        }
       } else if (Equal(id, kpp_error)) {
-	if (allow) {
-	  if (error_as_warning) {
-	    Swig_warning(WARN_PP_CPP_ERROR, Getfile(s), Getline(id), "CPP #error \"%s\".\n", value);
-	  } else {
-	    Swig_error(Getfile(s), Getline(id), "CPP #error \"%s\". Use the -cpperraswarn option to continue swig processing.\n", value);
-	  }
-	}
+        if (allow) {
+          if (error_as_warning) {
+            Swig_warning(WARN_PP_CPP_ERROR, Getfile(s), Getline(id), "CPP #error \"%s\".\n", value);
+          } else {
+            Swig_error(Getfile(s), Getline(id), "CPP #error \"%s\". Use the -cpperraswarn option to continue swig processing.\n", value);
+          }
+        }
       } else if (Equal(id, kpp_line)) {
       } else if (Equal(id, kpp_include)) {
-	if (((include_all) || (import_all)) && (allow)) {
-	  String *s1, *s2, *fn;
-	  String *dirname;
-	  int sysfile = 0;
-	  if (include_all && import_all) {
-	    Swig_warning(WARN_PP_INCLUDEALL_IMPORTALL, Getfile(s), Getline(id), "Both includeall and importall are defined: using includeall.\n");
-	    import_all = 0;
-	  }
-	  Seek(value, 0, SEEK_SET);
-	  fn = get_filename(value, &sysfile);
-	  s1 = cpp_include(fn, sysfile);
-	  if (s1) {
-	    if (include_all)
-	      Printf(ns, "%%includefile \"%s\" %%beginfile\n", Swig_filename_escape(Swig_last_file()));
-	    else if (import_all) {
-	      Printf(ns, "%%importfile \"%s\" %%beginfile\n", Swig_filename_escape(Swig_last_file()));
-	      push_imported();
-	    }
+        if (((include_all) || (import_all)) && (allow)) {
+          String *s1, *s2, *fn;
+          String *dirname;
+          int sysfile = 0;
+          if (include_all && import_all) {
+            Swig_warning(WARN_PP_INCLUDEALL_IMPORTALL, Getfile(s), Getline(id), "Both includeall and importall are defined: using includeall.\n");
+            import_all = 0;
+          }
+          Seek(value, 0, SEEK_SET);
+          fn = get_filename(value, &sysfile);
+          s1 = cpp_include(fn, sysfile);
+          if (s1) {
+            if (include_all)
+              Printf(ns, "%%includefile \"%s\" %%beginfile\n", Swig_filename_escape(Swig_last_file()));
+            else if (import_all) {
+              Printf(ns, "%%importfile \"%s\" %%beginfile\n", Swig_filename_escape(Swig_last_file()));
+              push_imported();
+            }
 
-	    /* See if the filename has a directory component */
-	    dirname = Swig_file_dirname(Swig_last_file());
-	    if (sysfile || !Len(dirname)) {
-	      Delete(dirname);
-	      dirname = 0;
-	    }
-	    if (dirname) {
-	      int len = Len(dirname);
-	      Delslice(dirname, len - 1, len); /* Kill trailing directory delimiter */
-	      Swig_push_directory(dirname);
-	    }
-	    s2 = Preprocessor_parse(s1);
-	    addline(ns, s2, allow);
-	    Append(ns, "%endoffile");
-	    if (dirname) {
-	      Swig_pop_directory();
-	    }
-	    if (import_all) {
-	      pop_imported();
-	    }
-	    Delete(s2);
-	    Delete(dirname);
-	    Delete(s1);
-	  }
-	  Delete(fn);
-	}
+            /* See if the filename has a directory component */
+            dirname = Swig_file_dirname(Swig_last_file());
+            if (sysfile || !Len(dirname)) {
+              Delete(dirname);
+              dirname = 0;
+            }
+            if (dirname) {
+              int len = Len(dirname);
+              Delslice(dirname, len - 1, len); /* Kill trailing directory delimiter */
+              Swig_push_directory(dirname);
+            }
+            s2 = Preprocessor_parse(s1);
+            addline(ns, s2, allow);
+            Append(ns, "%endoffile");
+            if (dirname) {
+              Swig_pop_directory();
+            }
+            if (import_all) {
+              pop_imported();
+            }
+            Delete(s2);
+            Delete(dirname);
+            Delete(s1);
+          }
+          Delete(fn);
+        }
       } else if (Equal(id, kpp_pragma)) {
-	if (Strncmp(value, "SWIG ", 5) == 0) {
-	  char *c = Char(value) + 5;
-	  while (*c && (isspace((int) *c)))
-	    c++;
-	  if (*c) {
-	    if (strncmp(c, "nowarn=", 7) == 0) {
-	      String *val = NewString(c + 7);
-	      String *nowarn = Preprocessor_replace(val, NULL);
-	      Swig_warnfilter(nowarn, 1);
-	      Delete(nowarn);
-	      Delete(val);
-	    } else if (strncmp(c, "cpperraswarn=", 13) == 0) {
-	      error_as_warning = atoi(c + 13);
-	    } else {
+        if (Strncmp(value, "SWIG ", 5) == 0) {
+          char *c = Char(value) + 5;
+          while (*c && (isspace((int) *c)))
+            c++;
+          if (*c) {
+            if (strncmp(c, "nowarn=", 7) == 0) {
+              String *val = NewString(c + 7);
+              String *nowarn = Preprocessor_replace(val, NULL);
+              Swig_warnfilter(nowarn, 1);
+              Delete(nowarn);
+              Delete(val);
+            } else if (strncmp(c, "cpperraswarn=", 13) == 0) {
+              error_as_warning = atoi(c + 13);
+            } else {
               Swig_error(Getfile(s), Getline(id), "Unknown SWIG pragma: %s\n", c);
             }
-	  }
-	}
+          }
+        }
       } else if (Equal(id, kpp_level)) {
-	Swig_error(Getfile(s), Getline(id), "cpp debug: level = %d, startlevel = %d\n", level, start_level);
+        Swig_error(Getfile(s), Getline(id), "cpp debug: level = %d, startlevel = %d\n", level, start_level);
       } else if (Equal(id, "")) {
-	/* Null directive */
+        /* Null directive */
       } else if (is_digits(id)) {
-	/* A gcc linemarker of the form '# linenum filename flags' (resulting from running gcc -E) */
+        /* A gcc linemarker of the form '# linenum filename flags' (resulting from running gcc -E) */
       } else {
-	/* Ignore unknown preprocessor directives which are inside an inactive
-	 * conditional (github issue #394). */
-	if (allow)
-	  Swig_error(Getfile(s), Getline(id), "Unknown SWIG preprocessor directive: %s (if this is a block of target language code, delimit it with %%{ and %%})\n", id);
+        /* Ignore unknown preprocessor directives which are inside an inactive
+         * conditional (github issue #394). */
+        if (allow)
+          Swig_error(Getfile(s), Getline(id), "Unknown SWIG preprocessor directive: %s (if this is a block of target language code, delimit it with %%{ and %%})\n", id);
       }
       for (i = 0; i < cpp_lines; i++)
-	Putc('\n', ns);
+        Putc('\n', ns);
       state = 0;
       break;
 
@@ -1947,56 +1947,56 @@ state1:
     case 100:
       /* %{,%} block  */
       if (c == '{') {
-	start_line = Getline(s);
-	copy_location(s, chunk);
-	add_chunk(ns, chunk, allow);
-	Putc('%', chunk);
-	Putc(c, chunk);
-	state = 105;
+        start_line = Getline(s);
+        copy_location(s, chunk);
+        add_chunk(ns, chunk, allow);
+        Putc('%', chunk);
+        Putc(c, chunk);
+        state = 105;
       }
       /* %#cpp -  an embedded C preprocessor directive (we strip off the %)  */
       else if (c == '#') {
-	add_chunk(ns, chunk, allow);
-	Putc(c, chunk);
-	state = 107;
+        add_chunk(ns, chunk, allow);
+        Putc(c, chunk);
+        state = 107;
       } else if (isidentifier(c)) {
-	Clear(decl);
-	Putc('%', decl);
-	Putc(c, decl);
-	state = 110;
+        Clear(decl);
+        Putc('%', decl);
+        Putc(c, decl);
+        state = 110;
       } else {
-	Putc('%', chunk);
-	Putc(c, chunk);
-	state = 1;
+        Putc('%', chunk);
+        Putc(c, chunk);
+        state = 1;
       }
       break;
 
     case 105:
       Putc(c, chunk);
       if (c == '%')
-	state = 106;
+        state = 106;
       break;
 
     case 106:
       Putc(c, chunk);
       if (c == '}') {
-	state = 1;
-	addline(ns, chunk, allow);
-	Clear(chunk);
-	copy_location(s, chunk);
+        state = 1;
+        addline(ns, chunk, allow);
+        Clear(chunk);
+        copy_location(s, chunk);
       } else {
-	state = 105;
+        state = 105;
       }
       break;
 
     case 107:
       Putc(c, chunk);
       if (c == '\n') {
-	addline(ns, chunk, allow);
-	Clear(chunk);
-	state = 0;
+        addline(ns, chunk, allow);
+        Clear(chunk);
+        state = 0;
       } else if (c == '\\') {
-	state = 108;
+        state = 108;
       }
       break;
 
@@ -2007,59 +2007,59 @@ state1:
 
     case 110:
       if (!isidchar(c)) {
-	Ungetc(c, s);
-	/* Look for common SWIG directives  */
-	if (Equal(decl, kpp_dinclude) || Equal(decl, kpp_dimport)) {
-	  /* Got some kind of file inclusion directive, eg: %import(option1="value1") "filename" */
-	  if (allow) {
-	    DOH *s1, *s2, *fn, *opt;
-	    String *options_whitespace = NewStringEmpty();
-	    String *filename_whitespace = NewStringEmpty();
-	    int sysfile = 0;
+        Ungetc(c, s);
+        /* Look for common SWIG directives  */
+        if (Equal(decl, kpp_dinclude) || Equal(decl, kpp_dimport)) {
+          /* Got some kind of file inclusion directive, eg: %import(option1="value1") "filename" */
+          if (allow) {
+            DOH *s1, *s2, *fn, *opt;
+            String *options_whitespace = NewStringEmpty();
+            String *filename_whitespace = NewStringEmpty();
+            int sysfile = 0;
 
-	    skip_whitespace(s, options_whitespace);
-	    opt = get_options(s);
+            skip_whitespace(s, options_whitespace);
+            opt = get_options(s);
 
-	    skip_whitespace(s, filename_whitespace);
-	    fn = get_filename(s, &sysfile);
-	    s1 = cpp_include(fn, sysfile);
-	    if (s1) {
-	      String *dirname;
-	      copy_location(s, chunk);
-	      add_chunk(ns, chunk, allow);
-	      Printf(ns, "%sfile%s%s%s\"%s\" %%beginfile\n", decl, options_whitespace, opt, filename_whitespace, Swig_filename_escape(Swig_last_file()));
-	      if (Equal(decl, kpp_dimport)) {
-		push_imported();
-	      }
-	      dirname = Swig_file_dirname(Swig_last_file());
-	      if (sysfile || !Len(dirname)) {
-		Delete(dirname);
-		dirname = 0;
-	      }
-	      if (dirname) {
-		int len = Len(dirname);
-		Delslice(dirname, len - 1, len); /* Kill trailing directory delimiter */
-		Swig_push_directory(dirname);
-	      }
-	      s2 = Preprocessor_parse(s1);
-	      if (dirname) {
-		Swig_pop_directory();
-	      }
-	      if (Equal(decl, kpp_dimport)) {
-		pop_imported();
-	      }
-	      addline(ns, s2, allow);
-	      Append(ns, "%endoffile");
-	      Delete(s2);
-	      Delete(dirname);
-	      Delete(s1);
-	    }
-	    Delete(fn);
-	    Delete(filename_whitespace);
-	    Delete(options_whitespace);
-	  }
-	  state = 1;
-	} else if (Equal(decl, kpp_dbeginfile)) {
+            skip_whitespace(s, filename_whitespace);
+            fn = get_filename(s, &sysfile);
+            s1 = cpp_include(fn, sysfile);
+            if (s1) {
+              String *dirname;
+              copy_location(s, chunk);
+              add_chunk(ns, chunk, allow);
+              Printf(ns, "%sfile%s%s%s\"%s\" %%beginfile\n", decl, options_whitespace, opt, filename_whitespace, Swig_filename_escape(Swig_last_file()));
+              if (Equal(decl, kpp_dimport)) {
+                push_imported();
+              }
+              dirname = Swig_file_dirname(Swig_last_file());
+              if (sysfile || !Len(dirname)) {
+                Delete(dirname);
+                dirname = 0;
+              }
+              if (dirname) {
+                int len = Len(dirname);
+                Delslice(dirname, len - 1, len); /* Kill trailing directory delimiter */
+                Swig_push_directory(dirname);
+              }
+              s2 = Preprocessor_parse(s1);
+              if (dirname) {
+                Swig_pop_directory();
+              }
+              if (Equal(decl, kpp_dimport)) {
+                pop_imported();
+              }
+              addline(ns, s2, allow);
+              Append(ns, "%endoffile");
+              Delete(s2);
+              Delete(dirname);
+              Delete(s1);
+            }
+            Delete(fn);
+            Delete(filename_whitespace);
+            Delete(options_whitespace);
+          }
+          state = 1;
+        } else if (Equal(decl, kpp_dbeginfile)) {
           /* Got an internal directive marking the beginning of an included file: %beginfile ... %endoffile */
           filelevel++;
           start_line = Getline(s);
@@ -2067,23 +2067,23 @@ state1:
           add_chunk(ns, chunk, allow);
           Append(chunk, decl);
           state = 120;
-	} else if (Equal(decl, kpp_dline)) {
-	  /* Got a line directive  */
-	  state = 1;
-	} else if (Equal(decl, kpp_ddefine)) {
-	  /* Got a define directive  */
-	  dlevel++;
-	  copy_location(s, chunk);
-	  add_chunk(ns, chunk, allow);
-	  Clear(value);
-	  copy_location(s, value);
-	  state = 150;
-	} else {
-	  Append(chunk, decl);
-	  state = 1;
-	}
+        } else if (Equal(decl, kpp_dline)) {
+          /* Got a line directive  */
+          state = 1;
+        } else if (Equal(decl, kpp_ddefine)) {
+          /* Got a define directive  */
+          dlevel++;
+          copy_location(s, chunk);
+          add_chunk(ns, chunk, allow);
+          Clear(value);
+          copy_location(s, value);
+          state = 150;
+        } else {
+          Append(chunk, decl);
+          state = 1;
+        }
       } else {
-	Putc(c, decl);
+        Putc(c, decl);
       }
       break;
 
@@ -2099,15 +2099,15 @@ state1:
           c = Getc(s);
           Putc(c, chunk);
           statement[i++] = (char)c;
-	  if (strncmp(statement, bf, i) && strncmp(statement, ef, i))
-	    break;
-	}
-	c = Getc(s);
-	Ungetc(c, s);
+          if (strncmp(statement, bf, i) && strncmp(statement, ef, i))
+            break;
+        }
+        c = Getc(s);
+        Ungetc(c, s);
         if ((i == 9) && (isspace(c))) {
-	  if (strncmp(statement, bf, i) == 0) {
-	    ++filelevel;
-	  } else if (strncmp(statement, ef, i) == 0) {
+          if (strncmp(statement, bf, i) == 0) {
+            ++filelevel;
+          } else if (strncmp(statement, ef, i) == 0) {
             --filelevel;
             if (!filelevel) {
               /* Reached end of included file */
@@ -2125,40 +2125,40 @@ state1:
     case 150:
       Putc(c, value);
       if (c == '%') {
-	const char *ed = "enddef";
-	const char *df = "define";
-	char statement[7];
-	int i = 0;
-	for (i = 0; i < 6;) {
-	  c = Getc(s);
-	  Putc(c, value);
-	  statement[i++] = (char)c;
-	  if (strncmp(statement, ed, i) && strncmp(statement, df, i))
-	    break;
-	}
-	c = Getc(s);
-	Ungetc(c, s);
-	if ((i == 6) && (isspace(c))) {
-	  if (strncmp(statement, df, i) == 0) {
-	    ++dlevel;
-	  } else {
-	    if (strncmp(statement, ed, i) == 0) {
-	      --dlevel;
-	      if (!dlevel) {
-		/* Got the macro  */
-		for (i = 0; i < 7; i++) {
-		  Delitem(value, DOH_END);
-		}
-		if (allow) {
-		  Seek(value, 0, SEEK_SET);
-		  Preprocessor_define(value, 1);
-		}
-		addline(ns, value, 0);
-		state = 0;
-	      }
-	    }
-	  }
-	}
+        const char *ed = "enddef";
+        const char *df = "define";
+        char statement[7];
+        int i = 0;
+        for (i = 0; i < 6;) {
+          c = Getc(s);
+          Putc(c, value);
+          statement[i++] = (char)c;
+          if (strncmp(statement, ed, i) && strncmp(statement, df, i))
+            break;
+        }
+        c = Getc(s);
+        Ungetc(c, s);
+        if ((i == 6) && (isspace(c))) {
+          if (strncmp(statement, df, i) == 0) {
+            ++dlevel;
+          } else {
+            if (strncmp(statement, ed, i) == 0) {
+              --dlevel;
+              if (!dlevel) {
+                /* Got the macro  */
+                for (i = 0; i < 7; i++) {
+                  Delitem(value, DOH_END);
+                }
+                if (allow) {
+                  Seek(value, 0, SEEK_SET);
+                  Preprocessor_define(value, 1);
+                }
+                addline(ns, value, 0);
+                state = 0;
+              }
+            }
+          }
+        }
       }
       break;
     default:

--- a/Source/Preprocessor/cpp.c
+++ b/Source/Preprocessor/cpp.c
@@ -21,26 +21,26 @@
 #include "preprocessor.h"
 #include <ctype.h>
 
-static Hash *cpp = 0;           /* C preprocessor data */
-static int include_all = 0;     /* Follow all includes */
+static Hash *cpp = 0;       /* C preprocessor data */
+static int include_all = 0; /* Follow all includes */
 static int ignore_missing = 0;
-static int import_all = 0;      /* Follow all includes, but as %import statements */
-static int imported_depth = 0;  /* Depth of %imported files */
-static int single_include = 1;  /* Only include each file once */
+static int import_all = 0;     /* Follow all includes, but as %import statements */
+static int imported_depth = 0; /* Depth of %imported files */
+static int single_include = 1; /* Only include each file once */
 static Hash *included_files = 0;
 static List *dependencies = 0;
 static Scanner *id_scan = 0;
-static int error_as_warning = 0;        /* Understand the cpp #error directive as a special #warning */
+static int error_as_warning = 0; /* Understand the cpp #error directive as a special #warning */
 static int expand_defined_operator = 0;
 static int macro_level = 0;
 static int macro_start_line = 0;
-static const String * macro_start_file = 0;
+static const String *macro_start_file = 0;
 
 /* Test a character to see if it starts an identifier */
 #define isidentifier(c) ((isalpha(c)) || (c == '_') || (c == '$'))
 
 /* Test a character to see if it valid in an identifier (after the first letter) */
-#define isidchar(c) ((isalnum(c)) || (c == '_') || (c == '$'))
+#define isidchar(c)     ((isalnum(c)) || (c == '_') || (c == '$'))
 
 static DOH *Preprocessor_replace(DOH *, DOH *);
 
@@ -80,8 +80,8 @@ static int skip_tochar_or_eol(String *s, int ch, String *out) {
   int c;
   while ((c = Getc(s)) != EOF) {
     if (c == '\n') {
-        Ungetc(c, s);
-        break;
+      Ungetc(c, s);
+      break;
     }
     if (out)
       Putc(c, out);
@@ -99,8 +99,8 @@ static int skip_tochar_or_eol(String *s, int ch, String *out) {
 }
 
 static void copy_location(const DOH *s1, DOH *s2) {
-  Setfile(s2, Getfile((DOH *) s1));
-  Setline(s2, Getline((DOH *) s1));
+  Setfile(s2, Getfile((DOH *)s1));
+  Setline(s2, Getline((DOH *)s1));
 }
 
 static String *cpp_include(const_String_or_char_ptr fn, int sysfile) {
@@ -219,7 +219,6 @@ void Preprocessor_init(void) {
   kpp_ddefine = NewString("%define");
   kpp_dline = NewString("%line");
 
-
   kpp_LINE = NewString("__LINE__");
   kpp_FILE = NewString("__FILE__");
 
@@ -230,11 +229,10 @@ void Preprocessor_init(void) {
   s = NewHash();
   Setattr(cpp, kpp_symbols, s);
   Delete(s);
-  Preprocessor_expr_init();     /* Initialize the expression evaluator */
+  Preprocessor_expr_init(); /* Initialize the expression evaluator */
   included_files = NewHash();
 
   id_scan = NewScanner();
-
 }
 
 void Preprocessor_delete(void) {
@@ -302,14 +300,12 @@ void Preprocessor_error_as_warning(int a) {
   error_as_warning = a;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Preprocessor_define()
  *
  * Defines a new C preprocessor symbol.   swigmacro specifies whether or not the macro has
  * SWIG macro semantics.
  * ----------------------------------------------------------------------------- */
-
 
 static String *Macro_vararg_name(const_String_or_char_ptr str, const_String_or_char_ptr line) {
   String *varargname;
@@ -350,7 +346,7 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
     copy_location(_str, s);
     str = s;
   } else {
-    str = NewString((char *) _str);
+    str = NewString((char *)_str);
   }
   Seek(str, 0, SEEK_SET);
   line = Getline(str);
@@ -514,8 +510,10 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
 
   /* Get rid of whitespace surrounding # */
   /*  Replace(macrovalue,"#","\001",DOH_REPLACE_NOQUOTE); */
-  while (Replace(macrovalue, "\001 ", "\001", DOH_REPLACE_ANY) > 0) { }
-  while (Replace(macrovalue, " \001", "\001", DOH_REPLACE_ANY) > 0) { }
+  while (Replace(macrovalue, "\001 ", "\001", DOH_REPLACE_ANY) > 0) {
+  }
+  while (Replace(macrovalue, " \001", "\001", DOH_REPLACE_ANY) > 0) {
+  }
   /* Replace '##' with a special token */
   Replace(macrovalue, "\001\001", "\002", DOH_REPLACE_ANY);
   /* Replace '#@' with a special token */
@@ -524,7 +522,7 @@ Hash *Preprocessor_define(const_String_or_char_ptr _str, int swigmacro) {
   Replace(macrovalue, "\002@", "\005", DOH_REPLACE_ANY);
   if (varargs) {
     /* Replace '__VA_OPT__' with a special token */
-    Replace(macrovalue, "__VA_OPT__", "\006", DOH_REPLACE_ID|DOH_REPLACE_ANY);
+    Replace(macrovalue, "__VA_OPT__", "\006", DOH_REPLACE_ID | DOH_REPLACE_ANY);
   }
 
   /* Go create the macro */
@@ -629,7 +627,7 @@ static List *find_args(String *s, int ismacro, String *macro_name) {
   /* Okay.  This appears to be a macro so we will start isolating arguments */
   while (c != EOF) {
     if (isspace(c)) {
-      skip_whitespace(s, 0);    /* Skip leading whitespace */
+      skip_whitespace(s, 0); /* Skip leading whitespace */
       c = Getc(s);
     }
     str = NewStringEmpty();
@@ -657,7 +655,8 @@ another_star:
               c = Getc(s);
               if (c == '/' || c == EOF)
                 break;
-              if (c == '*') goto another_star;
+              if (c == '*')
+                goto another_star;
             }
           }
           c = Getc(s);
@@ -667,7 +666,7 @@ another_star:
         if (c == '/') {
           while ((c = Getc(s)) != EOF) {
             if (c == '\n') {
-                break;
+              break;
             }
           }
           c = Getc(s);
@@ -770,31 +769,31 @@ static String *get_options(String *str) {
     while (((c = Getc(str)) != EOF)) {
       Putc(c, opt);
       switch (c) {
-        case ')':
-          level--;
-          if (!level)
-            return opt;
-          break;
-        case '(':
-          level++;
-          break;
-        case '"':
-          /* Skip over quoted strings */
-          while (1) {
+      case ')':
+        level--;
+        if (!level)
+          return opt;
+        break;
+      case '(':
+        level++;
+        break;
+      case '"':
+        /* Skip over quoted strings */
+        while (1) {
+          c = Getc(str);
+          if (c == EOF)
+            goto bad;
+          Putc(c, opt);
+          if (c == '"')
+            break;
+          if (c == '\\') {
             c = Getc(str);
             if (c == EOF)
               goto bad;
             Putc(c, opt);
-            if (c == '"')
-              break;
-            if (c == '\\') {
-              c = Getc(str);
-              if (c == EOF)
-                goto bad;
-              Putc(c, opt);
-            }
           }
-          break;
+        }
+        break;
       }
     }
 bad:
@@ -930,9 +929,9 @@ static String *expand_macro(String *name, List *args, String *line_file) {
     for (i = 0; i < l; i++) {
       DOH *arg, *aname;
       String *reparg;
-      arg = Getitem(args, i);   /* Get an argument value */
+      arg = Getitem(args, i); /* Get an argument value */
       reparg = Preprocessor_replace(arg, NULL);
-      aname = Getitem(margs, i);        /* Get macro argument name */
+      aname = Getitem(margs, i); /* Get macro argument name */
       if (strchr(Char(ns), '\001')) {
         /* Try to replace a quoted version of the argument */
         Clear(temp);
@@ -946,13 +945,15 @@ static String *expand_macro(String *name, List *args, String *line_file) {
         char *a = s;
         while ((a = strchr(a, '\006')) != NULL) {
           *a = ' ';
-          while (isspace((unsigned char)*++a)) { }
+          while (isspace((unsigned char)*++a)) {
+          }
           if (*a == '(') {
             char *e = a;
             int depth = 1;
             while (*++e) {
               if (*e == ')') {
-                if (--depth == 0) break;
+                if (--depth == 0)
+                  break;
               } else if (*e == '(') {
                 ++depth;
               }
@@ -990,7 +991,8 @@ static String *expand_macro(String *name, List *args, String *line_file) {
             char *t = a;
             while (--t >= s) {
               if (!isspace((unsigned char)*t)) {
-                if (*t == ',') *t = ' ';
+                if (*t == ',')
+                  *t = ' ';
                 break;
               }
             }
@@ -1047,14 +1049,14 @@ static String *expand_macro(String *name, List *args, String *line_file) {
       }
 
       /*      Replace(ns, aname, arg, DOH_REPLACE_ID); */
-      Replace(ns, aname, reparg, DOH_REPLACE_ID);       /* Replace expanded args */
-      Replace(ns, "\003", arg, DOH_REPLACE_ANY);        /* Replace unexpanded arg */
+      Replace(ns, aname, reparg, DOH_REPLACE_ID); /* Replace expanded args */
+      Replace(ns, "\003", arg, DOH_REPLACE_ANY);  /* Replace unexpanded arg */
       Delete(reparg);
     }
   }
-  Replace(ns, "\002", "", DOH_REPLACE_ANY);     /* Get rid of concatenation tokens */
-  Replace(ns, "\001", "#", DOH_REPLACE_ANY);    /* Put # back (non-standard C) */
-  Replace(ns, "\004", "#@", DOH_REPLACE_ANY);   /* Put # back (non-standard C) */
+  Replace(ns, "\002", "", DOH_REPLACE_ANY);   /* Get rid of concatenation tokens */
+  Replace(ns, "\001", "#", DOH_REPLACE_ANY);  /* Put # back (non-standard C) */
+  Replace(ns, "\004", "#@", DOH_REPLACE_ANY); /* Put # back (non-standard C) */
 
   /* Expand this macro even further */
   Setattr(macro, kpp_expanded, "1");
@@ -1169,7 +1171,7 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
         state = 4;
       }
       break;
-    case 4:                     /* An identifier */
+    case 4: /* An identifier */
       if (isidchar(c)) {
         Putc(c, id);
         state = 4;
@@ -1257,9 +1259,11 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
               Putc(c, arg);
             }
             if (Equal("#ifdef", id)) {
-              if (Getattr(symbols, arg)) allow = 1;
+              if (Getattr(symbols, arg))
+                allow = 1;
             } else {
-              if (!Getattr(symbols, arg)) allow = 1;
+              if (!Getattr(symbols, arg))
+                allow = 1;
             }
             Delete(arg);
           } else {
@@ -1385,7 +1389,6 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
   return ns;
 }
 
-
 /* -----------------------------------------------------------------------------
  * int checkpp_id(DOH *s)
  *
@@ -1458,7 +1461,6 @@ static void pop_imported(void) {
   }
 }
 
-
 /* -----------------------------------------------------------------------------
  * Preprocessor_parse()
  *
@@ -1473,7 +1475,7 @@ static void pop_imported(void) {
  * ----------------------------------------------------------------------------- */
 
 String *Preprocessor_parse(String *s) {
-  String *ns;                   /* New string containing the preprocessed text */
+  String *ns; /* New string containing the preprocessed text */
   String *chunk, *decl;
   Hash *symbols;
   String *id = 0, *value = 0, *comment = 0;
@@ -1491,7 +1493,7 @@ String *Preprocessor_parse(String *s) {
   /* Blow away all carriage returns */
   Replace(s, "\015", "", DOH_REPLACE_ANY);
 
-  ns = NewStringEmpty();        /* Return result */
+  ns = NewStringEmpty(); /* Return result */
 
   decl = NewStringEmpty();
   id = NewStringEmpty();
@@ -1505,7 +1507,7 @@ String *Preprocessor_parse(String *s) {
   state = 0;
   while ((c = Getc(s)) != EOF) {
     switch (state) {
-    case 0:                     /* Initial state - in first column */
+    case 0: /* Initial state - in first column */
       /* Look for C preprocessor directives.   Otherwise, go directly to state 1 */
       if (c == '#') {
         copy_location(s, chunk);
@@ -1520,32 +1522,33 @@ String *Preprocessor_parse(String *s) {
         Ungetc(c, s);
       }
       break;
-    case 1: {                   /* Non-preprocessor directive */
-      /* Look for SWIG directives */
+    case 1:
+      { /* Non-preprocessor directive */
+        /* Look for SWIG directives */
 state1:
-      if (c == '%') {
-        state = 100;
+        if (c == '%') {
+          state = 100;
+          break;
+        }
+        Putc(c, chunk);
+        if (c == '\n')
+          state = 0;
+        else if (c == '\"') {
+          start_line = Getline(s);
+          if (skip_tochar(s, '\"', chunk) < 0) {
+            Swig_error(Getfile(s), start_line, "Unterminated string constant\n");
+          }
+        } else if (c == '\'') {
+          start_line = Getline(s);
+          if (skip_tochar(s, '\'', chunk) < 0) {
+            Swig_error(Getfile(s), start_line, "Unterminated character constant\n");
+          }
+        } else if (c == '/')
+          state = 30; /* Comment */
         break;
       }
-      Putc(c, chunk);
-      if (c == '\n')
-        state = 0;
-      else if (c == '\"') {
-        start_line = Getline(s);
-        if (skip_tochar(s, '\"', chunk) < 0) {
-          Swig_error(Getfile(s), start_line, "Unterminated string constant\n");
-        }
-      } else if (c == '\'') {
-        start_line = Getline(s);
-        if (skip_tochar(s, '\'', chunk) < 0) {
-          Swig_error(Getfile(s), start_line, "Unterminated character constant\n");
-        }
-      } else if (c == '/')
-        state = 30;             /* Comment */
-      break;
-    }
 
-    case 30:                    /* Possibly a comment string of some sort */
+    case 30: /* Possibly a comment string of some sort */
       start_line = Getline(s);
       if (c == '/')
         state = 31;
@@ -1575,7 +1578,7 @@ state1:
         state = 32;
       break;
 
-    case 40:                    /* Start of a C preprocessor directive */
+    case 40: /* Start of a C preprocessor directive */
       if (c == '\n') {
         Putc('\n', chunk);
         state = 0;
@@ -1590,7 +1593,7 @@ state1:
       }
       break;
 
-    case 41:                    /* Build up the name of the preprocessor directive */
+    case 41: /* Build up the name of the preprocessor directive */
       if ((isspace(c) || (!isidchar(c)))) {
         Clear(value);
         Clear(comment);
@@ -1610,7 +1613,7 @@ state1:
       Putc(c, id);
       break;
 
-    case 42:                    /* Strip any leading space after the preprocessor directive (before preprocessor value) */
+    case 42: /* Strip any leading space after the preprocessor directive (before preprocessor value) */
       if (isspace(c)) {
         if (c == '\n') {
           Ungetc(c, s);
@@ -1910,7 +1913,7 @@ state1:
       } else if (Equal(id, kpp_pragma)) {
         if (Strncmp(value, "SWIG ", 5) == 0) {
           char *c = Char(value) + 5;
-          while (*c && (isspace((int) *c)))
+          while (*c && (isspace((int)*c)))
             c++;
           if (*c) {
             if (strncmp(c, "nowarn=", 7) == 0) {
@@ -1936,7 +1939,8 @@ state1:
         /* Ignore unknown preprocessor directives which are inside an inactive
          * conditional (github issue #394). */
         if (allow)
-          Swig_error(Getfile(s), Getline(id), "Unknown SWIG preprocessor directive: %s (if this is a block of target language code, delimit it with %%{ and %%})\n", id);
+          Swig_error(
+            Getfile(s), Getline(id), "Unknown SWIG preprocessor directive: %s (if this is a block of target language code, delimit it with %%{ and %%})\n", id);
       }
       for (i = 0; i < cpp_lines; i++)
         Putc('\n', ns);

--- a/Source/Preprocessor/cpp.c
+++ b/Source/Preprocessor/cpp.c
@@ -21,16 +21,16 @@
 #include "preprocessor.h"
 #include <ctype.h>
 
-static Hash *cpp = 0;		/* C preprocessor data */
-static int include_all = 0;	/* Follow all includes */
+static Hash *cpp = 0;           /* C preprocessor data */
+static int include_all = 0;     /* Follow all includes */
 static int ignore_missing = 0;
-static int import_all = 0;	/* Follow all includes, but as %import statements */
-static int imported_depth = 0;	/* Depth of %imported files */
-static int single_include = 1;	/* Only include each file once */
+static int import_all = 0;      /* Follow all includes, but as %import statements */
+static int imported_depth = 0;  /* Depth of %imported files */
+static int single_include = 1;  /* Only include each file once */
 static Hash *included_files = 0;
 static List *dependencies = 0;
 static Scanner *id_scan = 0;
-static int error_as_warning = 0;	/* Understand the cpp #error directive as a special #warning */
+static int error_as_warning = 0;        /* Understand the cpp #error directive as a special #warning */
 static int expand_defined_operator = 0;
 static int macro_level = 0;
 static int macro_start_line = 0;
@@ -230,7 +230,7 @@ void Preprocessor_init(void) {
   s = NewHash();
   Setattr(cpp, kpp_symbols, s);
   Delete(s);
-  Preprocessor_expr_init();	/* Initialize the expression evaluator */
+  Preprocessor_expr_init();     /* Initialize the expression evaluator */
   included_files = NewHash();
 
   id_scan = NewScanner();
@@ -629,7 +629,7 @@ static List *find_args(String *s, int ismacro, String *macro_name) {
   /* Okay.  This appears to be a macro so we will start isolating arguments */
   while (c != EOF) {
     if (isspace(c)) {
-      skip_whitespace(s, 0);	/* Skip leading whitespace */
+      skip_whitespace(s, 0);    /* Skip leading whitespace */
       c = Getc(s);
     }
     str = NewStringEmpty();
@@ -930,9 +930,9 @@ static String *expand_macro(String *name, List *args, String *line_file) {
     for (i = 0; i < l; i++) {
       DOH *arg, *aname;
       String *reparg;
-      arg = Getitem(args, i);	/* Get an argument value */
+      arg = Getitem(args, i);   /* Get an argument value */
       reparg = Preprocessor_replace(arg, NULL);
-      aname = Getitem(margs, i);	/* Get macro argument name */
+      aname = Getitem(margs, i);        /* Get macro argument name */
       if (strchr(Char(ns), '\001')) {
         /* Try to replace a quoted version of the argument */
         Clear(temp);
@@ -1047,14 +1047,14 @@ static String *expand_macro(String *name, List *args, String *line_file) {
       }
 
       /*      Replace(ns, aname, arg, DOH_REPLACE_ID); */
-      Replace(ns, aname, reparg, DOH_REPLACE_ID);	/* Replace expanded args */
-      Replace(ns, "\003", arg, DOH_REPLACE_ANY);	/* Replace unexpanded arg */
+      Replace(ns, aname, reparg, DOH_REPLACE_ID);       /* Replace expanded args */
+      Replace(ns, "\003", arg, DOH_REPLACE_ANY);        /* Replace unexpanded arg */
       Delete(reparg);
     }
   }
-  Replace(ns, "\002", "", DOH_REPLACE_ANY);	/* Get rid of concatenation tokens */
-  Replace(ns, "\001", "#", DOH_REPLACE_ANY);	/* Put # back (non-standard C) */
-  Replace(ns, "\004", "#@", DOH_REPLACE_ANY);	/* Put # back (non-standard C) */
+  Replace(ns, "\002", "", DOH_REPLACE_ANY);     /* Get rid of concatenation tokens */
+  Replace(ns, "\001", "#", DOH_REPLACE_ANY);    /* Put # back (non-standard C) */
+  Replace(ns, "\004", "#@", DOH_REPLACE_ANY);   /* Put # back (non-standard C) */
 
   /* Expand this macro even further */
   Setattr(macro, kpp_expanded, "1");
@@ -1169,7 +1169,7 @@ static DOH *Preprocessor_replace(DOH *s, DOH *line_file) {
         state = 4;
       }
       break;
-    case 4:			/* An identifier */
+    case 4:                     /* An identifier */
       if (isidchar(c)) {
         Putc(c, id);
         state = 4;
@@ -1473,7 +1473,7 @@ static void pop_imported(void) {
  * ----------------------------------------------------------------------------- */
 
 String *Preprocessor_parse(String *s) {
-  String *ns;			/* New string containing the preprocessed text */
+  String *ns;                   /* New string containing the preprocessed text */
   String *chunk, *decl;
   Hash *symbols;
   String *id = 0, *value = 0, *comment = 0;
@@ -1491,7 +1491,7 @@ String *Preprocessor_parse(String *s) {
   /* Blow away all carriage returns */
   Replace(s, "\015", "", DOH_REPLACE_ANY);
 
-  ns = NewStringEmpty();	/* Return result */
+  ns = NewStringEmpty();        /* Return result */
 
   decl = NewStringEmpty();
   id = NewStringEmpty();
@@ -1505,7 +1505,7 @@ String *Preprocessor_parse(String *s) {
   state = 0;
   while ((c = Getc(s)) != EOF) {
     switch (state) {
-    case 0:			/* Initial state - in first column */
+    case 0:                     /* Initial state - in first column */
       /* Look for C preprocessor directives.   Otherwise, go directly to state 1 */
       if (c == '#') {
         copy_location(s, chunk);
@@ -1520,7 +1520,7 @@ String *Preprocessor_parse(String *s) {
         Ungetc(c, s);
       }
       break;
-    case 1: {			/* Non-preprocessor directive */
+    case 1: {                   /* Non-preprocessor directive */
       /* Look for SWIG directives */
 state1:
       if (c == '%') {
@@ -1541,11 +1541,11 @@ state1:
           Swig_error(Getfile(s), start_line, "Unterminated character constant\n");
         }
       } else if (c == '/')
-        state = 30;		/* Comment */
+        state = 30;             /* Comment */
       break;
     }
 
-    case 30:			/* Possibly a comment string of some sort */
+    case 30:                    /* Possibly a comment string of some sort */
       start_line = Getline(s);
       if (c == '/')
         state = 31;
@@ -1575,7 +1575,7 @@ state1:
         state = 32;
       break;
 
-    case 40:			/* Start of a C preprocessor directive */
+    case 40:                    /* Start of a C preprocessor directive */
       if (c == '\n') {
         Putc('\n', chunk);
         state = 0;
@@ -1590,7 +1590,7 @@ state1:
       }
       break;
 
-    case 41:			/* Build up the name of the preprocessor directive */
+    case 41:                    /* Build up the name of the preprocessor directive */
       if ((isspace(c) || (!isidchar(c)))) {
         Clear(value);
         Clear(comment);
@@ -1610,7 +1610,7 @@ state1:
       Putc(c, id);
       break;
 
-    case 42:			/* Strip any leading space after the preprocessor directive (before preprocessor value) */
+    case 42:                    /* Strip any leading space after the preprocessor directive (before preprocessor value) */
       if (isspace(c)) {
         if (c == '\n') {
           Ungetc(c, s);

--- a/Source/Preprocessor/expr.c
+++ b/Source/Preprocessor/expr.c
@@ -84,9 +84,9 @@ static void init_precedence(void) {
 }
 
 #define UNARY_OP(token) (((token) == SWIG_TOKEN_NOT) || \
-			 ((token) == SWIG_TOKEN_LNOT) || \
-			 ((token) == OP_UMINUS) || \
-			 ((token) == OP_UPLUS))
+                         ((token) == SWIG_TOKEN_LNOT) || \
+                         ((token) == OP_UMINUS) || \
+                         ((token) == OP_UPLUS))
 
 /* Reduce a single operator on the stack */
 /* return 0 on failure, 1 on success */
@@ -215,20 +215,20 @@ static int reduce_op(void) {
       break;
     case SWIG_TOKEN_SLASH:
       if (stack[sp].value != 0) {
-	stack[sp - 2].value = stack[sp - 2].value / stack[sp].value;
-	sp -= 2;
+        stack[sp - 2].value = stack[sp - 2].value / stack[sp].value;
+        sp -= 2;
       } else {
-	errmsg = "Division by zero in expression";
-	return 0;
+        errmsg = "Division by zero in expression";
+        return 0;
       }
       break;
     case SWIG_TOKEN_PERCENT:
       if (stack[sp].value != 0) {
-	stack[sp - 2].value = stack[sp - 2].value % stack[sp].value;
-	sp -= 2;
+        stack[sp - 2].value = stack[sp - 2].value % stack[sp].value;
+        sp -= 2;
       } else {
-	errmsg = "Modulo by zero in expression";
-	return 0;
+        errmsg = "Modulo by zero in expression";
+        return 0;
       }
       break;
     case SWIG_TOKEN_LSHIFT:
@@ -314,72 +314,72 @@ int Preprocessor_expr(DOH *s, int *error) {
        */
       token = expr_token(scan);
       if (!token) {
-	errmsg = "Expected an expression";
-	*error = 1;
-	return 0;
+        errmsg = "Expected an expression";
+        *error = 1;
+        return 0;
       }
       if (token == SWIG_TOKEN_BOOL) {
-	/* A boolean value.  Reduce EXPR_TOP to an EXPR_VALUE */
-	String *cc = Scanner_text(scan);
-	if (Strcmp(cc, "true") == 0) {
-	  stack[sp].value = (long) 1;
-	} else {
-	  stack[sp].value = (long) 0;
-	}
-	stack[sp].svalue = 0;
-	stack[sp].op = EXPR_VALUE;
+        /* A boolean value.  Reduce EXPR_TOP to an EXPR_VALUE */
+        String *cc = Scanner_text(scan);
+        if (Strcmp(cc, "true") == 0) {
+          stack[sp].value = (long) 1;
+        } else {
+          stack[sp].value = (long) 0;
+        }
+        stack[sp].svalue = 0;
+        stack[sp].op = EXPR_VALUE;
       } else if ((token == SWIG_TOKEN_INT) || (token == SWIG_TOKEN_UINT) || (token == SWIG_TOKEN_LONG) || (token == SWIG_TOKEN_ULONG)) {
-	/* A number.  Reduce EXPR_TOP to an EXPR_VALUE */
-	char *c = Char(Scanner_text(scan));
-	if (c[0] == '0' && (c[1] == 'b' || c[1] == 'B')) {
-	  /* strtol() doesn't handle binary constants */
-	  stack[sp].value = (long) strtol(c + 2, 0, 2);
-	} else {
-	  stack[sp].value = (long) strtol(c, 0, 0);
-	}
-	stack[sp].svalue = 0;
-	stack[sp].op = EXPR_VALUE;
+        /* A number.  Reduce EXPR_TOP to an EXPR_VALUE */
+        char *c = Char(Scanner_text(scan));
+        if (c[0] == '0' && (c[1] == 'b' || c[1] == 'B')) {
+          /* strtol() doesn't handle binary constants */
+          stack[sp].value = (long) strtol(c + 2, 0, 2);
+        } else {
+          stack[sp].value = (long) strtol(c, 0, 0);
+        }
+        stack[sp].svalue = 0;
+        stack[sp].op = EXPR_VALUE;
       } else if ((token == SWIG_TOKEN_MINUS) || (token == SWIG_TOKEN_PLUS) || (token == SWIG_TOKEN_LNOT) || (token == SWIG_TOKEN_NOT)) {
-	if (token == SWIG_TOKEN_MINUS)
-	  token = OP_UMINUS;
-	else if (token == SWIG_TOKEN_PLUS)
-	  token = OP_UPLUS;
-	stack[sp].value = token;
-	stack[sp].op = EXPR_OP;
-	sp++;
-	stack[sp].op = EXPR_TOP;
+        if (token == SWIG_TOKEN_MINUS)
+          token = OP_UMINUS;
+        else if (token == SWIG_TOKEN_PLUS)
+          token = OP_UPLUS;
+        stack[sp].value = token;
+        stack[sp].op = EXPR_OP;
+        sp++;
+        stack[sp].op = EXPR_TOP;
       } else if (token == SWIG_TOKEN_LPAREN) {
-	stack[sp].op = EXPR_GROUP;
-	sp++;
-	stack[sp].op = EXPR_TOP;
+        stack[sp].op = EXPR_GROUP;
+        sp++;
+        stack[sp].op = EXPR_TOP;
       } else if (token == SWIG_TOKEN_ENDLINE) {
       } else if (token == SWIG_TOKEN_STRING) {
-	stack[sp].svalue = NewString(Scanner_text(scan));
-	stack[sp].op = EXPR_VALUE;
+        stack[sp].svalue = NewString(Scanner_text(scan));
+        stack[sp].op = EXPR_VALUE;
       } else if (token == SWIG_TOKEN_ID) {
-	int next_token = expr_token(scan);
-	if (next_token == SWIG_TOKEN_LPAREN) {
-	  /* This is a use of an unknown function-like macro so we emit a
-	   * warning.
-	   */
-	  errmsg = "Use of undefined function-like macro";
-	  *error = 1;
-	  return 0;
-	}
-	Scanner_pushtoken(scan, next_token, Scanner_text(scan));
+        int next_token = expr_token(scan);
+        if (next_token == SWIG_TOKEN_LPAREN) {
+          /* This is a use of an unknown function-like macro so we emit a
+           * warning.
+           */
+          errmsg = "Use of undefined function-like macro";
+          *error = 1;
+          return 0;
+        }
+        Scanner_pushtoken(scan, next_token, Scanner_text(scan));
 
-	/* Defined macros have been expanded already so this is an unknown
-	 * macro, which gets treated as zero.
-	 */
-	stack[sp].value = 0;
-	stack[sp].svalue = 0;
-	stack[sp].op = EXPR_VALUE;
+        /* Defined macros have been expanded already so this is an unknown
+         * macro, which gets treated as zero.
+         */
+        stack[sp].value = 0;
+        stack[sp].svalue = 0;
+        stack[sp].op = EXPR_VALUE;
       } else if (token == SWIG_TOKEN_FLOAT || token == SWIG_TOKEN_DOUBLE || token == SWIG_TOKEN_LONGDOUBLE) {
-	errmsg = "Floating point constant in preprocessor expression";
-	*error = 1;
-	return 0;
+        errmsg = "Floating point constant in preprocessor expression";
+        *error = 1;
+        return 0;
       } else
-	goto syntax_error;
+        goto syntax_error;
       break;
     case EXPR_VALUE:
       /* A value is on top of the stack.  We may reduce or evaluate depending
@@ -387,19 +387,19 @@ int Preprocessor_expr(DOH *s, int *error) {
        */
       token = expr_token(scan);
       if (!token) {
-	/* End of input. Might have to reduce if an operator is on stack */
-	while (sp > 0) {
-	  if (stack[sp - 1].op == EXPR_OP) {
-	    if (!reduce_op())
-	      goto reduce_error;
-	  } else if (stack[sp - 1].op == EXPR_GROUP) {
-	    errmsg = "Missing \')\'";
-	    *error = 1;
-	    return 0;
-	  } else
-	    goto syntax_error;
-	}
-	return stack[sp].value;
+        /* End of input. Might have to reduce if an operator is on stack */
+        while (sp > 0) {
+          if (stack[sp - 1].op == EXPR_OP) {
+            if (!reduce_op())
+              goto reduce_error;
+          } else if (stack[sp - 1].op == EXPR_GROUP) {
+            errmsg = "Missing \')\'";
+            *error = 1;
+            return 0;
+          } else
+            goto syntax_error;
+        }
+        return stack[sp].value;
       }
       /* Token must be an operator */
       switch (token) {
@@ -421,54 +421,54 @@ int Preprocessor_expr(DOH *s, int *error) {
       case SWIG_TOKEN_PERCENT:
       case SWIG_TOKEN_LSHIFT:
       case SWIG_TOKEN_RSHIFT:
-	if ((sp == 0) || (stack[sp - 1].op == EXPR_GROUP)) {
-	  /* No possibility of reduce. Push operator and expression */
-	  sp++;
-	  stack[sp].op = EXPR_OP;
-	  stack[sp].value = token;
-	  sp++;
-	  stack[sp].op = EXPR_TOP;
-	} else {
-	  if (stack[sp - 1].op != EXPR_OP)
-	    goto syntax_error_expected_operator;
-	  op = stack[sp - 1].value;	/* Previous operator */
+        if ((sp == 0) || (stack[sp - 1].op == EXPR_GROUP)) {
+          /* No possibility of reduce. Push operator and expression */
+          sp++;
+          stack[sp].op = EXPR_OP;
+          stack[sp].value = token;
+          sp++;
+          stack[sp].op = EXPR_TOP;
+        } else {
+          if (stack[sp - 1].op != EXPR_OP)
+            goto syntax_error_expected_operator;
+          op = stack[sp - 1].value;	/* Previous operator */
 
-	  /* Now, depending on the precedence relationship between the last operator and the current
-	     we will reduce or push */
+          /* Now, depending on the precedence relationship between the last operator and the current
+             we will reduce or push */
 
-	  if (prec[op] <= prec[token]) {
-	    /* Reduce the previous operator */
-	    if (!reduce_op())
-	      goto reduce_error;
-	  }
-	  sp++;
-	  stack[sp].op = EXPR_OP;
-	  stack[sp].value = token;
-	  sp++;
-	  stack[sp].op = EXPR_TOP;
-	}
-	break;
+          if (prec[op] <= prec[token]) {
+            /* Reduce the previous operator */
+            if (!reduce_op())
+              goto reduce_error;
+          }
+          sp++;
+          stack[sp].op = EXPR_OP;
+          stack[sp].value = token;
+          sp++;
+          stack[sp].op = EXPR_TOP;
+        }
+        break;
       case SWIG_TOKEN_RPAREN:
-	if (sp == 0)
-	  goto extra_rparen;
+        if (sp == 0)
+          goto extra_rparen;
 
-	/* Might have to reduce operators first */
-	while ((sp > 0) && (stack[sp - 1].op == EXPR_OP)) {
-	  if (!reduce_op())
-	    goto reduce_error;
-	}
-	if ((sp == 0) || (stack[sp - 1].op != EXPR_GROUP))
-	  goto extra_rparen;
-	stack[sp - 1].op = EXPR_VALUE;
-	stack[sp - 1].value = stack[sp].value;
-	stack[sp - 1].svalue = stack[sp].svalue;
-	sp--;
-	break;
+        /* Might have to reduce operators first */
+        while ((sp > 0) && (stack[sp - 1].op == EXPR_OP)) {
+          if (!reduce_op())
+            goto reduce_error;
+        }
+        if ((sp == 0) || (stack[sp - 1].op != EXPR_GROUP))
+          goto extra_rparen;
+        stack[sp - 1].op = EXPR_VALUE;
+        stack[sp - 1].value = stack[sp].value;
+        stack[sp - 1].svalue = stack[sp].svalue;
+        sp--;
+        break;
       case SWIG_TOKEN_LTEQUALGT:
-	goto spaceship_not_allowed;
+        goto spaceship_not_allowed;
       default:
-	goto syntax_error_expected_operator;
-	break;
+        goto syntax_error_expected_operator;
+        break;
       }
       break;
 

--- a/Source/Preprocessor/expr.c
+++ b/Source/Preprocessor/expr.c
@@ -39,22 +39,22 @@ typedef struct {
   String *svalue;
 } exprval;
 
-#define  EXPR_TOP      1
-#define  EXPR_VALUE    2
-#define  EXPR_OP       3
-#define  EXPR_GROUP    4
+#define EXPR_TOP   1
+#define EXPR_VALUE 2
+#define EXPR_OP    3
+#define EXPR_GROUP 4
 
 /* Special token values used here to distinguish from SWIG_TOKEN_MINUS
  * and SWIG_TOKEN_PLUS (which we use here for a two argument versions).
  */
-#define  OP_UMINUS   100
-#define  OP_UPLUS    101
+#define OP_UMINUS  100
+#define OP_UPLUS   101
 
-static exprval stack[256];      /* Parsing stack       */
-static int sp = 0;              /* Stack pointer       */
-static int prec[256];           /* Precedence rules    */
-static int expr_init = 0;       /* Initialization flag */
-static const char *errmsg = 0;  /* Parsing error       */
+static exprval stack[256];     /* Parsing stack       */
+static int sp = 0;             /* Stack pointer       */
+static int prec[256];          /* Precedence rules    */
+static int expr_init = 0;      /* Initialization flag */
+static const char *errmsg = 0; /* Parsing error       */
 
 /* Initialize the precedence table for various operators.  Low values have higher precedence */
 static void init_precedence(void) {
@@ -83,10 +83,7 @@ static void init_precedence(void) {
   expr_init = 1;
 }
 
-#define UNARY_OP(token) (((token) == SWIG_TOKEN_NOT) || \
-                         ((token) == SWIG_TOKEN_LNOT) || \
-                         ((token) == OP_UMINUS) || \
-                         ((token) == OP_UPLUS))
+#define UNARY_OP(token) (((token) == SWIG_TOKEN_NOT) || ((token) == SWIG_TOKEN_LNOT) || ((token) == OP_UMINUS) || ((token) == OP_UPLUS))
 
 /* Reduce a single operator on the stack */
 /* return 0 on failure, 1 on success */
@@ -245,7 +242,7 @@ static int reduce_op(void) {
     }
   }
   stack[sp].op = EXPR_VALUE;
-  stack[sp].svalue = 0;         /* ensure it's not a string! */
+  stack[sp].svalue = 0; /* ensure it's not a string! */
   return 1;
 }
 
@@ -266,12 +263,11 @@ void Preprocessor_expr_delete(void) {
   DelScanner(scan);
 }
 
-
 /* -----------------------------------------------------------------------------
  * Tokenizer
  * ----------------------------------------------------------------------------- */
 
-static int expr_token(Scanner * s) {
+static int expr_token(Scanner *s) {
   int t;
   while (1) {
     t = Scanner_token(s);
@@ -322,9 +318,9 @@ int Preprocessor_expr(DOH *s, int *error) {
         /* A boolean value.  Reduce EXPR_TOP to an EXPR_VALUE */
         String *cc = Scanner_text(scan);
         if (Strcmp(cc, "true") == 0) {
-          stack[sp].value = (long) 1;
+          stack[sp].value = (long)1;
         } else {
-          stack[sp].value = (long) 0;
+          stack[sp].value = (long)0;
         }
         stack[sp].svalue = 0;
         stack[sp].op = EXPR_VALUE;
@@ -333,9 +329,9 @@ int Preprocessor_expr(DOH *s, int *error) {
         char *c = Char(Scanner_text(scan));
         if (c[0] == '0' && (c[1] == 'b' || c[1] == 'B')) {
           /* strtol() doesn't handle binary constants */
-          stack[sp].value = (long) strtol(c + 2, 0, 2);
+          stack[sp].value = (long)strtol(c + 2, 0, 2);
         } else {
-          stack[sp].value = (long) strtol(c, 0, 0);
+          stack[sp].value = (long)strtol(c, 0, 0);
         }
         stack[sp].svalue = 0;
         stack[sp].op = EXPR_VALUE;
@@ -431,7 +427,7 @@ int Preprocessor_expr(DOH *s, int *error) {
         } else {
           if (stack[sp - 1].op != EXPR_OP)
             goto syntax_error_expected_operator;
-          op = stack[sp - 1].value;     /* Previous operator */
+          op = stack[sp - 1].value; /* Previous operator */
 
           /* Now, depending on the precedence relationship between the last operator and the current
              we will reduce or push */

--- a/Source/Preprocessor/expr.c
+++ b/Source/Preprocessor/expr.c
@@ -50,11 +50,11 @@ typedef struct {
 #define  OP_UMINUS   100
 #define  OP_UPLUS    101
 
-static exprval stack[256];	/* Parsing stack       */
-static int sp = 0;		/* Stack pointer       */
-static int prec[256];		/* Precedence rules    */
-static int expr_init = 0;	/* Initialization flag */
-static const char *errmsg = 0;	/* Parsing error       */
+static exprval stack[256];      /* Parsing stack       */
+static int sp = 0;              /* Stack pointer       */
+static int prec[256];           /* Precedence rules    */
+static int expr_init = 0;       /* Initialization flag */
+static const char *errmsg = 0;  /* Parsing error       */
 
 /* Initialize the precedence table for various operators.  Low values have higher precedence */
 static void init_precedence(void) {
@@ -245,7 +245,7 @@ static int reduce_op(void) {
     }
   }
   stack[sp].op = EXPR_VALUE;
-  stack[sp].svalue = 0;		/* ensure it's not a string! */
+  stack[sp].svalue = 0;         /* ensure it's not a string! */
   return 1;
 }
 
@@ -431,7 +431,7 @@ int Preprocessor_expr(DOH *s, int *error) {
         } else {
           if (stack[sp - 1].op != EXPR_OP)
             goto syntax_error_expected_operator;
-          op = stack[sp - 1].value;	/* Previous operator */
+          op = stack[sp - 1].value;     /* Previous operator */
 
           /* Now, depending on the precedence relationship between the last operator and the current
              we will reduce or push */

--- a/Source/Preprocessor/expr.c
+++ b/Source/Preprocessor/expr.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -268,7 +268,7 @@ void Preprocessor_expr_delete(void) {
 
 
 /* -----------------------------------------------------------------------------
- * Tokenizer 
+ * Tokenizer
  * ----------------------------------------------------------------------------- */
 
 static int expr_token(Scanner * s) {

--- a/Source/Preprocessor/preprocessor.h
+++ b/Source/Preprocessor/preprocessor.h
@@ -19,21 +19,21 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  extern int Preprocessor_expr(String *s, int *error);
-  extern const char *Preprocessor_expr_error(void);
-  extern Hash *Preprocessor_define(const_String_or_char_ptr str, int swigmacro);
-  extern void Preprocessor_undef(const_String_or_char_ptr name);
-  extern int Preprocessor_defined(const_String_or_char_ptr str);
-  extern void Preprocessor_init(void);
-  extern void Preprocessor_delete(void);
-  extern String *Preprocessor_parse(String *s);
-  extern void Preprocessor_include_all(int);
-  extern void Preprocessor_import_all(int);
-  extern void Preprocessor_ignore_missing(int);
-  extern void Preprocessor_error_as_warning(int);
-  extern List *Preprocessor_depend(void);
-  extern void Preprocessor_expr_init(void);
-  extern void Preprocessor_expr_delete(void);
+extern int Preprocessor_expr(String *s, int *error);
+extern const char *Preprocessor_expr_error(void);
+extern Hash *Preprocessor_define(const_String_or_char_ptr str, int swigmacro);
+extern void Preprocessor_undef(const_String_or_char_ptr name);
+extern int Preprocessor_defined(const_String_or_char_ptr str);
+extern void Preprocessor_init(void);
+extern void Preprocessor_delete(void);
+extern String *Preprocessor_parse(String *s);
+extern void Preprocessor_include_all(int);
+extern void Preprocessor_import_all(int);
+extern void Preprocessor_ignore_missing(int);
+extern void Preprocessor_error_as_warning(int);
+extern List *Preprocessor_depend(void);
+extern void Preprocessor_expr_init(void);
+extern void Preprocessor_expr_delete(void);
 
 #ifdef __cplusplus
 }

--- a/Source/Preprocessor/preprocessor.h
+++ b/Source/Preprocessor/preprocessor.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -183,7 +183,6 @@ static String *Swig_wrapped_member_var_type(SwigType *t, int varcref) {
   return ty;
 }
 
-
 static String *Swig_wrapped_var_deref(SwigType *t, const_String_or_char_ptr name, int varcref) {
   if (SwigType_isclass(t)) {
     if (varcref) {
@@ -267,7 +266,7 @@ int Swig_cargs(Wrapper *w, ParmList *p) {
           Delete(defvalue);
         }
       } else if (!pvalue && ((tycode == T_POINTER) || (tycode == T_STRING) || (tycode == T_WSTRING) || (tycode == T_ARRAY))) {
-        pvalue = (String *) "0";
+        pvalue = (String *)"0";
       }
       if (!altty) {
         local = Swig_clocal(pt, lname, pvalue);
@@ -427,7 +426,8 @@ String *Swig_cfunction_call(const_String_or_char_ptr name, ParmList *parms) {
  * set to "(*this)->" or some similar sequence.
  * ----------------------------------------------------------------------------- */
 
-static String *Swig_cmethod_call(const_String_or_char_ptr name, ParmList *parms, const_String_or_char_ptr self, String *explicit_qualifier, SwigType *director_type) {
+static String *Swig_cmethod_call(const_String_or_char_ptr name, ParmList *parms, const_String_or_char_ptr self, String *explicit_qualifier,
+                                 SwigType *director_type) {
   String *func, *nname;
   int i = 0;
   Parm *p = parms;
@@ -529,7 +529,6 @@ String *Swig_cconstructor_call(const_String_or_char_ptr name) {
   Printf(func, "calloc(1, sizeof(%s))", name);
   return func;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_cppconstructor_call()
@@ -709,7 +708,6 @@ String *Swig_cdestructor_call(Node *n) {
   }
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_cppdestructor_call()
  *
@@ -782,7 +780,6 @@ String *Swig_cmemberset_call(const_String_or_char_ptr name, SwigType *type, Stri
   Delete(pname1);
   return (func);
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_cmemberget_call()
@@ -859,7 +856,8 @@ void Swig_replace_special_variables(Node *n, Node *parentnode, String *code) {
  *        return_type function_name(parms) code
  *
  * ----------------------------------------------------------------------------- */
-static String *extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus, const String *self) {
+static String *extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus,
+                              const String *self) {
   String *parms_str = cplusplus ? ParmList_str_defaultargs(parms) : ParmList_str(parms);
   String *sig = NewStringf("%s(%s)", function_name, (cplusplus || Len(parms_str)) ? parms_str : "void");
   String *rt_sig = SwigType_str(return_type, sig);
@@ -885,13 +883,13 @@ static String *extension_code(Node *n, const String *function_name, ParmList *pa
  * See also extension_code()
  *
  * ----------------------------------------------------------------------------- */
-int Swig_add_extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus, const String *self) {
+int Swig_add_extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus,
+                            const String *self) {
   String *body = extension_code(n, function_name, parms, return_type, code, cplusplus, self);
   Setattr(n, "wrap:code", body);
   Delete(body);
   return SWIG_OK;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_MethodToFunction(Node *n)
@@ -917,15 +915,13 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
       if (qualifier && strncmp(Char(qualifier), "q(const)", 8) == 0) {
         self = NewString("(*(this))->");
         is_smart_pointer_overload = 1;
-      }
-      else if (Swig_storage_isstatic(n)) {
+      } else if (Swig_storage_isstatic(n)) {
         String *cname = Getattr(n, "extendsmartclassname") ? Getattr(n, "extendsmartclassname") : classname;
         String *ctname = SwigType_namestr(cname);
         self = NewStringf("(*(%s const *)this)->", ctname);
         is_smart_pointer_overload = 1;
         Delete(ctname);
-      }
-      else {
+      } else {
         self = NewString("(*this)->");
       }
     } else {
@@ -947,7 +943,7 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
   SwigType_add_pointer(type);
   p = NewParm(type, "self", n);
   Setattr(p, "self", "1");
-  Setattr(p, "hidden","1");
+  Setattr(p, "hidden", "1");
   /*
      Disable the 'this' ownership in 'self' to manage inplace
      operations like:
@@ -1086,8 +1082,7 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
           String *nclassname = SwigType_namestr(classname);
           fadd = NewStringf("(%s const *)((%s const *)%s)->operator ->()", ctname, nclassname, pname);
           Delete(nclassname);
-        }
-        else {
+        } else {
           fadd = NewStringf("(%s*)(%s)->operator ->()", ctname, pname);
         }
         Append(func, fadd);
@@ -1169,14 +1164,14 @@ Node *Swig_directormap(Node *module, String *type) {
   return 0;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_ConstructorToFunction()
  *
  * This function creates a C wrapper for a C constructor function.
  * ----------------------------------------------------------------------------- */
 
-int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, String *none_comparison, String *director_ctor, int cplus, int flags, String *directorname) {
+int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, String *none_comparison, String *director_ctor, int cplus,
+                               int flags, String *directorname) {
   Parm *p;
   ParmList *directorparms;
   SwigType *type;
@@ -1188,7 +1183,8 @@ int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String 
     Parm *p2, *p3;
 
     directorparms = CopyParmList(prefix_args);
-    for (p = directorparms; nextSibling(p); p = nextSibling(p));
+    for (p = directorparms; nextSibling(p); p = nextSibling(p))
+      ;
     for (p2 = parms; p2; p2 = nextSibling(p2)) {
       p3 = CopyParm(p2);
       set_nextSibling(p, p3);
@@ -1393,7 +1389,7 @@ int Swig_MembersetToFunction(Node *n, String *classname, int flags) {
   SwigType_add_pointer(t);
   parms = NewParm(t, "self", n);
   Setattr(parms, "self", "1");
-  Setattr(parms, "hidden","1");
+  Setattr(parms, "hidden", "1");
   Delete(t);
 
   ty = Swig_wrapped_member_var_type(type, varcref);
@@ -1485,7 +1481,7 @@ int Swig_MembergetToFunction(Node *n, String *classname, int flags) {
   SwigType_add_pointer(t);
   parms = NewParm(t, "self", n);
   Setattr(parms, "self", "1");
-  Setattr(parms, "hidden","1");
+  Setattr(parms, "hidden", "1");
   Delete(t);
 
   ty = Swig_wrapped_member_var_type(type, varcref);

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -289,7 +289,7 @@ int Swig_cargs(Wrapper *w, ParmList *p) {
  * Swig_cresult()
  *
  * This function generates the C code needed to set the result of a C
- * function call.  
+ * function call.
  * ----------------------------------------------------------------------------- */
 
 String *Swig_cresult(SwigType *t, const_String_or_char_ptr name, const_String_or_char_ptr decl) {
@@ -372,7 +372,7 @@ String *Swig_cfunction_call(const_String_or_char_ptr name, ParmList *parms) {
 
   /*
      SWIGTEMPLATEDISAMBIGUATOR is compiler dependent (swiglabels.swg),
-     - SUN Studio 9 requires 'template', 
+     - SUN Studio 9 requires 'template',
      - gcc-3.4 forbids the use of 'template'.
      the rest seems not caring very much,
    */
@@ -419,7 +419,7 @@ String *Swig_cfunction_call(const_String_or_char_ptr name, ParmList *parms) {
  * Swig_cmethod_call()
  *
  * Generates a string that calls a C++ method from a list of parameters.
- * 
+ *
  *    arg0->name(arg1, arg2, arg3, ..., argn)
  *
  * self is an argument that defines how to handle the first argument. Normally,
@@ -475,7 +475,7 @@ static String *Swig_cmethod_call(const_String_or_char_ptr name, ParmList *parms,
 
     /*
        SWIGTEMPLATEDESIMBUAGATOR is compiler dependent (swiglabels.swg),
-       - SUN Studio 9 requires 'template', 
+       - SUN Studio 9 requires 'template',
        - gcc-3.4 forbids the use of 'template' (correctly implementing the ISO C++ standard)
        the others don't seem to care,
      */
@@ -616,7 +616,7 @@ static String *Swig_cppconstructor_director_call(const_String_or_char_ptr name, 
  *
  * If you undefine the SWIG_FAST_REC_SEARCH no attribute will be set
  * while searching. This could be slower for large projects with very
- * large hierarchy trees... or maybe not. But it will be cleaner. 
+ * large hierarchy trees... or maybe not. But it will be cleaner.
  *
  * Maybe later a swig option can be added to switch at runtime.
  *
@@ -910,7 +910,7 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
   String *directorScope = NewString(nspace);
 
   Replace(directorScope, NSPACE_SEPARATOR, "_", DOH_REPLACE_ANY);
-  
+
   /* If smart pointer without const overload or mutable method, change self dereferencing */
   if (flags & CWRAP_SMART_POINTER) {
     if (flags & CWRAP_SMART_POINTER_OVERLOAD) {
@@ -1173,7 +1173,7 @@ Node *Swig_directormap(Node *module, String *type) {
 /* -----------------------------------------------------------------------------
  * Swig_ConstructorToFunction()
  *
- * This function creates a C wrapper for a C constructor function. 
+ * This function creates a C wrapper for a C constructor function.
  * ----------------------------------------------------------------------------- */
 
 int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, String *none_comparison, String *director_ctor, int cplus, int flags, String *directorname) {

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -145,11 +145,11 @@ String *Swig_wrapped_var_type(SwigType *t, int varcref) {
   if (SwigType_isclass(t)) {
     if (varcref) {
       if (cparse_cplusplus) {
-	if (!SwigType_isconst(ty))
-	  SwigType_add_qualifier(ty, "const");
-	SwigType_add_reference(ty);
+        if (!SwigType_isconst(ty))
+          SwigType_add_qualifier(ty, "const");
+        SwigType_add_reference(ty);
       } else {
-	return Copy(ty);
+        return Copy(ty);
       }
     } else {
       SwigType_add_pointer(ty);
@@ -170,11 +170,11 @@ static String *Swig_wrapped_member_var_type(SwigType *t, int varcref) {
   if (SwigType_isclass(t)) {
     if (varcref) {
       if (cparse_cplusplus) {
-	if (!SwigType_isconst(ty))
-	  SwigType_add_qualifier(ty, "const");
-	SwigType_add_reference(ty);
+        if (!SwigType_isconst(ty))
+          SwigType_add_qualifier(ty, "const");
+        SwigType_add_reference(ty);
       } else {
-	return Copy(ty);
+        return Copy(ty);
       }
     } else {
       SwigType_add_pointer(ty);
@@ -188,9 +188,9 @@ static String *Swig_wrapped_var_deref(SwigType *t, const_String_or_char_ptr name
   if (SwigType_isclass(t)) {
     if (varcref) {
       if (cparse_cplusplus) {
-	return NewStringf("*%s", name);
+        return NewStringf("*%s", name);
       } else {
-	return NewStringf("%s", name);
+        return NewStringf("%s", name);
       }
     } else {
       return NewStringf("*%s", name);
@@ -239,41 +239,41 @@ int Swig_cargs(Wrapper *w, ParmList *p) {
 
       int tycode = SwigType_type(type);
       if (tycode == T_REFERENCE) {
-	if (pvalue) {
-	  String *rvalue = SwigType_typedef_resolve_all(pvalue);
-	  String *qvalue = SwigType_typedef_qualified(rvalue);
-	  String *defname = NewStringf("%s_defvalue", lname);
-	  String *str = SwigType_str(pt, defname);
-	  String *defvalue = NewStringf("%s = %s", str, qvalue);
-	  Wrapper_add_localv(w, defname, defvalue, NIL);
-	  Delete(str);
-	  Delete(rvalue);
-	  Delete(qvalue);
-	  Delete(defname);
-	  Delete(defvalue);
-	}
+        if (pvalue) {
+          String *rvalue = SwigType_typedef_resolve_all(pvalue);
+          String *qvalue = SwigType_typedef_qualified(rvalue);
+          String *defname = NewStringf("%s_defvalue", lname);
+          String *str = SwigType_str(pt, defname);
+          String *defvalue = NewStringf("%s = %s", str, qvalue);
+          Wrapper_add_localv(w, defname, defvalue, NIL);
+          Delete(str);
+          Delete(rvalue);
+          Delete(qvalue);
+          Delete(defname);
+          Delete(defvalue);
+        }
       } else if (tycode == T_RVALUE_REFERENCE) {
-	if (pvalue) {
-	  String *rvalue = SwigType_typedef_resolve_all(pvalue);
-	  String *qvalue = SwigType_typedef_qualified(rvalue);
-	  String *defname = NewStringf("%s_defrvalue", lname);
-	  String *str = SwigType_str(pt, defname);
-	  String *defvalue = NewStringf("%s = %s", str, qvalue);
-	  Wrapper_add_localv(w, defname, defvalue, NIL);
-	  Delete(str);
-	  Delete(rvalue);
-	  Delete(qvalue);
-	  Delete(defname);
-	  Delete(defvalue);
-	}
+        if (pvalue) {
+          String *rvalue = SwigType_typedef_resolve_all(pvalue);
+          String *qvalue = SwigType_typedef_qualified(rvalue);
+          String *defname = NewStringf("%s_defrvalue", lname);
+          String *str = SwigType_str(pt, defname);
+          String *defvalue = NewStringf("%s = %s", str, qvalue);
+          Wrapper_add_localv(w, defname, defvalue, NIL);
+          Delete(str);
+          Delete(rvalue);
+          Delete(qvalue);
+          Delete(defname);
+          Delete(defvalue);
+        }
       } else if (!pvalue && ((tycode == T_POINTER) || (tycode == T_STRING) || (tycode == T_WSTRING) || (tycode == T_ARRAY))) {
-	pvalue = (String *) "0";
+        pvalue = (String *) "0";
       }
       if (!altty) {
-	local = Swig_clocal(pt, lname, pvalue);
+        local = Swig_clocal(pt, lname, pvalue);
       } else {
-	local = Swig_clocal(altty, lname, pvalue);
-	Delete(altty);
+        local = Swig_clocal(altty, lname, pvalue);
+        Delete(altty);
       }
       Wrapper_add_localv(w, lname, local, NIL);
       Delete(local);
@@ -398,11 +398,11 @@ String *Swig_cfunction_call(const_String_or_char_ptr name, ParmList *parms) {
       String *pname = Swig_cparm_name(p, i);
       String *rcaststr = SwigType_rcaststr(rpt, pname);
       if (comma)
-	Append(func, ",");
+        Append(func, ",");
       if (cparse_cplusplus && SwigType_type(rpt) == T_USER)
-	Printv(func, "SWIG_STD_MOVE(", rcaststr, ")", NIL);
+        Printv(func, "SWIG_STD_MOVE(", rcaststr, ")", NIL);
       else
-	Printv(func, rcaststr, NIL);
+        Printv(func, rcaststr, NIL);
       Delete(rpt);
       Delete(pname);
       Delete(rcaststr);
@@ -497,11 +497,11 @@ static String *Swig_cmethod_call(const_String_or_char_ptr name, ParmList *parms,
       String *pname = Swig_cparm_name(p, i);
       String *rcaststr = SwigType_rcaststr(pt, pname);
       if (comma)
-	Append(func, ",");
+        Append(func, ",");
       if (cparse_cplusplus && SwigType_type(pt) == T_USER)
-	Printv(func, "SWIG_STD_MOVE(", rcaststr, ")", NIL);
+        Printv(func, "SWIG_STD_MOVE(", rcaststr, ")", NIL);
       else
-	Printv(func, rcaststr, NIL);
+        Printv(func, rcaststr, NIL);
       Delete(rcaststr);
       Delete(pname);
       comma = 1;
@@ -562,22 +562,22 @@ static String *Swig_cppconstructor_base_call(const_String_or_char_ptr name, Parm
       String *rcaststr = 0;
       String *pname = 0;
       if (comma)
-	Append(func, ",");
+        Append(func, ",");
       if (!Getattr(p, "arg:byname")) {
-	pname = Swig_cparm_name(p, i);
-	i++;
+        pname = Swig_cparm_name(p, i);
+        i++;
       } else {
         pname = Getattr(p, "value");
-	if (pname)
-	  pname = Copy(pname);
-	else
-	  pname = Copy(Getattr(p, "name"));
+        if (pname)
+          pname = Copy(pname);
+        else
+          pname = Copy(Getattr(p, "name"));
       }
       rcaststr = SwigType_rcaststr(pt, pname);
       if (cparse_cplusplus && SwigType_type(pt) == T_USER)
-	Printv(func, "SWIG_STD_MOVE(", rcaststr, ")", NIL);
+        Printv(func, "SWIG_STD_MOVE(", rcaststr, ")", NIL);
       else
-	Printv(func, rcaststr, NIL);
+        Printv(func, rcaststr, NIL);
       Delete(rcaststr);
       comma = 1;
       Delete(pname);
@@ -637,13 +637,13 @@ static String *recursive_flag_search(Node *n, const String *attr, const String *
     if (bl) {
       Iterator bi;
       for (bi = First(bl); bi.item; bi = Next(bi)) {
-	f = recursive_flag_search(bi.item, attr, noattr);
-	if (f) {
+        f = recursive_flag_search(bi.item, attr, noattr);
+        if (f) {
 #ifdef SWIG_FAST_REC_SEARCH
-	  SetFlagAttr(n, attr, f);
+          SetFlagAttr(n, attr, f);
 #endif
-	  return f;
-	}
+          return f;
+        }
       }
     }
   }
@@ -755,20 +755,20 @@ String *Swig_cmemberset_call(const_String_or_char_ptr name, SwigType *type, Stri
       String *dref = Swig_wrapped_var_deref(type, pname1, varcref);
       int extra_cast = 0;
       if (cparse_cplusplusout) {
-	/* Required for C nested structs compiled as C++ as a duplicate of the nested struct is put into the global namespace.
-	 * We could improve this by adding the extra casts just for nested structs rather than all structs. */
-	String *base = SwigType_base(type);
-	extra_cast = SwigType_isclass(base);
-	Delete(base);
+        /* Required for C nested structs compiled as C++ as a duplicate of the nested struct is put into the global namespace.
+         * We could improve this by adding the extra casts just for nested structs rather than all structs. */
+        String *base = SwigType_base(type);
+        extra_cast = SwigType_isclass(base);
+        Delete(base);
       }
       if (extra_cast) {
-	String *lstr;
-	SwigType *ptype = Copy(type);
-	SwigType_add_pointer(ptype);
-	lstr = SwigType_lstr(ptype, 0);
-	Printf(func, "if (%s) *(%s)&%s%s = %s", pname0, lstr, self, name, dref);
-	Delete(lstr);
-	Delete(ptype);
+        String *lstr;
+        SwigType *ptype = Copy(type);
+        SwigType_add_pointer(ptype);
+        lstr = SwigType_lstr(ptype, 0);
+        Printf(func, "if (%s) *(%s)&%s%s = %s", pname0, lstr, self, name, dref);
+        Delete(lstr);
+        Delete(ptype);
       } else {
         Printf(func, "if (%s) %s%s = %s", pname0, self, name, dref);
       }
@@ -919,11 +919,11 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
         is_smart_pointer_overload = 1;
       }
       else if (Swig_storage_isstatic(n)) {
-	String *cname = Getattr(n, "extendsmartclassname") ? Getattr(n, "extendsmartclassname") : classname;
-	String *ctname = SwigType_namestr(cname);
+        String *cname = Getattr(n, "extendsmartclassname") ? Getattr(n, "extendsmartclassname") : classname;
+        String *ctname = SwigType_namestr(cname);
         self = NewStringf("(*(%s const *)this)->", ctname);
         is_smart_pointer_overload = 1;
-	Delete(ctname);
+        Delete(ctname);
       }
       else {
         self = NewString("(*this)->");
@@ -989,16 +989,16 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
     if ((flags & CWRAP_DIRECTOR_TWO_CALLS) || (flags & CWRAP_DIRECTOR_ONE_CALL)) {
       String *access = Getattr(n, "access");
       if (access && (Cmp(access, "protected") == 0)) {
-	/* If protected access (can only be if a director method) then call the extra public accessor method (language module must provide this) */
-	String *explicit_qualifier_tmp = SwigType_namestr(Getattr(Getattr(parentNode(n), "typescope"), "qname"));
-	explicitcall_name = NewStringf("%sSwigPublic", name);
+        /* If protected access (can only be if a director method) then call the extra public accessor method (language module must provide this) */
+        String *explicit_qualifier_tmp = SwigType_namestr(Getattr(Getattr(parentNode(n), "typescope"), "qname"));
+        explicitcall_name = NewStringf("%sSwigPublic", name);
         if (Len(directorScope) > 0)
-	  explicit_qualifier = NewStringf("SwigDirector_%s_%s", directorScope, explicit_qualifier_tmp);
+          explicit_qualifier = NewStringf("SwigDirector_%s_%s", directorScope, explicit_qualifier_tmp);
         else
-	  explicit_qualifier = NewStringf("SwigDirector_%s", explicit_qualifier_tmp);
-	Delete(explicit_qualifier_tmp);
+          explicit_qualifier = NewStringf("SwigDirector_%s", explicit_qualifier_tmp);
+        Delete(explicit_qualifier_tmp);
       } else {
-	explicit_qualifier = SwigType_namestr(Getattr(Getattr(parentNode(n), "typescope"), "qname"));
+        explicit_qualifier = SwigType_namestr(Getattr(Getattr(parentNode(n), "typescope"), "qname"));
       }
     }
 
@@ -1062,9 +1062,9 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
      */
     if (code) {
       if (Getattr(n, "sym:overloaded")) {
-	Append(mangled, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
+        Append(mangled, Getattr(defaultargs ? defaultargs : n, "sym:overname"));
       } else if (UseWrapperSuffix) {
-	Append(mangled, "__SWIG");
+        Append(mangled, "__SWIG");
       }
     }
 
@@ -1079,40 +1079,40 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
       String *cres;
 
       if (!Swig_storage_isstatic(n)) {
-	String *pname = Swig_cparm_name(pp, i);
-	String *ctname = SwigType_namestr(cname);
-	String *fadd = 0;
-	if (is_smart_pointer_overload) {
-	  String *nclassname = SwigType_namestr(classname);
-	  fadd = NewStringf("(%s const *)((%s const *)%s)->operator ->()", ctname, nclassname, pname);
-	  Delete(nclassname);
-	}
-	else {
-	  fadd = NewStringf("(%s*)(%s)->operator ->()", ctname, pname);
-	}
-	Append(func, fadd);
-	Delete(ctname);
-	Delete(fadd);
-	Delete(pname);
-	pp = nextSibling(pp);
-	if (pp)
-	  Append(func, ",");
+        String *pname = Swig_cparm_name(pp, i);
+        String *ctname = SwigType_namestr(cname);
+        String *fadd = 0;
+        if (is_smart_pointer_overload) {
+          String *nclassname = SwigType_namestr(classname);
+          fadd = NewStringf("(%s const *)((%s const *)%s)->operator ->()", ctname, nclassname, pname);
+          Delete(nclassname);
+        }
+        else {
+          fadd = NewStringf("(%s*)(%s)->operator ->()", ctname, pname);
+        }
+        Append(func, fadd);
+        Delete(ctname);
+        Delete(fadd);
+        Delete(pname);
+        pp = nextSibling(pp);
+        if (pp)
+          Append(func, ",");
       } else {
-	pp = nextSibling(pp);
+        pp = nextSibling(pp);
       }
       ++i;
       while (pp) {
-	SwigType *pt = Getattr(pp, "type");
-	if ((SwigType_type(pt) != T_VOID)) {
-	  String *pname = Swig_cparm_name(pp, i++);
-	  String *rcaststr = SwigType_rcaststr(pt, pname);
-	  Append(func, rcaststr);
-	  Delete(rcaststr);
-	  Delete(pname);
-	  pp = nextSibling(pp);
-	  if (pp)
-	    Append(func, ",");
-	}
+        SwigType *pt = Getattr(pp, "type");
+        if ((SwigType_type(pt) != T_VOID)) {
+          String *pname = Swig_cparm_name(pp, i++);
+          String *rcaststr = SwigType_rcaststr(pt, pname);
+          Append(func, rcaststr);
+          Delete(rcaststr);
+          Delete(pname);
+          pp = nextSibling(pp);
+          if (pp)
+            Append(func, ",");
+        }
       }
       Append(func, ")");
       cres = Swig_cresult(Getattr(n, "type"), Swig_cresult_name(), func);
@@ -1234,57 +1234,57 @@ int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String 
     if (cplus) {
       /* if a C++ director class exists, create it rather than the original class */
       if (use_director) {
-	Node *parent = Swig_methodclass(n);
-	int abstract = Getattr(parent, "abstracts") != 0;
-	String *action = NewStringEmpty();
-	String *tmp_none_comparison = Copy(none_comparison);
-	String *director_call;
-	String *nodirector_call;
+        Node *parent = Swig_methodclass(n);
+        int abstract = Getattr(parent, "abstracts") != 0;
+        String *action = NewStringEmpty();
+        String *tmp_none_comparison = Copy(none_comparison);
+        String *director_call;
+        String *nodirector_call;
 
-	Replaceall(tmp_none_comparison, "$arg", "arg1");
+        Replaceall(tmp_none_comparison, "$arg", "arg1");
 
-	director_call = Swig_cppconstructor_director_call(directorname, directorparms);
-	nodirector_call = prefix_args ? Swig_cppconstructor_director_call(classname, parms) : Swig_cppconstructor_nodirector_call(classname, parms);
+        director_call = Swig_cppconstructor_director_call(directorname, directorparms);
+        nodirector_call = prefix_args ? Swig_cppconstructor_director_call(classname, parms) : Swig_cppconstructor_nodirector_call(classname, parms);
 
-	if (abstract) {
-	  /* whether or not the abstract class has been subclassed in python,
-	   * create a director instance (there's no way to create a normal
-	   * instance).  if any of the pure virtual methods haven't been
-	   * implemented in the target language, calls to those methods will
-	   * generate Swig::DirectorPureVirtualException exceptions.
-	   */
-	  String *cres = Swig_cresult(type, Swig_cresult_name(), director_call);
-	  Append(action, cres);
-	  Delete(cres);
-	} else {
-	  /* (scottm): The code for creating a new director is now a string
-	     template that gets passed in via the director_ctor argument.
+        if (abstract) {
+          /* whether or not the abstract class has been subclassed in python,
+           * create a director instance (there's no way to create a normal
+           * instance).  if any of the pure virtual methods haven't been
+           * implemented in the target language, calls to those methods will
+           * generate Swig::DirectorPureVirtualException exceptions.
+           */
+          String *cres = Swig_cresult(type, Swig_cresult_name(), director_call);
+          Append(action, cres);
+          Delete(cres);
+        } else {
+          /* (scottm): The code for creating a new director is now a string
+             template that gets passed in via the director_ctor argument.
 
-	     $comparison : an 'if' comparison from none_comparison
-	     $director_new: Call new for director class
-	     $nondirector_new: Call new for non-director class
-	   */
-	  String *cres;
-	  Append(action, director_ctor);
-	  Replaceall(action, "$comparison", tmp_none_comparison);
+             $comparison : an 'if' comparison from none_comparison
+             $director_new: Call new for director class
+             $nondirector_new: Call new for non-director class
+           */
+          String *cres;
+          Append(action, director_ctor);
+          Replaceall(action, "$comparison", tmp_none_comparison);
 
-	  cres = Swig_cresult(type, Swig_cresult_name(), director_call);
-	  Replaceall(action, "$director_new", cres);
-	  Delete(cres);
+          cres = Swig_cresult(type, Swig_cresult_name(), director_call);
+          Replaceall(action, "$director_new", cres);
+          Delete(cres);
 
-	  cres = Swig_cresult(type, Swig_cresult_name(), nodirector_call);
-	  Replaceall(action, "$nondirector_new", cres);
-	  Delete(cres);
-	}
-	Setattr(n, "wrap:action", action);
-	Delete(tmp_none_comparison);
-	Delete(action);
+          cres = Swig_cresult(type, Swig_cresult_name(), nodirector_call);
+          Replaceall(action, "$nondirector_new", cres);
+          Delete(cres);
+        }
+        Setattr(n, "wrap:action", action);
+        Delete(tmp_none_comparison);
+        Delete(action);
       } else {
-	String *call = Swig_cppconstructor_call(classname, parms);
-	String *cres = Swig_cresult(type, Swig_cresult_name(), call);
-	Setattr(n, "wrap:action", cres);
-	Delete(cres);
-	Delete(call);
+        String *call = Swig_cppconstructor_call(classname, parms);
+        String *cres = Swig_cresult(type, Swig_cresult_name(), call);
+        Setattr(n, "wrap:action", cres);
+        Delete(cres);
+        Delete(call);
       }
     } else {
       String *call = Swig_cconstructor_call(classname);

--- a/Source/Swig/deprecate.c
+++ b/Source/Swig/deprecate.c
@@ -91,7 +91,7 @@ int ParmList_is_compactdefargs(ParmList *p) {
 String *ParmList_errorstr(ParmList *p) {
   String *out = NewStringEmpty();
   while (p) {
-    if (Getattr(p,"hidden")) {
+    if (Getattr(p, "hidden")) {
       p = nextSibling(p);
     } else {
       String *pstr = SwigType_str(Getattr(p, "type"), 0);

--- a/Source/Swig/deprecate.c
+++ b/Source/Swig/deprecate.c
@@ -98,7 +98,7 @@ String *ParmList_errorstr(ParmList *p) {
       Append(out, pstr);
       p = nextSibling(p);
       if (p) {
-	Append(out, ",");
+        Append(out, ",");
       }
       Delete(pstr);
     }

--- a/Source/Swig/deprecate.c
+++ b/Source/Swig/deprecate.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -8,7 +8,7 @@
  *
  * deprecate.c
  *
- * The functions in this file are SWIG core functions that are deprecated 
+ * The functions in this file are SWIG core functions that are deprecated
  * or which do not fit in nicely with everything else.  Generally this means
  * that the function and/or API needs to be changed in some future release.
  * ----------------------------------------------------------------------------- */
@@ -78,14 +78,14 @@ int ParmList_is_compactdefargs(ParmList *p) {
  * Similar to ParmList_protostr() but is also aware of hidden parameters.
  * ---------------------------------------------------------------------- */
 
-/* Discussion.  This function is used to generate error messages, but take 
+/* Discussion.  This function is used to generate error messages, but take
    into account that there might be a hidden parameter.  Although this involves
    parameter lists, it really isn't a core feature of swigparm.h or parms.c.
    This is because the "hidden" attribute of parameters is added elsewhere (cwrap.c).
 
    For now, this function is placed here because it doesn't really seem to fit in
    with the parms.c interface.
- 
+
 */
 
 String *ParmList_errorstr(ParmList *p) {

--- a/Source/Swig/error.c
+++ b/Source/Swig/error.c
@@ -40,8 +40,8 @@
 #  define  DEFAULT_ERROR_MSG_FORMAT EMF_STANDARD
 #endif
 static ErrorMessageFormat msg_format = DEFAULT_ERROR_MSG_FORMAT;
-static int silence = 0;		/* Silent operation */
-static String *filter = 0;	/* Warning filter */
+static int silence = 0;         /* Silent operation */
+static String *filter = 0;      /* Warning filter */
 static int warnall = 0;
 static int nwarning = 0;
 static int nerrors = 0;
@@ -94,11 +94,11 @@ void Swig_warning(int wnum, const_String_or_char_ptr filename, int line, const c
     sprintf(temp, "%d", wnum);
     while (*f != '\0' && (c = strstr(f, temp))) {
       if (*(c - 1) == '-') {
-        wrn = 0;		/* Warning disabled */
+        wrn = 0;                /* Warning disabled */
         break;
       }
       if (*(c - 1) == '+') {
-        wrn = 1;		/* Warning enabled */
+        wrn = 1;                /* Warning enabled */
         break;
       }
       f += strlen(temp);
@@ -256,7 +256,7 @@ void Swig_error_msg_format(ErrorMessageFormat format) {
   switch (format) {
   case EMF_MICROSOFT:
     fmt_line = "%s(%d) ";
-    fmt_eof = "%s(999999) ";	/* Is there a special character for EOF? Just use a large number. */
+    fmt_eof = "%s(999999) ";    /* Is there a special character for EOF? Just use a large number. */
     break;
   case EMF_STANDARD:
   default:

--- a/Source/Swig/error.c
+++ b/Source/Swig/error.c
@@ -94,11 +94,11 @@ void Swig_warning(int wnum, const_String_or_char_ptr filename, int line, const c
     sprintf(temp, "%d", wnum);
     while (*f != '\0' && (c = strstr(f, temp))) {
       if (*(c - 1) == '-') {
-	wrn = 0;		/* Warning disabled */
+        wrn = 0;		/* Warning disabled */
         break;
       }
       if (*(c - 1) == '+') {
-	wrn = 1;		/* Warning enabled */
+        wrn = 1;		/* Warning enabled */
         break;
       }
       f += strlen(temp);
@@ -203,19 +203,19 @@ void Swig_warnfilter(const_String_or_char_ptr wlist, int add) {
       /* Even if c is a digit, the rest of the string might not be, eg in the case of typemap 
        * warnings (a bit odd really), eg: %warnfilter(SWIGWARN_TYPEMAP_CHARLEAK_MSG) */
       if (add) {
-	Insert(filter, 0, c);
-	if (isdigit((int) *c)) {
-	  Insert(filter, 0, "-");
-	}
+        Insert(filter, 0, c);
+        if (isdigit((int) *c)) {
+          Insert(filter, 0, "-");
+        }
       } else {
-	char *temp = (char *)Malloc(sizeof(char)*strlen(c) + 2);
-	if (isdigit((int) *c)) {
-	  sprintf(temp, "-%s", c);
-	} else {
-	  strcpy(temp, c);
-	}
-	Replace(filter, temp, "", DOH_REPLACE_FIRST);
-	Free(temp);
+        char *temp = (char *)Malloc(sizeof(char)*strlen(c) + 2);
+        if (isdigit((int) *c)) {
+          sprintf(temp, "-%s", c);
+        } else {
+          strcpy(temp, c);
+        }
+        Replace(filter, temp, "", DOH_REPLACE_FIRST);
+        Free(temp);
       }
     }
     c = strtok(NULL, ", ");

--- a/Source/Swig/error.c
+++ b/Source/Swig/error.c
@@ -35,13 +35,13 @@
  * ----------------------------------------------------------------------------- */
 
 #if defined(_WIN32)
-#  define  DEFAULT_ERROR_MSG_FORMAT EMF_MICROSOFT
+#define DEFAULT_ERROR_MSG_FORMAT EMF_MICROSOFT
 #else
-#  define  DEFAULT_ERROR_MSG_FORMAT EMF_STANDARD
+#define DEFAULT_ERROR_MSG_FORMAT EMF_STANDARD
 #endif
 static ErrorMessageFormat msg_format = DEFAULT_ERROR_MSG_FORMAT;
-static int silence = 0;         /* Silent operation */
-static String *filter = 0;      /* Warning filter */
+static int silence = 0;    /* Silent operation */
+static String *filter = 0; /* Warning filter */
 static int warnall = 0;
 static int nwarning = 0;
 static int nerrors = 0;
@@ -78,7 +78,7 @@ void Swig_warning(int wnum, const_String_or_char_ptr filename, int line, const c
   vPrintf(out, fmt, ap);
 
   msg = Char(out);
-  if (isdigit((unsigned char) *msg)) {
+  if (isdigit((unsigned char)*msg)) {
     unsigned long result = strtoul(msg, &msg, 10);
     if (msg != Char(out)) {
       msg++;
@@ -94,11 +94,11 @@ void Swig_warning(int wnum, const_String_or_char_ptr filename, int line, const c
     sprintf(temp, "%d", wnum);
     while (*f != '\0' && (c = strstr(f, temp))) {
       if (*(c - 1) == '-') {
-        wrn = 0;                /* Warning disabled */
+        wrn = 0; /* Warning disabled */
         break;
       }
       if (*(c - 1) == '+') {
-        wrn = 1;                /* Warning enabled */
+        wrn = 1; /* Warning enabled */
         break;
       }
       f += strlen(temp);
@@ -174,7 +174,6 @@ void Swig_error_silent(int s) {
   silence = s;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_warnfilter()
  *
@@ -199,17 +198,17 @@ void Swig_warnfilter(const_String_or_char_ptr wlist, int add) {
   c = Char(s);
   c = strtok(c, ", ");
   while (c) {
-    if (isdigit((int) *c) || (*c == '+') || (*c == '-')) {
+    if (isdigit((int)*c) || (*c == '+') || (*c == '-')) {
       /* Even if c is a digit, the rest of the string might not be, eg in the case of typemap
        * warnings (a bit odd really), eg: %warnfilter(SWIGWARN_TYPEMAP_CHARLEAK_MSG) */
       if (add) {
         Insert(filter, 0, c);
-        if (isdigit((int) *c)) {
+        if (isdigit((int)*c)) {
           Insert(filter, 0, "-");
         }
       } else {
-        char *temp = (char *)Malloc(sizeof(char)*strlen(c) + 2);
-        if (isdigit((int) *c)) {
+        char *temp = (char *)Malloc(sizeof(char) * strlen(c) + 2);
+        if (isdigit((int)*c)) {
           sprintf(temp, "-%s", c);
         } else {
           strcpy(temp, c);
@@ -226,7 +225,6 @@ void Swig_warnfilter(const_String_or_char_ptr wlist, int add) {
 void Swig_warnall(void) {
   warnall = 1;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_warn_count()
@@ -256,7 +254,7 @@ void Swig_error_msg_format(ErrorMessageFormat format) {
   switch (format) {
   case EMF_MICROSOFT:
     fmt_line = "%s(%d) ";
-    fmt_eof = "%s(999999) ";    /* Is there a special character for EOF? Just use a large number. */
+    fmt_eof = "%s(999999) "; /* Is there a special character for EOF? Just use a large number. */
     break;
   case EMF_STANDARD:
   default:
@@ -347,4 +345,3 @@ void Swig_diagnostic(const_String_or_char_ptr filename, int line, const char *fm
   va_end(ap);
   Delete(formatted_filename);
 }
-

--- a/Source/Swig/error.c
+++ b/Source/Swig/error.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -27,7 +27,7 @@
  * The filter string is scanned left to right and the first occurrence
  * of a warning number is used to determine printing behavior.
  *
- * The same number may appear more than once in the string.  For example, in the 
+ * The same number may appear more than once in the string.  For example, in the
  * above string, "201" appears twice.  This simply means that warning 201
  * was disabled after it was previously enabled.  This may only be temporary
  * setting--the first number may be removed later in which case the warning
@@ -200,7 +200,7 @@ void Swig_warnfilter(const_String_or_char_ptr wlist, int add) {
   c = strtok(c, ", ");
   while (c) {
     if (isdigit((int) *c) || (*c == '+') || (*c == '-')) {
-      /* Even if c is a digit, the rest of the string might not be, eg in the case of typemap 
+      /* Even if c is a digit, the rest of the string might not be, eg in the case of typemap
        * warnings (a bit odd really), eg: %warnfilter(SWIGWARN_TYPEMAP_CHARLEAK_MSG) */
       if (add) {
         Insert(filter, 0, c);
@@ -228,7 +228,7 @@ void Swig_warnall(void) {
 }
 
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Swig_warn_count()
  *
  * Return the number of warnings

--- a/Source/Swig/extend.c
+++ b/Source/Swig/extend.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -54,7 +54,7 @@ void Swig_extend_merge(Node *cls, Node *am) {
             Setattr(n,"sym:name", Getattr(cls,"sym:name"));
           }
         }
-      } 
+      }
     }
 
     symname = Getattr(n,"sym:name");
@@ -98,7 +98,7 @@ void Swig_extend_append_previous(Node *cls, Node *am) {
   Node *ae = 0;
 
   if (!am) return;
-  
+
   n = firstChild(am);
   while (n) {
     ne = nextSibling(n);
@@ -110,13 +110,13 @@ void Swig_extend_append_previous(Node *cls, Node *am) {
     } else {
       if (!ae) ae = Swig_cparse_new_node("extend");
       appendChild(ae, n);
-    }    
+    }
     n = ne;
   }
   if (pe) prependChild(cls,pe);
   if (ae) appendChild(cls,ae);
 }
- 
+
 
 /* -----------------------------------------------------------------------------
  * Swig_extend_unused_check()
@@ -124,7 +124,7 @@ void Swig_extend_append_previous(Node *cls, Node *am) {
  * Check for unused %extend.  Special case, don't report unused
  * extensions for templates
  * ----------------------------------------------------------------------------- */
- 
+
 void Swig_extend_unused_check(void) {
   Iterator ki;
 

--- a/Source/Swig/extend.c
+++ b/Source/Swig/extend.c
@@ -45,15 +45,15 @@ void Swig_extend_merge(Node *cls, Node *am) {
     if (Strcmp(nodeType(n),"constructor") == 0) {
       symname = Getattr(n,"sym:name");
       if (symname) {
-	if (Strcmp(symname,Getattr(n,"name")) == 0) {
-	  /* If the name and the sym:name of a constructor are the same,
+        if (Strcmp(symname,Getattr(n,"name")) == 0) {
+          /* If the name and the sym:name of a constructor are the same,
              then it hasn't been renamed.  However---the name of the class
              itself might have been renamed so we need to do a consistency
              check here */
-	  if (Getattr(cls,"sym:name")) {
-	    Setattr(n,"sym:name", Getattr(cls,"sym:name"));
-	  }
-	}
+          if (Getattr(cls,"sym:name")) {
+            Setattr(n,"sym:name", Getattr(cls,"sym:name"));
+          }
+        }
       } 
     }
 
@@ -65,23 +65,23 @@ void Swig_extend_merge(Node *cls, Node *am) {
       Swig_symbol_remove(n);
       c = Swig_symbol_add(symname,n);
       if (c != n) {
-	/* Conflict with previous definition.  Nuke previous definition */
-	String *e = NewStringEmpty();
-	String *en = NewStringEmpty();
-	String *ec = NewStringEmpty();
-	Printf(ec, "Redefinition of identifier '%s' by %%extend ignored,", symname);
-	Printf(en, "%%extend definition of '%s'.", symname);
-	SWIG_WARN_NODE_BEGIN(n);
-	Swig_warning(WARN_PARSE_REDEFINED, Getfile(c), Getline(c), "%s\n", ec);
-	Swig_warning(WARN_PARSE_REDEFINED, Getfile(n), Getline(n), "%s\n", en);
-	SWIG_WARN_NODE_END(n);
-	Printf(e, "%s:%d:%s\n%s:%d:%s\n", Getfile(c), Getline(c), ec, Getfile(n),Getline(n),en);
-	Setattr(c, "error", e);
-	Delete(e);
-	Delete(en);
-	Delete(ec);
-	Swig_symbol_remove(c);                /* Remove class definition */
-	Swig_symbol_add(symname, n);          /* Insert extend definition */
+        /* Conflict with previous definition.  Nuke previous definition */
+        String *e = NewStringEmpty();
+        String *en = NewStringEmpty();
+        String *ec = NewStringEmpty();
+        Printf(ec, "Redefinition of identifier '%s' by %%extend ignored,", symname);
+        Printf(en, "%%extend definition of '%s'.", symname);
+        SWIG_WARN_NODE_BEGIN(n);
+        Swig_warning(WARN_PARSE_REDEFINED, Getfile(c), Getline(c), "%s\n", ec);
+        Swig_warning(WARN_PARSE_REDEFINED, Getfile(n), Getline(n), "%s\n", en);
+        SWIG_WARN_NODE_END(n);
+        Printf(e, "%s:%d:%s\n%s:%d:%s\n", Getfile(c), Getline(c), ec, Getfile(n),Getline(n),en);
+        Setattr(c, "error", e);
+        Delete(e);
+        Delete(en);
+        Delete(ec);
+        Swig_symbol_remove(c);                /* Remove class definition */
+        Swig_symbol_add(symname, n);          /* Insert extend definition */
       }
     }
     n = nextSibling(n);

--- a/Source/Swig/extend.c
+++ b/Source/Swig/extend.c
@@ -14,7 +14,7 @@
 #include "swig.h"
 #include "cparse.h"
 
-static Hash *extendhash = 0;     /* Hash table of added methods */
+static Hash *extendhash = 0; /* Hash table of added methods */
 
 /* -----------------------------------------------------------------------------
  * Swig_extend_hash()
@@ -42,28 +42,28 @@ void Swig_extend_merge(Node *cls, Node *am) {
   n = firstChild(am);
   while (n) {
     String *symname;
-    if (Strcmp(nodeType(n),"constructor") == 0) {
-      symname = Getattr(n,"sym:name");
+    if (Strcmp(nodeType(n), "constructor") == 0) {
+      symname = Getattr(n, "sym:name");
       if (symname) {
-        if (Strcmp(symname,Getattr(n,"name")) == 0) {
+        if (Strcmp(symname, Getattr(n, "name")) == 0) {
           /* If the name and the sym:name of a constructor are the same,
              then it hasn't been renamed.  However---the name of the class
              itself might have been renamed so we need to do a consistency
              check here */
-          if (Getattr(cls,"sym:name")) {
-            Setattr(n,"sym:name", Getattr(cls,"sym:name"));
+          if (Getattr(cls, "sym:name")) {
+            Setattr(n, "sym:name", Getattr(cls, "sym:name"));
           }
         }
       }
     }
 
-    symname = Getattr(n,"sym:name");
+    symname = Getattr(n, "sym:name");
     DohIncref(symname);
-    if ((symname) && (!Getattr(n,"error"))) {
+    if ((symname) && (!Getattr(n, "error"))) {
       Node *c;
       /* Remove node from its symbol table */
       Swig_symbol_remove(n);
-      c = Swig_symbol_add(symname,n);
+      c = Swig_symbol_add(symname, n);
       if (c != n) {
         /* Conflict with previous definition.  Nuke previous definition */
         String *e = NewStringEmpty();
@@ -75,13 +75,13 @@ void Swig_extend_merge(Node *cls, Node *am) {
         Swig_warning(WARN_PARSE_REDEFINED, Getfile(c), Getline(c), "%s\n", ec);
         Swig_warning(WARN_PARSE_REDEFINED, Getfile(n), Getline(n), "%s\n", en);
         SWIG_WARN_NODE_END(n);
-        Printf(e, "%s:%d:%s\n%s:%d:%s\n", Getfile(c), Getline(c), ec, Getfile(n),Getline(n),en);
+        Printf(e, "%s:%d:%s\n%s:%d:%s\n", Getfile(c), Getline(c), ec, Getfile(n), Getline(n), en);
         Setattr(c, "error", e);
         Delete(e);
         Delete(en);
         Delete(ec);
-        Swig_symbol_remove(c);                /* Remove class definition */
-        Swig_symbol_add(symname, n);          /* Insert extend definition */
+        Swig_symbol_remove(c);       /* Remove class definition */
+        Swig_symbol_add(symname, n); /* Insert extend definition */
       }
     }
     n = nextSibling(n);
@@ -97,26 +97,30 @@ void Swig_extend_append_previous(Node *cls, Node *am) {
   Node *pe = 0;
   Node *ae = 0;
 
-  if (!am) return;
+  if (!am)
+    return;
 
   n = firstChild(am);
   while (n) {
     ne = nextSibling(n);
-    set_nextSibling(n,0);
+    set_nextSibling(n, 0);
     /* typemaps and fragments need to be prepended */
-    if (((Cmp(nodeType(n),"typemap") == 0) || (Cmp(nodeType(n),"fragment") == 0)))  {
-      if (!pe) pe = Swig_cparse_new_node("extend");
+    if (((Cmp(nodeType(n), "typemap") == 0) || (Cmp(nodeType(n), "fragment") == 0))) {
+      if (!pe)
+        pe = Swig_cparse_new_node("extend");
       appendChild(pe, n);
     } else {
-      if (!ae) ae = Swig_cparse_new_node("extend");
+      if (!ae)
+        ae = Swig_cparse_new_node("extend");
       appendChild(ae, n);
     }
     n = ne;
   }
-  if (pe) prependChild(cls,pe);
-  if (ae) appendChild(cls,ae);
+  if (pe)
+    prependChild(cls, pe);
+  if (ae)
+    appendChild(cls, ae);
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_extend_unused_check()
@@ -128,13 +132,13 @@ void Swig_extend_append_previous(Node *cls, Node *am) {
 void Swig_extend_unused_check(void) {
   Iterator ki;
 
-  if (!extendhash) return;
+  if (!extendhash)
+    return;
   for (ki = First(extendhash); ki.key; ki = Next(ki)) {
-    if (!Strchr(ki.key,'<')) {
+    if (!Strchr(ki.key, '<')) {
       SWIG_WARN_NODE_BEGIN(ki.item);
-      Swig_warning(WARN_PARSE_EXTEND_UNDEF,Getfile(ki.item), Getline(ki.item), "%%extend defined for an undeclared class %s.\n", SwigType_namestr(ki.key));
+      Swig_warning(WARN_PARSE_EXTEND_UNDEF, Getfile(ki.item), Getline(ki.item), "%%extend defined for an undeclared class %s.\n", SwigType_namestr(ki.key));
       SWIG_WARN_NODE_END(ki.item);
     }
   }
 }
-

--- a/Source/Swig/fragment.c
+++ b/Source/Swig/fragment.c
@@ -24,7 +24,6 @@ static Hash *fragments = 0;
 static Hash *looking_fragments = 0;
 static int debug = 0;
 
-
 /* -----------------------------------------------------------------------------
  * Swig_fragment_register()
  *
@@ -79,8 +78,7 @@ void Swig_fragment_register(Node *fragment) {
  * Emit a fragment
  * ----------------------------------------------------------------------------- */
 
-static
-char *char_index(char *str, char c) {
+static char *char_index(char *str, char c) {
   while (*str && (c != *str))
     ++str;
   return (c == *str) ? str : 0;

--- a/Source/Swig/fragment.c
+++ b/Source/Swig/fragment.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -13,7 +13,7 @@
  * file (depending on what features are actually used in the interface).
  *
  * By using fragments, it's possible to greatly reduce the amount of
- * wrapper code and to generate cleaner wrapper files. 
+ * wrapper code and to generate cleaner wrapper files.
  * ----------------------------------------------------------------------------- */
 
 #include "swig.h"

--- a/Source/Swig/fragment.c
+++ b/Source/Swig/fragment.c
@@ -46,7 +46,7 @@ void Swig_fragment_register(Node *fragment) {
       Delete(mangle);
       Delete(rtype);
       if (debug)
-	Printf(stdout, "register fragment %s %s\n", name, type);
+        Printf(stdout, "register fragment %s %s\n", name, type);
     }
     if (!fragments) {
       fragments = NewHash();
@@ -57,7 +57,7 @@ void Swig_fragment_register(Node *fragment) {
       Hash *kwargs = Getattr(fragment, "kwargs");
       Setmeta(ccode, "section", section);
       if (kwargs) {
-	Setmeta(ccode, "kwargs", kwargs);
+        Setmeta(ccode, "kwargs", kwargs);
       }
       Setfile(ccode, Getfile(fragment));
       Setline(ccode, Getline(fragment));
@@ -65,7 +65,7 @@ void Swig_fragment_register(Node *fragment) {
       Swig_cparse_replace_descriptor(ccode);
       Setattr(fragments, name, ccode);
       if (debug)
-	Printf(stdout, "registering fragment %s %s\n", name, section);
+        Printf(stdout, "registering fragment %s %s\n", name, section);
       Delete(section);
       Delete(ccode);
     }
@@ -130,45 +130,45 @@ void Swig_fragment_emit(Node *n) {
       String *section = Getmeta(code, "section");
       Hash *nn = Getmeta(code, "kwargs");
       if (!looking_fragments)
-	looking_fragments = NewHash();
+        looking_fragments = NewHash();
       Setattr(looking_fragments, name, "1");
       while (nn) {
-	if (Equal(Getattr(nn, "name"), "fragment")) {
-	  if (debug)
-	    Printf(stdout, "emitting fragment %s %s\n", nn, type);
-	  Setfile(nn, Getfile(n));
-	  Setline(nn, Getline(n));
-	  Swig_fragment_emit(nn);
-	}
-	nn = nextSibling(nn);
+        if (Equal(Getattr(nn, "name"), "fragment")) {
+          if (debug)
+            Printf(stdout, "emitting fragment %s %s\n", nn, type);
+          Setfile(nn, Getfile(n));
+          Setline(nn, Getline(n));
+          Swig_fragment_emit(nn);
+        }
+        nn = nextSibling(nn);
       }
       if (section) {
-	File *f = Swig_filebyname(section);
-	if (!f) {
-	  Swig_error(Getfile(code), Getline(code), "Bad section '%s' in %%fragment declaration for code fragment '%s'\n", section, name);
-	} else {
-	  if (debug)
-	    Printf(stdout, "emitting subfragment %s %s\n", name, section);
-	  if (debug)
-	    Printf(f, "/* begin fragment %s */\n", name);
-	  Printf(f, "%s\n", code);
-	  if (debug)
-	    Printf(f, "/* end fragment %s */\n\n", name);
-	  Setattr(fragments, name, "ignore");
-	  Delattr(looking_fragments, name);
-	}
+        File *f = Swig_filebyname(section);
+        if (!f) {
+          Swig_error(Getfile(code), Getline(code), "Bad section '%s' in %%fragment declaration for code fragment '%s'\n", section, name);
+        } else {
+          if (debug)
+            Printf(stdout, "emitting subfragment %s %s\n", name, section);
+          if (debug)
+            Printf(f, "/* begin fragment %s */\n", name);
+          Printf(f, "%s\n", code);
+          if (debug)
+            Printf(f, "/* end fragment %s */\n\n", name);
+          Setattr(fragments, name, "ignore");
+          Delattr(looking_fragments, name);
+        }
       }
     } else if (!code && type) {
       SwigType *rtype = SwigType_typedef_resolve_all(type);
       if (!Equal(type, rtype)) {
-	String *name = Copy(Getattr(n, "value"));
-	String *mangle = Swig_name_mangle_type(type);
-	Append(name, mangle);
-	Setfile(name, Getfile(n));
-	Setline(name, Getline(n));
-	Swig_fragment_emit(name);
-	Delete(mangle);
-	Delete(name);
+        String *name = Copy(Getattr(n, "value"));
+        String *mangle = Swig_name_mangle_type(type);
+        Append(name, mangle);
+        Setfile(name, Getfile(n));
+        Setline(name, Getline(n));
+        Swig_fragment_emit(name);
+        Delete(mangle);
+        Delete(name);
       }
       Delete(rtype);
     }
@@ -180,7 +180,7 @@ void Swig_fragment_emit(Node *n) {
     if (tok) {
       pc = char_index(tok, ',');
       if (pc)
-	*pc = 0;
+        *pc = 0;
     }
     Delete(name);
   }

--- a/Source/Swig/getopt.c
+++ b/Source/Swig/getopt.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -14,8 +14,8 @@
  * there are no unrecognized options, each module is required to "mark"
  * the options that it uses.  Afterwards, we can make a quick scan to make
  * sure there are no unmarked options.
- * 
- * TODO: 
+ *
+ * TODO:
  *       Should have cleaner error handling in general.
  * ----------------------------------------------------------------------------- */
 
@@ -27,7 +27,7 @@ static int *marked;
 
 /* -----------------------------------------------------------------------------
  * Swig_init_args()
- * 
+ *
  * Initialize the argument list handler.
  * ----------------------------------------------------------------------------- */
 
@@ -43,7 +43,7 @@ void Swig_init_args(int argc, char **argv) {
 
 /* -----------------------------------------------------------------------------
  * Swig_mark_arg()
- * 
+ *
  * Marks an argument as being parsed.
  * ----------------------------------------------------------------------------- */
 
@@ -66,7 +66,7 @@ int Swig_check_marked(int n) {
 
 /* -----------------------------------------------------------------------------
  * Swig_check_options()
- * 
+ *
  * Checkers for unprocessed command line options and errors.
  * ----------------------------------------------------------------------------- */
 
@@ -93,7 +93,7 @@ void Swig_check_options(int check_input) {
 
 /* -----------------------------------------------------------------------------
  * Swig_arg_error()
- * 
+ *
  * Generates a generic error message and exits.
  * ----------------------------------------------------------------------------- */
 

--- a/Source/Swig/getopt.c
+++ b/Source/Swig/getopt.c
@@ -37,7 +37,7 @@ void Swig_init_args(int argc, char **argv) {
 
   numargs = argc;
   args = argv;
-  marked = (int *) Calloc(numargs, sizeof(int));
+  marked = (int *)Calloc(numargs, sizeof(int));
   marked[0] = 1;
 }
 

--- a/Source/Swig/include.c
+++ b/Source/Swig/include.c
@@ -15,10 +15,10 @@
 
 #include "swig.h"
 
-static List   *directories = 0;         /* List of include directories */
-static String *lastpath = 0;            /* Last file that was included */
-static List   *pdirectories = 0;        /* List of pushed directories  */
-static int     dopush = 1;              /* Whether to push directories */
+static List *directories = 0;  /* List of include directories */
+static String *lastpath = 0;   /* Last file that was included */
+static List *pdirectories = 0; /* List of pushed directories  */
+static int dopush = 1;         /* Whether to push directories */
 static int file_debug = 0;
 
 /* This functions determine whether to push/pop dirs in the preprocessor */
@@ -43,7 +43,7 @@ List *Swig_add_directory(const_String_or_char_ptr dirname) {
   assert(directories);
   if (dirname) {
     adirname = NewString(dirname);
-    Append(directories,adirname);
+    Append(directories, adirname);
     Delete(adirname);
   }
   return directories;
@@ -65,7 +65,7 @@ void Swig_push_directory(const_String_or_char_ptr dirname) {
   assert(pdirectories);
   pdirname = NewString(dirname);
   assert(pdirname);
-  Insert(pdirectories,0,pdirname);
+  Insert(pdirectories, 0, pdirname);
   Delete(pdirname);
 }
 
@@ -103,8 +103,8 @@ String *Swig_last_file(void) {
 
 static List *Swig_search_path_any(int syspath) {
   String *filename;
-  List   *slist;
-  int     i, ilen;
+  List *slist;
+  int i, ilen;
 
   slist = NewList();
   assert(slist);
@@ -118,23 +118,23 @@ static List *Swig_search_path_any(int syspath) {
   if (pdirectories) {
     ilen = Len(pdirectories);
     for (i = 0; i < ilen; i++) {
-      filename = NewString(Getitem(pdirectories,i));
-      Append(filename,SWIG_FILE_DELIMITER);
-      Append(slist,filename);
+      filename = NewString(Getitem(pdirectories, i));
+      Append(filename, SWIG_FILE_DELIMITER);
+      Append(slist, filename);
       Delete(filename);
     }
   }
   /* Add system directories next */
   ilen = Len(directories);
   for (i = 0; i < ilen; i++) {
-    filename = NewString(Getitem(directories,i));
-    Append(filename,SWIG_FILE_DELIMITER);
+    filename = NewString(Getitem(directories, i));
+    Append(filename, SWIG_FILE_DELIMITER);
     if (syspath) {
       /* If doing a system include, put the system directories first */
-      Insert(slist,i,filename);
+      Insert(slist, i, filename);
     } else {
       /* Otherwise, just put the system directories after the pushed directories (if any) */
-      Append(slist,filename);
+      Append(slist, filename);
     }
     Delete(filename);
   }
@@ -144,8 +144,6 @@ static List *Swig_search_path_any(int syspath) {
 List *Swig_search_path(void) {
   return Swig_search_path_any(0);
 }
-
-
 
 /* -----------------------------------------------------------------------------
  * Swig_open()
@@ -210,8 +208,6 @@ FILE *Swig_open(const_String_or_char_ptr name) {
   return Swig_open_file(name, 0, 0);
 }
 
-
-
 /* -----------------------------------------------------------------------------
  * Swig_read_file()
  *
@@ -226,8 +222,10 @@ String *Swig_read_file(FILE *f) {
   assert(str);
   while (1) {
     size_t c = fread(buffer, 1, sizeof(buffer), f);
-    if (c > 0) Write(str, buffer, (int)c);
-    if (c < sizeof(buffer)) break;
+    if (c > 0)
+      Write(str, buffer, (int)c);
+    if (c < sizeof(buffer))
+      break;
   }
   len = Len(str);
   /* Add a newline if not present on last line -- the preprocessor seems to

--- a/Source/Swig/include.c
+++ b/Source/Swig/include.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -86,8 +86,8 @@ void Swig_pop_directory(void) {
 
 /* -----------------------------------------------------------------------------
  * Swig_last_file()
- * 
- * Returns the full pathname of the last file opened. 
+ *
+ * Returns the full pathname of the last file opened.
  * ----------------------------------------------------------------------------- */
 
 String *Swig_last_file(void) {
@@ -96,8 +96,8 @@ String *Swig_last_file(void) {
 }
 
 /* -----------------------------------------------------------------------------
- * Swig_search_path_any() 
- * 
+ * Swig_search_path_any()
+ *
  * Returns a list of the current search paths.
  * ----------------------------------------------------------------------------- */
 
@@ -113,7 +113,7 @@ static List *Swig_search_path_any(int syspath) {
   Printf(filename, ".%s", SWIG_FILE_DELIMITER);
   Append(slist, filename);
   Delete(filename);
-  
+
   /* If there are any pushed directories.  Add them first */
   if (pdirectories) {
     ilen = Len(pdirectories);
@@ -150,7 +150,7 @@ List *Swig_search_path(void) {
 /* -----------------------------------------------------------------------------
  * Swig_open()
  *
- * open a file, optionally looking for it in the include path.  Returns an open  
+ * open a file, optionally looking for it in the include path.  Returns an open
  * FILE * on success.
  * ----------------------------------------------------------------------------- */
 
@@ -214,7 +214,7 @@ FILE *Swig_open(const_String_or_char_ptr name) {
 
 /* -----------------------------------------------------------------------------
  * Swig_read_file()
- * 
+ *
  * Reads data from an open FILE * and returns it as a string.
  * ----------------------------------------------------------------------------- */
 
@@ -230,7 +230,7 @@ String *Swig_read_file(FILE *f) {
     if (c < sizeof(buffer)) break;
   }
   len = Len(str);
-  /* Add a newline if not present on last line -- the preprocessor seems to 
+  /* Add a newline if not present on last line -- the preprocessor seems to
    * rely on \n and not EOF terminating lines */
   if (len) {
     char *cstr = Char(str);

--- a/Source/Swig/include.c
+++ b/Source/Swig/include.c
@@ -181,7 +181,7 @@ static FILE *Swig_open_file(const_String_or_char_ptr name, int sysfile, int use_
       Printf(filename, "%s%s", Getitem(spath, i), cname);
       f = fopen(Char(filename), "r");
       if (f)
-	break;
+        break;
     }
     Delete(spath);
   }

--- a/Source/Swig/include.c
+++ b/Source/Swig/include.c
@@ -15,10 +15,10 @@
 
 #include "swig.h"
 
-static List   *directories = 0;	        /* List of include directories */
-static String *lastpath = 0;	        /* Last file that was included */
+static List   *directories = 0;         /* List of include directories */
+static String *lastpath = 0;            /* Last file that was included */
 static List   *pdirectories = 0;        /* List of pushed directories  */
-static int     dopush = 1;		/* Whether to push directories */
+static int     dopush = 1;              /* Whether to push directories */
 static int file_debug = 0;
 
 /* This functions determine whether to push/pop dirs in the preprocessor */

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -278,7 +278,7 @@ void Swig_filename_correct(String *filename) {
 String *Swig_filename_escape(String *filename) {
   String *adjusted_filename = Copy(filename);
   Swig_filename_correct(adjusted_filename);
-#if defined(_WIN32)		/* Note not on Cygwin else filename is displayed with double '/' */
+#if defined(_WIN32)             /* Note not on Cygwin else filename is displayed with double '/' */
   Replaceall(adjusted_filename, "\\", "\\\\");
 #endif
   return adjusted_filename;

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -647,12 +647,12 @@ static String *Swig_string_ucase(String *s) {
 /* -----------------------------------------------------------------------------
  * Swig_string_first_upper()
  *
- * Make the first character in the string uppercase, leave all the 
+ * Make the first character in the string uppercase, leave all the
  * rest the same.  This is used by the Ruby module to provide backwards
  * compatibility with the old way of naming classes and constants.  For
  * more info see the Ruby documentation.
  *
- *      firstUpper -> FirstUpper 
+ *      firstUpper -> FirstUpper
  * ----------------------------------------------------------------------------- */
 
 static String *Swig_string_first_upper(String *s) {
@@ -668,12 +668,12 @@ static String *Swig_string_first_upper(String *s) {
 /* -----------------------------------------------------------------------------
  * Swig_string_first_lower()
  *
- * Make the first character in the string lowercase, leave all the 
+ * Make the first character in the string lowercase, leave all the
  * rest the same.  This is used by the Ruby module to provide backwards
  * compatibility with the old way of naming classes and constants.  For
  * more info see the Ruby documentation.
  *
- *      firstLower -> FirstLower 
+ *      firstLower -> FirstLower
  * ----------------------------------------------------------------------------- */
 
 static String *Swig_string_first_lower(String *s) {
@@ -822,7 +822,7 @@ String *Swig_scopename_prefix(const String *s) {
  * Swig_scopename_last()
  *
  * Take a qualified name like "A::B::C" and returns the last.  In this
- * case, "C". 
+ * case, "C".
  * ----------------------------------------------------------------------------- */
 
 String *Swig_scopename_last(const String *s) {
@@ -1061,7 +1061,7 @@ static String *Swig_string_command(String *s) {
 /* -----------------------------------------------------------------------------
  * Swig_string_strip()
  *
- * Strip given prefix from identifiers 
+ * Strip given prefix from identifiers
  *
  *  Printf(stderr,"%(strip:[wx])s","wxHello") -> Hello
  * ----------------------------------------------------------------------------- */
@@ -1091,7 +1091,7 @@ static String *Swig_string_strip(String *s) {
 /* -----------------------------------------------------------------------------
  * Swig_string_rstrip()
  *
- * Strip given suffix from identifiers 
+ * Strip given suffix from identifiers
  *
  *  Printf(stderr,"%(rstrip:[Cls])s","HelloCls") -> Hello
  * ----------------------------------------------------------------------------- */
@@ -1375,7 +1375,7 @@ String *Swig_pcre_version(void) {
 /* ------------------------------------------------------------
  * Swig_is_generated_overload()
  * Check if the function is an automatically generated
- * overload created because a method has default parameters. 
+ * overload created because a method has default parameters.
  * ------------------------------------------------------------ */
 
 int Swig_is_generated_overload(Node *n) {

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -40,7 +40,7 @@ static char *fake_version = 0;
 char *Swig_copy_string(const char *s) {
   char *c = 0;
   if (s) {
-    c = (char *) Malloc(strlen(s) + 1);
+    c = (char *)Malloc(strlen(s) + 1);
     strcpy(c, s);
   }
   return c;
@@ -114,7 +114,6 @@ void Swig_banner(File *f) {
   Printf(f, "/* ----------------------------------------------------------------------------\n");
   Swig_banner_target_lang(f, " *");
   Printf(f, " * ----------------------------------------------------------------------------- */\n");
-
 }
 
 /* -----------------------------------------------------------------------------
@@ -150,7 +149,7 @@ String *Swig_strip_c_comments(const String *s) {
       if (!*c)
         break;
       if (*c == '*')
-        comment_begin = c-1;
+        comment_begin = c - 1;
     } else if (comment_begin && !comment_end && *c == '*') {
       ++c;
       if (*c == '/') {
@@ -232,7 +231,9 @@ String *Swig_new_subdirectory(String *basedirectory, String *subdirectory) {
       Printf(dir, SWIG_FILE_DELIMITER);
     }
   } else {
-    error = NewStringf("Cannot create subdirectory %s under the base directory %s. Either the base does not exist as a directory or it is not readable.", subdirectory, basedirectory);
+    error = NewStringf("Cannot create subdirectory %s under the base directory %s. Either the base does not exist as a directory or it is not readable.",
+                       subdirectory,
+                       basedirectory);
   }
   return error;
 }
@@ -278,7 +279,7 @@ void Swig_filename_correct(String *filename) {
 String *Swig_filename_escape(String *filename) {
   String *adjusted_filename = Copy(filename);
   Swig_filename_correct(adjusted_filename);
-#if defined(_WIN32)             /* Note not on Cygwin else filename is displayed with double '/' */
+#if defined(_WIN32) /* Note not on Cygwin else filename is displayed with double '/' */
   Replaceall(adjusted_filename, "\\", "\\\\");
 #endif
   return adjusted_filename;
@@ -511,7 +512,6 @@ String *Swig_string_lower(String *s) {
   return ns;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_string_title()
  *
@@ -626,7 +626,8 @@ static String *Swig_string_ucase(String *s) {
   Seek(s, 0, SEEK_SET);
 
   while ((c = Getc(s)) != EOF) {
-    nextC = Getc(s); Ungetc(nextC, s);
+    nextC = Getc(s);
+    Ungetc(nextC, s);
     if (isdigit(c) && isalpha(lastC) && nextC != EOF)
       underscore = 1;
     else if (isupper(c) && isalpha(lastC) && !isupper(lastC))
@@ -703,7 +704,6 @@ static String *Swig_string_schemify(String *s) {
 static String *string_mangle(String *s) {
   return Swig_name_mangle_string(s);
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_scopename_split()
@@ -838,7 +838,6 @@ String *Swig_scopename_last(const String *s) {
     return NewString(co);
   }
 
-
   while (*c) {
     if ((*c == ':') && (*(c + 1) == ':')) {
       c += 2;
@@ -910,7 +909,6 @@ String *Swig_scopename_first(const String *s) {
     return 0;
   }
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_scopename_suffix()
@@ -1076,12 +1074,12 @@ static String *Swig_string_strip(String *s) {
     if (*cs != '[' || !ce) {
       ns = NewString(s);
     } else {
-      String *fmt = NewStringf("%%.%ds", ce-cs-1);
-      String *prefix = NewStringf(fmt, cs+1);
-      if (0 == Strncmp(ce+1, prefix, Len(prefix))) {
-        ns = NewString(ce+1+Len(prefix));
+      String *fmt = NewStringf("%%.%ds", ce - cs - 1);
+      String *prefix = NewStringf(fmt, cs + 1);
+      if (0 == Strncmp(ce + 1, prefix, Len(prefix))) {
+        ns = NewString(ce + 1 + Len(prefix));
       } else {
-        ns = NewString(ce+1);
+        ns = NewString(ce + 1);
       }
     }
   }
@@ -1107,14 +1105,14 @@ static String *Swig_string_rstrip(String *s) {
     if (*cs != '[' || !ce) {
       ns = NewString(s);
     } else {
-      String *fmt = NewStringf("%%.%ds", ce-cs-1);
-      String *suffix = NewStringf(fmt, cs+1);
+      String *fmt = NewStringf("%%.%ds", ce - cs - 1);
+      String *suffix = NewStringf(fmt, cs + 1);
       int suffix_len = Len(suffix);
-      if (0 == Strncmp(cs+len-suffix_len, suffix, suffix_len)) {
-        int copy_len = len-suffix_len-(int)(ce+1-cs);
-        ns = NewStringWithSize(ce+1, copy_len);
+      if (0 == Strncmp(cs + len - suffix_len, suffix, suffix_len)) {
+        int copy_len = len - suffix_len - (int)(ce + 1 - cs);
+        ns = NewStringWithSize(ce + 1, copy_len);
       } else {
-        ns = NewString(ce+1);
+        ns = NewString(ce + 1);
       }
     }
   }
@@ -1140,19 +1138,19 @@ void Swig_offset_string(String *s, int number) {
     start = strchr(start + 1, '\n');
   }
   /* do not count pending new line */
-  if ((Char(s))[len-1] == '\n')
+  if ((Char(s))[len - 1] == '\n')
     --lines;
   /* allocate a temporary storage for a padded string */
-  res = (char*)Malloc(len + lines * number * 2 + 1);
+  res = (char *)Malloc(len + lines * number * 2 + 1);
   res[len + lines * number * 2] = 0;
 
   /* copy lines to res, prepending tabs to each line */
-  p = res; /* output pointer */
-  start = Char(s); /* start of a current line */
+  p = res;                   /* output pointer */
+  start = Char(s);           /* start of a current line */
   end = strchr(start, '\n'); /* end of a current line */
   while (end) {
-    memset(p, ' ', number*2);
-    p += number*2;
+    memset(p, ' ', number * 2);
+    p += number * 2;
     memcpy(p, start, end - start + 1);
     p += end - start + 1;
     start = end + 1;
@@ -1160,8 +1158,8 @@ void Swig_offset_string(String *s, int number) {
   }
   /* process the last line */
   if (*start) {
-    memset(p, ' ', number*2);
-    p += number*2;
+    memset(p, ' ', number * 2);
+    p += number * 2;
     strcpy(p, start);
   }
   /* replace 's' contents with 'res' */
@@ -1170,33 +1168,34 @@ void Swig_offset_string(String *s, int number) {
   Free(res);
 }
 
-
 #ifdef HAVE_PCRE
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
 
-static int split_regex_pattern_subst(String *s, String **pattern, String **subst, const char **input)
-{
+static int split_regex_pattern_subst(String *s, String **pattern, String **subst, const char **input) {
   const char *pats, *pate;
   const char *subs, *sube;
 
   /* Locate the search pattern */
   const char *p = Char(s);
-  if (*p++ != '/') goto err_out;
+  if (*p++ != '/')
+    goto err_out;
   pats = p;
   p = strchr(p, '/');
-  if (!p) goto err_out;
+  if (!p)
+    goto err_out;
   pate = p;
 
   /* Locate the substitution string */
   subs = ++p;
   p = strchr(p, '/');
-  if (!p) goto err_out;
+  if (!p)
+    goto err_out;
   sube = p;
 
   *pattern = NewStringWithSize(pats, (int)(pate - pats));
-  *subst   = NewStringWithSize(subs, (int)(sube - subs));
-  *input   = p + 1;
+  *subst = NewStringWithSize(subs, (int)(sube - subs));
+  *input = p + 1;
   return 1;
 
 err_out:
@@ -1207,15 +1206,14 @@ err_out:
 
 /* This function copies len characters from src to dst, possibly applying case conversions to them: if convertCase is 1, to upper case and if it is -1, to lower
  * case. If convertNextOnly is 1, only a single character is converted (and convertCase is reset), otherwise all of them are. */
-static void copy_with_maybe_case_conversion(String *dst, const char *src, int len, int *convertCase, int convertNextOnly)
-{
+static void copy_with_maybe_case_conversion(String *dst, const char *src, int len, int *convertCase, int convertNextOnly) {
   /* Deal with the trivial cases first. */
   if (!len)
     return;
 
   if (!*convertCase) {
-      Write(dst, src, len);
-      return;
+    Write(dst, src, len);
+    return;
   }
 
   /* If we must convert only the first character, do it and write the rest at once. */
@@ -1236,8 +1234,7 @@ static void copy_with_maybe_case_conversion(String *dst, const char *src, int le
   }
 }
 
-static String *replace_captures(int num_captures, const char *input, String *subst, size_t captures[], String *pattern, String *s)
-{
+static String *replace_captures(int num_captures, const char *input, String *subst, size_t captures[], String *pattern, String *s) {
   int convertCase = 0, convertNextOnly = 0;
   String *result = NewStringEmpty();
   const char *p = Char(subst);
@@ -1258,41 +1255,45 @@ static String *replace_captures(int num_captures, const char *input, String *sub
     } else if (isdigit((unsigned char)*p)) {
       int group = *p++ - '0';
       if (group < num_captures) {
-        int l = (int)captures[group*2], r = (int)captures[group*2 + 1];
+        int l = (int)captures[group * 2], r = (int)captures[group * 2 + 1];
         if (l != -1) {
           copy_with_maybe_case_conversion(result, input + l, r - l, &convertCase, convertNextOnly);
         }
       } else {
-        Swig_error("SWIG", Getline(s), "PCRE capture replacement failed while matching \"%s\" using \"%s\" - request for group %d is greater than the number of captures %d.\n",
-            Char(pattern), input, group, num_captures-1);
+        Swig_error("SWIG",
+                   Getline(s),
+                   "PCRE capture replacement failed while matching \"%s\" using \"%s\" - request for group %d is greater than the number of captures %d.\n",
+                   Char(pattern),
+                   input,
+                   group,
+                   num_captures - 1);
       }
     } else {
-        /* Handle Perl-like case conversion escapes. */
-        switch (*p) {
-        case 'u':
-          convertCase = 1;
-          convertNextOnly = 1;
-          break;
-        case 'U':
-          convertCase = 1;
-          convertNextOnly = 0;
-          break;
-        case 'l':
-          convertCase = -1;
-          convertNextOnly = 1;
-          break;
-        case 'L':
-          convertCase = -1;
-          convertNextOnly = 0;
-          break;
-        case 'E':
-          convertCase = 0;
-          break;
-        default:
-          Swig_error("SWIG", Getline(s), "Unrecognized escape character '%c' in the replacement string \"%s\".\n",
-              *p, Char(subst));
-        }
-        p++;
+      /* Handle Perl-like case conversion escapes. */
+      switch (*p) {
+      case 'u':
+        convertCase = 1;
+        convertNextOnly = 1;
+        break;
+      case 'U':
+        convertCase = 1;
+        convertNextOnly = 0;
+        break;
+      case 'l':
+        convertCase = -1;
+        convertNextOnly = 1;
+        break;
+      case 'L':
+        convertCase = -1;
+        convertNextOnly = 0;
+        break;
+      case 'E':
+        convertCase = 0;
+        break;
+      default:
+        Swig_error("SWIG", Getline(s), "Unrecognized escape character '%c' in the replacement string \"%s\".\n", *p, Char(subst));
+      }
+      p++;
     }
   }
 
@@ -1321,22 +1322,19 @@ static String *Swig_string_regex(String *s) {
   if (split_regex_pattern_subst(s, &pattern, &subst, &input)) {
     int rc;
 
-    compiled_pat = pcre2_compile(
-          (PCRE2_SPTR8)Char(pattern), PCRE2_ZERO_TERMINATED, pcre_options, &pcre_errornum, &pcre_errorpos, NULL);
+    compiled_pat = pcre2_compile((PCRE2_SPTR8)Char(pattern), PCRE2_ZERO_TERMINATED, pcre_options, &pcre_errornum, &pcre_errorpos, NULL);
     if (!compiled_pat) {
-      pcre2_get_error_message (pcre_errornum, pcre_error, sizeof pcre_error);
-      Swig_error("SWIG", Getline(s), "PCRE compilation failed: '%s' in '%s':%i.\n",
-          pcre_error, Char(pattern), pcre_errorpos);
+      pcre2_get_error_message(pcre_errornum, pcre_error, sizeof pcre_error);
+      Swig_error("SWIG", Getline(s), "PCRE compilation failed: '%s' in '%s':%i.\n", pcre_error, Char(pattern), pcre_errorpos);
       Exit(EXIT_FAILURE);
     }
-    match_data = pcre2_match_data_create_from_pattern (compiled_pat, NULL);
+    match_data = pcre2_match_data_create_from_pattern(compiled_pat, NULL);
     rc = pcre2_match(compiled_pat, (PCRE2_SPTR8)input, PCRE2_ZERO_TERMINATED, 0, 0, match_data, NULL);
-    captures = pcre2_get_ovector_pointer (match_data);
+    captures = pcre2_get_ovector_pointer(match_data);
     if (rc >= 0) {
       res = replace_captures(rc, input, subst, captures, pattern, s);
     } else if (rc != PCRE2_ERROR_NOMATCH) {
-      Swig_error("SWIG", Getline(s), "PCRE execution failed: error %d while matching \"%s\" using \"%s\".\n",
-        rc, Char(pattern), input);
+      Swig_error("SWIG", Getline(s), "PCRE execution failed: error %d while matching \"%s\" using \"%s\".\n", rc, Char(pattern), input);
       Exit(EXIT_FAILURE);
     }
   }

--- a/Source/Swig/misc.c
+++ b/Source/Swig/misc.c
@@ -222,12 +222,12 @@ String *Swig_new_subdirectory(String *basedirectory, String *subdirectory) {
       result = mkdir(Char(dir), 0777);
 #endif
       if (result != 0 && errno != EEXIST) {
-	error = NewStringf("Cannot create directory %s: %s", dir, strerror(errno));
-	break;
+        error = NewStringf("Cannot create directory %s: %s", dir, strerror(errno));
+        break;
       }
       if (!is_directory(dir)) {
-	error = NewStringf("Cannot create directory %s: it may already exist but not be a directory", dir);
-	break;
+        error = NewStringf("Cannot create directory %s: it may already exist but not be a directory", dir);
+        break;
       }
       Printf(dir, SWIG_FILE_DELIMITER);
     }
@@ -392,10 +392,10 @@ String *Swig_string_escape(String *s) {
       int next_c = Getc(s);
       assert(c >= 0);
       if (next_c >= '0' && next_c < '8') {
-	/* We need to emit 3 octal digits. */
-	Printf(ns, "\\%03o", c);
+        /* We need to emit 3 octal digits. */
+        Printf(ns, "\\%03o", c);
       } else {
-	Printf(ns, "\\%o", c);
+        Printf(ns, "\\%o", c);
       }
       c = next_c;
       continue;
@@ -741,17 +741,17 @@ void Swig_scopename_split(const String *s, String **rprefix, String **rlast) {
       c += 2;
     } else {
       if (*c == '<') {
-	int level = 1;
-	c++;
-	while (*c && level) {
-	  if (*c == '<')
-	    level++;
-	  if (*c == '>')
-	    level--;
-	  c++;
-	}
+        int level = 1;
+        c++;
+        while (*c && level) {
+          if (*c == '<')
+            level++;
+          if (*c == '>')
+            level--;
+          c++;
+        }
       } else {
-	c++;
+        c++;
       }
     }
   }
@@ -796,17 +796,17 @@ String *Swig_scopename_prefix(const String *s) {
       c += 2;
     } else {
       if (*c == '<') {
-	int level = 1;
-	c++;
-	while (*c && level) {
-	  if (*c == '<')
-	    level++;
-	  if (*c == '>')
-	    level--;
-	  c++;
-	}
+        int level = 1;
+        c++;
+        while (*c && level) {
+          if (*c == '<')
+            level++;
+          if (*c == '>')
+            level--;
+          c++;
+        }
       } else {
-	c++;
+        c++;
       }
     }
   }
@@ -845,17 +845,17 @@ String *Swig_scopename_last(const String *s) {
       cc = c;
     } else {
       if (*c == '<') {
-	int level = 1;
-	c++;
-	while (*c && level) {
-	  if (*c == '<')
-	    level++;
-	  if (*c == '>')
-	    level--;
-	  c++;
-	}
+        int level = 1;
+        c++;
+        while (*c && level) {
+          if (*c == '<')
+            level++;
+          if (*c == '>')
+            level--;
+          c++;
+        }
       } else {
-	c++;
+        c++;
       }
     }
   }
@@ -890,17 +890,17 @@ String *Swig_scopename_first(const String *s) {
       break;
     } else {
       if (*c == '<') {
-	int level = 1;
-	c++;
-	while (*c && level) {
-	  if (*c == '<')
-	    level++;
-	  if (*c == '>')
-	    level--;
-	  c++;
-	}
+        int level = 1;
+        c++;
+        while (*c && level) {
+          if (*c == '<')
+            level++;
+          if (*c == '>')
+            level--;
+          c++;
+        }
       } else {
-	c++;
+        c++;
       }
     }
   }
@@ -936,17 +936,17 @@ String *Swig_scopename_suffix(const String *s) {
       break;
     } else {
       if (*c == '<') {
-	int level = 1;
-	c++;
-	while (*c && level) {
-	  if (*c == '<')
-	    level++;
-	  if (*c == '>')
-	    level--;
-	  c++;
-	}
+        int level = 1;
+        c++;
+        while (*c && level) {
+          if (*c == '<')
+            level++;
+          if (*c == '>')
+            level--;
+          c++;
+        }
       } else {
-	c++;
+        c++;
       }
     }
   }
@@ -1029,17 +1029,17 @@ int Swig_scopename_check(const String *s) {
       return 1;
     } else {
       if (*c == '<') {
-	int level = 1;
-	c++;
-	while (*c && level) {
-	  if (*c == '<')
-	    level++;
-	  if (*c == '>')
-	    level--;
-	  c++;
-	}
+        int level = 1;
+        c++;
+        while (*c && level) {
+          if (*c == '<')
+            level++;
+          if (*c == '>')
+            level--;
+          c++;
+        }
       } else {
-	c++;
+        c++;
       }
     }
   }
@@ -1111,7 +1111,7 @@ static String *Swig_string_rstrip(String *s) {
       String *suffix = NewStringf(fmt, cs+1);
       int suffix_len = Len(suffix);
       if (0 == Strncmp(cs+len-suffix_len, suffix, suffix_len)) {
-	int copy_len = len-suffix_len-(int)(ce+1-cs);
+        int copy_len = len-suffix_len-(int)(ce+1-cs);
         ns = NewStringWithSize(ce+1, copy_len);
       } else {
         ns = NewString(ce+1);
@@ -1258,41 +1258,41 @@ static String *replace_captures(int num_captures, const char *input, String *sub
     } else if (isdigit((unsigned char)*p)) {
       int group = *p++ - '0';
       if (group < num_captures) {
-	int l = (int)captures[group*2], r = (int)captures[group*2 + 1];
-	if (l != -1) {
-	  copy_with_maybe_case_conversion(result, input + l, r - l, &convertCase, convertNextOnly);
-	}
+        int l = (int)captures[group*2], r = (int)captures[group*2 + 1];
+        if (l != -1) {
+          copy_with_maybe_case_conversion(result, input + l, r - l, &convertCase, convertNextOnly);
+        }
       } else {
-	Swig_error("SWIG", Getline(s), "PCRE capture replacement failed while matching \"%s\" using \"%s\" - request for group %d is greater than the number of captures %d.\n",
-	    Char(pattern), input, group, num_captures-1);
+        Swig_error("SWIG", Getline(s), "PCRE capture replacement failed while matching \"%s\" using \"%s\" - request for group %d is greater than the number of captures %d.\n",
+            Char(pattern), input, group, num_captures-1);
       }
     } else {
-	/* Handle Perl-like case conversion escapes. */
-	switch (*p) {
-	case 'u':
-	  convertCase = 1;
-	  convertNextOnly = 1;
-	  break;
-	case 'U':
-	  convertCase = 1;
-	  convertNextOnly = 0;
-	  break;
-	case 'l':
-	  convertCase = -1;
-	  convertNextOnly = 1;
-	  break;
-	case 'L':
-	  convertCase = -1;
-	  convertNextOnly = 0;
-	  break;
-	case 'E':
-	  convertCase = 0;
-	  break;
-	default:
-	  Swig_error("SWIG", Getline(s), "Unrecognized escape character '%c' in the replacement string \"%s\".\n",
-	      *p, Char(subst));
-	}
-	p++;
+        /* Handle Perl-like case conversion escapes. */
+        switch (*p) {
+        case 'u':
+          convertCase = 1;
+          convertNextOnly = 1;
+          break;
+        case 'U':
+          convertCase = 1;
+          convertNextOnly = 0;
+          break;
+        case 'l':
+          convertCase = -1;
+          convertNextOnly = 1;
+          break;
+        case 'L':
+          convertCase = -1;
+          convertNextOnly = 0;
+          break;
+        case 'E':
+          convertCase = 0;
+          break;
+        default:
+          Swig_error("SWIG", Getline(s), "Unrecognized escape character '%c' in the replacement string \"%s\".\n",
+              *p, Char(subst));
+        }
+        p++;
     }
   }
 
@@ -1336,7 +1336,7 @@ static String *Swig_string_regex(String *s) {
       res = replace_captures(rc, input, subst, captures, pattern, s);
     } else if (rc != PCRE2_ERROR_NOMATCH) {
       Swig_error("SWIG", Getline(s), "PCRE execution failed: error %d while matching \"%s\" using \"%s\".\n",
-	rc, Char(pattern), input);
+        rc, Char(pattern), input);
       Exit(EXIT_FAILURE);
     }
   }
@@ -1398,8 +1398,8 @@ Node *Swig_item_in_list(List *list, const DOH *item) {
     Iterator it;
     for (it = First(list); it.item; it = Next(it)) {
       if (DohCmp(item, it.item) == 0) {
-	found_item = it.item;
-	break;
+        found_item = it.item;
+        break;
       }
     }
   }

--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -68,68 +68,68 @@ static int name_mangle(String *r) {
       special = 1;
       switch (*c) {
       case '+':
-	*c = 'a';
-	break;
+        *c = 'a';
+        break;
       case '-':
-	*c = 's';
-	break;
+        *c = 's';
+        break;
       case '*':
-	*c = 'm';
-	break;
+        *c = 'm';
+        break;
       case '/':
-	*c = 'd';
-	break;
+        *c = 'd';
+        break;
       case '<':
-	*c = 'l';
-	break;
+        *c = 'l';
+        break;
       case '>':
-	*c = 'g';
-	break;
+        *c = 'g';
+        break;
       case '=':
-	*c = 'e';
-	break;
+        *c = 'e';
+        break;
       case ',':
-	*c = 'c';
-	break;
+        *c = 'c';
+        break;
       case '(':
-	*c = 'p';
-	break;
+        *c = 'p';
+        break;
       case ')':
-	*c = 'P';
-	break;
+        *c = 'P';
+        break;
       case '[':
-	*c = 'b';
-	break;
+        *c = 'b';
+        break;
       case ']':
-	*c = 'B';
-	break;
+        *c = 'B';
+        break;
       case '^':
-	*c = 'x';
-	break;
+        *c = 'x';
+        break;
       case '&':
-	*c = 'A';
-	break;
+        *c = 'A';
+        break;
       case '|':
-	*c = 'o';
-	break;
+        *c = 'o';
+        break;
       case '~':
-	*c = 'n';
-	break;
+        *c = 'n';
+        break;
       case '!':
-	*c = 'N';
-	break;
+        *c = 'N';
+        break;
       case '%':
-	*c = 'M';
-	break;
+        *c = 'M';
+        break;
       case '.':
-	*c = 'f';
-	break;
+        *c = 'f';
+        break;
       case '?':
-	*c = 'q';
-	break;
+        *c = 'q';
+        break;
       default:
-	*c = '_';
-	break;
+        *c = '_';
+        break;
       }
     }
     c++;
@@ -241,102 +241,102 @@ String *Swig_name_mangle_string(const String *s) {
     if (isalnum((int) c) || (c == '_')) {
       state = 1;
       if (space && (space == state)) {
-	Append(result, "_SS_");
+        Append(result, "_SS_");
       }
       space = 0;
       Printf(result, "%c", (int) c);
 
     } else {
       if (isspace((int) c)) {
-	space = state;
-	++pc;
-	continue;
+        space = state;
+        ++pc;
+        continue;
       } else {
-	state = 3;
-	space = 0;
+        state = 3;
+        space = 0;
       }
       switch (c) {
       case '.':
-	if ((cb != pc) && (*(pc - 1) == 'p')) {
-	  Append(result, "_");
-	  ++pc;
-	  continue;
-	} else {
-	  c = 'f';
-	}
-	break;
+        if ((cb != pc) && (*(pc - 1) == 'p')) {
+          Append(result, "_");
+          ++pc;
+          continue;
+        } else {
+          c = 'f';
+        }
+        break;
       case ':':
-	if (*(pc + 1) == ':') {
-	  Append(result, "_");
-	  ++pc;
-	  ++pc;
-	  continue;
-	}
-	break;
+        if (*(pc + 1) == ':') {
+          Append(result, "_");
+          ++pc;
+          ++pc;
+          continue;
+        }
+        break;
       case '*':
-	c = 'm';
-	break;
+        c = 'm';
+        break;
       case '&':
-	c = 'A';
-	break;
+        c = 'A';
+        break;
       case '<':
-	c = 'l';
-	break;
+        c = 'l';
+        break;
       case '>':
-	c = 'g';
-	break;
+        c = 'g';
+        break;
       case '=':
-	c = 'e';
-	break;
+        c = 'e';
+        break;
       case ',':
-	c = 'c';
-	break;
+        c = 'c';
+        break;
       case '(':
-	c = 'p';
-	break;
+        c = 'p';
+        break;
       case ')':
-	c = 'P';
-	break;
+        c = 'P';
+        break;
       case '[':
-	c = 'b';
-	break;
+        c = 'b';
+        break;
       case ']':
-	c = 'B';
-	break;
+        c = 'B';
+        break;
       case '^':
-	c = 'x';
-	break;
+        c = 'x';
+        break;
       case '|':
-	c = 'o';
-	break;
+        c = 'o';
+        break;
       case '~':
-	c = 'n';
-	break;
+        c = 'n';
+        break;
       case '!':
-	c = 'N';
-	break;
+        c = 'N';
+        break;
       case '%':
-	c = 'M';
-	break;
+        c = 'M';
+        break;
       case '?':
-	c = 'q';
-	break;
+        c = 'q';
+        break;
       case '+':
-	c = 'a';
-	break;
+        c = 'a';
+        break;
       case '-':
-	c = 's';
-	break;
+        c = 's';
+        break;
       case '/':
-	c = 'd';
-	break;
+        c = 'd';
+        break;
       default:
-	break;
+        break;
       }
       if (isalpha((int) c)) {
-	Printf(result, "_S%c_", (int) c);
+        Printf(result, "_S%c_", (int) c);
       } else {
-	Printf(result, "_S%02X_", (int) c);
+        Printf(result, "_S%02X_", (int) c);
       }
     }
     ++pc;
@@ -566,30 +566,30 @@ DOH *Swig_name_object_get(Hash *namehash, String *prefix, String *name, SwigType
       Printf(tname, "%s::%s", prefix, name);
       rn = name_object_get(namehash, tname, decl, ncdecl);
       if (!rn) {
-	String *cls = Swig_scopename_last(prefix);
-	if (!Equal(cls, prefix)) {
-	  Clear(tname);
-	  Printf(tname, "*::%s::%s", cls, name);
-	  rn = name_object_get(namehash, tname, decl, ncdecl);
-	}
-	Delete(cls);
+        String *cls = Swig_scopename_last(prefix);
+        if (!Equal(cls, prefix)) {
+          Clear(tname);
+          Printf(tname, "*::%s::%s", cls, name);
+          rn = name_object_get(namehash, tname, decl, ncdecl);
+        }
+        Delete(cls);
       }
       /* Lookup a name within a templated-based class */
       if (!rn) {
-	String *t_name = SwigType_istemplate_templateprefix(prefix);
-	if (t_name) {
-	  Clear(tname);
-	  Printf(tname, "%s::%s", t_name, name);
-	  rn = name_object_get(namehash, tname, decl, ncdecl);
-	  Delete(t_name);
-	}
+        String *t_name = SwigType_istemplate_templateprefix(prefix);
+        if (t_name) {
+          Clear(tname);
+          Printf(tname, "%s::%s", t_name, name);
+          rn = name_object_get(namehash, tname, decl, ncdecl);
+          Delete(t_name);
+        }
       }
       /* Lookup a template-based name within a class */
       if (!rn) {
-	String *t_name = SwigType_istemplate_templateprefix(name);
-	if (t_name)
-	  rn = Swig_name_object_get(namehash, prefix, t_name, decl);
-	Delete(t_name);
+        String *t_name = SwigType_istemplate_templateprefix(name);
+        if (t_name)
+          rn = Swig_name_object_get(namehash, prefix, t_name, decl);
+        Delete(t_name);
       }
     }
     /* A wildcard-based class lookup */
@@ -662,19 +662,19 @@ void Swig_name_object_inherit(Hash *namehash, String *base, String *derived) {
       /* Don't overwrite an existing value for the derived class, if any. */
       newh = Getattr(namehash, nkey);
       if (!newh) {
-	if (!derh)
-	  derh = NewHash();
+        if (!derh)
+          derh = NewHash();
 
-	newh = NewHash();
-	Setattr(derh, nkey, newh);
-	Delete(newh);
+        newh = NewHash();
+        Setattr(derh, nkey, newh);
+        Delete(newh);
       }
       for (oi = First(n); oi.key; oi = Next(oi)) {
-	if (!Getattr(newh, oi.key)) {
-	  String *ci = Copy(oi.item);
-	  Setattr(newh, oi.key, ci);
-	  Delete(ci);
-	}
+        if (!Getattr(newh, oi.key)) {
+          String *ci = Copy(oi.item);
+          Setattr(newh, oi.key, ci);
+          Delete(ci);
+        }
       }
       Delete(nkey);
     }
@@ -756,13 +756,13 @@ void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *d
       tprefix = SwigType_templateprefix(nlast);
       Delete(nlast);
       if (Len(nprefix)) {
-	Append(nprefix, "::");
-	Append(nprefix, tprefix);
-	Delete(tprefix);
-	rname = nprefix;
+        Append(nprefix, "::");
+        Append(nprefix, tprefix);
+        Delete(tprefix);
+        rname = nprefix;
       } else {
-	rname = tprefix;
-	Delete(nprefix);
+        rname = tprefix;
+        Delete(nprefix);
       }
       rdecl = Copy(decl);
       Replaceall(rdecl, name, rname);
@@ -790,8 +790,8 @@ void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *d
     if (prefix) {
       /* A class-generic feature */
       if (Len(prefix)) {
-	Printf(tname, "%s::", prefix);
-	features_get(features, tname, decl, ncdecl, node);
+        Printf(tname, "%s::", prefix);
+        features_get(features, tname, decl, ncdecl, node);
       }
       /* A wildcard-based class lookup */
       Clear(tname);
@@ -799,17 +799,17 @@ void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *d
       features_get(features, tname, decl, ncdecl, node);
       /* A specific class lookup */
       if (Len(prefix)) {
-	/* A template-based class lookup */
-	String *tprefix = SwigType_istemplate_templateprefix(prefix);
-	if (tprefix) {
-	  Clear(tname);
-	  Printf(tname, "%s::%s", tprefix, name);
-	  features_get(features, tname, decl, ncdecl, node);
-	}
-	Clear(tname);
-	Printf(tname, "%s::%s", prefix, name);
-	features_get(features, tname, decl, ncdecl, node);
-	Delete(tprefix);
+        /* A template-based class lookup */
+        String *tprefix = SwigType_istemplate_templateprefix(prefix);
+        if (tprefix) {
+          Clear(tname);
+          Printf(tname, "%s::%s", tprefix, name);
+          features_get(features, tname, decl, ncdecl, node);
+        }
+        Clear(tname);
+        Printf(tname, "%s::%s", prefix, name);
+        features_get(features, tname, decl, ncdecl, node);
+        Delete(tprefix);
       }
     } else {
       /* Lookup in the global namespace only */
@@ -888,10 +888,10 @@ void Swig_feature_set(Hash *features, const_String_or_char_ptr name, SwigType *d
       String *attribname = Getattr(attribs, "name");
       String *featureattribname = NewStringf("%s:%s", featurename, attribname);
       if (value) {
-	String *attribvalue = Getattr(attribs, "value");
-	Setattr(fhash, featureattribname, attribvalue);
+        String *attribvalue = Getattr(attribs, "value");
+        Setattr(fhash, featureattribname, attribvalue);
       } else {
-	Delattr(fhash, featureattribname);
+        Delattr(fhash, featureattribname);
       }
       attribs = nextSibling(attribs);
       Delete(featureattribname);
@@ -999,12 +999,12 @@ static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
     String *b_storage = Getattr(b, "storage");
 
     if ((Cmp(a_storage, "typedef") == 0)
-	|| (Cmp(b_storage, "typedef") == 0)) {
+        || (Cmp(b_storage, "typedef") == 0)) {
       if (Cmp(a_storage, b_storage) == 0) {
-	String *a_type = (Getattr(a, "type"));
-	String *b_type = (Getattr(b, "type"));
-	if (Cmp(a_type, b_type) == 0)
-	  return 1;
+        String *a_type = (Getattr(a, "type"));
+        String *b_type = (Getattr(b, "type"));
+        if (Cmp(a_type, b_type) == 0)
+          return 1;
       }
       return 0;
     }
@@ -1012,7 +1012,7 @@ static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
     /* static functions */
     if (Swig_storage_isstatic(a) || Swig_storage_isstatic(b)) {
       if (Cmp(a_storage, b_storage) != 0)
-	return 0;
+        return 0;
     }
 
     /* friend methods */
@@ -1023,32 +1023,32 @@ static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
       String *a_decl = (Getattr(a, "decl"));
       String *b_decl = (Getattr(b, "decl"));
       if (Cmp(a_decl, b_decl) == 0) {
-	/* check return type */
-	String *a_type = (Getattr(a, "type"));
-	String *b_type = (Getattr(b, "type"));
-	if (Cmp(a_type, b_type) == 0) {
-	  /* check parameters */
-	  Parm *ap = (Getattr(a, "parms"));
-	  Parm *bp = (Getattr(b, "parms"));
-	  while (ap && bp) {
-	    SwigType *at = Getattr(ap, "type");
-	    SwigType *bt = Getattr(bp, "type");
-	    if (Cmp(at, bt) != 0)
-	      return 0;
-	    ap = nextSibling(ap);
-	    bp = nextSibling(bp);
-	  }
-	  if (ap || bp) {
-	    return 0;
-	  } else {
-	    Node *a_template = Getattr(a, "template");
-	    Node *b_template = Getattr(b, "template");
-	    /* Not equivalent if one is a template instantiation (via %template) and the other is a non-templated function */
-	    if ((a_template && !b_template) || (!a_template && b_template))
-	      return 0;
-	  }
-	  return 1;
-	}
+        /* check return type */
+        String *a_type = (Getattr(a, "type"));
+        String *b_type = (Getattr(b, "type"));
+        if (Cmp(a_type, b_type) == 0) {
+          /* check parameters */
+          Parm *ap = (Getattr(a, "parms"));
+          Parm *bp = (Getattr(b, "parms"));
+          while (ap && bp) {
+            SwigType *at = Getattr(ap, "type");
+            SwigType *bt = Getattr(bp, "type");
+            if (Cmp(at, bt) != 0)
+              return 0;
+            ap = nextSibling(ap);
+            bp = nextSibling(bp);
+          }
+          if (ap || bp) {
+            return 0;
+          } else {
+            Node *a_template = Getattr(a, "template");
+            Node *b_template = Getattr(b, "template");
+            /* Not equivalent if one is a template instantiation (via %template) and the other is a non-templated function */
+            if ((a_template && !b_template) || (!a_template && b_template))
+              return 0;
+          }
+          return 1;
+        }
       }
     }
   } else if (Equal(ta, "using")) {
@@ -1058,26 +1058,26 @@ static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
       String *a_name = Getattr(a, "name");
       String *b_name = Getattr(b, "name");
       if (Equal(a_name, b_name))
-	return 1;
+        return 1;
     }
   } else {
     /* both %constant case */
     String *a_storage = Getattr(a, "storage");
     String *b_storage = Getattr(b, "storage");
     if ((Cmp(a_storage, "%constant") == 0)
-	|| (Cmp(b_storage, "%constant") == 0)) {
+        || (Cmp(b_storage, "%constant") == 0)) {
       if (Cmp(a_storage, b_storage) == 0) {
-	String *a_type = (Getattr(a, "type"));
-	String *b_type = (Getattr(b, "type"));
-	if ((Cmp(a_type, b_type) == 0)
-	    && (Cmp(Getattr(a, "value"), Getattr(b, "value")) == 0))
-	  return 1;
+        String *a_type = (Getattr(a, "type"));
+        String *b_type = (Getattr(b, "type"));
+        if ((Cmp(a_type, b_type) == 0)
+            && (Cmp(Getattr(a, "value"), Getattr(b, "value")) == 0))
+          return 1;
       }
       return 0;
     }
     if (Equal(ta, "template") && Equal(tb, "template")) {
       if (Strstr(a_storage, "friend") || Strstr(b_storage, "friend"))
-	return 1;
+        return 1;
     }
   }
   return 0;
@@ -1173,30 +1173,30 @@ static void name_object_attach_keys(const char *keys[], Hash *nameobj) {
       int isnotmatch = 0;
       int isregexmatch = 0;
       if ((strncmp(ckey, "match", 5) == 0)
-	  || (isnotmatch = (strncmp(ckey, "notmatch", 8) == 0))
-	  || (isregexmatch = (strncmp(ckey, "regexmatch", 10) == 0))
-	  || (isnotmatch = isregexmatch = (strncmp(ckey, "notregexmatch", 13) == 0))) {
-	Hash *mi = NewHash();
-	List *attrlist = make_attrlist(ckey);
-	if (!matchlist)
-	  matchlist = NewList();
-	Setattr(mi, "value", Getattr(kw, "value"));
-	Setattr(mi, "attrlist", attrlist);
-	if (isnotmatch)
-	  SetFlag(mi, "notmatch");
-	if (isregexmatch)
-	  SetFlag(mi, "regexmatch");
-	Delete(attrlist);
-	Append(matchlist, mi);
-	Delete(mi);
-	removeNode(kw);
+          || (isnotmatch = (strncmp(ckey, "notmatch", 8) == 0))
+          || (isregexmatch = (strncmp(ckey, "regexmatch", 10) == 0))
+          || (isnotmatch = isregexmatch = (strncmp(ckey, "notregexmatch", 13) == 0))) {
+        Hash *mi = NewHash();
+        List *attrlist = make_attrlist(ckey);
+        if (!matchlist)
+          matchlist = NewList();
+        Setattr(mi, "value", Getattr(kw, "value"));
+        Setattr(mi, "attrlist", attrlist);
+        if (isnotmatch)
+          SetFlag(mi, "notmatch");
+        if (isregexmatch)
+          SetFlag(mi, "regexmatch");
+        Delete(attrlist);
+        Append(matchlist, mi);
+        Delete(mi);
+        removeNode(kw);
       } else {
-	for (rkey = keys; *rkey != 0; ++rkey) {
-	  if (strcmp(ckey, *rkey) == 0) {
-	    Setattr(nameobj, *rkey, Getattr(kw, "value"));
-	    removeNode(kw);
-	  }
-	}
+        for (rkey = keys; *rkey != 0; ++rkey) {
+          if (strcmp(ckey, *rkey) == 0) {
+            Setattr(nameobj, *rkey, Getattr(kw, "value"));
+            removeNode(kw);
+          }
+        }
       }
     }
     kw = next;
@@ -1356,15 +1356,15 @@ static int name_match_nameobj(Hash *rn, Node *n) {
       int regexmatch = GetFlag(mi, "regexmatch");
       match = 0;
       if (nval) {
-	String *kwval = Getattr(mi, "value");
-	match = regexmatch ? name_regexmatch_value(n, kwval, nval)
-	    : name_match_value(kwval, nval);
+        String *kwval = Getattr(mi, "value");
+        match = regexmatch ? name_regexmatch_value(n, kwval, nval)
+            : name_match_value(kwval, nval);
 #ifdef SWIG_DEBUG
-	Printf(stdout, "val %s %s %d %d \n", nval, kwval, match, ilen);
+        Printf(stdout, "val %s %s %d %d \n", nval, kwval, match, ilen);
 #endif
       }
       if (notmatch)
-	match = !match;
+        match = !match;
     }
   }
 #ifdef SWIG_DEBUG
@@ -1390,46 +1390,46 @@ static Hash *name_nameobj_lget(List *namelist, Node *n, String *prefix, String *
       Hash *rn = Getitem(namelist, i);
       String *rdecl = Getattr(rn, "decl");
       if (rdecl && (!decl || !Equal(rdecl, decl))) {
-	continue;
+        continue;
       } else if (name_match_nameobj(rn, n)) {
-	String *tname = Getattr(rn, "targetname");
-	if (tname) {
-	  String *sfmt = Getattr(rn, "sourcefmt");
-	  String *sname = 0;
-	  int fullname = GetFlag(rn, "fullname");
-	  int regextarget = GetFlag(rn, "regextarget");
-	  if (sfmt) {
-	    if (fullname && prefix) {
-	      String *pname = NewStringf("%s::%s", prefix, name);
-	      sname = NewStringf(sfmt, pname);
-	      Delete(pname);
-	    } else {
-	      sname = NewStringf(sfmt, name);
-	    }
-	  } else {
-	    if (fullname && prefix) {
-	      sname = NewStringf("%s::%s", prefix, name);
-	    } else {
-	      sname = name;
-	      DohIncref(name);
-	    }
-	  }
-	  match = regextarget ? name_regexmatch_value(n, tname, sname)
-	    : name_match_value(tname, sname);
-	  Delete(sname);
-	} else {
-	  /* Applying the renaming rule may fail if it contains a %(regex)s expression that doesn't match the given name. */
-	  String *sname = NewStringf(Getattr(rn, "name"), name);
-	  if (sname) {
-	    if (Len(sname))
-	      match = 1;
-	    Delete(sname);
-	  }
-	}
+        String *tname = Getattr(rn, "targetname");
+        if (tname) {
+          String *sfmt = Getattr(rn, "sourcefmt");
+          String *sname = 0;
+          int fullname = GetFlag(rn, "fullname");
+          int regextarget = GetFlag(rn, "regextarget");
+          if (sfmt) {
+            if (fullname && prefix) {
+              String *pname = NewStringf("%s::%s", prefix, name);
+              sname = NewStringf(sfmt, pname);
+              Delete(pname);
+            } else {
+              sname = NewStringf(sfmt, name);
+            }
+          } else {
+            if (fullname && prefix) {
+              sname = NewStringf("%s::%s", prefix, name);
+            } else {
+              sname = name;
+              DohIncref(name);
+            }
+          }
+          match = regextarget ? name_regexmatch_value(n, tname, sname)
+            : name_match_value(tname, sname);
+          Delete(sname);
+        } else {
+          /* Applying the renaming rule may fail if it contains a %(regex)s expression that doesn't match the given name. */
+          String *sname = NewStringf(Getattr(rn, "name"), name);
+          if (sname) {
+            if (Len(sname))
+              match = 1;
+            Delete(sname);
+          }
+        }
       }
       if (match) {
-	res = rn;
-	break;
+        res = rn;
+        break;
       }
     }
   }
@@ -1467,7 +1467,7 @@ static Hash *name_namewarn_get(Node *n, String *prefix, String *name, SwigType *
       String *access = Getattr(n, "access");
       int is_public = !access || Equal(access, "public");
       if (!is_public && !Swig_need_protected(n)) {
-	return 0;
+        return 0;
       }
     }
   }
@@ -1481,9 +1481,9 @@ static Hash *name_namewarn_get(Node *n, String *prefix, String *name, SwigType *
     }
     if (wrn && Getattr(wrn, "error")) {
       if (n) {
-	Swig_error(Getfile(n), Getline(n), "%s\n", Getattr(wrn, "name"));
+        Swig_error(Getfile(n), Getline(n), "%s\n", Getattr(wrn, "name"));
       } else {
-	Swig_error(cparse_file, cparse_line, "%s\n", Getattr(wrn, "name"));
+        Swig_error(cparse_file, cparse_line, "%s\n", Getattr(wrn, "name"));
       }
     }
     return wrn;
@@ -1532,22 +1532,22 @@ void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *ne
     while (declparms) {
       if (ParmList_has_defaultargs(declparms)) {
 
-	/* Create a parameter list for the new rename by copying all
-	   but the last (defaulted) parameter */
-	ParmList *newparms = CopyParmListMax(declparms,ParmList_len(declparms)-1);
+        /* Create a parameter list for the new rename by copying all
+           but the last (defaulted) parameter */
+        ParmList *newparms = CopyParmListMax(declparms,ParmList_len(declparms)-1);
 
-	/* Create new declaration - with the last parameter removed */
-	SwigType *newdecl = Copy(decl);
-	Delete(SwigType_pop_function(newdecl));	/* remove the old parameter list from newdecl */
-	SwigType_add_function(newdecl, newparms);
-	if (constqualifier)
-	  SwigType_add_qualifier(newdecl, "const");
+        /* Create new declaration - with the last parameter removed */
+        SwigType *newdecl = Copy(decl);
+        Delete(SwigType_pop_function(newdecl));	/* remove the old parameter list from newdecl */
+        SwigType_add_function(newdecl, newparms);
+        if (constqualifier)
+          SwigType_add_qualifier(newdecl, "const");
 
-	single_rename_add(prefix, name, newdecl, newname);
-	declparms = newparms;
-	Delete(newdecl);
+        single_rename_add(prefix, name, newdecl, newname);
+        declparms = newparms;
+        Delete(newdecl);
       } else {
-	declparms = 0;
+        declparms = 0;
       }
     }
   }
@@ -1562,25 +1562,25 @@ static String *apply_rename(Node* n, String *newname, int fullname, String *pref
       /* $ignore doesn't apply to parameters and while it's rare to explicitly write %ignore directives for them they could be caught by a wildcard ignore using
          regex match, just ignore the attempt to ignore them in this case */
       if (!Equal(nodeType(n), "parm"))
-	result = Copy(newname);
+        result = Copy(newname);
     } else {
       char *cnewname = Char(newname);
       if (cnewname) {
-	int destructor = name && (*(Char(name)) == '~');
-	String *fmt = newname;
-	/* use name as a fmt, but avoid C++ "%" and "%=" operators */
-	if (Len(newname) > 1 && strchr(cnewname, '%') && !(strcmp(cnewname, "%=") == 0)) {
-	  if (fullname && prefix) {
-	    result = NewStringf(fmt, prefix, name);
-	  } else {
-	    result = NewStringf(fmt, name);
-	  }
-	} else {
-	  result = Copy(newname);
-	}
-	if (destructor && result && (*(Char(result)) != '~')) {
-	  Insert(result, 0, "~");
-	}
+        int destructor = name && (*(Char(name)) == '~');
+        String *fmt = newname;
+        /* use name as a fmt, but avoid C++ "%" and "%=" operators */
+        if (Len(newname) > 1 && strchr(cnewname, '%') && !(strcmp(cnewname, "%=") == 0)) {
+          if (fullname && prefix) {
+            result = NewStringf(fmt, prefix, name);
+          } else {
+            result = NewStringf(fmt, name);
+          }
+        } else {
+          result = Copy(newname);
+        }
+        if (destructor && result && (*(Char(result)) != '~')) {
+          Insert(result, 0, "~");
+        }
       }
     }
   }
@@ -1618,13 +1618,13 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
       tprefix = SwigType_templateprefix(nlast);
       Delete(nlast);
       if (Len(nprefix)) {
-	Append(nprefix, "::");
-	Append(nprefix, tprefix);
-	Delete(tprefix);
-	rname = nprefix;
+        Append(nprefix, "::");
+        Append(nprefix, tprefix);
+        Delete(tprefix);
+        rname = nprefix;
       } else {
-	rname = tprefix;
-	Delete(nprefix);
+        rname = tprefix;
+        Delete(nprefix);
       }
       rdecl = Copy(decl);
       Replaceall(rdecl, name, rname);
@@ -1642,19 +1642,19 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
     if (!rn || !name_match_nameobj(rn, n)) {
       rn = name_nameobj_lget(name_rename_list(), n, prefix, name, decl);
       if (rn) {
-	String *sfmt = Getattr(rn, "sourcefmt");
-	int fullname = GetFlag(rn, "fullname");
-	if (fullname && prefix) {
-	  String *sname = NewStringf("%s::%s", prefix, name);
-	  Delete(name);
-	  name = sname;
-	  prefix = 0;
-	}
-	if (sfmt) {
-	  String *sname = NewStringf(sfmt, name);
-	  Delete(name);
-	  name = sname;
-	}
+        String *sfmt = Getattr(rn, "sourcefmt");
+        int fullname = GetFlag(rn, "fullname");
+        if (fullname && prefix) {
+          String *sname = NewStringf("%s::%s", prefix, name);
+          Delete(name);
+          name = sname;
+          prefix = 0;
+        }
+        if (sfmt) {
+          String *sname = NewStringf(sfmt, name);
+          Delete(name);
+          name = sname;
+        }
       }
     }
     if (rn) {
@@ -1666,13 +1666,13 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
       /* operators in C++ allow aliases, we look for them */
       char *cresult = Char(result);
       if (cresult && (strncmp(cresult, "operator ", 9) == 0)) {
-	String *nresult = Swig_name_make(n, prefix, result, decl, oldname);
-	if (!Equal(nresult, result)) {
-	  Delete(result);
-	  result = nresult;
-	} else {
-	  Delete(nresult);
-	}
+        String *nresult = Swig_name_make(n, prefix, result, decl, oldname);
+        if (!Equal(nresult, result)) {
+          Delete(result);
+          result = nresult;
+        } else {
+          Delete(nresult);
+        }
       }
     }
     nname = result ? result : name;
@@ -1680,39 +1680,39 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
     if (wrn) {
       String *rename = Getattr(wrn, "rename");
       if (rename) {
-	String *msg = Getattr(wrn, "name");
-	int fullname = GetFlag(wrn, "fullname");
-	if (result)
-	  Delete(result);
-	result = apply_rename(n, rename, fullname, prefix, name);
-	if ((msg) && (Len(msg))) {
-	  if (!Getmeta(nname, "already_warned")) {
-	    String* suffix = 0;
-	    if (Strcmp(result, "$ignore") == 0) {
-	      suffix = NewStringf(": ignoring '%s'\n", name);
-	    } else if (Strcmp(result, name) != 0) {
-	      suffix = NewStringf(", renaming to '%s'\n", result);
-	    } else {
-	      /* No rename was performed */
-	      suffix = NewString("\n");
-	    }
-	    if (n) {
-	      /* Parameter renaming is not fully implemented. Mainly because there is no C/C++ syntax to
-	       * for %rename to fully qualify a function's parameter name from outside the function. Hence it
-	       * is not possible to implemented targeted warning suppression on one parameter in one function. */
-	      int suppress_parameter_rename_warning = Equal(nodeType(n), "parm");
-	      if (!suppress_parameter_rename_warning) {
-		SWIG_WARN_NODE_BEGIN(n);
-	      Swig_warning(0, Getfile(n), Getline(n), "%s%s", msg, suffix);
-		SWIG_WARN_NODE_END(n);
-	      }
-	    } else {
-	      Swig_warning(0, Getfile(name), Getline(name), "%s%s", msg, suffix);
-	    }
-	    Setmeta(nname, "already_warned", "1");
-	    Delete(suffix);
-	  }
-	}
+        String *msg = Getattr(wrn, "name");
+        int fullname = GetFlag(wrn, "fullname");
+        if (result)
+          Delete(result);
+        result = apply_rename(n, rename, fullname, prefix, name);
+        if ((msg) && (Len(msg))) {
+          if (!Getmeta(nname, "already_warned")) {
+            String* suffix = 0;
+            if (Strcmp(result, "$ignore") == 0) {
+              suffix = NewStringf(": ignoring '%s'\n", name);
+            } else if (Strcmp(result, name) != 0) {
+              suffix = NewStringf(", renaming to '%s'\n", result);
+            } else {
+              /* No rename was performed */
+              suffix = NewString("\n");
+            }
+            if (n) {
+              /* Parameter renaming is not fully implemented. Mainly because there is no C/C++ syntax to
+               * for %rename to fully qualify a function's parameter name from outside the function. Hence it
+               * is not possible to implemented targeted warning suppression on one parameter in one function. */
+              int suppress_parameter_rename_warning = Equal(nodeType(n), "parm");
+              if (!suppress_parameter_rename_warning) {
+                SWIG_WARN_NODE_BEGIN(n);
+              Swig_warning(0, Getfile(n), Getline(n), "%s%s", msg, suffix);
+                SWIG_WARN_NODE_END(n);
+              }
+            } else {
+              Swig_warning(0, Getfile(name), Getline(name), "%s%s", msg, suffix);
+            }
+            Setmeta(nname, "already_warned", "1");
+            Delete(suffix);
+          }
+        }
       }
     }
   }
@@ -1758,9 +1758,9 @@ void Swig_inherit_base_symbols(List *bases) {
     for (s = First(bases); s.item; s = Next(s)) {
       Symtab *st = Getattr(s.item, "symtab");
       if (st) {
-	Setfile(st, Getfile(s.item));
-	Setline(st, Getline(s.item));
-	Swig_symbol_inherit(st);
+        Setfile(st, Getfile(s.item));
+        Setline(st, Getline(s.item));
+        Swig_symbol_inherit(st);
       }
     }
     Delete(bases);
@@ -1789,26 +1789,26 @@ List *Swig_make_inherit_list(String *clsname, List *names, String *Namespacepref
     Node *s = Swig_symbol_clookup(n, 0);
     if (s) {
       while (s && (Strcmp(nodeType(s), "class") != 0)) {
-	/* Not a class.  Could be a typedef though. */
-	String *storage = Getattr(s, "storage");
-	if (storage && (Strcmp(storage, "typedef") == 0)) {
-	  String *nn = Getattr(s, "type");
-	  s = Swig_symbol_clookup(nn, Getattr(s, "sym:symtab"));
-	} else {
-	  break;
-	}
+        /* Not a class.  Could be a typedef though. */
+        String *storage = Getattr(s, "storage");
+        if (storage && (Strcmp(storage, "typedef") == 0)) {
+          String *nn = Getattr(s, "type");
+          s = Swig_symbol_clookup(nn, Getattr(s, "sym:symtab"));
+        } else {
+          break;
+        }
       }
       if (s && ((Strcmp(nodeType(s), "class") == 0) || (Strcmp(nodeType(s), "template") == 0))) {
-	String *q = Swig_symbol_qualified(s);
-	Append(bases, s);
-	if (q) {
-	  base = NewStringf("%s::%s", q, Getattr(s, "name"));
-	  Delete(q);
-	} else {
-	  base = NewString(Getattr(s, "name"));
-	}
+        String *q = Swig_symbol_qualified(s);
+        Append(bases, s);
+        if (q) {
+          base = NewStringf("%s::%s", q, Getattr(s, "name"));
+          Delete(q);
+        } else {
+          base = NewString(Getattr(s, "name"));
+        }
       } else {
-	base = NewString(n);
+        base = NewString(n);
       }
     } else {
       base = NewString(n);
@@ -1899,9 +1899,9 @@ String *Swig_name_decl(Node *n) {
       SwigType *qualifiers = SwigType_pop_function_qualifiers(decl_temp);
       Printv(decl, "(", ParmList_errorstr(Getattr(n, "parms")), ")", NIL);
       if (qualifiers) {
-	String *qualifiers_string = SwigType_str(qualifiers, 0);
-	Printv(decl, " ", qualifiers_string, NIL);
-	Delete(qualifiers_string);
+        String *qualifiers_string = SwigType_str(qualifiers, 0);
+        Printv(decl, " ", qualifiers_string, NIL);
+        Delete(qualifiers_string);
       }
       Delete(decl_temp);
     }

--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -51,8 +51,8 @@ void Swig_name_unregister(const_String_or_char_ptr method) {
 }
 
 /* Return naming format for the specified method or the default format if none was explicitly registered */
-static String* get_naming_format_for(const char *method, const char *def_format) {
-  String* f = naming_hash ? Getattr(naming_hash, method) : NULL;
+static String *get_naming_format_for(const char *method, const char *def_format) {
+  String *f = naming_hash ? Getattr(naming_hash, method) : NULL;
 
   return f ? Copy(f) : NewString(def_format);
 }
@@ -64,7 +64,7 @@ static int name_mangle(String *r) {
   Replaceall(r, "::", "_");
   c = Char(r);
   while (*c) {
-    if (!isalnum((int) *c) && (*c != '_')) {
+    if (!isalnum((int)*c) && (*c != '_')) {
       special = 1;
       switch (*c) {
       case '+':
@@ -189,14 +189,14 @@ String *Swig_name_mangle_type(const SwigType *s) {
 
 String *Swig_name_type(const_String_or_char_ptr tname) {
   String *r, *s;
-  String* f = naming_hash ? Getattr(naming_hash, "type") : NULL;
+  String *f = naming_hash ? Getattr(naming_hash, "type") : NULL;
 
   /* Don't bother doing anything else if there is no special naming format. */
   if (f) {
     s = Copy(f);
     Replace(s, "%c", tname, DOH_REPLACE_ANY);
   } else {
-    s = (String*)tname;
+    s = (String *)tname;
   }
 
   r = Swig_name_mangle_string(s);
@@ -238,16 +238,16 @@ String *Swig_name_mangle_string(const String *s) {
   pc = cb = Char(s);
   while (*pc) {
     char c = *pc;
-    if (isalnum((int) c) || (c == '_')) {
+    if (isalnum((int)c) || (c == '_')) {
       state = 1;
       if (space && (space == state)) {
         Append(result, "_SS_");
       }
       space = 0;
-      Printf(result, "%c", (int) c);
+      Printf(result, "%c", (int)c);
 
     } else {
-      if (isspace((int) c)) {
+      if (isspace((int)c)) {
         space = state;
         ++pc;
         continue;
@@ -333,17 +333,16 @@ String *Swig_name_mangle_string(const String *s) {
       default:
         break;
       }
-      if (isalpha((int) c)) {
-        Printf(result, "_S%c_", (int) c);
+      if (isalpha((int)c)) {
+        Printf(result, "_S%c_", (int)c);
       } else {
-        Printf(result, "_S%02X_", (int) c);
+        Printf(result, "_S%02X_", (int)c);
       }
     }
     ++pc;
   }
   return result;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_name_wrapper()
@@ -358,7 +357,6 @@ String *Swig_name_wrapper(const_String_or_char_ptr fname) {
   name_mangle(r);
   return r;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_name_member()
@@ -452,7 +450,6 @@ String *Swig_name_construct(const_String_or_char_ptr nspace, const_String_or_cha
   return make_full_name_for("construct", "new_%n%c", nspace, classname);
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_name_copyconstructor()
  *
@@ -473,7 +470,6 @@ String *Swig_name_destroy(const_String_or_char_ptr nspace, const_String_or_char_
   return make_full_name_for("destroy", "delete_%n%c", nspace, classname);
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_name_disown()
  *
@@ -483,7 +479,6 @@ String *Swig_name_destroy(const_String_or_char_ptr nspace, const_String_or_char_
 String *Swig_name_disown(const_String_or_char_ptr nspace, const_String_or_char_ptr classname) {
   return make_full_name_for("disown", "disown_%n%c", nspace, classname);
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_name_object_set()
@@ -512,7 +507,6 @@ void Swig_name_object_set(Hash *namehash, String *name, SwigType *decl, DOH *obj
     Delete(cd);
   }
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_name_object_get()
@@ -558,7 +552,6 @@ DOH *Swig_name_object_get(Hash *namehash, String *prefix, String *name, SwigType
 #ifdef SWIG_DEBUG
   Printf(stdout, "Swig_name_object_get:  '%s' '%s', '%s'\n", prefix, name, decl);
 #endif
-
 
   /* Perform a class-based lookup (if class prefix supplied) */
   if (prefix) {
@@ -835,7 +828,6 @@ void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *d
     Delete(rdecl);
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_feature_set()
  *
@@ -844,7 +836,8 @@ void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *d
  * concatenating the feature name plus ':' plus the attribute name.
  * ----------------------------------------------------------------------------- */
 
-void Swig_feature_set(Hash *features, const_String_or_char_ptr name, SwigType *decl, const_String_or_char_ptr featurename, const_String_or_char_ptr value, Hash *featureattribs) {
+void Swig_feature_set(Hash *features, const_String_or_char_ptr name, SwigType *decl, const_String_or_char_ptr featurename, const_String_or_char_ptr value,
+                      Hash *featureattribs) {
   Hash *n;
   Hash *fhash;
 
@@ -998,8 +991,7 @@ static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
     String *a_storage = Getattr(a, "storage");
     String *b_storage = Getattr(b, "storage");
 
-    if ((Cmp(a_storage, "typedef") == 0)
-        || (Cmp(b_storage, "typedef") == 0)) {
+    if ((Cmp(a_storage, "typedef") == 0) || (Cmp(b_storage, "typedef") == 0)) {
       if (Cmp(a_storage, b_storage) == 0) {
         String *a_type = (Getattr(a, "type"));
         String *b_type = (Getattr(b, "type"));
@@ -1064,13 +1056,11 @@ static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
     /* both %constant case */
     String *a_storage = Getattr(a, "storage");
     String *b_storage = Getattr(b, "storage");
-    if ((Cmp(a_storage, "%constant") == 0)
-        || (Cmp(b_storage, "%constant") == 0)) {
+    if ((Cmp(a_storage, "%constant") == 0) || (Cmp(b_storage, "%constant") == 0)) {
       if (Cmp(a_storage, b_storage) == 0) {
         String *a_type = (Getattr(a, "type"));
         String *b_type = (Getattr(b, "type"));
-        if ((Cmp(a_type, b_type) == 0)
-            && (Cmp(Getattr(a, "value"), Getattr(b, "value")) == 0))
+        if ((Cmp(a_type, b_type) == 0) && (Cmp(Getattr(a, "value"), Getattr(b, "value")) == 0))
           return 1;
       }
       return 0;
@@ -1089,17 +1079,14 @@ int Swig_need_redefined_warn(Node *a, Node *b, int InClass) {
   String *a_symname = Getattr(a, "sym:name");
   String *b_symname = Getattr(b, "sym:name");
   /* always send a warning if a 'rename' is involved */
-  if ((a_symname && !Equal(a_symname, a_name))
-      || (b_symname && !Equal(b_symname, b_name))) {
+  if ((a_symname && !Equal(a_symname, a_name)) || (b_symname && !Equal(b_symname, b_name))) {
     if (!Equal(a_name, b_name)) {
       return 1;
     }
   }
 
-
   return !nodes_are_equivalent(a, b, InClass);
 }
-
 
 /* -----------------------------------------------------------------------------
  * int Swig_need_protected(Node* n)
@@ -1172,10 +1159,8 @@ static void name_object_attach_keys(const char *keys[], Hash *nameobj) {
       const char **rkey;
       int isnotmatch = 0;
       int isregexmatch = 0;
-      if ((strncmp(ckey, "match", 5) == 0)
-          || (isnotmatch = (strncmp(ckey, "notmatch", 8) == 0))
-          || (isregexmatch = (strncmp(ckey, "regexmatch", 10) == 0))
-          || (isnotmatch = isregexmatch = (strncmp(ckey, "notregexmatch", 13) == 0))) {
+      if ((strncmp(ckey, "match", 5) == 0) || (isnotmatch = (strncmp(ckey, "notmatch", 8) == 0)) || (isregexmatch = (strncmp(ckey, "regexmatch", 10) == 0)) ||
+          (isnotmatch = isregexmatch = (strncmp(ckey, "notregexmatch", 13) == 0))) {
         Hash *mi = NewHash();
         List *attrlist = make_attrlist(ckey);
         if (!matchlist)
@@ -1219,7 +1204,7 @@ static void name_nameobj_add(Hash *name_hash, List *name_list, String *prefix, S
     }
   }
 
-  if (!nname || !Len(nname) || Getattr(nameobj, "fullname") ||  /* any of these options trigger a 'list' nameobj */
+  if (!nname || !Len(nname) || Getattr(nameobj, "fullname") || /* any of these options trigger a 'list' nameobj */
       Getattr(nameobj, "sourcefmt") || Getattr(nameobj, "matchlist") || Getattr(nameobj, "regextarget")) {
     if (decl)
       Setattr(nameobj, "decl", decl);
@@ -1275,14 +1260,12 @@ static int name_regexmatch_value(Node *n, String *pattern, String *s) {
 
   compiled_pat = pcre2_compile((PCRE2_SPTR8)Char(pattern), PCRE2_ZERO_TERMINATED, 0, &errornum, &errpos, NULL);
   if (!compiled_pat) {
-    pcre2_get_error_message (errornum, err, sizeof err);
-    Swig_error("SWIG", Getline(n),
-               "Invalid regex \"%s\": compilation failed at %d: %s\n",
-               Char(pattern), errpos, err);
+    pcre2_get_error_message(errornum, err, sizeof err);
+    Swig_error("SWIG", Getline(n), "Invalid regex \"%s\": compilation failed at %d: %s\n", Char(pattern), errpos, err);
     Exit(EXIT_FAILURE);
   }
 
-  match_data = pcre2_match_data_create_from_pattern (compiled_pat, NULL);
+  match_data = pcre2_match_data_create_from_pattern(compiled_pat, NULL);
   rc = pcre2_match(compiled_pat, (PCRE2_SPTR8)Char(s), PCRE2_ZERO_TERMINATED, 0, 0, match_data, 0);
   pcre2_code_free(compiled_pat);
   pcre2_match_data_free(match_data);
@@ -1290,10 +1273,8 @@ static int name_regexmatch_value(Node *n, String *pattern, String *s) {
   if (rc == PCRE2_ERROR_NOMATCH)
     return 0;
 
-  if (rc < 0 ) {
-    Swig_error("SWIG", Getline(n),
-               "Matching \"%s\" against regex \"%s\" failed: %d\n",
-               Char(s), Char(pattern), rc);
+  if (rc < 0) {
+    Swig_error("SWIG", Getline(n), "Matching \"%s\" against regex \"%s\" failed: %d\n", Char(s), Char(pattern), rc);
     Exit(EXIT_FAILURE);
   }
 
@@ -1305,8 +1286,7 @@ static int name_regexmatch_value(Node *n, String *pattern, String *s) {
 static int name_regexmatch_value(Node *n, String *pattern, String *s) {
   (void)pattern;
   (void)s;
-  Swig_error("SWIG", Getline(n),
-             "PCRE regex matching is not available in this SWIG build.\n");
+  Swig_error("SWIG", Getline(n), "PCRE regex matching is not available in this SWIG build.\n");
   Exit(EXIT_FAILURE);
   return 0;
 }
@@ -1357,8 +1337,7 @@ static int name_match_nameobj(Hash *rn, Node *n) {
       match = 0;
       if (nval) {
         String *kwval = Getattr(mi, "value");
-        match = regexmatch ? name_regexmatch_value(n, kwval, nval)
-            : name_match_value(kwval, nval);
+        match = regexmatch ? name_regexmatch_value(n, kwval, nval) : name_match_value(kwval, nval);
 #ifdef SWIG_DEBUG
         Printf(stdout, "val %s %s %d %d \n", nval, kwval, match, ilen);
 #endif
@@ -1414,8 +1393,7 @@ static Hash *name_nameobj_lget(List *namelist, Node *n, String *prefix, String *
               DohIncref(name);
             }
           }
-          match = regextarget ? name_regexmatch_value(n, tname, sname)
-            : name_match_value(tname, sname);
+          match = regextarget ? name_regexmatch_value(n, tname, sname) : name_match_value(tname, sname);
           Delete(sname);
         } else {
           /* Applying the renaming rule may fail if it contains a %(regex)s expression that doesn't match the given name. */
@@ -1444,7 +1422,7 @@ static Hash *name_nameobj_lget(List *namelist, Node *n, String *prefix, String *
  * ----------------------------------------------------------------------------- */
 
 void Swig_name_namewarn_add(String *prefix, String *name, SwigType *decl, Hash *namewrn) {
-  const char *namewrn_keys[] = { "rename", "error", "fullname", "sourcefmt", "targetfmt", 0 };
+  const char *namewrn_keys[] = {"rename", "error", "fullname", "sourcefmt", "targetfmt", 0};
   name_object_attach_keys(namewrn_keys, namewrn);
   name_nameobj_add(name_namewarn_hash(), name_namewarn_list(), prefix, name, decl, namewrn);
 }
@@ -1520,7 +1498,7 @@ void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *ne
 
   ParmList *declparms = declaratorparms;
 
-  const char *rename_keys[] = { "fullname", "sourcefmt", "targetfmt", "continue", "regextarget", 0 };
+  const char *rename_keys[] = {"fullname", "sourcefmt", "targetfmt", "continue", "regextarget", 0};
   name_object_attach_keys(rename_keys, newname);
 
   /* Add the name */
@@ -1534,7 +1512,7 @@ void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *ne
 
         /* Create a parameter list for the new rename by copying all
            but the last (defaulted) parameter */
-        ParmList *newparms = CopyParmListMax(declparms,ParmList_len(declparms)-1);
+        ParmList *newparms = CopyParmListMax(declparms, ParmList_len(declparms) - 1);
 
         /* Create new declaration - with the last parameter removed */
         SwigType *newdecl = Copy(decl);
@@ -1553,9 +1531,8 @@ void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *ne
   }
 }
 
-
 /* Create a name for the given node applying rename/namewarn if needed */
-static String *apply_rename(Node* n, String *newname, int fullname, String *prefix, String *name) {
+static String *apply_rename(Node *n, String *newname, int fullname, String *prefix, String *name) {
   String *result = 0;
   if (newname && Len(newname)) {
     if (Strcmp(newname, "$ignore") == 0) {
@@ -1687,7 +1664,7 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
         result = apply_rename(n, rename, fullname, prefix, name);
         if ((msg) && (Len(msg))) {
           if (!Getmeta(nname, "already_warned")) {
-            String* suffix = 0;
+            String *suffix = 0;
             if (Strcmp(result, "$ignore") == 0) {
               suffix = NewStringf(": ignoring '%s'\n", name);
             } else if (Strcmp(result, name) != 0) {
@@ -1703,7 +1680,7 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
               int suppress_parameter_rename_warning = Equal(nodeType(n), "parm");
               if (!suppress_parameter_rename_warning) {
                 SWIG_WARN_NODE_BEGIN(n);
-              Swig_warning(0, Getfile(n), Getline(n), "%s%s", msg, suffix);
+                Swig_warning(0, Getfile(n), Getline(n), "%s%s", msg, suffix);
                 SWIG_WARN_NODE_END(n);
               }
             } else {
@@ -1820,7 +1797,6 @@ List *Swig_make_inherit_list(String *clsname, List *names, String *Namespacepref
   }
   return bases;
 }
-
 
 /* -----------------------------------------------------------------------------
  * void Swig_name_str()
@@ -1940,4 +1916,3 @@ String *Swig_name_fulldecl(Node *n) {
   }
   return fulldecl;
 }
-

--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -1219,7 +1219,7 @@ static void name_nameobj_add(Hash *name_hash, List *name_list, String *prefix, S
     }
   }
 
-  if (!nname || !Len(nname) || Getattr(nameobj, "fullname") ||	/* any of these options trigger a 'list' nameobj */
+  if (!nname || !Len(nname) || Getattr(nameobj, "fullname") ||  /* any of these options trigger a 'list' nameobj */
       Getattr(nameobj, "sourcefmt") || Getattr(nameobj, "matchlist") || Getattr(nameobj, "regextarget")) {
     if (decl)
       Setattr(nameobj, "decl", decl);
@@ -1538,7 +1538,7 @@ void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *ne
 
         /* Create new declaration - with the last parameter removed */
         SwigType *newdecl = Copy(decl);
-        Delete(SwigType_pop_function(newdecl));	/* remove the old parameter list from newdecl */
+        Delete(SwigType_pop_function(newdecl)); /* remove the old parameter list from newdecl */
         SwigType_add_function(newdecl, newparms);
         if (constqualifier)
           SwigType_add_qualifier(newdecl, "const");

--- a/Source/Swig/naming.c
+++ b/Source/Swig/naming.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -158,7 +158,7 @@ static void replace_nspace(String *name, const_String_or_char_ptr nspace) {
 
 /* -----------------------------------------------------------------------------
  * Swig_name_mangle_type()
- * 
+ *
  * Same as Swig_name_mangle_string, but converting internal SwigType * to a human
  * readable string of the type (for templates). Simplifies a type that is a
  * template to the default template if possible.
@@ -209,7 +209,7 @@ String *Swig_name_type(const_String_or_char_ptr tname) {
 
 /* -----------------------------------------------------------------------------
  * Swig_name_mangle_string()
- * 
+ *
  * Take a string and mangle it by stripping all non-valid C identifier
  * characters.
  *
@@ -226,7 +226,7 @@ String *Swig_name_type(const_String_or_char_ptr tname) {
  *
  * Having a perfect mangling will break some examples and code which
  * assume, for example, that A::get_value will be mangled as
- * A_get_value. 
+ * A_get_value.
  * ----------------------------------------------------------------------------- */
 
 String *Swig_name_mangle_string(const String *s) {
@@ -407,7 +407,7 @@ String *Swig_name_get(const_String_or_char_ptr nspace, const_String_or_char_ptr 
   return r;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Swig_name_set()
  *
  * Returns the name of the accessor function used to set a variable.
@@ -488,7 +488,7 @@ String *Swig_name_disown(const_String_or_char_ptr nspace, const_String_or_char_p
 /* -----------------------------------------------------------------------------
  * Swig_name_object_set()
  *
- * Sets an object associated with a name and optional declarators. 
+ * Sets an object associated with a name and optional declarators.
  * ----------------------------------------------------------------------------- */
 
 void Swig_name_object_set(Hash *namehash, String *name, SwigType *decl, DOH *object) {
@@ -517,7 +517,7 @@ void Swig_name_object_set(Hash *namehash, String *name, SwigType *decl, DOH *obj
 /* -----------------------------------------------------------------------------
  * Swig_name_object_get()
  *
- * Return an object associated with an optional class prefix, name, and 
+ * Return an object associated with an optional class prefix, name, and
  * declarator.   This function operates according to name matching rules
  * described for the %rename directive in the SWIG manual.
  * ----------------------------------------------------------------------------- */
@@ -629,7 +629,7 @@ DOH *Swig_name_object_get(Hash *namehash, String *prefix, String *name, SwigType
 /* -----------------------------------------------------------------------------
  * Swig_name_object_inherit()
  *
- * Implements name-based inheritance scheme. 
+ * Implements name-based inheritance scheme.
  * ----------------------------------------------------------------------------- */
 
 void Swig_name_object_inherit(Hash *namehash, String *base, String *derived) {
@@ -944,13 +944,13 @@ static List *name_rename_list(void) {
 /* -----------------------------------------------------------------------------
  * int need_name_warning(Node *n)
  *
- * Detects if a node needs name warnings 
+ * Detects if a node needs name warnings
  *
  * ----------------------------------------------------------------------------- */
 
 static int need_name_warning(Node *n) {
   int need = 1;
-  /* 
+  /*
      We don't use name warnings for:
      - class forwards, no symbol is generated at the target language.
      - template declarations, only for real instances using %template(name).
@@ -979,7 +979,7 @@ static int need_name_warning(Node *n) {
  * int Swig_need_redefined_warn()
  *
  * Detects when a redefined object needs a warning
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static int nodes_are_equivalent(Node *a, Node *b, int a_inclass) {
@@ -1106,7 +1106,7 @@ int Swig_need_redefined_warn(Node *a, Node *b, int InClass) {
  *
  * Detects when we need to fully register the protected member.
  * This is basically any protected members when the allprotected mode is set.
- * Otherwise we take just the protected virtual methods and non-static methods 
+ * Otherwise we take just the protected virtual methods and non-static methods
  * (potentially virtual methods) as well as constructors/destructors.
  * Also any "using" statements in a class may potentially be virtual.
  * ----------------------------------------------------------------------------- */
@@ -1136,7 +1136,7 @@ int Swig_need_protected(Node *n) {
  * void name_nameobj_add()
  *
  * Add nameobj (rename/namewarn)
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static List *make_attrlist(const char *ckey) {
@@ -1239,7 +1239,7 @@ static void name_nameobj_add(Hash *name_hash, List *name_list, String *prefix, S
  * int name_match_nameobj()
  *
  * Apply and check the nameobj's math list to the node
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static DOH *get_lattr(Node *n, List *lattr) {
@@ -1377,7 +1377,7 @@ static int name_match_nameobj(Hash *rn, Node *n) {
  * Hash *name_nameobj_lget()
  *
  * Get a nameobj (rename/namewarn) from the list of filters
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static Hash *name_nameobj_lget(List *namelist, Node *n, String *prefix, String *name, String *decl) {
@@ -1440,7 +1440,7 @@ static Hash *name_nameobj_lget(List *namelist, Node *n, String *prefix, String *
  * Swig_name_namewarn_add
  *
  * Add a namewarn objects
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 void Swig_name_namewarn_add(String *prefix, String *name, SwigType *decl, Hash *namewrn) {
@@ -1453,7 +1453,7 @@ void Swig_name_namewarn_add(String *prefix, String *name, SwigType *decl, Hash *
  * Hash *name_namewarn_get()
  *
  * Return the namewarn object, if there is one.
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static Hash *name_namewarn_get(Node *n, String *prefix, String *name, SwigType *decl) {
@@ -1496,7 +1496,7 @@ static Hash *name_namewarn_get(Node *n, String *prefix, String *name, SwigType *
  * String *Swig_name_warning()
  *
  * Return the name warning, if there is one.
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 String *Swig_name_warning(Node *n, String *prefix, String *name, SwigType *decl) {
@@ -1508,7 +1508,7 @@ String *Swig_name_warning(Node *n, String *prefix, String *name, SwigType *decl)
  * Swig_name_rename_add()
  *
  * Manage the rename objects
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static void single_rename_add(String *prefix, String *name, SwigType *decl, Hash *newname) {
@@ -1592,7 +1592,7 @@ static String *apply_rename(Node* n, String *newname, int fullname, String *pref
  * String *Swig_name_make()
  *
  * Make a name after applying all the rename/namewarn objects
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, SwigType *decl, String *oldname) {
@@ -1738,7 +1738,7 @@ String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, 
  * void Swig_name_inherit()
  *
  * Inherit namewarn, rename, and feature objects
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 void Swig_name_inherit(String *base, String *derived) {
@@ -1832,7 +1832,7 @@ List *Swig_make_inherit_list(String *clsname, List *names, String *Namespacepref
  *   "MyNameSpace::ABC::ABC"
  *   "MyNameSpace::ABC::constmethod"
  *   "MyNameSpace::ABC::variablename"
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 String *Swig_name_str(Node *n) {
@@ -1921,7 +1921,7 @@ String *Swig_name_decl(Node *n) {
  *   "MyNameSpace::MyTemplate<MyNameSpace::ABC >::~MyTemplate()"
  *   "MyNameSpace::ABC::ABC(int,double)"
  *   "int * MyNameSpace::ABC::constmethod(int) const"
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 String *Swig_name_fulldecl(Node *n) {

--- a/Source/Swig/parms.c
+++ b/Source/Swig/parms.c
@@ -70,7 +70,7 @@ Parm *CopyParm(Parm *p) {
   for (ki = First(p); ki.key; ki = Next(ki)) {
     if (DohIsString(ki.item)) {
       DOH *c = Copy(ki.item);
-      Setattr(np,ki.key,c);
+      Setattr(np, ki.key, c);
       Delete(c);
     }
   }
@@ -93,7 +93,8 @@ ParmList *CopyParmListMax(ParmList *p, int count) {
     return 0;
 
   while (p) {
-    if (count == 0) break;
+    if (count == 0)
+      break;
     np = CopyParm(p);
     if (pp) {
       set_nextSibling(pp, np);
@@ -109,7 +110,7 @@ ParmList *CopyParmListMax(ParmList *p, int count) {
 }
 
 ParmList *CopyParmList(ParmList *p) {
-  return CopyParmListMax(p,-1);
+  return CopyParmListMax(p, -1);
 }
 
 /* -----------------------------------------------------------------------------

--- a/Source/Swig/parms.c
+++ b/Source/Swig/parms.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -398,108 +398,108 @@ static void get_escape(Scanner *s) {
     switch (state) {
     case 0:
       if (c == 'n') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\n");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\n");
+        return;
       }
       if (c == 'r') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\r");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\r");
+        return;
       }
       if (c == 't') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\t");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\t");
+        return;
       }
       if (c == 'a') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\a");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\a");
+        return;
       }
       if (c == 'b') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\b");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\b");
+        return;
       }
       if (c == 'f') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\f");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\f");
+        return;
       }
       if (c == '\\') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\\");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\\");
+        return;
       }
       if (c == 'v') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\v");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\v");
+        return;
       }
       if (c == 'e') {
-	// '\e' is a non-standard alternative to '\033' (the escape character)
-	// in both C and C++, but is supported by at least GCC and clang.  MSVC
-	// issues a warning and treats it as an 'e'.
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\033");
-	return;
+        // '\e' is a non-standard alternative to '\033' (the escape character)
+        // in both C and C++, but is supported by at least GCC and clang.  MSVC
+        // issues a warning and treats it as an 'e'.
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\033");
+        return;
       }
       if (c == '\'') {
-	Delitem(s->text, DOH_END);
-	Append(s->text,"\'");
-	return;
+        Delitem(s->text, DOH_END);
+        Append(s->text,"\'");
+        return;
       }
       if (c == '\"') {
-	Delitem(s->text, DOH_END);	
-	Append(s->text,"\"");
-	return;
+        Delitem(s->text, DOH_END);	
+        Append(s->text,"\"");
+        return;
       }
       if (c == '\n') {
-	Delitem(s->text, DOH_END);
-	return;
+        Delitem(s->text, DOH_END);
+        return;
       }
       if (isdigit(c)) {
-	state = 10;
-	result = (c - '0');
-	Delitem(s->text, DOH_END);
+        state = 10;
+        result = (c - '0');
+        Delitem(s->text, DOH_END);
       } else if (c == 'x') {
-	state = 20;
-	Delitem(s->text, DOH_END);
+        state = 20;
+        Delitem(s->text, DOH_END);
       } else {
-	Delitem(s->text, DOH_END);
-	Putc('\\',s->text);
-	Putc((char)c,s->text);
-	return;
+        Delitem(s->text, DOH_END);
+        Putc('\\',s->text);
+        Putc((char)c,s->text);
+        return;
       }
       break;
     case 10: // Second digit of octal escape sequence
     case 11: // Third digit of octal escape sequence
       if (c < '0' || c > '7') {
-	retract(s,1);
-	Putc((char)result,s->text);
-	return;
+        retract(s,1);
+        Putc((char)result,s->text);
+        return;
       }
       result = (result << 3) + (c - '0');
       Delitem(s->text, DOH_END);
       if (state == 11) {
-	if (result > 255)
-	  Swig_error(Scanner_file(s), Scanner_line(s), "octal escape sequence out of range\n");
-	Putc((char)result,s->text);
-	return;
+        if (result > 255)
+          Swig_error(Scanner_file(s), Scanner_line(s), "octal escape sequence out of range\n");
+        Putc((char)result,s->text);
+        return;
       }
       state = 11;
       break;
     case 20:
       if (!isxdigit(c)) {
-	retract(s,1);
-	Putc((char)result, s->text);
-	return;
+        retract(s,1);
+        Putc((char)result, s->text);
+        return;
       }
       if (isdigit(c))
-	result = (result << 4) + (c - '0');
+        result = (result << 4) + (c - '0');
       else
-	result = (result << 4) + (10 + tolower(c) - 'a');
+        result = (result << 4) + (10 + tolower(c) - 'a');
       Delitem(s->text, DOH_END);
       break;
     }
@@ -527,18 +527,18 @@ static int look(Scanner *s) {
     switch (state) {
     case 0:
       if ((c = nextchar(s)) == EOF)
-	return (0);
+        return (0);
 
       /* Process delimiters */
 
       if (c == '\n') {
-	return SWIG_TOKEN_ENDLINE;
+        return SWIG_TOKEN_ENDLINE;
       } else if (!isspace(c)) {
-	retract(s, 1);
-	state = 1000;
-	Clear(s->text);
-	Setline(s->text, s->line);
-	Setfile(s->text, Getfile(s->str));
+        retract(s, 1);
+        state = 1000;
+        Clear(s->text);
+        Setline(s->text, s->line);
+        Setfile(s->text, Getfile(s->str));
       }
       break;
 
@@ -546,446 +546,446 @@ static int look(Scanner *s) {
       if ((c = nextchar(s)) == EOF)
         return (0);
       if (c == '%')
-	state = 4;		/* Possibly a SWIG directive */
+        state = 4;		/* Possibly a SWIG directive */
       
       /* Look for possible identifiers or unicode/delimiter strings */
       else if ((isalpha(c)) || (c == '_') ||
-	       (s->idstart && strchr(s->idstart, c))) {
-	state = 7;
+               (s->idstart && strchr(s->idstart, c))) {
+        state = 7;
       }
 
       /* Look for single character symbols */
 
       else if (c == '(') {
         brackets_push(s);
-	return SWIG_TOKEN_LPAREN;
+        return SWIG_TOKEN_LPAREN;
       }
       else if (c == ')') {
         brackets_pop(s);
-	return SWIG_TOKEN_RPAREN;
+        return SWIG_TOKEN_RPAREN;
       }
       else if (c == ';') {
         brackets_clear(s);
-	return SWIG_TOKEN_SEMI;
+        return SWIG_TOKEN_SEMI;
       }
       else if (c == ',')
-	return SWIG_TOKEN_COMMA;
+        return SWIG_TOKEN_COMMA;
       else if (c == '*')
-	state = 220;
+        state = 220;
       else if (c == '}')
-	return SWIG_TOKEN_RBRACE;
+        return SWIG_TOKEN_RBRACE;
       else if (c == '{') {
         brackets_reset(s);
-	return SWIG_TOKEN_LBRACE;
+        return SWIG_TOKEN_LBRACE;
       }
       else if (c == '=')
-	state = 33;
+        state = 33;
       else if (c == '+')
-	state = 200;
+        state = 200;
       else if (c == '-')
-	state = 210;
+        state = 210;
       else if (c == '&')
-	state = 31;
+        state = 31;
       else if (c == '|')
-	state = 32;
+        state = 32;
       else if (c == '^')
-	state = 230;
+        state = 230;
       else if (c == '<')
-	state = 60;
+        state = 60;
       else if (c == '>')
-	state = 61;
+        state = 61;
       else if (c == '~')
-	return SWIG_TOKEN_NOT;
+        return SWIG_TOKEN_NOT;
       else if (c == '!')
-	state = 3;
+        state = 3;
       else if (c == '\\')
-	return SWIG_TOKEN_BACKSLASH;
+        return SWIG_TOKEN_BACKSLASH;
       else if (c == '@')
-	return SWIG_TOKEN_AT;
+        return SWIG_TOKEN_AT;
       else if (c == '$')
-	state = 75;
+        state = 75;
       else if (c == '#')
-	return SWIG_TOKEN_POUND;
+        return SWIG_TOKEN_POUND;
       else if (c == '?')
-	return SWIG_TOKEN_QUESTION;
+        return SWIG_TOKEN_QUESTION;
 
       /* Look for multi-character sequences */
 
       else if (c == '/') {
-	state = 1;		/* Comment (maybe)  */
-	s->start_line = s->line;
+        state = 1;		/* Comment (maybe)  */
+        s->start_line = s->line;
       }
 
       else if (c == ':')
-	state = 5;		/* maybe double colon */
+        state = 5;		/* maybe double colon */
       else if (c == '0')
-	state = 83;		/* Maybe a hex, octal or binary number */
+        state = 83;		/* Maybe a hex, octal or binary number */
       else if (c == '\"') {
-	state = 2;              /* A string constant */
-	s->start_line = s->line;
-	Clear(s->text);
+        state = 2;              /* A string constant */
+        s->start_line = s->line;
+        Clear(s->text);
       }
       else if (c == '\'') {
-	s->start_line = s->line;
-	Clear(s->text);
-	state = 9;		/* A character constant */
+        s->start_line = s->line;
+        Clear(s->text);
+        state = 9;		/* A character constant */
       }
 
       else if (c == '.')
-	state = 100;		/* Maybe a number, maybe ellipsis, just a period */
+        state = 100;		/* Maybe a number, maybe ellipsis, just a period */
       else if (c == '[')
         state = 102;            /* Maybe a bracket or a double bracket */
       else if (c == ']')
         state = 103;            /* Maybe a bracket or a double bracket */
       else if (isdigit(c))
-	state = 8;		/* A numerical value */
+        state = 8;		/* A numerical value */
       else
-	state = 99;		/* An error */
+        state = 99;		/* An error */
       break;
 
     case 1:			/*  Comment block */
       if ((c = nextchar(s)) == EOF)
-	return (0);
+        return (0);
       if (c == '/') {
-	state = 10;		/* C++ style comment */
-	Clear(s->text);
-	Setline(s->text, Getline(s->str));
-	Setfile(s->text, Getfile(s->str));
-	Append(s->text, "//");
+        state = 10;		/* C++ style comment */
+        Clear(s->text);
+        Setline(s->text, Getline(s->str));
+        Setfile(s->text, Getfile(s->str));
+        Append(s->text, "//");
       } else if (c == '*') {
-	state = 11;		/* C style comment */
-	Clear(s->text);
-	Setline(s->text, Getline(s->str));
-	Setfile(s->text, Getfile(s->str));
-	Append(s->text, "/*");
+        state = 11;		/* C style comment */
+        Clear(s->text);
+        Setline(s->text, Getline(s->str));
+        Setfile(s->text, Getfile(s->str));
+        Append(s->text, "/*");
       } else if (c == '=') {
-	return SWIG_TOKEN_DIVEQUAL;
+        return SWIG_TOKEN_DIVEQUAL;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_SLASH;
+        retract(s, 1);
+        return SWIG_TOKEN_SLASH;
       }
       break;
     case 10:			/* C++ style comment */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '\n') {
-	retract(s,1);
-	return SWIG_TOKEN_COMMENT;
+        retract(s,1);
+        return SWIG_TOKEN_COMMENT;
       } else {
-	state = 10;
+        state = 10;
       }
       break;
     case 11:			/* C style comment block */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '*') {
-	state = 12;
+        state = 12;
       } else {
-	state = 11;
+        state = 11;
       }
       break;
     case 12:			/* Still in C style comment */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '*') {
-	state = 12;
+        state = 12;
       } else if (c == '/') {
-	return SWIG_TOKEN_COMMENT;
+        return SWIG_TOKEN_COMMENT;
       } else {
-	state = 11;
+        state = 11;
       }
       break;
 
     case 2:			/* Processing a string */
       if (!str_delimiter) {
-	state=20;
-	break;
+        state=20;
+        break;
       }
       
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
+        return SWIG_TOKEN_ERROR;
       }
       else if (c == '(') {
-	state = 20;
+        state = 20;
       }
       else {
-	Putc( (char)c, str_delimiter );
+        Putc( (char)c, str_delimiter );
       }
     
       break;
 
     case 20:			/* Inside the string */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
+        return SWIG_TOKEN_ERROR;
       }
       
       if (!str_delimiter) { /* Ordinary string: "value" */
-	if (c == '\"') {
-	  Delitem(s->text, DOH_END);
-	  return SWIG_TOKEN_STRING;
-	} else if (c == '\\') {
-	  Delitem(s->text, DOH_END);
-	  get_escape(s);
-	}
+        if (c == '\"') {
+          Delitem(s->text, DOH_END);
+          return SWIG_TOKEN_STRING;
+        } else if (c == '\\') {
+          Delitem(s->text, DOH_END);
+          get_escape(s);
+        }
       } else {             /* Custom delimiter string: R"XXXX(value)XXXX" */
-	if (c==')') {
-	  int i=0;
-	  String *end_delimiter = NewStringEmpty();
-	  while ((c = nextchar(s)) != EOF && c != '\"') {
-	    Putc( (char)c, end_delimiter );
-	    i++;
-	  }
-	  
-	  if (Strcmp( str_delimiter, end_delimiter )==0) {
-	    int len = Len(s->text);
-	    Delslice(s->text, len - 2 - Len(str_delimiter), len); /* Delete ending )XXXX" */
-	    Delslice(s->text, 0, Len(str_delimiter) + 1); /* Delete starting XXXX( */
-	    Delete( end_delimiter ); /* Correct end delimiter )XXXX" occurred */
-	    Delete( str_delimiter );
-	    str_delimiter = 0;
-	    return SWIG_TOKEN_STRING;
-	  } else {                   /* Incorrect end delimiter occurred */
-	    if (c == EOF) {
-	      Swig_error(cparse_file, cparse_start_line, "Unterminated raw string, started with R\"%s( is not terminated by )%s\"\n", str_delimiter, str_delimiter);
-	      return SWIG_TOKEN_ERROR;
-	    }
-	    retract( s, i );
-	    Delete( end_delimiter );
-	  }
-	}
+        if (c==')') {
+          int i=0;
+          String *end_delimiter = NewStringEmpty();
+          while ((c = nextchar(s)) != EOF && c != '\"') {
+            Putc( (char)c, end_delimiter );
+            i++;
+          }
+          
+          if (Strcmp( str_delimiter, end_delimiter )==0) {
+            int len = Len(s->text);
+            Delslice(s->text, len - 2 - Len(str_delimiter), len); /* Delete ending )XXXX" */
+            Delslice(s->text, 0, Len(str_delimiter) + 1); /* Delete starting XXXX( */
+            Delete( end_delimiter ); /* Correct end delimiter )XXXX" occurred */
+            Delete( str_delimiter );
+            str_delimiter = 0;
+            return SWIG_TOKEN_STRING;
+          } else {                   /* Incorrect end delimiter occurred */
+            if (c == EOF) {
+              Swig_error(cparse_file, cparse_start_line, "Unterminated raw string, started with R\"%s( is not terminated by )%s\"\n", str_delimiter, str_delimiter);
+              return SWIG_TOKEN_ERROR;
+            }
+            retract( s, i );
+            Delete( end_delimiter );
+          }
+        }
       }
       
       break;
 
     case 3:			/* Maybe a not equals */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_LNOT;
+        return SWIG_TOKEN_LNOT;
       else if (c == '=')
-	return SWIG_TOKEN_NOTEQUAL;
+        return SWIG_TOKEN_NOTEQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_LNOT;
+        retract(s, 1);
+        return SWIG_TOKEN_LNOT;
       }
       break;
 
     case 31:			/* AND or Logical AND or ANDEQUAL */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_AND;
+        return SWIG_TOKEN_AND;
       else if (c == '&')
-	return SWIG_TOKEN_LAND;
+        return SWIG_TOKEN_LAND;
       else if (c == '=')
-	return SWIG_TOKEN_ANDEQUAL;
+        return SWIG_TOKEN_ANDEQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_AND;
+        retract(s, 1);
+        return SWIG_TOKEN_AND;
       }
       break;
 
     case 32:			/* OR or Logical OR */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_OR;
+        return SWIG_TOKEN_OR;
       else if (c == '|')
-	return SWIG_TOKEN_LOR;
+        return SWIG_TOKEN_LOR;
       else if (c == '=')
-	return SWIG_TOKEN_OREQUAL;
+        return SWIG_TOKEN_OREQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_OR;
+        retract(s, 1);
+        return SWIG_TOKEN_OR;
       }
       break;
 
     case 33:			/* EQUAL or EQUALTO */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_EQUAL;
+        return SWIG_TOKEN_EQUAL;
       else if (c == '=')
-	return SWIG_TOKEN_EQUALTO;
+        return SWIG_TOKEN_EQUALTO;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_EQUAL;
+        retract(s, 1);
+        return SWIG_TOKEN_EQUAL;
       }
       break;
 
     case 4:			/* A wrapper generator directive (maybe) */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_PERCENT;
+        return SWIG_TOKEN_PERCENT;
       if (c == '{') {
-	state = 40;		/* Include block */
-	Clear(s->text);
-	Setline(s->text, Getline(s->str));
-	Setfile(s->text, Getfile(s->str));
-	s->start_line = s->line;
+        state = 40;		/* Include block */
+        Clear(s->text);
+        Setline(s->text, Getline(s->str));
+        Setfile(s->text, Getfile(s->str));
+        s->start_line = s->line;
       } else if (s->idstart && strchr(s->idstart, '%') &&
-	         ((isalpha(c)) || (c == '_'))) {
-	state = 7;
+                 ((isalpha(c)) || (c == '_'))) {
+        state = 7;
       } else if (c == '=') {
-	return SWIG_TOKEN_MODEQUAL;
+        return SWIG_TOKEN_MODEQUAL;
       } else if (c == '}') {
-	Swig_error(cparse_file, cparse_line, "Syntax error. Extraneous '%%}'\n");
-	Exit(EXIT_FAILURE);
+        Swig_error(cparse_file, cparse_line, "Syntax error. Extraneous '%%}'\n");
+        Exit(EXIT_FAILURE);
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_PERCENT;
+        retract(s, 1);
+        return SWIG_TOKEN_PERCENT;
       }
       break;
 
     case 40:			/* Process an include block */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated block\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated block\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '%')
-	state = 41;
+        state = 41;
       break;
     case 41:			/* Still processing include block */
       if ((c = nextchar(s)) == EOF) {
-	set_error(s,s->start_line,"Unterminated code block");
-	return 0;
+        set_error(s,s->start_line,"Unterminated code block");
+        return 0;
       }
       if (c == '}') {
-	Delitem(s->text, DOH_END);
-	Delitem(s->text, DOH_END);
-	Seek(s->text,0,SEEK_SET);
-	return SWIG_TOKEN_CODEBLOCK;
+        Delitem(s->text, DOH_END);
+        Delitem(s->text, DOH_END);
+        Seek(s->text,0,SEEK_SET);
+        return SWIG_TOKEN_CODEBLOCK;
       } else {
-	state = 40;
+        state = 40;
       }
       break;
 
     case 5:			/* Maybe a double colon */
 
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_COLON;
+        return SWIG_TOKEN_COLON;
       if (c == ':')
-	state = 50;
+        state = 50;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_COLON;
+        retract(s, 1);
+        return SWIG_TOKEN_COLON;
       }
       break;
 
     case 50:			/* DCOLON, DCOLONSTAR */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_DCOLON;
+        return SWIG_TOKEN_DCOLON;
       else if (c == '*')
-	return SWIG_TOKEN_DCOLONSTAR;
+        return SWIG_TOKEN_DCOLONSTAR;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_DCOLON;
+        retract(s, 1);
+        return SWIG_TOKEN_DCOLON;
       }
       break;
 
     case 60:			/* shift operators */
       if ((c = nextchar(s)) == EOF) {
-	brackets_increment(s);
-	return SWIG_TOKEN_LESSTHAN;
+        brackets_increment(s);
+        return SWIG_TOKEN_LESSTHAN;
       }
       if (c == '<')
-	state = 240;
+        state = 240;
       else if (c == '=') {
-	if ((c = nextchar(s)) == EOF) {
-	  return SWIG_TOKEN_LTEQUAL;
-	} else if (c == '>' && cparse_cplusplus) { /* Spaceship operator */
-	  return SWIG_TOKEN_LTEQUALGT;
-	} else {
-	  retract(s, 1);
-	  return SWIG_TOKEN_LTEQUAL;
-	}
+        if ((c = nextchar(s)) == EOF) {
+          return SWIG_TOKEN_LTEQUAL;
+        } else if (c == '>' && cparse_cplusplus) { /* Spaceship operator */
+          return SWIG_TOKEN_LTEQUALGT;
+        } else {
+          retract(s, 1);
+          return SWIG_TOKEN_LTEQUAL;
+        }
       } else {
-	retract(s, 1);
-	brackets_increment(s);
-	return SWIG_TOKEN_LESSTHAN;
+        retract(s, 1);
+        brackets_increment(s);
+        return SWIG_TOKEN_LESSTHAN;
       }
       break;
     case 61:
       if ((c = nextchar(s)) == EOF) {
         brackets_decrement(s);
-	return SWIG_TOKEN_GREATERTHAN;
+        return SWIG_TOKEN_GREATERTHAN;
       }
       if (c == '>' && brackets_allow_shift(s))
-	state = 250;
+        state = 250;
       else if (c == '=')
-	return SWIG_TOKEN_GTEQUAL;
+        return SWIG_TOKEN_GTEQUAL;
       else {
-	retract(s, 1);
+        retract(s, 1);
         brackets_decrement(s);
-	return SWIG_TOKEN_GREATERTHAN;
+        return SWIG_TOKEN_GREATERTHAN;
       }
       break;
     
     case 7:			/* Identifier or true/false or unicode/custom delimiter string */
       if (c == 'R') { /* Possibly CUSTOM DELIMITER string */
-	state = 72;
-	break;
+        state = 72;
+        break;
       }
       else if (c == 'L') { /* Probably identifier but may be a wide string literal */
-	state = 77;
-	break;
+        state = 77;
+        break;
       }
       else if (c != 'u' && c != 'U') { /* Definitely an identifier */
-	state = 70;
-	break;
+        state = 70;
+        break;
       }
       
       if ((c = nextchar(s)) == EOF) {
-	state = 76;
+        state = 76;
       }
       else if (c == '\"') { /* Definitely u, U or L string */
-	retract(s, 1);
-	state = 1000;
+        retract(s, 1);
+        state = 1000;
       }
       else if (c == '\'') { /* Definitely u, U or L char */
-	retract(s, 1);
-	state = 77;
+        retract(s, 1);
+        state = 77;
       }
       else if (c == 'R') { /* Possibly CUSTOM DELIMITER u, U, L string */
-	state = 73;
+        state = 73;
       }
       else if (c == '8') { /* Possibly u8 string/char */
-	state = 71;
+        state = 71;
       }
       else {
-	retract(s, 1);   /* Definitely an identifier */
-	state = 70;
+        retract(s, 1);   /* Definitely an identifier */
+        state = 70;
       }
       break;
 
     case 70:			/* Identifier */
       if ((c = nextchar(s)) == EOF)
-	state = 76;
+        state = 76;
       else if (isalnum(c) || (c == '_') || (c == '$')) {
-	state = 70;
+        state = 70;
       } else {
-	retract(s, 1);
-	state = 76;
+        retract(s, 1);
+        state = 76;
       }
       break;
     
     case 71:			/* Possibly u8 string/char */
       if ((c = nextchar(s)) == EOF) {
-	state = 76;
+        state = 76;
       }
       else if (c=='\"') {
-	retract(s, 1); /* Definitely u8 string */
-	state = 1000;
+        retract(s, 1); /* Definitely u8 string */
+        state = 1000;
       }
       else if (c=='\'') {
-	retract(s, 1); /* Definitely u8 char */
-	state = 77;
+        retract(s, 1); /* Definitely u8 char */
+        state = 77;
       }
       else if (c=='R') {
-	state = 74; /* Possibly CUSTOM DELIMITER u8 string */
+        state = 74; /* Possibly CUSTOM DELIMITER u8 string */
       }
       else {
-	retract(s, 2); /* Definitely an identifier. Retract 8" */
-	state = 70;
+        retract(s, 2); /* Definitely an identifier. Retract 8" */
+        state = 70;
       }
       
       break;
@@ -994,311 +994,311 @@ static int look(Scanner *s) {
     case 73:
     case 74:
       if ((c = nextchar(s)) == EOF) {
-	state = 76;
+        state = 76;
       }
       else if (c=='\"') {
-	retract(s, 1); /* Definitely custom delimiter u, U or L string */
-	str_delimiter = NewStringEmpty();
-	state = 1000;
+        retract(s, 1); /* Definitely custom delimiter u, U or L string */
+        str_delimiter = NewStringEmpty();
+        state = 1000;
       }
       else {
-	if (state==72) {
-	  retract(s, 1); /* Definitely an identifier. Retract ? */
-	}
-	else if (state==73) {
-	  retract(s, 2); /* Definitely an identifier. Retract R? */
-	}
-	else if (state==74) {
-	  retract(s, 3); /* Definitely an identifier. Retract 8R? */
-	}
-	state = 70;
+        if (state==72) {
+          retract(s, 1); /* Definitely an identifier. Retract ? */
+        }
+        else if (state==73) {
+          retract(s, 2); /* Definitely an identifier. Retract R? */
+        }
+        else if (state==74) {
+          retract(s, 3); /* Definitely an identifier. Retract 8R? */
+        }
+        state = 70;
       }
       
       break;
 
     case 75:			/* Special identifier $ */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_DOLLAR;
+        return SWIG_TOKEN_DOLLAR;
       if (isalnum(c) || (c == '_') || (c == '*') || (c == '&')) {
-	state = 70;
+        state = 70;
       } else {
-	retract(s,1);
-	if (Len(s->text) == 1) return SWIG_TOKEN_DOLLAR;
-	state = 76;
+        retract(s,1);
+        if (Len(s->text) == 1) return SWIG_TOKEN_DOLLAR;
+        state = 76;
       }
       break;
 
     case 76:			/* Identifier, true/false or alternative token */
       if (cparse_cplusplus) {
-	if (Strcmp(s->text, "true") == 0)
-	  return SWIG_TOKEN_BOOL;
-	if (Strcmp(s->text, "false") == 0)
-	  return SWIG_TOKEN_BOOL;
+        if (Strcmp(s->text, "true") == 0)
+          return SWIG_TOKEN_BOOL;
+        if (Strcmp(s->text, "false") == 0)
+          return SWIG_TOKEN_BOOL;
 
-	if (Strcmp(s->text, "and") == 0)
-	  return SWIG_TOKEN_LAND;
-	if (Strcmp(s->text, "and_eq") == 0)
-	  return SWIG_TOKEN_ANDEQUAL;
-	if (Strcmp(s->text, "bitand") == 0)
-	  return SWIG_TOKEN_AND;
-	if (Strcmp(s->text, "bitor") == 0)
-	  return SWIG_TOKEN_OR;
-	if (Strcmp(s->text, "compl") == 0)
-	  return SWIG_TOKEN_NOT;
-	if (Strcmp(s->text, "not") == 0)
-	  return SWIG_TOKEN_LNOT;
-	if (Strcmp(s->text, "not_eq") == 0)
-	  return SWIG_TOKEN_NOTEQUAL;
-	if (Strcmp(s->text, "or") == 0)
-	  return SWIG_TOKEN_LOR;
-	if (Strcmp(s->text, "or_eq") == 0)
-	  return SWIG_TOKEN_OREQUAL;
-	if (Strcmp(s->text, "xor") == 0)
-	  return SWIG_TOKEN_XOR;
-	if (Strcmp(s->text, "xor_eq") == 0)
-	  return SWIG_TOKEN_XOREQUAL;
+        if (Strcmp(s->text, "and") == 0)
+          return SWIG_TOKEN_LAND;
+        if (Strcmp(s->text, "and_eq") == 0)
+          return SWIG_TOKEN_ANDEQUAL;
+        if (Strcmp(s->text, "bitand") == 0)
+          return SWIG_TOKEN_AND;
+        if (Strcmp(s->text, "bitor") == 0)
+          return SWIG_TOKEN_OR;
+        if (Strcmp(s->text, "compl") == 0)
+          return SWIG_TOKEN_NOT;
+        if (Strcmp(s->text, "not") == 0)
+          return SWIG_TOKEN_LNOT;
+        if (Strcmp(s->text, "not_eq") == 0)
+          return SWIG_TOKEN_NOTEQUAL;
+        if (Strcmp(s->text, "or") == 0)
+          return SWIG_TOKEN_LOR;
+        if (Strcmp(s->text, "or_eq") == 0)
+          return SWIG_TOKEN_OREQUAL;
+        if (Strcmp(s->text, "xor") == 0)
+          return SWIG_TOKEN_XOR;
+        if (Strcmp(s->text, "xor_eq") == 0)
+          return SWIG_TOKEN_XOREQUAL;
       }
       return SWIG_TOKEN_ID;
 
     case 77: /*identifier or wide string literal*/
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_ID;
+        return SWIG_TOKEN_ID;
       else if (c == '\"') {
-	s->start_line = s->line;
-	Clear(s->text);
-	state = 78;
+        s->start_line = s->line;
+        Clear(s->text);
+        state = 78;
       }
       else if (c == '\'') {
-	s->start_line = s->line;
-	Clear(s->text);
-	state = 79;
+        s->start_line = s->line;
+        Clear(s->text);
+        state = 79;
       }
       else if (isalnum(c) || (c == '_') || (c == '$'))
-	state = 7;
+        state = 7;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_ID;
+        retract(s, 1);
+        return SWIG_TOKEN_ID;
       }
     break;
 
     case 78:			/* Processing a wide string literal*/
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '\"') {
-	Delitem(s->text, DOH_END);
-	return SWIG_TOKEN_WSTRING;
+        Delitem(s->text, DOH_END);
+        return SWIG_TOKEN_WSTRING;
       } else if (c == '\\') {
-	Delitem(s->text, DOH_END);
-	get_escape(s);
+        Delitem(s->text, DOH_END);
+        get_escape(s);
       }
       break;
 
     case 79:			/* Processing a wide char literal */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated wide character constant\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated wide character constant\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '\'') {
-	Delitem(s->text, DOH_END);
-	return (SWIG_TOKEN_WCHAR);
+        Delitem(s->text, DOH_END);
+        return (SWIG_TOKEN_WCHAR);
       } else if (c == '\\') {
-	Delitem(s->text, DOH_END);
-	get_escape(s);
+        Delitem(s->text, DOH_END);
+        get_escape(s);
       }
       break;
 
     case 8:			/* A numerical digit */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_INT;
+        return SWIG_TOKEN_INT;
       if (c == '.') {
-	state = 81;
+        state = 81;
       } else if ((c == 'e') || (c == 'E')) {
-	state = 82;
+        state = 82;
       } else if ((c == 'f') || (c == 'F')) {
-	return SWIG_TOKEN_FLOAT;
+        return SWIG_TOKEN_FLOAT;
       } else if (isdigit(c)) {
-	state = 8;
+        state = 8;
       } else if ((c == 'l') || (c == 'L')) {
-	state = 87;
+        state = 87;
       } else if ((c == 'u') || (c == 'U')) {
-	state = 88;
+        state = 88;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_INT;
+        retract(s, 1);
+        return SWIG_TOKEN_INT;
       }
       break;
     case 81:			/* A floating pointer number of some sort */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_DOUBLE;
+        return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
-	state = 81;
+        state = 81;
       else if ((c == 'e') || (c == 'E'))
-	state = 820;
+        state = 820;
       else if ((c == 'f') || (c == 'F')) {
-	return SWIG_TOKEN_FLOAT;
+        return SWIG_TOKEN_FLOAT;
       } else if ((c == 'l') || (c == 'L')) {
-	Delitem(s->text, DOH_END);
-	return SWIG_TOKEN_LONGDOUBLE;
+        Delitem(s->text, DOH_END);
+        return SWIG_TOKEN_LONGDOUBLE;
       } else {
-	retract(s, 1);
-	return (SWIG_TOKEN_DOUBLE);
+        retract(s, 1);
+        return (SWIG_TOKEN_DOUBLE);
       }
       break;
     case 82:
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
+        return SWIG_TOKEN_ERROR;
       }
       if ((isdigit(c)) || (c == '-') || (c == '+'))
-	state = 86;
+        state = 86;
       else {
-	retract(s, 2);
-	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
-	return SWIG_TOKEN_ERROR;
+        retract(s, 2);
+        Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
+        return SWIG_TOKEN_ERROR;
       }
       break;
     case 820:
       /* Like case 82, but we've seen a decimal point. */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
+        return SWIG_TOKEN_ERROR;
       }
       if ((isdigit(c)) || (c == '-') || (c == '+'))
-	state = 86;
+        state = 86;
       else {
-	retract(s, 2);
-	Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
-	return SWIG_TOKEN_ERROR;
+        retract(s, 2);
+        Swig_error(cparse_file, cparse_start_line, "Exponent does not have any digits\n");
+        return SWIG_TOKEN_ERROR;
       }
       break;
     case 83:
       /* Might be a hexadecimal, octal or binary number */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_INT;
+        return SWIG_TOKEN_INT;
       if (isdigit(c))
-	state = 84;
+        state = 84;
       else if ((c == 'e') || (c == 'E'))
-	state = 82;
+        state = 82;
       else if ((c == 'x') || (c == 'X'))
-	state = 85;
+        state = 85;
       else if ((c == 'b') || (c == 'B'))
-	state = 850;
+        state = 850;
       else if (c == '.')
-	state = 81;
+        state = 81;
       else if ((c == 'l') || (c == 'L')) {
-	state = 87;
+        state = 87;
       } else if ((c == 'u') || (c == 'U')) {
-	state = 88;
+        state = 88;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_INT;
+        retract(s, 1);
+        return SWIG_TOKEN_INT;
       }
       break;
     case 84:
       /* This is an octal number */
       if (c == '8' || c == '9') {
-	Swig_error(Scanner_file(s), Scanner_line(s), "Invalid digit '%c' in octal constant\n", c);
+        Swig_error(Scanner_file(s), Scanner_line(s), "Invalid digit '%c' in octal constant\n", c);
       }
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_INT;
+        return SWIG_TOKEN_INT;
       if (isdigit(c))
-	state = 84;
+        state = 84;
       else if (c == '.')
-	state = 81;
+        state = 81;
       else if ((c == 'e') || (c == 'E'))
-	state = 82;
+        state = 82;
       else if ((c == 'l') || (c == 'L')) {
-	state = 87;
+        state = 87;
       } else if ((c == 'u') || (c == 'U')) {
-	state = 88;
+        state = 88;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_INT;
+        retract(s, 1);
+        return SWIG_TOKEN_INT;
       }
       break;
     case 85:
       /* This is an hex number */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_INT;
+        return SWIG_TOKEN_INT;
       if (isxdigit(c))
-	state = 85;
+        state = 85;
       else if (c == '.') /* hexadecimal float */
-	state = 860;
+        state = 860;
       else if ((c == 'p') || (c == 'P')) /* hexadecimal float */
-	state = 820;
+        state = 820;
       else if ((c == 'l') || (c == 'L')) {
-	state = 87;
+        state = 87;
       } else if ((c == 'u') || (c == 'U')) {
-	state = 88;
+        state = 88;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_INT;
+        retract(s, 1);
+        return SWIG_TOKEN_INT;
       }
       break;
     case 850:
       /* This is a binary number */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_INT;
+        return SWIG_TOKEN_INT;
       if ((c == '0') || (c == '1'))
-	state = 850;
+        state = 850;
       else if (isdigit(c)) {
-	Swig_error(Scanner_file(s), Scanner_line(s), "Invalid digit '%c' in binary constant\n", c);
+        Swig_error(Scanner_file(s), Scanner_line(s), "Invalid digit '%c' in binary constant\n", c);
       } else if ((c == 'l') || (c == 'L')) {
-	state = 87;
+        state = 87;
       } else if ((c == 'u') || (c == 'U')) {
-	state = 88;
+        state = 88;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_INT;
+        retract(s, 1);
+        return SWIG_TOKEN_INT;
       }
       break;
     case 860:
       /* hexadecimal float */
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Hexadecimal floating literals require an exponent\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Hexadecimal floating literals require an exponent\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (isxdigit(c))
-	state = 860;
+        state = 860;
       else if ((c == 'p') || (c == 'P'))
-	state = 820;
+        state = 820;
       else {
-	retract(s, 2);
-	Swig_error(cparse_file, cparse_start_line, "Hexadecimal floating literals require an exponent\n");
-	return SWIG_TOKEN_ERROR;
+        retract(s, 2);
+        Swig_error(cparse_file, cparse_start_line, "Hexadecimal floating literals require an exponent\n");
+        return SWIG_TOKEN_ERROR;
       }
       break;
     case 86:
       /* Rest of floating point number */
 
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_DOUBLE;
+        return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
-	state = 86;
+        state = 86;
       else if ((c == 'f') || (c == 'F')) {
-	return SWIG_TOKEN_FLOAT;
+        return SWIG_TOKEN_FLOAT;
       } else if ((c == 'l') || (c == 'L')) {
-	Delitem(s->text, DOH_END);
-	return SWIG_TOKEN_LONGDOUBLE;
+        Delitem(s->text, DOH_END);
+        return SWIG_TOKEN_LONGDOUBLE;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_DOUBLE;
+        retract(s, 1);
+        return SWIG_TOKEN_DOUBLE;
       }
       break;
 
     case 87:
       /* A long integer of some sort */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_LONG;
+        return SWIG_TOKEN_LONG;
       if ((c == 'u') || (c == 'U')) {
-	return SWIG_TOKEN_ULONG;
+        return SWIG_TOKEN_ULONG;
       } else if ((c == 'l') || (c == 'L')) {
-	state = 870;
+        state = 870;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_LONG;
+        retract(s, 1);
+        return SWIG_TOKEN_LONG;
       }
       break;
 
@@ -1306,50 +1306,50 @@ static int look(Scanner *s) {
 
     case 870:
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_LONGLONG;
+        return SWIG_TOKEN_LONGLONG;
       if ((c == 'u') || (c == 'U')) {
-	return SWIG_TOKEN_ULONGLONG;
+        return SWIG_TOKEN_ULONGLONG;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_LONGLONG;
+        retract(s, 1);
+        return SWIG_TOKEN_LONGLONG;
       }
 
       /* An unsigned number */
     case 88:
 
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_UINT;
+        return SWIG_TOKEN_UINT;
       if ((c == 'l') || (c == 'L')) {
-	state = 880;
+        state = 880;
       } else {
-	retract(s, 1);
-	return SWIG_TOKEN_UINT;
+        retract(s, 1);
+        return SWIG_TOKEN_UINT;
       }
       break;
 
       /* Possibly an unsigned long long or unsigned long */
     case 880:
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_ULONG;
+        return SWIG_TOKEN_ULONG;
       if ((c == 'l') || (c == 'L'))
-	return SWIG_TOKEN_ULONGLONG;
+        return SWIG_TOKEN_ULONGLONG;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_ULONG;
+        retract(s, 1);
+        return SWIG_TOKEN_ULONG;
       }
 
       /* A character constant */
     case 9:
       if ((c = nextchar(s)) == EOF) {
-	Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
-	return SWIG_TOKEN_ERROR;
+        Swig_error(cparse_file, cparse_start_line, "Unterminated character constant\n");
+        return SWIG_TOKEN_ERROR;
       }
       if (c == '\'') {
-	Delitem(s->text, DOH_END);
-	return (SWIG_TOKEN_CHAR);
+        Delitem(s->text, DOH_END);
+        return (SWIG_TOKEN_CHAR);
       } else if (c == '\\') {
-	Delitem(s->text, DOH_END);
-	get_escape(s);
+        Delitem(s->text, DOH_END);
+        get_escape(s);
       }
       break;
 
@@ -1357,14 +1357,14 @@ static int look(Scanner *s) {
 
     case 100:
       if ((c = nextchar(s)) == EOF)
-	return (0);
+        return (0);
       if (isdigit(c))
-	state = 81;
+        state = 81;
       else if (c == '.')
-	state = 101;
+        state = 101;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_PERIOD;
+        retract(s, 1);
+        return SWIG_TOKEN_PERIOD;
       }
       break;
 
@@ -1372,12 +1372,12 @@ static int look(Scanner *s) {
 
     case 101:
       if ((c = nextchar(s)) == EOF)
-	return (0);
+        return (0);
       if (c == '.') {
-	return SWIG_TOKEN_ELLIPSIS;
+        return SWIG_TOKEN_ELLIPSIS;
       } else {
-	retract(s, 2);
-	return SWIG_TOKEN_PERIOD;
+        retract(s, 2);
+        return SWIG_TOKEN_PERIOD;
       }
       break;
 
@@ -1408,85 +1408,85 @@ static int look(Scanner *s) {
 
     case 200:			/* PLUS, PLUSPLUS, PLUSEQUAL */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_PLUS;
+        return SWIG_TOKEN_PLUS;
       else if (c == '+')
-	return SWIG_TOKEN_PLUSPLUS;
+        return SWIG_TOKEN_PLUSPLUS;
       else if (c == '=')
-	return SWIG_TOKEN_PLUSEQUAL;
+        return SWIG_TOKEN_PLUSEQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_PLUS;
+        retract(s, 1);
+        return SWIG_TOKEN_PLUS;
       }
       break;
 
     case 210:			/* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_MINUS;
+        return SWIG_TOKEN_MINUS;
       else if (c == '-')
-	return SWIG_TOKEN_MINUSMINUS;
+        return SWIG_TOKEN_MINUSMINUS;
       else if (c == '=')
-	return SWIG_TOKEN_MINUSEQUAL;
+        return SWIG_TOKEN_MINUSEQUAL;
       else if (c == '>')
-	state = 211;
+        state = 211;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_MINUS;
+        retract(s, 1);
+        return SWIG_TOKEN_MINUS;
       }
       break;
 
     case 211:			/* ARROW, ARROWSTAR */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_ARROW;
+        return SWIG_TOKEN_ARROW;
       else if (c == '*')
-	return SWIG_TOKEN_ARROWSTAR;
+        return SWIG_TOKEN_ARROWSTAR;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_ARROW;
+        retract(s, 1);
+        return SWIG_TOKEN_ARROW;
       }
       break;
 
 
     case 220:			/* STAR, TIMESEQUAL */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_STAR;
+        return SWIG_TOKEN_STAR;
       else if (c == '=')
-	return SWIG_TOKEN_TIMESEQUAL;
+        return SWIG_TOKEN_TIMESEQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_STAR;
+        retract(s, 1);
+        return SWIG_TOKEN_STAR;
       }
       break;
 
     case 230:			/* XOR, XOREQUAL */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_XOR;
+        return SWIG_TOKEN_XOR;
       else if (c == '=')
-	return SWIG_TOKEN_XOREQUAL;
+        return SWIG_TOKEN_XOREQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_XOR;
+        retract(s, 1);
+        return SWIG_TOKEN_XOR;
       }
       break;
 
     case 240:			/* LSHIFT, LSEQUAL */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_LSHIFT;
+        return SWIG_TOKEN_LSHIFT;
       else if (c == '=')
-	return SWIG_TOKEN_LSEQUAL;
+        return SWIG_TOKEN_LSEQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_LSHIFT;
+        retract(s, 1);
+        return SWIG_TOKEN_LSHIFT;
       }
       break;
 
     case 250:			/* RSHIFT, RSEQUAL */
       if ((c = nextchar(s)) == EOF)
-	return SWIG_TOKEN_RSHIFT;
+        return SWIG_TOKEN_RSHIFT;
       else if (c == '=')
-	return SWIG_TOKEN_RSEQUAL;
+        return SWIG_TOKEN_RSEQUAL;
       else {
-	retract(s, 1);
-	return SWIG_TOKEN_RSHIFT;
+        retract(s, 1);
+        return SWIG_TOKEN_RSHIFT;
       }
       break;
 
@@ -1599,13 +1599,13 @@ int Scanner_skip_balanced(Scanner *s, int startchar, int endchar) {
     } else if (tok == SWIG_TOKEN_RRBRACKET && endtok == SWIG_TOKEN_RBRACKET) {
       num_levels -= 2;
       if (num_levels <= 0) {
-	if (num_levels < 0) Scanner_pushtoken(s, SWIG_TOKEN_RBRACKET, "]");
-	break;
+        if (num_levels < 0) Scanner_pushtoken(s, SWIG_TOKEN_RBRACKET, "]");
+        break;
       }
     } else if (tok == SWIG_TOKEN_COMMENT) {
       char *loc = Char(s->text);
       if (strncmp(loc, "/*@SWIG", 7) == 0 && loc[Len(s->text)-3] == '@') {
-	Scanner_locator(s, s->text);
+        Scanner_locator(s, s->text);
       }
     } else if (tok == 0) {
       return -1;
@@ -1614,7 +1614,7 @@ int Scanner_skip_balanced(Scanner *s, int startchar, int endchar) {
 
   Delete(s->text);
   s->text = NewStringWithSize(Char(s->str) + position - 1,
-			      Tell(s->str) - position + 1);
+                              Tell(s->str) - position + 1);
   Char(s->text)[0] = startchar;
   Setfile(s->text, Getfile(s->str));
   Setline(s->text, old_line);
@@ -1664,17 +1664,17 @@ String *Scanner_get_raw_text_balanced(Scanner *s, int startchar, int endchar) {
       num_levels++;
     } else if (tok == endtok) {
       if (--num_levels == 0) {
-	result = NewStringWithSize(Char(s->str) + position - 1,
-				   Tell(s->str) - position + 1);
-	Char(result)[0] = startchar;
-	Setfile(result, Getfile(s->str));
-	Setline(result, old_line);
-	break;
+        result = NewStringWithSize(Char(s->str) + position - 1,
+                                   Tell(s->str) - position + 1);
+        Char(result)[0] = startchar;
+        Setfile(result, Getfile(s->str));
+        Setline(result, old_line);
+        break;
       }
     } else if (tok == SWIG_TOKEN_COMMENT) {
       char *loc = Char(s->text);
       if (strncmp(loc, "/*@SWIG", 7) == 0 && loc[Len(s->text)-3] == '@') {
-	Scanner_locator(s, s->text);
+        Scanner_locator(s, s->text);
       }
     } else if (tok == 0) {
       break;
@@ -1720,7 +1720,7 @@ void Scanner_locator(Scanner *s, String *loc) {
     if (Equal(loc, "/*@SWIG@*/")) {
       /* End locator. */
       if (expanding_macro)
-	--expanding_macro;
+        --expanding_macro;
     } else {
       /* Begin locator. */
       ++expanding_macro;
@@ -1735,12 +1735,12 @@ void Scanner_locator(Scanner *s, String *loc) {
     if (c == '@') {
       /* Empty locator.  We pop the last location off */
       if (locs) {
-	Scanner_set_location(s, locs->filename, locs->line_number);
-	cparse_file = locs->filename;
-	cparse_line = locs->line_number;
-	l = locs->next;
-	Free(locs);
-	locs = l;
+        Scanner_set_location(s, locs->filename, locs->line_number);
+        cparse_file = locs->filename;
+        cparse_line = locs->line_number;
+        l = locs->next;
+        Free(locs);
+        locs = l;
       }
       return;
     }
@@ -1758,27 +1758,27 @@ void Scanner_locator(Scanner *s, String *loc) {
       /*      Putc(c, fn); */
       
       while ((c = Getc(loc)) != EOF) {
-	if ((c == '@') || (c == ','))
-	  break;
-	Putc(c, fn);
+        if ((c == '@') || (c == ','))
+          break;
+        Putc(c, fn);
       }
       cparse_file = Swig_copy_string(Char(fn));
       Clear(fn);
       cparse_line = 1;
       /* Get the line number */
       while ((c = Getc(loc)) != EOF) {
-	if ((c == '@') || (c == ','))
-	  break;
-	Putc(c, fn);
+        if ((c == '@') || (c == ','))
+          break;
+        Putc(c, fn);
       }
       cparse_line = atoi(Char(fn));
       Clear(fn);
       
       /* Get the rest of it */
       while ((c = Getc(loc)) != EOF) {
-	if (c == '@')
-	  break;
-	Putc(c, fn);
+        if (c == '@')
+          break;
+        Putc(c, fn);
       }
       /*  Swig_diagnostic(cparse_file, cparse_line, "Scanner_set_location\n"); */
       Scanner_set_location(s, cparse_file, cparse_line);

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -23,23 +23,23 @@ extern int cparse_cplusplus;
 extern int cparse_start_line;
 
 struct Scanner {
-  String *text;                 /* Current token value */
-  List   *scanobjs;             /* Objects being scanned */
-  String *str;                  /* Current object being scanned */
-  char   *idstart;              /* Optional identifier start characters */
-  int     nexttoken;            /* Next token to be returned */
-  int     start_line;           /* Starting line of certain declarations */
-  int     line;
-  int     yylen;                /* Length of text pushed into text */
-  String *error;                /* Last error message (if any) */
-  int     error_line;           /* Error line number */
-  int     freeze_line;          /* Suspend line number updates */
-  List   *brackets;             /* Current level of < > brackets on each level */
+  String *text;   /* Current token value */
+  List *scanobjs; /* Objects being scanned */
+  String *str;    /* Current object being scanned */
+  char *idstart;  /* Optional identifier start characters */
+  int nexttoken;  /* Next token to be returned */
+  int start_line; /* Starting line of certain declarations */
+  int line;
+  int yylen;       /* Length of text pushed into text */
+  String *error;   /* Last error message (if any) */
+  int error_line;  /* Error line number */
+  int freeze_line; /* Suspend line number updates */
+  List *brackets;  /* Current level of < > brackets on each level */
 };
 
 typedef struct Locator {
-  String         *filename;
-  int             line_number;
+  String *filename;
+  int line_number;
   struct Locator *next;
 } Locator;
 static int follow_locators = 0;
@@ -55,7 +55,7 @@ static void brackets_clear(Scanner *);
 
 Scanner *NewScanner(void) {
   Scanner *s;
-  s = (Scanner *) Malloc(sizeof(Scanner));
+  s = (Scanner *)Malloc(sizeof(Scanner));
   s->line = 1;
   s->nexttoken = -1;
   s->start_line = 1;
@@ -126,7 +126,7 @@ void Scanner_push(Scanner *s, String *txt) {
   assert(s && txt);
   Push(s->scanobjs, txt);
   if (s->str) {
-    Setline(s->str,s->line);
+    Setline(s->str, s->line);
     Delete(s->str);
   }
   s->str = txt;
@@ -145,9 +145,9 @@ void Scanner_pushtoken(Scanner *s, int nt, const_String_or_char_ptr val) {
   assert(s);
   assert((nt >= 0) && (nt < SWIG_MAXTOKENS));
   s->nexttoken = nt;
-  if ( Char(val) != Char(s->text) ) {
+  if (Char(val) != Char(s->text)) {
     Clear(s->text);
-    Append(s->text,val);
+    Append(s->text, val);
   }
 }
 
@@ -373,7 +373,8 @@ static void retract(Scanner *s, int n) {
   assert(n <= l);
   for (i = 0; i < n; i++) {
     if (str[l - 1] == '\n') {
-      if (!s->freeze_line) s->line--;
+      if (!s->freeze_line)
+        s->line--;
     }
     (void)Seek(s->str, -1, SEEK_CUR);
     Delitem(s->text, DOH_END);
@@ -399,42 +400,42 @@ static void get_escape(Scanner *s) {
     case 0:
       if (c == 'n') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\n");
+        Append(s->text, "\n");
         return;
       }
       if (c == 'r') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\r");
+        Append(s->text, "\r");
         return;
       }
       if (c == 't') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\t");
+        Append(s->text, "\t");
         return;
       }
       if (c == 'a') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\a");
+        Append(s->text, "\a");
         return;
       }
       if (c == 'b') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\b");
+        Append(s->text, "\b");
         return;
       }
       if (c == 'f') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\f");
+        Append(s->text, "\f");
         return;
       }
       if (c == '\\') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\\");
+        Append(s->text, "\\");
         return;
       }
       if (c == 'v') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\v");
+        Append(s->text, "\v");
         return;
       }
       if (c == 'e') {
@@ -442,17 +443,17 @@ static void get_escape(Scanner *s) {
         // in both C and C++, but is supported by at least GCC and clang.  MSVC
         // issues a warning and treats it as an 'e'.
         Delitem(s->text, DOH_END);
-        Append(s->text,"\033");
+        Append(s->text, "\033");
         return;
       }
       if (c == '\'') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\'");
+        Append(s->text, "\'");
         return;
       }
       if (c == '\"') {
         Delitem(s->text, DOH_END);
-        Append(s->text,"\"");
+        Append(s->text, "\"");
         return;
       }
       if (c == '\n') {
@@ -468,16 +469,16 @@ static void get_escape(Scanner *s) {
         Delitem(s->text, DOH_END);
       } else {
         Delitem(s->text, DOH_END);
-        Putc('\\',s->text);
-        Putc((char)c,s->text);
+        Putc('\\', s->text);
+        Putc((char)c, s->text);
         return;
       }
       break;
-    case 10: // Second digit of octal escape sequence
-    case 11: // Third digit of octal escape sequence
+    case 10:  // Second digit of octal escape sequence
+    case 11:  // Third digit of octal escape sequence
       if (c < '0' || c > '7') {
-        retract(s,1);
-        Putc((char)result,s->text);
+        retract(s, 1);
+        Putc((char)result, s->text);
         return;
       }
       result = (result << 3) + (c - '0');
@@ -485,14 +486,14 @@ static void get_escape(Scanner *s) {
       if (state == 11) {
         if (result > 255)
           Swig_error(Scanner_file(s), Scanner_line(s), "octal escape sequence out of range\n");
-        Putc((char)result,s->text);
+        Putc((char)result, s->text);
         return;
       }
       state = 11;
       break;
     case 20:
       if (!isxdigit(c)) {
-        retract(s,1);
+        retract(s, 1);
         Putc((char)result, s->text);
         return;
       }
@@ -522,7 +523,6 @@ static int look(Scanner *s) {
   s->start_line = s->line;
   Setfile(s->text, Getfile(s->str));
 
-
   while (1) {
     switch (state) {
     case 0:
@@ -546,11 +546,10 @@ static int look(Scanner *s) {
       if ((c = nextchar(s)) == EOF)
         return (0);
       if (c == '%')
-        state = 4;              /* Possibly a SWIG directive */
+        state = 4; /* Possibly a SWIG directive */
 
       /* Look for possible identifiers or unicode/delimiter strings */
-      else if ((isalpha(c)) || (c == '_') ||
-               (s->idstart && strchr(s->idstart, c))) {
+      else if ((isalpha(c)) || (c == '_') || (s->idstart && strchr(s->idstart, c))) {
         state = 7;
       }
 
@@ -559,16 +558,13 @@ static int look(Scanner *s) {
       else if (c == '(') {
         brackets_push(s);
         return SWIG_TOKEN_LPAREN;
-      }
-      else if (c == ')') {
+      } else if (c == ')') {
         brackets_pop(s);
         return SWIG_TOKEN_RPAREN;
-      }
-      else if (c == ';') {
+      } else if (c == ';') {
         brackets_clear(s);
         return SWIG_TOKEN_SEMI;
-      }
-      else if (c == ',')
+      } else if (c == ',')
         return SWIG_TOKEN_COMMA;
       else if (c == '*')
         state = 220;
@@ -577,8 +573,7 @@ static int look(Scanner *s) {
       else if (c == '{') {
         brackets_reset(s);
         return SWIG_TOKEN_LBRACE;
-      }
-      else if (c == '=')
+      } else if (c == '=')
         state = 33;
       else if (c == '+')
         state = 200;
@@ -612,48 +607,47 @@ static int look(Scanner *s) {
       /* Look for multi-character sequences */
 
       else if (c == '/') {
-        state = 1;              /* Comment (maybe)  */
+        state = 1; /* Comment (maybe)  */
         s->start_line = s->line;
       }
 
       else if (c == ':')
-        state = 5;              /* maybe double colon */
+        state = 5; /* maybe double colon */
       else if (c == '0')
-        state = 83;             /* Maybe a hex, octal or binary number */
+        state = 83; /* Maybe a hex, octal or binary number */
       else if (c == '\"') {
-        state = 2;              /* A string constant */
+        state = 2; /* A string constant */
         s->start_line = s->line;
         Clear(s->text);
-      }
-      else if (c == '\'') {
+      } else if (c == '\'') {
         s->start_line = s->line;
         Clear(s->text);
-        state = 9;              /* A character constant */
+        state = 9; /* A character constant */
       }
 
       else if (c == '.')
-        state = 100;            /* Maybe a number, maybe ellipsis, just a period */
+        state = 100; /* Maybe a number, maybe ellipsis, just a period */
       else if (c == '[')
-        state = 102;            /* Maybe a bracket or a double bracket */
+        state = 102; /* Maybe a bracket or a double bracket */
       else if (c == ']')
-        state = 103;            /* Maybe a bracket or a double bracket */
+        state = 103; /* Maybe a bracket or a double bracket */
       else if (isdigit(c))
-        state = 8;              /* A numerical value */
+        state = 8; /* A numerical value */
       else
-        state = 99;             /* An error */
+        state = 99; /* An error */
       break;
 
-    case 1:                     /*  Comment block */
+    case 1: /*  Comment block */
       if ((c = nextchar(s)) == EOF)
         return (0);
       if (c == '/') {
-        state = 10;             /* C++ style comment */
+        state = 10; /* C++ style comment */
         Clear(s->text);
         Setline(s->text, Getline(s->str));
         Setfile(s->text, Getfile(s->str));
         Append(s->text, "//");
       } else if (c == '*') {
-        state = 11;             /* C style comment */
+        state = 11; /* C style comment */
         Clear(s->text);
         Setline(s->text, Getline(s->str));
         Setfile(s->text, Getfile(s->str));
@@ -665,19 +659,19 @@ static int look(Scanner *s) {
         return SWIG_TOKEN_SLASH;
       }
       break;
-    case 10:                    /* C++ style comment */
+    case 10: /* C++ style comment */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
         return SWIG_TOKEN_ERROR;
       }
       if (c == '\n') {
-        retract(s,1);
+        retract(s, 1);
         return SWIG_TOKEN_COMMENT;
       } else {
         state = 10;
       }
       break;
-    case 11:                    /* C style comment block */
+    case 11: /* C style comment block */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
         return SWIG_TOKEN_ERROR;
@@ -688,7 +682,7 @@ static int look(Scanner *s) {
         state = 11;
       }
       break;
-    case 12:                    /* Still in C style comment */
+    case 12: /* Still in C style comment */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
         return SWIG_TOKEN_ERROR;
@@ -702,26 +696,24 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 2:                     /* Processing a string */
+    case 2: /* Processing a string */
       if (!str_delimiter) {
-        state=20;
+        state = 20;
         break;
       }
 
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
         return SWIG_TOKEN_ERROR;
-      }
-      else if (c == '(') {
+      } else if (c == '(') {
         state = 20;
-      }
-      else {
-        Putc( (char)c, str_delimiter );
+      } else {
+        Putc((char)c, str_delimiter);
       }
 
       break;
 
-    case 20:                    /* Inside the string */
+    case 20: /* Inside the string */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
         return SWIG_TOKEN_ERROR;
@@ -735,37 +727,38 @@ static int look(Scanner *s) {
           Delitem(s->text, DOH_END);
           get_escape(s);
         }
-      } else {             /* Custom delimiter string: R"XXXX(value)XXXX" */
-        if (c==')') {
-          int i=0;
+      } else { /* Custom delimiter string: R"XXXX(value)XXXX" */
+        if (c == ')') {
+          int i = 0;
           String *end_delimiter = NewStringEmpty();
           while ((c = nextchar(s)) != EOF && c != '\"') {
-            Putc( (char)c, end_delimiter );
+            Putc((char)c, end_delimiter);
             i++;
           }
 
-          if (Strcmp( str_delimiter, end_delimiter )==0) {
+          if (Strcmp(str_delimiter, end_delimiter) == 0) {
             int len = Len(s->text);
             Delslice(s->text, len - 2 - Len(str_delimiter), len); /* Delete ending )XXXX" */
-            Delslice(s->text, 0, Len(str_delimiter) + 1); /* Delete starting XXXX( */
-            Delete( end_delimiter ); /* Correct end delimiter )XXXX" occurred */
-            Delete( str_delimiter );
+            Delslice(s->text, 0, Len(str_delimiter) + 1);         /* Delete starting XXXX( */
+            Delete(end_delimiter);                                /* Correct end delimiter )XXXX" occurred */
+            Delete(str_delimiter);
             str_delimiter = 0;
             return SWIG_TOKEN_STRING;
-          } else {                   /* Incorrect end delimiter occurred */
+          } else { /* Incorrect end delimiter occurred */
             if (c == EOF) {
-              Swig_error(cparse_file, cparse_start_line, "Unterminated raw string, started with R\"%s( is not terminated by )%s\"\n", str_delimiter, str_delimiter);
+              Swig_error(
+                cparse_file, cparse_start_line, "Unterminated raw string, started with R\"%s( is not terminated by )%s\"\n", str_delimiter, str_delimiter);
               return SWIG_TOKEN_ERROR;
             }
-            retract( s, i );
-            Delete( end_delimiter );
+            retract(s, i);
+            Delete(end_delimiter);
           }
         }
       }
 
       break;
 
-    case 3:                     /* Maybe a not equals */
+    case 3: /* Maybe a not equals */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_LNOT;
       else if (c == '=')
@@ -776,7 +769,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 31:                    /* AND or Logical AND or ANDEQUAL */
+    case 31: /* AND or Logical AND or ANDEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_AND;
       else if (c == '&')
@@ -789,7 +782,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 32:                    /* OR or Logical OR */
+    case 32: /* OR or Logical OR */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_OR;
       else if (c == '|')
@@ -802,7 +795,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 33:                    /* EQUAL or EQUALTO */
+    case 33: /* EQUAL or EQUALTO */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_EQUAL;
       else if (c == '=')
@@ -813,17 +806,16 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 4:                     /* A wrapper generator directive (maybe) */
+    case 4: /* A wrapper generator directive (maybe) */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_PERCENT;
       if (c == '{') {
-        state = 40;             /* Include block */
+        state = 40; /* Include block */
         Clear(s->text);
         Setline(s->text, Getline(s->str));
         Setfile(s->text, Getfile(s->str));
         s->start_line = s->line;
-      } else if (s->idstart && strchr(s->idstart, '%') &&
-                 ((isalpha(c)) || (c == '_'))) {
+      } else if (s->idstart && strchr(s->idstart, '%') && ((isalpha(c)) || (c == '_'))) {
         state = 7;
       } else if (c == '=') {
         return SWIG_TOKEN_MODEQUAL;
@@ -836,7 +828,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 40:                    /* Process an include block */
+    case 40: /* Process an include block */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated block\n");
         return SWIG_TOKEN_ERROR;
@@ -844,22 +836,22 @@ static int look(Scanner *s) {
       if (c == '%')
         state = 41;
       break;
-    case 41:                    /* Still processing include block */
+    case 41: /* Still processing include block */
       if ((c = nextchar(s)) == EOF) {
-        set_error(s,s->start_line,"Unterminated code block");
+        set_error(s, s->start_line, "Unterminated code block");
         return 0;
       }
       if (c == '}') {
         Delitem(s->text, DOH_END);
         Delitem(s->text, DOH_END);
-        Seek(s->text,0,SEEK_SET);
+        Seek(s->text, 0, SEEK_SET);
         return SWIG_TOKEN_CODEBLOCK;
       } else {
         state = 40;
       }
       break;
 
-    case 5:                     /* Maybe a double colon */
+    case 5: /* Maybe a double colon */
 
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_COLON;
@@ -871,7 +863,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 50:                    /* DCOLON, DCOLONSTAR */
+    case 50: /* DCOLON, DCOLONSTAR */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_DCOLON;
       else if (c == '*')
@@ -882,7 +874,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 60:                    /* shift operators */
+    case 60: /* shift operators */
       if ((c = nextchar(s)) == EOF) {
         brackets_increment(s);
         return SWIG_TOKEN_LESSTHAN;
@@ -920,44 +912,37 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 7:                     /* Identifier or true/false or unicode/custom delimiter string */
+    case 7:           /* Identifier or true/false or unicode/custom delimiter string */
       if (c == 'R') { /* Possibly CUSTOM DELIMITER string */
         state = 72;
         break;
-      }
-      else if (c == 'L') { /* Probably identifier but may be a wide string literal */
+      } else if (c == 'L') { /* Probably identifier but may be a wide string literal */
         state = 77;
         break;
-      }
-      else if (c != 'u' && c != 'U') { /* Definitely an identifier */
+      } else if (c != 'u' && c != 'U') { /* Definitely an identifier */
         state = 70;
         break;
       }
 
       if ((c = nextchar(s)) == EOF) {
         state = 76;
-      }
-      else if (c == '\"') { /* Definitely u, U or L string */
+      } else if (c == '\"') { /* Definitely u, U or L string */
         retract(s, 1);
         state = 1000;
-      }
-      else if (c == '\'') { /* Definitely u, U or L char */
+      } else if (c == '\'') { /* Definitely u, U or L char */
         retract(s, 1);
         state = 77;
-      }
-      else if (c == 'R') { /* Possibly CUSTOM DELIMITER u, U, L string */
+      } else if (c == 'R') { /* Possibly CUSTOM DELIMITER u, U, L string */
         state = 73;
-      }
-      else if (c == '8') { /* Possibly u8 string/char */
+      } else if (c == '8') { /* Possibly u8 string/char */
         state = 71;
-      }
-      else {
-        retract(s, 1);   /* Definitely an identifier */
+      } else {
+        retract(s, 1); /* Definitely an identifier */
         state = 70;
       }
       break;
 
-    case 70:                    /* Identifier */
+    case 70: /* Identifier */
       if ((c = nextchar(s)) == EOF)
         state = 76;
       else if (isalnum(c) || (c == '_') || (c == '$')) {
@@ -968,47 +953,39 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 71:                    /* Possibly u8 string/char */
+    case 71: /* Possibly u8 string/char */
       if ((c = nextchar(s)) == EOF) {
         state = 76;
-      }
-      else if (c=='\"') {
+      } else if (c == '\"') {
         retract(s, 1); /* Definitely u8 string */
         state = 1000;
-      }
-      else if (c=='\'') {
+      } else if (c == '\'') {
         retract(s, 1); /* Definitely u8 char */
         state = 77;
-      }
-      else if (c=='R') {
+      } else if (c == 'R') {
         state = 74; /* Possibly CUSTOM DELIMITER u8 string */
-      }
-      else {
+      } else {
         retract(s, 2); /* Definitely an identifier. Retract 8" */
         state = 70;
       }
 
       break;
 
-    case 72:                    /* Possibly CUSTOM DELIMITER string */
+    case 72: /* Possibly CUSTOM DELIMITER string */
     case 73:
     case 74:
       if ((c = nextchar(s)) == EOF) {
         state = 76;
-      }
-      else if (c=='\"') {
+      } else if (c == '\"') {
         retract(s, 1); /* Definitely custom delimiter u, U or L string */
         str_delimiter = NewStringEmpty();
         state = 1000;
-      }
-      else {
-        if (state==72) {
+      } else {
+        if (state == 72) {
           retract(s, 1); /* Definitely an identifier. Retract ? */
-        }
-        else if (state==73) {
+        } else if (state == 73) {
           retract(s, 2); /* Definitely an identifier. Retract R? */
-        }
-        else if (state==74) {
+        } else if (state == 74) {
           retract(s, 3); /* Definitely an identifier. Retract 8R? */
         }
         state = 70;
@@ -1016,19 +993,20 @@ static int look(Scanner *s) {
 
       break;
 
-    case 75:                    /* Special identifier $ */
+    case 75: /* Special identifier $ */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_DOLLAR;
       if (isalnum(c) || (c == '_') || (c == '*') || (c == '&')) {
         state = 70;
       } else {
-        retract(s,1);
-        if (Len(s->text) == 1) return SWIG_TOKEN_DOLLAR;
+        retract(s, 1);
+        if (Len(s->text) == 1)
+          return SWIG_TOKEN_DOLLAR;
         state = 76;
       }
       break;
 
-    case 76:                    /* Identifier, true/false or alternative token */
+    case 76: /* Identifier, true/false or alternative token */
       if (cparse_cplusplus) {
         if (Strcmp(s->text, "true") == 0)
           return SWIG_TOKEN_BOOL;
@@ -1067,21 +1045,19 @@ static int look(Scanner *s) {
         s->start_line = s->line;
         Clear(s->text);
         state = 78;
-      }
-      else if (c == '\'') {
+      } else if (c == '\'') {
         s->start_line = s->line;
         Clear(s->text);
         state = 79;
-      }
-      else if (isalnum(c) || (c == '_') || (c == '$'))
+      } else if (isalnum(c) || (c == '_') || (c == '$'))
         state = 7;
       else {
         retract(s, 1);
         return SWIG_TOKEN_ID;
       }
-    break;
+      break;
 
-    case 78:                    /* Processing a wide string literal*/
+    case 78: /* Processing a wide string literal*/
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
         return SWIG_TOKEN_ERROR;
@@ -1095,7 +1071,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 79:                    /* Processing a wide char literal */
+    case 79: /* Processing a wide char literal */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated wide character constant\n");
         return SWIG_TOKEN_ERROR;
@@ -1109,7 +1085,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 8:                     /* A numerical digit */
+    case 8: /* A numerical digit */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_INT;
       if (c == '.') {
@@ -1129,7 +1105,7 @@ static int look(Scanner *s) {
         return SWIG_TOKEN_INT;
       }
       break;
-    case 81:                    /* A floating pointer number of some sort */
+    case 81: /* A floating pointer number of some sort */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
@@ -1406,7 +1382,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 200:                   /* PLUS, PLUSPLUS, PLUSEQUAL */
+    case 200: /* PLUS, PLUSPLUS, PLUSEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_PLUS;
       else if (c == '+')
@@ -1419,7 +1395,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 210:                   /* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
+    case 210: /* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_MINUS;
       else if (c == '-')
@@ -1434,7 +1410,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 211:                   /* ARROW, ARROWSTAR */
+    case 211: /* ARROW, ARROWSTAR */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_ARROW;
       else if (c == '*')
@@ -1445,8 +1421,7 @@ static int look(Scanner *s) {
       }
       break;
 
-
-    case 220:                   /* STAR, TIMESEQUAL */
+    case 220: /* STAR, TIMESEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_STAR;
       else if (c == '=')
@@ -1457,7 +1432,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 230:                   /* XOR, XOREQUAL */
+    case 230: /* XOR, XOREQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_XOR;
       else if (c == '=')
@@ -1468,7 +1443,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 240:                   /* LSHIFT, LSEQUAL */
+    case 240: /* LSHIFT, LSEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_LSHIFT;
       else if (c == '=')
@@ -1479,7 +1454,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 250:                   /* RSHIFT, RSEQUAL */
+    case 250: /* RSHIFT, RSEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_RSHIFT;
       else if (c == '=')
@@ -1514,9 +1489,9 @@ int Scanner_token(Scanner *s) {
   s->start_line = 0;
   t = look(s);
   if (!s->start_line) {
-    Setline(s->text,s->line);
+    Setline(s->text, s->line);
   } else {
-    Setline(s->text,s->start_line);
+    Setline(s->text, s->start_line);
   }
   return t;
 }
@@ -1570,24 +1545,24 @@ int Scanner_skip_balanced(Scanner *s, int startchar, int endchar) {
   int starttok = 0;
   int endtok = 0;
   switch (endchar) {
-    case '}':
-      starttok = SWIG_TOKEN_LBRACE;
-      endtok = SWIG_TOKEN_RBRACE;
-      break;
-    case ')':
-      starttok = SWIG_TOKEN_LPAREN;
-      endtok = SWIG_TOKEN_RPAREN;
-      break;
-    case ']':
-      starttok = SWIG_TOKEN_LBRACKET;
-      endtok = SWIG_TOKEN_RBRACKET;
-      break;
-    case '>':
-      starttok = SWIG_TOKEN_LESSTHAN;
-      endtok = SWIG_TOKEN_GREATERTHAN;
-      break;
-    default:
-      assert(0);
+  case '}':
+    starttok = SWIG_TOKEN_LBRACE;
+    endtok = SWIG_TOKEN_RBRACE;
+    break;
+  case ')':
+    starttok = SWIG_TOKEN_LPAREN;
+    endtok = SWIG_TOKEN_RPAREN;
+    break;
+  case ']':
+    starttok = SWIG_TOKEN_LBRACKET;
+    endtok = SWIG_TOKEN_RBRACKET;
+    break;
+  case '>':
+    starttok = SWIG_TOKEN_LESSTHAN;
+    endtok = SWIG_TOKEN_GREATERTHAN;
+    break;
+  default:
+    assert(0);
   }
 
   while (1) {
@@ -1595,16 +1570,18 @@ int Scanner_skip_balanced(Scanner *s, int startchar, int endchar) {
     if (tok == starttok) {
       num_levels++;
     } else if (tok == endtok) {
-      if (--num_levels == 0) break;
+      if (--num_levels == 0)
+        break;
     } else if (tok == SWIG_TOKEN_RRBRACKET && endtok == SWIG_TOKEN_RBRACKET) {
       num_levels -= 2;
       if (num_levels <= 0) {
-        if (num_levels < 0) Scanner_pushtoken(s, SWIG_TOKEN_RBRACKET, "]");
+        if (num_levels < 0)
+          Scanner_pushtoken(s, SWIG_TOKEN_RBRACKET, "]");
         break;
       }
     } else if (tok == SWIG_TOKEN_COMMENT) {
       char *loc = Char(s->text);
-      if (strncmp(loc, "/*@SWIG", 7) == 0 && loc[Len(s->text)-3] == '@') {
+      if (strncmp(loc, "/*@SWIG", 7) == 0 && loc[Len(s->text) - 3] == '@') {
         Scanner_locator(s, s->text);
       }
     } else if (tok == 0) {
@@ -1613,8 +1590,7 @@ int Scanner_skip_balanced(Scanner *s, int startchar, int endchar) {
   }
 
   Delete(s->text);
-  s->text = NewStringWithSize(Char(s->str) + position - 1,
-                              Tell(s->str) - position + 1);
+  s->text = NewStringWithSize(Char(s->str) + position - 1, Tell(s->str) - position + 1);
   Char(s->text)[0] = startchar;
   Setfile(s->text, Getfile(s->str));
   Setline(s->text, old_line);
@@ -1638,24 +1614,24 @@ String *Scanner_get_raw_text_balanced(Scanner *s, int startchar, int endchar) {
   int starttok = 0;
   int endtok = 0;
   switch (endchar) {
-    case '}':
-      starttok = SWIG_TOKEN_LBRACE;
-      endtok = SWIG_TOKEN_RBRACE;
-      break;
-    case ')':
-      starttok = SWIG_TOKEN_LPAREN;
-      endtok = SWIG_TOKEN_RPAREN;
-      break;
-    case ']':
-      starttok = SWIG_TOKEN_LBRACKET;
-      endtok = SWIG_TOKEN_RBRACKET;
-      break;
-    case '>':
-      starttok = SWIG_TOKEN_LESSTHAN;
-      endtok = SWIG_TOKEN_GREATERTHAN;
-      break;
-    default:
-      assert(0);
+  case '}':
+    starttok = SWIG_TOKEN_LBRACE;
+    endtok = SWIG_TOKEN_RBRACE;
+    break;
+  case ')':
+    starttok = SWIG_TOKEN_LPAREN;
+    endtok = SWIG_TOKEN_RPAREN;
+    break;
+  case ']':
+    starttok = SWIG_TOKEN_LBRACKET;
+    endtok = SWIG_TOKEN_RBRACKET;
+    break;
+  case '>':
+    starttok = SWIG_TOKEN_LESSTHAN;
+    endtok = SWIG_TOKEN_GREATERTHAN;
+    break;
+  default:
+    assert(0);
   }
 
   while (1) {
@@ -1664,8 +1640,7 @@ String *Scanner_get_raw_text_balanced(Scanner *s, int startchar, int endchar) {
       num_levels++;
     } else if (tok == endtok) {
       if (--num_levels == 0) {
-        result = NewStringWithSize(Char(s->str) + position - 1,
-                                   Tell(s->str) - position + 1);
+        result = NewStringWithSize(Char(s->str) + position - 1, Tell(s->str) - position + 1);
         Char(result)[0] = startchar;
         Setfile(result, Getfile(s->str));
         Setline(result, old_line);
@@ -1673,7 +1648,7 @@ String *Scanner_get_raw_text_balanced(Scanner *s, int startchar, int endchar) {
       }
     } else if (tok == SWIG_TOKEN_COMMENT) {
       char *loc = Char(s->text);
-      if (strncmp(loc, "/*@SWIG", 7) == 0 && loc[Len(s->text)-3] == '@') {
+      if (strncmp(loc, "/*@SWIG", 7) == 0 && loc[Len(s->text) - 3] == '@') {
         Scanner_locator(s, s->text);
       }
     } else if (tok == 0) {
@@ -1698,7 +1673,8 @@ String *Scanner_get_raw_text_balanced(Scanner *s, int startchar, int endchar) {
  * ----------------------------------------------------------------------------- */
 
 int Scanner_isoperator(int tokval) {
-  if (tokval >= 100) return 1;
+  if (tokval >= 100)
+    return 1;
   return 0;
 }
 
@@ -1710,7 +1686,6 @@ int Scanner_isoperator(int tokval) {
  * are primarily used for macro line number reporting.
  * We just use the locator to mark when to activate/deactivate linecounting.
  * ---------------------------------------------------------------------- */
-
 
 void Scanner_locator(Scanner *s, String *loc) {
   static Locator *locs = 0;
@@ -1726,7 +1701,7 @@ void Scanner_locator(Scanner *s, String *loc) {
       ++expanding_macro;
     }
     /* Freeze line number processing in Scanner */
-    freeze_line(s,expanding_macro);
+    freeze_line(s, expanding_macro);
   } else {
     int c;
     Locator *l;
@@ -1746,7 +1721,7 @@ void Scanner_locator(Scanner *s, String *loc) {
     }
 
     /* We're going to push a new location */
-    l = (Locator *) Malloc(sizeof(Locator));
+    l = (Locator *)Malloc(sizeof(Locator));
     l->filename = cparse_file;
     l->line_number = cparse_line;
     l->next = locs;
@@ -1788,7 +1763,5 @@ void Scanner_locator(Scanner *s, String *loc) {
 }
 
 void Swig_cparse_follow_locators(int v) {
-   follow_locators = v;
+  follow_locators = v;
 }
-
-

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -23,14 +23,14 @@ extern int cparse_cplusplus;
 extern int cparse_start_line;
 
 struct Scanner {
-  String *text;			/* Current token value */
-  List   *scanobjs;		/* Objects being scanned */
-  String *str;			/* Current object being scanned */
-  char   *idstart;		/* Optional identifier start characters */
-  int     nexttoken;		/* Next token to be returned */
-  int     start_line;		/* Starting line of certain declarations */
+  String *text;                 /* Current token value */
+  List   *scanobjs;             /* Objects being scanned */
+  String *str;                  /* Current object being scanned */
+  char   *idstart;              /* Optional identifier start characters */
+  int     nexttoken;            /* Next token to be returned */
+  int     start_line;           /* Starting line of certain declarations */
   int     line;
-  int     yylen;	        /* Length of text pushed into text */
+  int     yylen;                /* Length of text pushed into text */
   String *error;                /* Last error message (if any) */
   int     error_line;           /* Error line number */
   int     freeze_line;          /* Suspend line number updates */
@@ -546,7 +546,7 @@ static int look(Scanner *s) {
       if ((c = nextchar(s)) == EOF)
         return (0);
       if (c == '%')
-        state = 4;		/* Possibly a SWIG directive */
+        state = 4;              /* Possibly a SWIG directive */
 
       /* Look for possible identifiers or unicode/delimiter strings */
       else if ((isalpha(c)) || (c == '_') ||
@@ -612,14 +612,14 @@ static int look(Scanner *s) {
       /* Look for multi-character sequences */
 
       else if (c == '/') {
-        state = 1;		/* Comment (maybe)  */
+        state = 1;              /* Comment (maybe)  */
         s->start_line = s->line;
       }
 
       else if (c == ':')
-        state = 5;		/* maybe double colon */
+        state = 5;              /* maybe double colon */
       else if (c == '0')
-        state = 83;		/* Maybe a hex, octal or binary number */
+        state = 83;             /* Maybe a hex, octal or binary number */
       else if (c == '\"') {
         state = 2;              /* A string constant */
         s->start_line = s->line;
@@ -628,32 +628,32 @@ static int look(Scanner *s) {
       else if (c == '\'') {
         s->start_line = s->line;
         Clear(s->text);
-        state = 9;		/* A character constant */
+        state = 9;              /* A character constant */
       }
 
       else if (c == '.')
-        state = 100;		/* Maybe a number, maybe ellipsis, just a period */
+        state = 100;            /* Maybe a number, maybe ellipsis, just a period */
       else if (c == '[')
         state = 102;            /* Maybe a bracket or a double bracket */
       else if (c == ']')
         state = 103;            /* Maybe a bracket or a double bracket */
       else if (isdigit(c))
-        state = 8;		/* A numerical value */
+        state = 8;              /* A numerical value */
       else
-        state = 99;		/* An error */
+        state = 99;             /* An error */
       break;
 
-    case 1:			/*  Comment block */
+    case 1:                     /*  Comment block */
       if ((c = nextchar(s)) == EOF)
         return (0);
       if (c == '/') {
-        state = 10;		/* C++ style comment */
+        state = 10;             /* C++ style comment */
         Clear(s->text);
         Setline(s->text, Getline(s->str));
         Setfile(s->text, Getfile(s->str));
         Append(s->text, "//");
       } else if (c == '*') {
-        state = 11;		/* C style comment */
+        state = 11;             /* C style comment */
         Clear(s->text);
         Setline(s->text, Getline(s->str));
         Setfile(s->text, Getfile(s->str));
@@ -665,7 +665,7 @@ static int look(Scanner *s) {
         return SWIG_TOKEN_SLASH;
       }
       break;
-    case 10:			/* C++ style comment */
+    case 10:                    /* C++ style comment */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
         return SWIG_TOKEN_ERROR;
@@ -677,7 +677,7 @@ static int look(Scanner *s) {
         state = 10;
       }
       break;
-    case 11:			/* C style comment block */
+    case 11:                    /* C style comment block */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
         return SWIG_TOKEN_ERROR;
@@ -688,7 +688,7 @@ static int look(Scanner *s) {
         state = 11;
       }
       break;
-    case 12:			/* Still in C style comment */
+    case 12:                    /* Still in C style comment */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated comment\n");
         return SWIG_TOKEN_ERROR;
@@ -702,7 +702,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 2:			/* Processing a string */
+    case 2:                     /* Processing a string */
       if (!str_delimiter) {
         state=20;
         break;
@@ -721,7 +721,7 @@ static int look(Scanner *s) {
 
       break;
 
-    case 20:			/* Inside the string */
+    case 20:                    /* Inside the string */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
         return SWIG_TOKEN_ERROR;
@@ -765,7 +765,7 @@ static int look(Scanner *s) {
 
       break;
 
-    case 3:			/* Maybe a not equals */
+    case 3:                     /* Maybe a not equals */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_LNOT;
       else if (c == '=')
@@ -776,7 +776,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 31:			/* AND or Logical AND or ANDEQUAL */
+    case 31:                    /* AND or Logical AND or ANDEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_AND;
       else if (c == '&')
@@ -789,7 +789,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 32:			/* OR or Logical OR */
+    case 32:                    /* OR or Logical OR */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_OR;
       else if (c == '|')
@@ -802,7 +802,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 33:			/* EQUAL or EQUALTO */
+    case 33:                    /* EQUAL or EQUALTO */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_EQUAL;
       else if (c == '=')
@@ -813,11 +813,11 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 4:			/* A wrapper generator directive (maybe) */
+    case 4:                     /* A wrapper generator directive (maybe) */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_PERCENT;
       if (c == '{') {
-        state = 40;		/* Include block */
+        state = 40;             /* Include block */
         Clear(s->text);
         Setline(s->text, Getline(s->str));
         Setfile(s->text, Getfile(s->str));
@@ -836,7 +836,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 40:			/* Process an include block */
+    case 40:                    /* Process an include block */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated block\n");
         return SWIG_TOKEN_ERROR;
@@ -844,7 +844,7 @@ static int look(Scanner *s) {
       if (c == '%')
         state = 41;
       break;
-    case 41:			/* Still processing include block */
+    case 41:                    /* Still processing include block */
       if ((c = nextchar(s)) == EOF) {
         set_error(s,s->start_line,"Unterminated code block");
         return 0;
@@ -859,7 +859,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 5:			/* Maybe a double colon */
+    case 5:                     /* Maybe a double colon */
 
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_COLON;
@@ -871,7 +871,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 50:			/* DCOLON, DCOLONSTAR */
+    case 50:                    /* DCOLON, DCOLONSTAR */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_DCOLON;
       else if (c == '*')
@@ -882,7 +882,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 60:			/* shift operators */
+    case 60:                    /* shift operators */
       if ((c = nextchar(s)) == EOF) {
         brackets_increment(s);
         return SWIG_TOKEN_LESSTHAN;
@@ -920,7 +920,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 7:			/* Identifier or true/false or unicode/custom delimiter string */
+    case 7:                     /* Identifier or true/false or unicode/custom delimiter string */
       if (c == 'R') { /* Possibly CUSTOM DELIMITER string */
         state = 72;
         break;
@@ -957,7 +957,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 70:			/* Identifier */
+    case 70:                    /* Identifier */
       if ((c = nextchar(s)) == EOF)
         state = 76;
       else if (isalnum(c) || (c == '_') || (c == '$')) {
@@ -968,7 +968,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 71:			/* Possibly u8 string/char */
+    case 71:                    /* Possibly u8 string/char */
       if ((c = nextchar(s)) == EOF) {
         state = 76;
       }
@@ -990,7 +990,7 @@ static int look(Scanner *s) {
 
       break;
 
-    case 72:			/* Possibly CUSTOM DELIMITER string */
+    case 72:                    /* Possibly CUSTOM DELIMITER string */
     case 73:
     case 74:
       if ((c = nextchar(s)) == EOF) {
@@ -1016,7 +1016,7 @@ static int look(Scanner *s) {
 
       break;
 
-    case 75:			/* Special identifier $ */
+    case 75:                    /* Special identifier $ */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_DOLLAR;
       if (isalnum(c) || (c == '_') || (c == '*') || (c == '&')) {
@@ -1028,7 +1028,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 76:			/* Identifier, true/false or alternative token */
+    case 76:                    /* Identifier, true/false or alternative token */
       if (cparse_cplusplus) {
         if (Strcmp(s->text, "true") == 0)
           return SWIG_TOKEN_BOOL;
@@ -1081,7 +1081,7 @@ static int look(Scanner *s) {
       }
     break;
 
-    case 78:			/* Processing a wide string literal*/
+    case 78:                    /* Processing a wide string literal*/
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated wide string\n");
         return SWIG_TOKEN_ERROR;
@@ -1095,7 +1095,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 79:			/* Processing a wide char literal */
+    case 79:                    /* Processing a wide char literal */
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated wide character constant\n");
         return SWIG_TOKEN_ERROR;
@@ -1109,7 +1109,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 8:			/* A numerical digit */
+    case 8:                     /* A numerical digit */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_INT;
       if (c == '.') {
@@ -1129,7 +1129,7 @@ static int look(Scanner *s) {
         return SWIG_TOKEN_INT;
       }
       break;
-    case 81:			/* A floating pointer number of some sort */
+    case 81:                    /* A floating pointer number of some sort */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_DOUBLE;
       if (isdigit(c))
@@ -1406,7 +1406,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 200:			/* PLUS, PLUSPLUS, PLUSEQUAL */
+    case 200:                   /* PLUS, PLUSPLUS, PLUSEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_PLUS;
       else if (c == '+')
@@ -1419,7 +1419,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 210:			/* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
+    case 210:                   /* MINUS, MINUSMINUS, MINUSEQUAL, ARROW */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_MINUS;
       else if (c == '-')
@@ -1434,7 +1434,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 211:			/* ARROW, ARROWSTAR */
+    case 211:                   /* ARROW, ARROWSTAR */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_ARROW;
       else if (c == '*')
@@ -1446,7 +1446,7 @@ static int look(Scanner *s) {
       break;
 
 
-    case 220:			/* STAR, TIMESEQUAL */
+    case 220:                   /* STAR, TIMESEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_STAR;
       else if (c == '=')
@@ -1457,7 +1457,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 230:			/* XOR, XOREQUAL */
+    case 230:                   /* XOR, XOREQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_XOR;
       else if (c == '=')
@@ -1468,7 +1468,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 240:			/* LSHIFT, LSEQUAL */
+    case 240:                   /* LSHIFT, LSEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_LSHIFT;
       else if (c == '=')
@@ -1479,7 +1479,7 @@ static int look(Scanner *s) {
       }
       break;
 
-    case 250:			/* RSHIFT, RSEQUAL */
+    case 250:                   /* RSHIFT, RSEQUAL */
       if ((c = nextchar(s)) == EOF)
         return SWIG_TOKEN_RSHIFT;
       else if (c == '=')

--- a/Source/Swig/scanner.c
+++ b/Source/Swig/scanner.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -204,7 +204,7 @@ void Scanner_idstart(Scanner *s, const char *id) {
 
 /* -----------------------------------------------------------------------------
  * nextchar()
- * 
+ *
  * Returns the next character from the scanner or EOF if end of the string.
  * ----------------------------------------------------------------------------- */
 static int nextchar(Scanner *s) {
@@ -221,14 +221,14 @@ static int nextchar(Scanner *s) {
     s->line = Getline(s->str);
     DohIncref(s->str);
   }
-  if ((nc == '\n') && (!s->freeze_line)) 
+  if ((nc == '\n') && (!s->freeze_line))
     s->line++;
   Putc(nc, s->text);
   return nc;
 }
 
 /* -----------------------------------------------------------------------------
- * set_error() 
+ * set_error()
  *
  * Sets error information on the scanner.
  * ----------------------------------------------------------------------------- */
@@ -382,7 +382,7 @@ static void retract(Scanner *s, int n) {
 
 /* -----------------------------------------------------------------------------
  * get_escape()
- * 
+ *
  * Get escape sequence.  Called when a backslash is found in a string
  * ----------------------------------------------------------------------------- */
 
@@ -451,7 +451,7 @@ static void get_escape(Scanner *s) {
         return;
       }
       if (c == '\"') {
-        Delitem(s->text, DOH_END);	
+        Delitem(s->text, DOH_END);
         Append(s->text,"\"");
         return;
       }
@@ -547,7 +547,7 @@ static int look(Scanner *s) {
         return (0);
       if (c == '%')
         state = 4;		/* Possibly a SWIG directive */
-      
+
       /* Look for possible identifiers or unicode/delimiter strings */
       else if ((isalpha(c)) || (c == '_') ||
                (s->idstart && strchr(s->idstart, c))) {
@@ -707,7 +707,7 @@ static int look(Scanner *s) {
         state=20;
         break;
       }
-      
+
       if ((c = nextchar(s)) == EOF) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
         return SWIG_TOKEN_ERROR;
@@ -718,7 +718,7 @@ static int look(Scanner *s) {
       else {
         Putc( (char)c, str_delimiter );
       }
-    
+
       break;
 
     case 20:			/* Inside the string */
@@ -726,7 +726,7 @@ static int look(Scanner *s) {
         Swig_error(cparse_file, cparse_start_line, "Unterminated string\n");
         return SWIG_TOKEN_ERROR;
       }
-      
+
       if (!str_delimiter) { /* Ordinary string: "value" */
         if (c == '\"') {
           Delitem(s->text, DOH_END);
@@ -743,7 +743,7 @@ static int look(Scanner *s) {
             Putc( (char)c, end_delimiter );
             i++;
           }
-          
+
           if (Strcmp( str_delimiter, end_delimiter )==0) {
             int len = Len(s->text);
             Delslice(s->text, len - 2 - Len(str_delimiter), len); /* Delete ending )XXXX" */
@@ -762,7 +762,7 @@ static int look(Scanner *s) {
           }
         }
       }
-      
+
       break;
 
     case 3:			/* Maybe a not equals */
@@ -919,7 +919,7 @@ static int look(Scanner *s) {
         return SWIG_TOKEN_GREATERTHAN;
       }
       break;
-    
+
     case 7:			/* Identifier or true/false or unicode/custom delimiter string */
       if (c == 'R') { /* Possibly CUSTOM DELIMITER string */
         state = 72;
@@ -933,7 +933,7 @@ static int look(Scanner *s) {
         state = 70;
         break;
       }
-      
+
       if ((c = nextchar(s)) == EOF) {
         state = 76;
       }
@@ -967,7 +967,7 @@ static int look(Scanner *s) {
         state = 76;
       }
       break;
-    
+
     case 71:			/* Possibly u8 string/char */
       if ((c = nextchar(s)) == EOF) {
         state = 76;
@@ -987,7 +987,7 @@ static int look(Scanner *s) {
         retract(s, 2); /* Definitely an identifier. Retract 8" */
         state = 70;
       }
-      
+
       break;
 
     case 72:			/* Possibly CUSTOM DELIMITER string */
@@ -1013,7 +1013,7 @@ static int look(Scanner *s) {
         }
         state = 70;
       }
-      
+
       break;
 
     case 75:			/* Special identifier $ */
@@ -1756,7 +1756,7 @@ void Scanner_locator(Scanner *s, String *loc) {
     {
       String *fn = NewStringEmpty();
       /*      Putc(c, fn); */
-      
+
       while ((c = Getc(loc)) != EOF) {
         if ((c == '@') || (c == ','))
           break;
@@ -1773,7 +1773,7 @@ void Scanner_locator(Scanner *s, String *loc) {
       }
       cparse_line = atoi(Char(fn));
       Clear(fn);
-      
+
       /* Get the rest of it */
       while ((c = Getc(loc)) != EOF) {
         if (c == '@')

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -1231,7 +1231,7 @@ static String *manglestr_default(const SwigType *s) {
     base = b;
   }
 
-  Replace(base, "struct ", "", DOH_REPLACE_ANY);	/* This might be problematic */
+  Replace(base, "struct ", "", DOH_REPLACE_ANY);        /* This might be problematic */
   Replace(base, "class ", "", DOH_REPLACE_ANY);
   Replace(base, "union ", "", DOH_REPLACE_ANY);
   Replace(base, "enum ", "", DOH_REPLACE_ANY);

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -104,7 +104,6 @@
  * would that be easier to use than a few simple string operations?
  * ----------------------------------------------------------------------------- */
 
-
 SwigType *NewSwigType(int t) {
   switch (t) {
   case T_BOOL:
@@ -141,7 +140,8 @@ SwigType *NewSwigType(int t) {
     return NewString("signed char");
   case T_UCHAR:
     return NewString("unsigned char");
-  case T_STRING: {
+  case T_STRING:
+    {
       SwigType *t = NewString("char");
       SwigType_add_qualifier(t, "const");
       SwigType_add_pointer(t);
@@ -149,11 +149,12 @@ SwigType *NewSwigType(int t) {
     }
   case T_WCHAR:
     return NewString("wchar_t");
-  case T_WSTRING: {
-    SwigType *t = NewString("wchar_t");
-    SwigType_add_pointer(t);
-    return t;
-  }
+  case T_WSTRING:
+    {
+      SwigType *t = NewString("wchar_t");
+      SwigType_add_pointer(t);
+      return t;
+    }
   case T_LONGLONG:
     return NewString("long long");
   case T_ULONGLONG:
@@ -342,11 +343,11 @@ SwigType *SwigType_default_create(const SwigType *ty) {
     numitems = Len(l);
 
     if (numitems >= 1) {
-      String *last_subtype = Getitem(l, numitems-1);
+      String *last_subtype = Getitem(l, numitems - 1);
       if (SwigType_isenum(last_subtype))
-        Setitem(l, numitems-1, NewString("enum SWIGTYPE"));
+        Setitem(l, numitems - 1, NewString("enum SWIGTYPE"));
       else
-        Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        Setitem(l, numitems - 1, NewString("SWIGTYPE"));
     }
 
     for (it = First(l); it.item; it = Next(it)) {
@@ -418,15 +419,15 @@ SwigType *SwigType_default_deduce(const SwigType *t) {
 
   numitems = Len(l);
   if (numitems >= 1) {
-    String *last_subtype = Getitem(l, numitems-1);
+    String *last_subtype = Getitem(l, numitems - 1);
     int is_enum = SwigType_isenum(last_subtype);
 
-    if (numitems >=2 ) {
-      String *subtype = Getitem(l, numitems-2); /* last but one */
+    if (numitems >= 2) {
+      String *subtype = Getitem(l, numitems - 2); /* last but one */
       if (SwigType_isarray(subtype)) {
         if (is_enum) {
           /* enum deduction, enum SWIGTYPE => SWIGTYPE */
-          Setitem(l, numitems-1, NewString("SWIGTYPE"));
+          Setitem(l, numitems - 1, NewString("SWIGTYPE"));
         } else {
           /* array deduction, a(ANY). => a(). => p. */
           String *deduced_subtype = 0;
@@ -437,23 +438,23 @@ SwigType *SwigType_default_deduce(const SwigType *t) {
           } else {
             assert(0);
           }
-          Setitem(l, numitems-2, deduced_subtype);
+          Setitem(l, numitems - 2, deduced_subtype);
         }
       } else if (SwigType_ismemberpointer(subtype)) {
         /* member pointer deduction, m(CLASS). => p. */
-        Setitem(l, numitems-2, NewString("p."));
+        Setitem(l, numitems - 2, NewString("p."));
       } else if (is_enum && !SwigType_isqualifier(subtype)) {
         /* enum deduction, enum SWIGTYPE => SWIGTYPE */
-        Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        Setitem(l, numitems - 1, NewString("SWIGTYPE"));
       } else {
         /* simple type deduction, eg, r.p.p. => r.p. */
         /* also function pointers eg, p.f(ANY). => p. */
-        Delitem(l, numitems-2);
+        Delitem(l, numitems - 2);
       }
     } else {
       if (is_enum) {
         /* enum deduction, enum SWIGTYPE => SWIGTYPE */
-        Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        Setitem(l, numitems - 1, NewString("SWIGTYPE"));
       } else {
         /* delete the only item, we are done with deduction */
         Delitem(l, 0);
@@ -475,7 +476,6 @@ SwigType *SwigType_default_deduce(const SwigType *t) {
   Delete(l);
   return r;
 }
-
 
 /* -----------------------------------------------------------------------------
  * SwigType_namestr()
@@ -1002,7 +1002,6 @@ String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr name) {
   return cast;
 }
 
-
 /* -----------------------------------------------------------------------------
  * SwigType_lcaststr()
  *
@@ -1221,7 +1220,7 @@ static String *manglestr_default(const SwigType *s) {
 
   c = Char(result);
   while (*c) {
-    if (!isalnum((int) *c))
+    if (!isalnum((int)*c))
       *c = '_';
     c++;
   }
@@ -1231,7 +1230,7 @@ static String *manglestr_default(const SwigType *s) {
     base = b;
   }
 
-  Replace(base, "struct ", "", DOH_REPLACE_ANY);        /* This might be problematic */
+  Replace(base, "struct ", "", DOH_REPLACE_ANY); /* This might be problematic */
   Replace(base, "class ", "", DOH_REPLACE_ANY);
   Replace(base, "union ", "", DOH_REPLACE_ANY);
   Replace(base, "enum ", "", DOH_REPLACE_ANY);
@@ -1254,7 +1253,7 @@ static String *manglestr_default(const SwigType *s) {
       *c = 'f';
     else if (*c == ')')
       *c = 'F';
-    else if (!isalnum((int) *c))
+    else if (!isalnum((int)*c))
       *c = '_';
     c++;
   }
@@ -1335,7 +1334,7 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
            */
           if (Len(e) > len) {
             String *firstPartOfType = NewStringWithSize(e, len);
-            const char* e_as_char = Char(e);
+            const char *e_as_char = Char(e);
 
             if (Equal(firstPartOfType, pat) && e_as_char[len] == '<') {
               String *repbase = SwigType_templateprefix(rep);

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -20,7 +20,7 @@
  * Synopsis
  *
  * The purpose of this module is to provide a general purpose type representation
- * based on simple text strings. 
+ * based on simple text strings.
  *
  * General idea:
  *
@@ -38,7 +38,7 @@
  *        p.q(const).char                 char const *
  *
  * All type constructors are denoted by a trailing '.':
- * 
+ *
  *  'p.'                = Pointer (*)
  *  'r.'                = Reference (&)
  *  'z.'                = Rvalue reference (&&)
@@ -83,7 +83,7 @@
  * characters (*, [, <, etc...) in its type encoding.  One reason for this
  * is that SWIG might be extended to encode data in formats such as XML
  * where you might want to do this:
- * 
+ *
  *      <function>
  *         <type>p.p.int</type>
  *         ...
@@ -101,7 +101,7 @@
  * this pretty easy.
  *
  * Why not use a bunch of nested data structures?  Are you kidding? How
- * would that be easier to use than a few simple string operations? 
+ * would that be easier to use than a few simple string operations?
  * ----------------------------------------------------------------------------- */
 
 
@@ -814,7 +814,7 @@ String *SwigType_lstr(const SwigType *s, const_String_or_char_ptr id) {
 /* -----------------------------------------------------------------------------
  * SwigType_rcaststr()
  *
- * Produces a casting string that maps the type returned by lstr() to the real 
+ * Produces a casting string that maps the type returned by lstr() to the real
  * datatype printed by str().
  * ----------------------------------------------------------------------------- */
 
@@ -1065,8 +1065,8 @@ String *SwigType_lcaststr(const SwigType *s, const_String_or_char_ptr name) {
       typedef int Integer;
       void test2(bar<Integer *> *x);
     }
-    Mangling is more consistent and changes from 
-    _p_foo__barT_int_p_t to 
+    Mangling is more consistent and changes from
+    _p_foo__barT_int_p_t to
     _p_foo__barT_p_int_t.
 */
 static void mangle_stringcopy(String *destination, const char *source, int count) {
@@ -1485,7 +1485,7 @@ void SwigType_variadic_replace(SwigType *t, Parm *unexpanded_variadic_parm, Parm
 /* -----------------------------------------------------------------------------
  * SwigType_remove_global_scope_prefix()
  *
- * Removes the unary scope operator (::) prefix indicating global scope in all 
+ * Removes the unary scope operator (::) prefix indicating global scope in all
  * components of the type
  * ----------------------------------------------------------------------------- */
 

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -280,11 +280,11 @@ int SwigType_issimple(const SwigType *t) {
       int nest = 1;
       c++;
       while (*c && nest) {
-	if (*c == '<')
-	  nest++;
-	if (*c == '>')
-	  nest--;
-	c++;
+        if (*c == '<')
+          nest++;
+        if (*c == '>')
+          nest--;
+        c++;
       }
       c--;
     }
@@ -344,26 +344,26 @@ SwigType *SwigType_default_create(const SwigType *ty) {
     if (numitems >= 1) {
       String *last_subtype = Getitem(l, numitems-1);
       if (SwigType_isenum(last_subtype))
-	Setitem(l, numitems-1, NewString("enum SWIGTYPE"));
+        Setitem(l, numitems-1, NewString("enum SWIGTYPE"));
       else
-	Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        Setitem(l, numitems-1, NewString("SWIGTYPE"));
     }
 
     for (it = First(l); it.item; it = Next(it)) {
       String *subtype = it.item;
       if (SwigType_isarray(subtype)) {
-	if (Equal(subtype, "a()."))
-	  Append(r, NewString("a()."));
-	else
-	  Append(r, NewString("a(ANY)."));
+        if (Equal(subtype, "a()."))
+          Append(r, NewString("a()."));
+        else
+          Append(r, NewString("a(ANY)."));
       } else if (SwigType_isfunction(subtype)) {
-	Append(r, NewString("f(ANY).SWIGTYPE"));
-	break;
+        Append(r, NewString("f(ANY).SWIGTYPE"));
+        break;
       } else if (SwigType_ismemberpointer(subtype)) {
-	Append(r, NewString("m(CLASS).SWIGTYPE"));
-	break;
+        Append(r, NewString("m(CLASS).SWIGTYPE"));
+        break;
       } else {
-	Append(r, subtype);
+        Append(r, subtype);
       }
     }
 
@@ -424,39 +424,39 @@ SwigType *SwigType_default_deduce(const SwigType *t) {
     if (numitems >=2 ) {
       String *subtype = Getitem(l, numitems-2); /* last but one */
       if (SwigType_isarray(subtype)) {
-	if (is_enum) {
-	  /* enum deduction, enum SWIGTYPE => SWIGTYPE */
-	  Setitem(l, numitems-1, NewString("SWIGTYPE"));
-	} else {
-	  /* array deduction, a(ANY). => a(). => p. */
-	  String *deduced_subtype = 0;
-	  if (Strcmp(subtype, "a().") == 0) {
-	    deduced_subtype = NewString("p.");
-	  } else if (Strcmp(subtype, "a(ANY).") == 0) {
-	    deduced_subtype = NewString("a().");
-	  } else {
-	    assert(0);
-	  }
-	  Setitem(l, numitems-2, deduced_subtype);
-	}
+        if (is_enum) {
+          /* enum deduction, enum SWIGTYPE => SWIGTYPE */
+          Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        } else {
+          /* array deduction, a(ANY). => a(). => p. */
+          String *deduced_subtype = 0;
+          if (Strcmp(subtype, "a().") == 0) {
+            deduced_subtype = NewString("p.");
+          } else if (Strcmp(subtype, "a(ANY).") == 0) {
+            deduced_subtype = NewString("a().");
+          } else {
+            assert(0);
+          }
+          Setitem(l, numitems-2, deduced_subtype);
+        }
       } else if (SwigType_ismemberpointer(subtype)) {
-	/* member pointer deduction, m(CLASS). => p. */
-	Setitem(l, numitems-2, NewString("p."));
+        /* member pointer deduction, m(CLASS). => p. */
+        Setitem(l, numitems-2, NewString("p."));
       } else if (is_enum && !SwigType_isqualifier(subtype)) {
-	/* enum deduction, enum SWIGTYPE => SWIGTYPE */
-	Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        /* enum deduction, enum SWIGTYPE => SWIGTYPE */
+        Setitem(l, numitems-1, NewString("SWIGTYPE"));
       } else {
-	/* simple type deduction, eg, r.p.p. => r.p. */
-	/* also function pointers eg, p.f(ANY). => p. */
-	Delitem(l, numitems-2);
+        /* simple type deduction, eg, r.p.p. => r.p. */
+        /* also function pointers eg, p.f(ANY). => p. */
+        Delitem(l, numitems-2);
       }
     } else {
       if (is_enum) {
-	/* enum deduction, enum SWIGTYPE => SWIGTYPE */
-	Setitem(l, numitems-1, NewString("SWIGTYPE"));
+        /* enum deduction, enum SWIGTYPE => SWIGTYPE */
+        Setitem(l, numitems-1, NewString("SWIGTYPE"));
       } else {
-	/* delete the only item, we are done with deduction */
-	Delitem(l, 0);
+        /* delete the only item, we are done with deduction */
+        Delitem(l, 0);
       }
     }
   } else {
@@ -562,8 +562,8 @@ String *SwigType_str(const SwigType *s, const_String_or_char_ptr id) {
       nextelement = Getitem(elements, i + 1);
       forwardelement = nextelement;
       if (SwigType_isqualifier(nextelement)) {
-	if (i < (nelements - 2))
-	  forwardelement = Getitem(elements, i + 2);
+        if (i < (nelements - 2))
+          forwardelement = Getitem(elements, i + 2);
       }
     } else {
       nextelement = 0;
@@ -571,17 +571,17 @@ String *SwigType_str(const SwigType *s, const_String_or_char_ptr id) {
     }
     if (SwigType_isqualifier(element)) {
       if (!member_function_qualifiers) {
-	DOH *q = 0;
-	q = SwigType_parm(element);
-	Insert(result, 0, " ");
-	Insert(result, 0, q);
-	Delete(q);
+        DOH *q = 0;
+        q = SwigType_parm(element);
+        Insert(result, 0, " ");
+        Insert(result, 0, q);
+        Delete(q);
       }
     } else if (SwigType_ispointer(element)) {
       Insert(result, 0, "*");
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
     } else if (SwigType_ismemberpointer(element)) {
       String *q;
@@ -589,39 +589,39 @@ String *SwigType_str(const SwigType *s, const_String_or_char_ptr id) {
       Insert(result, 0, "::*");
       Insert(result, 0, q);
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
       {
-	String *next3elements = NewStringEmpty();
-	int j;
-	for (j = i + 1; j < i + 4 && j < nelements; j++) {
-	  Append(next3elements, Getitem(elements, j));
-	}
-	if (SwigType_isfunction(next3elements))
-	  member_function_qualifiers = SwigType_pop_function_qualifiers(next3elements);
-	Delete(next3elements);
+        String *next3elements = NewStringEmpty();
+        int j;
+        for (j = i + 1; j < i + 4 && j < nelements; j++) {
+          Append(next3elements, Getitem(elements, j));
+        }
+        if (SwigType_isfunction(next3elements))
+          member_function_qualifiers = SwigType_pop_function_qualifiers(next3elements);
+        Delete(next3elements);
       }
       Delete(q);
     } else if (SwigType_isreference(element)) {
       if (!member_function_qualifiers)
-	Insert(result, 0, "&");
+        Insert(result, 0, "&");
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
     } else if (SwigType_isrvalue_reference(element)) {
       if (!member_function_qualifiers)
-	Insert(result, 0, "&&");
+        Insert(result, 0, "&&");
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
     } else if (SwigType_isvariadic(element)) {
       Insert(result, 0, "...");
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
     } else if (SwigType_isarray(element)) {
       DOH *size;
@@ -637,29 +637,29 @@ String *SwigType_str(const SwigType *s, const_String_or_char_ptr id) {
       parms = SwigType_parmlist(element);
       plen = Len(parms);
       for (j = 0; j < plen; j++) {
-	p = SwigType_str(Getitem(parms, j), 0);
-	Append(result, p);
-	if (j < (plen - 1))
-	  Append(result, ",");
+        p = SwigType_str(Getitem(parms, j), 0);
+        Append(result, p);
+        if (j < (plen - 1))
+          Append(result, ",");
       }
       Append(result, ")");
       if (member_function_qualifiers) {
-	String *p = SwigType_str(member_function_qualifiers, 0);
-	Append(result, " ");
-	Append(result, p);
-	Delete(p);
-	Delete(member_function_qualifiers);
-	member_function_qualifiers = 0;
+        String *p = SwigType_str(member_function_qualifiers, 0);
+        Append(result, " ");
+        Append(result, p);
+        Delete(p);
+        Delete(member_function_qualifiers);
+        member_function_qualifiers = 0;
       }
       Delete(parms);
     } else {
       if (strcmp(Char(element), "v(...)") == 0) {
-	Insert(result, 0, "...");
+        Insert(result, 0, "...");
       } else {
-	String *bs = SwigType_namestr(element);
-	Insert(result, 0, " ");
-	Insert(result, 0, bs);
-	Delete(bs);
+        String *bs = SwigType_namestr(element);
+        Insert(result, 0, " ");
+        Insert(result, 0, bs);
+        Delete(bs);
       }
     }
     element = nextelement;
@@ -697,12 +697,12 @@ SwigType *SwigType_ltype(const SwigType *s) {
     td = 0;
     while ((td = SwigType_typedef_resolve(tt))) {
       if (td && (SwigType_isconst(td) || SwigType_isarray(td) || SwigType_isreference(td) || SwigType_isrvalue_reference(td))) {
-	/* We need to use the typedef type */
-	Delete(tt);
-	break;
+        /* We need to use the typedef type */
+        Delete(tt);
+        break;
       } else if (td) {
-	Delete(tt);
-	tt = td;
+        Delete(tt);
+        tt = td;
       }
     }
     if (td) {
@@ -732,49 +732,49 @@ SwigType *SwigType_ltype(const SwigType *s) {
     } else if (SwigType_ismemberpointer(element)) {
       Append(result, element);
       {
-	String *next3elements = NewStringEmpty();
-	int j;
-	for (j = i + 1; j < i + 4 && j < nelements; j++) {
-	  Append(next3elements, Getitem(elements, j));
-	}
-	if (SwigType_isfunction(next3elements)) {
-	  SwigType *member_function_qualifiers = SwigType_pop_function_qualifiers(next3elements);
-	  /* compilers won't let us cast from a member function without qualifiers to one with qualifiers, so the qualifiers are kept in the ltype */
-	  if (member_function_qualifiers)
-	    Append(result, member_function_qualifiers);
-	  Delete(member_function_qualifiers);
-	  ignore_member_function_qualifiers = 1;
-	}
-	Delete(next3elements);
+        String *next3elements = NewStringEmpty();
+        int j;
+        for (j = i + 1; j < i + 4 && j < nelements; j++) {
+          Append(next3elements, Getitem(elements, j));
+        }
+        if (SwigType_isfunction(next3elements)) {
+          SwigType *member_function_qualifiers = SwigType_pop_function_qualifiers(next3elements);
+          /* compilers won't let us cast from a member function without qualifiers to one with qualifiers, so the qualifiers are kept in the ltype */
+          if (member_function_qualifiers)
+            Append(result, member_function_qualifiers);
+          Delete(member_function_qualifiers);
+          ignore_member_function_qualifiers = 1;
+        }
+        Delete(next3elements);
       }
       firstarray = 0;
     } else if (SwigType_isreference(element)) {
       if (notypeconv) {
-	Append(result, element);
+        Append(result, element);
       } else {
-	Append(result, "p.");
+        Append(result, "p.");
       }
       firstarray = 0;
     } else if (SwigType_isrvalue_reference(element)) {
       if (notypeconv) {
-	Append(result, element);
+        Append(result, element);
       } else {
-	Append(result, "p.");
+        Append(result, "p.");
       }
       firstarray = 0;
     } else if (SwigType_isarray(element) && firstarray) {
       if (notypeconv) {
-	Append(result, element);
+        Append(result, element);
       } else {
-	Append(result, "p.");
+        Append(result, "p.");
       }
       firstarray = 0;
     } else if (SwigType_isenum(element)) {
       int anonymous_enum = (Cmp(element, "enum ") == 0);
       if (notypeconv || !anonymous_enum) {
-	Append(result, element);
+        Append(result, element);
       } else {
-	Append(result, "int");
+        Append(result, "int");
       }
     } else {
       Append(result, element);
@@ -874,8 +874,8 @@ String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr name) {
       nextelement = Getitem(elements, i + 1);
       forwardelement = nextelement;
       if (SwigType_isqualifier(nextelement)) {
-	if (i < (nelements - 2))
-	  forwardelement = Getitem(elements, i + 2);
+        if (i < (nelements - 2))
+          forwardelement = Getitem(elements, i + 2);
       }
     } else {
       nextelement = 0;
@@ -883,18 +883,18 @@ String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr name) {
     }
     if (SwigType_isqualifier(element)) {
       if (!member_function_qualifiers) {
-	DOH *q = 0;
-	q = SwigType_parm(element);
-	Insert(result, 0, " ");
-	Insert(result, 0, q);
-	Delete(q);
-	clear = 0;
+        DOH *q = 0;
+        q = SwigType_parm(element);
+        Insert(result, 0, " ");
+        Insert(result, 0, q);
+        Delete(q);
+        clear = 0;
       }
     } else if (SwigType_ispointer(element)) {
       Insert(result, 0, "*");
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
       firstarray = 0;
     } else if (SwigType_ismemberpointer(element)) {
@@ -903,54 +903,54 @@ String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr name) {
       q = SwigType_parm(element);
       Insert(result, 0, q);
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
       {
-	String *next3elements = NewStringEmpty();
-	int j;
-	for (j = i + 1; j < i + 4 && j < nelements; j++) {
-	  Append(next3elements, Getitem(elements, j));
-	}
-	if (SwigType_isfunction(next3elements))
-	  member_function_qualifiers = SwigType_pop_function_qualifiers(next3elements);
-	Delete(next3elements);
+        String *next3elements = NewStringEmpty();
+        int j;
+        for (j = i + 1; j < i + 4 && j < nelements; j++) {
+          Append(next3elements, Getitem(elements, j));
+        }
+        if (SwigType_isfunction(next3elements))
+          member_function_qualifiers = SwigType_pop_function_qualifiers(next3elements);
+        Delete(next3elements);
       }
       firstarray = 0;
       Delete(q);
     } else if (SwigType_isreference(element)) {
       if (!member_function_qualifiers) {
-	Insert(result, 0, "&");
-	if (!isfunction)
-	  isreference = 1;
+        Insert(result, 0, "&");
+        if (!isfunction)
+          isreference = 1;
       }
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
     } else if (SwigType_isrvalue_reference(element)) {
       if (!member_function_qualifiers) {
-	Insert(result, 0, "&&");
-	if (!isfunction)
-	  isreference = 1;
+        Insert(result, 0, "&&");
+        if (!isfunction)
+          isreference = 1;
       }
       if ((forwardelement) && ((SwigType_isfunction(forwardelement) || (SwigType_isarray(forwardelement))))) {
-	Insert(result, 0, "(");
-	Append(result, ")");
+        Insert(result, 0, "(");
+        Append(result, ")");
       }
       clear = 0;
     } else if (SwigType_isarray(element)) {
       DOH *size;
       if (firstarray && !isreference) {
-	Append(result, "(*)");
-	firstarray = 0;
+        Append(result, "(*)");
+        firstarray = 0;
       } else {
-	Append(result, "[");
-	size = SwigType_parm(element);
-	Append(result, size);
-	Append(result, "]");
-	Delete(size);
-	clear = 0;
+        Append(result, "[");
+        size = SwigType_parm(element);
+        Append(result, size);
+        Append(result, "]");
+        Delete(size);
+        clear = 0;
       }
     } else if (SwigType_isfunction(element)) {
       DOH *parms, *p;
@@ -959,22 +959,22 @@ String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr name) {
       parms = SwigType_parmlist(element);
       plen = Len(parms);
       for (j = 0; j < plen; j++) {
-	p = SwigType_str(Getitem(parms, j), 0);
-	Append(result, p);
-	Delete(p);
-	if (j < (plen - 1))
-	  Append(result, ",");
+        p = SwigType_str(Getitem(parms, j), 0);
+        Append(result, p);
+        Delete(p);
+        if (j < (plen - 1))
+          Append(result, ",");
       }
       Append(result, ")");
       Delete(parms);
       if (member_function_qualifiers) {
-	String *p = SwigType_str(member_function_qualifiers, 0);
-	Append(result, " ");
-	Append(result, p);
-	Delete(p);
-	Delete(member_function_qualifiers);
-	member_function_qualifiers = 0;
-	clear = 0;
+        String *p = SwigType_str(member_function_qualifiers, 0);
+        Append(result, " ");
+        Append(result, p);
+        Delete(p);
+        Delete(member_function_qualifiers);
+        member_function_qualifiers = 0;
+        clear = 0;
       }
       isfunction = 1;
     } else {
@@ -1047,7 +1047,7 @@ String *SwigType_lcaststr(const SwigType *s, const_String_or_char_ptr name) {
       Delete(lstr);
     } else {
       if (name)
-	Append(result, name);
+        Append(result, name);
     }
     Delete(sc);
   } else {
@@ -1133,15 +1133,15 @@ static void mangle_namestr(String *mangled, SwigType *t) {
       p = SwigType_parmlist(c + 1);
       sz = Len(p);
       for (i = 0; i < sz; i++) {
-	mangle_subtype(mangled, Getitem(p, i));
-	Putc('_', mangled);
+        mangle_subtype(mangled, Getitem(p, i));
+        Putc('_', mangled);
       }
       Putc('t', mangled);
       suffix = SwigType_templatesuffix(t);
       if (Len(suffix) > 0) {
-	mangle_namestr(mangled, suffix);
+        mangle_namestr(mangled, suffix);
       } else {
-	Append(mangled, suffix);
+        Append(mangled, suffix);
       }
       Delete(suffix);
       Delete(p);
@@ -1311,84 +1311,84 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
     String *e = Getitem(elem, i);
     if (SwigType_issimple(e)) {
       if (Equal(e, pat)) {
-	/* Replaces a type of the form 'pat' with 'rep<args>' */
-	if (SwigType_isconst(rep) && i > 0 && SwigType_isconst(Getitem(elem, i - 1))) {
-	  /* Collapse duplicate const into a single const */
-	  SwigType *rep_without_const = Copy(rep);
-	  Delete(SwigType_pop(rep_without_const));
-	  Replace(e, pat, rep_without_const, DOH_REPLACE_ANY);
-	  Delete(rep_without_const);
-	} else {
-	  Replace(e, pat, rep, DOH_REPLACE_ANY);
-	}
+        /* Replaces a type of the form 'pat' with 'rep<args>' */
+        if (SwigType_isconst(rep) && i > 0 && SwigType_isconst(Getitem(elem, i - 1))) {
+          /* Collapse duplicate const into a single const */
+          SwigType *rep_without_const = Copy(rep);
+          Delete(SwigType_pop(rep_without_const));
+          Replace(e, pat, rep_without_const, DOH_REPLACE_ANY);
+          Delete(rep_without_const);
+        } else {
+          Replace(e, pat, rep, DOH_REPLACE_ANY);
+        }
       } else if (SwigType_istemplate(e)) {
-	/* Replaces a type of the form 'pat<args>' with 'rep' */
-	{
-	  /* To match "e=TemplateTemplateT<(float)>"
-	   * with "pat=TemplateTemplateT"
-	   * we need to compare only the first part of the string e.
-	   */
-	  int len = Len(pat);
+        /* Replaces a type of the form 'pat<args>' with 'rep' */
+        {
+          /* To match "e=TemplateTemplateT<(float)>"
+           * with "pat=TemplateTemplateT"
+           * we need to compare only the first part of the string e.
+           */
+          int len = Len(pat);
 
-	  /* Len(e) > len, not >= (because we expect at least a
-	   * character '<' following the template typename)
-	   */
-	  if (Len(e) > len) {
-	    String *firstPartOfType = NewStringWithSize(e, len);
-	    const char* e_as_char = Char(e);
+          /* Len(e) > len, not >= (because we expect at least a
+           * character '<' following the template typename)
+           */
+          if (Len(e) > len) {
+            String *firstPartOfType = NewStringWithSize(e, len);
+            const char* e_as_char = Char(e);
 
-	    if (Equal(firstPartOfType, pat) && e_as_char[len] == '<') {
-	      String *repbase = SwigType_templateprefix(rep);
-	      Replace(e, pat, repbase, DOH_REPLACE_ID | DOH_REPLACE_FIRST);
-	      Delete(repbase);
-	    }
-	    Delete(firstPartOfType);
-	  }
-	}
+            if (Equal(firstPartOfType, pat) && e_as_char[len] == '<') {
+              String *repbase = SwigType_templateprefix(rep);
+              Replace(e, pat, repbase, DOH_REPLACE_ID | DOH_REPLACE_FIRST);
+              Delete(repbase);
+            }
+            Delete(firstPartOfType);
+          }
+        }
 
-	{
-	  String *tsuffix;
-	  List *tparms = SwigType_parmlist(e);
-	  int j, jlen;
-	  String *nt = SwigType_templateprefix(e);
-	  Append(nt, "<(");
-	  jlen = Len(tparms);
-	  for (j = 0; j < jlen; j++) {
-	    SwigType_typename_replace(Getitem(tparms, j), pat, rep);
-	    Append(nt, Getitem(tparms, j));
-	    if (j < (jlen - 1))
-	      Putc(',', nt);
-	  }
-	  tsuffix = SwigType_templatesuffix(e);
-	  SwigType_typename_replace(tsuffix, pat, rep);
-	  Printf(nt, ")>%s", tsuffix);
-	  Delete(tsuffix);
-	  Clear(e);
-	  Append(e, nt);
-	  Delete(nt);
-	  Delete(tparms);
-	}
+        {
+          String *tsuffix;
+          List *tparms = SwigType_parmlist(e);
+          int j, jlen;
+          String *nt = SwigType_templateprefix(e);
+          Append(nt, "<(");
+          jlen = Len(tparms);
+          for (j = 0; j < jlen; j++) {
+            SwigType_typename_replace(Getitem(tparms, j), pat, rep);
+            Append(nt, Getitem(tparms, j));
+            if (j < (jlen - 1))
+              Putc(',', nt);
+          }
+          tsuffix = SwigType_templatesuffix(e);
+          SwigType_typename_replace(tsuffix, pat, rep);
+          Printf(nt, ")>%s", tsuffix);
+          Delete(tsuffix);
+          Clear(e);
+          Append(e, nt);
+          Delete(nt);
+          Delete(tparms);
+        }
       } else if (Swig_scopename_check(e)) {
-	String *first = 0;
-	String *rest = 0;
-	Swig_scopename_split(e, &first, &rest);
+        String *first = 0;
+        String *rest = 0;
+        Swig_scopename_split(e, &first, &rest);
 
-	/* Swig_scopename_split doesn't handle :: prefix very well ... could do with a rework */
-	if (Strncmp(rest, "::", 2) == 0) {
-	  String *tmp = NewString(Char(rest) + 2);
-	  Clear(rest);
-	  Printv(rest, tmp, NIL);
-	  Delete(tmp);
-	  assert(!first);
-	}
+        /* Swig_scopename_split doesn't handle :: prefix very well ... could do with a rework */
+        if (Strncmp(rest, "::", 2) == 0) {
+          String *tmp = NewString(Char(rest) + 2);
+          Clear(rest);
+          Printv(rest, tmp, NIL);
+          Delete(tmp);
+          assert(!first);
+        }
 
-	Clear(e);
-	if (first)
-	  SwigType_typename_replace(first, pat, rep);
-	SwigType_typename_replace(rest, pat, rep);
-	Printv(e, first ? first : "", "::", rest, NIL);
-	Delete(first);
-	Delete(rest);
+        Clear(e);
+        if (first)
+          SwigType_typename_replace(first, pat, rep);
+        SwigType_typename_replace(rest, pat, rep);
+        Printv(e, first ? first : "", "::", rest, NIL);
+        Delete(first);
+        Delete(rest);
       }
     } else if (SwigType_isfunction(e)) {
       int j, jlen;
@@ -1397,10 +1397,10 @@ void SwigType_typename_replace(SwigType *t, String *pat, String *rep) {
       Append(e, "f(");
       jlen = Len(fparms);
       for (j = 0; j < jlen; j++) {
-	SwigType_typename_replace(Getitem(fparms, j), pat, rep);
-	Append(e, Getitem(fparms, j));
-	if (j < (jlen - 1))
-	  Putc(',', e);
+        SwigType_typename_replace(Getitem(fparms, j), pat, rep);
+        Append(e, Getitem(fparms, j));
+        if (j < (jlen - 1))
+          Putc(',', e);
       }
       Append(e, ").");
       Delete(fparms);
@@ -1461,15 +1461,15 @@ void SwigType_variadic_replace(SwigType *t, Parm *unexpanded_variadic_parm, Parm
       Append(e, "f(");
       jlen = Len(fparms);
       for (j = 0; j < jlen; j++) {
-	SwigType *type = Getitem(fparms, j);
-	SwigType_variadic_replace(type, unexpanded_variadic_parm, expanded_variadic_parms);
-	if (Len(type) > 0) {
-	  if (j != 0)
-	    Putc(',', e);
-	  Append(e, type);
-	} else {
-	  assert(j == jlen - 1); /* A variadic parm was replaced with zero parms, variadic parms are only changed at the end of the list */
-	}
+        SwigType *type = Getitem(fparms, j);
+        SwigType_variadic_replace(type, unexpanded_variadic_parm, expanded_variadic_parms);
+        if (Len(type) > 0) {
+          if (j != 0)
+            Putc(',', e);
+          Append(e, type);
+        } else {
+          assert(j == jlen - 1); /* A variadic parm was replaced with zero parms, variadic parms are only changed at the end of the list */
+        }
       }
       Append(e, ").");
       Delete(fparms);

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -51,10 +51,10 @@ extern "C" {
   typedef DOH Typetab;
   typedef DOH SwigType;
 
-/* --- Legacy DataType interface.  These type codes are provided solely 
+/* --- Legacy DataType interface.  These type codes are provided solely
        for backwards compatibility with older modules --- */
 
-/* --- The ordering of type values is used to determine type-promotion 
+/* --- The ordering of type values is used to determine type-promotion
        in the parser.  Do not change */
 
 /* Numeric types */

--- a/Source/Swig/swig.h
+++ b/Source/Swig/swig.h
@@ -29,27 +29,27 @@ extern "C" {
 
 /* Status codes */
 
-#define SWIG_OK         1
-#define SWIG_ERROR      0
-#define SWIG_NOWRAP     0
+#define SWIG_OK          1
+#define SWIG_ERROR       0
+#define SWIG_NOWRAP      0
 
 /* Global macros */
 #define NSPACE_SEPARATOR "." /* Namespace separator for the nspace feature - this should be changed to a target language configurable variable */
-#define NSPACE_TODO 0 /* Languages that still need to implement and test the nspace feature use this */
+#define NSPACE_TODO      0   /* Languages that still need to implement and test the nspace feature use this */
 
 /* Short names for common data types */
 
-  typedef DOH String;
-  typedef DOH Hash;
-  typedef DOH List;
-  typedef DOH String_or_char;
-  typedef DOH File;
-  typedef DOH Parm;
-  typedef DOH ParmList;
-  typedef DOH Node;
-  typedef DOH Symtab;
-  typedef DOH Typetab;
-  typedef DOH SwigType;
+typedef DOH String;
+typedef DOH Hash;
+typedef DOH List;
+typedef DOH String_or_char;
+typedef DOH File;
+typedef DOH Parm;
+typedef DOH ParmList;
+typedef DOH Node;
+typedef DOH Symtab;
+typedef DOH Typetab;
+typedef DOH SwigType;
 
 /* --- Legacy DataType interface.  These type codes are provided solely
        for backwards compatibility with older modules --- */
@@ -59,42 +59,42 @@ extern "C" {
 
 /* Numeric types */
 
-#define   T_BOOL       1
-#define   T_SCHAR      2
-#define   T_UCHAR      3
-#define   T_SHORT      4
-#define   T_USHORT     5
-#define   T_INT        7
-#define   T_UINT       8
-#define   T_LONG       9
-#define   T_ULONG      10
-#define   T_LONGLONG   11
-#define   T_ULONGLONG  12
-#define   T_FLOAT      20
-#define   T_DOUBLE     21
-#define   T_LONGDOUBLE 22
-#define   T_FLTCPLX    23
-#define   T_DBLCPLX    24
-#define   T_AUTO       26
+#define T_BOOL             1
+#define T_SCHAR            2
+#define T_UCHAR            3
+#define T_SHORT            4
+#define T_USHORT           5
+#define T_INT              7
+#define T_UINT             8
+#define T_LONG             9
+#define T_ULONG            10
+#define T_LONGLONG         11
+#define T_ULONGLONG        12
+#define T_FLOAT            20
+#define T_DOUBLE           21
+#define T_LONGDOUBLE       22
+#define T_FLTCPLX          23
+#define T_DBLCPLX          24
+#define T_AUTO             26
 
-#define   T_COMPLEX    T_DBLCPLX
+#define T_COMPLEX          T_DBLCPLX
 
 /* non-numeric */
 
-#define   T_CHAR       29
-#define   T_WCHAR      30
-#define   T_USER       31
-#define   T_VOID       32
-#define   T_STRING     33
-#define   T_POINTER    34
-#define   T_REFERENCE  35
-#define   T_ARRAY      36
-#define   T_FUNCTION   37
-#define   T_MPOINTER   38
-#define   T_VARARGS    39
-#define   T_RVALUE_REFERENCE  40
-#define   T_WSTRING    41
-#define   T_UNKNOWN    42
+#define T_CHAR             29
+#define T_WCHAR            30
+#define T_USER             31
+#define T_VOID             32
+#define T_STRING           33
+#define T_POINTER          34
+#define T_REFERENCE        35
+#define T_ARRAY            36
+#define T_FUNCTION         37
+#define T_MPOINTER         38
+#define T_VARARGS          39
+#define T_RVALUE_REFERENCE 40
+#define T_WSTRING          41
+#define T_UNKNOWN          42
 
 /* --- File interface --- */
 
@@ -110,156 +110,156 @@ extern "C" {
 
 /* --- Functions for manipulating the string-based type encoding --- */
 
-  extern SwigType *NewSwigType(int typecode);
-  extern SwigType *SwigType_del_element(SwigType *t);
-  extern SwigType *SwigType_add_pointer(SwigType *t);
-  extern SwigType *SwigType_add_memberpointer(SwigType *t, const_String_or_char_ptr qual);
-  extern SwigType *SwigType_del_memberpointer(SwigType *t);
-  extern SwigType *SwigType_del_pointer(SwigType *t);
-  extern SwigType *SwigType_add_array(SwigType *t, const_String_or_char_ptr size);
-  extern SwigType *SwigType_del_array(SwigType *t);
-  extern SwigType *SwigType_pop_arrays(SwigType *t);
-  extern SwigType *SwigType_add_reference(SwigType *t);
-  extern SwigType *SwigType_del_reference(SwigType *t);
-  extern SwigType *SwigType_add_rvalue_reference(SwigType *t);
-  extern SwigType *SwigType_del_rvalue_reference(SwigType *t);
-  extern SwigType *SwigType_add_variadic(SwigType *t);
-  extern SwigType *SwigType_del_variadic(SwigType *t);
-  extern SwigType *SwigType_add_qualifier(SwigType *t, const_String_or_char_ptr qual);
-  extern SwigType *SwigType_del_qualifier(SwigType *t);
-  extern SwigType *SwigType_add_function(SwigType *t, ParmList *parms);
-  extern SwigType *SwigType_add_template(SwigType *t, ParmList *parms);
-  extern SwigType *SwigType_pop_function(SwigType *t);
-  extern SwigType *SwigType_pop_function_qualifiers(SwigType *t);
-  extern SwigType *SwigType_function_parms_only(ParmList *parms);
-  extern ParmList *SwigType_function_parms(const SwigType *t, Node *file_line_node);
-  extern List *SwigType_split(const SwigType *t);
-  extern String *SwigType_pop(SwigType *t);
-  extern void SwigType_push(SwigType *t, String *s);
-  extern SwigType *SwigType_last(SwigType *t);
-  extern List *SwigType_parmlist(const SwigType *p);
-  extern String *SwigType_parm(const SwigType *p);
-  extern String *SwigType_str(const SwigType *s, const_String_or_char_ptr id);
-  extern String *SwigType_lstr(const SwigType *s, const_String_or_char_ptr id);
-  extern String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr id);
-  extern String *SwigType_lcaststr(const SwigType *s, const_String_or_char_ptr id);
-  extern String *SwigType_manglestr(const SwigType *t);
-  extern SwigType *SwigType_ltype(const SwigType *t);
-  extern int SwigType_ispointer(const SwigType *t);
-  extern int SwigType_ispointer_return(const SwigType *t);
-  extern int SwigType_isfunctionpointer(const SwigType *t);
-  extern int SwigType_ismemberpointer(const SwigType *t);
-  extern int SwigType_isreference(const SwigType *t);
-  extern int SwigType_isreference_return(const SwigType *t);
-  extern int SwigType_isrvalue_reference(const SwigType *t);
-  extern int SwigType_isvariadic(const SwigType *t);
-  extern int SwigType_isarray(const SwigType *t);
-  extern int SwigType_prefix_is_simple_1D_array(const SwigType *t);
-  extern int SwigType_isfunction(const SwigType *t);
-  extern int SwigType_isqualifier(const SwigType *t);
-  extern int SwigType_isconst(const SwigType *t);
-  extern int SwigType_issimple(const SwigType *t);
-  extern int SwigType_ismutable(const SwigType *t);
-  extern int SwigType_isvarargs(const SwigType *t);
-  extern int SwigType_istemplate(const SwigType *t);
-  extern int SwigType_isenum(const SwigType *t);
-  extern int SwigType_check_decl(const SwigType *t, const_String_or_char_ptr decl);
-  extern SwigType *SwigType_strip_qualifiers(const SwigType *t);
-  extern SwigType *SwigType_strip_single_qualifier(const SwigType *t);
-  extern SwigType *SwigType_functionpointer_decompose(SwigType *t);
-  extern String *SwigType_base(const SwigType *t);
-  extern String *SwigType_namestr(const SwigType *t);
-  extern String *SwigType_templateprefix(const SwigType *t);
-  extern String *SwigType_templatesuffix(const SwigType *t);
-  extern String *SwigType_istemplate_templateprefix(const SwigType *t);
-  extern String *SwigType_istemplate_only_templateprefix(const SwigType *t);
-  extern String *SwigType_templateargs(const SwigType *t);
-  extern String *SwigType_prefix(const SwigType *t);
-  extern int SwigType_array_ndim(const SwigType *t);
-  extern String *SwigType_array_getdim(const SwigType *t, int n);
-  extern void SwigType_array_setdim(SwigType *t, int n, const_String_or_char_ptr rep);
-  extern SwigType *SwigType_array_type(const SwigType *t);
-  extern SwigType *SwigType_default_create(const SwigType *ty);
-  extern SwigType *SwigType_default_deduce(const SwigType *t);
-  extern void SwigType_typename_replace(SwigType *t, String *pat, String *rep);
-  extern void SwigType_variadic_replace(SwigType *t, Parm *unexpanded_variadic_parm, ParmList *expanded_variadic_parms);
-  extern SwigType *SwigType_remove_global_scope_prefix(const SwigType *t);
-  extern SwigType *SwigType_alttype(const SwigType *t, int ltmap);
+extern SwigType *NewSwigType(int typecode);
+extern SwigType *SwigType_del_element(SwigType *t);
+extern SwigType *SwigType_add_pointer(SwigType *t);
+extern SwigType *SwigType_add_memberpointer(SwigType *t, const_String_or_char_ptr qual);
+extern SwigType *SwigType_del_memberpointer(SwigType *t);
+extern SwigType *SwigType_del_pointer(SwigType *t);
+extern SwigType *SwigType_add_array(SwigType *t, const_String_or_char_ptr size);
+extern SwigType *SwigType_del_array(SwigType *t);
+extern SwigType *SwigType_pop_arrays(SwigType *t);
+extern SwigType *SwigType_add_reference(SwigType *t);
+extern SwigType *SwigType_del_reference(SwigType *t);
+extern SwigType *SwigType_add_rvalue_reference(SwigType *t);
+extern SwigType *SwigType_del_rvalue_reference(SwigType *t);
+extern SwigType *SwigType_add_variadic(SwigType *t);
+extern SwigType *SwigType_del_variadic(SwigType *t);
+extern SwigType *SwigType_add_qualifier(SwigType *t, const_String_or_char_ptr qual);
+extern SwigType *SwigType_del_qualifier(SwigType *t);
+extern SwigType *SwigType_add_function(SwigType *t, ParmList *parms);
+extern SwigType *SwigType_add_template(SwigType *t, ParmList *parms);
+extern SwigType *SwigType_pop_function(SwigType *t);
+extern SwigType *SwigType_pop_function_qualifiers(SwigType *t);
+extern SwigType *SwigType_function_parms_only(ParmList *parms);
+extern ParmList *SwigType_function_parms(const SwigType *t, Node *file_line_node);
+extern List *SwigType_split(const SwigType *t);
+extern String *SwigType_pop(SwigType *t);
+extern void SwigType_push(SwigType *t, String *s);
+extern SwigType *SwigType_last(SwigType *t);
+extern List *SwigType_parmlist(const SwigType *p);
+extern String *SwigType_parm(const SwigType *p);
+extern String *SwigType_str(const SwigType *s, const_String_or_char_ptr id);
+extern String *SwigType_lstr(const SwigType *s, const_String_or_char_ptr id);
+extern String *SwigType_rcaststr(const SwigType *s, const_String_or_char_ptr id);
+extern String *SwigType_lcaststr(const SwigType *s, const_String_or_char_ptr id);
+extern String *SwigType_manglestr(const SwigType *t);
+extern SwigType *SwigType_ltype(const SwigType *t);
+extern int SwigType_ispointer(const SwigType *t);
+extern int SwigType_ispointer_return(const SwigType *t);
+extern int SwigType_isfunctionpointer(const SwigType *t);
+extern int SwigType_ismemberpointer(const SwigType *t);
+extern int SwigType_isreference(const SwigType *t);
+extern int SwigType_isreference_return(const SwigType *t);
+extern int SwigType_isrvalue_reference(const SwigType *t);
+extern int SwigType_isvariadic(const SwigType *t);
+extern int SwigType_isarray(const SwigType *t);
+extern int SwigType_prefix_is_simple_1D_array(const SwigType *t);
+extern int SwigType_isfunction(const SwigType *t);
+extern int SwigType_isqualifier(const SwigType *t);
+extern int SwigType_isconst(const SwigType *t);
+extern int SwigType_issimple(const SwigType *t);
+extern int SwigType_ismutable(const SwigType *t);
+extern int SwigType_isvarargs(const SwigType *t);
+extern int SwigType_istemplate(const SwigType *t);
+extern int SwigType_isenum(const SwigType *t);
+extern int SwigType_check_decl(const SwigType *t, const_String_or_char_ptr decl);
+extern SwigType *SwigType_strip_qualifiers(const SwigType *t);
+extern SwigType *SwigType_strip_single_qualifier(const SwigType *t);
+extern SwigType *SwigType_functionpointer_decompose(SwigType *t);
+extern String *SwigType_base(const SwigType *t);
+extern String *SwigType_namestr(const SwigType *t);
+extern String *SwigType_templateprefix(const SwigType *t);
+extern String *SwigType_templatesuffix(const SwigType *t);
+extern String *SwigType_istemplate_templateprefix(const SwigType *t);
+extern String *SwigType_istemplate_only_templateprefix(const SwigType *t);
+extern String *SwigType_templateargs(const SwigType *t);
+extern String *SwigType_prefix(const SwigType *t);
+extern int SwigType_array_ndim(const SwigType *t);
+extern String *SwigType_array_getdim(const SwigType *t, int n);
+extern void SwigType_array_setdim(SwigType *t, int n, const_String_or_char_ptr rep);
+extern SwigType *SwigType_array_type(const SwigType *t);
+extern SwigType *SwigType_default_create(const SwigType *ty);
+extern SwigType *SwigType_default_deduce(const SwigType *t);
+extern void SwigType_typename_replace(SwigType *t, String *pat, String *rep);
+extern void SwigType_variadic_replace(SwigType *t, Parm *unexpanded_variadic_parm, ParmList *expanded_variadic_parms);
+extern SwigType *SwigType_remove_global_scope_prefix(const SwigType *t);
+extern SwigType *SwigType_alttype(const SwigType *t, int ltmap);
 
 /* --- Type-system management --- */
-  extern void SwigType_typesystem_init(void);
-  extern int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name);
-  extern int SwigType_typedef_class(const_String_or_char_ptr name);
-  extern int SwigType_typedef_using(const_String_or_char_ptr qname);
-  extern void SwigType_inherit(String *subclass, String *baseclass, String *cast, String *conversioncode);
-  extern int SwigType_issubtype(const SwigType *subtype, const SwigType *basetype);
-  extern void SwigType_scope_alias(String *aliasname, Typetab *t);
-  extern void SwigType_using_scope(Typetab *t);
-  extern void SwigType_new_scope(const_String_or_char_ptr name);
-  extern void SwigType_inherit_scope(Typetab *scope);
-  extern Typetab *SwigType_pop_scope(void);
-  extern Typetab *SwigType_set_scope(Typetab *h);
-  extern void SwigType_print_scope(void);
-  extern SwigType *SwigType_typedef_resolve(const SwigType *t);
-  extern SwigType *SwigType_typedef_resolve_all(const SwigType *t);
-  extern SwigType *SwigType_typedef_qualified(const SwigType *t);
-  extern int SwigType_istypedef(const SwigType *t);
-  extern int SwigType_isclass(const SwigType *t);
-  extern void SwigType_attach_symtab(Symtab *syms);
-  extern void SwigType_remember(const SwigType *t);
-  extern void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr clientdata);
-  extern void SwigType_remember_mangleddata(String *mangled, const_String_or_char_ptr clientdata);
-  extern void (*SwigType_remember_trace(void (*tf) (const SwigType *, String *, String *))) (const SwigType *, String *, String *);
-  extern void SwigType_emit_type_table(File *f_headers, File *f_table);
-  extern int SwigType_type(const SwigType *t);
+extern void SwigType_typesystem_init(void);
+extern int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name);
+extern int SwigType_typedef_class(const_String_or_char_ptr name);
+extern int SwigType_typedef_using(const_String_or_char_ptr qname);
+extern void SwigType_inherit(String *subclass, String *baseclass, String *cast, String *conversioncode);
+extern int SwigType_issubtype(const SwigType *subtype, const SwigType *basetype);
+extern void SwigType_scope_alias(String *aliasname, Typetab *t);
+extern void SwigType_using_scope(Typetab *t);
+extern void SwigType_new_scope(const_String_or_char_ptr name);
+extern void SwigType_inherit_scope(Typetab *scope);
+extern Typetab *SwigType_pop_scope(void);
+extern Typetab *SwigType_set_scope(Typetab *h);
+extern void SwigType_print_scope(void);
+extern SwigType *SwigType_typedef_resolve(const SwigType *t);
+extern SwigType *SwigType_typedef_resolve_all(const SwigType *t);
+extern SwigType *SwigType_typedef_qualified(const SwigType *t);
+extern int SwigType_istypedef(const SwigType *t);
+extern int SwigType_isclass(const SwigType *t);
+extern void SwigType_attach_symtab(Symtab *syms);
+extern void SwigType_remember(const SwigType *t);
+extern void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr clientdata);
+extern void SwigType_remember_mangleddata(String *mangled, const_String_or_char_ptr clientdata);
+extern void (*SwigType_remember_trace(void (*tf)(const SwigType *, String *, String *)))(const SwigType *, String *, String *);
+extern void SwigType_emit_type_table(File *f_headers, File *f_table);
+extern int SwigType_type(const SwigType *t);
 
 /* --- Symbol table module --- */
 
-  extern void Swig_symbol_print_tables(Symtab *symtab);
-  extern void Swig_symbol_print_tables_summary(void);
-  extern void Swig_symbol_print_symbols(void);
-  extern void Swig_symbol_print_csymbols(void);
-  extern void Swig_symbol_init(void);
-  extern void Swig_symbol_setscopename(const_String_or_char_ptr name);
-  extern String *Swig_symbol_getscopename(void);
-  extern String *Swig_symbol_qualifiedscopename(Symtab *symtab);
-  extern String *Swig_symbol_qualified_language_scopename(Symtab *symtab);
-  extern Symtab *Swig_symbol_newscope(void);
-  extern Symtab *Swig_symbol_setscope(Symtab *);
-  extern Symtab *Swig_symbol_getscope(const_String_or_char_ptr symname);
-  extern Symtab *Swig_symbol_global_scope(void);
-  extern Symtab *Swig_symbol_current(void);
-  extern Symtab *Swig_symbol_popscope(void);
-  extern Node *Swig_symbol_add(const_String_or_char_ptr symname, Node *n);
-  extern void Swig_symbol_conflict_warn(Node *n, Node *c, const String *symname, int inclass);
-  extern void Swig_symbol_cadd(const_String_or_char_ptr symname, Node *n);
-  extern Node *Swig_symbol_clookup(const_String_or_char_ptr symname, Symtab *tab);
-  extern Node *Swig_symbol_clookup_check(const_String_or_char_ptr symname, Symtab *tab, Node *(*checkfunc) (Node *));
-  extern Node *Swig_symbol_clookup_no_inherit(const_String_or_char_ptr name, Symtab *n);
-  extern Symtab *Swig_symbol_cscope(const_String_or_char_ptr symname, Symtab *tab);
-  extern Node *Swig_symbol_clookup_local(const_String_or_char_ptr symname, Symtab *tab);
-  extern Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr symname, Symtab *tab, Node *(*checkfunc) (Node *));
-  extern String *Swig_symbol_qualified(Node *n);
-  extern Node *Swig_symbol_isoverloaded(Node *n);
-  extern void Swig_symbol_remove(Node *n);
-  extern void Swig_symbol_fix_overname(Node *n);
-  extern void Swig_symbol_alias(const_String_or_char_ptr aliasname, Symtab *tab);
-  extern void Swig_symbol_inherit(Symtab *tab);
-  extern SwigType *Swig_symbol_type_qualify(const SwigType *ty, Symtab *tab);
-  extern String *Swig_symbol_string_qualify(String *s, Symtab *tab);
-  extern SwigType *Swig_symbol_typedef_reduce(const SwigType *ty, Symtab *tab);
+extern void Swig_symbol_print_tables(Symtab *symtab);
+extern void Swig_symbol_print_tables_summary(void);
+extern void Swig_symbol_print_symbols(void);
+extern void Swig_symbol_print_csymbols(void);
+extern void Swig_symbol_init(void);
+extern void Swig_symbol_setscopename(const_String_or_char_ptr name);
+extern String *Swig_symbol_getscopename(void);
+extern String *Swig_symbol_qualifiedscopename(Symtab *symtab);
+extern String *Swig_symbol_qualified_language_scopename(Symtab *symtab);
+extern Symtab *Swig_symbol_newscope(void);
+extern Symtab *Swig_symbol_setscope(Symtab *);
+extern Symtab *Swig_symbol_getscope(const_String_or_char_ptr symname);
+extern Symtab *Swig_symbol_global_scope(void);
+extern Symtab *Swig_symbol_current(void);
+extern Symtab *Swig_symbol_popscope(void);
+extern Node *Swig_symbol_add(const_String_or_char_ptr symname, Node *n);
+extern void Swig_symbol_conflict_warn(Node *n, Node *c, const String *symname, int inclass);
+extern void Swig_symbol_cadd(const_String_or_char_ptr symname, Node *n);
+extern Node *Swig_symbol_clookup(const_String_or_char_ptr symname, Symtab *tab);
+extern Node *Swig_symbol_clookup_check(const_String_or_char_ptr symname, Symtab *tab, Node *(*checkfunc)(Node *));
+extern Node *Swig_symbol_clookup_no_inherit(const_String_or_char_ptr name, Symtab *n);
+extern Symtab *Swig_symbol_cscope(const_String_or_char_ptr symname, Symtab *tab);
+extern Node *Swig_symbol_clookup_local(const_String_or_char_ptr symname, Symtab *tab);
+extern Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr symname, Symtab *tab, Node *(*checkfunc)(Node *));
+extern String *Swig_symbol_qualified(Node *n);
+extern Node *Swig_symbol_isoverloaded(Node *n);
+extern void Swig_symbol_remove(Node *n);
+extern void Swig_symbol_fix_overname(Node *n);
+extern void Swig_symbol_alias(const_String_or_char_ptr aliasname, Symtab *tab);
+extern void Swig_symbol_inherit(Symtab *tab);
+extern SwigType *Swig_symbol_type_qualify(const SwigType *ty, Symtab *tab);
+extern String *Swig_symbol_string_qualify(String *s, Symtab *tab);
+extern SwigType *Swig_symbol_typedef_reduce(const SwigType *ty, Symtab *tab);
 
-  extern ParmList *Swig_symbol_template_defargs(Parm *parms, Parm *targs, Symtab *tscope, Symtab *tsdecl);
-  extern SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope);
-  extern SwigType *Swig_symbol_template_param_eval(const SwigType *p, Symtab *symtab);
-  extern int Swig_symbol_isvalid(const String *s);
+extern ParmList *Swig_symbol_template_defargs(Parm *parms, Parm *targs, Symtab *tscope, Symtab *tsdecl);
+extern SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope);
+extern SwigType *Swig_symbol_template_param_eval(const SwigType *p, Symtab *symtab);
+extern int Swig_symbol_isvalid(const String *s);
 
 /* --- Parameters and Parameter Lists --- */
 
 #include "swigparm.h"
 
-extern String    *ParmList_errorstr(ParmList *);
-extern int        ParmList_is_compactdefargs(ParmList *p);
+extern String *ParmList_errorstr(ParmList *);
+extern int ParmList_is_compactdefargs(ParmList *p);
 
 /* --- Parse tree support --- */
 
@@ -271,184 +271,186 @@ extern int        ParmList_is_compactdefargs(ParmList *p);
 
 /* --- Naming functions --- */
 
-  extern void Swig_name_register(const_String_or_char_ptr method, const_String_or_char_ptr format);
-  extern void Swig_name_unregister(const_String_or_char_ptr method);
-  extern String *Swig_name_type(const_String_or_char_ptr tname);
-  extern String *Swig_name_mangle_string(const String *s);
-  extern String *Swig_name_mangle_type(const SwigType *s);
-  extern String *Swig_name_wrapper(const_String_or_char_ptr fname);
-  extern String *Swig_name_member(const_String_or_char_ptr nspace, const_String_or_char_ptr classname, const_String_or_char_ptr membername);
-  extern String *Swig_name_get(const_String_or_char_ptr nspace, const_String_or_char_ptr vname);
-  extern String *Swig_name_set(const_String_or_char_ptr nspace, const_String_or_char_ptr vname);
-  extern String *Swig_name_construct(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
-  extern String *Swig_name_copyconstructor(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
-  extern String *Swig_name_destroy(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
-  extern String *Swig_name_disown(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
+extern void Swig_name_register(const_String_or_char_ptr method, const_String_or_char_ptr format);
+extern void Swig_name_unregister(const_String_or_char_ptr method);
+extern String *Swig_name_type(const_String_or_char_ptr tname);
+extern String *Swig_name_mangle_string(const String *s);
+extern String *Swig_name_mangle_type(const SwigType *s);
+extern String *Swig_name_wrapper(const_String_or_char_ptr fname);
+extern String *Swig_name_member(const_String_or_char_ptr nspace, const_String_or_char_ptr classname, const_String_or_char_ptr membername);
+extern String *Swig_name_get(const_String_or_char_ptr nspace, const_String_or_char_ptr vname);
+extern String *Swig_name_set(const_String_or_char_ptr nspace, const_String_or_char_ptr vname);
+extern String *Swig_name_construct(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
+extern String *Swig_name_copyconstructor(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
+extern String *Swig_name_destroy(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
+extern String *Swig_name_disown(const_String_or_char_ptr nspace, const_String_or_char_ptr classname);
 
-  extern void Swig_naming_init(void);
-  extern void Swig_name_namewarn_add(String *prefix, String *name, SwigType *decl, Hash *namewrn);
-  extern void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *namewrn, ParmList *declaratorparms);
-  extern void Swig_name_inherit(String *base, String *derived);
-  extern List *Swig_make_inherit_list(String *clsname, List *names, String *Namespaceprefix);
-  extern void Swig_inherit_base_symbols(List *bases);
-  extern int Swig_need_protected(Node *n);
-  extern int Swig_need_redefined_warn(Node *a, Node *b, int InClass);
+extern void Swig_naming_init(void);
+extern void Swig_name_namewarn_add(String *prefix, String *name, SwigType *decl, Hash *namewrn);
+extern void Swig_name_rename_add(String *prefix, String *name, SwigType *decl, Hash *namewrn, ParmList *declaratorparms);
+extern void Swig_name_inherit(String *base, String *derived);
+extern List *Swig_make_inherit_list(String *clsname, List *names, String *Namespaceprefix);
+extern void Swig_inherit_base_symbols(List *bases);
+extern int Swig_need_protected(Node *n);
+extern int Swig_need_redefined_warn(Node *a, Node *b, int InClass);
 
-  extern String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, SwigType *decl, String *oldname);
-  extern String *Swig_name_warning(Node *n, String *prefix, String *name, SwigType *decl);
-  extern String *Swig_name_str(Node *n);
-  extern String *Swig_name_decl(Node *n);
-  extern String *Swig_name_fulldecl(Node *n);
+extern String *Swig_name_make(Node *n, String *prefix, const_String_or_char_ptr cname, SwigType *decl, String *oldname);
+extern String *Swig_name_warning(Node *n, String *prefix, String *name, SwigType *decl);
+extern String *Swig_name_str(Node *n);
+extern String *Swig_name_decl(Node *n);
+extern String *Swig_name_fulldecl(Node *n);
 
 /* --- parameterized rename functions --- */
 
-  extern void Swig_name_object_set(Hash *namehash, String *name, SwigType *decl, DOH *object);
-  extern DOH *Swig_name_object_get(Hash *namehash, String *prefix, String *name, SwigType *decl);
-  extern void Swig_name_object_inherit(Hash *namehash, String *base, String *derived);
-  extern void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *decl, Node *n);
-  extern void Swig_feature_set(Hash *features, const_String_or_char_ptr name, SwigType *decl, const_String_or_char_ptr featurename, const_String_or_char_ptr value, Hash *featureattribs);
+extern void Swig_name_object_set(Hash *namehash, String *name, SwigType *decl, DOH *object);
+extern DOH *Swig_name_object_get(Hash *namehash, String *prefix, String *name, SwigType *decl);
+extern void Swig_name_object_inherit(Hash *namehash, String *base, String *derived);
+extern void Swig_features_get(Hash *features, String *prefix, String *name, SwigType *decl, Node *n);
+extern void Swig_feature_set(Hash *features, const_String_or_char_ptr name, SwigType *decl, const_String_or_char_ptr featurename,
+                             const_String_or_char_ptr value, Hash *featureattribs);
 
 /* --- Misc --- */
-  extern char *Swig_copy_string(const char *c);
-  extern void Swig_set_fakeversion(const char *version);
-  extern const char *Swig_package_version(void);
-  extern String *Swig_package_version_hex(void);
-  extern void Swig_obligatory_macros(String *f_runtime, const char *language);
-  extern void Swig_banner(File *f);
-  extern void Swig_banner_target_lang(File *f, const_String_or_char_ptr commentchar);
-  extern String *Swig_strip_c_comments(const String *s);
-  extern String *Swig_new_subdirectory(String *basedirectory, String *subdirectory);
-  extern void Swig_filename_correct(String *filename);
-  extern String *Swig_filename_escape(String *filename);
-  extern String *Swig_filename_escape_space(String *filename);
-  extern void Swig_filename_unescape(String *filename);
-  extern int Swig_storage_isextern(Node *n);
-  extern int Swig_storage_isexternc(Node *n);
-  extern int Swig_storage_isstatic_custom(Node *n, const_String_or_char_ptr storage);
-  extern int Swig_storage_isstatic(Node *n);
-  extern String *Swig_string_escape(String *s);
-  extern void Swig_scopename_split(const String *s, String **prefix, String **last);
-  extern String *Swig_scopename_prefix(const String *s);
-  extern String *Swig_scopename_last(const String *s);
-  extern String *Swig_scopename_first(const String *s);
-  extern String *Swig_scopename_suffix(const String *s);
-  extern List *Swig_scopename_tolist(const String *s);
-  extern int Swig_scopename_check(const String *s);
-  extern int Swig_scopename_isvalid(const String *s);
-  extern String *Swig_string_lower(String *s);
-  extern String *Swig_string_upper(String *s);
-  extern String *Swig_string_title(String *s);
-  extern void Swig_offset_string(String *s, int number);
-  extern String *Swig_pcre_version(void);
-  extern void Swig_init(void);
+extern char *Swig_copy_string(const char *c);
+extern void Swig_set_fakeversion(const char *version);
+extern const char *Swig_package_version(void);
+extern String *Swig_package_version_hex(void);
+extern void Swig_obligatory_macros(String *f_runtime, const char *language);
+extern void Swig_banner(File *f);
+extern void Swig_banner_target_lang(File *f, const_String_or_char_ptr commentchar);
+extern String *Swig_strip_c_comments(const String *s);
+extern String *Swig_new_subdirectory(String *basedirectory, String *subdirectory);
+extern void Swig_filename_correct(String *filename);
+extern String *Swig_filename_escape(String *filename);
+extern String *Swig_filename_escape_space(String *filename);
+extern void Swig_filename_unescape(String *filename);
+extern int Swig_storage_isextern(Node *n);
+extern int Swig_storage_isexternc(Node *n);
+extern int Swig_storage_isstatic_custom(Node *n, const_String_or_char_ptr storage);
+extern int Swig_storage_isstatic(Node *n);
+extern String *Swig_string_escape(String *s);
+extern void Swig_scopename_split(const String *s, String **prefix, String **last);
+extern String *Swig_scopename_prefix(const String *s);
+extern String *Swig_scopename_last(const String *s);
+extern String *Swig_scopename_first(const String *s);
+extern String *Swig_scopename_suffix(const String *s);
+extern List *Swig_scopename_tolist(const String *s);
+extern int Swig_scopename_check(const String *s);
+extern int Swig_scopename_isvalid(const String *s);
+extern String *Swig_string_lower(String *s);
+extern String *Swig_string_upper(String *s);
+extern String *Swig_string_title(String *s);
+extern void Swig_offset_string(String *s, int number);
+extern String *Swig_pcre_version(void);
+extern void Swig_init(void);
 
-  extern int Swig_value_wrapper_mode(int mode);
-  extern int Swig_is_generated_overload(Node *n);
-  extern Node *Swig_item_in_list(List *list, const DOH *item);
+extern int Swig_value_wrapper_mode(int mode);
+extern int Swig_is_generated_overload(Node *n);
+extern Node *Swig_item_in_list(List *list, const DOH *item);
 
-  typedef enum { EMF_STANDARD, EMF_MICROSOFT } ErrorMessageFormat;
+typedef enum { EMF_STANDARD, EMF_MICROSOFT } ErrorMessageFormat;
 
-  extern void Swig_warning(int num, const_String_or_char_ptr filename, int line, const char *fmt, ...);
-  extern void Swig_error(const_String_or_char_ptr filename, int line, const char *fmt, ...);
-  extern int Swig_error_count(void);
-  extern void Swig_error_silent(int s);
-  extern void Swig_warnfilter(const_String_or_char_ptr wlist, int val);
-  extern void Swig_warnall(void);
-  extern int Swig_warn_count(void);
-  extern void Swig_error_msg_format(ErrorMessageFormat format);
-  extern void Swig_diagnostic(const_String_or_char_ptr filename, int line, const char *fmt, ...);
-  extern String *Swig_stringify_with_location(DOH *object);
+extern void Swig_warning(int num, const_String_or_char_ptr filename, int line, const char *fmt, ...);
+extern void Swig_error(const_String_or_char_ptr filename, int line, const char *fmt, ...);
+extern int Swig_error_count(void);
+extern void Swig_error_silent(int s);
+extern void Swig_warnfilter(const_String_or_char_ptr wlist, int val);
+extern void Swig_warnall(void);
+extern int Swig_warn_count(void);
+extern void Swig_error_msg_format(ErrorMessageFormat format);
+extern void Swig_diagnostic(const_String_or_char_ptr filename, int line, const char *fmt, ...);
+extern String *Swig_stringify_with_location(DOH *object);
 
 /* --- C Wrappers --- */
-  extern void Swig_cresult_name_set(const char *new_name);
-  extern const char *Swig_cresult_name(void);
-  extern String *Swig_cparm_name(Parm *p, int i);
-  extern String *Swig_wrapped_var_type(SwigType *t, int varcref);
-  extern int Swig_cargs(Wrapper *w, ParmList *l);
-  extern String *Swig_cresult(SwigType *t, const_String_or_char_ptr name, const_String_or_char_ptr decl);
+extern void Swig_cresult_name_set(const char *new_name);
+extern const char *Swig_cresult_name(void);
+extern String *Swig_cparm_name(Parm *p, int i);
+extern String *Swig_wrapped_var_type(SwigType *t, int varcref);
+extern int Swig_cargs(Wrapper *w, ParmList *l);
+extern String *Swig_cresult(SwigType *t, const_String_or_char_ptr name, const_String_or_char_ptr decl);
 
-  extern String *Swig_cfunction_call(const_String_or_char_ptr name, ParmList *parms);
-  extern String *Swig_cconstructor_call(const_String_or_char_ptr name);
-  extern String *Swig_cppconstructor_call(const_String_or_char_ptr name, ParmList *parms);
-  extern String *Swig_unref_call(Node *n);
-  extern String *Swig_ref_call(Node *n, const String *lname);
-  extern String *Swig_cdestructor_call(Node *n);
-  extern String *Swig_cppdestructor_call(Node *n);
-  extern String *Swig_cmemberset_call(const_String_or_char_ptr name, SwigType *type, String *self, int varcref);
-  extern String *Swig_cmemberget_call(const_String_or_char_ptr name, SwigType *t, String *self, int varcref);
+extern String *Swig_cfunction_call(const_String_or_char_ptr name, ParmList *parms);
+extern String *Swig_cconstructor_call(const_String_or_char_ptr name);
+extern String *Swig_cppconstructor_call(const_String_or_char_ptr name, ParmList *parms);
+extern String *Swig_unref_call(Node *n);
+extern String *Swig_ref_call(Node *n, const String *lname);
+extern String *Swig_cdestructor_call(Node *n);
+extern String *Swig_cppdestructor_call(Node *n);
+extern String *Swig_cmemberset_call(const_String_or_char_ptr name, SwigType *type, String *self, int varcref);
+extern String *Swig_cmemberget_call(const_String_or_char_ptr name, SwigType *t, String *self, int varcref);
 
-  extern int Swig_add_extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus, const String *self);
-  extern void Swig_replace_special_variables(Node *n, Node *parentnode, String *code);
+extern int Swig_add_extension_code(Node *n, const String *function_name, ParmList *parms, SwigType *return_type, const String *code, int cplusplus,
+                                   const String *self);
+extern void Swig_replace_special_variables(Node *n, Node *parentnode, String *code);
 
 /* --- Transformations --- */
 
-  extern int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, int flags, SwigType *director_type, int is_director);
-  extern int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, String *none_comparison, String *director_ctor, int cplus, int flags, String *directorname);
-  extern int Swig_DestructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, int cplus, int flags);
-  extern int Swig_MembersetToFunction(Node *n, String *classname, int flags);
-  extern int Swig_MembergetToFunction(Node *n, String *classname, int flags);
-  extern int Swig_VargetToFunction(Node *n, int flags);
-  extern int Swig_VarsetToFunction(Node *n, int flags);
+extern int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, int flags, SwigType *director_type, int is_director);
+extern int Swig_ConstructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, String *none_comparison, String *director_ctor, int cplus,
+                                      int flags, String *directorname);
+extern int Swig_DestructorToFunction(Node *n, const_String_or_char_ptr nspace, String *classname, int cplus, int flags);
+extern int Swig_MembersetToFunction(Node *n, String *classname, int flags);
+extern int Swig_MembergetToFunction(Node *n, String *classname, int flags);
+extern int Swig_VargetToFunction(Node *n, int flags);
+extern int Swig_VarsetToFunction(Node *n, int flags);
 
-#define  CWRAP_EXTEND                 0x01
-#define  CWRAP_SMART_POINTER          0x02
-#define  CWRAP_NATURAL_VAR            0x04
-#define  CWRAP_DIRECTOR_ONE_CALL      0x08
-#define  CWRAP_DIRECTOR_TWO_CALLS     0x10
-#define  CWRAP_ALL_PROTECTED_ACCESS   0x20
-#define  CWRAP_SMART_POINTER_OVERLOAD 0x40
+#define CWRAP_EXTEND                 0x01
+#define CWRAP_SMART_POINTER          0x02
+#define CWRAP_NATURAL_VAR            0x04
+#define CWRAP_DIRECTOR_ONE_CALL      0x08
+#define CWRAP_DIRECTOR_TWO_CALLS     0x10
+#define CWRAP_ALL_PROTECTED_ACCESS   0x20
+#define CWRAP_SMART_POINTER_OVERLOAD 0x40
 
 /* --- Director Helpers --- */
-  extern Node *Swig_methodclass(Node *n);
-  extern int Swig_directorclass(Node *n);
-  extern Node *Swig_directormap(Node *n, String *type);
+extern Node *Swig_methodclass(Node *n);
+extern int Swig_directorclass(Node *n);
+extern Node *Swig_directormap(Node *n, String *type);
 
 /* --- Legacy Typemap API (somewhat simplified, ha!) --- */
 
-  extern void Swig_typemap_init(void);
-  extern void Swig_typemap_register(const_String_or_char_ptr tmap_method, ParmList *pattern, const_String_or_char_ptr code, ParmList *locals, ParmList *kwargs);
-  extern int Swig_typemap_copy(const_String_or_char_ptr tmap_method, ParmList *srcpattern, ParmList *pattern);
-  extern void Swig_typemap_clear(const_String_or_char_ptr tmap_method, ParmList *pattern);
-  extern int Swig_typemap_apply(ParmList *srcpat, ParmList *destpat);
-  extern void Swig_typemap_clear_apply(ParmList *pattern);
-  extern void Swig_typemap_replace_embedded_typemap(String *s, Node *file_line_node);
-  extern void Swig_typemap_debug(void);
-  extern void Swig_typemap_search_debug_set(void);
-  extern void Swig_typemap_used_debug_set(void);
-  extern void Swig_typemap_register_debug_set(void);
+extern void Swig_typemap_init(void);
+extern void Swig_typemap_register(const_String_or_char_ptr tmap_method, ParmList *pattern, const_String_or_char_ptr code, ParmList *locals, ParmList *kwargs);
+extern int Swig_typemap_copy(const_String_or_char_ptr tmap_method, ParmList *srcpattern, ParmList *pattern);
+extern void Swig_typemap_clear(const_String_or_char_ptr tmap_method, ParmList *pattern);
+extern int Swig_typemap_apply(ParmList *srcpat, ParmList *destpat);
+extern void Swig_typemap_clear_apply(ParmList *pattern);
+extern void Swig_typemap_replace_embedded_typemap(String *s, Node *file_line_node);
+extern void Swig_typemap_debug(void);
+extern void Swig_typemap_search_debug_set(void);
+extern void Swig_typemap_used_debug_set(void);
+extern void Swig_typemap_register_debug_set(void);
 
-  extern String *Swig_typemap_lookup(const_String_or_char_ptr tmap_method, Node *n, const_String_or_char_ptr lname, Wrapper *f);
-  extern String *Swig_typemap_lookup_out(const_String_or_char_ptr tmap_method, Node *n, const_String_or_char_ptr lname, Wrapper *f, String *actioncode);
+extern String *Swig_typemap_lookup(const_String_or_char_ptr tmap_method, Node *n, const_String_or_char_ptr lname, Wrapper *f);
+extern String *Swig_typemap_lookup_out(const_String_or_char_ptr tmap_method, Node *n, const_String_or_char_ptr lname, Wrapper *f, String *actioncode);
 
-  extern void Swig_typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList *parms, Wrapper *f);
+extern void Swig_typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList *parms, Wrapper *f);
 
 /* --- Code fragment support --- */
 
-  extern void Swig_fragment_register(Node *fragment);
-  extern void Swig_fragment_emit(String *name);
-  extern void Swig_fragment_clear(String *section);
+extern void Swig_fragment_register(Node *fragment);
+extern void Swig_fragment_emit(String *name);
+extern void Swig_fragment_clear(String *section);
 
 /* --- Extension support --- */
 
-  extern Hash *Swig_extend_hash(void);
-  extern void Swig_extend_merge(Node *cls, Node *am);
-  extern void Swig_extend_append_previous(Node *cls, Node *am);
-  extern void Swig_extend_unused_check(void);
+extern Hash *Swig_extend_hash(void);
+extern void Swig_extend_merge(Node *cls, Node *am);
+extern void Swig_extend_append_previous(Node *cls, Node *am);
+extern void Swig_extend_unused_check(void);
 
 /* hacks defined in C++ ! */
-  extern int Swig_director_mode(void);
-  extern int Swig_director_protected_mode(void);
-  extern int Swig_all_protected_mode(void);
-  extern void Wrapper_director_mode_set(int);
-  extern void Wrapper_director_protected_mode_set(int);
-  extern void Wrapper_all_protected_mode_set(int);
-  extern void Language_replace_special_variables(String *method, String *tm, Parm *parm);
-  extern void Swig_print(DOH *object, int count);
-  extern void Swig_print_with_location(DOH *object, int count);
+extern int Swig_director_mode(void);
+extern int Swig_director_protected_mode(void);
+extern int Swig_all_protected_mode(void);
+extern void Wrapper_director_mode_set(int);
+extern void Wrapper_director_protected_mode_set(int);
+extern void Wrapper_all_protected_mode_set(int);
+extern void Language_replace_special_variables(String *method, String *tm, Parm *parm);
+extern void Swig_print(DOH *object, int count);
+extern void Swig_print_with_location(DOH *object, int count);
 
 /* -- template init -- */
-  extern void SwigType_template_init(void);
-
+extern void SwigType_template_init(void);
 
 #ifdef __cplusplus
 }

--- a/Source/Swig/swigfile.h
+++ b/Source/Swig/swigfile.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -18,7 +18,7 @@ extern String *Swig_last_file(void);
 extern List   *Swig_search_path(void);
 extern FILE   *Swig_include_open(const_String_or_char_ptr name);
 extern FILE   *Swig_open(const_String_or_char_ptr name);
-extern String *Swig_read_file(FILE *f); 
+extern String *Swig_read_file(FILE *f);
 extern String *Swig_include(const_String_or_char_ptr name);
 extern String *Swig_include_sys(const_String_or_char_ptr name);
 extern int     Swig_insert_file(const_String_or_char_ptr name, File *outfile);

--- a/Source/Swig/swigfile.h
+++ b/Source/Swig/swigfile.h
@@ -11,31 +11,31 @@
  * File handling functions in the SWIG core
  * ----------------------------------------------------------------------------- */
 
-extern List   *Swig_add_directory(const_String_or_char_ptr dirname);
-extern void    Swig_push_directory(const_String_or_char_ptr dirname);
-extern void    Swig_pop_directory(void);
+extern List *Swig_add_directory(const_String_or_char_ptr dirname);
+extern void Swig_push_directory(const_String_or_char_ptr dirname);
+extern void Swig_pop_directory(void);
 extern String *Swig_last_file(void);
-extern List   *Swig_search_path(void);
-extern FILE   *Swig_include_open(const_String_or_char_ptr name);
-extern FILE   *Swig_open(const_String_or_char_ptr name);
+extern List *Swig_search_path(void);
+extern FILE *Swig_include_open(const_String_or_char_ptr name);
+extern FILE *Swig_open(const_String_or_char_ptr name);
 extern String *Swig_read_file(FILE *f);
 extern String *Swig_include(const_String_or_char_ptr name);
 extern String *Swig_include_sys(const_String_or_char_ptr name);
-extern int     Swig_insert_file(const_String_or_char_ptr name, File *outfile);
-extern void    Swig_set_push_dir(int dopush);
-extern int     Swig_get_push_dir(void);
-extern void    Swig_register_filebyname(const_String_or_char_ptr filename, File *outfile);
-extern File   *Swig_filebyname(const_String_or_char_ptr filename);
+extern int Swig_insert_file(const_String_or_char_ptr name, File *outfile);
+extern void Swig_set_push_dir(int dopush);
+extern int Swig_get_push_dir(void);
+extern void Swig_register_filebyname(const_String_or_char_ptr filename, File *outfile);
+extern File *Swig_filebyname(const_String_or_char_ptr filename);
 extern String *Swig_file_extension(const_String_or_char_ptr filename);
 extern String *Swig_file_basename(const_String_or_char_ptr filename);
 extern String *Swig_file_filename(const_String_or_char_ptr filename);
 extern String *Swig_file_dirname(const_String_or_char_ptr filename);
-extern void   Swig_file_debug_set(void);
+extern void Swig_file_debug_set(void);
 
 /* Delimiter used in accessing files and directories */
 
 #if defined(_WIN32)
-#  define SWIG_FILE_DELIMITER "\\"
+#define SWIG_FILE_DELIMITER "\\"
 #else
-#  define SWIG_FILE_DELIMITER "/"
+#define SWIG_FILE_DELIMITER "/"
 #endif

--- a/Source/Swig/swigopt.h
+++ b/Source/Swig/swigopt.h
@@ -11,8 +11,8 @@
  * Header file for the SWIG command line processing functions
  * ----------------------------------------------------------------------------- */
 
- extern void  Swig_init_args(int argc, char **argv);
- extern void  Swig_mark_arg(int n);
- extern int   Swig_check_marked(int n);
- extern void  Swig_check_options(int check_input);
- extern void  Swig_arg_error(void);
+extern void Swig_init_args(int argc, char **argv);
+extern void Swig_mark_arg(int n);
+extern int Swig_check_marked(int n);
+extern void Swig_check_options(int check_input);
+extern void Swig_arg_error(void);

--- a/Source/Swig/swigopt.h
+++ b/Source/Swig/swigopt.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Swig/swigparm.h
+++ b/Source/Swig/swigparm.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -9,7 +9,7 @@
  * swigparm.h
  *
  * Functions related to the handling of function/method parameters and
- * parameter lists.  
+ * parameter lists.
  * ----------------------------------------------------------------------------- */
 
 /* Individual parameters */

--- a/Source/Swig/swigparm.h
+++ b/Source/Swig/swigparm.h
@@ -13,28 +13,26 @@
  * ----------------------------------------------------------------------------- */
 
 /* Individual parameters */
-extern Parm      *NewParm(SwigType *type, const_String_or_char_ptr name, Node *from_node);
-extern Parm      *NewParmWithoutFileLineInfo(SwigType *type, const_String_or_char_ptr name);
-extern Parm      *NewParmNode(SwigType *type, Node *from_node);
-extern Parm      *CopyParm(Parm *p);
+extern Parm *NewParm(SwigType *type, const_String_or_char_ptr name, Node *from_node);
+extern Parm *NewParmWithoutFileLineInfo(SwigType *type, const_String_or_char_ptr name);
+extern Parm *NewParmNode(SwigType *type, Node *from_node);
+extern Parm *CopyParm(Parm *p);
 
 /* Parameter lists */
-extern ParmList  *CopyParmList(ParmList *p);
-extern ParmList  *CopyParmListMax(ParmList *p, int count);
-extern ParmList  *ParmList_join(ParmList *p, ParmList *p2);
-extern ParmList  *ParmList_replace_last(ParmList *p, ParmList *p2);
-extern Parm      *ParmList_nth_parm(ParmList *p, unsigned int n);
-extern Parm      *ParmList_variadic_parm(ParmList *p);
-extern Parm      *ParmList_add_parm(ParmList *p, Parm *newparm);
-extern int        ParmList_numrequired(ParmList *);
-extern int        ParmList_len(ParmList *);
-extern int        ParmList_has_defaultargs(ParmList *p);
-extern int        ParmList_has_varargs(ParmList *p);
+extern ParmList *CopyParmList(ParmList *p);
+extern ParmList *CopyParmListMax(ParmList *p, int count);
+extern ParmList *ParmList_join(ParmList *p, ParmList *p2);
+extern ParmList *ParmList_replace_last(ParmList *p, ParmList *p2);
+extern Parm *ParmList_nth_parm(ParmList *p, unsigned int n);
+extern Parm *ParmList_variadic_parm(ParmList *p);
+extern Parm *ParmList_add_parm(ParmList *p, Parm *newparm);
+extern int ParmList_numrequired(ParmList *);
+extern int ParmList_len(ParmList *);
+extern int ParmList_has_defaultargs(ParmList *p);
+extern int ParmList_has_varargs(ParmList *p);
 
 /* Output functions */
-extern String    *ParmList_str(ParmList *);
-extern String    *ParmList_str_defaultargs(ParmList *);
-extern String    *ParmList_str_multibrackets(ParmList *);
-extern String    *ParmList_protostr(ParmList *);
-
-
+extern String *ParmList_str(ParmList *);
+extern String *ParmList_str_defaultargs(ParmList *);
+extern String *ParmList_str_multibrackets(ParmList *);
+extern String *ParmList_protostr(ParmList *);

--- a/Source/Swig/swigscan.h
+++ b/Source/Swig/swigscan.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -8,7 +8,7 @@
  *
  * swigscan.h
  *
- * C/C++ scanner. 
+ * C/C++ scanner.
  * ----------------------------------------------------------------------------- */
 
 typedef struct Scanner Scanner;

--- a/Source/Swig/swigscan.h
+++ b/Source/Swig/swigscan.h
@@ -13,104 +13,104 @@
 
 typedef struct Scanner Scanner;
 
-extern Scanner     *NewScanner(void);
-extern void         DelScanner(Scanner *);
-extern void         Scanner_clear(Scanner *);
-extern void         Scanner_push(Scanner *, String *);
-extern void         Scanner_pushtoken(Scanner *, int, const_String_or_char_ptr value);
-extern int          Scanner_token(Scanner *);
-extern String      *Scanner_text(Scanner *);
-extern void         Scanner_skip_line(Scanner *);
-extern int          Scanner_skip_balanced(Scanner *, int startchar, int endchar);
-extern String      *Scanner_get_raw_text_balanced(Scanner *, int startchar, int endchar);
-extern void         Scanner_set_location(Scanner *, String *file, int line);
-extern String      *Scanner_file(Scanner *);
-extern int          Scanner_line(Scanner *);
-extern int          Scanner_start_line(Scanner *);
-extern void         Scanner_idstart(Scanner *, const char *idchar);
-extern String      *Scanner_errmsg(Scanner *);
-extern int          Scanner_errline(Scanner *);
-extern int          Scanner_isoperator(int tokval);
-extern void         Scanner_locator(Scanner *, String *loc);
+extern Scanner *NewScanner(void);
+extern void DelScanner(Scanner *);
+extern void Scanner_clear(Scanner *);
+extern void Scanner_push(Scanner *, String *);
+extern void Scanner_pushtoken(Scanner *, int, const_String_or_char_ptr value);
+extern int Scanner_token(Scanner *);
+extern String *Scanner_text(Scanner *);
+extern void Scanner_skip_line(Scanner *);
+extern int Scanner_skip_balanced(Scanner *, int startchar, int endchar);
+extern String *Scanner_get_raw_text_balanced(Scanner *, int startchar, int endchar);
+extern void Scanner_set_location(Scanner *, String *file, int line);
+extern String *Scanner_file(Scanner *);
+extern int Scanner_line(Scanner *);
+extern int Scanner_start_line(Scanner *);
+extern void Scanner_idstart(Scanner *, const char *idchar);
+extern String *Scanner_errmsg(Scanner *);
+extern int Scanner_errline(Scanner *);
+extern int Scanner_isoperator(int tokval);
+extern void Scanner_locator(Scanner *, String *loc);
 
 /* Note: Tokens in range 100+ are for C/C++ operators */
 
-#define   SWIG_MAXTOKENS          200
-#define   SWIG_TOKEN_LPAREN       1        /* ( */
-#define   SWIG_TOKEN_RPAREN       2        /* ) */
-#define   SWIG_TOKEN_SEMI         3        /* ; */
-#define   SWIG_TOKEN_LBRACE       4        /* { */
-#define   SWIG_TOKEN_RBRACE       5        /* } */
-#define   SWIG_TOKEN_LBRACKET     6        /* [ */
-#define   SWIG_TOKEN_RBRACKET     7        /* ] */
-#define   SWIG_TOKEN_BACKSLASH    8        /* \ */
-#define   SWIG_TOKEN_ENDLINE      9        /* \n */
-#define   SWIG_TOKEN_STRING       10       /* "str" */
-#define   SWIG_TOKEN_POUND        11       /* # */
-#define   SWIG_TOKEN_COLON        12       /* : */
-#define   SWIG_TOKEN_DCOLON       13       /* :: */
-#define   SWIG_TOKEN_DCOLONSTAR   14       /* ::* */
-#define   SWIG_TOKEN_ID           15       /* identifier */
-#define   SWIG_TOKEN_FLOAT        16       /* 3.1415F */
-#define   SWIG_TOKEN_DOUBLE       17       /* 3.1415 */
-#define   SWIG_TOKEN_LONGDOUBLE   18       /* 3.1415L */
-#define   SWIG_TOKEN_INT          19       /* 314 */
-#define   SWIG_TOKEN_UINT         20       /* 314U */
-#define   SWIG_TOKEN_LONG         21       /* 314L */
-#define   SWIG_TOKEN_ULONG        22       /* 314UL */
-#define   SWIG_TOKEN_CHAR         23       /* 'charconst' */
-#define   SWIG_TOKEN_PERIOD       24       /* . */
-#define   SWIG_TOKEN_AT           25       /* @ */
-#define   SWIG_TOKEN_DOLLAR       26       /* $ */
-#define   SWIG_TOKEN_CODEBLOCK    27       /* %{ ... %} ... */
-#define   SWIG_TOKEN_LONGLONG     29       /* 314LL */
-#define   SWIG_TOKEN_ULONGLONG    30       /* 314ULL */
-#define   SWIG_TOKEN_QUESTION     31       /* ? */
-#define   SWIG_TOKEN_COMMENT      32       /* C or C++ comment */
-#define   SWIG_TOKEN_BOOL         33       /* true or false */
-#define   SWIG_TOKEN_WSTRING      34       /* L"str" */
-#define   SWIG_TOKEN_WCHAR        35       /* L'c' */
-#define   SWIG_TOKEN_ELLIPSIS     36       /* ... */
-#define   SWIG_TOKEN_LLBRACKET    37       /* [[ */
-#define   SWIG_TOKEN_RRBRACKET    38       /* ]] */
+#define SWIG_MAXTOKENS         200
+#define SWIG_TOKEN_LPAREN      1  /* ( */
+#define SWIG_TOKEN_RPAREN      2  /* ) */
+#define SWIG_TOKEN_SEMI        3  /* ; */
+#define SWIG_TOKEN_LBRACE      4  /* { */
+#define SWIG_TOKEN_RBRACE      5  /* } */
+#define SWIG_TOKEN_LBRACKET    6  /* [ */
+#define SWIG_TOKEN_RBRACKET    7  /* ] */
+#define SWIG_TOKEN_BACKSLASH   8  /* \ */
+#define SWIG_TOKEN_ENDLINE     9  /* \n */
+#define SWIG_TOKEN_STRING      10 /* "str" */
+#define SWIG_TOKEN_POUND       11 /* # */
+#define SWIG_TOKEN_COLON       12 /* : */
+#define SWIG_TOKEN_DCOLON      13 /* :: */
+#define SWIG_TOKEN_DCOLONSTAR  14 /* ::* */
+#define SWIG_TOKEN_ID          15 /* identifier */
+#define SWIG_TOKEN_FLOAT       16 /* 3.1415F */
+#define SWIG_TOKEN_DOUBLE      17 /* 3.1415 */
+#define SWIG_TOKEN_LONGDOUBLE  18 /* 3.1415L */
+#define SWIG_TOKEN_INT         19 /* 314 */
+#define SWIG_TOKEN_UINT        20 /* 314U */
+#define SWIG_TOKEN_LONG        21 /* 314L */
+#define SWIG_TOKEN_ULONG       22 /* 314UL */
+#define SWIG_TOKEN_CHAR        23 /* 'charconst' */
+#define SWIG_TOKEN_PERIOD      24 /* . */
+#define SWIG_TOKEN_AT          25 /* @ */
+#define SWIG_TOKEN_DOLLAR      26 /* $ */
+#define SWIG_TOKEN_CODEBLOCK   27 /* %{ ... %} ... */
+#define SWIG_TOKEN_LONGLONG    29 /* 314LL */
+#define SWIG_TOKEN_ULONGLONG   30 /* 314ULL */
+#define SWIG_TOKEN_QUESTION    31 /* ? */
+#define SWIG_TOKEN_COMMENT     32 /* C or C++ comment */
+#define SWIG_TOKEN_BOOL        33 /* true or false */
+#define SWIG_TOKEN_WSTRING     34 /* L"str" */
+#define SWIG_TOKEN_WCHAR       35 /* L'c' */
+#define SWIG_TOKEN_ELLIPSIS    36 /* ... */
+#define SWIG_TOKEN_LLBRACKET   37 /* [[ */
+#define SWIG_TOKEN_RRBRACKET   38 /* ]] */
 
-#define   SWIG_TOKEN_ILLEGAL      99
-#define   SWIG_TOKEN_ERROR        -1
+#define SWIG_TOKEN_ILLEGAL     99
+#define SWIG_TOKEN_ERROR       -1
 
-#define   SWIG_TOKEN_COMMA        101      /* , */
-#define   SWIG_TOKEN_STAR         102      /* * */
-#define   SWIG_TOKEN_EQUAL        103      /* = */
-#define   SWIG_TOKEN_EQUALTO      104      /* == */
-#define   SWIG_TOKEN_NOTEQUAL     105      /* != */
-#define   SWIG_TOKEN_PLUS         106      /* + */
-#define   SWIG_TOKEN_MINUS        107      /* - */
-#define   SWIG_TOKEN_AND          108      /* & */
-#define   SWIG_TOKEN_LAND         109      /* && */
-#define   SWIG_TOKEN_OR           110      /* | */
-#define   SWIG_TOKEN_LOR          111      /* || */
-#define   SWIG_TOKEN_XOR          112      /* ^ */
-#define   SWIG_TOKEN_LESSTHAN     113      /* < */
-#define   SWIG_TOKEN_GREATERTHAN  114      /* > */
-#define   SWIG_TOKEN_LTEQUAL      115      /* <= */
-#define   SWIG_TOKEN_GTEQUAL      116      /* >= */
-#define   SWIG_TOKEN_NOT          117      /* ~ */
-#define   SWIG_TOKEN_LNOT         118      /* ! */
-#define   SWIG_TOKEN_SLASH        119      /* / */
-#define   SWIG_TOKEN_PERCENT      120      /* % */
-#define   SWIG_TOKEN_LSHIFT       121      /* << */
-#define   SWIG_TOKEN_RSHIFT       122      /* >> */
-#define   SWIG_TOKEN_PLUSPLUS     123      /* ++ */
-#define   SWIG_TOKEN_MINUSMINUS   124      /* -- */
-#define   SWIG_TOKEN_PLUSEQUAL    125      /* += */
-#define   SWIG_TOKEN_MINUSEQUAL   126      /* -= */
-#define   SWIG_TOKEN_TIMESEQUAL   127      /* *= */
-#define   SWIG_TOKEN_DIVEQUAL     128      /* /= */
-#define   SWIG_TOKEN_ANDEQUAL     129      /* &= */
-#define   SWIG_TOKEN_OREQUAL      130      /* |= */
-#define   SWIG_TOKEN_XOREQUAL     131      /* ^= */
-#define   SWIG_TOKEN_LSEQUAL      132      /* <<= */
-#define   SWIG_TOKEN_RSEQUAL      133      /* >>= */
-#define   SWIG_TOKEN_MODEQUAL     134      /* %= */
-#define   SWIG_TOKEN_ARROW        135      /* -> */
-#define   SWIG_TOKEN_ARROWSTAR    136      /* ->* */
-#define   SWIG_TOKEN_LTEQUALGT    137      /* <=> */
+#define SWIG_TOKEN_COMMA       101 /* , */
+#define SWIG_TOKEN_STAR        102 /* * */
+#define SWIG_TOKEN_EQUAL       103 /* = */
+#define SWIG_TOKEN_EQUALTO     104 /* == */
+#define SWIG_TOKEN_NOTEQUAL    105 /* != */
+#define SWIG_TOKEN_PLUS        106 /* + */
+#define SWIG_TOKEN_MINUS       107 /* - */
+#define SWIG_TOKEN_AND         108 /* & */
+#define SWIG_TOKEN_LAND        109 /* && */
+#define SWIG_TOKEN_OR          110 /* | */
+#define SWIG_TOKEN_LOR         111 /* || */
+#define SWIG_TOKEN_XOR         112 /* ^ */
+#define SWIG_TOKEN_LESSTHAN    113 /* < */
+#define SWIG_TOKEN_GREATERTHAN 114 /* > */
+#define SWIG_TOKEN_LTEQUAL     115 /* <= */
+#define SWIG_TOKEN_GTEQUAL     116 /* >= */
+#define SWIG_TOKEN_NOT         117 /* ~ */
+#define SWIG_TOKEN_LNOT        118 /* ! */
+#define SWIG_TOKEN_SLASH       119 /* / */
+#define SWIG_TOKEN_PERCENT     120 /* % */
+#define SWIG_TOKEN_LSHIFT      121 /* << */
+#define SWIG_TOKEN_RSHIFT      122 /* >> */
+#define SWIG_TOKEN_PLUSPLUS    123 /* ++ */
+#define SWIG_TOKEN_MINUSMINUS  124 /* -- */
+#define SWIG_TOKEN_PLUSEQUAL   125 /* += */
+#define SWIG_TOKEN_MINUSEQUAL  126 /* -= */
+#define SWIG_TOKEN_TIMESEQUAL  127 /* *= */
+#define SWIG_TOKEN_DIVEQUAL    128 /* /= */
+#define SWIG_TOKEN_ANDEQUAL    129 /* &= */
+#define SWIG_TOKEN_OREQUAL     130 /* |= */
+#define SWIG_TOKEN_XOREQUAL    131 /* ^= */
+#define SWIG_TOKEN_LSEQUAL     132 /* <<= */
+#define SWIG_TOKEN_RSEQUAL     133 /* >>= */
+#define SWIG_TOKEN_MODEQUAL    134 /* %= */
+#define SWIG_TOKEN_ARROW       135 /* -> */
+#define SWIG_TOKEN_ARROWSTAR   136 /* ->* */
+#define SWIG_TOKEN_LTEQUALGT   137 /* <=> */

--- a/Source/Swig/swigtree.h
+++ b/Source/Swig/swigtree.h
@@ -15,36 +15,36 @@
 
 /* Macros to traverse the DOM tree */
 
-#define  nodeType(x)               Getattr(x,"nodeType")
-#define  parentNode(x)             Getattr(x,"parentNode")
-#define  previousSibling(x)        Getattr(x,"previousSibling")
-#define  nextSibling(x)            Getattr(x,"nextSibling")
-#define  firstChild(x)             Getattr(x,"firstChild")
-#define  lastChild(x)              Getattr(x,"lastChild")
+#define nodeType(x)               Getattr(x, "nodeType")
+#define parentNode(x)             Getattr(x, "parentNode")
+#define previousSibling(x)        Getattr(x, "previousSibling")
+#define nextSibling(x)            Getattr(x, "nextSibling")
+#define firstChild(x)             Getattr(x, "firstChild")
+#define lastChild(x)              Getattr(x, "lastChild")
 
 /* Macros to set up the DOM tree (mostly used by the parser) */
 
-#define  set_nodeType(x,v)         Setattr(x,"nodeType",v)
-#define  set_parentNode(x,v)       Setattr(x,"parentNode",v)
-#define  set_previousSibling(x,v)  Setattr(x,"previousSibling",v)
-#define  set_nextSibling(x,v)      Setattr(x,"nextSibling",v)
-#define  set_firstChild(x,v)       Setattr(x,"firstChild",v)
-#define  set_lastChild(x,v)        Setattr(x,"lastChild",v)
+#define set_nodeType(x, v)        Setattr(x, "nodeType", v)
+#define set_parentNode(x, v)      Setattr(x, "parentNode", v)
+#define set_previousSibling(x, v) Setattr(x, "previousSibling", v)
+#define set_nextSibling(x, v)     Setattr(x, "nextSibling", v)
+#define set_firstChild(x, v)      Setattr(x, "firstChild", v)
+#define set_lastChild(x, v)       Setattr(x, "lastChild", v)
 
 /* Utility functions */
 
-extern int    checkAttribute(Node *obj, const_String_or_char_ptr name, const_String_or_char_ptr value);
-extern void   appendChild(Node *node, Node *child);
-extern void   prependChild(Node *node, Node *child);
-extern void   removeNode(Node *node);
-extern Node  *copyNode(Node *node);
-extern void   appendSibling(Node *node, Node *child);
+extern int checkAttribute(Node *obj, const_String_or_char_ptr name, const_String_or_char_ptr value);
+extern void appendChild(Node *node, Node *child);
+extern void prependChild(Node *node, Node *child);
+extern void removeNode(Node *node);
+extern Node *copyNode(Node *node);
+extern void appendSibling(Node *node, Node *child);
 
 /* Node restoration/restore functions */
 
-extern void  Swig_require(const char *ns, Node *node, ...);
-extern void  Swig_save(const char *ns, Node *node, ...);
-extern void  Swig_restore(Node *node);
+extern void Swig_require(const char *ns, Node *node, ...);
+extern void Swig_save(const char *ns, Node *node, ...);
+extern void Swig_restore(Node *node);
 
 /* Debugging of parse trees */
 

--- a/Source/Swig/swigtree.h
+++ b/Source/Swig/swigtree.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -9,7 +9,7 @@
  * swigtree.h
  *
  * These functions are used to access and manipulate the SWIG parse tree.
- * The structure of this tree is modeled directly after XML-DOM.  The attribute 
+ * The structure of this tree is modeled directly after XML-DOM.  The attribute
  * and function names are meant to be similar.
  * ----------------------------------------------------------------------------- */
 

--- a/Source/Swig/swigwrap.h
+++ b/Source/Swig/swigwrap.h
@@ -12,20 +12,20 @@
  * ----------------------------------------------------------------------------- */
 
 typedef struct Wrapper {
-    Hash *localh;
-    String *def;
-    String *locals;
-    String *code;
+  Hash *localh;
+  String *def;
+  String *locals;
+  String *code;
 } Wrapper;
 
 extern Wrapper *NewWrapper(void);
-extern void     DelWrapper(Wrapper *w);
-extern void     Wrapper_compact_print_mode_set(int flag);
-extern void     Wrapper_pretty_print(String *str, File *f);
-extern void     Wrapper_compact_print(String *str, File *f);
-extern void     Wrapper_print(Wrapper *w, File *f);
-extern int      Wrapper_add_local(Wrapper *w, const_String_or_char_ptr name, const_String_or_char_ptr decl);
-extern int      Wrapper_add_localv(Wrapper *w, const_String_or_char_ptr name, ...);
-extern int      Wrapper_check_local(Wrapper *w, const_String_or_char_ptr name);
-extern char    *Wrapper_new_local(Wrapper *w, const_String_or_char_ptr name, const_String_or_char_ptr decl);
-extern char    *Wrapper_new_localv(Wrapper *w, const_String_or_char_ptr name, ...);
+extern void DelWrapper(Wrapper *w);
+extern void Wrapper_compact_print_mode_set(int flag);
+extern void Wrapper_pretty_print(String *str, File *f);
+extern void Wrapper_compact_print(String *str, File *f);
+extern void Wrapper_print(Wrapper *w, File *f);
+extern int Wrapper_add_local(Wrapper *w, const_String_or_char_ptr name, const_String_or_char_ptr decl);
+extern int Wrapper_add_localv(Wrapper *w, const_String_or_char_ptr name, ...);
+extern int Wrapper_check_local(Wrapper *w, const_String_or_char_ptr name);
+extern char *Wrapper_new_local(Wrapper *w, const_String_or_char_ptr name, const_String_or_char_ptr decl);
+extern char *Wrapper_new_localv(Wrapper *w, const_String_or_char_ptr name, ...);

--- a/Source/Swig/swigwrap.h
+++ b/Source/Swig/swigwrap.h
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -38,22 +38,22 @@
  *  typedef int *blah;             ---->    "name" : 'blah'
  *                                          "type" : 'int'
  *                                          "decl" : 'p.'
- *                                       "storage" : 'typedef'          
- * 
+ *                                       "storage" : 'typedef'
+ *
  * In some cases, the symbol table needs to manage overloaded entries.  For instance,
  * overloaded functions.  In this case, a linked list is built.  The "sym:nextSibling"
  * attribute is reserved to hold a link to the next entry.  For example:
  *
  * int foo(int);            --> "name" : "foo"         "name" : "foo"
- * int foo(int,double);         "type" : "int"         "type" : "int" 
+ * int foo(int,double);         "type" : "int"         "type" : "int"
  *                              "decl" : "f(int)."     "decl" : "f(int,double)."
  *                               ...                    ...
  *                   "sym:nextSibling" :  --------> "sym:nextSibling": --------> ...
  *
- * When more than one symbol has the same name, the symbol declarator is 
+ * When more than one symbol has the same name, the symbol declarator is
  * used to detect duplicates.  For example, in the above case, foo(int) and
  * foo(int,double) are different because their "decl" attribute is different.
- * However, if a third declaration "foo(int)" was made, it would generate a 
+ * However, if a third declaration "foo(int)" was made, it would generate a
  * conflict (due to having a declarator that matches a previous entry).
  *
  * Structures and classes:
@@ -68,26 +68,26 @@
  *             ...
  *        }
  *
- *        int Foo();       // Error. Name clash.  Works in C though 
- * 
+ *        int Foo();       // Error. Name clash.  Works in C though
+ *
  * Due to the unified namespace for structures, special handling is performed for
  * the following:
  *
  *        typedef struct Foo {
  *
  *        } Foo;
- * 
+ *
  * In this case, the symbol table contains an entry for the structure itself.  The
  * typedef is left out of the symbol table.
  *
  * Target language vs C:
  *
  * The symbol tables are normally managed *in the namespace of the target language*.
- * This means that name-collisions can be resolved using %rename and related 
+ * This means that name-collisions can be resolved using %rename and related
  * directives.   A quirk of this is that sometimes the symbol tables need to
  * be used for C type resolution as well.  To handle this, each symbol table
- * also has a C-symbol table lurking behind the scenes.  This is used to locate 
- * symbols in the C namespace.  However, this symbol table is not used for error 
+ * also has a C-symbol table lurking behind the scenes.  This is used to locate
+ * symbols in the C namespace.  However, this symbol table is not used for error
  * reporting nor is it used for anything else during code generation.
  *
  * Symbol table structure:
@@ -106,17 +106,17 @@
  *
  * When a symbol is placed in the symbol table, the following attributes
  * are set:
- *       
+ *
  *     sym:name             -- Symbol name
  *     sym:nextSibling      -- Next symbol (if overloaded)
  *     sym:previousSibling  -- Previous symbol (if overloaded)
  *     sym:symtab           -- Symbol table object holding the symbol
  *     sym:overloaded       -- Set to the first symbol if overloaded
  *
- * These names are modeled after XML namespaces.  In particular, every attribute 
- * pertaining to symbol table management is prefaced by the "sym:" prefix.   
+ * These names are modeled after XML namespaces.  In particular, every attribute
+ * pertaining to symbol table management is prefaced by the "sym:" prefix.
  *
- * An example dump of the parse tree showing symbol table entries for the 
+ * An example dump of the parse tree showing symbol table entries for the
  * following code should clarify this:
  *
  *   namespace OuterNamespace {
@@ -134,31 +134,31 @@
  *   | symtab       - 0xa064bf0
  *   | sym:symtab   - 0xa041690
  *   | sym:overname - "__SWIG_0"
- *  
+ *
  *         +++ namespace ----------------------------------------
  *         | sym:name     - "InnerNamespace"
  *         | symtab       - 0xa064cc0
  *         | sym:symtab   - 0xa064bf0
  *         | sym:overname - "__SWIG_0"
- *  
+ *
  *               +++ class ----------------------------------------
  *               | sym:name     - "Class"
  *               | symtab       - 0xa064d80
  *               | sym:symtab   - 0xa064cc0
  *               | sym:overname - "__SWIG_0"
- *               | 
+ *               |
  *               +++ class ----------------------------------------
  *               | sym:name     - "Struct"
  *               | symtab       - 0xa064f00
  *               | sym:symtab   - 0xa064cc0
  *               | sym:overname - "__SWIG_0"
- *  
+ *
  *                     +++ cdecl ----------------------------------------
  *                     | sym:name     - "Var"
  *                     | sym:symtab   - 0xa064f00
  *                     | sym:overname - "__SWIG_0"
- *                     | 
- *  
+ *                     |
+ *
  *
  * Each class and namespace has its own scope and thus a new symbol table (sym)
  * is created. The sym attribute is only set for the first entry in the symbol
@@ -197,7 +197,7 @@ void Swig_symbol_print_tables(Symtab *symtab) {
 /* -----------------------------------------------------------------------------
  * Swig_symbol_print_tables_summary()
  *
- * Debug summary display of all symbol tables by fully-qualified name 
+ * Debug summary display of all symbol tables by fully-qualified name
  * ----------------------------------------------------------------------------- */
 
 void Swig_symbol_print_tables_summary(void) {
@@ -336,7 +336,7 @@ Symtab *Swig_symbol_getscope(const_String_or_char_ptr name) {
   return Getattr(symtabs, name);
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Swig_symbol_qualifiedscopename()
  *
  * Get the fully qualified C scopename of a symbol table.  Note, this only pertains
@@ -367,7 +367,7 @@ String *Swig_symbol_qualifiedscopename(Symtab *symtab) {
   return result;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Swig_symbol_qualified_language_scopename()
  *
  * Get the fully qualified C scopename of a symbol table but using a language
@@ -530,12 +530,12 @@ void Swig_symbol_inherit(Symtab *s) {
 void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
   Node *append = 0;
   Node *cn;
-  /* There are a few options for weak symbols.  A "weak" symbol 
+  /* There are a few options for weak symbols.  A "weak" symbol
      is any symbol that can be replaced by another symbol in the C symbol
      table.  An example would be a forward class declaration.  A forward
      class sits in the symbol table until a real class declaration comes along.
 
-     Certain symbols are marked as "sym:typename".  These are important 
+     Certain symbols are marked as "sym:typename".  These are important
      symbols related to the C++ type-system and take precedence in the C
      symbol table.  An example might be code like this:
 
@@ -701,7 +701,7 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
   }
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Swig_symbol_add()
  *
  * Adds a node to the symbol table.  Returns the node itself if successfully
@@ -727,12 +727,12 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
      when compiling the wrapper code */
 
 
-  /* There are a few options for weak symbols.  A "weak" symbol 
+  /* There are a few options for weak symbols.  A "weak" symbol
      is any symbol that can be replaced by another symbol in the C symbol
      table.  An example would be a forward class declaration.  A forward
      class sits in the symbol table until a real class declaration comes along.
 
-     Certain symbols are marked as "sym:typename".  These are important 
+     Certain symbols are marked as "sym:typename".  These are important
      symbols related to the C++ type-system and take precedence in the C
      symbol table.  An example might be code like this:
 
@@ -776,7 +776,7 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
     /* There is a symbol table conflict.  There are a few cases to consider here:
        (1) A conflict between a class/enum and a typedef declaration is okay.
        In this case, the symbol table entry is set to the class/enum declaration
-       itself, not the typedef.   
+       itself, not the typedef.
        (2) A conflict between namespaces is okay--namespaces are open
        (3) Otherwise, overloading is only allowed for functions
        (4) This special case is okay: a class template instantiated with same name as the template's name
@@ -1015,7 +1015,7 @@ void Swig_symbol_conflict_warn(Node *n, Node *c, const String *symname, int incl
  *
  * Internal function to handle fully qualified symbol table lookups.  This
  * works from the symbol table supplied in symtab and unwinds its way out
- * towards the global scope. 
+ * towards the global scope.
  *
  * This function operates in the C namespace, not the target namespace.
  *
@@ -1264,7 +1264,7 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
  * accepts a callback function that is invoked to determine a symbol match.
  * The purpose of this function is to support complicated algorithms that need
  * to examine multiple definitions of the same symbol that might appear in an
- * inheritance hierarchy. 
+ * inheritance hierarchy.
  * ----------------------------------------------------------------------------- */
 
 Node *Swig_symbol_clookup_check(const_String_or_char_ptr name, Symtab *n, Node *(*checkfunc) (Node *n)) {
@@ -1591,7 +1591,7 @@ String *Swig_symbol_qualified(Node *n) {
 
 /* -----------------------------------------------------------------------------
  * Swig_symbol_isoverloaded()
- * 
+ *
  * Check if a symbol is overloaded.  Returns the first symbol if so.
  * ----------------------------------------------------------------------------- */
 
@@ -1775,7 +1775,7 @@ SwigType *Swig_symbol_type_qualify(const SwigType *t, Symtab *st) {
  *   typedef int Int;
  *   typedef Int Integer;
  * with input:
- *   Foo<(Int,Integer)> 
+ *   Foo<(Int,Integer)>
  * returns:
  *   Foo<(int,int)>
  * ----------------------------------------------------------------------------- */
@@ -1970,7 +1970,7 @@ String *Swig_symbol_string_qualify(String *s, Symtab *st) {
 /* -----------------------------------------------------------------------------
  * Swig_symbol_template_defargs()
  *
- * Apply default arg from generic template default args 
+ * Apply default arg from generic template default args
  * Returns a parameter list which contains missing default arguments (if any)
  * Note side effects: parms will also contain the extra parameters in its list
  * (but only if non-zero).

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -222,22 +222,22 @@ static void symbol_print_symbols(const char *symboltabletype, const char *nextSi
       Symtab *symtab = Getattr(Getattr(table, k), symboltabletype);
       Iterator it = First(symtab);
       while (it.key) {
-	String *symname = it.key;
-	Printf(stdout, "  %s (%s)", symname, nodeType(it.item));
+        String *symname = it.key;
+        Printf(stdout, "  %s (%s)", symname, nodeType(it.item));
         if (show_pointers)
-	  Printf(stdout, " %p", it.item);
-	Printf(stdout, "\n");
-	{
-	  Node *sibling = Getattr(it.item, nextSibling);
-	  while (sibling) {
-	    Printf(stdout, "  %s (%s)", symname, nodeType(sibling));
-	    if (show_pointers)
-	      Printf(stdout, " %p", sibling);
-	    Printf(stdout, "\n");
-	    sibling = Getattr(sibling, nextSibling);
-	  }
-	}
-	it = Next(it);
+          Printf(stdout, " %p", it.item);
+        Printf(stdout, "\n");
+        {
+          Node *sibling = Getattr(it.item, nextSibling);
+          while (sibling) {
+            Printf(stdout, "  %s (%s)", symname, nodeType(sibling));
+            if (show_pointers)
+              Printf(stdout, " %p", sibling);
+            Printf(stdout, "\n");
+            sibling = Getattr(sibling, nextSibling);
+          }
+        }
+        it = Next(it);
       }
     }
     ki = Next(ki);
@@ -576,7 +576,7 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
   } else if (cn && (Getattr(cn, "sym:weak"))) {
     /* The node in the symbol table is weak. Replace it */
     if (checkAttribute(cn, "nodeType", "template")
-	&& checkAttribute(cn, "templatetype", "classforward")) {
+        && checkAttribute(cn, "templatetype", "classforward")) {
       /* The node is a template classforward declaration, and the
          default template parameters here take precedence. */
       ParmList *pc = Getattr(cn, "templateparms");
@@ -585,15 +585,15 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
       Printf(stderr, "found template classforward %s\n", Getattr(cn, "name"));
 #endif
       while (pc && pn) {
-	String *value = Getattr(pc, "value");
-	if (value) {
+        String *value = Getattr(pc, "value");
+        if (value) {
 #ifdef SWIG_DEBUG
-	  Printf(stderr, "add default template value %s %s\n", Getattr(pc, "name"), value);
+          Printf(stderr, "add default template value %s %s\n", Getattr(pc, "name"), value);
 #endif
-	  Setattr(pn, "value", value);
-	}
-	pc = nextSibling(pc);
-	pn = nextSibling(pn);
+          Setattr(pn, "value", value);
+        }
+        pc = nextSibling(pc);
+        pn = nextSibling(pn);
       }
       Setattr(n, "templateparms", Getattr(cn, "templateparms"));
     }
@@ -624,8 +624,8 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
     while (fn) {
       pn = fn;
       if (fn == append) {
-	/* already added. Bail */
-	return;
+        /* already added. Bail */
+        return;
       }
       fn = Getattr(fn, "csym:nextSibling");
     }
@@ -673,29 +673,29 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
 
        */
       if (td1) {
-	String *st = 0;
-	String *sn = Getattr(td, "name");
-	if (Equal(nodeType(td1), "cdecl") && Checkattr(td1, "storage", "typedef"))
-	  st = Getattr(td1, "type");
-	else if (Equal(nodeType(td1), "using") && !Getattr(td1, "namespace"))
-	  st = Getattr(td1, "uname");
-	if (st && sn && Equal(st, sn)) {
-	  Symtab *sc = Getattr(current_symtab, "parentNode");
-	  if (sc)
-	    td1 = Swig_symbol_clookup(type, sc);
-	}
+        String *st = 0;
+        String *sn = Getattr(td, "name");
+        if (Equal(nodeType(td1), "cdecl") && Checkattr(td1, "storage", "typedef"))
+          st = Getattr(td1, "type");
+        else if (Equal(nodeType(td1), "using") && !Getattr(td1, "namespace"))
+          st = Getattr(td1, "uname");
+        if (st && sn && Equal(st, sn)) {
+          Symtab *sc = Getattr(current_symtab, "parentNode");
+          if (sc)
+            td1 = Swig_symbol_clookup(type, sc);
+        }
       }
 
       Delete(type);
       if (td1 == td)
-	break;
+        break;
       td = td1;
       if (td) {
-	Symtab *st = Getattr(td, "symtab");
-	if (st) {
-	  Swig_symbol_alias(Getattr(n, "name"), st);
-	  break;
-	}
+        Symtab *st = Getattr(td, "symtab");
+        if (st) {
+          Swig_symbol_alias(Getattr(n, "name"), st);
+          break;
+        }
       }
     }
   }
@@ -788,8 +788,8 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
       Node *cl, *pcl = 0;
       cl = c;
       while (cl) {
-	pcl = cl;
-	cl = Getattr(cl, "sym:nextSibling");
+        pcl = cl;
+        cl = Getattr(cl, "sym:nextSibling");
       }
       Setattr(pcl, "sym:nextSibling", n);
       Setattr(n, "sym:symtab", current_symtab);
@@ -803,16 +803,16 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
       String *nt1 = Getattr(c, "templatetype");
       String *nt2 = nodeType(n);
       if (Equal(nt1, "class") && Equal(nt1, nt2)) {
-	if (Getattr(n, "template")) {
-	  /* Finally check that another %template with same name doesn't already exist */
-	  if (!Getattr(c, "sym:nextSibling")) {
-	    Setattr(c, "sym:nextSibling", n);
-	    Setattr(n, "sym:symtab", current_symtab);
-	    Setattr(n, "sym:name", symname);
-	    Setattr(n, "sym:previousSibling", c);
-	    return n;
-	  }
-	}
+        if (Getattr(n, "template")) {
+          /* Finally check that another %template with same name doesn't already exist */
+          if (!Getattr(c, "sym:nextSibling")) {
+            Setattr(c, "sym:nextSibling", n);
+            Setattr(n, "sym:symtab", current_symtab);
+            Setattr(n, "sym:name", symname);
+            Setattr(n, "sym:previousSibling", c);
+            return n;
+          }
+        }
       }
     }
 
@@ -827,27 +827,27 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
          both don't--this would be a conflict */
 
       if (nt && ct)
-	return c;
+        return c;
 
       /* Figure out which node allows the typedef */
       if (nt) {
-	td = n;
-	other = c;
+        td = n;
+        other = c;
       } else {
-	td = c;
-	other = n;
+        td = c;
+        other = n;
       }
       /* Make sure the other node is a typedef */
       s = Getattr(other, "storage");
       if (!s || (!Equal(s, "typedef")))
-	return c;		/* No.  This is a conflict */
+        return c;		/* No.  This is a conflict */
 
       /* Hmmm.  This appears to be okay.  Make sure the symbol table refers to the allow_type node */
 
       Setattr(n, "sym:symtab", current_symtab);
       Setattr(n, "sym:name", symname);
       if (td == n) {
-	Setattr(current, symname, td);
+        Setattr(current, symname, td);
       }
       return n;
     }
@@ -859,22 +859,22 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
       String *nt1, *nt2;
       nt1 = Getattr(n, "nodeType");
       if (Equal(nt1, "template"))
-	nt1 = Getattr(n, "templatetype");
+        nt1 = Getattr(n, "templatetype");
       nt2 = Getattr(c, "nodeType");
       if (Equal(nt2, "template"))
-	nt2 = Getattr(c, "templatetype");
+        nt2 = Getattr(c, "templatetype");
       if (Equal(nt1, "using"))
-	u1 = 1;
+        u1 = 1;
       if (Equal(nt2, "using"))
-	u2 = 1;
+        u2 = 1;
 
       if ((!Equal(nt1, nt2)) && !(u1 || u2))
-	return c;
+        return c;
     }
     if (!(u1 || u2)) {
       if ((!SwigType_isfunction(decl)) || (!SwigType_isfunction(ndecl))) {
-	/* Symbol table conflict */
-	return c;
+        /* Symbol table conflict */
+        return c;
       }
     }
 
@@ -899,24 +899,24 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
       Node *cn = c;
       pn = 0;
       while (cn) {
-	decl = Getattr(cn, "decl");
-	if (!(u1 || u2)) {
-	  if (Cmp(ndecl, decl) == 0) {
-	    /* Declarator conflict */
-	    /* Now check we don't have a non-templated function overloaded by a templated function with same params,
-	     * eg void foo(); template<typename> void foo(); */
-	    String *cnt = Getattr(cn, "nodeType");
-	    int cn_template = Equal(cnt, "template") && Checkattr(cn, "templatetype", "cdecl");
-	    int cn_plain_cdecl = Equal(cnt, "cdecl");
-	    if (!((n_template && cn_plain_cdecl) || (cn_template && n_plain_cdecl))) {
-	      /* found a conflict */
-	      return cn;
-	    }
-	  }
-	}
-	cl = cn;
-	cn = Getattr(cn, "sym:nextSibling");
-	pn++;
+        decl = Getattr(cn, "decl");
+        if (!(u1 || u2)) {
+          if (Cmp(ndecl, decl) == 0) {
+            /* Declarator conflict */
+            /* Now check we don't have a non-templated function overloaded by a templated function with same params,
+             * eg void foo(); template<typename> void foo(); */
+            String *cnt = Getattr(cn, "nodeType");
+            int cn_template = Equal(cnt, "template") && Checkattr(cn, "templatetype", "cdecl");
+            int cn_plain_cdecl = Equal(cnt, "cdecl");
+            if (!((n_template && cn_plain_cdecl) || (cn_template && n_plain_cdecl))) {
+              /* found a conflict */
+              return cn;
+            }
+          }
+        }
+        cl = cn;
+        cn = Getattr(cn, "sym:nextSibling");
+        pn++;
       }
     }
     /* Well, we made it this far.  Guess we can drop the symbol in place */
@@ -1043,9 +1043,9 @@ static Node *_symbol_lookup(const String *name, Symtab *symtab, Node *(*checkfun
     if (checkfunc) {
       Node *cn = checkfunc(n);
       if (cn) {
-	Setmark(symtab, 0);
-	/* Note that checkfunc can return n != cn, where cn could be a node further down the csym linked list starting at n */
-	return cn;
+        Setmark(symtab, 0);
+        /* Note that checkfunc can return n != cn, where cn could be a node further down the csym linked list starting at n */
+        return cn;
       }
     } else {
       Setmark(symtab, 0);
@@ -1073,8 +1073,8 @@ static Node *_symbol_lookup(const String *name, Symtab *symtab, Node *(*checkfun
     for (i = 0; i < len; i++) {
       n = _symbol_lookup(name, Getitem(inherit, i), checkfunc);
       if (n) {
-	Setmark(symtab, 0);
-	return n;
+        Setmark(symtab, 0);
+        return n;
       }
     }
   }
@@ -1124,11 +1124,11 @@ static Node *symbol_lookup_qualified(const_String_or_char_ptr name, Symtab *symt
     const String *cqname;
     if (qname) {
       if (Len(qname)) {
-	if (prefix && Len(prefix)) {
-	  Printv(qname, "::", prefix, NIL);
-	}
+        if (prefix && Len(prefix)) {
+          Printv(qname, "::", prefix, NIL);
+        }
       } else {
-	Append(qname, prefix);
+        Append(qname, prefix);
       }
       qalloc = qname;
       cqname = qname;
@@ -1139,9 +1139,9 @@ static Node *symbol_lookup_qualified(const_String_or_char_ptr name, Symtab *symt
     /* Found a scope match */
     if (st) {
       if (!name) {
-	if (qalloc)
-	  Delete(qalloc);
-	return st;
+        if (qalloc)
+          Delete(qalloc);
+        return st;
       }
       n = symbol_lookup(name, st, checkfunc);
     }
@@ -1150,30 +1150,30 @@ static Node *symbol_lookup_qualified(const_String_or_char_ptr name, Symtab *symt
 
     if (!n) {
       if (!local) {
-	Node *pn = Getattr(symtab, "parentNode");
-	if (pn)
-	  n = symbol_lookup_qualified(name, pn, prefix, local, checkfunc);
+        Node *pn = Getattr(symtab, "parentNode");
+        if (pn)
+          n = symbol_lookup_qualified(name, pn, prefix, local, checkfunc);
 
-	/* Check inherited scopes */
-	if (!n) {
-	  List *inherit = Getattr(symtab, "inherit");
-	  if (inherit && use_inherit) {
-	    int i, len;
-	    len = Len(inherit);
-	    for (i = 0; i < len; i++) {
-	      Node *prefix_node = symbol_lookup(prefix, Getitem(inherit, i), checkfunc);
-	      if (prefix_node) {
-		Node *prefix_symtab = Getattr(prefix_node, "symtab");
-		if (prefix_symtab) {
-		  n = symbol_lookup(name, prefix_symtab, checkfunc);
-		  break;
-		}
-	      }
-	    }
-	  }
-	}
+        /* Check inherited scopes */
+        if (!n) {
+          List *inherit = Getattr(symtab, "inherit");
+          if (inherit && use_inherit) {
+            int i, len;
+            len = Len(inherit);
+            for (i = 0; i < len; i++) {
+              Node *prefix_node = symbol_lookup(prefix, Getitem(inherit, i), checkfunc);
+              if (prefix_node) {
+                Node *prefix_symtab = Getattr(prefix_node, "symtab");
+                if (prefix_symtab) {
+                  n = symbol_lookup(name, prefix_symtab, checkfunc);
+                  break;
+                }
+              }
+            }
+          }
+        }
       } else {
-	n = 0;
+        n = 0;
       }
     }
     return n;
@@ -1210,19 +1210,19 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
     if (strncmp(cname, "::", 2) == 0) {
       String *nname = NewString(cname + 2);
       if (Swig_scopename_check(nname)) {
-	s = symbol_lookup_qualified(nname, global_scope, 0, 0, 0);
+        s = symbol_lookup_qualified(nname, global_scope, 0, 0, 0);
       } else {
-	s = symbol_lookup(nname, global_scope, 0);
+        s = symbol_lookup(nname, global_scope, 0);
       }
       Delete(nname);
     } else {
       String *prefix = Swig_scopename_prefix(name);
       if (prefix) {
-	s = symbol_lookup_qualified(name, hsym, 0, 0, 0);
-	Delete(prefix);
-	if (!s) {
-	  return 0;
-	}
+        s = symbol_lookup_qualified(name, hsym, 0, 0, 0);
+        Delete(prefix);
+        if (!s) {
+          return 0;
+        }
       }
     }
   }
@@ -1230,10 +1230,10 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
     while (hsym) {
       s = symbol_lookup(name, hsym, 0);
       if (s)
-	break;
+        break;
       hsym = Getattr(hsym, "parentNode");
       if (!hsym)
-	break;
+        break;
     }
   }
 
@@ -1247,9 +1247,9 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
       Symtab *un = Getattr(s, "sym:symtab");
       Node *ss = (!Equal(name, uname) || (un != n)) ? Swig_symbol_clookup(uname, un) : 0;	/* avoid infinity loop */
       if (!ss) {
-	SWIG_WARN_NODE_BEGIN(s);
-	Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
-	SWIG_WARN_NODE_END(s);
+        SWIG_WARN_NODE_BEGIN(s);
+        Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
+        SWIG_WARN_NODE_END(s);
       }
       s = ss;
     }
@@ -1288,19 +1288,19 @@ Node *Swig_symbol_clookup_check(const_String_or_char_ptr name, Symtab *n, Node *
     if (strncmp(cname, "::", 2) == 0) {
       String *nname = NewString(cname + 2);
       if (Swig_scopename_check(nname)) {
-	s = symbol_lookup_qualified(nname, global_scope, 0, 0, checkfunc);
+        s = symbol_lookup_qualified(nname, global_scope, 0, 0, checkfunc);
       } else {
-	s = symbol_lookup(nname, global_scope, checkfunc);
+        s = symbol_lookup(nname, global_scope, checkfunc);
       }
       Delete(nname);
     } else {
       String *prefix = Swig_scopename_prefix(name);
       if (prefix) {
-	s = symbol_lookup_qualified(name, hsym, 0, 0, checkfunc);
-	Delete(prefix);
-	if (!s) {
-	  return 0;
-	}
+        s = symbol_lookup_qualified(name, hsym, 0, 0, checkfunc);
+        Delete(prefix);
+        if (!s) {
+          return 0;
+        }
       }
     }
   }
@@ -1308,10 +1308,10 @@ Node *Swig_symbol_clookup_check(const_String_or_char_ptr name, Symtab *n, Node *
     while (hsym) {
       s = symbol_lookup(name, hsym, checkfunc);
       if (s)
-	break;
+        break;
       hsym = Getattr(hsym, "parentNode");
       if (!hsym)
-	break;
+        break;
     }
   }
 
@@ -1325,9 +1325,9 @@ Node *Swig_symbol_clookup_check(const_String_or_char_ptr name, Symtab *n, Node *
       Symtab *un = Getattr(s, "sym:symtab");
       Node *ss = Swig_symbol_clookup_check(uname, un, checkfunc);
       if (!ss && !checkfunc) {
-	SWIG_WARN_NODE_BEGIN(s);
-	Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
-	SWIG_WARN_NODE_END(s);
+        SWIG_WARN_NODE_BEGIN(s);
+        Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
+        SWIG_WARN_NODE_END(s);
       }
       s = ss;
     }
@@ -1361,9 +1361,9 @@ Node *Swig_symbol_clookup_local(const_String_or_char_ptr name, Symtab *n) {
     if (strncmp(cname, "::", 2) == 0) {
       String *nname = NewString(cname + 2);
       if (Swig_scopename_check(nname)) {
-	s = symbol_lookup_qualified(nname, global_scope, 0, 0, 0);
+        s = symbol_lookup_qualified(nname, global_scope, 0, 0, 0);
       } else {
-	s = symbol_lookup(nname, global_scope, 0);
+        s = symbol_lookup(nname, global_scope, 0);
       }
       Delete(nname);
     } else {
@@ -1384,9 +1384,9 @@ Node *Swig_symbol_clookup_local(const_String_or_char_ptr name, Symtab *n) {
       Symtab *un = Getattr(s, "sym:symtab");
       Node *ss = Swig_symbol_clookup_local(uname, un);
       if (!ss) {
-	SWIG_WARN_NODE_BEGIN(s);
-	Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
-	SWIG_WARN_NODE_END(s);
+        SWIG_WARN_NODE_BEGIN(s);
+        Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
+        SWIG_WARN_NODE_END(s);
       }
       s = ss;
     }
@@ -1417,9 +1417,9 @@ Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr name, Symtab *n, 
     if (strncmp(cname, "::", 2) == 0) {
       String *nname = NewString(cname + 2);
       if (Swig_scopename_check(nname)) {
-	s = symbol_lookup_qualified(nname, global_scope, 0, 0, checkfunc);
+        s = symbol_lookup_qualified(nname, global_scope, 0, 0, checkfunc);
       } else {
-	s = symbol_lookup(nname, global_scope, checkfunc);
+        s = symbol_lookup(nname, global_scope, checkfunc);
       }
       Delete(nname);
     } else {
@@ -1440,9 +1440,9 @@ Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr name, Symtab *n, 
       Symtab *un = Getattr(s, "sym:symtab");
       Node *ss = Swig_symbol_clookup_local_check(uname, un, checkfunc);
       if (!ss && !checkfunc) {
-	SWIG_WARN_NODE_BEGIN(s);
-	Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
-	SWIG_WARN_NODE_END(s);
+        SWIG_WARN_NODE_BEGIN(s);
+        Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
+        SWIG_WARN_NODE_END(s);
       }
       s = ss;
     }
@@ -1514,7 +1514,7 @@ void Swig_symbol_remove(Node *n) {
       fixovername = symnext;	/* fix as symbol to remove is at head of linked list */
     } else {
       if (symname)
-	Delattr(symtab, symname);
+        Delattr(symtab, symname);
     }
   }
   if (symnext) {
@@ -1711,32 +1711,32 @@ SwigType *Swig_symbol_type_qualify(const SwigType *t, Symtab *st) {
       /* Note: the unary scope operator (::) is being removed from the template parameters here. */
       Node *n = Swig_symbol_clookup_check(e, st, symbol_no_constructor);
       if (n) {
-	String *name = Getattr(n, "name");
-	Clear(e);
-	Append(e, name);
+        String *name = Getattr(n, "name");
+        Clear(e);
+        Append(e, name);
 #ifdef SWIG_DEBUG
-	Printf(stderr, "symbol_qual_ei %d %s %s %p\n", i, name, e, st);
+        Printf(stderr, "symbol_qual_ei %d %s %s %p\n", i, name, e, st);
 #endif
-	if (!Swig_scopename_check(name)) {
-	  String *qname = Swig_symbol_qualified(n);
-	  if (qname && Len(qname)) {
-	    Insert(e, 0, "::");
-	    Insert(e, 0, qname);
-	  }
+        if (!Swig_scopename_check(name)) {
+          String *qname = Swig_symbol_qualified(n);
+          if (qname && Len(qname)) {
+            Insert(e, 0, "::");
+            Insert(e, 0, qname);
+          }
 #ifdef SWIG_DEBUG
-	  Printf(stderr, "symbol_qual_sc %d %s %s %p\n", i, qname, e, st);
+          Printf(stderr, "symbol_qual_sc %d %s %s %p\n", i, qname, e, st);
 #endif
-	  Delete(qname);
-	}
+          Delete(qname);
+        }
       } else if (SwigType_istemplate(e)) {
-	SwigType *ty = symbol_template_qualify(e, st);
-	Clear(e);
-	Append(e, ty);
-	Delete(ty);
+        SwigType *ty = symbol_template_qualify(e, st);
+        Clear(e);
+        Append(e, ty);
+        Delete(ty);
       }
       if (strncmp(Char(e), "::", 2) == 0) {
-	Delitem(e, 0);
-	Delitem(e, 0);
+        Delitem(e, 0);
+        Delitem(e, 0);
       }
       Append(result, e);
     } else if (SwigType_isfunction(e)) {
@@ -1744,13 +1744,13 @@ SwigType *Swig_symbol_type_qualify(const SwigType *t, Symtab *st) {
       String *s = NewString("f(");
       Iterator pi = First(parms);
       while (pi.item) {
-	String *pf = Swig_symbol_type_qualify(pi.item, st);
-	Append(s, pf);
-	pi = Next(pi);
-	if (pi.item) {
-	  Append(s, ",");
-	}
-	Delete(pf);
+        String *pf = Swig_symbol_type_qualify(pi.item, st);
+        Append(s, pf);
+        pi = Next(pi);
+        if (pi.item) {
+          Append(s, ",");
+        }
+        Delete(pf);
       }
       Append(s, ").");
       Append(result, s);
@@ -1801,8 +1801,8 @@ SwigType *Swig_symbol_template_reduce(SwigType *qt, Symtab *ntab) {
       Delete(tp);
       tp = np;
       if (qual && Len(qual)) {
-	Insert(np, 0, "::");
-	Insert(np, 0, qual);
+        Insert(np, 0, "::");
+        Insert(np, 0, qual);
       }
       Delete(qual);
     } else {
@@ -1865,12 +1865,12 @@ SwigType *Swig_symbol_typedef_reduce(const SwigType *ty, Symtab *tab) {
     if (uname) {
       n = Swig_symbol_clookup(base, Getattr(n, "sym:symtab"));
       if (!n) {
-	Delete(base);
-	Delete(prefix);
+        Delete(base);
+        Delete(prefix);
 #ifdef SWIG_DEBUG
-	Printf(stderr, "symbol_reduce (c) %s %s\n", ty, ty);
+        Printf(stderr, "symbol_reduce (c) %s %s\n", ty, ty);
 #endif
-	return Copy(ty);
+        return Copy(ty);
       }
     }
   }
@@ -1885,18 +1885,18 @@ SwigType *Swig_symbol_typedef_reduce(const SwigType *ty, Symtab *tab) {
 
       /* Fix for case 'typedef struct Hello hello;' */
       {
-	const char *dclass[3] = { "struct ", "union ", "class " };
-	int i;
-	char *c = Char(nt);
-	for (i = 0; i < 3; i++) {
-	  if (strstr(c, dclass[i]) == c) {
-	    Replace(nt, dclass[i], "", DOH_REPLACE_FIRST);
-	  }
-	}
+        const char *dclass[3] = { "struct ", "union ", "class " };
+        int i;
+        char *c = Char(nt);
+        for (i = 0; i < 3; i++) {
+          if (strstr(c, dclass[i]) == c) {
+            Replace(nt, dclass[i], "", DOH_REPLACE_FIRST);
+          }
+        }
       }
       decl = Getattr(n, "decl");
       if (decl) {
-	SwigType_push(nt, decl);
+        SwigType_push(nt, decl);
       }
       SwigType_push(nt, prefix);
       Delete(base);
@@ -1905,9 +1905,9 @@ SwigType *Swig_symbol_typedef_reduce(const SwigType *ty, Symtab *tab) {
       rt = Swig_symbol_typedef_reduce(nt, ntab);
       qt = Swig_symbol_type_qualify(rt, ntab);
       if (SwigType_istemplate(qt)) {
-	SwigType *qtr = Swig_symbol_template_reduce(qt, ntab);
-	Delete(qt);
-	qt = qtr;
+        SwigType *qtr = Swig_symbol_template_reduce(qt, ntab);
+        Delete(qt);
+        qt = qtr;
       }
       Delete(nt);
       Delete(rt);
@@ -1946,11 +1946,11 @@ String *Swig_symbol_string_qualify(String *s, Symtab *st) {
       have_id = 1;
     } else {
       if (have_id) {
-	String *qid = Swig_symbol_type_qualify(id, st);
-	Append(r, qid);
-	Clear(id);
-	Delete(qid);
-	have_id = 0;
+        String *qid = Swig_symbol_type_qualify(id, st);
+        Append(r, qid);
+        Clear(id);
+        Delete(qid);
+        have_id = 0;
       }
       Putc(*c, r);
     }
@@ -1987,49 +1987,49 @@ ParmList *Swig_symbol_template_defargs(Parm *parms, Parm *targs, Symtab *tscope,
       p = nextSibling(p);
       tp = nextSibling(tp);
       if (p)
-	lp = p;
+        lp = p;
     }
     while (tp) {
       String *value = Getattr(tp, "value");
       if (value) {
-	Parm *cp;
-	Parm *ta = targs;
-	Parm *p = parms;
-	SwigType *nt = Swig_symbol_string_qualify(value, tsdecl);
-	SwigType *ntq = 0;
+        Parm *cp;
+        Parm *ta = targs;
+        Parm *p = parms;
+        SwigType *nt = Swig_symbol_string_qualify(value, tsdecl);
+        SwigType *ntq = 0;
 #ifdef SWIG_DEBUG
-	Printf(stderr, "value %s %s %s\n", value, nt, tsdecl ? Getattr(tsdecl, "name") : tsdecl);
+        Printf(stderr, "value %s %s %s\n", value, nt, tsdecl ? Getattr(tsdecl, "name") : tsdecl);
 #endif
-	while (p && ta) {
-	  String *name = Getattr(ta, "name");
-	  String *pvalue = Getattr(p, "value");
-	  String *value = pvalue ? pvalue : Getattr(p, "type");
-	  String *ttq = Swig_symbol_type_qualify(value, tscope);
-	  /* value = SwigType_typedef_resolve_all(value); */
-	  Replaceid(nt, name, ttq);
-	  p = nextSibling(p);
-	  ta = nextSibling(ta);
-	  Delete(ttq);
-	}
-	ntq = Swig_symbol_type_qualify(nt, tsdecl);
-	if (SwigType_istemplate(ntq)) {
-	  String *ty = Swig_symbol_template_deftype(ntq, tscope);
-	  Delete(ntq);
-	  ntq = ty;
-	}
-	cp = NewParmWithoutFileLineInfo(ntq, 0);
-	if (lp) {
-	  set_nextSibling(lp, cp);
-	  Delete(cp);
-	} else {
-	  expandedparms = cp;
-	}
-	lp = cp;
-	tp = nextSibling(tp);
-	Delete(nt);
-	Delete(ntq);
+        while (p && ta) {
+          String *name = Getattr(ta, "name");
+          String *pvalue = Getattr(p, "value");
+          String *value = pvalue ? pvalue : Getattr(p, "type");
+          String *ttq = Swig_symbol_type_qualify(value, tscope);
+          /* value = SwigType_typedef_resolve_all(value); */
+          Replaceid(nt, name, ttq);
+          p = nextSibling(p);
+          ta = nextSibling(ta);
+          Delete(ttq);
+        }
+        ntq = Swig_symbol_type_qualify(nt, tsdecl);
+        if (SwigType_istemplate(ntq)) {
+          String *ty = Swig_symbol_template_deftype(ntq, tscope);
+          Delete(ntq);
+          ntq = ty;
+        }
+        cp = NewParmWithoutFileLineInfo(ntq, 0);
+        if (lp) {
+          set_nextSibling(lp, cp);
+          Delete(cp);
+        } else {
+          expandedparms = cp;
+        }
+        lp = cp;
+        tp = nextSibling(tp);
+        Delete(nt);
+        Delete(ntq);
       } else {
-	tp = 0;
+        tp = 0;
       }
     }
   }
@@ -2095,14 +2095,14 @@ SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope) {
       List *parms = SwigType_parmlist(e);
       Iterator pi = First(parms);
       while (pi.item) {
-	String *pf = SwigType_istemplate(e) ? Swig_symbol_template_deftype(pi.item, tscope)
-	    : Swig_symbol_type_qualify(pi.item, tscope);
-	Append(s, pf);
-	pi = Next(pi);
-	if (pi.item) {
-	  Append(s, ",");
-	}
-	Delete(pf);
+        String *pf = SwigType_istemplate(e) ? Swig_symbol_template_deftype(pi.item, tscope)
+            : Swig_symbol_type_qualify(pi.item, tscope);
+        Append(s, pf);
+        pi = Next(pi);
+        if (pi.item) {
+          Append(s, ",");
+        }
+        Delete(pf);
       }
       Append(s, ").");
       Append(result, s);
@@ -2117,56 +2117,56 @@ SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope) {
       ParmList *tparms = SwigType_function_parms(targs, 0);
       Node *tempn = Swig_symbol_clookup_local_check(tprefix, tscope, symbol_is_template);
       if (!tempn && tsuffix && Len(tsuffix)) {
-	tempn = Swig_symbol_clookup_check(tprefix, 0, symbol_is_template);
+        tempn = Swig_symbol_clookup_check(tprefix, 0, symbol_is_template);
       }
 #ifdef SWIG_DEBUG
       Printf(stderr, "deftype type %s %s %d\n", e, tprefix, (long) tempn);
 #endif
       if (tempn) {
-	ParmList *tnargs = Getattr(tempn, "templateparms");
+        ParmList *tnargs = Getattr(tempn, "templateparms");
         ParmList *expandedparms;
-	Parm *p;
-	Symtab *tsdecl = Getattr(tempn, "sym:symtab");
+        Parm *p;
+        Symtab *tsdecl = Getattr(tempn, "sym:symtab");
 
 #ifdef SWIG_DEBUG
-	Printf(stderr, "deftype type %s %s %s\n", tprefix, targs, tsuffix);
+        Printf(stderr, "deftype type %s %s %s\n", tprefix, targs, tsuffix);
 #endif
-	Append(tprefix, "<(");
-	expandedparms = Swig_symbol_template_defargs(tparms, tnargs, tscope, tsdecl);
-	p = expandedparms;
-	tscope = tsdecl;
-	while (p) {
-	  SwigType *ptype = Getattr(p, "type");
-	  SwigType *ttr = ptype ? ptype : Getattr(p, "value");
-	  SwigType *ttf = Swig_symbol_type_qualify(ttr, tscope);
-	  SwigType *ttq = Swig_symbol_template_param_eval(ttf, tscope);
+        Append(tprefix, "<(");
+        expandedparms = Swig_symbol_template_defargs(tparms, tnargs, tscope, tsdecl);
+        p = expandedparms;
+        tscope = tsdecl;
+        while (p) {
+          SwigType *ptype = Getattr(p, "type");
+          SwigType *ttr = ptype ? ptype : Getattr(p, "value");
+          SwigType *ttf = Swig_symbol_type_qualify(ttr, tscope);
+          SwigType *ttq = Swig_symbol_template_param_eval(ttf, tscope);
 #ifdef SWIG_DEBUG
-	  Printf(stderr, "arg type %s\n", ttq);
+          Printf(stderr, "arg type %s\n", ttq);
 #endif
-	  if (SwigType_istemplate(ttq)) {
-	    SwigType *ttd = Swig_symbol_template_deftype(ttq, tscope);
-	    Delete(ttq);
-	    ttq = ttd;
+          if (SwigType_istemplate(ttq)) {
+            SwigType *ttd = Swig_symbol_template_deftype(ttq, tscope);
+            Delete(ttq);
+            ttq = ttd;
 #ifdef SWIG_DEBUG
-	    Printf(stderr, "arg deftype %s\n", ttq);
+            Printf(stderr, "arg deftype %s\n", ttq);
 #endif
-	  }
-	  Append(tprefix, ttq);
-	  p = nextSibling(p);
-	  if (p)
-	    Putc(',', tprefix);
-	  Delete(ttf);
-	  Delete(ttq);
-	}
-	Append(tprefix, ")>");
-	Append(tprefix, tsuffix);
-	Append(prefix, tprefix);
+          }
+          Append(tprefix, ttq);
+          p = nextSibling(p);
+          if (p)
+            Putc(',', tprefix);
+          Delete(ttf);
+          Delete(ttq);
+        }
+        Append(tprefix, ")>");
+        Append(tprefix, tsuffix);
+        Append(prefix, tprefix);
 #ifdef SWIG_DEBUG
-	Printf(stderr, "deftype %s %s \n", type, tprefix);
+        Printf(stderr, "deftype %s %s \n", type, tprefix);
 #endif
-	Append(result, prefix);
+        Append(result, prefix);
       } else {
-	Append(result, e);
+        Append(result, e);
       }
       Delete(prefix);
       Delete(base);
@@ -2198,25 +2198,25 @@ SwigType *Swig_symbol_template_param_eval(const SwigType *p, Symtab *symtab) {
     if (n) {
       String *nt = Getattr(n, "nodeType");
       if (Equal(nt, "enumitem")) {
-	/* An enum item.   Generate a fully qualified name */
-	String *qn = Swig_symbol_qualified(n);
-	if (qn && Len(qn)) {
-	  Append(qn, "::");
-	  Append(qn, Getattr(n, "name"));
-	  Delete(value);
-	  value = qn;
-	  continue;
-	} else {
-	  Delete(qn);
-	  break;
-	}
+        /* An enum item.   Generate a fully qualified name */
+        String *qn = Swig_symbol_qualified(n);
+        if (qn && Len(qn)) {
+          Append(qn, "::");
+          Append(qn, Getattr(n, "name"));
+          Delete(value);
+          value = qn;
+          continue;
+        } else {
+          Delete(qn);
+          break;
+        }
       } else if ((Equal(nt, "cdecl"))) {
-	String *nv = Getattr(n, "value");
-	if (nv) {
-	  Delete(value);
-	  value = Copy(nv);
-	  continue;
-	}
+        String *nv = Getattr(n, "value");
+        if (nv) {
+          Delete(value);
+          value = Copy(nv);
+          continue;
+        }
       }
     }
     break;

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -168,11 +168,11 @@
  *
  * ----------------------------------------------------------------------------- */
 
-static Hash *current = 0;	/* The current symbol table hash */
-static Hash *ccurrent = 0;	/* The current c symbol table hash */
-static Hash *current_symtab = 0;	/* Current symbol table node */
-static Hash *symtabs = 0;	/* Hash of all symbol tables by fully-qualified name */
-static Hash *global_scope = 0;	/* Global scope */
+static Hash *current = 0;       /* The current symbol table hash */
+static Hash *ccurrent = 0;      /* The current c symbol table hash */
+static Hash *current_symtab = 0;        /* Current symbol table node */
+static Hash *symtabs = 0;       /* Hash of all symbol tables by fully-qualified name */
+static Hash *global_scope = 0;  /* Global scope */
 
 static int use_inherit = 1;
 
@@ -516,7 +516,7 @@ void Swig_symbol_inherit(Symtab *s) {
   for (i = 0; i < ilen; i++) {
     Node *n = Getitem(inherit, i);
     if (n == s)
-      return;			/* Already inherited */
+      return;                   /* Already inherited */
   }
   Append(inherit, s);
 }
@@ -840,7 +840,7 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
       /* Make sure the other node is a typedef */
       s = Getattr(other, "storage");
       if (!s || (!Equal(s, "typedef")))
-        return c;		/* No.  This is a conflict */
+        return c;               /* No.  This is a conflict */
 
       /* Hmmm.  This appears to be okay.  Make sure the symbol table refers to the allow_type node */
 
@@ -1245,7 +1245,7 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
     } else {
       String *uname = Getattr(s, "uname");
       Symtab *un = Getattr(s, "sym:symtab");
-      Node *ss = (!Equal(name, uname) || (un != n)) ? Swig_symbol_clookup(uname, un) : 0;	/* avoid infinity loop */
+      Node *ss = (!Equal(name, uname) || (un != n)) ? Swig_symbol_clookup(uname, un) : 0;       /* avoid infinity loop */
       if (!ss) {
         SWIG_WARN_NODE_BEGIN(s);
         Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
@@ -1493,8 +1493,8 @@ void Swig_symbol_remove(Node *n) {
   Node *symprev;
   Node *symnext;
   Node *fixovername = 0;
-  symtab = Getattr(n, "sym:symtab");	/* Get symbol table object */
-  symtab = Getattr(symtab, "symtab");	/* Get actual hash table of symbols */
+  symtab = Getattr(n, "sym:symtab");    /* Get symbol table object */
+  symtab = Getattr(symtab, "symtab");   /* Get actual hash table of symbols */
   symname = Getattr(n, "sym:name");
   symprev = Getattr(n, "sym:previousSibling");
   symnext = Getattr(n, "sym:nextSibling");
@@ -1503,7 +1503,7 @@ void Swig_symbol_remove(Node *n) {
   if (symprev) {
     if (symnext) {
       Setattr(symprev, "sym:nextSibling", symnext);
-      fixovername = symprev;	/* fix as symbol to remove is somewhere in the middle of the linked list */
+      fixovername = symprev;    /* fix as symbol to remove is somewhere in the middle of the linked list */
     } else {
       Delattr(symprev, "sym:nextSibling");
     }
@@ -1511,7 +1511,7 @@ void Swig_symbol_remove(Node *n) {
     /* If no previous symbol, see if there is a next symbol */
     if (symnext) {
       Setattr(symtab, symname, symnext);
-      fixovername = symnext;	/* fix as symbol to remove is at head of linked list */
+      fixovername = symnext;    /* fix as symbol to remove is at head of linked list */
     } else {
       if (symname)
         Delattr(symtab, symname);

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -168,16 +168,15 @@
  *
  * ----------------------------------------------------------------------------- */
 
-static Hash *current = 0;       /* The current symbol table hash */
-static Hash *ccurrent = 0;      /* The current c symbol table hash */
-static Hash *current_symtab = 0;        /* Current symbol table node */
-static Hash *symtabs = 0;       /* Hash of all symbol tables by fully-qualified name */
-static Hash *global_scope = 0;  /* Global scope */
+static Hash *current = 0;        /* The current symbol table hash */
+static Hash *ccurrent = 0;       /* The current c symbol table hash */
+static Hash *current_symtab = 0; /* Current symbol table node */
+static Hash *symtabs = 0;        /* Hash of all symbol tables by fully-qualified name */
+static Hash *global_scope = 0;   /* Global scope */
 
 static int use_inherit = 1;
 
 /* common attribute keys, to avoid calling find_key all the times */
-
 
 /* -----------------------------------------------------------------------------
  * Swig_symbol_print_tables()
@@ -331,7 +330,7 @@ String *Swig_symbol_getscopename(void) {
 Symtab *Swig_symbol_getscope(const_String_or_char_ptr name) {
   if (!symtabs)
     return 0;
-  if (Equal("::", (const_String_or_char_ptr ) name))
+  if (Equal("::", (const_String_or_char_ptr)name))
     name = "";
   return Getattr(symtabs, name);
 }
@@ -516,7 +515,7 @@ void Swig_symbol_inherit(Symtab *s) {
   for (i = 0; i < ilen; i++) {
     Node *n = Getitem(inherit, i);
     if (n == s)
-      return;                   /* Already inherited */
+      return; /* Already inherited */
   }
   Append(inherit, s);
 }
@@ -575,8 +574,7 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
     append = n;
   } else if (cn && (Getattr(cn, "sym:weak"))) {
     /* The node in the symbol table is weak. Replace it */
-    if (checkAttribute(cn, "nodeType", "template")
-        && checkAttribute(cn, "templatetype", "classforward")) {
+    if (checkAttribute(cn, "nodeType", "template") && checkAttribute(cn, "templatetype", "classforward")) {
       /* The node is a template classforward declaration, and the
          default template parameters here take precedence. */
       ParmList *pc = Getattr(cn, "templateparms");
@@ -726,7 +724,6 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
      in C namespaces are errors, but these will be caught by the C++ compiler
      when compiling the wrapper code */
 
-
   /* There are a few options for weak symbols.  A "weak" symbol
      is any symbol that can be replaced by another symbol in the C symbol
      table.  An example would be a forward class declaration.  A forward
@@ -840,7 +837,7 @@ static Node *symbol_add(const_String_or_char_ptr symname, Node *n) {
       /* Make sure the other node is a typedef */
       s = Getattr(other, "storage");
       if (!s || (!Equal(s, "typedef")))
-        return c;               /* No.  This is a conflict */
+        return c; /* No.  This is a conflict */
 
       /* Hmmm.  This appears to be okay.  Make sure the symbol table refers to the allow_type node */
 
@@ -1024,7 +1021,7 @@ void Swig_symbol_conflict_warn(Node *n, Node *c, const String *symname, int incl
  * verifying that a class hierarchy implements all pure virtual methods.
  * ----------------------------------------------------------------------------- */
 
-static Node *_symbol_lookup(const String *name, Symtab *symtab, Node *(*checkfunc) (Node *n)) {
+static Node *_symbol_lookup(const String *name, Symtab *symtab, Node *(*checkfunc)(Node *n)) {
   Node *n;
   List *inherit;
   Hash *sym = Getattr(symtab, "csymtab");
@@ -1083,7 +1080,7 @@ static Node *_symbol_lookup(const String *name, Symtab *symtab, Node *(*checkfun
   return 0;
 }
 
-static Node *symbol_lookup(const_String_or_char_ptr name, Symtab *symtab, Node *(*checkfunc) (Node *n)) {
+static Node *symbol_lookup(const_String_or_char_ptr name, Symtab *symtab, Node *(*checkfunc)(Node *n)) {
   Node *n = 0;
   if (DohCheck(name)) {
     n = _symbol_lookup(name, symtab, checkfunc);
@@ -1095,13 +1092,11 @@ static Node *symbol_lookup(const_String_or_char_ptr name, Symtab *symtab, Node *
   return n;
 }
 
-
-
 /* -----------------------------------------------------------------------------
  * symbol_lookup_qualified()
  * ----------------------------------------------------------------------------- */
 
-static Node *symbol_lookup_qualified(const_String_or_char_ptr name, Symtab *symtab, const String *prefix, int local, Node *(*checkfunc) (Node *n)) {
+static Node *symbol_lookup_qualified(const_String_or_char_ptr name, Symtab *symtab, const String *prefix, int local, Node *(*checkfunc)(Node *n)) {
   /* This is a little funky, we search by fully qualified names */
 
   if (!symtab)
@@ -1245,7 +1240,7 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
     } else {
       String *uname = Getattr(s, "uname");
       Symtab *un = Getattr(s, "sym:symtab");
-      Node *ss = (!Equal(name, uname) || (un != n)) ? Swig_symbol_clookup(uname, un) : 0;       /* avoid infinity loop */
+      Node *ss = (!Equal(name, uname) || (un != n)) ? Swig_symbol_clookup(uname, un) : 0; /* avoid infinity loop */
       if (!ss) {
         SWIG_WARN_NODE_BEGIN(s);
         Swig_warning(WARN_PARSE_USING_UNDEF, Getfile(s), Getline(s), "Nothing known about '%s'.\n", SwigType_namestr(uname));
@@ -1267,7 +1262,7 @@ Node *Swig_symbol_clookup(const_String_or_char_ptr name, Symtab *n) {
  * inheritance hierarchy.
  * ----------------------------------------------------------------------------- */
 
-Node *Swig_symbol_clookup_check(const_String_or_char_ptr name, Symtab *n, Node *(*checkfunc) (Node *n)) {
+Node *Swig_symbol_clookup_check(const_String_or_char_ptr name, Symtab *n, Node *(*checkfunc)(Node *n)) {
   Hash *hsym = 0;
   Node *s = 0;
 
@@ -1398,7 +1393,7 @@ Node *Swig_symbol_clookup_local(const_String_or_char_ptr name, Symtab *n) {
  * Swig_symbol_clookup_local_check()
  * ----------------------------------------------------------------------------- */
 
-Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr name, Symtab *n, Node *(*checkfunc) (Node *)) {
+Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr name, Symtab *n, Node *(*checkfunc)(Node *)) {
   Hash *hsym;
   Node *s = 0;
 
@@ -1459,7 +1454,7 @@ Node *Swig_symbol_clookup_local_check(const_String_or_char_ptr name, Symtab *n, 
 
 Node *Swig_symbol_clookup_no_inherit(const_String_or_char_ptr name, Symtab *n) {
   Node *s = 0;
-  assert(use_inherit==1);
+  assert(use_inherit == 1);
   use_inherit = 0;
   s = Swig_symbol_clookup(name, n);
   use_inherit = 1;
@@ -1493,8 +1488,8 @@ void Swig_symbol_remove(Node *n) {
   Node *symprev;
   Node *symnext;
   Node *fixovername = 0;
-  symtab = Getattr(n, "sym:symtab");    /* Get symbol table object */
-  symtab = Getattr(symtab, "symtab");   /* Get actual hash table of symbols */
+  symtab = Getattr(n, "sym:symtab");  /* Get symbol table object */
+  symtab = Getattr(symtab, "symtab"); /* Get actual hash table of symbols */
   symname = Getattr(n, "sym:name");
   symprev = Getattr(n, "sym:previousSibling");
   symnext = Getattr(n, "sym:nextSibling");
@@ -1503,7 +1498,7 @@ void Swig_symbol_remove(Node *n) {
   if (symprev) {
     if (symnext) {
       Setattr(symprev, "sym:nextSibling", symnext);
-      fixovername = symprev;    /* fix as symbol to remove is somewhere in the middle of the linked list */
+      fixovername = symprev; /* fix as symbol to remove is somewhere in the middle of the linked list */
     } else {
       Delattr(symprev, "sym:nextSibling");
     }
@@ -1511,7 +1506,7 @@ void Swig_symbol_remove(Node *n) {
     /* If no previous symbol, see if there is a next symbol */
     if (symnext) {
       Setattr(symtab, symname, symnext);
-      fixovername = symnext;    /* fix as symbol to remove is at head of linked list */
+      fixovername = symnext; /* fix as symbol to remove is at head of linked list */
     } else {
       if (symname)
         Delattr(symtab, symname);
@@ -1617,8 +1612,7 @@ static SwigType *symbol_template_qualify(const SwigType *e, Symtab *st) {
   Iterator ti;
 #ifdef SWIG_TEMPLATE_QUALIFY_CACHE
   static Hash *qualify_cache = 0;
-  String *scopetype = st ? NewStringf("%s::%s", Getattr(st, "name"), e)
-      : NewStringf("%s::%s", Swig_symbol_getscopename(), e);
+  String *scopetype = st ? NewStringf("%s::%s", Getattr(st, "name"), e) : NewStringf("%s::%s", Swig_symbol_getscopename(), e);
   if (!qualify_cache) {
     qualify_cache = NewHash();
   }
@@ -1675,7 +1669,6 @@ static SwigType *symbol_template_qualify(const SwigType *e, Symtab *st) {
 
   return qprefix;
 }
-
 
 static Node *symbol_no_constructor(Node *n) {
   return Checkattr(n, "nodeType", "constructor") ? 0 : n;
@@ -1780,8 +1773,7 @@ SwigType *Swig_symbol_type_qualify(const SwigType *t, Symtab *st) {
  *   Foo<(int,int)>
  * ----------------------------------------------------------------------------- */
 
-static
-SwigType *Swig_symbol_template_reduce(SwigType *qt, Symtab *ntab) {
+static SwigType *Swig_symbol_template_reduce(SwigType *qt, Symtab *ntab) {
   Parm *p;
   String *templateargs = SwigType_templateargs(qt);
   List *parms = SwigType_parmlist(templateargs);
@@ -1824,7 +1816,6 @@ SwigType *Swig_symbol_template_reduce(SwigType *qt, Symtab *ntab) {
   Delete(templateargs);
   return qprefix;
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_symbol_typedef_reduce()
@@ -1885,7 +1876,7 @@ SwigType *Swig_symbol_typedef_reduce(const SwigType *ty, Symtab *tab) {
 
       /* Fix for case 'typedef struct Hello hello;' */
       {
-        const char *dclass[3] = { "struct ", "union ", "class " };
+        const char *dclass[3] = {"struct ", "union ", "class "};
         int i;
         char *c = Char(nt);
         for (i = 0; i < 3; i++) {
@@ -1941,7 +1932,7 @@ String *Swig_symbol_string_qualify(String *s, Symtab *st) {
   char *c = Char(s);
   int first_char = 1;
   while (*c) {
-    if (isalpha((int) *c) || (*c == '_') || (*c == ':') || (*c == '~' && first_char) || (isdigit((int) *c) && !first_char)) {
+    if (isalpha((int)*c) || (*c == '_') || (*c == ':') || (*c == '~' && first_char) || (isdigit((int)*c) && !first_char)) {
       Putc(*c, id);
       have_id = 1;
     } else {
@@ -1966,7 +1957,6 @@ String *Swig_symbol_string_qualify(String *s, Symtab *st) {
   return r;
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_symbol_template_defargs()
  *
@@ -1975,7 +1965,6 @@ String *Swig_symbol_string_qualify(String *s, Symtab *st) {
  * Note side effects: parms will also contain the extra parameters in its list
  * (but only if non-zero).
  * ----------------------------------------------------------------------------- */
-
 
 ParmList *Swig_symbol_template_defargs(Parm *parms, Parm *targs, Symtab *tscope, Symtab *tsdecl) {
   ParmList *expandedparms = parms;
@@ -2055,13 +2044,10 @@ SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope) {
   /* The lookup depends on the current scope and potential namespace qualification.
      Looking up x in namespace y is not the same as looking up x::y in outer scope.
      -> we use a 2-level hash: first scope and then symbol. */
-  String *scope_name = tscope
-      ? Swig_symbol_qualifiedscopename(tscope)
-      : Swig_symbol_qualifiedscopename(current_symtab);
-  String *type_name = tscope
-      ? NewStringf("%s::%s", Getattr(tscope, "name"), type)
-      : NewStringf("%s::%s", Swig_symbol_getscopename(), type);
-  if (!scope_name) scope_name = NewString("::");
+  String *scope_name = tscope ? Swig_symbol_qualifiedscopename(tscope) : Swig_symbol_qualifiedscopename(current_symtab);
+  String *type_name = tscope ? NewStringf("%s::%s", Getattr(tscope, "name"), type) : NewStringf("%s::%s", Swig_symbol_getscopename(), type);
+  if (!scope_name)
+    scope_name = NewString("::");
   if (!s_cache) {
     s_cache = NewHash();
   }
@@ -2078,9 +2064,9 @@ SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope) {
       return result;
     }
   } else {
-      scope_cache = NewHash();
-      Setattr(s_cache, scope_name, scope_cache);
-      Delete(scope_name);
+    scope_cache = NewHash();
+    Setattr(s_cache, scope_name, scope_cache);
+    Delete(scope_name);
   }
 #endif
 
@@ -2095,8 +2081,7 @@ SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope) {
       List *parms = SwigType_parmlist(e);
       Iterator pi = First(parms);
       while (pi.item) {
-        String *pf = SwigType_istemplate(e) ? Swig_symbol_template_deftype(pi.item, tscope)
-            : Swig_symbol_type_qualify(pi.item, tscope);
+        String *pf = SwigType_istemplate(e) ? Swig_symbol_template_deftype(pi.item, tscope) : Swig_symbol_type_qualify(pi.item, tscope);
         Append(s, pf);
         pi = Next(pi);
         if (pi.item) {
@@ -2120,7 +2105,7 @@ SwigType *Swig_symbol_template_deftype(const SwigType *type, Symtab *tscope) {
         tempn = Swig_symbol_clookup_check(tprefix, 0, symbol_is_template);
       }
 #ifdef SWIG_DEBUG
-      Printf(stderr, "deftype type %s %s %d\n", e, tprefix, (long) tempn);
+      Printf(stderr, "deftype type %s %s %d\n", e, tprefix, (long)tempn);
 #endif
       if (tempn) {
         ParmList *tnargs = Getattr(tempn, "templateparms");

--- a/Source/Swig/tree.c
+++ b/Source/Swig/tree.c
@@ -96,8 +96,8 @@ void Swig_print_node(Node *obj) {
     if (Equal(k, "nodeType") || (*(Char(k)) == '$')) {
       /* Do nothing */
     } else if (debug_quiet && (Equal(k, "firstChild") || Equal(k, "lastChild") || Equal(k, "parentNode") || Equal(k, "nextSibling") ||
-	Equal(k, "previousSibling") || Equal(k, "symtab") || Equal(k, "csymtab") || Equal(k, "sym:symtab") || Equal(k, "sym:nextSibling") ||
-	Equal(k, "sym:previousSibling") || Equal(k, "csym:nextSibling") || Equal(k, "csym:previousSibling"))) {
+        Equal(k, "previousSibling") || Equal(k, "symtab") || Equal(k, "csymtab") || Equal(k, "sym:symtab") || Equal(k, "sym:nextSibling") ||
+        Equal(k, "sym:previousSibling") || Equal(k, "csym:nextSibling") || Equal(k, "csym:previousSibling"))) {
       /* Do nothing */
     } else if (Equal(k, "kwargs") || Equal(k, "parms") || Equal(k, "wrap:parms") || Equal(k, "pattern") || Equal(k, "templateparms") || Equal(k, "templateparmsraw") || Equal(k, "template_parameters") || Equal(k, "throws")) {
       print_indent(2);
@@ -108,18 +108,18 @@ void Swig_print_node(Node *obj) {
       const char *trunc = "";
       print_indent(2);
       if (DohIsString(value)) {
-	o = Str(value);
-	if (Len(o) > 80) {
-	  trunc = "...";
-	}
-	Printf(stdout, "%-12s - \"%(escape)-0.80s%s\"\n", k, o, trunc);
-	Delete(o);
+        o = Str(value);
+        if (Len(o) > 80) {
+          trunc = "...";
+        }
+        Printf(stdout, "%-12s - \"%(escape)-0.80s%s\"\n", k, o, trunc);
+        Delete(o);
 /*
       } else if (DohIsSequence(value)) {
-	Printf(stdout, "%-12s - %s\n", k, value);
+        Printf(stdout, "%-12s - %s\n", k, value);
 */
       } else {
-	Printf(stdout, "%-12s - %p\n", k, value);
+        Printf(stdout, "%-12s - %p\n", k, value);
       }
     }
     ki = Next(ki);
@@ -340,8 +340,8 @@ void Swig_require(const char *ns, Node *n, ...) {
     String *view = Getattr(n, "view");
     if (view) {
       if (Strcmp(view, ns) != 0) {
-	Setattr(n, NewStringf("%s:view", ns), view);
-	Setattr(n, "view", NewString(ns));
+        Setattr(n, NewStringf("%s:view", ns), view);
+        Setattr(n, "view", NewString(ns));
       }
     } else {
       Setattr(n, "view", NewString(ns));
@@ -386,8 +386,8 @@ void Swig_save(const char *ns, Node *n, ...) {
     String *view = Getattr(n, "view");
     if (view) {
       if (Strcmp(view, ns) != 0) {
-	Setattr(n, NewStringf("%s:view", ns), view);
-	Setattr(n, "view", NewString(ns));
+        Setattr(n, NewStringf("%s:view", ns), view);
+        Setattr(n, "view", NewString(ns));
       }
     } else {
       Setattr(n, "view", NewString(ns));

--- a/Source/Swig/tree.c
+++ b/Source/Swig/tree.c
@@ -72,7 +72,6 @@ static void print_indent(int l) {
   }
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_print_node(Node *n)
  * ----------------------------------------------------------------------------- */
@@ -95,11 +94,13 @@ void Swig_print_node(Node *obj) {
     DOH *value = Getattr(obj, k);
     if (Equal(k, "nodeType") || (*(Char(k)) == '$')) {
       /* Do nothing */
-    } else if (debug_quiet && (Equal(k, "firstChild") || Equal(k, "lastChild") || Equal(k, "parentNode") || Equal(k, "nextSibling") ||
-        Equal(k, "previousSibling") || Equal(k, "symtab") || Equal(k, "csymtab") || Equal(k, "sym:symtab") || Equal(k, "sym:nextSibling") ||
-        Equal(k, "sym:previousSibling") || Equal(k, "csym:nextSibling") || Equal(k, "csym:previousSibling"))) {
+    } else if (debug_quiet &&
+               (Equal(k, "firstChild") || Equal(k, "lastChild") || Equal(k, "parentNode") || Equal(k, "nextSibling") || Equal(k, "previousSibling") ||
+                Equal(k, "symtab") || Equal(k, "csymtab") || Equal(k, "sym:symtab") || Equal(k, "sym:nextSibling") || Equal(k, "sym:previousSibling") ||
+                Equal(k, "csym:nextSibling") || Equal(k, "csym:previousSibling"))) {
       /* Do nothing */
-    } else if (Equal(k, "kwargs") || Equal(k, "parms") || Equal(k, "wrap:parms") || Equal(k, "pattern") || Equal(k, "templateparms") || Equal(k, "templateparmsraw") || Equal(k, "template_parameters") || Equal(k, "throws")) {
+    } else if (Equal(k, "kwargs") || Equal(k, "parms") || Equal(k, "wrap:parms") || Equal(k, "pattern") || Equal(k, "templateparms") ||
+               Equal(k, "templateparmsraw") || Equal(k, "template_parameters") || Equal(k, "throws")) {
       print_indent(2);
       /* Differentiate parameter lists by displaying within single quotes */
       Printf(stdout, "%-12s - \'%s\'\n", k, ParmList_str_defaultargs(value));
@@ -114,10 +115,10 @@ void Swig_print_node(Node *obj) {
         }
         Printf(stdout, "%-12s - \"%(escape)-0.80s%s\"\n", k, o, trunc);
         Delete(o);
-/*
-      } else if (DohIsSequence(value)) {
-        Printf(stdout, "%-12s - %s\n", k, value);
-*/
+        /*
+              } else if (DohIsSequence(value)) {
+                Printf(stdout, "%-12s - %s\n", k, value);
+        */
       } else {
         Printf(stdout, "%-12s - %p\n", k, value);
       }
@@ -231,7 +232,8 @@ void removeNode(Node *n) {
   Node *next;
 
   parent = parentNode(n);
-  if (!parent) return;
+  if (!parent)
+    return;
 
   prev = previousSibling(n);
   next = nextSibling(n);
@@ -251,9 +253,9 @@ void removeNode(Node *n) {
   }
 
   /* Delete attributes */
-  Delattr(n,"parentNode");
-  Delattr(n,"nextSibling");
-  Delattr(n,"previousSibling");
+  Delattr(n, "parentNode");
+  Delattr(n, "nextSibling");
+  Delattr(n, "previousSibling");
 }
 
 /* -----------------------------------------------------------------------------
@@ -348,7 +350,6 @@ void Swig_require(const char *ns, Node *n, ...) {
     }
   }
 }
-
 
 /* -----------------------------------------------------------------------------
  * Swig_save()

--- a/Source/Swig/tree.c
+++ b/Source/Swig/tree.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -660,7 +660,7 @@ static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm
   if (tm && cqualifiedname) {
     tm1 = Getattr(tm, cqualifiedname);
     if (tm1) {
-      result = Getattr(tm1, tm_method);	/* See if there is a type - qualified name match */
+      result = Getattr(tm1, tm_method); /* See if there is a type - qualified name match */
       if (result && Getattr(result, "code"))
         goto ret_result;
       if (result)
@@ -672,7 +672,7 @@ static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm
   if (tm && cname) {
     tm1 = Getattr(tm, cname);
     if (tm1) {
-      result = Getattr(tm1, tm_method);	/* See if there is a type - name match */
+      result = Getattr(tm1, tm_method); /* See if there is a type - name match */
       if (result && Getattr(result, "code"))
         goto ret_result;
       if (result)
@@ -682,7 +682,7 @@ static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm
   if (debug_display)
     Printf(stdout, "  Looking for: %s\n", SwigType_str(ctype, 0));
   if (tm) {
-    result = Getattr(tm, tm_method);	/* See if there is simply a type without name match */
+    result = Getattr(tm, tm_method);    /* See if there is simply a type without name match */
     if (result && Getattr(result, "code"))
       goto ret_result;
     if (result)
@@ -1457,7 +1457,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
   if (Cmp(s, "pass") == 0)
     return sdef;
 
-  s = Copy(s);			/* Make a local copy of the typemap code */
+  s = Copy(s);                  /* Make a local copy of the typemap code */
 
   /* Look in the "out" typemap for the "optimal" attribute */
   if (Cmp(cmethod, "out") == 0) {
@@ -1624,7 +1624,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
   Delete(cname);
   Delete(clname);
   Delete(mtype);
-  if (sdef) {			/* put 'ref' and 'newfree' codes together */
+  if (sdef) {                   /* put 'ref' and 'newfree' codes together */
     String *p = NewStringf("%s\n%s", sdef, s);
     Delete(s);
     Delete(sdef);
@@ -1887,7 +1887,7 @@ static void typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList 
 #ifdef SWIG_DEBUG
     Printf(stdout, "attach: %s %s %s\n", Getattr(firstp, "name"), typemap_method_name(tmap_method), s);
 #endif
-    Setattr(firstp, typemap_method_name(tmap_method), s);	/* Code object */
+    Setattr(firstp, typemap_method_name(tmap_method), s);       /* Code object */
 
     if (locals) {
       sprintf(temp, "%s:locals", cmethod);
@@ -2029,8 +2029,8 @@ void Swig_typemap_replace_embedded_typemap(String *s, Node *file_line_node) {
  * and if found will substitute in the typemap contents, making appropriate variable replacements.
  *
  * For example:
- *   $typemap(in, int)			     # simple usage matching %typemap(in) int { ... }
- *   $typemap(in, int b)		     # simple usage matching %typemap(in) int b { ... } or above %typemap
+ *   $typemap(in, int)                       # simple usage matching %typemap(in) int { ... }
+ *   $typemap(in, int b)                     # simple usage matching %typemap(in) int b { ... } or above %typemap
  *   $typemap(in, (Foo<int, bool> a, int b)) # multi-argument typemap matching %typemap(in) (Foo<int, bool> a, int b) {...}
  * ----------------------------------------------------------------------------- */
 

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -33,7 +33,7 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
  * [ type ]
  *    +-------- [ name ]
  *    +-------- [ name ]
- *    
+ *
  * Each hash table [ type ] or [ name ] then contains references to the
  * different typemap methods.    These are referenced by names such as
  * "tmap:in", "tmap:out", "tmap:argout", and so forth.
@@ -46,7 +46,7 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
  *    "source"  -  Source directive (%apply or %typemap) for the typemap
  *    "locals"  -  Local variables (if any)
  *    "kwargs"  -  Typemap attributes
- * 
+ *
  * Example for a typemap method named "in":
  *   %typemap(in, warning="987:my warning", noblock=1) int &my_int (int tmp) "$1 = $input;"
  *
@@ -56,7 +56,7 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
  *    "source"  -  typemap(in) int &my_int
  *    "locals"  -  int tmp
  *    "kwargs"  -  warning="987:my typemap warning", foo=123
- * 
+ *
  * ----------------------------------------------------------------------------- */
 
 static Hash *typemaps;
@@ -183,7 +183,7 @@ static String *typemap_method_name(const_String_or_char_ptr tmap_method) {
   return s;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * typemap_register()
  *
  * Internal implementation for Swig_typemap_register()
@@ -256,7 +256,7 @@ static void typemap_register(const_String_or_char_ptr tmap_method, ParmList *par
      "in-int+foo:-p.int+bar:   char *blah[]
 
      Notice how the typemap method name expands to encode information about
-     previous arguments.        
+     previous arguments.
 
    */
 
@@ -289,7 +289,7 @@ static void typemap_register(const_String_or_char_ptr tmap_method, ParmList *par
   }
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Swig_typemap_register()
  *
  * Add a new, possibly multi-argument, typemap
@@ -518,7 +518,7 @@ int Swig_typemap_apply(ParmList *src, ParmList *dest) {
     Hash *deferred_add;
     match = 1;
 
-    /* Since typemap_register can modify the `sm` hash, we *cannot* call typemap_register while iterating over sm. 
+    /* Since typemap_register can modify the `sm` hash, we *cannot* call typemap_register while iterating over sm.
      * Create a temporary hash of typemaps to add immediately after. */
     deferred_add = NewHash();
     for (ki = First(sm); ki.key; ki = Next(ki)) {
@@ -569,7 +569,7 @@ int Swig_typemap_apply(ParmList *src, ParmList *dest) {
 /* -----------------------------------------------------------------------------
  * Swig_typemap_clear_apply()
  *
- * %clear directive.   Clears all typemaps for a type (in the current scope only).    
+ * %clear directive.   Clears all typemaps for a type (in the current scope only).
  * ----------------------------------------------------------------------------- */
 
 /* Multi-argument %clear directive */
@@ -649,7 +649,7 @@ static void debug_search_result_display(Node *tm) {
  * tm. A match is sought in this order:
  * %typemap(tm_method) ctype cqualifiedname
  * %typemap(tm_method) ctype cname
- * %typemap(tm_method) ctype 
+ * %typemap(tm_method) ctype
  * ----------------------------------------------------------------------------- */
 
 static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm_method, SwigType *ctype, const String *cqualifiedname, const String *cname, Hash **backup) {
@@ -695,8 +695,8 @@ ret_result:
 /* -----------------------------------------------------------------------------
  * typemap_search()
  *
- * Search for a typemap match. This is where the typemap pattern matching rules 
- * are implemented... tries to find the most specific typemap that includes a 
+ * Search for a typemap match. This is where the typemap pattern matching rules
+ * are implemented... tries to find the most specific typemap that includes a
  * 'code' attribute.
  * ----------------------------------------------------------------------------- */
 
@@ -1354,8 +1354,8 @@ static void typemap_merge_fragment_kwargs(Parm *kw) {
  *
  * The node should contain the "type" and "name" attributes for the typemap match on.
  * input. The typemap code and typemap attribute values are attached onto the node
- * prefixed with "tmap:". For example with tmap_method="in", the typemap code can be retrieved 
- * with a call to Getattr(node, "tmap:in") (this is also the string returned) and the 
+ * prefixed with "tmap:". For example with tmap_method="in", the typemap code can be retrieved
+ * with a call to Getattr(node, "tmap:in") (this is also the string returned) and the
  * "noblock" attribute can be retrieved with a call to Getattr(node, "tmap:in:noblock").
  *
  * tmap_method - typemap method, eg "in", "out", "newfree"
@@ -1395,7 +1395,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
     return sdef;
 
   /* Special hook (hack!). Check for the 'ref' feature and add code it contains to any 'newfree' typemap code.
-   * We could choose to put this hook into a number of different typemaps, not necessarily 'newfree'... 
+   * We could choose to put this hook into a number of different typemaps, not necessarily 'newfree'...
    * Rather confusingly 'newfree' is used to release memory and the 'ref' feature is used to add in memory references - yuck! */
   if (Cmp(tmap_method, "newfree") == 0) {
     String *base = SwigType_base(type);
@@ -1470,7 +1470,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
       kw = nextSibling(kw);
     }
   }
-  
+
   if (optimal_attribute) {
     /* Note: "out" typemap is the only typemap that will have the "optimal" attribute set.
      * If f and actioncode are NULL, then the caller is just looking to attach the "out" attributes
@@ -1481,7 +1481,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
        * The code should be in the form "result = ...;\n". We need to extract
        * the "..." part. This may not be possible for various reasons, eg
        * code added by %exception. This optimal code generation is bit of a
-       * hack and circumvents the normal requirement for a temporary variable 
+       * hack and circumvents the normal requirement for a temporary variable
        * to hold the result returned from a wrapped function call.
        */
       if (Strncmp(actioncode, result_equals, Len(result_equals)) == 0 &&
@@ -1737,7 +1737,7 @@ static String *typemap_get_option(Hash *tm, const_String_or_char_ptr name) {
  * Swig_typemap_attach_parms()
  *
  * Given a parameter list, this function attaches all of the typemaps and typemap
- * attributes to the parameter for each type in the parameter list. 
+ * attributes to the parameter for each type in the parameter list.
  *
  * This function basically provides the typemap code and typemap attribute values as
  * attributes on each parameter prefixed with "tmap:". For example with tmap_method="in", the typemap
@@ -2076,13 +2076,13 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
         ParmList *to_match_parms;
         tmap_method = Getitem(l, 0);
 
-        /* the second parameter might contain multiple sub-parameters for multi-argument 
+        /* the second parameter might contain multiple sub-parameters for multi-argument
          * typemap matching, so split these parameters apart */
         to_match_parms = Swig_cparse_parms(Getitem(l, 1), file_line_node);
         if (to_match_parms) {
           Parm *p = to_match_parms;
           Parm *sub_p = parm_sublist;
-          String *empty_string = NewStringEmpty(); 
+          String *empty_string = NewStringEmpty();
           String *lname = empty_string;
           while (p) {
             if (sub_p) {
@@ -2173,7 +2173,7 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
             }
             Delete(attr);
           } else {
-            /* Simple recursive call check to prevent infinite recursion - this strategy only allows a limited 
+            /* Simple recursive call check to prevent infinite recursion - this strategy only allows a limited
              * number of calls by a embedded typemaps to other embedded typemaps though */
             String *dtypemap = NewString(dollar_typemap);
             Replaceall(dtypemap, "$TYPEMAP", "$typemap");

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -79,8 +79,8 @@ static SwigType *typemap_identifier_fix(const SwigType *s) {
     ta = SwigType_templateargs(s);
     tq = Swig_symbol_type_qualify(ta, 0);
     tr = SwigType_typedef_resolve_all(ta);
-    Append(tp,tr);
-    Append(tp,ts);
+    Append(tp, tr);
+    Append(tp, ts);
     Delete(ts);
     Delete(ta);
     Delete(tq);
@@ -145,7 +145,6 @@ static void set_typemap(const SwigType *type, Hash **tmhash) {
   Delete(new_tm);
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_typemap_init()
  *
@@ -189,7 +188,8 @@ static String *typemap_method_name(const_String_or_char_ptr tmap_method) {
  * Internal implementation for Swig_typemap_register()
  * ----------------------------------------------------------------------------- */
 
-static void typemap_register(const_String_or_char_ptr tmap_method, ParmList *parms, const_String_or_char_ptr code, ParmList *locals, ParmList *kwargs, String *source_directive) {
+static void typemap_register(const_String_or_char_ptr tmap_method, ParmList *parms, const_String_or_char_ptr code, ParmList *locals, ParmList *kwargs,
+                             String *source_directive) {
   Hash *tm;
   Hash *tm1;
   Hash *tm2;
@@ -201,8 +201,8 @@ static void typemap_register(const_String_or_char_ptr tmap_method, ParmList *par
     return;
 
   if (typemap_register_debug) {
-      Printf(stdout, "Registering - %s\n", tmap_method);
-      Swig_print_node(parms);
+    Printf(stdout, "Registering - %s\n", tmap_method);
+    Swig_print_node(parms);
   }
 
   tm_method = typemap_method_name(tmap_method);
@@ -380,7 +380,6 @@ int Swig_typemap_copy(const_String_or_char_ptr tmap_method, ParmList *srcparms, 
 
   /* Not found */
   return -1;
-
 }
 
 /* -----------------------------------------------------------------------------
@@ -652,7 +651,8 @@ static void debug_search_result_display(Node *tm) {
  * %typemap(tm_method) ctype
  * ----------------------------------------------------------------------------- */
 
-static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm_method, SwigType *ctype, const String *cqualifiedname, const String *cname, Hash **backup) {
+static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm_method, SwigType *ctype, const String *cqualifiedname, const String *cname,
+                                   Hash **backup) {
   Hash *result = 0;
   Hash *tm1;
   if (debug_display && cqualifiedname)
@@ -682,7 +682,7 @@ static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm
   if (debug_display)
     Printf(stdout, "  Looking for: %s\n", SwigType_str(ctype, 0));
   if (tm) {
-    result = Getattr(tm, tm_method);    /* See if there is simply a type without name match */
+    result = Getattr(tm, tm_method); /* See if there is simply a type without name match */
     if (result && Getattr(result, "code"))
       goto ret_result;
     if (result)
@@ -700,7 +700,8 @@ ret_result:
  * 'code' attribute.
  * ----------------------------------------------------------------------------- */
 
-static Hash *typemap_search(const_String_or_char_ptr tmap_method, SwigType *type, const_String_or_char_ptr name, const_String_or_char_ptr qualifiedname, SwigType **matchtype, Node *node) {
+static Hash *typemap_search(const_String_or_char_ptr tmap_method, SwigType *type, const_String_or_char_ptr name, const_String_or_char_ptr qualifiedname,
+                            SwigType **matchtype, Node *node) {
   Hash *result = 0;
   Hash *tm;
   Hash *backup = 0;
@@ -810,7 +811,6 @@ ret_result:
   return result;
 }
 
-
 /* -----------------------------------------------------------------------------
  * typemap_search_multi()
  *
@@ -867,7 +867,6 @@ static Hash *typemap_search_multi(const_String_or_char_ptr tmap_method, ParmList
 
   return tm;
 }
-
 
 static int replace_with_override(String *src, const DOHString_or_char *token, const DOHString_or_char *replace, int flags, Hash *override_vars) {
   String *override_replace = override_vars ? Getattr(override_vars, token) : NULL;
@@ -1457,7 +1456,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
   if (Cmp(s, "pass") == 0)
     return sdef;
 
-  s = Copy(s);                  /* Make a local copy of the typemap code */
+  s = Copy(s); /* Make a local copy of the typemap code */
 
   /* Look in the "out" typemap for the "optimal" attribute */
   if (Cmp(cmethod, "out") == 0) {
@@ -1484,17 +1483,20 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
        * hack and circumvents the normal requirement for a temporary variable
        * to hold the result returned from a wrapped function call.
        */
-      if (Strncmp(actioncode, result_equals, Len(result_equals)) == 0 &&
-          Strchr(actioncode, ';') == Char(actioncode) + Len(actioncode) - 2 &&
+      if (Strncmp(actioncode, result_equals, Len(result_equals)) == 0 && Strchr(actioncode, ';') == Char(actioncode) + Len(actioncode) - 2 &&
           Char(actioncode)[Len(actioncode) - 1] == '\n') {
-        clname = NewStringWithSize(Char(actioncode) + Len(result_equals),
-                                   Len(actioncode) - Len(result_equals) - 2);
+        clname = NewStringWithSize(Char(actioncode) + Len(result_equals), Len(actioncode) - Len(result_equals) - 2);
         lname = clname;
         actioncode = 0;
         optimal_substitution = 1;
       } else {
-        Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(node), Getline(node), "Method %s usage of the optimal attribute ignored\n", Swig_name_decl(node));
-        Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(s), Getline(s), "in the out typemap as the following cannot be used to generate optimal code: %s\n", actioncode);
+        Swig_warning(
+          WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(node), Getline(node), "Method %s usage of the optimal attribute ignored\n", Swig_name_decl(node));
+        Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED,
+                     Getfile(s),
+                     Getline(s),
+                     "in the out typemap as the following cannot be used to generate optimal code: %s\n",
+                     actioncode);
         delete_optimal_attribute = 1;
       }
     } else {
@@ -1519,13 +1521,13 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
       pname = cname;
     }
   }
-  if (SwigType_istemplate((char *) lname)) {
-    clname = SwigType_namestr((char *) lname);
+  if (SwigType_istemplate((char *)lname)) {
+    clname = SwigType_namestr((char *)lname);
     lname = clname;
   }
 
   matchtype = mtype && SwigType_isarray(mtype) ? mtype : type;
-  num_substitutions = typemap_replace_vars(s, locals, matchtype, type, pname, (char *) lname, 1, NULL);
+  num_substitutions = typemap_replace_vars(s, locals, matchtype, type, pname, (char *)lname, 1, NULL);
   if (optimal_substitution && num_substitutions > 1) {
     Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_MULTIPLE, Getfile(node), Getline(node), "Multiple calls to %s might be generated due to\n", Swig_name_decl(node));
     Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_MULTIPLE, Getfile(s), Getline(s), "optimal attribute usage in the out typemap.\n");
@@ -1599,7 +1601,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
   /* Print warnings, if any */
   warning = typemap_warn(cmethod, node);
   if (warning) {
-    typemap_replace_vars(warning, 0, matchtype, type, pname, (char *) lname, 1, NULL);
+    typemap_replace_vars(warning, 0, matchtype, type, pname, (char *)lname, 1, NULL);
     Replace(warning, "$name", pname, DOH_REPLACE_ANY);
     if (symname)
       Replace(warning, "$symname", symname, DOH_REPLACE_ANY);
@@ -1624,7 +1626,7 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
   Delete(cname);
   Delete(clname);
   Delete(mtype);
-  if (sdef) {                   /* put 'ref' and 'newfree' codes together */
+  if (sdef) { /* put 'ref' and 'newfree' codes together */
     String *p = NewStringf("%s\n%s", sdef, s);
     Delete(s);
     Delete(sdef);
@@ -1827,7 +1829,6 @@ static void typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList 
               continue;
             }
           }
-
         }
       } else {
         p = nextSibling(p);
@@ -1887,7 +1888,7 @@ static void typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList 
 #ifdef SWIG_DEBUG
     Printf(stdout, "attach: %s %s %s\n", Getattr(firstp, "name"), typemap_method_name(tmap_method), s);
 #endif
-    Setattr(firstp, typemap_method_name(tmap_method), s);       /* Code object */
+    Setattr(firstp, typemap_method_name(tmap_method), s); /* Code object */
 
     if (locals) {
       sprintf(temp, "%s:locals", cmethod);
@@ -1929,12 +1930,10 @@ static void typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList 
 #ifdef SWIG_DEBUG
     Printf(stdout, "res: %s %s %s\n", Getattr(firstp, "name"), typemap_method_name(tmap_method), Getattr(firstp, typemap_method_name(tmap_method)));
 #endif
-
   }
 #ifdef SWIG_DEBUG
   Printf(stdout, "Swig_typemap_attach_parms: end\n");
 #endif
-
 }
 
 void Swig_typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList *parms, Wrapper *f) {
@@ -1987,9 +1986,9 @@ static List *split_embedded_typemap(String *s) {
       angle_level++;
     if (*c == '>' && *(c - 1) != '-')
       angle_level--;
-    if (isspace((int) *c) && leading)
+    if (isspace((int)*c) && leading)
       start++;
-    if (!isspace((int) *c))
+    if (!isspace((int)*c))
       leading = 0;
     c++;
   }
@@ -2125,7 +2124,7 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
           Printf(stdout, "Swig_typemap_attach_parms:  embedded\n");
 #endif
           if (already_substituting < 10) {
-            char* found_colon;
+            char *found_colon;
             already_substituting++;
             if ((in_typemap_search_multi == 0) && typemap_search_debug) {
               String *dtypemap = NewString(dollar_typemap);
@@ -2211,7 +2210,6 @@ void Swig_typemap_debug(void) {
   Printf(stdout, "-----------------------------------------------------------------------------\n");
 }
 
-
 /* -----------------------------------------------------------------------------
  * Swig_typemap_search_debug_set()
  *
@@ -2241,4 +2239,3 @@ void Swig_typemap_used_debug_set(void) {
 void Swig_typemap_register_debug_set(void) {
   typemap_register_debug = 1;
 }
-

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -524,25 +524,25 @@ int Swig_typemap_apply(ParmList *src, ParmList *dest) {
     for (ki = First(sm); ki.key; ki = Next(ki)) {
       /* Check for a signature match with the source signature */
       if ((count_args(ki.key) == narg) && (Strstr(ki.key, ssig))) {
-	String *oldm;
-	/* A typemap we have to copy */
-	String *nkey = Copy(ki.key);
-	Replace(nkey, ssig, dsig, DOH_REPLACE_ANY);
+        String *oldm;
+        /* A typemap we have to copy */
+        String *nkey = Copy(ki.key);
+        Replace(nkey, ssig, dsig, DOH_REPLACE_ANY);
 
-	/* Make sure the typemap doesn't already exist in the target map */
-	oldm = Getattr(tm, nkey);
-	if (!oldm || (!Getattr(tm, "code"))) {
-	  String *code;
-	  Hash *sm1 = ki.item;
+        /* Make sure the typemap doesn't already exist in the target map */
+        oldm = Getattr(tm, nkey);
+        if (!oldm || (!Getattr(tm, "code"))) {
+          String *code;
+          Hash *sm1 = ki.item;
 
-	  code = Getattr(sm1, "code");
-	  if (code) {
-	    Replace(nkey, dsig, "", DOH_REPLACE_ANY);
-	    Replace(nkey, "tmap:", "", DOH_REPLACE_ANY);
-	    Setattr(deferred_add, nkey, sm1);
-	  }
-	}
-	Delete(nkey);
+          code = Getattr(sm1, "code");
+          if (code) {
+            Replace(nkey, dsig, "", DOH_REPLACE_ANY);
+            Replace(nkey, "tmap:", "", DOH_REPLACE_ANY);
+            Setattr(deferred_add, nkey, sm1);
+          }
+        }
+        Delete(nkey);
       }
     }
 
@@ -609,13 +609,13 @@ void Swig_typemap_clear_apply(Parm *parms) {
     for (ki = First(tm); ki.key; ki = Next(ki)) {
       char *ckey = Char(ki.key);
       if (strncmp(ckey, "tmap:", 5) == 0) {
-	int na = count_args(ki.key);
-	if ((na == narg) && strstr(ckey, ctsig)) {
-	  Hash *h = ki.item;
-	  for (ki2 = First(h); ki2.key; ki2 = Next(ki2)) {
-	    Delattr(h, ki2.key);
-	  }
-	}
+        int na = count_args(ki.key);
+        if ((na == narg) && strstr(ckey, ctsig)) {
+          Hash *h = ki.item;
+          for (ki2 = First(h); ki2.key; ki2 = Next(ki2)) {
+            Delattr(h, ki2.key);
+          }
+        }
       }
     }
   }
@@ -662,9 +662,9 @@ static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm
     if (tm1) {
       result = Getattr(tm1, tm_method);	/* See if there is a type - qualified name match */
       if (result && Getattr(result, "code"))
-	goto ret_result;
+        goto ret_result;
       if (result)
-	*backup = result;
+        *backup = result;
     }
   }
   if (debug_display && cname)
@@ -674,9 +674,9 @@ static Hash *typemap_search_helper(int debug_display, Hash *tm, const String *tm
     if (tm1) {
       result = Getattr(tm1, tm_method);	/* See if there is a type - name match */
       if (result && Getattr(result, "code"))
-	goto ret_result;
+        goto ret_result;
       if (result)
-	*backup = result;
+        *backup = result;
     }
   }
   if (debug_display)
@@ -736,11 +736,11 @@ static Hash *typemap_search(const_String_or_char_ptr tmap_method, SwigType *type
       /* Look for the type reduced to just the template prefix - for templated types without the template parameter list being specified */
       SwigType *template_prefix = SwigType_istemplate_only_templateprefix(ctype);
       if (template_prefix) {
-	tm = get_typemap(template_prefix);
-	result = typemap_search_helper(debug_display, tm, tm_method, template_prefix, cqualifiedname, cname, &backup);
-	Delete(template_prefix);
-	if (result && Getattr(result, "code"))
-	  goto ret_result;
+        tm = get_typemap(template_prefix);
+        result = typemap_search_helper(debug_display, tm, tm_method, template_prefix, cqualifiedname, cname, &backup);
+        Delete(template_prefix);
+        if (result && Getattr(result, "code"))
+          goto ret_result;
       }
     }
 
@@ -748,13 +748,13 @@ static Hash *typemap_search(const_String_or_char_ptr tmap_method, SwigType *type
     isarray = SwigType_isarray(ctype);
     if (isarray) {
       /* If working with arrays, strip away all of the dimensions and replace with "ANY".
-	 See if that generates a match */
+         See if that generates a match */
       SwigType *noarrays = strip_arrays(ctype);
       tm = get_typemap(noarrays);
       result = typemap_search_helper(debug_display, tm, tm_method, noarrays, cqualifiedname, cname, &backup);
       Delete(noarrays);
       if (result && Getattr(result, "code"))
-	goto ret_result;
+        goto ret_result;
     }
 
     /* No match so far - try with a qualifier stripped (strip one qualifier at a time until none remain)
@@ -764,8 +764,8 @@ static Hash *typemap_search(const_String_or_char_ptr tmap_method, SwigType *type
       SwigType *oldctype = ctype;
       ctype = SwigType_strip_single_qualifier(oldctype);
       if (!Equal(ctype, oldctype)) {
-	Delete(oldctype);
-	continue;
+        Delete(oldctype);
+        continue;
       }
       Delete(oldctype);
     }
@@ -848,7 +848,7 @@ static Hash *typemap_search_multi(const_String_or_char_ptr tmap_method, ParmList
     if (Getattr(tm, "code")) {
       *(nmatch) = *nmatch + 1;
       if (typemap_search_debug && tm1 && (in_typemap_search_multi == 0)) {
-	Printf(stdout, "  Multi-argument typemap found...\n");
+        Printf(stdout, "  Multi-argument typemap found...\n");
       }
     } else {
       tm = 0;
@@ -934,7 +934,7 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
     while (p) {
       String *pname = Getattr(p, "name");
       if (Strchr(Getattr(p, "type"), '$') || (pname && Strchr(pname, '$')))
-	replace = 1;
+        replace = 1;
       p = nextSibling(p);
     }
     if (!replace)
@@ -958,16 +958,16 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
     for (i = 0; i < ndim; i++) {
       String *dim = SwigType_array_getdim(type, i);
       if (index == 1) {
-	char t[32];
-	sprintf(t, "$dim%d", i);
-	Replace(s, t, dim, DOH_REPLACE_ANY);
-	replace_local_types(locals, t, dim);
+        char t[32];
+        sprintf(t, "$dim%d", i);
+        Replace(s, t, dim, DOH_REPLACE_ANY);
+        replace_local_types(locals, t, dim);
       }
       sprintf(varname, "dim%d", i);
       Replace(s, var, dim, DOH_REPLACE_ANY);
       replace_local_types(locals, var, dim);
       if (Len(size))
-	Putc('*', size);
+        Putc('*', size);
       Append(size, dim);
       Delete(dim);
     }
@@ -999,8 +999,8 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
       /* Given type : $type */
       ts = SwigType_str(type, 0);
       if (index == 1) {
-	Replace(s, "$type", ts, DOH_REPLACE_ANY);
-	replace_local_types(locals, "$type", type);
+        Replace(s, "$type", ts, DOH_REPLACE_ANY);
+        replace_local_types(locals, "$type", type);
       }
       strcpy(varname, "type");
       Replace(s, var, ts, DOH_REPLACE_ANY);
@@ -1013,8 +1013,8 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
       ltype = SwigType_ltype(type);
       ts = SwigType_str(ltype, 0);
       if (index == 1) {
-	Replace(s, "$ltype", ts, DOH_REPLACE_ANY);
-	replace_local_types(locals, "$ltype", ltype);
+        Replace(s, "$ltype", ts, DOH_REPLACE_ANY);
+        replace_local_types(locals, "$ltype", ltype);
       }
       strcpy(varname, "ltype");
       Replace(s, var, ts, DOH_REPLACE_ANY);
@@ -1028,19 +1028,19 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
 
       mangle = SwigType_manglestr(type);
       if (index == 1)
-	Replace(s, "$mangle", mangle, DOH_REPLACE_ANY);
+        Replace(s, "$mangle", mangle, DOH_REPLACE_ANY);
       strcpy(varname, "mangle");
       Replace(s, var, mangle, DOH_REPLACE_ANY);
 
       descriptor = NewStringf("SWIGTYPE%s", mangle);
 
       if (index == 1)
-	if (Replace(s, "$descriptor", descriptor, DOH_REPLACE_ANY))
-	  SwigType_remember(type);
+        if (Replace(s, "$descriptor", descriptor, DOH_REPLACE_ANY))
+          SwigType_remember(type);
 
       strcpy(varname, "descriptor");
       if (Replace(s, var, descriptor, DOH_REPLACE_ANY))
-	SwigType_remember(type);
+        SwigType_remember(type);
 
       Delete(descriptor);
       Delete(mangle);
@@ -1054,33 +1054,33 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
 
     if (SwigType_ispointer(ftype) || (SwigType_isarray(ftype)) || (SwigType_isreference(ftype)) || (SwigType_isrvalue_reference(ftype))) {
       if (!(SwigType_isarray(type) || SwigType_ispointer(type) || SwigType_isreference(type) || SwigType_isrvalue_reference(type))) {
-	star_type = Copy(ftype);
+        star_type = Copy(ftype);
       } else {
-	star_type = Copy(type);
+        star_type = Copy(type);
       }
       if (!(SwigType_isreference(star_type) || SwigType_isrvalue_reference(star_type))) {
-	if (SwigType_isarray(star_type)) {
-	  SwigType_del_element(star_type);
-	} else {
-	  SwigType_del_pointer(star_type);
-	}
-	ts = SwigType_str(star_type, 0);
-	if (index == 1) {
-	  Replace(s, "$*type", ts, DOH_REPLACE_ANY);
-	  replace_local_types(locals, "$*type", star_type);
-	}
-	sprintf(varname, "$*%d_type", index);
-	Replace(s, varname, ts, DOH_REPLACE_ANY);
-	replace_local_types(locals, varname, star_type);
-	Delete(ts);
+        if (SwigType_isarray(star_type)) {
+          SwigType_del_element(star_type);
+        } else {
+          SwigType_del_pointer(star_type);
+        }
+        ts = SwigType_str(star_type, 0);
+        if (index == 1) {
+          Replace(s, "$*type", ts, DOH_REPLACE_ANY);
+          replace_local_types(locals, "$*type", star_type);
+        }
+        sprintf(varname, "$*%d_type", index);
+        Replace(s, varname, ts, DOH_REPLACE_ANY);
+        replace_local_types(locals, varname, star_type);
+        Delete(ts);
       } else {
-	SwigType_del_element(star_type);
+        SwigType_del_element(star_type);
       }
       star_ltype = SwigType_ltype(star_type);
       ts = SwigType_str(star_ltype, 0);
       if (index == 1) {
-	Replace(s, "$*ltype", ts, DOH_REPLACE_ANY);
-	replace_local_types(locals, "$*ltype", star_ltype);
+        Replace(s, "$*ltype", ts, DOH_REPLACE_ANY);
+        replace_local_types(locals, "$*ltype", star_ltype);
       }
       sprintf(varname, "$*%d_ltype", index);
       Replace(s, varname, ts, DOH_REPLACE_ANY);
@@ -1090,18 +1090,18 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
 
       star_mangle = SwigType_manglestr(star_type);
       if (index == 1)
-	Replace(s, "$*mangle", star_mangle, DOH_REPLACE_ANY);
+        Replace(s, "$*mangle", star_mangle, DOH_REPLACE_ANY);
 
       sprintf(varname, "$*%d_mangle", index);
       Replace(s, varname, star_mangle, DOH_REPLACE_ANY);
 
       star_descriptor = NewStringf("SWIGTYPE%s", star_mangle);
       if (index == 1)
-	if (Replace(s, "$*descriptor", star_descriptor, DOH_REPLACE_ANY))
-	  SwigType_remember(star_type);
+        if (Replace(s, "$*descriptor", star_descriptor, DOH_REPLACE_ANY))
+          SwigType_remember(star_type);
       sprintf(varname, "$*%d_descriptor", index);
       if (Replace(s, varname, star_descriptor, DOH_REPLACE_ANY))
-	SwigType_remember(star_type);
+        SwigType_remember(star_type);
 
       Delete(star_descriptor);
       Delete(star_mangle);
@@ -1146,7 +1146,7 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
     amp_descriptor = NewStringf("SWIGTYPE%s", amp_mangle);
     if (index == 1)
       if (Replace(s, "$&descriptor", amp_descriptor, DOH_REPLACE_ANY))
-	SwigType_remember(amp_type);
+        SwigType_remember(amp_type);
     sprintf(varname, "$&%d_descriptor", index);
     if (Replace(s, varname, amp_descriptor, DOH_REPLACE_ANY))
       SwigType_remember(amp_type);
@@ -1229,44 +1229,44 @@ static void typemap_locals(String *s, ParmList *l, Wrapper *f, int argnum) {
       pt = at;
     if (pn) {
       if (Len(pn) > 0) {
-	String *str;
-	int isglobal = 0;
+        String *str;
+        int isglobal = 0;
 
-	str = NewStringEmpty();
+        str = NewStringEmpty();
 
-	if (strncmp(Char(pn), "_global_", 8) == 0) {
-	  isglobal = 1;
-	}
+        if (strncmp(Char(pn), "_global_", 8) == 0) {
+          isglobal = 1;
+        }
 
-	/* If the user gave us $type as the name of the local variable, we'll use
-	   the passed datatype instead */
+        /* If the user gave us $type as the name of the local variable, we'll use
+           the passed datatype instead */
 
-	if ((argnum >= 0) && !isglobal && !Getattr(p, "origname")) {
-	  Printf(str, "%s%d", pn, argnum);
-	} else {
-	  Append(str, pn);
-	}
-	if (isglobal && Wrapper_check_local(f, str)) {
-	  p = nextSibling(p);
-	  Delete(str);
-	  if (at)
-	    Delete(at);
-	  continue;
-	}
-	if (value) {
-	  String *pstr = SwigType_str(pt, str);
-	  new_name = Wrapper_new_localv(f, str, pstr, "=", value, NIL);
-	  Delete(pstr);
-	} else {
-	  String *pstr = SwigType_str(pt, str);
-	  new_name = Wrapper_new_localv(f, str, pstr, NIL);
-	  Delete(pstr);
-	}
-	if (!isglobal) {
-	  /* Substitute  */
-	  Replace(s, pn, new_name, DOH_REPLACE_ID | DOH_REPLACE_NOQUOTE);
-	}
-	Delete(str);
+        if ((argnum >= 0) && !isglobal && !Getattr(p, "origname")) {
+          Printf(str, "%s%d", pn, argnum);
+        } else {
+          Append(str, pn);
+        }
+        if (isglobal && Wrapper_check_local(f, str)) {
+          p = nextSibling(p);
+          Delete(str);
+          if (at)
+            Delete(at);
+          continue;
+        }
+        if (value) {
+          String *pstr = SwigType_str(pt, str);
+          new_name = Wrapper_new_localv(f, str, pstr, "=", value, NIL);
+          Delete(pstr);
+        } else {
+          String *pstr = SwigType_str(pt, str);
+          new_name = Wrapper_new_localv(f, str, pstr, NIL);
+          Delete(pstr);
+        }
+        if (!isglobal) {
+          /* Substitute  */
+          Replace(s, pn, new_name, DOH_REPLACE_ID | DOH_REPLACE_NOQUOTE);
+        }
+        Delete(str);
       }
     }
     p = nextSibling(p);
@@ -1308,13 +1308,13 @@ static void typemap_merge_fragment_kwargs(Parm *kw) {
       String *thisfragment = Getattr(kw, "value");
       String *kwtype = Getattr(kw, "type");
       if (!fragment) {
-	/* First fragment found; it should remain in the list */
-	fragment = thisfragment;
-	prev_kw = kw;
+        /* First fragment found; it should remain in the list */
+        fragment = thisfragment;
+        prev_kw = kw;
       } else {
-	/* Concatenate to previously found fragment */
-	Printv(fragment, ",", thisfragment, NULL);
-	reattach_kw = prev_kw;
+        /* Concatenate to previously found fragment */
+        Printv(fragment, ",", thisfragment, NULL);
+        reattach_kw = prev_kw;
       }
       if (kwtype) {
         String *mangle = Swig_name_mangle_type(kwtype);
@@ -1326,12 +1326,12 @@ static void typemap_merge_fragment_kwargs(Parm *kw) {
     } else {
       /* Not a fragment */
       if (reattach_kw) {
-	/* Update linked list to remove duplicate fragment */
-	DohIncref(kw);
-	set_nextSibling(reattach_kw, kw);
-	set_previousSibling(kw, reattach_kw);
-	Delete(reattach_kw);
-	reattach_kw = NULL;
+        /* Update linked list to remove duplicate fragment */
+        DohIncref(kw);
+        set_nextSibling(reattach_kw, kw);
+        set_previousSibling(kw, reattach_kw);
+        Delete(reattach_kw);
+        reattach_kw = NULL;
       }
       prev_kw = kw;
     }
@@ -1464,8 +1464,8 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
     kw = Getattr(tm, "kwargs");
     while (kw) {
       if (Cmp(Getattr(kw, "name"), "optimal") == 0) {
-	optimal_attribute = GetFlag(kw, "value");
-	break;
+        optimal_attribute = GetFlag(kw, "value");
+        break;
       }
       kw = nextSibling(kw);
     }
@@ -1485,17 +1485,17 @@ static String *Swig_typemap_lookup_impl(const_String_or_char_ptr tmap_method, No
        * to hold the result returned from a wrapped function call.
        */
       if (Strncmp(actioncode, result_equals, Len(result_equals)) == 0 &&
-	  Strchr(actioncode, ';') == Char(actioncode) + Len(actioncode) - 2 &&
-	  Char(actioncode)[Len(actioncode) - 1] == '\n') {
-	clname = NewStringWithSize(Char(actioncode) + Len(result_equals),
-				   Len(actioncode) - Len(result_equals) - 2);
-	lname = clname;
-	actioncode = 0;
-	optimal_substitution = 1;
+          Strchr(actioncode, ';') == Char(actioncode) + Len(actioncode) - 2 &&
+          Char(actioncode)[Len(actioncode) - 1] == '\n') {
+        clname = NewStringWithSize(Char(actioncode) + Len(result_equals),
+                                   Len(actioncode) - Len(result_equals) - 2);
+        lname = clname;
+        actioncode = 0;
+        optimal_substitution = 1;
       } else {
-	Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(node), Getline(node), "Method %s usage of the optimal attribute ignored\n", Swig_name_decl(node));
-	Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(s), Getline(s), "in the out typemap as the following cannot be used to generate optimal code: %s\n", actioncode);
-	delete_optimal_attribute = 1;
+        Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(node), Getline(node), "Method %s usage of the optimal attribute ignored\n", Swig_name_decl(node));
+        Swig_warning(WARN_TYPEMAP_OUT_OPTIMAL_IGNORED, Getfile(s), Getline(s), "in the out typemap as the following cannot be used to generate optimal code: %s\n", actioncode);
+        delete_optimal_attribute = 1;
       }
     } else {
       assert(!f);
@@ -1800,38 +1800,38 @@ static void typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList 
       Delete(tmname);
 #ifdef SWIG_DEBUG
       if (tm)
-	Printf(stdout, "matching:  %s\n", kwmatch);
+        Printf(stdout, "matching:  %s\n", kwmatch);
 #endif
       if (tmin) {
-	String *tmninp = NewStringf("tmap:%s:numinputs", kwmatch);
-	String *ninp = Getattr(p, tmninp);
-	Delete(tmninp);
-	if (ninp && Equal(ninp, "0")) {
-	  p = nextSibling(p);
-	  continue;
-	} else {
-	  SwigType *typetm = Getattr(tm, "type");
-	  String *temp = NewStringf("tmap:%s:match_type", kwmatch);
-	  SwigType *typein = Getattr(p, temp);
-	  Delete(temp);
-	  if (!Equal(typein, typetm)) {
-	    p = nextSibling(p);
-	    continue;
-	  } else {
-	    int nnmatch;
-	    Hash *tmapin = typemap_search_multi(kwmatch, p, &nnmatch);
-	    String *tmname = Getattr(tm, "pname");
-	    String *tnname = Getattr(tmapin, "pname");
-	    if (!(tmname && tnname && Equal(tmname, tnname)) && !(!tmname && !tnname)) {
-	      p = nextSibling(p);
-	      continue;
-	    }
-	  }
+        String *tmninp = NewStringf("tmap:%s:numinputs", kwmatch);
+        String *ninp = Getattr(p, tmninp);
+        Delete(tmninp);
+        if (ninp && Equal(ninp, "0")) {
+          p = nextSibling(p);
+          continue;
+        } else {
+          SwigType *typetm = Getattr(tm, "type");
+          String *temp = NewStringf("tmap:%s:match_type", kwmatch);
+          SwigType *typein = Getattr(p, temp);
+          Delete(temp);
+          if (!Equal(typein, typetm)) {
+            p = nextSibling(p);
+            continue;
+          } else {
+            int nnmatch;
+            Hash *tmapin = typemap_search_multi(kwmatch, p, &nnmatch);
+            String *tmname = Getattr(tm, "pname");
+            String *tnname = Getattr(tmapin, "pname");
+            if (!(tmname && tnname && Equal(tmname, tnname)) && !(!tmname && !tnname)) {
+              p = nextSibling(p);
+              continue;
+            }
+          }
 
-	}
+        }
       } else {
-	p = nextSibling(p);
-	continue;
+        p = nextSibling(p);
+        continue;
       }
     }
 
@@ -1868,11 +1868,11 @@ static void typemap_attach_parms(const_String_or_char_ptr tmap_method, ParmList 
 
       typemap_replace_vars(s, locals, matchtype, type, pname, lname, i + 1, override_vars);
       if (mtype)
-	Delattr(p, "tmap:match");
+        Delattr(p, "tmap:match");
 
       if (Checkattr(tm, "type", "SWIGTYPE")) {
-	sprintf(temp, "%s:SWIGTYPE", cmethod);
-	Setattr(p, typemap_method_name(temp), "1");
+        sprintf(temp, "%s:SWIGTYPE", cmethod);
+        Setattr(p, typemap_method_name(temp), "1");
       }
       p = nextSibling(p);
     }
@@ -1959,13 +1959,13 @@ static List *split_embedded_typemap(String *s) {
     if (*c == '\"') {
       c++;
       while (*c) {
-	if (*c == '\\') {
-	  c++;
-	} else {
-	  if (*c == '\"')
-	    break;
-	}
-	c++;
+        if (*c == '\\') {
+          c++;
+        } else {
+          if (*c == '\"')
+            break;
+        }
+        c++;
       }
     }
     if ((level == 0) && angle_level == 0 && ((*c == ',') || (*c == ')'))) {
@@ -1975,7 +1975,7 @@ static List *split_embedded_typemap(String *s) {
       start = c + 1;
       leading = 1;
       if (*c == ')')
-	break;
+        break;
       c++;
       continue;
     }
@@ -2046,13 +2046,13 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
     c = start;
     while (*c) {
       if (*c == '(')
-	level++;
+        level++;
       if (*c == ')') {
-	level--;
-	if (level == 0) {
-	  end = c + 1;
-	  break;
-	}
+        level--;
+        if (level == 0) {
+          end = c + 1;
+          break;
+        }
       }
       c++;
     }
@@ -2073,116 +2073,116 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
       l = split_embedded_typemap(dollar_typemap);
 
       if (Len(l) >= 2) {
-	ParmList *to_match_parms;
-	tmap_method = Getitem(l, 0);
+        ParmList *to_match_parms;
+        tmap_method = Getitem(l, 0);
 
-	/* the second parameter might contain multiple sub-parameters for multi-argument 
-	 * typemap matching, so split these parameters apart */
-	to_match_parms = Swig_cparse_parms(Getitem(l, 1), file_line_node);
-	if (to_match_parms) {
-	  Parm *p = to_match_parms;
-	  Parm *sub_p = parm_sublist;
-	  String *empty_string = NewStringEmpty(); 
-	  String *lname = empty_string;
-	  while (p) {
-	    if (sub_p) {
-	      lname = Getattr(sub_p, "lname");
-	      sub_p = nextSibling(sub_p);
-	    }
-	    Setattr(p, "lname", lname);
-	    p = nextSibling(p);
-	  }
-	  Delete(empty_string);
-	}
+        /* the second parameter might contain multiple sub-parameters for multi-argument 
+         * typemap matching, so split these parameters apart */
+        to_match_parms = Swig_cparse_parms(Getitem(l, 1), file_line_node);
+        if (to_match_parms) {
+          Parm *p = to_match_parms;
+          Parm *sub_p = parm_sublist;
+          String *empty_string = NewStringEmpty(); 
+          String *lname = empty_string;
+          while (p) {
+            if (sub_p) {
+              lname = Getattr(sub_p, "lname");
+              sub_p = nextSibling(sub_p);
+            }
+            Setattr(p, "lname", lname);
+            p = nextSibling(p);
+          }
+          Delete(empty_string);
+        }
 
-	/* process optional extra parameters - the override variable replacements (undocumented) */
-	override_vars = NewHash();
-	{
-	  int i, ilen;
-	  ilen = Len(l);
-	  for (i = 2; i < ilen; i++) {
-	    String *parm = Getitem(l, i);
-	    char *eq = strchr(Char(parm), '=');
-	    char *c = Char(parm);
-	    if (eq && (eq - c > 0)) {
-	      String *name = NewStringWithSize(c, (int)(eq - c));
-	      String *value = NewString(eq + 1);
-	      Insert(name, 0, "$");
-	      Setattr(override_vars, name, value);
-	    } else {
-	      to_match_parms = 0; /* error - variable replacement parameters must be of form varname=value */
-	    }
-	  }
-	}
+        /* process optional extra parameters - the override variable replacements (undocumented) */
+        override_vars = NewHash();
+        {
+          int i, ilen;
+          ilen = Len(l);
+          for (i = 2; i < ilen; i++) {
+            String *parm = Getitem(l, i);
+            char *eq = strchr(Char(parm), '=');
+            char *c = Char(parm);
+            if (eq && (eq - c > 0)) {
+              String *name = NewStringWithSize(c, (int)(eq - c));
+              String *value = NewString(eq + 1);
+              Insert(name, 0, "$");
+              Setattr(override_vars, name, value);
+            } else {
+              to_match_parms = 0; /* error - variable replacement parameters must be of form varname=value */
+            }
+          }
+        }
 
-	/* Perform a typemap search */
-	if (to_match_parms) {
-	  static int already_substituting = 0;
-	  String *tm;
-	  String *attr;
-	  int match = 0;
+        /* Perform a typemap search */
+        if (to_match_parms) {
+          static int already_substituting = 0;
+          String *tm;
+          String *attr;
+          int match = 0;
 #ifdef SWIG_DEBUG
-	  Printf(stdout, "Swig_typemap_attach_parms:  embedded\n");
+          Printf(stdout, "Swig_typemap_attach_parms:  embedded\n");
 #endif
-	  if (already_substituting < 10) {
-	    char* found_colon;
-	    already_substituting++;
-	    if ((in_typemap_search_multi == 0) && typemap_search_debug) {
-	      String *dtypemap = NewString(dollar_typemap);
-	      Replaceall(dtypemap, "$TYPEMAP", "$typemap");
-	      Printf(stdout, "  Containing: %s\n", dtypemap);
-	      Delete(dtypemap);
-	    }
-	    found_colon = Strchr(tmap_method, ':');
-	    if (found_colon) {
-	      /* Substitute from a keyword argument to a typemap. Avoid emitting local variables from the attached typemap by passing NULL for the file. */
-	      String *temp_tmap_method = NewStringWithSize(Char(tmap_method), (int)(found_colon - Char(tmap_method)));
-	      typemap_attach_parms(temp_tmap_method, to_match_parms, NULL, override_vars);
-	      Delete(temp_tmap_method);
-	    } else {
-	      typemap_attach_parms(tmap_method, to_match_parms, f, override_vars);
-	    }
-	    already_substituting--;
+          if (already_substituting < 10) {
+            char* found_colon;
+            already_substituting++;
+            if ((in_typemap_search_multi == 0) && typemap_search_debug) {
+              String *dtypemap = NewString(dollar_typemap);
+              Replaceall(dtypemap, "$TYPEMAP", "$typemap");
+              Printf(stdout, "  Containing: %s\n", dtypemap);
+              Delete(dtypemap);
+            }
+            found_colon = Strchr(tmap_method, ':');
+            if (found_colon) {
+              /* Substitute from a keyword argument to a typemap. Avoid emitting local variables from the attached typemap by passing NULL for the file. */
+              String *temp_tmap_method = NewStringWithSize(Char(tmap_method), (int)(found_colon - Char(tmap_method)));
+              typemap_attach_parms(temp_tmap_method, to_match_parms, NULL, override_vars);
+              Delete(temp_tmap_method);
+            } else {
+              typemap_attach_parms(tmap_method, to_match_parms, f, override_vars);
+            }
+            already_substituting--;
 
-	    /* Look for the typemap code */
-	    attr = NewStringf("tmap:%s", tmap_method);
-	    tm = Getattr(to_match_parms, attr);
-	    if (tm) {
-	      Printf(attr, "%s", ":next");
-	      /* fail if multi-argument lookup requested in $typemap(...) and the lookup failed */
-	      if (!Getattr(to_match_parms, attr)) {
-		/* Replace parameter variables */
-		Iterator ki;
-		for (ki = First(override_vars); ki.key; ki = Next(ki)) {
-		  Replace(tm, ki.key, ki.item, DOH_REPLACE_ANY);
-		}
-		/* offer the target language module the chance to make special variable substitutions */
-		Language_replace_special_variables(tmap_method, tm, to_match_parms);
-		/* finish up - do the substitution */
-		Replace(s, dollar_typemap, tm, DOH_REPLACE_ANY);
-		Delete(tm);
-		match = 1;
-	      }
-	    }
+            /* Look for the typemap code */
+            attr = NewStringf("tmap:%s", tmap_method);
+            tm = Getattr(to_match_parms, attr);
+            if (tm) {
+              Printf(attr, "%s", ":next");
+              /* fail if multi-argument lookup requested in $typemap(...) and the lookup failed */
+              if (!Getattr(to_match_parms, attr)) {
+                /* Replace parameter variables */
+                Iterator ki;
+                for (ki = First(override_vars); ki.key; ki = Next(ki)) {
+                  Replace(tm, ki.key, ki.item, DOH_REPLACE_ANY);
+                }
+                /* offer the target language module the chance to make special variable substitutions */
+                Language_replace_special_variables(tmap_method, tm, to_match_parms);
+                /* finish up - do the substitution */
+                Replace(s, dollar_typemap, tm, DOH_REPLACE_ANY);
+                Delete(tm);
+                match = 1;
+              }
+            }
 
-	    if (!match) {
-	      String *dtypemap = NewString(dollar_typemap);
-	      Replaceall(dtypemap, "$TYPEMAP", "$typemap");
-	      Swig_error(Getfile(s), Getline(s), "No typemap found for %s\n", dtypemap);
-	      Delete(dtypemap);
-	    }
-	    Delete(attr);
-	  } else {
-	    /* Simple recursive call check to prevent infinite recursion - this strategy only allows a limited 
-	     * number of calls by a embedded typemaps to other embedded typemaps though */
-	    String *dtypemap = NewString(dollar_typemap);
-	    Replaceall(dtypemap, "$TYPEMAP", "$typemap");
-	    Swig_error(Getfile(s), Getline(s), "Likely recursive $typemap calls containing %s. Use -debug-tmsearch to debug.\n", dtypemap);
-	    Delete(dtypemap);
-	  }
-	  syntax_error = 0;
-	}
-	Delete(override_vars);
+            if (!match) {
+              String *dtypemap = NewString(dollar_typemap);
+              Replaceall(dtypemap, "$TYPEMAP", "$typemap");
+              Swig_error(Getfile(s), Getline(s), "No typemap found for %s\n", dtypemap);
+              Delete(dtypemap);
+            }
+            Delete(attr);
+          } else {
+            /* Simple recursive call check to prevent infinite recursion - this strategy only allows a limited 
+             * number of calls by a embedded typemaps to other embedded typemaps though */
+            String *dtypemap = NewString(dollar_typemap);
+            Replaceall(dtypemap, "$TYPEMAP", "$typemap");
+            Swig_error(Getfile(s), Getline(s), "Likely recursive $typemap calls containing %s. Use -debug-tmsearch to debug.\n", dtypemap);
+            Delete(dtypemap);
+          }
+          syntax_error = 0;
+        }
+        Delete(override_vars);
       }
       Delete(l);
     }

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -135,7 +135,7 @@ static int element_size(char *c) {
   while (*c) {
     if (*c == '.') {
       c++;
-      return (int) (c - s);
+      return (int)(c - s);
     } else if (*c == '(') {
       nparen = 1;
       c++;
@@ -153,7 +153,7 @@ static int element_size(char *c) {
     if (*c)
       c++;
   }
-  return (int) (c - s);
+  return (int)(c - s);
 }
 
 /* -----------------------------------------------------------------------------
@@ -265,7 +265,7 @@ String *SwigType_parm(const SwigType *t) {
     }
     c++;
   }
-  return NewStringWithSize(start, (int) (c - start));
+  return NewStringWithSize(start, (int)(c - start));
 }
 
 /* -----------------------------------------------------------------------------
@@ -330,7 +330,7 @@ List *SwigType_parmlist(const SwigType *p) {
   itemstart = c;
   while (*c) {
     if (*c == ',') {
-      size = (int) (c - itemstart);
+      size = (int)(c - itemstart);
       item = NewStringWithSize(itemstart, size);
       Append(list, item);
       Delete(item);
@@ -354,7 +354,7 @@ List *SwigType_parmlist(const SwigType *p) {
     if (*c)
       c++;
   }
-  size = (int) (c - itemstart);
+  size = (int)(c - itemstart);
   if (size > 0) {
     item = NewStringWithSize(itemstart, size);
     Append(list, item);
@@ -561,7 +561,7 @@ SwigType *SwigType_add_qualifier(SwigType *t, const_String_or_char_ptr qual) {
   if (strncmp(c, "q(", 2) == 0) {
     allq = SwigType_parm(t);
     Append(allq, " ");
-    SwigType_del_element(t);     /* delete old qualifier list from 't' */
+    SwigType_del_element(t); /* delete old qualifier list from 't' */
   } else {
     allq = NewStringEmpty();
   }
@@ -748,7 +748,6 @@ int SwigType_prefix_is_simple_1D_array(const SwigType *t) {
   return 0;
 }
 
-
 /* Remove all arrays */
 SwigType *SwigType_pop_arrays(SwigType *t) {
   String *ta;
@@ -844,7 +843,6 @@ SwigType *SwigType_array_type(const SwigType *ty) {
   }
   return t;
 }
-
 
 /* -----------------------------------------------------------------------------
  *                                    Functions
@@ -1054,7 +1052,6 @@ SwigType *SwigType_add_template(SwigType *t, ParmList *parms) {
   Append(t, ")>");
   return t;
 }
-
 
 /* -----------------------------------------------------------------------------
  * SwigType_templateprefix()
@@ -1401,4 +1398,3 @@ SwigType *SwigType_strip_single_qualifier(const SwigType *t) {
   }
   return r;
 }
-

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -41,7 +41,7 @@
  *        p.q(const).char                 char const *
  *
  * All type constructors are denoted by a trailing '.':
- * 
+ *
  *  'p.'                = Pointer (*)
  *  'r.'                = Reference or ref-qualifier (&)
  *  'z.'                = Rvalue reference or ref-qualifier (&&)
@@ -102,20 +102,20 @@
  *
  * Finally, there are some data extraction functions that can be used to
  * extract array dimensions, template arguments, and so forth.
- * 
+ *
  * It is very important for developers to realize that the functions in this
  * module do *NOT* incorporate higher-level type system features like typedef.
  * For example, you could have C code like this:
  *
  *        typedef  int  *intptr;
- *       
+ *
  * In this case, a SwigType of type 'intptr' will be treated as a simple type and
  * functions like SwigType_ispointer() will evaluate as false.  It is strongly
  * advised that developers use the TypeSys_* interface to check types in a more
  * reliable manner.
  * ----------------------------------------------------------------------------- */
 
-/* The next few functions are utility functions used in the construction and 
+/* The next few functions are utility functions used in the construction and
    management of types */
 
 /* -----------------------------------------------------------------------------
@@ -125,7 +125,7 @@
  * Type elements are always delimited by periods, but may be nested with
  * parentheses.  A nested element is always handled as a single item.
  *
- * Returns the integer size of the element (which can be used to extract a 
+ * Returns the integer size of the element (which can be used to extract a
  * substring, to chop the element off, or for other purposes).
  * ----------------------------------------------------------------------------- */
 
@@ -159,7 +159,7 @@ static int element_size(char *c) {
 /* -----------------------------------------------------------------------------
  * SwigType_del_element()
  *
- * Deletes one type element from the type.  
+ * Deletes one type element from the type.
  * ----------------------------------------------------------------------------- */
 
 SwigType *SwigType_del_element(SwigType *t) {
@@ -170,7 +170,7 @@ SwigType *SwigType_del_element(SwigType *t) {
 
 /* -----------------------------------------------------------------------------
  * SwigType_pop()
- * 
+ *
  * Pop one type element off the type.
  * For example:
  *   t in:   q(const).p.Integer
@@ -199,7 +199,7 @@ SwigType *SwigType_pop(SwigType *t) {
 
 /* -----------------------------------------------------------------------------
  * SwigType_last()
- * 
+ *
  * Return the last element of the given (partial) type.
  * For example:
  *   t:      q(const).p.
@@ -310,7 +310,7 @@ List *SwigType_split(const SwigType *t) {
  *    std::string
  *    p.f().Bar<(int,double)>
  * ----------------------------------------------------------------------------- */
- 
+
 List *SwigType_parmlist(const SwigType *p) {
   String *item = 0;
   List *list;
@@ -990,7 +990,7 @@ int SwigType_isfunction(const SwigType *t) {
   return 0;
 }
 
-/* Create a list of parameters from the type t, using the file_line_node Node for 
+/* Create a list of parameters from the type t, using the file_line_node Node for
  * file and line numbering for the parameters */
 ParmList *SwigType_function_parms(const SwigType *t, Node *file_line_node) {
   List *l = SwigType_parmlist(t);
@@ -1308,7 +1308,7 @@ String *SwigType_prefix(const SwigType *t) {
 
 /* -----------------------------------------------------------------------------
  * SwigType_strip_qualifiers()
- * 
+ *
  * Strip all qualifiers from a type and return a new type
  * ----------------------------------------------------------------------------- */
 
@@ -1346,11 +1346,11 @@ SwigType *SwigType_strip_qualifiers(const SwigType *t) {
 
 /* -----------------------------------------------------------------------------
  * SwigType_strip_single_qualifier()
- * 
+ *
  * If the type contains a qualifier, strip one qualifier and return a new type.
  * The left most qualifier is stripped first (when viewed as C source code) but
  * this is the equivalent to the right most qualifier using SwigType notation.
- * Example: 
+ * Example:
  *    r.q(const).p.q(const).int => r.q(const).p.int
  *    r.q(const).p.int          => r.p.int
  *    r.p.int                   => r.p.int

--- a/Source/Swig/typeobj.c
+++ b/Source/Swig/typeobj.c
@@ -140,14 +140,14 @@ static int element_size(char *c) {
       nparen = 1;
       c++;
       while (*c) {
-	if (*c == '(')
-	  nparen++;
-	if (*c == ')') {
-	  nparen--;
-	  if (nparen == 0)
-	    break;
-	}
-	c++;
+        if (*c == '(')
+          nparen++;
+        if (*c == ')') {
+          nparen--;
+          if (nparen == 0)
+            break;
+        }
+        c++;
       }
     }
     if (*c)
@@ -258,7 +258,7 @@ String *SwigType_parm(const SwigType *t) {
   while (*c) {
     if (*c == ')') {
       if (nparens == 0)
-	break;
+        break;
       nparens--;
     } else if (*c == '(') {
       nparens++;
@@ -339,14 +339,14 @@ List *SwigType_parmlist(const SwigType *p) {
       int nparens = 1;
       c++;
       while (*c) {
-	if (*c == '(')
-	  nparens++;
-	if (*c == ')') {
-	  nparens--;
-	  if (nparens == 0)
-	    break;
-	}
-	c++;
+        if (*c == '(')
+          nparens++;
+        if (*c == ')') {
+          nparens--;
+          if (nparens == 0)
+            break;
+        }
+        c++;
       }
     } else if (*c == ')') {
       break;
@@ -1094,11 +1094,11 @@ String *SwigType_templatesuffix(const SwigType *t) {
       int nest = 1;
       c++;
       while ((d > c) && nest) {
-	if (*c == '<' && *(c + 1) == '(')
-	  nest++;
-	if (*c == '>' && *(c - 1) == ')')
-	  nest--;
-	c++;
+        if (*c == '<' && *(c + 1) == '(')
+          nest++;
+        if (*c == '>' && *(c - 1) == ')')
+          nest--;
+        c++;
       }
       return NewString(c);
     }
@@ -1174,11 +1174,11 @@ String *SwigType_templateargs(const SwigType *t) {
       start = c;
       c++;
       while ((d > c) && nest) {
-	if (*c == '<' && *(c + 1) == '(')
-	  nest++;
-	if (*c == '>' && *(c - 1) == ')')
-	  nest--;
-	c++;
+        if (*c == '<' && *(c + 1) == '(')
+          nest++;
+        if (*c == '>' && *(c - 1) == ')')
+          nest--;
+        c++;
       }
       return NewStringWithSize(start, (int)(c - start));
     }
@@ -1219,7 +1219,7 @@ SwigType *SwigType_base(const SwigType *t) {
   while (*c) {
     if (*c == '.') {
       if (*(c + 1)) {
-	lastop = c + 1;
+        lastop = c + 1;
       }
       c++;
       continue;
@@ -1233,14 +1233,14 @@ SwigType *SwigType_base(const SwigType *t) {
       int nparen = 1;
       c++;
       while ((*c) && (nparen > 0)) {
-	if (*c == '(')
-	  nparen++;
-	else if (*c == ')')
-	  nparen--;
-	c++;
+        if (*c == '(')
+          nparen++;
+        else if (*c == ')')
+          nparen--;
+        c++;
       }
       if (nparen)
-	break;
+        break;
       continue;
     }
     c++;
@@ -1274,11 +1274,11 @@ String *SwigType_prefix(const SwigType *t) {
       d--;
       d--;
       while ((d > c) && (nest)) {
-	if (*d == '>' && *(d - 1) == ')')
-	  nest++;
-	if (*d == '<' && *(d + 1) == '(')
-	  nest--;
-	d--;
+        if (*d == '>' && *(d - 1) == ')')
+          nest++;
+        if (*d == '<' && *(d + 1) == '(')
+          nest--;
+        d--;
       }
     }
 
@@ -1287,11 +1287,11 @@ String *SwigType_prefix(const SwigType *t) {
       int nparen = 1;
       d--;
       while ((d > c) && (nparen)) {
-	if (*d == ')')
-	  nparen++;
-	if (*d == '(')
-	  nparen--;
-	d--;
+        if (*d == ')')
+          nparen++;
+        if (*d == '(')
+          nparen--;
+        d--;
       }
     }
 
@@ -1377,13 +1377,13 @@ SwigType *SwigType_strip_single_qualifier(const SwigType *t) {
     for (item = numitems - 2; item >= 0; --item) {
       String *subtype = Getitem(l, item);
       if (SwigType_isqualifier(subtype)) {
-	Iterator it;
-	Delitem(l, item);
-	r = NewStringEmpty();
-	for (it = First(l); it.item; it = Next(it)) {
-	  Append(r, it.item);
-	}
-	break;
+        Iterator it;
+        Delitem(l, item);
+        r = NewStringEmpty();
+        for (it = First(l); it.item; it = Next(it)) {
+          Append(r, it.item);
+        }
+        break;
       }
     }
   }

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -147,11 +147,11 @@
  *
  *----------------------------------------------------------------------------- */
 
-static Typetab *current_scope = 0;	/* Current type scope                           */
-static Hash *current_typetab = 0;	/* Current type table                           */
-static Hash *current_symtab = 0;	/* Current symbol table                         */
-static Typetab *global_scope = 0;	/* The global scope                             */
-static Hash *scopes = 0;	/* Hash table containing fully qualified scopes */
+static Typetab *current_scope = 0;      /* Current type scope                           */
+static Hash *current_typetab = 0;       /* Current type table                           */
+static Hash *current_symtab = 0;        /* Current symbol table                         */
+static Typetab *global_scope = 0;       /* The global scope                             */
+static Hash *scopes = 0;        /* Hash table containing fully qualified scopes */
 
 /* Performance optimization */
 #define SWIG_TYPEDEF_RESOLVE_CACHE
@@ -197,7 +197,7 @@ void SwigType_typesystem_init(void) {
   current_scope = NewHash();
   global_scope = current_scope;
 
-  Setattr(current_scope, "name", "");	/* No name for global scope */
+  Setattr(current_scope, "name", "");   /* No name for global scope */
   current_typetab = NewHash();
   Setattr(current_scope, "typetab", current_typetab);
 
@@ -217,8 +217,8 @@ void SwigType_typesystem_init(void) {
 int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name) {
   /* Printf(stdout, "typedef %s %s\n", type, name); */
   if (Getattr(current_typetab, name))
-    return -1;			/* Already defined */
-  if (Strcmp(type, name) == 0) {	/* Can't typedef a name to itself */
+    return -1;                  /* Already defined */
+  if (Strcmp(type, name) == 0) {        /* Can't typedef a name to itself */
     return 0;
   }
 
@@ -249,7 +249,7 @@ int SwigType_typedef_class(const_String_or_char_ptr name) {
   String *cname;
   /*  Printf(stdout,"class : '%s'\n", name); */
   if (Getattr(current_typetab, name))
-    return -1;			/* Already defined */
+    return -1;                  /* Already defined */
   cname = NewString(name);
   Setmeta(cname, "class", "1");
   Setattr(current_typetab, cname, cname);
@@ -1155,7 +1155,7 @@ SwigType *SwigType_typedef_qualified(const SwigType *t) {
         while ((p = pi.item)) {
           /* TODO: the logic here should be synchronised with that in symbol_template_qualify() in symbol.c */
           String *qt = SwigType_typedef_qualified(p);
-          if (Equal(qt, p)) {	/*  && (!Swig_scopename_check(qt))) */
+          if (Equal(qt, p)) {   /*  && (!Swig_scopename_check(qt))) */
             /* No change in value.  It is entirely possible that the parameter is an integer value.
                If there is a symbol table associated with this scope, we're going to check for this */
 
@@ -1294,7 +1294,7 @@ int SwigType_typedef_using(const_String_or_char_ptr name) {
   /* Printf(stdout, "using %s\n", name); */
 
   if (!Swig_scopename_check(name))
-    return -1;			/* Not properly qualified */
+    return -1;                  /* Not properly qualified */
   base = Swig_scopename_last(name);
 
   /* See if the base is already defined in this scope */
@@ -1624,12 +1624,12 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
  * compute the transitive closure.
  * ----------------------------------------------------------------------------- */
 
-static Hash *r_mangled = 0;	/* Hash mapping mangled types to fully resolved types */
-static Hash *r_resolved = 0;	/* Hash mapping resolved types to mangled types       */
-static Hash *r_ltype = 0;	/* Hash mapping mangled names to their local c type   */
-static Hash *r_clientdata = 0;	/* Hash mapping resolved types to client data         */
-static Hash *r_mangleddata = 0;	/* Hash mapping mangled types to client data         */
-static Hash *r_remembered = 0;	/* Hash of types we remembered already */
+static Hash *r_mangled = 0;     /* Hash mapping mangled types to fully resolved types */
+static Hash *r_resolved = 0;    /* Hash mapping resolved types to mangled types       */
+static Hash *r_ltype = 0;       /* Hash mapping mangled names to their local c type   */
+static Hash *r_clientdata = 0;  /* Hash mapping resolved types to client data         */
+static Hash *r_mangleddata = 0; /* Hash mapping mangled types to client data         */
+static Hash *r_remembered = 0;  /* Hash of types we remembered already */
 
 static void (*r_tracefunc) (const SwigType *t, String *mangled, String *clientdata) = 0;
 
@@ -1672,7 +1672,7 @@ void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr cl
   Delete(tkey);
   Delete(cd);
 
-  mt = SwigType_manglestr(t);	/* Create mangled string */
+  mt = SwigType_manglestr(t);   /* Create mangled string */
 
   if (r_tracefunc) {
     (*r_tracefunc) (t, mt, (String *) clientdata);
@@ -1692,7 +1692,7 @@ void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr cl
   Setattr(lthash, lt, "1");
   Delete(lt);
 
-  fr = SwigType_typedef_resolve_all(t);	/* Create fully resolved type */
+  fr = SwigType_typedef_resolve_all(t); /* Create fully resolved type */
   qr = SwigType_typedef_qualified(fr);
   Delete(fr);
 
@@ -1787,7 +1787,7 @@ static List *SwigType_equivalent_mangle(String *ms, Hash *checked, Hash *found) 
     ch = NewHash();
   }
   if (Getattr(ch, ms))
-    goto check_exit;		/* Already checked this type */
+    goto check_exit;            /* Already checked this type */
   Setattr(h, ms, "1");
   Setattr(ch, ms, "1");
   mh = Getattr(r_mangled, ms);

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * This file is part of SWIG, which is licensed as a whole under version 3 
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -9,7 +9,7 @@
  * typesys.c
  *
  * SWIG type system management.   These functions are used to manage
- * the C++ type system including typenames, typedef, type scopes, 
+ * the C++ type system including typenames, typedef, type scopes,
  * inheritance, and namespaces.   Generation of support code for the
  * run-time type checker is also handled here.
  * ----------------------------------------------------------------------------- */
@@ -22,7 +22,7 @@
  *
  * The purpose of this module is to manage type names and scoping issues related
  * to the C++ type system.   The primary use is tracking typenames through typedef
- * and inheritance. 
+ * and inheritance.
  *
  * New typenames are introduced by typedef, class, and enum declarations.
  * Each type is declared in a scope.  This is either the global scope, a
@@ -36,7 +36,7 @@
  *    typedef int A;       // Typename A, in scope Bar::
  *  }
  *
- * To manage scopes, the type system is constructed as a tree of hash tables.  Each 
+ * To manage scopes, the type system is constructed as a tree of hash tables.  Each
  * hash table contains the following attributes:
  *
  *    "name"            -  Scope name
@@ -45,9 +45,9 @@
  *                         For a given key in the typetab table, the value is a fully
  *                         qualified name if not pointing to itself.
  *    "symtab"          -  Hash table of symbols defined in a scope
- *    "inherit"         -  List of inherited scopes       
+ *    "inherit"         -  List of inherited scopes
  *    "parent"          -  Parent scope
- * 
+ *
  * The contents of these tables can be viewed for debugging using the -debug-typedef
  * option which calls SwigType_print_scope().
  *
@@ -85,7 +85,7 @@
  *
  * typetab in scope '' contains:
  *      "S" : "N::S"
- * 
+ *
  * and typetab in scope 'N' contains:
  *      "SS" : "NN::SS"
  *      "S" : "S"
@@ -109,7 +109,7 @@
  *      "Integer" : "int"
  * and scope 'Bar' inherits from 'Foo' but is empty (observe that blah is not a scope or typedef)
  *
- * The argument type of Bar::blah will be set to Foo::Integer.   
+ * The argument type of Bar::blah will be set to Foo::Integer.
  *
  *
  * The scope-inheritance mechanism is used to manage C++ using directives.
@@ -140,9 +140,9 @@
  *      namespace F = Foo;
  *
  * In this case, F is defined as a scope that "inherits" from Foo.  Internally,
- * F will merely be an empty scope that points to Foo.  SWIG will never 
+ * F will merely be an empty scope that points to Foo.  SWIG will never
  * place new type information into a namespace alias---attempts to do so
- * will generate a warning message (in the parser) and will place information into 
+ * will generate a warning message (in the parser) and will place information into
  * Foo instead.
  *
  *----------------------------------------------------------------------------- */
@@ -154,7 +154,7 @@ static Typetab *global_scope = 0;	/* The global scope                           
 static Hash *scopes = 0;	/* Hash table containing fully qualified scopes */
 
 /* Performance optimization */
-#define SWIG_TYPEDEF_RESOLVE_CACHE 
+#define SWIG_TYPEDEF_RESOLVE_CACHE
 static Hash *typedef_resolve_cache = 0;
 static Hash *typedef_all_cache = 0;
 static Hash *typedef_qualified_cache = 0;
@@ -163,15 +163,15 @@ static Typetab *SwigType_find_scope(Typetab *s, const SwigType *nameprefix);
 
 /* common attribute keys, to avoid calling find_key all the times */
 
-/* 
+/*
    Enable this one if your language fully support SwigValueWrapper<T>.
-   
+
    Leaving at '0' keeps the old swig behavior, which is not
    always safe, but is well known.
 
    Setting at '1' activates the new scheme, which is always safe but
    it requires all the typemaps to be ready for that.
-  
+
 */
 static int value_wrapper_mode = 0;
 int Swig_value_wrapper_mode(int mode) {
@@ -210,8 +210,8 @@ void SwigType_typesystem_init(void) {
 /* -----------------------------------------------------------------------------
  * SwigType_typedef()
  *
- * Defines a new typedef in the current scope. Returns -1 if the type name is 
- * already defined.  
+ * Defines a new typedef in the current scope. Returns -1 if the type name is
+ * already defined.
  * ----------------------------------------------------------------------------- */
 
 int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name) {
@@ -242,7 +242,7 @@ int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name) {
 /* -----------------------------------------------------------------------------
  * SwigType_typedef_class()
  *
- * Defines a class in the current scope. 
+ * Defines a class in the current scope.
  * ----------------------------------------------------------------------------- */
 
 int SwigType_typedef_class(const_String_or_char_ptr name) {
@@ -555,7 +555,7 @@ static Typetab *SwigType_find_scope(Typetab *s, const SwigType *nameprefix) {
   return 0;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * typedef_resolve()
  *
  * Resolves a typedef and returns a new type string.  Returns 0 if there is no
@@ -611,7 +611,7 @@ static SwigType *_typedef_resolve(Typetab *s, String *base, int look_parent) {
   return type;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * template_parameters_resolve()
  *
  * For use with templates only. Attempts to resolve one template parameter.
@@ -667,7 +667,7 @@ static SwigType *typedef_resolve(Typetab *s, String *base) {
 }
 
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * SwigType_typedef_resolve()
  *
  * Given a type declaration, this function looks to reduce/resolve the type via a
@@ -1256,7 +1256,7 @@ SwigType *SwigType_typedef_qualified(const SwigType *t) {
   return result;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * SwigType_istypedef()
  *
  * Checks a typename to see if it is a typedef.
@@ -1594,7 +1594,7 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
  * modules to actually call this function--it is not done automatically.
  *
  * Type tracking is managed through two separate hash tables.  The hash 'r_mangled'
- * is mapping between mangled type names (used in the target language) and 
+ * is mapping between mangled type names (used in the target language) and
  * fully-resolved C datatypes used in the source input.   The second hash 'r_resolved'
  * is the inverse mapping that maps fully-resolved C datatypes to all of the mangled
  * names in the scripting languages.  For example, consider the following set of

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -147,11 +147,11 @@
  *
  *----------------------------------------------------------------------------- */
 
-static Typetab *current_scope = 0;      /* Current type scope                           */
-static Hash *current_typetab = 0;       /* Current type table                           */
-static Hash *current_symtab = 0;        /* Current symbol table                         */
-static Typetab *global_scope = 0;       /* The global scope                             */
-static Hash *scopes = 0;        /* Hash table containing fully qualified scopes */
+static Typetab *current_scope = 0; /* Current type scope                           */
+static Hash *current_typetab = 0;  /* Current type table                           */
+static Hash *current_symtab = 0;   /* Current symbol table                         */
+static Typetab *global_scope = 0;  /* The global scope                             */
+static Hash *scopes = 0;           /* Hash table containing fully qualified scopes */
 
 /* Performance optimization */
 #define SWIG_TYPEDEF_RESOLVE_CACHE
@@ -179,7 +179,6 @@ int Swig_value_wrapper_mode(int mode) {
   return mode;
 }
 
-
 static void flush_cache(void) {
   typedef_resolve_cache = 0;
   typedef_all_cache = 0;
@@ -197,7 +196,7 @@ void SwigType_typesystem_init(void) {
   current_scope = NewHash();
   global_scope = current_scope;
 
-  Setattr(current_scope, "name", "");   /* No name for global scope */
+  Setattr(current_scope, "name", ""); /* No name for global scope */
   current_typetab = NewHash();
   Setattr(current_scope, "typetab", current_typetab);
 
@@ -205,7 +204,6 @@ void SwigType_typesystem_init(void) {
   scopes = NewHash();
   Setattr(scopes, "", current_scope);
 }
-
 
 /* -----------------------------------------------------------------------------
  * SwigType_typedef()
@@ -217,8 +215,8 @@ void SwigType_typesystem_init(void) {
 int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name) {
   /* Printf(stdout, "typedef %s %s\n", type, name); */
   if (Getattr(current_typetab, name))
-    return -1;                  /* Already defined */
-  if (Strcmp(type, name) == 0) {        /* Can't typedef a name to itself */
+    return -1;                   /* Already defined */
+  if (Strcmp(type, name) == 0) { /* Can't typedef a name to itself */
     return 0;
   }
 
@@ -238,7 +236,6 @@ int SwigType_typedef(const SwigType *type, const_String_or_char_ptr name) {
   return 0;
 }
 
-
 /* -----------------------------------------------------------------------------
  * SwigType_typedef_class()
  *
@@ -249,7 +246,7 @@ int SwigType_typedef_class(const_String_or_char_ptr name) {
   String *cname;
   /*  Printf(stdout,"class : '%s'\n", name); */
   if (Getattr(current_typetab, name))
-    return -1;                  /* Already defined */
+    return -1; /* Already defined */
   cname = NewString(name);
   Setmeta(cname, "class", "1");
   Setattr(current_typetab, cname, cname);
@@ -573,7 +570,7 @@ static SwigType *_typedef_resolve(Typetab *s, String *base, int look_parent) {
   List *inherit;
   Typetab *parent;
 
-  /* if (!s) return 0; *//* now is checked below */
+  /* if (!s) return 0; */ /* now is checked below */
   /* Printf(stdout,"Typetab %s : %s\n", Getattr(s,"name"), base);  */
 
   if (!Getmark(s)) {
@@ -666,7 +663,6 @@ static SwigType *typedef_resolve(Typetab *s, String *base) {
   return _typedef_resolve(s, base, 1);
 }
 
-
 /* -----------------------------------------------------------------------------
  * SwigType_typedef_resolve()
  *
@@ -736,7 +732,7 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
 #endif
         if (nameprefix) {
           rnameprefix = SwigType_typedef_resolve(nameprefix);
-          if(rnameprefix != NULL) {
+          if (rnameprefix != NULL) {
 #ifdef SWIG_DEBUG
             Printf(stdout, "nameprefix '%s' is a typedef to '%s'\n", nameprefix, rnameprefix);
 #endif
@@ -931,7 +927,7 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
     int r_sz;
     r_elem = SwigType_split(r);
     r_sz = Len(r_elem);
-    r_qual = Getitem(r_elem, r_sz-1);
+    r_qual = Getitem(r_elem, r_sz - 1);
     if (SwigType_isqualifier(r_qual)) {
       String *new_r;
       String *new_type;
@@ -955,7 +951,7 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
       Setitem(type_elem, i, type_qual);
 
       new_r = NewStringEmpty();
-      for (i = 0; i < r_sz-1; ++i) {
+      for (i = 0; i < r_sz - 1; ++i) {
         Append(new_r, Getitem(r_elem, i));
       }
       new_type = NewStringEmpty();
@@ -1027,7 +1023,12 @@ SwigType *SwigType_typedef_resolve_all(const SwigType *t) {
     Delete(r);
     r = n;
     if (++count >= 512) {
-      Swig_error(Getfile(t), Getline(t), "Recursive typedef detected resolving '%s' to '%s' to '%s' and so on...\n", SwigType_str(t, 0), SwigType_str(SwigType_typedef_resolve(t), 0), SwigType_str(SwigType_typedef_resolve(SwigType_typedef_resolve(t)), 0));
+      Swig_error(Getfile(t),
+                 Getline(t),
+                 "Recursive typedef detected resolving '%s' to '%s' to '%s' and so on...\n",
+                 SwigType_str(t, 0),
+                 SwigType_str(SwigType_typedef_resolve(t), 0),
+                 SwigType_str(SwigType_typedef_resolve(SwigType_typedef_resolve(t)), 0));
       break;
     }
   }
@@ -1046,7 +1047,6 @@ SwigType *SwigType_typedef_resolve_all(const SwigType *t) {
 #endif
   return r;
 }
-
 
 /* -----------------------------------------------------------------------------
  * SwigType_typedef_qualified()
@@ -1155,7 +1155,7 @@ SwigType *SwigType_typedef_qualified(const SwigType *t) {
         while ((p = pi.item)) {
           /* TODO: the logic here should be synchronised with that in symbol_template_qualify() in symbol.c */
           String *qt = SwigType_typedef_qualified(p);
-          if (Equal(qt, p)) {   /*  && (!Swig_scopename_check(qt))) */
+          if (Equal(qt, p)) { /*  && (!Swig_scopename_check(qt))) */
             /* No change in value.  It is entirely possible that the parameter is an integer value.
                If there is a symbol table associated with this scope, we're going to check for this */
 
@@ -1274,7 +1274,6 @@ int SwigType_istypedef(const SwigType *t) {
   }
 }
 
-
 /* -----------------------------------------------------------------------------
  * SwigType_typedef_using()
  *
@@ -1294,7 +1293,7 @@ int SwigType_typedef_using(const_String_or_char_ptr name) {
   /* Printf(stdout, "using %s\n", name); */
 
   if (!Swig_scopename_check(name))
-    return -1;                  /* Not properly qualified */
+    return -1; /* Not properly qualified */
   base = Swig_scopename_last(name);
 
   /* See if the base is already defined in this scope */
@@ -1325,7 +1324,6 @@ int SwigType_typedef_using(const_String_or_char_ptr name) {
   }
   if (td)
     Delete(td);
-
 
   /* Figure out the scope the using directive refers to */
   {
@@ -1539,9 +1537,7 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
         if (GetFlag(n, "feature:valuewrapper")) {
           use_wrapper = 1;
         } else {
-          if (Checkattr(n, "nodeType", "class")
-              && (!Getattr(n, "allocate:default_constructor")
-                  || (Getattr(n, "allocate:noassign")))) {
+          if (Checkattr(n, "nodeType", "class") && (!Getattr(n, "allocate:default_constructor") || (Getattr(n, "allocate:noassign")))) {
             use_wrapper = !GetFlag(n, "feature:novaluewrapper") || GetFlag(n, "feature:nodefault");
           }
         }
@@ -1560,10 +1556,8 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
       use_wrapper = 1;
       n = Swig_symbol_clookup(td, 0);
       if (n) {
-        if ((Checkattr(n, "nodeType", "class")
-             && !Getattr(n, "allocate:noassign")
-             && (Getattr(n, "allocate:default_constructor")))
-            || (GetFlag(n, "feature:novaluewrapper"))) {
+        if ((Checkattr(n, "nodeType", "class") && !Getattr(n, "allocate:noassign") && (Getattr(n, "allocate:default_constructor"))) ||
+            (GetFlag(n, "feature:novaluewrapper"))) {
           use_wrapper = GetFlag(n, "feature:valuewrapper");
         }
       }
@@ -1631,7 +1625,7 @@ static Hash *r_clientdata = 0;  /* Hash mapping resolved types to client data   
 static Hash *r_mangleddata = 0; /* Hash mapping mangled types to client data         */
 static Hash *r_remembered = 0;  /* Hash of types we remembered already */
 
-static void (*r_tracefunc) (const SwigType *t, String *mangled, String *clientdata) = 0;
+static void (*r_tracefunc)(const SwigType *t, String *mangled, String *clientdata) = 0;
 
 void SwigType_remember_mangleddata(String *mangled, const_String_or_char_ptr clientdata) {
   if (!r_mangleddata) {
@@ -1639,7 +1633,6 @@ void SwigType_remember_mangleddata(String *mangled, const_String_or_char_ptr cli
   }
   Setattr(r_mangleddata, mangled, clientdata);
 }
-
 
 void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr clientdata) {
   String *mt;
@@ -1672,10 +1665,10 @@ void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr cl
   Delete(tkey);
   Delete(cd);
 
-  mt = SwigType_manglestr(t);   /* Create mangled string */
+  mt = SwigType_manglestr(t); /* Create mangled string */
 
   if (r_tracefunc) {
-    (*r_tracefunc) (t, mt, (String *) clientdata);
+    (*r_tracefunc)(t, mt, (String *)clientdata);
   }
 
   if (SwigType_istypedef(t)) {
@@ -1755,8 +1748,8 @@ void SwigType_remember(const SwigType *ty) {
   SwigType_remember_clientdata(ty, 0);
 }
 
-void (*SwigType_remember_trace(void (*tf) (const SwigType *, String *, String *))) (const SwigType *, String *, String *) {
-  void (*o) (const SwigType *, String *, String *) = r_tracefunc;
+void (*SwigType_remember_trace(void (*tf)(const SwigType *, String *, String *)))(const SwigType *, String *, String *) {
+  void (*o)(const SwigType *, String *, String *) = r_tracefunc;
   r_tracefunc = tf;
   return o;
 }
@@ -1787,7 +1780,7 @@ static List *SwigType_equivalent_mangle(String *ms, Hash *checked, Hash *found) 
     ch = NewHash();
   }
   if (Getattr(ch, ms))
-    goto check_exit;            /* Already checked this type */
+    goto check_exit; /* Already checked this type */
   Setattr(h, ms, "1");
   Setattr(ch, ms, "1");
   mh = Getattr(r_mangled, ms);
@@ -1831,8 +1824,7 @@ check_exit:
  * Returns the clientdata field for a mangled type-string.
  * ----------------------------------------------------------------------------- */
 
-static
-String *SwigType_clientdata_collect(String *ms) {
+static String *SwigType_clientdata_collect(String *ms) {
   Hash *mh;
   String *clientdata = 0;
 
@@ -1855,9 +1847,6 @@ String *SwigType_clientdata_collect(String *ms) {
   }
   return clientdata;
 }
-
-
-
 
 /* -----------------------------------------------------------------------------
  * SwigType_inherit()
@@ -2106,7 +2095,7 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
 
   SwigType_inherit_equiv(f_table);
 
-   /*#define DEBUG 1*/
+  /*#define DEBUG 1*/
 #ifdef DEBUG
   Printf(stdout, "---r_mangled---\n");
   Swig_print(r_mangled, 2);
@@ -2210,9 +2199,9 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
     while (ltiter.item) {
       if (!Equal(resolved_lstr, ltiter.item)) {
         if (nt) {
-           Printf(nt, "|%s", ltiter.item);
+          Printf(nt, "|%s", ltiter.item);
         } else {
-           nt = NewString(ltiter.item);
+          nt = NewString(ltiter.item);
         }
       }
       ltiter = Next(ltiter);
@@ -2221,9 +2210,9 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
      * There can be more than one resolved type and the chosen one is simply the
      * shortest in length, arguably the most user friendly/readable. */
     if (nt) {
-       Printf(nt, "|%s", resolved_lstr);
+      Printf(nt, "|%s", resolved_lstr);
     } else {
-       nt = NewString(resolved_lstr);
+      nt = NewString(resolved_lstr);
     }
     Delete(ntlist);
     Delete(nthash);

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -393,7 +393,7 @@ void SwigType_using_scope(Typetab *scope) {
     for (i = 0; i < len; i++) {
       Typetab *n = Getitem(ulist, i);
       if (n == scope)
-	return;
+        return;
     }
     Append(ulist, scope);
   }
@@ -466,10 +466,10 @@ void SwigType_print_scope(void) {
     {
       List *inherit = Getattr(i.item, "inherit");
       if (inherit) {
-	Iterator j;
-	for (j = First(inherit); j.item; j = Next(j)) {
-	  Printf(stdout, "    Inherits from '%s' (%p)\n", Getattr(j.item, "qname"), j.item);
-	}
+        Iterator j;
+        for (j = First(inherit); j.item; j = Next(j)) {
+          Printf(stdout, "    Inherits from '%s' (%p)\n", Getattr(j.item, "qname"), j.item);
+        }
       }
     }
     for (j = First(ttab); j.key; j = Next(j)) {
@@ -503,7 +503,7 @@ static Typetab *SwigType_find_scope(Typetab *s, const SwigType *nameprefix) {
     if (qname) {
       full = NewStringf("%s::%s", qname, nameprefix);
       if (Strncmp(full, "enum ", 5) == 0) {
-	Delslice(full, 0, 5);
+        Delslice(full, 0, 5);
       }
     } else {
       full = NewString(nameprefix);
@@ -518,7 +518,7 @@ static Typetab *SwigType_find_scope(Typetab *s, const SwigType *nameprefix) {
     Delete(full);
     if (s) {
       if (nnameprefix)
-	Delete(nnameprefix);
+        Delete(nnameprefix);
       Setmark(s_orig, 0);
       return s;
     }
@@ -527,22 +527,22 @@ static Typetab *SwigType_find_scope(Typetab *s, const SwigType *nameprefix) {
       List *inherit;
       inherit = Getattr(ss, "using");
       if (inherit) {
-	Typetab *ttab;
-	int i, len;
-	len = Len(inherit);
-	for (i = 0; i < len; i++) {
-	  int oldcp = check_parent;
-	  ttab = Getitem(inherit, i);
-	  check_parent = 0;
-	  s = SwigType_find_scope(ttab, nameprefix);
-	  check_parent = oldcp;
-	  if (s) {
-	    if (nnameprefix)
-	      Delete(nnameprefix);
-	    Setmark(s_orig, 0);
-	    return s;
-	  }
-	}
+        Typetab *ttab;
+        int i, len;
+        len = Len(inherit);
+        for (i = 0; i < len; i++) {
+          int oldcp = check_parent;
+          ttab = Getitem(inherit, i);
+          check_parent = 0;
+          s = SwigType_find_scope(ttab, nameprefix);
+          check_parent = oldcp;
+          if (s) {
+            if (nnameprefix)
+              Delete(nnameprefix);
+            Setmark(s_orig, 0);
+            return s;
+          }
+        }
       }
     }
     if (!check_parent)
@@ -588,22 +588,22 @@ static SwigType *_typedef_resolve(Typetab *s, String *base, int look_parent) {
       /* Hmmm. Not found in my scope.  It could be in an inherited scope */
       inherit = Getattr(s, "inherit");
       if (inherit) {
-	int i, len;
-	len = Len(inherit);
-	for (i = 0; i < len; i++) {
-	  type = _typedef_resolve(Getitem(inherit, i), base, 0);
-	  if (type) {
-	    Setmark(s, 0);
-	    break;
-	  }
-	}
+        int i, len;
+        len = Len(inherit);
+        for (i = 0; i < len; i++) {
+          type = _typedef_resolve(Getitem(inherit, i), base, 0);
+          if (type) {
+            Setmark(s, 0);
+            break;
+          }
+        }
       }
       if (!type) {
-	/* Hmmm. Not found in my scope.  check parent */
-	if (look_parent) {
-	  parent = Getattr(s, "parent");
-	  type = parent ? _typedef_resolve(parent, base, 1) : 0;
-	}
+        /* Hmmm. Not found in my scope.  check parent */
+        if (look_parent) {
+          parent = Getattr(s, "parent");
+          type = parent ? _typedef_resolve(parent, base, 1) : 0;
+        }
       }
       Setmark(s, 0);
     }
@@ -729,82 +729,82 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
     if (!type) {
       /* Didn't find in this scope.   We need to do a little more searching */
       if (Swig_scopename_check(base)) {
-	/* A qualified name. */
-	Swig_scopename_split(base, &nameprefix, &namebase);
+        /* A qualified name. */
+        Swig_scopename_split(base, &nameprefix, &namebase);
 #ifdef SWIG_DEBUG
-	Printf(stdout, "nameprefix = '%s'\n", nameprefix);
+        Printf(stdout, "nameprefix = '%s'\n", nameprefix);
 #endif
-	if (nameprefix) {
-	  rnameprefix = SwigType_typedef_resolve(nameprefix);
-	  if(rnameprefix != NULL) {
+        if (nameprefix) {
+          rnameprefix = SwigType_typedef_resolve(nameprefix);
+          if(rnameprefix != NULL) {
 #ifdef SWIG_DEBUG
-	    Printf(stdout, "nameprefix '%s' is a typedef to '%s'\n", nameprefix, rnameprefix);
+            Printf(stdout, "nameprefix '%s' is a typedef to '%s'\n", nameprefix, rnameprefix);
 #endif
-	    type = Copy(namebase);
-	    Insert(type, 0, "::");
-	    Insert(type, 0, rnameprefix);
-	    if (Strncmp(type, "enum ", 5) == 0) {
-	      Delslice(type, 0, 5);
-	    }
-	    if (Strncmp(type, "::", 2) == 0) {
-	      Delslice(type, 0, 2);
-	    }
-	    newtype = 1;
-	  } else {
-	    /* Name had a prefix on it.   See if we can locate the proper scope for it */
-	    String *rnameprefix = template_parameters_resolve(nameprefix);
-	    nameprefix = rnameprefix ? Copy(rnameprefix) : nameprefix;
-	    Delete(rnameprefix);
-	    s = SwigType_find_scope(s, nameprefix);
+            type = Copy(namebase);
+            Insert(type, 0, "::");
+            Insert(type, 0, rnameprefix);
+            if (Strncmp(type, "enum ", 5) == 0) {
+              Delslice(type, 0, 5);
+            }
+            if (Strncmp(type, "::", 2) == 0) {
+              Delslice(type, 0, 2);
+            }
+            newtype = 1;
+          } else {
+            /* Name had a prefix on it.   See if we can locate the proper scope for it */
+            String *rnameprefix = template_parameters_resolve(nameprefix);
+            nameprefix = rnameprefix ? Copy(rnameprefix) : nameprefix;
+            Delete(rnameprefix);
+            s = SwigType_find_scope(s, nameprefix);
 
-	    /* Couldn't locate a scope for the type.  */
-	    if (!s) {
-	      Delete(base);
-	      Delete(namebase);
-	      Delete(nameprefix);
-	      r = 0;
-	      goto return_result;
-	    }
-	    /* Try to locate the name starting in the scope */
+            /* Couldn't locate a scope for the type.  */
+            if (!s) {
+              Delete(base);
+              Delete(namebase);
+              Delete(nameprefix);
+              r = 0;
+              goto return_result;
+            }
+            /* Try to locate the name starting in the scope */
 #ifdef SWIG_DEBUG
-	    Printf(stdout, "namebase = '%s'\n", namebase);
+            Printf(stdout, "namebase = '%s'\n", namebase);
 #endif
-	    type = typedef_resolve(s, namebase);
-	    if (type && resolved_scope) {
-	      /* we need to look for the resolved type, this will also
-	         fix the resolved_scope if 'type' and 'namebase' are
-	         declared in different scopes */
-	      String *rtype = 0;
-	      rtype = typedef_resolve(resolved_scope, type);
-	      if (rtype)
-	        type = rtype;
-	    }
+            type = typedef_resolve(s, namebase);
+            if (type && resolved_scope) {
+              /* we need to look for the resolved type, this will also
+                 fix the resolved_scope if 'type' and 'namebase' are
+                 declared in different scopes */
+              String *rtype = 0;
+              rtype = typedef_resolve(resolved_scope, type);
+              if (rtype)
+                type = rtype;
+            }
 #ifdef SWIG_DEBUG
-	    Printf(stdout, "%s type = '%s'\n", Getattr(s, "name"), type);
+            Printf(stdout, "%s type = '%s'\n", Getattr(s, "name"), type);
 #endif
-	    if ((type) && (!Swig_scopename_check(type)) && resolved_scope) {
-	      Typetab *rtab = resolved_scope;
-	      String *qname = Getattr(resolved_scope, "qname");
-	      /* If qualified *and* the typename is defined from the resolved scope, we qualify */
-	      if ((qname) && typedef_resolve(resolved_scope, type)) {
-	        type = Copy(type);
-	        Insert(type, 0, "::");
-	        Insert(type, 0, qname);
+            if ((type) && (!Swig_scopename_check(type)) && resolved_scope) {
+              Typetab *rtab = resolved_scope;
+              String *qname = Getattr(resolved_scope, "qname");
+              /* If qualified *and* the typename is defined from the resolved scope, we qualify */
+              if ((qname) && typedef_resolve(resolved_scope, type)) {
+                type = Copy(type);
+                Insert(type, 0, "::");
+                Insert(type, 0, qname);
 #ifdef SWIG_DEBUG
-	        Printf(stdout, "qual %s \n", type);
+                Printf(stdout, "qual %s \n", type);
 #endif
-	        newtype = 1;
-	      }
-	      resolved_scope = rtab;
-	    }
-	  }
-	} else {
-	  /* Name is unqualified. */
-	  type = typedef_resolve(s, base);
-	}
+                newtype = 1;
+              }
+              resolved_scope = rtab;
+            }
+          }
+        } else {
+          /* Name is unqualified. */
+          type = typedef_resolve(s, base);
+        }
       } else {
-	/* Name is unqualified. */
-	type = typedef_resolve(s, base);
+        /* Name is unqualified. */
+        type = typedef_resolve(s, base);
       }
     }
 
@@ -814,22 +814,22 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
       /* We're looking for a using declaration on the template prefix to resolve the template prefix
        * in another scope. Using declaration do not have template parameters. */
       if (rtprefix && !SwigType_istemplate(rtprefix)) {
-	String *tsuffix = SwigType_templatesuffix(base);
-	String *targs = SwigType_templateargs(base);
-	type = NewString(rtprefix);
-	newtype = 1;
-	Append(type, targs);
-	Append(type, tsuffix);
-	Delete(targs);
-	Delete(tsuffix);
-	Delete(rtprefix);
+        String *tsuffix = SwigType_templatesuffix(base);
+        String *targs = SwigType_templateargs(base);
+        type = NewString(rtprefix);
+        newtype = 1;
+        Append(type, targs);
+        Append(type, tsuffix);
+        Delete(targs);
+        Delete(tsuffix);
+        Delete(rtprefix);
       }
       Delete(tprefix);
     }
 
     if (type && (Equal(base, type))) {
       if (newtype)
-	Delete(type);
+        Delete(type);
       Delete(base);
       Delete(namebase);
       Delete(nameprefix);
@@ -856,37 +856,37 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
       parms = SwigType_parmlist(base);
       sz = Len(parms);
       for (i = 0; i < sz; i++) {
-	SwigType *tpr;
-	SwigType *tp = Getitem(parms, i);
-	if (!rep) {
-	  tpr = SwigType_typedef_resolve(tp);
-	} else {
-	  tpr = 0;
-	}
-	if (tpr) {
-	  Append(type, tpr);
-	  Delete(tpr);
-	  rep = 1;
-	} else {
-	  Append(type, tp);
-	}
-	if ((i + 1) < sz)
-	  Append(type, ",");
+        SwigType *tpr;
+        SwigType *tp = Getitem(parms, i);
+        if (!rep) {
+          tpr = SwigType_typedef_resolve(tp);
+        } else {
+          tpr = 0;
+        }
+        if (tpr) {
+          Append(type, tpr);
+          Delete(tpr);
+          rep = 1;
+        } else {
+          Append(type, tp);
+        }
+        if ((i + 1) < sz)
+          Append(type, ",");
       }
       Append(type, ").");
       Delete(parms);
       if (!rep) {
-	Delete(type);
-	type = 0;
+        Delete(type);
+        type = 0;
       }
     } else if (SwigType_ismemberpointer(base)) {
       String *rt;
       String *mtype = SwigType_parm(base);
       rt = SwigType_typedef_resolve(mtype);
       if (rt) {
-	type = NewStringf("m(%s).", rt);
-	newtype = 1;
-	Delete(rt);
+        type = NewStringf("m(%s).", rt);
+        newtype = 1;
+        Delete(rt);
       }
       Delete(mtype);
     } else {
@@ -898,14 +898,14 @@ SwigType *SwigType_typedef_resolve(const SwigType *t) {
     if (r && Len(r)) {
       char *cr = Char(r);
       if ((strstr(cr, "f(") || (strstr(cr, "m(")))) {
-	SwigType *rt = SwigType_typedef_resolve(r);
-	if (rt) {
-	  Delete(r);
-	  Append(rt, base);
-	  Delete(base);
-	  r = rt;
-	  goto return_result;
-	}
+        SwigType *rt = SwigType_typedef_resolve(r);
+        if (rt) {
+          Delete(r);
+          Append(rt, base);
+          Delete(base);
+          r = rt;
+          goto return_result;
+        }
       }
     }
     Delete(r);
@@ -1087,131 +1087,131 @@ SwigType *SwigType_typedef_qualified(const SwigType *t) {
     String *e = Getitem(elements, i);
     if (SwigType_issimple(e)) {
       if (!SwigType_istemplate(e)) {
-	String *isenum = 0;
-	if (SwigType_isenum(e)) {
-	  isenum = NewString("enum ");
-	  ty = NewString(Char(e) + 5);
-	  e = ty;
-	}
-	resolved_scope = 0;
-	if (typedef_resolve(current_scope, e) && resolved_scope) {
-	  /* resolved_scope contains the scope that actually resolved the symbol */
-	  String *qname = Getattr(resolved_scope, "qname");
-	  if (qname) {
-	    Insert(e, 0, "::");
-	    Insert(e, 0, qname);
-	  }
-	} else {
-	  if (Swig_scopename_check(e)) {
-	    String *qlast;
-	    String *qname;
-	    Swig_scopename_split(e, &qname, &qlast);
-	    if (qname) {
-	      String *tqname = SwigType_typedef_qualified(qname);
-	      Clear(e);
-	      Printf(e, "%s::%s", tqname, qlast);
-	      Delete(qname);
-	      Delete(tqname);
-	    }
-	    Delete(qlast);
+        String *isenum = 0;
+        if (SwigType_isenum(e)) {
+          isenum = NewString("enum ");
+          ty = NewString(Char(e) + 5);
+          e = ty;
+        }
+        resolved_scope = 0;
+        if (typedef_resolve(current_scope, e) && resolved_scope) {
+          /* resolved_scope contains the scope that actually resolved the symbol */
+          String *qname = Getattr(resolved_scope, "qname");
+          if (qname) {
+            Insert(e, 0, "::");
+            Insert(e, 0, qname);
+          }
+        } else {
+          if (Swig_scopename_check(e)) {
+            String *qlast;
+            String *qname;
+            Swig_scopename_split(e, &qname, &qlast);
+            if (qname) {
+              String *tqname = SwigType_typedef_qualified(qname);
+              Clear(e);
+              Printf(e, "%s::%s", tqname, qlast);
+              Delete(qname);
+              Delete(tqname);
+            }
+            Delete(qlast);
 
-	    /* Automatic template instantiation might go here??? */
-	  } else {
-	    /* It's a bare name.  It's entirely possible, that the
-	       name is part of a namespace. We'll check this by unrolling
-	       out of the current scope */
+            /* Automatic template instantiation might go here??? */
+          } else {
+            /* It's a bare name.  It's entirely possible, that the
+               name is part of a namespace. We'll check this by unrolling
+               out of the current scope */
 
-	    Typetab *cs = current_scope;
-	    if (cs) {
-	      Typetab *found_scope = SwigType_find_scope(cs, e);
-	      if (found_scope) {
-		String *qs = SwigType_scope_name(found_scope);
-		Clear(e);
-		Append(e, qs);
-		Delete(qs);
-	      }
-	    }
-	  }
-	}
-	if (isenum) {
-	  Insert(e, 0, isenum);
-	  Delete(isenum);
-	}
+            Typetab *cs = current_scope;
+            if (cs) {
+              Typetab *found_scope = SwigType_find_scope(cs, e);
+              if (found_scope) {
+                String *qs = SwigType_scope_name(found_scope);
+                Clear(e);
+                Append(e, qs);
+                Delete(qs);
+              }
+            }
+          }
+        }
+        if (isenum) {
+          Insert(e, 0, isenum);
+          Delete(isenum);
+        }
       } else {
-	/* Template.  We need to qualify template parameters as well as the template itself */
-	String *tprefix, *qprefix;
-	String *tsuffix;
-	Iterator pi;
-	Parm *p;
-	List *parms;
-	ty = Swig_symbol_template_deftype(e, current_symtab);
-	e = ty;
-	parms = SwigType_parmlist(e);
-	tprefix = SwigType_templateprefix(e);
-	tsuffix = SwigType_templatesuffix(e);
-	qprefix = SwigType_typedef_qualified(tprefix);
-	Append(qprefix, "<(");
-	pi = First(parms);
-	while ((p = pi.item)) {
-	  /* TODO: the logic here should be synchronised with that in symbol_template_qualify() in symbol.c */
-	  String *qt = SwigType_typedef_qualified(p);
-	  if (Equal(qt, p)) {	/*  && (!Swig_scopename_check(qt))) */
-	    /* No change in value.  It is entirely possible that the parameter is an integer value.
-	       If there is a symbol table associated with this scope, we're going to check for this */
+        /* Template.  We need to qualify template parameters as well as the template itself */
+        String *tprefix, *qprefix;
+        String *tsuffix;
+        Iterator pi;
+        Parm *p;
+        List *parms;
+        ty = Swig_symbol_template_deftype(e, current_symtab);
+        e = ty;
+        parms = SwigType_parmlist(e);
+        tprefix = SwigType_templateprefix(e);
+        tsuffix = SwigType_templatesuffix(e);
+        qprefix = SwigType_typedef_qualified(tprefix);
+        Append(qprefix, "<(");
+        pi = First(parms);
+        while ((p = pi.item)) {
+          /* TODO: the logic here should be synchronised with that in symbol_template_qualify() in symbol.c */
+          String *qt = SwigType_typedef_qualified(p);
+          if (Equal(qt, p)) {	/*  && (!Swig_scopename_check(qt))) */
+            /* No change in value.  It is entirely possible that the parameter is an integer value.
+               If there is a symbol table associated with this scope, we're going to check for this */
 
-	    if (current_symtab) {
-	      Node *lastnode = 0;
-	      String *value = Copy(p);
-	      while (1) {
-		Node *n = Swig_symbol_clookup(value, current_symtab);
-		if (n == lastnode)
-		  break;
-		lastnode = n;
-		if (n) {
-		  char *ntype = Char(nodeType(n));
-		  if (strcmp(ntype, "enumitem") == 0) {
-		    /* An enum item.   Generate a fully qualified name */
-		    String *qn = Swig_symbol_qualified(n);
-		    if (Len(qn)) {
-		      Append(qn, "::");
-		      Append(qn, Getattr(n, "name"));
-		      Delete(value);
-		      value = qn;
-		      continue;
-		    } else {
-		      Delete(qn);
-		      break;
-		    }
-		  } else if ((strcmp(ntype, "cdecl") == 0) && (Getattr(n, "value"))) {
-		    Delete(value);
-		    value = Copy(Getattr(n, "value"));
-		    continue;
-		  }
-		}
-		break;
-	      }
-	      Append(qprefix, value);
-	      Delete(value);
-	    } else {
-	      Append(qprefix, p);
-	    }
-	  } else {
-	    Append(qprefix, qt);
-	  }
-	  Delete(qt);
-	  pi = Next(pi);
-	  if (pi.item) {
-	    Append(qprefix, ",");
-	  }
-	}
-	Append(qprefix, ")>");
-	Append(qprefix, tsuffix);
-	Delete(tsuffix);
-	Clear(e);
-	Append(e, qprefix);
-	Delete(tprefix);
-	Delete(qprefix);
-	Delete(parms);
+            if (current_symtab) {
+              Node *lastnode = 0;
+              String *value = Copy(p);
+              while (1) {
+                Node *n = Swig_symbol_clookup(value, current_symtab);
+                if (n == lastnode)
+                  break;
+                lastnode = n;
+                if (n) {
+                  char *ntype = Char(nodeType(n));
+                  if (strcmp(ntype, "enumitem") == 0) {
+                    /* An enum item.   Generate a fully qualified name */
+                    String *qn = Swig_symbol_qualified(n);
+                    if (Len(qn)) {
+                      Append(qn, "::");
+                      Append(qn, Getattr(n, "name"));
+                      Delete(value);
+                      value = qn;
+                      continue;
+                    } else {
+                      Delete(qn);
+                      break;
+                    }
+                  } else if ((strcmp(ntype, "cdecl") == 0) && (Getattr(n, "value"))) {
+                    Delete(value);
+                    value = Copy(Getattr(n, "value"));
+                    continue;
+                  }
+                }
+                break;
+              }
+              Append(qprefix, value);
+              Delete(value);
+            } else {
+              Append(qprefix, p);
+            }
+          } else {
+            Append(qprefix, qt);
+          }
+          Delete(qt);
+          pi = Next(pi);
+          if (pi.item) {
+            Append(qprefix, ",");
+          }
+        }
+        Append(qprefix, ")>");
+        Append(qprefix, tsuffix);
+        Delete(tsuffix);
+        Clear(e);
+        Append(e, qprefix);
+        Delete(tprefix);
+        Delete(qprefix);
+        Delete(parms);
       }
       Append(result, e);
       Delete(ty);
@@ -1221,13 +1221,13 @@ SwigType *SwigType_typedef_qualified(const SwigType *t) {
       Iterator pi;
       pi = First(parms);
       while (pi.item) {
-	String *pq = SwigType_typedef_qualified(pi.item);
-	Append(s, pq);
-	Delete(pq);
-	pi = Next(pi);
-	if (pi.item) {
-	  Append(s, ",");
-	}
+        String *pq = SwigType_typedef_qualified(pi.item);
+        Append(s, pq);
+        Delete(pq);
+        pi = Next(pi);
+        if (pi.item) {
+          Append(s, ",");
+        }
       }
       Append(s, ").");
       Append(result, s);
@@ -1333,10 +1333,10 @@ int SwigType_typedef_using(const_String_or_char_ptr name) {
     if (prefix) {
       s = SwigType_find_scope(current_scope, prefix);
       if (s) {
-	Hash *ttab = Getattr(s, "typetab");
-	if (!Getattr(ttab, base) && defined_name) {
-	  Setattr(ttab, base, defined_name);
-	}
+        Hash *ttab = Getattr(s, "typetab");
+        if (!Getattr(ttab, base) && defined_name) {
+          Setattr(ttab, base, defined_name);
+        }
       }
     }
   }
@@ -1381,7 +1381,7 @@ int SwigType_isclass(const SwigType *t) {
     if (!isclass) {
       String *tp = SwigType_istemplate_templateprefix(qtys);
       if (tp && Strcmp(tp, t) != 0) {
-	isclass = SwigType_isclass(tp);
+        isclass = SwigType_isclass(tp);
       }
       Delete(tp);
     }
@@ -1536,19 +1536,19 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
       Delete(ftd);
       n = Swig_symbol_clookup(td, 0);
       if (n) {
-	if (GetFlag(n, "feature:valuewrapper")) {
-	  use_wrapper = 1;
-	} else {
-	  if (Checkattr(n, "nodeType", "class")
-	      && (!Getattr(n, "allocate:default_constructor")
-		  || (Getattr(n, "allocate:noassign")))) {
-	    use_wrapper = !GetFlag(n, "feature:novaluewrapper") || GetFlag(n, "feature:nodefault");
-	  }
-	}
+        if (GetFlag(n, "feature:valuewrapper")) {
+          use_wrapper = 1;
+        } else {
+          if (Checkattr(n, "nodeType", "class")
+              && (!Getattr(n, "allocate:default_constructor")
+                  || (Getattr(n, "allocate:noassign")))) {
+            use_wrapper = !GetFlag(n, "feature:novaluewrapper") || GetFlag(n, "feature:nodefault");
+          }
+        }
       } else {
-	if (SwigType_issimple(td) && SwigType_istemplate(td)) {
-	  use_wrapper = 1;
-	}
+        if (SwigType_issimple(td) && SwigType_istemplate(td)) {
+          use_wrapper = 1;
+        }
       }
     }
   } else {
@@ -1560,12 +1560,12 @@ SwigType *SwigType_alttype(const SwigType *t, int local_tmap) {
       use_wrapper = 1;
       n = Swig_symbol_clookup(td, 0);
       if (n) {
-	if ((Checkattr(n, "nodeType", "class")
-	     && !Getattr(n, "allocate:noassign")
-	     && (Getattr(n, "allocate:default_constructor")))
-	    || (GetFlag(n, "feature:novaluewrapper"))) {
-	  use_wrapper = GetFlag(n, "feature:valuewrapper");
-	}
+        if ((Checkattr(n, "nodeType", "class")
+             && !Getattr(n, "allocate:noassign")
+             && (Getattr(n, "allocate:default_constructor")))
+            || (GetFlag(n, "feature:novaluewrapper"))) {
+          use_wrapper = GetFlag(n, "feature:valuewrapper");
+        }
       }
     }
   }
@@ -1723,9 +1723,9 @@ void SwigType_remember_clientdata(const SwigType *t, const_String_or_char_ptr cl
     String *cd = Getattr(r_clientdata, fr);
     if (cd) {
       if (Strcmp(clientdata, cd) != 0) {
-	Printf(stderr, "*** Internal error. Inconsistent clientdata for type '%s'\n", SwigType_str(fr, 0));
-	Printf(stderr, "*** '%s' != '%s'\n", clientdata, cd);
-	assert(0);
+        Printf(stderr, "*** Internal error. Inconsistent clientdata for type '%s'\n", SwigType_str(fr, 0));
+        Printf(stderr, "*** '%s' != '%s'\n", clientdata, cd);
+        assert(0);
       }
     } else {
       String *cstr = NewString(clientdata);
@@ -1797,19 +1797,19 @@ static List *SwigType_equivalent_mangle(String *ms, Hash *checked, Hash *found) 
     while (ki.key) {
       Hash *rh;
       if (Getattr(ch, ki.key)) {
-	ki = Next(ki);
-	continue;
+        ki = Next(ki);
+        continue;
       }
       Setattr(ch, ki.key, "1");
       rh = Getattr(r_resolved, ki.key);
       if (rh) {
-	Iterator rk;
-	rk = First(rh);
-	while (rk.key) {
-	  Setattr(h, rk.key, "1");
-	  SwigType_equivalent_mangle(rk.key, ch, h);
-	  rk = Next(rk);
-	}
+        Iterator rk;
+        rk = First(rh);
+        while (rk.key) {
+          Setattr(h, rk.key, "1");
+          SwigType_equivalent_mangle(rk.key, ch, h);
+          rk = Next(rk);
+        }
       }
       ki = Next(ki);
     }
@@ -1849,7 +1849,7 @@ String *SwigType_clientdata_collect(String *ms) {
     while (ki.key) {
       clientdata = Getattr(r_clientdata, ki.key);
       if (clientdata)
-	break;
+        break;
       ki = Next(ki);
     }
   }
@@ -2012,9 +2012,9 @@ static void SwigType_inherit_equiv(File *out) {
       mkey = SwigType_manglestr(rk.item);
       ckey = NewStringf("%s+%s", mprefix, mkey);
       if (!Getattr(conversions, ckey)) {
-	String *convname = NewStringf("%sTo%s", mprefix, mkey);
-	String *lkey = SwigType_lstr(rk.item, 0);
-	String *lprefix = SwigType_lstr(prefix, 0);
+        String *convname = NewStringf("%sTo%s", mprefix, mkey);
+        String *lkey = SwigType_lstr(rk.item, 0);
+        String *lprefix = SwigType_lstr(prefix, 0);
         Hash *subhash = Getattr(sub, bk.item);
         String *convcode = Getattr(subhash, "convcode");
         if (convcode) {
@@ -2031,45 +2031,45 @@ static void SwigType_inherit_equiv(File *out) {
             Printf(out, "%s", cast);
           Printf(out, " ((%s) x));\n", lprefix);
         }
-	Printf(out, "}\n");
-	Setattr(conversions, ckey, convname);
-	Delete(ckey);
-	Delete(lkey);
-	Delete(lprefix);
+        Printf(out, "}\n");
+        Setattr(conversions, ckey, convname);
+        Delete(ckey);
+        Delete(lkey);
+        Delete(lprefix);
 
-	/* This inserts conversions for typedefs */
-	{
-	  Hash *r = Getattr(r_resolved, prefix);
-	  if (r) {
-	    Iterator rrk;
-	    rrk = First(r);
-	    while (rrk.key) {
-	      Iterator rlk;
-	      String *rkeymangle;
+        /* This inserts conversions for typedefs */
+        {
+          Hash *r = Getattr(r_resolved, prefix);
+          if (r) {
+            Iterator rrk;
+            rrk = First(r);
+            while (rrk.key) {
+              Iterator rlk;
+              String *rkeymangle;
 
-	      /* Make sure this name equivalence is not due to inheritance */
-	      if (Cmp(prefix, Getattr(r, rrk.key)) == 0) {
-		rkeymangle = Copy(mkey);
-		ckey = NewStringf("%s+%s", rrk.key, rkeymangle);
-		if (!Getattr(conversions, ckey)) {
-		  Setattr(conversions, ckey, convname);
-		}
-		Delete(ckey);
-		for (rlk = First(rlist); rlk.item; rlk = Next(rlk)) {
-		  ckey = NewStringf("%s+%s", rrk.key, rlk.item);
-		  Setattr(conversions, ckey, convname);
-		  Delete(ckey);
-		}
-		Delete(rkeymangle);
-		/* This is needed to pick up other alternative names for the same type.
-		   Needed to make templates work */
-		Setattr(rh, rrk.key, rrk.item);
-	      }
-	      rrk = Next(rrk);
-	    }
-	  }
-	}
-	Delete(convname);
+              /* Make sure this name equivalence is not due to inheritance */
+              if (Cmp(prefix, Getattr(r, rrk.key)) == 0) {
+                rkeymangle = Copy(mkey);
+                ckey = NewStringf("%s+%s", rrk.key, rkeymangle);
+                if (!Getattr(conversions, ckey)) {
+                  Setattr(conversions, ckey, convname);
+                }
+                Delete(ckey);
+                for (rlk = First(rlist); rlk.item; rlk = Next(rlk)) {
+                  ckey = NewStringf("%s+%s", rrk.key, rlk.item);
+                  Setattr(conversions, ckey, convname);
+                  Delete(ckey);
+                }
+                Delete(rkeymangle);
+                /* This is needed to pick up other alternative names for the same type.
+                   Needed to make templates work */
+                Setattr(rh, rrk.key, rrk.item);
+              }
+              rrk = Next(rrk);
+            }
+          }
+        }
+        Delete(convname);
       }
       Delete(prefix);
       Delete(mprefix);
@@ -2178,14 +2178,14 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
       if (Equal(ln, rn)) {
         Setattr(nthash, ln, "1");
       } else {
-	Setattr(nthash, rn, "1");
-	Setattr(nthash, ln, "1");
+        Setattr(nthash, rn, "1");
+        Setattr(nthash, ln, "1");
       }
       if (!resolved_lstr) {
-	resolved_lstr = Copy(rn);
+        resolved_lstr = Copy(rn);
       } else if (Len(rn) < Len(resolved_lstr)) {
-	Delete(resolved_lstr);
-	resolved_lstr = Copy(rn);
+        Delete(resolved_lstr);
+        resolved_lstr = Copy(rn);
       }
       if (SwigType_istemplate(rt)) {
         String *dt = Swig_symbol_template_deftype(rt, 0);
@@ -2209,11 +2209,11 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
     nt = 0;
     while (ltiter.item) {
       if (!Equal(resolved_lstr, ltiter.item)) {
-	if (nt) {
-	   Printf(nt, "|%s", ltiter.item);
-	} else {
-	   nt = NewString(ltiter.item);
-	}
+        if (nt) {
+           Printf(nt, "|%s", ltiter.item);
+        } else {
+           nt = NewString(ltiter.item);
+        }
       }
       ltiter = Next(ltiter);
     }
@@ -2239,20 +2239,20 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
       ckey = NewStringf("%s+%s", ei.item, ki.item);
       conv = Getattr(conversions, ckey);
       if (conv) {
-	Printf(cast_temp_conv, "  {&_swigt_%s, %s, 0, 0},", ei.item, conv);
+        Printf(cast_temp_conv, "  {&_swigt_%s, %s, 0, 0},", ei.item, conv);
       } else {
-	Printf(cast_temp, "  {&_swigt_%s, 0, 0, 0},", ei.item);
+        Printf(cast_temp, "  {&_swigt_%s, 0, 0, 0},", ei.item);
       }
       Delete(ckey);
 
       if (!Getattr(r_mangled, ei.item) && !Getattr(imported_types, ei.item)) {
-	Printf(types, "static swig_type_info _swigt_%s = {\"%s\", 0, 0, 0, 0, 0};\n", ei.item, ei.item);
-	Append(table_list, ei.item);
+        Printf(types, "static swig_type_info _swigt_%s = {\"%s\", 0, 0, 0, 0, 0};\n", ei.item, ei.item);
+        Append(table_list, ei.item);
 
-	Printf(cast, "static swig_cast_info _swigc_%s[] = {{&_swigt_%s, 0, 0, 0},{0, 0, 0, 0}};\n", ei.item, ei.item);
-	i++;
+        Printf(cast, "static swig_cast_info _swigc_%s[] = {{&_swigt_%s, 0, 0, 0},{0, 0, 0, 0}};\n", ei.item, ei.item);
+        i++;
 
-	Setattr(imported_types, ei.item, "1");
+        Setattr(imported_types, ei.item, "1");
       }
     }
     Delete(el);

--- a/Source/Swig/wrapfunc.c
+++ b/Source/Swig/wrapfunc.c
@@ -80,32 +80,32 @@ void Wrapper_pretty_print(String *str, File *f) {
     if (c == '\"') {
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
-	if (c == '\\') {
-	  Putc(c, ts);
-	  c = Getc(str);
-	}
-	Putc(c, ts);
-	if (c == '\"')
-	  break;
+        if (c == '\\') {
+          Putc(c, ts);
+          c = Getc(str);
+        }
+        Putc(c, ts);
+        if (c == '\"')
+          break;
       }
       empty = 0;
     } else if (c == '\'') {
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
-	if (c == '\\') {
-	  Putc(c, ts);
-	  c = Getc(str);
-	}
-	Putc(c, ts);
-	if (c == '\'')
-	  break;
+        if (c == '\\') {
+          Putc(c, ts);
+          c = Getc(str);
+        }
+        Putc(c, ts);
+        if (c == '\'')
+          break;
       }
       empty = 0;
     } else if (c == ':') {
       Putc(c, ts);
       if ((c = Getc(str)) == '\n') {
-	if (!empty && !strchr(Char(ts), '?'))
-	  label = 1;
+        if (!empty && !strchr(Char(ts), '?'))
+          label = 1;
       }
       Ungetc(c, str);
     } else if (c == '(') {
@@ -120,24 +120,24 @@ void Wrapper_pretty_print(String *str, File *f) {
       Putc(c, ts);
       Putc('\n', ts);
       for (i = 0; i < level; i++)
-	Putc(' ', f);
+        Putc(' ', f);
       Printf(f, "%s", ts);
       Clear(ts);
       level += indent;
       while ((c = Getc(str)) != EOF) {
-	if (!isspace(c)) {
-	  Ungetc(c, str);
-	  break;
-	}
+        if (!isspace(c)) {
+          Ungetc(c, str);
+          break;
+        }
       }
       empty = 0;
     } else if (c == '}') {
       if (!empty) {
-	Putc('\n', ts);
-	for (i = 0; i < level; i++)
-	  Putc(' ', f);
-	Printf(f, "%s", ts);
-	Clear(ts);
+        Putc('\n', ts);
+        for (i = 0; i < level; i++)
+          Putc(' ', f);
+        Printf(f, "%s", ts);
+        Clear(ts);
       }
       level -= indent;
       Putc(c, ts);
@@ -146,16 +146,16 @@ void Wrapper_pretty_print(String *str, File *f) {
       Putc(c, ts);
       empty = 0;
       if (!empty) {
-	int slevel = level;
-	if (label && (slevel >= indent))
-	  slevel -= indent;
-	if ((Char(ts))[0] != '#') {
-	  for (i = 0; i < slevel; i++)
-	    Putc(' ', f);
-	}
-	Printf(f, "%s", ts);
-	for (i = 0; i < plevel; i++)
-	  Putc(' ', f);
+        int slevel = level;
+        if (label && (slevel >= indent))
+          slevel -= indent;
+        if ((Char(ts))[0] != '#') {
+          for (i = 0; i < slevel; i++)
+            Putc(' ', f);
+        }
+        Printf(f, "%s", ts);
+        for (i = 0; i < plevel; i++)
+          Putc(' ', f);
       }
       Clear(ts);
       label = 0;
@@ -165,35 +165,35 @@ void Wrapper_pretty_print(String *str, File *f) {
       Putc(c, ts);
       c = Getc(str);
       if (c != EOF) {
-	Putc(c, ts);
-	if (c == '/') {		/* C++ comment */
-	  while ((c = Getc(str)) != EOF) {
-	    if (c == '\n') {
-	      Ungetc(c, str);
-	      break;
-	    }
-	    Putc(c, ts);
-	  }
-	} else if (c == '*') {	/* C comment */
-	  int endstar = 0;
-	  while ((c = Getc(str)) != EOF) {
-	    if (endstar && c == '/') {	/* end of C comment */
-	      Putc(c, ts);
-	      break;
-	    }
-	    endstar = (c == '*');
-	    Putc(c, ts);
-	    if (c == '\n') {	/* multi-line C comment. Could be improved slightly. */
-	      for (i = 0; i < level; i++)
-		Putc(' ', ts);
-	    }
-	  }
-	}
+        Putc(c, ts);
+        if (c == '/') {		/* C++ comment */
+          while ((c = Getc(str)) != EOF) {
+            if (c == '\n') {
+              Ungetc(c, str);
+              break;
+            }
+            Putc(c, ts);
+          }
+        } else if (c == '*') {	/* C comment */
+          int endstar = 0;
+          while ((c = Getc(str)) != EOF) {
+            if (endstar && c == '/') {	/* end of C comment */
+              Putc(c, ts);
+              break;
+            }
+            endstar = (c == '*');
+            Putc(c, ts);
+            if (c == '\n') {	/* multi-line C comment. Could be improved slightly. */
+              for (i = 0; i < level; i++)
+                Putc(' ', ts);
+            }
+          }
+        }
       }
     } else {
       if (!empty || !isspace(c)) {
-	Putc(c, ts);
-	empty = 0;
+        Putc(c, ts);
+        empty = 0;
       }
     }
   }
@@ -226,63 +226,63 @@ void Wrapper_compact_print(String *str, File *f) {
       empty = 0;
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
-	if (c == '\\') {
-	  Putc(c, ts);
-	  c = Getc(str);
-	}
-	Putc(c, ts);
-	if (c == '\"')
-	  break;
+        if (c == '\\') {
+          Putc(c, ts);
+          c = Getc(str);
+        }
+        Putc(c, ts);
+        if (c == '\"')
+          break;
       }
     } else if (c == '\'') {	/* string 2 */
       empty = 0;
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
-	if (c == '\\') {
-	  Putc(c, ts);
-	  c = Getc(str);
-	}
-	Putc(c, ts);
-	if (c == '\'')
-	  break;
+        if (c == '\\') {
+          Putc(c, ts);
+          c = Getc(str);
+        }
+        Putc(c, ts);
+        if (c == '\'')
+          break;
       }
     } else if (c == '{') {	/* start of {...} */
       empty = 0;
       Putc(c, ts);
       if (Len(tf) == 0) {
-	for (i = 0; i < level; i++)
-	  Putc(' ', tf);
+        for (i = 0; i < level; i++)
+          Putc(' ', tf);
       } else if ((Len(tf) + Len(ts)) < Max_line_size) {
-	Putc(' ', tf);
+        Putc(' ', tf);
       } else {
-	Putc('\n', tf);
-	Printf(f, "%s", tf);
-	Clear(tf);
-	for (i = 0; i < level; i++)
-	  Putc(' ', tf);
+        Putc('\n', tf);
+        Printf(f, "%s", tf);
+        Clear(tf);
+        for (i = 0; i < level; i++)
+          Putc(' ', tf);
       }
       Append(tf, ts);
       Clear(ts);
       level += indent;
       while ((c = Getc(str)) != EOF) {
-	if (!isspace(c)) {
-	  Ungetc(c, str);
-	  break;
-	}
+        if (!isspace(c)) {
+          Ungetc(c, str);
+          break;
+        }
       }
     } else if (c == '}') {	/* end of {...} */
       empty = 0;
       if (Len(tf) == 0) {
-	for (i = 0; i < level; i++)
-	  Putc(' ', tf);
+        for (i = 0; i < level; i++)
+          Putc(' ', tf);
       } else if ((Len(tf) + Len(ts)) < Max_line_size) {
-	Putc(' ', tf);
+        Putc(' ', tf);
       } else {
-	Putc('\n', tf);
-	Printf(f, "%s", tf);
-	Clear(tf);
-	for (i = 0; i < level; i++)
-	  Putc(' ', tf);
+        Putc('\n', tf);
+        Printf(f, "%s", tf);
+        Clear(tf);
+        for (i = 0; i < level; i++)
+          Putc(' ', tf);
       }
       Append(tf, ts);
       Putc(c, tf);
@@ -290,28 +290,28 @@ void Wrapper_compact_print(String *str, File *f) {
       level -= indent;
     } else if (c == '\n') {	/* line end */
       while ((c = Getc(str)) != EOF) {
-	if (!isspace(c))
-	  break;
+        if (!isspace(c))
+          break;
       }
       if (c == '#') {
-	Putc('\n', ts);
+        Putc('\n', ts);
       } else if (c == '}') {
-	Putc(' ', ts);
+        Putc(' ', ts);
       } else if ((c != EOF) || (Len(ts) != 0)) {
-	if (Len(tf) == 0) {
-	  for (i = 0; i < level; i++)
-	    Putc(' ', tf);
-	} else if ((Len(tf) + Len(ts)) < Max_line_size) {
-	  Putc(' ', tf);
-	} else {
-	  Putc('\n', tf);
-	  Printf(f, "%s", tf);
-	  Clear(tf);
-	  for (i = 0; i < level; i++)
-	    Putc(' ', tf);
-	}
-	Append(tf, ts);
-	Clear(ts);
+        if (Len(tf) == 0) {
+          for (i = 0; i < level; i++)
+            Putc(' ', tf);
+        } else if ((Len(tf) + Len(ts)) < Max_line_size) {
+          Putc(' ', tf);
+        } else {
+          Putc('\n', tf);
+          Printf(f, "%s", tf);
+          Clear(tf);
+          for (i = 0; i < level; i++)
+            Putc(' ', tf);
+        }
+        Append(tf, ts);
+        Clear(ts);
       }
       Ungetc(c, str);
 
@@ -320,53 +320,53 @@ void Wrapper_compact_print(String *str, File *f) {
       empty = 0;
       c = Getc(str);
       if (c != EOF) {
-	if (c == '/') {		/* C++ comment */
-	  while ((c = Getc(str)) != EOF) {
-	    if (c == '\n') {
-	      Ungetc(c, str);
-	      break;
-	    }
-	  }
-	} else if (c == '*') {	/* C comment */
-	  int endstar = 0;
-	  while ((c = Getc(str)) != EOF) {
-	    if (endstar && c == '/') {	/* end of C comment */
-	      break;
-	    }
-	    endstar = (c == '*');
-	  }
-	} else {
-	  Putc('/', ts);
-	  Putc(c, ts);
-	}
+        if (c == '/') {		/* C++ comment */
+          while ((c = Getc(str)) != EOF) {
+            if (c == '\n') {
+              Ungetc(c, str);
+              break;
+            }
+          }
+        } else if (c == '*') {	/* C comment */
+          int endstar = 0;
+          while ((c = Getc(str)) != EOF) {
+            if (endstar && c == '/') {	/* end of C comment */
+              break;
+            }
+            endstar = (c == '*');
+          }
+        } else {
+          Putc('/', ts);
+          Putc(c, ts);
+        }
       }
     } else if (c == '#') {	/* Preprocessor line */
       Putc('#', ts);
       while ((c = Getc(str)) != EOF) {
-	Putc(c, ts);
-	if (c == '\\') {	/* Continued line of the same PP */
-	  c = Getc(str);
-	  if (c == '\n')
-	    Putc(c, ts);
-	  else
-	    Ungetc(c, str);
-	} else if (c == '\n')
-	  break;
+        Putc(c, ts);
+        if (c == '\\') {	/* Continued line of the same PP */
+          c = Getc(str);
+          if (c == '\n')
+            Putc(c, ts);
+          else
+            Ungetc(c, str);
+        } else if (c == '\n')
+          break;
       }
       if (!empty) {
-	Append(tf, "\n");
+        Append(tf, "\n");
       }
       Append(tf, ts);
       Printf(f, "%s", tf);
       Clear(tf);
       Clear(ts);
       for (i = 0; i < level; i++)
-	Putc(' ', tf);
+        Putc(' ', tf);
       empty = 1;
     } else {
       if (!empty || !isspace(c)) {
-	Putc(c, ts);
-	empty = 0;
+        Putc(c, ts);
+        empty = 0;
       }
     }
   }

--- a/Source/Swig/wrapfunc.c
+++ b/Source/Swig/wrapfunc.c
@@ -16,7 +16,7 @@
 #include "swig.h"
 #include <ctype.h>
 
-static int Compact_mode = 0;    /* set to 0 on default */
+static int Compact_mode = 0; /* set to 0 on default */
 static int Max_line_size = 128;
 
 /* -----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ static int Max_line_size = 128;
 
 Wrapper *NewWrapper(void) {
   Wrapper *w;
-  w = (Wrapper *) Malloc(sizeof(Wrapper));
+  w = (Wrapper *)Malloc(sizeof(Wrapper));
   w->localh = NewHash();
   w->locals = NewStringEmpty();
   w->code = NewStringEmpty();
@@ -166,7 +166,7 @@ void Wrapper_pretty_print(String *str, File *f) {
       c = Getc(str);
       if (c != EOF) {
         Putc(c, ts);
-        if (c == '/') {         /* C++ comment */
+        if (c == '/') { /* C++ comment */
           while ((c = Getc(str)) != EOF) {
             if (c == '\n') {
               Ungetc(c, str);
@@ -174,16 +174,16 @@ void Wrapper_pretty_print(String *str, File *f) {
             }
             Putc(c, ts);
           }
-        } else if (c == '*') {  /* C comment */
+        } else if (c == '*') { /* C comment */
           int endstar = 0;
           while ((c = Getc(str)) != EOF) {
-            if (endstar && c == '/') {  /* end of C comment */
+            if (endstar && c == '/') { /* end of C comment */
               Putc(c, ts);
               break;
             }
             endstar = (c == '*');
             Putc(c, ts);
-            if (c == '\n') {    /* multi-line C comment. Could be improved slightly. */
+            if (c == '\n') { /* multi-line C comment. Could be improved slightly. */
               for (i = 0; i < level; i++)
                 Putc(' ', ts);
             }
@@ -211,7 +211,7 @@ void Wrapper_pretty_print(String *str, File *f) {
  * ----------------------------------------------------------------------------- */
 
 void Wrapper_compact_print(String *str, File *f) {
-  String *ts, *tf;              /*temp string & temp file */
+  String *ts, *tf; /*temp string & temp file */
   int level = 0;
   int c, i;
   int empty = 1;
@@ -222,7 +222,7 @@ void Wrapper_compact_print(String *str, File *f) {
   Seek(str, 0, SEEK_SET);
 
   while ((c = Getc(str)) != EOF) {
-    if (c == '\"') {            /* string 1 */
+    if (c == '\"') { /* string 1 */
       empty = 0;
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
@@ -234,7 +234,7 @@ void Wrapper_compact_print(String *str, File *f) {
         if (c == '\"')
           break;
       }
-    } else if (c == '\'') {     /* string 2 */
+    } else if (c == '\'') { /* string 2 */
       empty = 0;
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
@@ -246,7 +246,7 @@ void Wrapper_compact_print(String *str, File *f) {
         if (c == '\'')
           break;
       }
-    } else if (c == '{') {      /* start of {...} */
+    } else if (c == '{') { /* start of {...} */
       empty = 0;
       Putc(c, ts);
       if (Len(tf) == 0) {
@@ -270,7 +270,7 @@ void Wrapper_compact_print(String *str, File *f) {
           break;
         }
       }
-    } else if (c == '}') {      /* end of {...} */
+    } else if (c == '}') { /* end of {...} */
       empty = 0;
       if (Len(tf) == 0) {
         for (i = 0; i < level; i++)
@@ -288,7 +288,7 @@ void Wrapper_compact_print(String *str, File *f) {
       Putc(c, tf);
       Clear(ts);
       level -= indent;
-    } else if (c == '\n') {     /* line end */
+    } else if (c == '\n') { /* line end */
       while ((c = Getc(str)) != EOF) {
         if (!isspace(c))
           break;
@@ -316,21 +316,21 @@ void Wrapper_compact_print(String *str, File *f) {
       Ungetc(c, str);
 
       empty = 1;
-    } else if (c == '/') {      /* comment */
+    } else if (c == '/') { /* comment */
       empty = 0;
       c = Getc(str);
       if (c != EOF) {
-        if (c == '/') {         /* C++ comment */
+        if (c == '/') { /* C++ comment */
           while ((c = Getc(str)) != EOF) {
             if (c == '\n') {
               Ungetc(c, str);
               break;
             }
           }
-        } else if (c == '*') {  /* C comment */
+        } else if (c == '*') { /* C comment */
           int endstar = 0;
           while ((c = Getc(str)) != EOF) {
-            if (endstar && c == '/') {  /* end of C comment */
+            if (endstar && c == '/') { /* end of C comment */
               break;
             }
             endstar = (c == '*');
@@ -340,11 +340,11 @@ void Wrapper_compact_print(String *str, File *f) {
           Putc(c, ts);
         }
       }
-    } else if (c == '#') {      /* Preprocessor line */
+    } else if (c == '#') { /* Preprocessor line */
       Putc('#', ts);
       while ((c = Getc(str)) != EOF) {
         Putc(c, ts);
-        if (c == '\\') {        /* Continued line of the same PP */
+        if (c == '\\') { /* Continued line of the same PP */
           c = Getc(str);
           if (c == '\n')
             Putc(c, ts);
@@ -486,9 +486,8 @@ char *Wrapper_new_local(Wrapper *w, const_String_or_char_ptr name, const_String_
   ret = Char(nname);
   Delete(nname);
   Delete(ndecl);
-  return ret;                   /* Note: nname should still exists in the w->localh hash */
+  return ret; /* Note: nname should still exists in the w->localh hash */
 }
-
 
 /* -----------------------------------------------------------------------------
  * Wrapper_new_localv()

--- a/Source/Swig/wrapfunc.c
+++ b/Source/Swig/wrapfunc.c
@@ -16,7 +16,7 @@
 #include "swig.h"
 #include <ctype.h>
 
-static int Compact_mode = 0;	/* set to 0 on default */
+static int Compact_mode = 0;    /* set to 0 on default */
 static int Max_line_size = 128;
 
 /* -----------------------------------------------------------------------------
@@ -166,7 +166,7 @@ void Wrapper_pretty_print(String *str, File *f) {
       c = Getc(str);
       if (c != EOF) {
         Putc(c, ts);
-        if (c == '/') {		/* C++ comment */
+        if (c == '/') {         /* C++ comment */
           while ((c = Getc(str)) != EOF) {
             if (c == '\n') {
               Ungetc(c, str);
@@ -174,16 +174,16 @@ void Wrapper_pretty_print(String *str, File *f) {
             }
             Putc(c, ts);
           }
-        } else if (c == '*') {	/* C comment */
+        } else if (c == '*') {  /* C comment */
           int endstar = 0;
           while ((c = Getc(str)) != EOF) {
-            if (endstar && c == '/') {	/* end of C comment */
+            if (endstar && c == '/') {  /* end of C comment */
               Putc(c, ts);
               break;
             }
             endstar = (c == '*');
             Putc(c, ts);
-            if (c == '\n') {	/* multi-line C comment. Could be improved slightly. */
+            if (c == '\n') {    /* multi-line C comment. Could be improved slightly. */
               for (i = 0; i < level; i++)
                 Putc(' ', ts);
             }
@@ -211,7 +211,7 @@ void Wrapper_pretty_print(String *str, File *f) {
  * ----------------------------------------------------------------------------- */
 
 void Wrapper_compact_print(String *str, File *f) {
-  String *ts, *tf;		/*temp string & temp file */
+  String *ts, *tf;              /*temp string & temp file */
   int level = 0;
   int c, i;
   int empty = 1;
@@ -222,7 +222,7 @@ void Wrapper_compact_print(String *str, File *f) {
   Seek(str, 0, SEEK_SET);
 
   while ((c = Getc(str)) != EOF) {
-    if (c == '\"') {		/* string 1 */
+    if (c == '\"') {            /* string 1 */
       empty = 0;
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
@@ -234,7 +234,7 @@ void Wrapper_compact_print(String *str, File *f) {
         if (c == '\"')
           break;
       }
-    } else if (c == '\'') {	/* string 2 */
+    } else if (c == '\'') {     /* string 2 */
       empty = 0;
       Putc(c, ts);
       while ((c = Getc(str)) != EOF) {
@@ -246,7 +246,7 @@ void Wrapper_compact_print(String *str, File *f) {
         if (c == '\'')
           break;
       }
-    } else if (c == '{') {	/* start of {...} */
+    } else if (c == '{') {      /* start of {...} */
       empty = 0;
       Putc(c, ts);
       if (Len(tf) == 0) {
@@ -270,7 +270,7 @@ void Wrapper_compact_print(String *str, File *f) {
           break;
         }
       }
-    } else if (c == '}') {	/* end of {...} */
+    } else if (c == '}') {      /* end of {...} */
       empty = 0;
       if (Len(tf) == 0) {
         for (i = 0; i < level; i++)
@@ -288,7 +288,7 @@ void Wrapper_compact_print(String *str, File *f) {
       Putc(c, tf);
       Clear(ts);
       level -= indent;
-    } else if (c == '\n') {	/* line end */
+    } else if (c == '\n') {     /* line end */
       while ((c = Getc(str)) != EOF) {
         if (!isspace(c))
           break;
@@ -316,21 +316,21 @@ void Wrapper_compact_print(String *str, File *f) {
       Ungetc(c, str);
 
       empty = 1;
-    } else if (c == '/') {	/* comment */
+    } else if (c == '/') {      /* comment */
       empty = 0;
       c = Getc(str);
       if (c != EOF) {
-        if (c == '/') {		/* C++ comment */
+        if (c == '/') {         /* C++ comment */
           while ((c = Getc(str)) != EOF) {
             if (c == '\n') {
               Ungetc(c, str);
               break;
             }
           }
-        } else if (c == '*') {	/* C comment */
+        } else if (c == '*') {  /* C comment */
           int endstar = 0;
           while ((c = Getc(str)) != EOF) {
-            if (endstar && c == '/') {	/* end of C comment */
+            if (endstar && c == '/') {  /* end of C comment */
               break;
             }
             endstar = (c == '*');
@@ -340,11 +340,11 @@ void Wrapper_compact_print(String *str, File *f) {
           Putc(c, ts);
         }
       }
-    } else if (c == '#') {	/* Preprocessor line */
+    } else if (c == '#') {      /* Preprocessor line */
       Putc('#', ts);
       while ((c = Getc(str)) != EOF) {
         Putc(c, ts);
-        if (c == '\\') {	/* Continued line of the same PP */
+        if (c == '\\') {        /* Continued line of the same PP */
           c = Getc(str);
           if (c == '\n')
             Putc(c, ts);
@@ -486,7 +486,7 @@ char *Wrapper_new_local(Wrapper *w, const_String_or_char_ptr name, const_String_
   ret = Char(nname);
   Delete(nname);
   Delete(ndecl);
-  return ret;			/* Note: nname should still exists in the w->localh hash */
+  return ret;                   /* Note: nname should still exists in the w->localh hash */
 }
 
 

--- a/Source/Swig/wrapfunc.c
+++ b/Source/Swig/wrapfunc.c
@@ -1,5 +1,5 @@
-/* ----------------------------------------------------------------------------- 
- * This file is part of SWIG, which is licensed as a whole under version 3 
+/* -----------------------------------------------------------------------------
+ * This file is part of SWIG, which is licensed as a whole under version 3
  * (or any later version) of the GNU General Public License. Some additional
  * terms also apply to certain portions of SWIG. The full details of the SWIG
  * license and copyrights can be found in the LICENSE and COPYRIGHT files
@@ -460,7 +460,7 @@ int Wrapper_check_local(Wrapper *w, const_String_or_char_ptr name) {
   return 0;
 }
 
-/* ----------------------------------------------------------------------------- 
+/* -----------------------------------------------------------------------------
  * Wrapper_new_local()
  *
  * Adds a new local variable with a guarantee that a unique local name will be

--- a/Tools/pre-commit
+++ b/Tools/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Pre-commit git hook for SWIG repository, copy to .git/hooks/pre-commit
+
+clang_format=clang-format
+files_to_format=$(git diff-index --diff-filter=d --name-only HEAD ':Source/*/*.c' ':Source/*/*.cxx' ':Source/*/*.h')
+if [ -n "$files_to_format" ]; then
+    printf "Running ${clang_format} in git pre-commit hook to validate modified files...\n"
+    if ! ${clang_format} --dry-run --Werror ${files_to_format}; then
+        printf "Error: Fix formatting before committing, see Doc/Manual/Extending.html#Extending_coding_style_guidelines.\n"
+        exit 1
+    fi
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -519,6 +519,41 @@ case $host in
 esac
 AC_SUBST(SHELL_PATH_SEP)
 
+#----------------------------------------------------------------
+# clang-format
+#----------------------------------------------------------------
+
+AC_ARG_WITH(clang-format, AS_HELP_STRING([--without-clang-format], [Disable clang-format])
+AS_HELP_STRING([--with-clang-format=path], [Set location of clang-format executable]),[with_clang_format="$withval"], [with_clang_format="yes"])
+
+# First, check for "--without-clang-format" or "--with-clang-format=no".
+if test x"$with_clang_format" = xno; then
+  AC_MSG_NOTICE([Disabling clang-format])
+  CLANG_FORMAT=
+else
+  if test "x$with_clang_format" = xyes; then
+    AC_CHECK_PROGS(CLANG_FORMAT, clang-format)
+  else
+    AC_MSG_CHECKING([clang-format])
+    CLANG_FORMAT="$with_clang_format"
+    AC_MSG_RESULT([$CLANG_FORMAT])
+  fi
+fi
+if test -n "$CLANG_FORMAT" ; then
+  AC_MSG_CHECKING([for clang-format major version])
+  clang_format_version=[$($CLANG_FORMAT --version | sed -e 's/^.*version \([0-9]\+\)\(.[0-9.]*\).*$/\1/')]
+  AC_MSG_RESULT([$clang_format_version])
+  AC_MSG_CHECKING([whether clang-format version >= 18 and should be used]) # 18 is first version to support .clang-format-ignore
+  if test "$clang_format_version" -ge "18"; then
+    AC_MSG_RESULT([yes])
+  else
+    AC_MSG_RESULT([no])
+    CLANG_FORMAT=
+  fi
+fi
+
+AC_SUBST(CLANG_FORMAT)
+
 #--------------------------------------------------------------------
 # Target languages
 #--------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -154,11 +154,11 @@ else
 fi
 if test -n "$CLANG_FORMAT" ; then
   AC_MSG_CHECKING([for clang-format version])
-  clang_format_version=[$($CLANG_FORMAT --version | sed -e 's/^.*version \([0-9]\+.[0-9.]*\).*$/\1/')]
+  clang_format_version=[$($CLANG_FORMAT --version | sed 's/^.*version \([0-9][0-9.]*\).*$/\1/')]
   AC_MSG_RESULT([$clang_format_version])
-  clang_format_major_version=[$(echo "$clang_format_version" | sed -e 's/^\([0-9]\+\)\(.[0-9.]*\).*$/\1/')]
+  clang_format_major_version=[$(echo "$clang_format_version" | sed 's/^\([0-9][0-9]*\)\(.[0-9.]*\).*$/\1/')]
   AC_MSG_CHECKING([whether clang-format major version ($clang_format_major_version) >= required minimum version (18) and should be enabled]) # 18 is first version to support .clang-format-ignore
-  if test "$clang_format_major_version" -ge "18"; then
+  if test $clang_format_major_version -ge 18; then
     AC_MSG_RESULT([yes])
   else
     AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -540,11 +540,12 @@ else
   fi
 fi
 if test -n "$CLANG_FORMAT" ; then
-  AC_MSG_CHECKING([for clang-format major version])
-  clang_format_version=[$($CLANG_FORMAT --version | sed -e 's/^.*version \([0-9]\+\)\(.[0-9.]*\).*$/\1/')]
+  AC_MSG_CHECKING([for clang-format version])
+  clang_format_version=[$($CLANG_FORMAT --version | sed -e 's/^.*version \([0-9]\+.[0-9.]*\).*$/\1/')]
   AC_MSG_RESULT([$clang_format_version])
-  AC_MSG_CHECKING([whether clang-format version >= 18 and should be used]) # 18 is first version to support .clang-format-ignore
-  if test "$clang_format_version" -ge "18"; then
+  clang_format_major_version=[$(echo "$clang_format_version" | sed -e 's/^\([0-9]\+\)\(.[0-9.]*\).*$/\1/')]
+  AC_MSG_CHECKING([whether clang-format major version ($clang_format_major_version) >= required minimum version (18) and should be enabled]) # 18 is first version to support .clang-format-ignore
+  if test "$clang_format_major_version" -ge "18"; then
     AC_MSG_RESULT([yes])
   else
     AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,9 @@ if test "$enable_ccache" = yes; then
 fi
 AC_SUBST(ENABLE_CCACHE)
 
+#----------------------------------------------------------------
+# Optional packages for development
+#----------------------------------------------------------------
 
 echo ""
 echo "Checking packages required for SWIG developers."
@@ -128,6 +131,46 @@ echo "Note : None of the following packages are required for users to compile an
 echo ""
 
 AC_CHECK_PROGS([BISON], [bison], [$MISSING bison])
+
+#----------------------------------------------------------------
+# clang-format
+#----------------------------------------------------------------
+
+AC_ARG_WITH(clang-format, AS_HELP_STRING([--without-clang-format], [Disable clang-format])
+AS_HELP_STRING([--with-clang-format=path], [Set location of clang-format executable]),[with_clang_format="$withval"], [with_clang_format="yes"])
+
+# First, check for "--without-clang-format" or "--with-clang-format=no".
+if test x"$with_clang_format" = xno; then
+  AC_MSG_NOTICE([Disabling clang-format])
+  CLANG_FORMAT=
+else
+  if test "x$with_clang_format" = xyes; then
+    AC_CHECK_PROGS(CLANG_FORMAT, clang-format)
+  else
+    AC_MSG_CHECKING([clang-format])
+    CLANG_FORMAT="$with_clang_format"
+    AC_MSG_RESULT([$CLANG_FORMAT])
+  fi
+fi
+if test -n "$CLANG_FORMAT" ; then
+  AC_MSG_CHECKING([for clang-format version])
+  clang_format_version=[$($CLANG_FORMAT --version | sed -e 's/^.*version \([0-9]\+.[0-9.]*\).*$/\1/')]
+  AC_MSG_RESULT([$clang_format_version])
+  clang_format_major_version=[$(echo "$clang_format_version" | sed -e 's/^\([0-9]\+\)\(.[0-9.]*\).*$/\1/')]
+  AC_MSG_CHECKING([whether clang-format major version ($clang_format_major_version) >= required minimum version (18) and should be enabled]) # 18 is first version to support .clang-format-ignore
+  if test "$clang_format_major_version" -ge "18"; then
+    AC_MSG_RESULT([yes])
+  else
+    AC_MSG_RESULT([no])
+    CLANG_FORMAT=
+  fi
+fi
+
+AC_SUBST(CLANG_FORMAT)
+
+#----------------------------------------------------------------
+# Optional for target language examples/testing
+#----------------------------------------------------------------
 
 echo ""
 echo "Checking for installed target languages and other information in order to compile and run"
@@ -518,42 +561,6 @@ case $host in
     ;;
 esac
 AC_SUBST(SHELL_PATH_SEP)
-
-#----------------------------------------------------------------
-# clang-format
-#----------------------------------------------------------------
-
-AC_ARG_WITH(clang-format, AS_HELP_STRING([--without-clang-format], [Disable clang-format])
-AS_HELP_STRING([--with-clang-format=path], [Set location of clang-format executable]),[with_clang_format="$withval"], [with_clang_format="yes"])
-
-# First, check for "--without-clang-format" or "--with-clang-format=no".
-if test x"$with_clang_format" = xno; then
-  AC_MSG_NOTICE([Disabling clang-format])
-  CLANG_FORMAT=
-else
-  if test "x$with_clang_format" = xyes; then
-    AC_CHECK_PROGS(CLANG_FORMAT, clang-format)
-  else
-    AC_MSG_CHECKING([clang-format])
-    CLANG_FORMAT="$with_clang_format"
-    AC_MSG_RESULT([$CLANG_FORMAT])
-  fi
-fi
-if test -n "$CLANG_FORMAT" ; then
-  AC_MSG_CHECKING([for clang-format version])
-  clang_format_version=[$($CLANG_FORMAT --version | sed -e 's/^.*version \([0-9]\+.[0-9.]*\).*$/\1/')]
-  AC_MSG_RESULT([$clang_format_version])
-  clang_format_major_version=[$(echo "$clang_format_version" | sed -e 's/^\([0-9]\+\)\(.[0-9.]*\).*$/\1/')]
-  AC_MSG_CHECKING([whether clang-format major version ($clang_format_major_version) >= required minimum version (18) and should be enabled]) # 18 is first version to support .clang-format-ignore
-  if test "$clang_format_major_version" -ge "18"; then
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no])
-    CLANG_FORMAT=
-  fi
-fi
-
-AC_SUBST(CLANG_FORMAT)
 
 #--------------------------------------------------------------------
 # Target languages


### PR DESCRIPTION
I find during code reviews I end up spending time on looking at, getting distracted by and fixing code formatting. I would like to remove this problem to speed up reviews as well as helping contributors understanding SWIG's coding style with a bonus of keeping the formatting consistent in the source code base.

My first attempt back in 2006 was to introduce the 'beautify' target in Source/Makefiles.am. This used the GNU indent tool to format the code. This was problematic, as while it worked okay with C code, it managed to make a mess of C++ code and required manual fixups. So, it could never be automatically invoked. In fact it was hardly used Twenty years later, the obvious replacement choice is clang-format.

In an ideal world, we would switch to clang-format to use the identical formatting (for C code) that GNU indent uses in order to avoid a large purely whitespace commit. I've spent some time now experimenting with clang-format and propose using the .clang-format config file in this merge request. I think I've found a fairly good close equivalent but with one important change. I found that its output was a bit buggy/weird if the tab setup we use was used for indentation. But I have had good success if we switch to spaces instead of tabs. I think our tab and indentation setup was always viewed as a bit odd, so I'm proposing to use a 2 space indent and no tabs going forwards.

The other notable changes are:
1. Fixing up the currently haphazard and inconsistent formatting of calling a function that take many parameters. They can either be one long line now or one parameter per line.
2. Fixing up the currently haphazard formatting of multi-line if statements. Single line if statements only (broken at 160 characters if too long).

From what I understand, the clang-format tool parses the code losing the input format, then strictly reformats the code according to the global input config file. There is no way to 'break the rules' except by using `\\ clang-format off` comments. There is also a regex tool, but it isn't a serious option really. This means that we can't 100% match the original format nor can we have many localised special exception cases. But this is one of the strengths; once we've reformatted the code, it will remain consistently formatted going forwards if we use the tool for every commit.

I havn't enforced the use of the tool in this merge request, nor documented it. I'll work on that next. I thought I'd put in this merge request as a heads up to see if anyone with experience of clang-format would like to offer some guidance and improvements before I land it in master.

I havn't tackled parser.y yet as clang does not support yacc files. Instead, I plan on moving the C functions out of parser.y into a .c file and whitespace correct parser.y for the time being. I also plan to add checks to enforce a ban on tabs in the Source directory (except of course in Makefiles).

Description of different commits
================================
The first 5 commits are a few small changes to make the current code base more clang-format friendly and removes a couple of subtle differences different versions (I tested versions 14-20). The next 3 commits are whitespace only changes for which clang-format is not necessarily needed. They convert tabs to 8 spaces and remove trailing whitespace in the same way that git commit does. clang-format can do these whitespace changes, but I've committed these separately to remove noise in the actual (more interesting) code reformatting. The final commit, 93af82c1ae793069a87bd148436a41edc1bd28ac, contains the remaining/actual formatting changes/corrections that clang-format makes.

Some stats to consider:
Total lines of code (.c .h .cxx), using wc -l: 111491

| Commit    | Lines changed | Lines changed (%) | Commit heading |
------------|---------------|-------------------|----------------|
| 7166e2e4e | 25    |   0.0  | Minor code changes in preparation for clang-format |
| 6f8ea0001 | 90    |   0.1  | Remove some use of tab4 and tab8 in perl, lua, python, perl |
| e5bf1c891 | 89    |   0.1  | Tweaks in python.cxx for clang-format |
| e485e1b1d | 6     |   0.0  | clang-format changes for older versions of clang-format |
| d5e375a14 | 19245 |   17.3 | Remove tabs at start of source files - cosmetic whitespace only change |
| c70d946d9 | 519   |   0.5  | Remove trailing whitespace in source - cosmetic whitespace only change |
| 399581948 | 749   |   0.7  | Convert remaining tabs to spaces |
| 93af82c1a | 7259  |   6.5  | Beautify using swig specific .clang-format |

The 'Lines changed' column is the number of lines deleted in the output of `diff diff --stat`.

From the above the switch to tabs from spaces is 18.0% of the lines and the remaining formatting adjustments are 6.5% of the line count. The 18% is higher than I'd hoped, but it'll be a one off and there should be no more whitespace only commits going forwards so seems like a good trade-off to me.