### PR TITLE
gcc 13 on Ubuntu 22 is broken, use Ubuntu 24

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,10 @@ jobs:
           os: ubuntu-22.04
         - SWIGLANG: ""
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
+        - SWIGLANG: ""
+          GCC: 14
+          os: ubuntu-24.04
         - SWIGLANG: ""
           compiler: clang
           os: ubuntu-22.04
@@ -314,17 +317,21 @@ jobs:
         - SWIGLANG: csharp
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: go
           VER: '1.20'
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
           CSTD: gnu17
         - SWIGLANG: guile
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: java
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: java
           VER: 8
         - SWIGLANG: java
@@ -340,27 +347,34 @@ jobs:
           VER: '18'
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: javascript
           ENGINE: napi
           VER: '20'
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: lua
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: octave
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: perl5
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: php
           CPPSTD: c++17
           CSTD: gnu17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: python
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: r
           CPPSTD: c++17
           GCC: 13
@@ -368,45 +382,48 @@ jobs:
         - SWIGLANG: ruby
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: scilab
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         - SWIGLANG: tcl
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
         # c++20 testing (using gcc13)
         - SWIGLANG: c
           CPPSTD: c++20
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
         - SWIGLANG: python
           CPPSTD: c++20
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
         - SWIGLANG: javascript
           ENGINE: jsc
           CPPSTD: c++20
           VER: '4.1'
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
         - SWIGLANG: javascript
           ENGINE: napi
           VER: '22'
           CPPSTD: c++20
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
         - SWIGLANG: javascript
           ENGINE: node
           VER: '20'
           CPPSTD: c++20
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
         - SWIGLANG: javascript
           ENGINE: node
           VER: '22'
           CPPSTD: c++20
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
         - SWIGLANG: javascript
           ENGINE: v8
           CSTD: c++14
@@ -422,7 +439,7 @@ jobs:
         - SWIGLANG: ocaml
           CPPSTD: c++17
           GCC: 13
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           continue-on-error: true
       # Run all of them, as opposed to aborting when one fails
       fail-fast: false


### PR DESCRIPTION
GCC comes from Ubuntu toolchain repository
https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/ppa

It seems GCC 13 on Ubuntu 22 is broken, times to move to Ubuntu 24.