### PR TITLE
Ruby: Avoid usage of deprecated untyped API

### DIFF
--- a/Examples/test-suite/ruby_manual_proxy.i
+++ b/Examples/test-suite/ruby_manual_proxy.i
@@ -42,17 +42,28 @@ static void svn_swig_rb_raise_svn_fs_already_close(void) {
 }
 
 static VALUE svn_fs_swig_rb_close(VALUE self) {
-  if (!DATA_PTR(self)) {
+  void *ptr = 0;
+  int res;
+
+  res = SWIG_ConvertPtr(self, &ptr, NULL, 0);
+  if (res != SWIG_OK) SWIG_Error(res, "Can't get C++ pointer");
+  if (!ptr) {
     svn_swig_rb_raise_svn_fs_already_close();
   }
 
-  DATA_PTR(self) = NULL;
+  res = SWIG_ConvertPtr(self, NULL, NULL, SWIG_POINTER_CLEAR);
+  if (res != SWIG_OK) SWIG_Error(res, "Can't release C++ object");
 
   return Qnil;
 }
 
 static VALUE svn_fs_swig_rb_closed(VALUE self) {
-  return DATA_PTR(self) ? Qfalse : Qtrue;
+  void *ptr = 0;
+  int res;
+
+  res = SWIG_ConvertPtr(self, &ptr, NULL, 0);
+  if (res != SWIG_OK) SWIG_Error(res, "Can't get C++ pointer");
+  return ptr ? Qfalse : Qtrue;
 }
 %}
 

--- a/Lib/ruby/rubyhead.swg
+++ b/Lib/ruby/rubyhead.swg
@@ -112,7 +112,15 @@
 #ifndef RTYPEDDATA_P
 # define RTYPEDDATA_P(x) (TYPE(x) != T_DATA)
 #endif
+#ifndef TYPED_DATA_EMBEDDED
+# define RTYPEDDATA_GET_DATA(x) RTYPEDDATA_DATA(x)
+#endif
 
+struct ruby_wrapped_object {
+  void *data;
+  void (*dmark)(void *);
+  void (*dfree)(void *);
+};
 
 
 /*

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -69,6 +69,7 @@ typedef struct {
   VALUE mImpl;
   void  (*mark)(void *);
   void  (*destroy)(void *);
+  rb_data_type_t cext_type;
   int trackObjects;
 } swig_class;
 
@@ -162,6 +163,27 @@ SWIG_Ruby_define_class(swig_type_info *type)
   free((void *) klass_name);
 }
 
+static void SWIG_Ruby_mark_swig_type(void *_wrobj)
+{
+  struct ruby_wrapped_object *wrobj = (struct ruby_wrapped_object *)_wrobj;
+  if (wrobj->dmark) {
+    wrobj->dmark(wrobj->data);
+  }
+}
+
+static void SWIG_Ruby_free_swig_type(void *_wrobj)
+{
+  struct ruby_wrapped_object *wrobj = (struct ruby_wrapped_object *)_wrobj;
+  if (wrobj->dfree) {
+    wrobj->dfree(wrobj->data);
+  }
+  free(wrobj);
+}
+
+static const rb_data_type_t swig_type_type = {
+    .wrap_struct_name = "swig_type"
+};
+
 /* Create a new pointer object */
 SWIGRUNTIME VALUE
 SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
@@ -172,6 +194,7 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
   swig_class *sklass;
   VALUE klass;
   VALUE obj;
+  struct ruby_wrapped_object *wrobj;
 
   if (!ptr)
     return Qnil;
@@ -199,10 +222,11 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
     }
 
     /* Create a new Ruby object */
-    obj = Data_Wrap_Struct(sklass->klass, VOIDFUNC(sklass->mark), 
-			   ( own ? VOIDFUNC(sklass->destroy) : 
-			     (track ? VOIDFUNC(SWIG_RubyRemoveTracking) : 0 )
-			     ), ptr);
+    obj = TypedData_Make_Struct(sklass->klass, struct ruby_wrapped_object, &sklass->cext_type, wrobj);
+    wrobj->data = ptr;
+    wrobj->dmark = sklass->mark;
+    wrobj->dfree = own ? sklass->destroy:
+                  (track ? VOIDFUNC(SWIG_RubyRemoveTracking) : 0 );
 
     /* If tracking is on for this class then track this object. */
     if (track) {
@@ -214,7 +238,11 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
     SWIG_snprintf(klass_name, klass_len, "TYPE%s", type->name);
     klass = rb_const_get(_mSWIG, rb_intern(klass_name));
     free((void *) klass_name);
-    obj = Data_Wrap_Struct(klass, 0, 0, ptr);
+
+    obj = TypedData_Make_Struct(klass, struct ruby_wrapped_object, &swig_type_type, wrobj);
+    wrobj->data = ptr;
+    wrobj->dmark = 0;
+    wrobj->dfree = 0;
   }
   rb_iv_set(obj, "@__swigtype__", rb_str_new2(type->name));
 
