### PR TITLE
Allow typedef enum values to use the typedef type name.

### DIFF
--- a/Source/Modules/go.cxx
+++ b/Source/Modules/go.cxx
@@ -1930,7 +1930,13 @@ private:
     Node *parent = parentNode(n);
 
     if (Getattr(parent, "unnamed")) {
-      Setattr(n, "type", NewString("int"));
+      char* tdname = GetChar(parent, "tdname");
+      if (tdname && strlen(tdname)) {
+        // Use the typedef as the typename.
+        Setattr(n, "type", tdname);
+      } else {
+        Setattr(n, "type", NewString("int"));
+      }
     } else {
       Setattr(n, "type", Getattr(parent, "enumtype"));
     }


### PR DESCRIPTION
Previously, the type name for enum values derived from a C-style typedef enum would resolve to int even though a proper Go type for the enum was properly emitted. Now the enum value emitter checks if the enum value type has a "tdname" attribute first before falling back to int.