### PR TITLE
Fix cross-module type cast lookup in SWIG_InitializeModule

### DIFF
--- a/Lib/swiginit.swg
+++ b/Lib/swiginit.swg
@@ -269,7 +269,10 @@ SWIG_InitializeModule(SWIG_INIT_CLIENT_DATA_TYPE clientdata) {
 #ifdef SWIGRUNTIME_DEBUG
             if (ocast) printf("SWIG_InitializeModule: skip old cast %s\n", target_type->name);
 #endif
-            if (!ocast) target_type = 0;
+            if (!ocast) {
+              cast->type = target_type;
+              target_type = 0;
+            }
           }
         }
       }


### PR DESCRIPTION
When multiple SWIG modules share a type table (via `SWIG_TYPE_TABLE`), `SWIG_InitializeModule` merges each module's cast chains into the shared type entries. However, when adding a new cast entry to a type that already exists in the shared table, the cast entry's `type` pointer was not updated from the module-local `swig_type_info` to the shared `swig_type_info`.

`SWIG_TypeCheckStruct` uses pointer comparison (`head->type == from`) to match cast entries, so the lookup always failed when the local and shared pointers differed.

The first branch (line 264 of `swiginit.swg`, for types that are still local) correctly does `cast->type = target_type`, but the second branch (line 272, for types already in the shared table) was missing this update.

This affects any multi-module SWIG setup where:
1. Multiple modules share a type table (`SWIG_TYPE_TABLE`)
2. A derived type (in module B) needs to be cast to a base type first registered by a different module (module A)
3. The derived type was also first registered by a third module that loaded before module B (so the type already exists in the shared table when module B processes its cast entries)

Discovered while building Guile bindings for MFEM with 11 modules sharing `SWIG_TYPE_TABLE=GuileMFEM`. Passing a `DenseMatrix` smob (from the densemat module) to `Operator-Height` (from the operators module) would fail with "Wrong type argument", despite the DenseMatrix→Operator cast being correctly registered in the shared type table (verified with `SWIGRUNTIME_DEBUG`).