### PR TITLE
Windows canonical of `SWIG_LIB`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -433,9 +433,7 @@ jobs:
       run: |
           echo "Output of ./swig.exe -swiglib"
           ./swig.exe -swiglib
-          # Use first line with SWIG_LIB,
-          # ignore second line which uses SWIG_LIB_WIN_UNIX
-          win_swig_lib="$(./swig.exe -swiglib | head -1)"
+          win_swig_lib="$(./swig.exe -swiglib)"
           pwd_based_lib="$(cygpath -w "$PWD/Lib")"
           # path is based on executable location
           if ! [[ "$win_swig_lib" = "$pwd_based_lib" ]]; then
@@ -445,7 +443,7 @@ jobs:
           # Ensure path change based on application path
           mkdir other_dir
           cp swig.exe other_dir/
-          win_swig_lib2="$(./other_dir/swig.exe -swiglib | head -1)"
+          win_swig_lib2="$(./other_dir/swig.exe -swiglib)"
           pwd_based_lib2="$(cygpath -w "$PWD/other_dir/Lib")"
           if ! [[ "$win_swig_lib2" = "$pwd_based_lib2" ]]; then
             echo "Second test fail"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,10 +76,6 @@ if (WITH_PCRE)
   set (HAVE_PCRE 1)
 endif()
 
