### PR TITLE
Fix segfault in Guile -proxy when class has public member variable

### DIFF
--- a/Source/Modules/guile.cxx
+++ b/Source/Modules/guile.cxx
@@ -927,16 +927,18 @@ public:
 
 	if (!is_setter) {
 	  /* Strip off "-get" */
+	  String *slot_name = NewStringWithSize(pc, len - 4);
 	  if (struct_member == 2) {
 	    /* There was a setter, so create a procedure with setter */
 	    Printf(f_init, "scm_c_define");
-	    Printf(f_init, "(\"%.*s\", " "scm_make_procedure_with_setter(getter, setter));\n", pc, len - 4);
+	    Printf(f_init, "(\"%s\", " "scm_make_procedure_with_setter(getter, setter));\n", slot_name);
 	  } else {
 	    /* There was no setter, so make an alias to the getter */
 	    Printf(f_init, "scm_c_define");
-	    Printf(f_init, "(\"%.*s\", getter);\n", pc, len - 4);
+	    Printf(f_init, "(\"%s\", getter);\n", slot_name);
 	  }
-	  Printf(exported_symbols, "\"%.*s\", ", pc, len - 4);
+	  Printf(exported_symbols, "\"%s\", ", slot_name);
+	  Delete(slot_name);
 	}
       } else {
 	/* Register the function */


### PR DESCRIPTION
## Summary

SWIG segfaults when generating Guile proxy (GOOPS) wrappers for any C++ class that has a public data member and inherits from a base class with virtual methods. This affects `-proxy`, `-shadow`, and any combination with `-emit-setters` or `-scmstub`.

Even SWIG's own `Examples/guile/class/example.h` triggers this — it has `Shape` with public `double x, y` and virtual methods — but the example builds with `-Linkage passive` (no proxy), so the bug path is never exercised.

## Minimal reproducer

```cpp
// test.hpp
class Base {
public:
    virtual void foo() {}
    virtual ~Base() {}
};
class Derived : public Base {
public:
    int member;  // triggers segfault
};
```

```swig
// test.i
%module test
%{ #include "test.hpp" %}
%include "test.hpp"
```

```sh
$ swig -c++ -guile -Linkage module -proxy test.i
Segmentation fault
```

## Root cause

In `functionWrapper()` (`guile.cxx`), the code that generates procedure-with-setter bindings for struct member variables uses the `%.*s` printf format specifier:

```c
Printf(f_init, "(\"%.*s\", ...)\n", pc, len - 4);
```

In standard C printf, `%.*s` expects `(int precision, char* string)`, so this would print the first `(len-4)` characters of `pc`. However, SWIG's `DohvPrintf` (`DOH/fio.c`) processes `%.*s` differently: when it encounters the `*` width specifier, it calls `va_arg(ap, int)` to read the precision, then when it encounters `s`, it calls `va_arg(ap, DOH*)` to read the string. Since the arguments are passed as `(char* pc, int len-4)`, `DohvPrintf` interprets the pointer `pc` as an integer precision (garbage value) and the small integer `(len-4)` as a memory address to read a string from — causing the segfault.

## Fix

Replace the three `%.*s` call sites with explicit substring construction using `NewStringWithSize()`, which looks like the standard DOH idiom used throughout the codebase for this purpose.

Before:
```c
Printf(f_init, "(\"%.*s\", getter);\n", pc, len - 4);
```

After:
```c
String *slot_name = NewStringWithSize(pc, len - 4);
Printf(f_init, "(\"%s\", getter);\n", slot_name);
Delete(slot_name);
```