### PR TITLE
More MacOS CI + Go cleanup

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -295,7 +295,7 @@ jobs:
             cflags="$($GITHUB_WORKSPACE/Tools/testflags.py --language $SWIGLANG --cflags --std=$CSTD --compiler=$CC_NAME)"
             cxxflags="$($GITHUB_WORKSPACE/Tools/testflags.py --language $SWIGLANG --cxxflags --std=$CPPSTD --compiler=$CC_NAME)"
             # Include for the boost headers
-            cxxflags=" -I$BOOST_INC"
+            cxxflags+=" -I$BOOST_INC"
             make check-$SWIGLANG-version
             make check-$SWIGLANG-enabled
             make $SWIGJOBS check-$SWIGLANG-examples CFLAGS="$cflags" CXXFLAGS="$cxxflags"

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -95,7 +95,7 @@ run_testcase = \
 	  export CGO_CFLAGS; \
 	  CGO_CXXFLAGS="$(CXXFLAGS)"; \
 	  export CGO_CXXFLAGS; \
-	  CGO_LDFLAGS="$(LDFLAGS) -lm"; \
+	  CGO_LDFLAGS="$(LDFLAGS)"; \
 	  export CGO_LDFLAGS; \
 	  mkdir gopath/src/swigtests 2>/dev/null || true; \
 	  mkdir gopath/src/swigtests/$* 2>/dev/null || true; \
@@ -116,7 +116,7 @@ run_testcase_cpp = \
 	  export CGO_CFLAGS; \
 	  CGO_CXXFLAGS="$(CXXFLAGS)"; \
 	  export CGO_CXXFLAGS; \
-	  CGO_LDFLAGS="$(LDFLAGS) -lm"; \
+	  CGO_LDFLAGS="$(LDFLAGS)"; \
 	  export CGO_LDFLAGS; \
 	  mkdir gopath/src/swigtests 2>/dev/null || true; \
 	  mkdir gopath/src/swigtests/$* 2>/dev/null || true; \
@@ -140,7 +140,7 @@ run_multi_testcase = \
 	  export CGO_CFLAGS; \
 	  CGO_CXXFLAGS="$(CXXFLAGS)"; \
 	  export CGO_CXXFLAGS; \
-	  CGO_LDFLAGS="$(LDFLAGS) -lm"; \
+	  CGO_LDFLAGS="$(LDFLAGS)"; \
 	  export CGO_LDFLAGS; \
 	  (cd gopath/$*/src/$* && \
 	    $(COMPILETOOL) $(GO) build `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme) && \


### PR DESCRIPTION
Hi, @wsfulton 

In continue to #3329 :
- I forgot to add '+' the second `cxxflags`.
- Found more `-lm` in `Examples/test-suite/go/Makefile.in`