-#if (WIN32)
-#  file (TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/${SWIG_LIB} SWIG_LIB_WIN_UNIX)
-#  string (REGEX REPLACE "\\\\" "\\\\\\\\" SWIG_LIB_WIN_UNIX "${SWIG_LIB_WIN_UNIX}")
-#endif ()
 configure_file (${SWIG_ROOT}/Tools/cmake/swigconfig.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/Source/Include/swigconfig.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,6 @@ if (WITH_PCRE)
   set (HAVE_PCRE 1)
 endif()
 
-#if (WIN32)
-#  file (TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/${SWIG_LIB} SWIG_LIB_WIN_UNIX)
-#  string (REGEX REPLACE "\\\\" "\\\\\\\\" SWIG_LIB_WIN_UNIX "${SWIG_LIB_WIN_UNIX}")
-#endif ()
 configure_file (${SWIG_ROOT}/Tools/cmake/swigconfig.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/Source/Include/swigconfig.h)
 

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -65,9 +65,8 @@ PCHSUPPORT = @PCHSUPPORT@
 # SWIG_LIB_DIR and SWIGEXE must be explicitly set by Makefiles using this Makefile
 SWIG_LIB_DIR = ./Lib
 SWIGEXE    = swig
-SWIG_LIB_SET = @SWIG_LIB_SET@
 SWIGTOOL   =
-SWIG       = $(SWIG_LIB_SET) $(SWIGTOOL) $(SWIGEXE)
+SWIG       = env SWIG_LIB=$(SWIG_LIB_DIR) $(SWIGTOOL) $(SWIGEXE)
 
 LIBM       = @LIBM@
 LIBC       = @LIBC@

--- a/Examples/test-suite/errors/Makefile.in
+++ b/Examples/test-suite/errors/Makefile.in
@@ -24,8 +24,7 @@ srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@
 
-SWIG_LIB_SET = @SWIG_LIB_SET@
-SWIGINVOKE   = $(SWIG_LIB_SET) $(SWIGTOOL) $(SWIGEXE)
+SWIGINVOKE   = env SWIG_LIB=$(SWIG_LIB_DIR) $(SWIGTOOL) $(SWIGEXE)
 
 # All .i files with prefix 'cpp_' will be treated as C++ input and remaining .i files as C input
 ALL_ERROR_TEST_CASES := $(sort $(patsubst %.i,%, $(notdir $(wildcard $(srcdir)/*.i))))

--- a/Examples/test-suite/errors/Makefile.in
+++ b/Examples/test-suite/errors/Makefile.in
@@ -26,8 +26,7 @@ srcdir       = @srcdir@
 top_srcdir   = @top_srcdir@
 top_builddir = @top_builddir@
 
-SWIG_LIB_SET = @SWIG_LIB_SET@
-SWIGINVOKE   = $(SWIG_LIB_SET) $(SWIGTOOL) $(SWIGEXE)
+SWIGINVOKE   = env SWIG_LIB=$(SWIG_LIB_DIR) $(SWIGTOOL) $(SWIGEXE)
 
 # All .i files with prefix 'cpp_' will be treated as C++ input and remaining .i files as C input
 ALL_ERROR_TEST_CASES := $(sort $(patsubst %.i,%, $(notdir $(wildcard $(srcdir)/*.i))))

--- a/Source/Modules/main.cxx
+++ b/Source/Modules/main.cxx
@@ -170,9 +170,8 @@ Arguments may also be passed in a file, separated by whitespace. For example:\n\
 \n";
 
 // Local variables
-static String *LangSubDir = 0;      // Target language library subdirectory
-static String *SwigLib = 0;         // Library directory
-static String *SwigLibWinUnix = 0;  // Extra library directory on Windows
+static String *LangSubDir = 0;  // Target language library subdirectory
+static String *SwigLib = 0;     // Library directory
 static int freeze = 0;
 static String *lang_config = 0;
 static const char *hpp_extension = "h";
@@ -596,8 +595,6 @@ static void getoptions(int argc, char *argv[]) {
         Swig_mark_arg(i);
       } else if (strcmp(argv[i], "-swiglib") == 0) {
         Printf(stdout, "%s\n", SwigLib);
-        if (SwigLibWinUnix)
-          Printf(stdout, "%s\n", SwigLibWinUnix);
         Exit(EXIT_SUCCESS);
       } else if (strcmp(argv[i], "-o") == 0) {
         Swig_mark_arg(i);
@@ -915,8 +912,6 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     } else {
       SwigLib = NewStringf("");  // Unexpected error
     }
-    if (Len(SWIG_LIB_WIN_UNIX) > 0)
-      SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX);  // Unix installation path using a drive letter (for msys/mingw)
 #else
     SwigLib = NewString(SWIG_LIB);
 #endif
@@ -986,19 +981,12 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
     String *rl = NewString("");
     Printf(rl, ".%sswig_lib%s%s", SWIG_FILE_DELIMITER, SWIG_FILE_DELIMITER, LangSubDir);
     Swig_add_directory(rl);
-    if (SwigLibWinUnix) {
-      rl = NewString("");
-      Printf(rl, "%s%s%s", SwigLibWinUnix, SWIG_FILE_DELIMITER, LangSubDir);
-      Swig_add_directory(rl);
-    }
     rl = NewString("");
     Printf(rl, "%s%s%s", SwigLib, SWIG_FILE_DELIMITER, LangSubDir);
     Swig_add_directory(rl);
   }
 
   Swig_add_directory((String *)"." SWIG_FILE_DELIMITER "swig_lib");
-  if (SwigLibWinUnix)
-    Swig_add_directory((String *)SwigLibWinUnix);
   Swig_add_directory(SwigLib);
 
   if (Verbose) {
@@ -1144,8 +1132,7 @@ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
           for (int i = 0; i < Len(files); i++) {
             int use_file = 1;
             if (depend == 2) {
-              if ((Strncmp(Getitem(files, i), SwigLib, Len(SwigLib)) == 0) ||
-                  (SwigLibWinUnix && (Strncmp(Getitem(files, i), SwigLibWinUnix, Len(SwigLibWinUnix)) == 0)))
+              if ((Strncmp(Getitem(files, i), SwigLib, Len(SwigLib)) == 0))
                 use_file = 0;
             }
             if (use_file) {

--- a/Tools/cmake/swigconfig.h.in
+++ b/Tools/cmake/swigconfig.h.in
@@ -77,10 +77,6 @@
 /* Directory for SWIG system-independent libraries */
 #define SWIG_LIB "@CMAKE_INSTALL_PREFIX@/@SWIG_LIB@"
 
-/* Directory for SWIG system-independent libraries (Unix install on native
-   Windows) */
-#define SWIG_LIB_WIN_UNIX "@SWIG_LIB_WIN_UNIX@"
-
 /* Platform that SWIG is built for */
 #define SWIG_PLATFORM "@CMAKE_SYSTEM_NAME@"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2708,29 +2708,8 @@ SWIG_LIB_INSTALL=${swig_lib}
 AC_SUBST(SWIG_LIB_INSTALL)
 AC_DEFINE_DIR(SWIG_LIB, swig_lib, [Directory for SWIG system-independent libraries])
 
-case $build in
-  # Windows does not understand unix directories. Convert into a windows directory with drive letter.
-  *-*-mingw*) SWIG_LIB_WIN_UNIX=`${srcdir}/Tools/convertpath -m $SWIG_LIB`;;
-  *-*-cygwin*) SWIG_LIB_WIN_UNIX=`cygpath --mixed "$SWIG_LIB"`;;
-  *) SWIG_LIB_WIN_UNIX="";;
-esac
-AC_DEFINE_UNQUOTED(SWIG_LIB_WIN_UNIX, ["$SWIG_LIB_WIN_UNIX"], [Directory for SWIG system-independent libraries (Unix install on native Windows)])
-
 SWIG_LIB_PREINST=$ABS_SRCDIR/Lib
 AC_SUBST(SWIG_LIB_PREINST)
-
-dnl For testing purposes, clear SWIG_LIB when building SWIG in the source
-dnl directory under Windows because it is supposed to work without SWIG_LIB
-dnl being set. Otherwise it always needs to be set.
-SWIG_LIB_SET="env SWIG_LIB=\$(SWIG_LIB_DIR)"
-if test "${srcdir}" = "."; then
-    AC_EGREP_CPP([yes],
-    [#ifdef _WIN32
-     yes
-    #endif
-    ], [SWIG_LIB_SET="env SWIG_LIB="], [])
-fi
-AC_SUBST(SWIG_LIB_SET)
 
 AC_SUBST(EXAMPLE_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2733,28 +2733,8 @@ SWIG_LIB_INSTALL=${swig_lib}
 AC_SUBST(SWIG_LIB_INSTALL)
 AC_DEFINE_DIR(SWIG_LIB, swig_lib, [Directory for SWIG system-independent libraries])
 
-case $build in
-  # Windows does not understand unix directories. Convert into a windows directory with drive letter.
-  *-*-cygwin* | *-*-mingw*) SWIG_LIB_WIN_UNIX=`$CYGPATH -m "$SWIG_LIB"`;;
-  *) SWIG_LIB_WIN_UNIX="";;
-esac
-AC_DEFINE_UNQUOTED(SWIG_LIB_WIN_UNIX, ["$SWIG_LIB_WIN_UNIX"], [Directory for SWIG system-independent libraries (Unix install on native Windows)])
-
 SWIG_LIB_PREINST=$ABS_SRCDIR/Lib
 AC_SUBST(SWIG_LIB_PREINST)
-
-dnl For testing purposes, clear SWIG_LIB when building SWIG in the source
-dnl directory under Windows because it is supposed to work without SWIG_LIB
-dnl being set. Otherwise it always needs to be set.
-SWIG_LIB_SET="env SWIG_LIB=\$(SWIG_LIB_DIR)"
-if test "${srcdir}" = "."; then
-    AC_EGREP_CPP([yes],
-    [#ifdef _WIN32
-     yes
-    #endif
-    ], [SWIG_LIB_SET="env SWIG_LIB="], [])
-fi
-AC_SUBST(SWIG_LIB_SET)
 
 AC_SUBST(EXAMPLE_LIBS)
 


### PR DESCRIPTION
Reduce Windows only changes with the use of `SWIG_LIB`. Leave only essential use.

- Remove `SWIG_LIB_WIN_UNIX`.   
  Windows does not need a separate environment.
  Windows users can set `SWIG_LIB` like any other platform.
- Remove `SWIG_LIB_SET`.
  We have a dedicated test to verify native Windows library setting.
  There is no need to complicate the test suit.
- Leave the use of swig executable as base for `SWIG_LIB` path as is.
- Remove head filter in `Test swiglib` as `-swiglib` print one `SWIG_LIB`.