### PR TITLE
More fixes for GitHub windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -157,7 +157,7 @@ jobs:
               mingw_variant=mingw-w64-ucrt-x86_64
               MORE_MSYS_PKGS+=" $mingw_variant-gcc"
               if [[ -n "$VER" ]]; then
-                ruby_dir=$(ls -d /c/hostedtoolcache/windows/Ruby/$VER*)/x64/bin
+                ruby_dir=$(ls -d /c/hostedtoolcache/windows/Ruby/$VER.*)/x64/bin
                 RUBYDIR=$(cygpath -w $ruby_dir)
                 echo "$RUBYDIR" >> $GITHUB_PATH
               else
@@ -206,22 +206,16 @@ jobs:
             if [[ -n "$VER" ]]; then
               case "$SWIGLANG" in
               python)
-                PYTHONDIR_UNIX=$(ls -d /c/hostedtoolcache/windows/Python/$VER*)/x64
-                PYTHONDIR=$(cygpath -w $PYTHONDIR_UNIX)
+                python_dir=$(ls -d /c/hostedtoolcache/windows/Python/$VER.*)/x64
+                PYTHONDIR=$(cygpath -w $python_dir)
                 echo "$PYTHONDIR\\Script" >> $GITHUB_PATH
                 echo "$PYTHONDIR" >> $GITHUB_PATH
-                ;;
-              ruby)
-                RUBYDIR_UNIX=$(ls -d /c/hostedtoolcache/windows/Ruby/$VER*)/x64
-                RUBYDIR=$(cygpath -w $RUBYDIR_UNIX)
-                echo "$RUBYDIR\\bin" >> $GITHUB_PATH
                 ;;
               esac
             fi
           fi # COMPILER
 
-          # Java must use VER!
-          if [[ "$SWIGLANG" = "java" ]]; then
+          if [[ "$SWIGLANG" = "java" ]] && [[ -n "$VER" ]]; then
             declare -n java_path="JAVA_HOME_${VER}_X64"
             echo "JAVA_HOME=$java_path" >> $GITHUB_ENV
           fi

--- a/configure.ac
+++ b/configure.ac
@@ -2072,9 +2072,7 @@ else
 
       AC_MSG_CHECKING([for Python 3.x version])
 
-      # Need to do this hack since autoconf replaces __file__ with the name of the configure file
-      filehack="file__"
-      PY3VERSION=`($PYTHON3 -c "import string,operator,os.path; print(operator.getitem(os.path.split(operator.getitem(os.path.split(string.__$filehack),0)),1))") 2>/dev/null`
+      PY3VERSION=`($PYTHON3 -c "import sys;print('python%d.%d' % (sys.version_info.major, sys.version_info.minor))") 2>/dev/null`
       AC_MSG_RESULT($PY3VERSION)
 
       # Find the directory for libraries this is necessary to deal with


### PR DESCRIPTION
- Add dot after the `VER` variable, in search paths, to avoid fetching the wrong version. i.e. prevent `VER=3.1` to use version `3.10`.
- Ruby installations on GitHub Windows image, never use the MSVC compiler.
- There is a default Java. The currently default Java version is 17. With proper `JAVA_HOME` variable in the environment.
- Fix `PY3VERSION`: old `string.__file__`ends with `string.py`, while new ends with `string/__init__.py`. Using the file path requires more filtering, and might prone to more changes in the future. Use `sys.version_info` to fetch proper python version. This method might bent too, but is less likely to change.