@@ -227,7 +255,13 @@ SWIG_Ruby_NewClassInstance(VALUE klass, swig_type_info *type)
 {
   VALUE obj;
   swig_class *sklass = (swig_class *) type->clientdata;
-  obj = Data_Wrap_Struct(klass, VOIDFUNC(sklass->mark), VOIDFUNC(sklass->destroy), 0);
+  struct ruby_wrapped_object *wrobj;
+
+  obj = TypedData_Make_Struct(klass, struct ruby_wrapped_object, &sklass->cext_type, wrobj);
+  wrobj->data = 0;
+  wrobj->dmark = sklass->mark;
+  wrobj->dfree = sklass->destroy;
+
   rb_iv_set(obj, "@__swigtype__", rb_str_new2(type->name));
   return obj;
 }
@@ -251,9 +285,10 @@ typedef struct {
 SWIGRUNTIME swig_ruby_owntype
 SWIG_Ruby_AcquirePtr(VALUE obj, swig_ruby_owntype own) {
   swig_ruby_owntype oldown = {0, 0};
-  if (TYPE(obj) == T_DATA && !RTYPEDDATA_P(obj)) {
-    oldown.datafree = RDATA(obj)->dfree;
-    RDATA(obj)->dfree = own.datafree;
+  if (RB_TYPE_P(obj, RUBY_T_DATA) && RTYPEDDATA_P(obj)) {
+    struct ruby_wrapped_object *wrobj = (struct ruby_wrapped_object *)RTYPEDDATA_GET_DATA(obj);
+    oldown.datafree = wrobj->dfree;
+    wrobj->dfree = own.datafree;
   }
   return oldown;
 }
@@ -265,26 +300,27 @@ SWIG_Ruby_ConvertPtrAndOwn(VALUE obj, void **ptr, swig_type_info *ty, int flags,
   char *c;
   swig_cast_info *tc;
   void *vptr = 0;
+  struct ruby_wrapped_object *wrobj;
 
   /* Grab the pointer */
   if (NIL_P(obj)) {
     if (ptr)
       *ptr = 0;
     return (flags & SWIG_POINTER_NO_NULL) ? SWIG_NullReferenceError : SWIG_OK;
+  } else if (RB_TYPE_P(obj, RUBY_T_DATA) && RTYPEDDATA_P(obj)) {
+    wrobj = (struct ruby_wrapped_object *)RTYPEDDATA_GET_DATA(obj);
+    vptr = wrobj->data;
   } else {
-    if (TYPE(obj) != T_DATA || (TYPE(obj) == T_DATA && RTYPEDDATA_P(obj))) {
-      return SWIG_ERROR;
-    }
-    Data_Get_Struct(obj, void, vptr);
+    return SWIG_ERROR;
   }
   
   if (own) {
-    own->datafree = RDATA(obj)->dfree;
+    own->datafree = wrobj->dfree;
     own->own = 0;
   }
     
   if (((flags & SWIG_POINTER_RELEASE) == SWIG_POINTER_RELEASE)) {
-    if (!RDATA(obj)->dfree)
+    if (!wrobj->dfree)
       return SWIG_ERROR_RELEASE_NOT_OWNED;
   }
 
@@ -307,14 +343,14 @@ SWIG_Ruby_ConvertPtrAndOwn(VALUE obj, void **ptr, swig_type_info *ty, int flags,
        * when the Ruby object is garbage collected.  If we don't
        * do this, then it is possible we will return a reference 
        * to a Ruby object that no longer exists thereby crashing Ruby. */
-      RDATA(obj)->dfree = SWIG_RubyRemoveTracking;
+      wrobj->dfree = SWIG_RubyRemoveTracking;
     } else {    
-      RDATA(obj)->dfree = 0;
+      wrobj->dfree = 0;
     }
   }
 
   if (flags & SWIG_POINTER_CLEAR) {
-    DATA_PTR(obj) = 0;
+    wrobj->data = 0;
   }
 
   /* Do type-checking if type info was provided */
@@ -398,6 +434,11 @@ SWIG_Ruby_ConvertPacked(VALUE obj, void *ptr, int sz, swig_type_info *ty) {
   return SWIG_ERROR;
 }
 
+
+static const rb_data_type_t swig_runtime_data_type = {
+    .wrap_struct_name = "swig_runtime_data" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME
+};
+
 SWIGRUNTIME swig_module_info *
 SWIG_Ruby_GetModule(void *SWIGUNUSEDPARM(clientdata))
 {
@@ -407,11 +448,13 @@ SWIG_Ruby_GetModule(void *SWIGUNUSEDPARM(clientdata))
 
  /* temporarily disable warnings, since the pointer check causes warnings with 'ruby -w' */
   rb_gv_set("VERBOSE", Qfalse);
-  
+
   /* first check if pointer already created */
   pointer = rb_gv_get("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME);
   if (pointer != Qnil) {
-    Data_Get_Struct(pointer, swig_module_info, ret);
+    /* Can not use TypedData_Get_Struct because swig_runtime_data_type is not global, but once per file. */
+    if (!RB_TYPE_P(pointer, RUBY_T_DATA)) rb_check_typeddata(pointer, &swig_runtime_data_type);
+    ret = (swig_module_info *)RTYPEDDATA_GET_DATA(pointer);
   }
 
   /* reinstate warnings */
@@ -426,7 +469,7 @@ SWIG_Ruby_SetModule(swig_module_info *pointer)
   VALUE cl = rb_define_class("swig_runtime_data", rb_cObject);
   rb_undef_alloc_func(cl);
   /* create and store the structure pointer to a global variable */
-  swig_runtime_data_type_pointer = Data_Wrap_Struct(cl, 0, 0, pointer);
+  swig_runtime_data_type_pointer = TypedData_Wrap_Struct(cl, &swig_runtime_data_type, pointer);
   rb_define_readonly_variable("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME, &swig_runtime_data_type_pointer);
 }
 

--- a/Lib/ruby/rubytracking.swg
+++ b/Lib/ruby/rubytracking.swg
@@ -111,7 +111,7 @@ SWIGRUNTIME void SWIG_RubyUnlinkObjects(void* ptr) {
     // object might have the T_ZOMBIE type, but that's just
     // because the GC has flagged it as such for a deferred
     // destruction. Until then, it's still a T_DATA object.
-    DATA_PTR(object) = 0;
+    ((struct ruby_wrapped_object *)RTYPEDDATA_GET_DATA(object))->data = 0;
   }
 }
 

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -1802,7 +1802,7 @@ public:
             Wrapper_add_local(f, result_name, result_var);
             Printf(action, "\n%s = new %s(%s);", result_name, SwigType_namestr(smart), Swig_cresult_name());
           }
-          Printf(action, "\nDATA_PTR(self) = %s;", result_name);
+          Printf(action, "\n((struct ruby_wrapped_object *)RTYPEDDATA_GET_DATA(self))->data = %s;", result_name);
           if (GetFlag(pn, "feature:trackobjects")) {
             Printf(action, "\nSWIG_RubyAddTracking(%s, self);", result_name);
           }
@@ -2426,14 +2426,23 @@ public:
   }
 
   /**
+   * Set class name for better debug messages and statistics by Ruby.
+   */
+  void handleClassName(Node *) {
+    Printf(klass->init, "SwigClass%s.cext_type.wrap_struct_name = \"C++ class %s\";\n", klass->name, klass->cname);
+  }
+
+  /**
    * Check to see if a %markfunc was specified.
    */
   void handleMarkFuncDirective(Node *n) {
     String *markfunc = Getattr(n, "feature:markfunc");
     if (markfunc) {
       Printf(klass->init, "SwigClass%s.mark = (void (*)(void *)) %s;\n", klass->name, markfunc);
+      Printf(klass->init, "SwigClass%s.cext_type.function.dmark = SWIG_Ruby_mark_swig_type;\n", klass->name);
     } else {
       Printf(klass->init, "SwigClass%s.mark = 0;\n", klass->name);
+      Printf(klass->init, "SwigClass%s.cext_type.function.dmark = SWIG_Ruby_mark_swig_type;\n", klass->name);
     }
   }
 
@@ -2444,9 +2453,11 @@ public:
     String *freefunc = Getattr(n, "feature:freefunc");
     if (freefunc) {
       Printf(klass->init, "SwigClass%s.destroy = (void (*)(void *)) %s;\n", klass->name, freefunc);
+      Printf(klass->init, "SwigClass%s.cext_type.function.dfree = SWIG_Ruby_free_swig_type;\n", klass->name);
     } else {
       if (klass->destructor_defined) {
         Printf(klass->init, "SwigClass%s.destroy = (void (*)(void *)) free_%s;\n", klass->name, klass->mname);
+        Printf(klass->init, "SwigClass%s.cext_type.function.dfree = SWIG_Ruby_free_swig_type;\n", klass->name);
       }
     }
   }
@@ -2521,6 +2532,7 @@ public:
     Language::classHandler(n);
 
     handleBaseClasses(n);
+    handleClassName(n);
     handleMarkFuncDirective(n);
     handleFreeFuncDirective(n);
     handleTrackDirective(n);


### PR DESCRIPTION
This is only a starting point for now. Some examples already work, some don't.

My use case is https://github.com/larskanis/fxruby which doesn't work at the current state.

I know the ruby internals quite well, but have trouble to understand the swig internals. It rewrites the mark and free pointers of object instances in certain cases, which is no longer possible with the new API. So I guess we need static mark and free functions, which jump to the dynamic (per instance) mark/free function.

Fixes #3170