### PR TITLE
[Go] Improve version detection and update to version 1.20

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -408,6 +408,7 @@ GCCGO = @GCCGO@
 GOOPT = @GOOPT@
 GCCGOOPT = @GCCGOOPT@
 GOVERSIONOPTION = @GOVERSIONOPTION@
+GOMINVER = @GOMINVER@
 
 ifneq (false, $(GOGCC))
 GOSWIGARG = -gccgo
@@ -436,7 +437,7 @@ $(GOPATHPARENTDIR)/go.mod:
 	@mkdir $(GOPATHDIR) 2>/dev/null || true
 	echo "module swigtests" > $(GOPATHDIR)/go.mod
 	echo "" >> $(GOPATHDIR)/go.mod
-	echo "go 1.20" >> $(GOPATHDIR)/go.mod
+	echo "go $(GOMINVER)" >> $(GOPATHDIR)/go.mod
 	mv -f $(GOPATHDIR)/go.mod $(GOPATHPARENTDIR)/go.mod
 
 go: $(SRCDIR_SRCS) $(GOPATHPARENTDIR)/go.mod

--- a/configure.ac
+++ b/configure.ac
@@ -799,20 +799,17 @@ else
   GOOPT=
   GCCGOOPT=
   GOVERSIONOPTION=
+  GOMINVER='1.20'
 
   if test -n "$GO" ; then
     GOVERSIONOPTION=version
-    go_version=$($GO $GOVERSIONOPTION | sed -e 's/go version //')
+    go_version="$($GO $GOVERSIONOPTION | sed 's%go *%%g;s%version *%%;s% .*%%')"
     AC_MSG_CHECKING([whether go version is too old])
-    case $go_version in
-    go1.[012]*)
-      AC_MSG_RESULT([yes - minimum version is 1.3])
-      GO=
-      ;;
-    *)
-      AC_MSG_RESULT([no])
-      ;;
-    esac
+    AS_VERSION_COMPARE(["$go_version"], ["$GOMINVER"],
+                   [AC_MSG_RESULT([yes - minimum version is $GOMINVER])
+                    AS_UNSET([GO])],        dnl bellow GOMINVER
+                   [AC_MSG_RESULT([no])],   dnl equal GOMINVER
+                   [AC_MSG_RESULT([no])])   dnl above GOMINVER
   fi
 
   AC_CHECK_PROGS(GCCGO, gccgo)
@@ -848,6 +845,7 @@ AC_SUBST(GO15)
 AC_SUBST(GOOPT)
 AC_SUBST(GCCGOOPT)
 AC_SUBST(GOVERSIONOPTION)
+AC_SUBST(GOMINVER)
 
 #----------------------------------------------------------------
 # Look for Guile


### PR DESCRIPTION
- Update minimum version of `go` to 1.20
- Use `AS_VERSION_COMPARE` to handle version comparison of `x.x.x`.

See `AS_VERSION_COMPARE` at:
https://www.gnu.org/software/autoconf/manual/autoconf-2.67/autoconf.html#Common-Shell-Constructs

Fix #3356