### PR TITLE
[Go] Add support for Windows Golang tests

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -132,6 +132,14 @@ jobs:
           VER: '3.3'
           COMPILER: gcc
           MSYS2_ENV: ucrt64
+        - SWIGLANG: go
+          VER: '1.25'
+          COMPILER: gcc
+          CSTD: gnu11
+        - SWIGLANG: go
+          COMPILER: gcc
+          CSTD: gnu11
+          MSYS2_ENV: ucrt64
       # Run all of them, as opposed to aborting when one fails
       fail-fast: false
 
@@ -217,6 +225,10 @@ jobs:
               # The matched MSYS2 packages prefix
               mingw_variant=mingw-w64-ucrt-x86_64-
               ;;
+            CLANG64) # Use LLVM/Clang
+              # The matched MSYS2 packages prefix
+              mingw_variant=mingw-w64-clang-x86_64-
+              ;;
             esac
             # The matched MSYS2 active environment path prefix
             if [[ -z "$mingw_dir" ]]; then
@@ -237,6 +249,16 @@ jobs:
                 echo "$RUBYDIR" >> $GITHUB_PATH
               else
                 MORE_MSYS_PKGS+=" ${mingw_variant}ruby"
+              fi
+              ;;
+            go)
+              if [[ -n "$VER" ]]; then
+                go_dir="$(ls -d /c/hostedtoolcache/windows/go/$VER.*)/x64/bin"
+                GODIR="$(cygpath -w $go_dir)"
+                echo "$GODIR" >> $GITHUB_PATH
+              else
+                MORE_MSYS_PKGS+=" ${mingw_variant}go"
+                echo "GOROOT=$mingw_dir/lib/go" >> $GITHUB_ENV
               fi
               ;;
             esac

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -42,12 +42,14 @@ else
 SRCDIR_INCLUDE = -I. -I$(SRCDIR)
 endif
 
+ROOT_DIR   = @ROOT_DIR@
 TARGET     =
 CC         = @CC@
 CXX        = @CXX@
+BOOST_CPPFLAGS = @BOOST_CPPFLAGS@
 CPPFLAGS   = $(SRCDIR_INCLUDE) $(EXTRA_CPPFLAGS)
 CFLAGS     = @PLATCFLAGS@ $(EXTRA_CFLAGS)
-CXXFLAGS   = @BOOST_CPPFLAGS@ @PLATCXXFLAGS@ $(EXTRA_CXXFLAGS)
+CXXFLAGS   = $(BOOST_CPPFLAGS) @PLATCXXFLAGS@ $(EXTRA_CXXFLAGS)
 LDFLAGS    = $(EXTRA_LDFLAGS)
 prefix     = @prefix@
 exec_prefix= @exec_prefix@
@@ -402,6 +404,8 @@ d_clean:
 #####                       Go                              ######
 ##################################################################
 
+# Use to print the commands 'go build' use during build
+# GOBUILDDBG=-x
 GO = @GO@
 GOGCC = @GOGCC@
 GCCGO = @GCCGO@
@@ -409,13 +413,14 @@ GOOPT = @GOOPT@
 GCCGOOPT = @GCCGOOPT@
 GOVERSIONOPTION = @GOVERSIONOPTION@
 GOMINVER = @GOMINVER@
+GO_CYGPATH = @GO_CYGPATH@
 
+GOBUILDARG=$(GOBUILDDBG)
 ifneq (false, $(GOGCC))
 GOSWIGARG = -gccgo
-GOBUILDARG = -compiler=gccgo
+GOBUILDARG+= -compiler=gccgo
 else
 GOSWIGARG =
-GOBUILDARG =
 endif
 
 GOSRCS = $(INTERFACE:.i=.go)
@@ -431,63 +436,65 @@ GOPATHDIR = $(GOPATHPARENTDIR)/$(INTERFACE:.i=)
 # ----------------------------------------------------------------
 
 $(GOPATHPARENTDIR)/go.mod:
-	@mkdir gopath 2>/dev/null || true
-	@mkdir gopath/$(GOMOD) 2>/dev/null || true
-	@mkdir gopath/$(GOMOD)/src 2>/dev/null || true
-	@mkdir $(GOPATHDIR) 2>/dev/null || true
-	echo "module swigtests" > $(GOPATHDIR)/go.mod
-	echo "" >> $(GOPATHDIR)/go.mod
-	echo "go $(GOMINVER)" >> $(GOPATHDIR)/go.mod
-	mv -f $(GOPATHDIR)/go.mod $(GOPATHPARENTDIR)/go.mod
+	mkdir -p "$(@D)"
+	printf "module swigtests\n\ngo $(GOMINVER)\n" > "$@"
 
 go: $(SRCDIR_SRCS) $(GOPATHPARENTDIR)/go.mod
+	mkdir -p "$(GOPATHDIR)"
 	$(SWIG) -go -import-prefix swigtests $(GOOPT) $(GOSWIGARG) $(SWIGOPT) -o $(ISRCS) $(INTERFACEPATH)
-	@mkdir gopath 2>/dev/null || true
-	@mkdir gopath/$(GOMOD) 2>/dev/null || true
-	@mkdir gopath/$(GOMOD)/src 2>/dev/null || true
-	@mkdir $(GOPATHDIR) 2>/dev/null || true
 	rm -rf $(GOPATHDIR)/*
-	cp $(ISRCS) $(GOPATHDIR)/
-	if test -f $(IWRAP:.i=.h); then \
-	  cp $(IWRAP:.i=.h) $(GOPATHDIR)/; \
+	cp "$(ISRCS)" "$(GOPATHDIR)/"
+	if test -f "$(IWRAP:.i=.h)"; then \
+	  cp "$(IWRAP:.i=.h)" "$(GOPATHDIR)/"; \
 	fi
 	if test -n "$(SRCDIR_SRCS)"; then \
-	  cp $(SRCDIR_SRCS) $(GOPATHDIR)/; \
+	  cp "$(SRCDIR_SRCS)" "$(GOPATHDIR)/"; \
 	fi
-	cp $(GOSRCS) $(GOPATHDIR)/
-	@if test -f $(SRCDIR)$(RUNME).go; then \
-	  mkdir gopath/$(GOMOD)/src/runme 2>/dev/null || true; \
-	  rm -f gopath/$(GOMOD)/src/runme/*; \
+	cp $(GOSRCS) "$(GOPATHDIR)/"
+	if test -f "$(SRCDIR)$(RUNME).go"; then \
+	  mkdir -p "$(GOPATHPARENTDIR)/runme"; \
+	  rm -f $(GOPATHPARENTDIR)/runme/*; \
 	fi
-	if test -f $(SRCDIR)$(RUNME).go; then \
-	  cp $(SRCDIR)$(RUNME).go gopath/$(GOMOD)/src/runme/; \
+	if test -f "$(SRCDIR)$(RUNME).go"; then \
+	  cp "$(SRCDIR)$(RUNME).go" "$(GOPATHPARENTDIR)/runme/"; \
 	fi
 	GOPATH=`pwd`/gopath/$(GOMOD); \
-	export GOPATH; \
-	CGO_CPPFLAGS="$(CPPFLAGS) $(INCLUDES) -I `cd $(SRCDIR) && pwd` -I `pwd`"; \
-	export CGO_CPPFLAGS; \
-	CGO_CFLAGS="$(CFLAGS)"; \
-	export CGO_CFLAGS; \
+	includes="$(INCLUDES) -I `pwd` "; \
+	if test -n '$(SRCDIR)'; then \
+	  includes="$$includes -I `cd '$(SRCDIR)' && pwd` "; \
+	fi; \
+	if test -n "$(GO_CYGPATH)"; then \
+	  n_includes=''; \
+	  for n in $${includes//-I}; do \
+	    if test -d "$$n"; then \
+	      n_includes="$$n_includes -I `$(GO_CYGPATH) -w $$n`"; \
+	    else \
+	      n_includes="$$n_includes $$n"; \
+	    fi; \
+	  done; \
+	  includes="$$n_includes"; \
+	fi; \
+	CGO_CPPFLAGS="$(CPPFLAGS) $$includes"; \
+	CGO_CFLAGS="$(CFLAGS) $$includes"; \
 	CGO_LDFLAGS="$(LDFLAGS)"; \
-	export CGO_LDFLAGS; \
-	(cd $(GOPATHDIR)/ && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o $(GOPACKAGE)); \
+	export GOPATH CGO_CPPFLAGS CGO_CFLAGS CGO_LDFLAGS; \
+	(cd "$(GOPATHDIR)" && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o $(GOPACKAGE)); \
 	stat=$$?; \
-	if test $$stat != 0; then \
+	if test $$stat -ne 0; then \
 	  exit $$stat; \
 	fi; \
 	if $(GOGCC); then \
-	  cp $(GOPATHDIR)/$(GOPACKAGE) $(GOPATHDIR)/$(GOPACKAGE:.a=.gox); \
+	  cp "$(GOPATHDIR)/$(GOPACKAGE)" "$(GOPATHDIR)/$(GOPACKAGE:.a=.gox)"; \
 	fi; \
-	if test -f $(SRCDIR)$(RUNME).go; then \
-	  mkdir gopath/$(GOMOD)/src/swigtests 2>/dev/null || true; \
-	  mkdir gopath/$(GOMOD)/src/swigtests/$(INTERFACE:.i=) 2>/dev/null || true; \
-	  cp $(GOPATHDIR)/* gopath/$(GOMOD)/src/swigtests/$(INTERFACE:.i=)/; \
-	  (cd gopath/$(GOMOD)/src/runme && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o runme $(RUNME).go); \
+	if test -f "$(SRCDIR)$(RUNME).go"; then \
+	  mkdir -p "$(GOPATHPARENTDIR)/swigtests/$(INTERFACE:.i=)"; \
+	  cp $(GOPATHDIR)/* "$(GOPATHPARENTDIR)/swigtests/$(INTERFACE:.i=)/"; \
+	  (cd "$(GOPATHPARENTDIR)/runme" && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o runme $(RUNME).go); \
 	  stat=$$?; \
-	  if test $$stat != 0; then \
+	  if test $$stat -ne 0; then \
 	    exit $$stat; \
 	  fi; \
-	  cp gopath/$(GOMOD)/src/runme/runme $(RUNME); \
+	  cp "$(GOPATHPARENTDIR)/runme/runme" "$(RUNME)"; \
 	fi
 
 # ----------------------------------------------------------------
@@ -495,58 +502,65 @@ go: $(SRCDIR_SRCS) $(GOPATHPARENTDIR)/go.mod
 # ----------------------------------------------------------------
 
 go_cpp: $(SRCDIR_SRCS) $(GOPATHPARENTDIR)/go.mod
+	mkdir -p "$(GOPATHDIR)"
 	$(SWIG) -go -c++ -import-prefix swigtests $(GOOPT) $(GOSWIGARG) $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
-	@mkdir gopath 2>/dev/null || true
-	@mkdir gopath/$(GOMOD) 2>/dev/null || true
-	@mkdir gopath/$(GOMOD)/src 2>/dev/null || true
-	@mkdir $(GOPATHDIR) 2>/dev/null || true
 	rm -rf $(GOPATHDIR)/*
-	cp $(ICXXSRCS) $(GOPATHDIR)/
-	if test -f $(IWRAP:.i=.h); then \
-	  cp $(IWRAP:.i=.h) $(GOPATHDIR)/; \
+	cp "$(ICXXSRCS)" "$(GOPATHDIR)/"
+	if test -f "$(IWRAP:.i=.h)"; then \
+	  cp "$(IWRAP:.i=.h)" "$(GOPATHDIR)/"; \
 	fi
 	if test -n "$(SRCDIR_CXXSRCS)"; then \
-	  cp $(SRCDIR_CXXSRCS) $(GOPATHDIR)/; \
+	  cp "$(SRCDIR_CXXSRCS)" "$(GOPATHDIR)/"; \
 	fi
 	if test -n "$(SRCDIR_SRCS)"; then \
-	  cp $(SRCDIR_SRCS) $(GOPATHDIR)/; \
+	  cp "$(SRCDIR_SRCS)" "$(GOPATHDIR)/"; \
 	fi
-	cp $(GOSRCS) $(GOPATHDIR)/
-	@if test -f $(SRCDIR)$(RUNME).go; then \
-	  mkdir gopath/$(GOMOD)/src/runme 2>/dev/null || true; \
-	  rm -f gopath/$(GOMOD)/src/runme/*; \
+	cp $(GOSRCS) "$(GOPATHDIR)/"
+	if test -f "$(SRCDIR)$(RUNME).go"; then \
+	  mkdir -p "$(GOPATHPARENTDIR)/runme"; \
+	  rm -f $(GOPATHPARENTDIR)/runme/*; \
 	fi
-	if test -f $(SRCDIR)$(RUNME).go; then \
-	  cp $(SRCDIR)$(RUNME).go gopath/$(GOMOD)/src/runme/; \
+	if test -f "$(SRCDIR)$(RUNME).go"; then \
+	  cp "$(SRCDIR)$(RUNME).go" "$(GOPATHPARENTDIR)/runme/"; \
 	fi
 	GOPATH=`pwd`/gopath/$(GOMOD); \
-	export GOPATH; \
-	CGO_CPPFLAGS="$(CPPFLAGS) $(INCLUDES) -I `cd $(SRCDIR) && pwd` -I `pwd`"; \
-	export CGO_CPPFLAGS; \
-	CGO_CFLAGS="$(CFLAGS)"; \
-	export CGO_CFLAGS; \
-	CGO_CXXFLAGS="$(CXXFLAGS)"; \
-	export CGO_CXXFLAGS; \
+	includes="$(INCLUDES) -I `pwd` "; \
+	if test -n '$(SRCDIR)'; then \
+	  includes="$$includes -I `cd '$(SRCDIR)' && pwd` "; \
+	fi; \
+	if test -n "$(GO_CYGPATH)"; then \
+	  n_includes=''; \
+	  includes="$$includes $(BOOST_CPPFLAGS)"; \
+	  for n in $${includes//-I}; do \
+	    if test -d "$$n"; then \
+	      n_includes="$$n_includes -I `$(GO_CYGPATH) -w $$n`"; \
+	    else \
+	      n_includes="$$n_includes $$n"; \
+	    fi; \
+	  done; \
+	  includes="$$n_includes"; \
+	fi; \
+	CGO_CPPFLAGS="$(CPPFLAGS) $$includes"; \
+	CGO_CXXFLAGS="$(CXXFLAGS) $$includes"; \
 	CGO_LDFLAGS="$(LDFLAGS)"; \
-	export CGO_LDFLAGS; \
-	(cd $(GOPATHDIR) && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o $(GOPACKAGE)); \
+	export GOPATH CGO_CXXFLAGS CGO_LDFLAGS; \
+	(cd "$(GOPATHDIR)" && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o $(GOPACKAGE)); \
 	stat=$$?; \
-	if test $$stat != 0; then \
+	if test $$stat -ne 0; then \
 	  exit $$stat; \
 	fi; \
 	if $(GOGCC); then \
-	  cp $(GOPATHDIR)/$(GOPACKAGE) $(GOPATHDIR)/$(GOPACKAGE:.a=.gox); \
+	  cp "$(GOPATHDIR)/$(GOPACKAGE)" "$(GOPATHDIR)/$(GOPACKAGE:.a=.gox)"; \
 	fi; \
-	if test -f $(SRCDIR)$(RUNME).go; then \
-	  mkdir gopath/$(GOMOD)/src/swigtests 2>/dev/null || true; \
-	  mkdir gopath/$(GOMOD)/src/swigtests/$(INTERFACE:.i=) 2>/dev/null || true; \
-	  cp $(GOPATHDIR)/* gopath/$(GOMOD)/src/swigtests/$(INTERFACE:.i=)/; \
-	  (cd gopath/$(GOMOD)/src/runme && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o runme $(RUNME).go); \
+	if test -f "$(SRCDIR)$(RUNME).go"; then \
+	  mkdir -p "$(GOPATHPARENTDIR)/swigtests/$(INTERFACE:.i=)"; \
+	  cp $(GOPATHDIR)/* "$(GOPATHPARENTDIR)/swigtests/$(INTERFACE:.i=)/"; \
+	  (cd "$(GOPATHPARENTDIR)/runme" && $(COMPILETOOL) $(GO) build $(GOBUILDARG) -o runme $(RUNME).go); \
 	  stat=$$?; \
-	  if test $$stat != 0; then \
+	  if test $$stat -ne 0; then \
 	    exit $$stat; \
 	  fi; \
-	  cp gopath/$(GOMOD)/src/runme/runme $(RUNME); \
+	  cp "$(GOPATHPARENTDIR)/runme/runme" "$(RUNME)"; \
 	fi
 
 # -----------------------------------------------------------------
@@ -728,7 +742,6 @@ java_clean:
 # There is a common makefile, 'Examples/javascript/js_example.mk' to simplify
 # create a configuration for a new example.
 
-ROOT_DIR = @ROOT_DIR@
 JSINCLUDES = @JSCOREINC@ @JSV8INC@
 JSDYNAMICLINKING = @JSCOREDYNAMICLINKING@ @JSV8DYNAMICLINKING@
 NODEJS = @NODEJS@

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -2,6 +2,8 @@
 # Makefile for Go test-suite
 #######################################################################
 
+# Use to print the commands 'go build' use during build
+# GOBUILDDBG=-x
 LANGUAGE	= go
 GO		= @GO@
 GOGCC		= @GOGCC@
@@ -9,6 +11,7 @@ GCCGO		= @GCCGO@
 GOVERSIONOPTION	= @GOVERSIONOPTION@
 host		= @host@
 SCRIPTSUFFIX	= _runme.go
+GO_CYGPATH = @GO_CYGPATH@
 
 SO = @SO@
 
@@ -20,6 +23,7 @@ srcdir         = @srcdir@
 top_srcdir     = @top_srcdir@
 top_builddir   = @top_builddir@
 abs_top_srcdir = @abs_top_srcdir@
+BOOST_CPPFLAGS = @BOOST_CPPFLAGS@
 
 CPP_TEST_CASES = \
 	go_inout \
@@ -50,9 +54,9 @@ SWIGOPT += -Werror
 
 %.multicpptest:
 	$(setup)
-	$(go_multicpp_setup)
 	+for f in `cat $(top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)/$*.list` ; do \
-	  $(call swig_and_compile_cpp_helper,$${f},'$(SWIGOPT)') GOMOD="$*"; \
+	  n=`printf "$$f" | tr -d '\r\n\t '`; \
+	  $(call swig_and_compile_cpp_helper,$${n},'$(SWIGOPT)') GOMOD="$*"; \
 	done
 	$(run_multi_testcase)
 
@@ -62,9 +66,7 @@ li_windows.cpptest:
 
 go_subdir_import.multicpptest:
 	$(setup)
-	$(go_multicpp_setup)
-	mkdir -p testdir/go_subdir_import 2>/dev/null || true
-	mkdir -p gopath/go_subdir_import/src/testdir/go_subdir_import 2>/dev/null || true
+	mkdir -p testdir/go_subdir_import gopath/go_subdir_import/src/testdir/go_subdir_import
 	$(MAKE) -f $(top_builddir)/$(EXAMPLES)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' \
 	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
 	LIBS='$(LIBS)' INTERFACEPATH='$(SRCDIR)$(INTERFACEDIR)go_subdir_import_b.i' \
@@ -78,72 +80,97 @@ go_subdir_import.multicpptest:
 	done
 	$(run_multi_testcase)
 
-go_multicpp_setup = \
-	mkdir -p gopath/$*/src 2>/dev/null || true; \
-	if ! test -d gopath/$*/src/swigtests; then \
-	  (cd gopath/$*/src && ln -s . swigtests); \
-	fi
-
 # Runs the testcase.
 run_testcase = \
-	if test -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX); then \
-	  GOPATH=`pwd`/gopath/; \
-	  export GOPATH; \
-	  CGO_CPPFLAGS="$(CPPFLAGS) $(INCLUDES) -I `cd $(SRCDIR) && pwd` -I `pwd`"; \
-	  export CGO_CPPFLAGS; \
-	  CGO_CFLAGS="$(CFLAGS)"; \
-	  export CGO_CFLAGS; \
-	  CGO_CXXFLAGS="$(CXXFLAGS)"; \
-	  export CGO_CXXFLAGS; \
+	if test -f "$(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX)"; then \
+	  GOPATH="`pwd`/gopath/"; \
+	  includes="$(INCLUDES) -I `pwd` "; \
+	  if test -n '$(SRCDIR)'; then \
+	    includes="$$includes -I `cd '$(SRCDIR)' && pwd` "; \
+	  fi; \
+	  if test -n "$(GO_CYGPATH)"; then \
+	    n_includes=''; \
+	    for n in $${includes//-I}; do \
+	      if test -d "$$n"; then \
+	        n_includes="$$n_includes -I `$(GO_CYGPATH) -w $$n`"; \
+	      else \
+	        n_includes="$$n_includes $$n"; \
+	      fi; \
+	    done; \
+	    includes="$$n_includes"; \
+	  fi; \
+	  CGO_CPPFLAGS="$(CPPFLAGS) $$includes"; \
+	  CGO_CFLAGS="$(CFLAGS) $$includes"; \
 	  CGO_LDFLAGS="$(LDFLAGS)"; \
-	  export CGO_LDFLAGS; \
-	  mkdir gopath/src/swigtests 2>/dev/null || true; \
-	  mkdir gopath/src/swigtests/$* 2>/dev/null || true; \
+	  export GOPATH CGO_CPPFLAGS CGO_CFLAGS CGO_LDFLAGS; \
+	  mkdir -p "gopath/src/swigtests/$*"; \
 	  cp gopath/src/$*/* gopath/src/swigtests/$*/; \
-	  mkdir gopath/src/$*/runme 2>/dev/null || true; \
+	  mkdir -p "gopath/src/$*/runme"; \
 	  cp $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) gopath/src/$*/runme/runme.go; \
-	  (cd gopath/src/$*/runme && $(COMPILETOOL) $(GO) build `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme runme.go); \
+	  (cd gopath/src/$*/runme && $(COMPILETOOL) $(GO) build $(GOBUILDDBG) `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme runme.go); \
 	  env LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(RUNTOOL) ./$*_runme; \
 	fi
 
 run_testcase_cpp = \
 	if test -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX); then \
-	  GOPATH=`pwd`/gopath/; \
-	  export GOPATH; \
-	  CGO_CPPFLAGS="$(CPPFLAGS) $(INCLUDES) -I `cd $(SRCDIR) && pwd` -I `pwd`"; \
-	  export CGO_CPPFLAGS; \
-	  CGO_CFLAGS="$(CFLAGS)"; \
-	  export CGO_CFLAGS; \
-	  CGO_CXXFLAGS="$(CXXFLAGS)"; \
-	  export CGO_CXXFLAGS; \
+	  GOPATH="`pwd`/gopath/"; \
+	  includes="$(INCLUDES) -I `pwd` "; \
+	  if test -n '$(SRCDIR)'; then \
+	    includes="$$includes -I `cd '$(SRCDIR)' && pwd` "; \
+	  fi; \
+	  if test -n "$(GO_CYGPATH)"; then \
+	    n_includes=''; \
+	    includes="$$includes $(BOOST_CPPFLAGS)"; \
+	    for n in $${includes//-I}; do \
+	      if test -d "$$n"; then \
+	        n_includes="$$n_includes -I `$(GO_CYGPATH) -w $$n`"; \
+	      else \
+	        n_includes="$$n_includes $$n"; \
+	      fi; \
+	    done; \
+	    includes="$$n_includes"; \
+	  fi; \
+	  CGO_CPPFLAGS="$(CPPFLAGS) $$includes"; \
+	  CGO_CXXFLAGS="$(CXXFLAGS) $$includes"; \
 	  CGO_LDFLAGS="$(LDFLAGS)"; \
-	  export CGO_LDFLAGS; \
-	  mkdir gopath/src/swigtests 2>/dev/null || true; \
-	  mkdir gopath/src/swigtests/$* 2>/dev/null || true; \
+	  export GOPATH CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS; \
+	  mkdir -p "gopath/src/swigtests/$*"; \
 	  cp gopath/src/$*/* gopath/src/swigtests/$*/; \
-	  mkdir gopath/src/$*/runme 2>/dev/null || true; \
+	  mkdir -p "gopath/src/$*/runme"; \
 	  cp $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) gopath/src/$*/runme/runme.go; \
-	  (cd gopath/src/$*/runme && $(COMPILETOOL) $(GO) build `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme runme.go); \
+	  (cd gopath/src/$*/runme && $(COMPILETOOL) $(GO) build $(GOBUILDDBG) `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme runme.go); \
 	  env LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(RUNTOOL) ./$*_runme; \
 	fi
 
 run_multi_testcase = \
 	if test -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX); then \
-	  files=`cat $(top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)/$*.list`; \
-	  mkdir gopath/$*/src/$* 2>/dev/null || true; \
-	  cp $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX) gopath/$*/src/$*; \
+	  mkdir -p "gopath/$*/src/$*"; \
+	  cp "$(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX)" "gopath/$*/src/$*"; \
 	  GOPATH="`pwd`/gopath/$*"; \
-	  export GOPATH; \
-	  CGO_CPPFLAGS="$(CPPFLAGS) $(INCLUDES) `for f in $$files; do echo -I ../$$f; done`"; \
-	  export CGO_CPPFLAGS; \
-	  CGO_CFLAGS="$(CFLAGS)"; \
-	  export CGO_CFLAGS; \
-	  CGO_CXXFLAGS="$(CXXFLAGS)"; \
-	  export CGO_CXXFLAGS; \
+	  includes="$(INCLUDES) -I `pwd` "; \
+	  if test -n '$(SRCDIR)'; then \
+	    includes="$$includes -I `cd '$(SRCDIR)' && pwd` "; \
+	  fi; \
+	  if test -n "$(GO_CYGPATH)"; then \
+	    n_includes=''; \
+	    includes="$$includes $(BOOST_CPPFLAGS)"; \
+	    for n in $${includes//-I}; do \
+	      if test -d "$$n"; then \
+	        n_includes="$$n_includes -I `$(GO_CYGPATH) -w $$n`"; \
+	      else \
+	        n_includes="$$n_includes $$n"; \
+	      fi; \
+	    done; \
+	    includes="$$n_includes"; \
+	  fi; \
+	  CGO_CPPFLAGS="$(CPPFLAGS) $$includes"; \
+	  CGO_CXXFLAGS="$(CXXFLAGS) $$includes"; \
 	  CGO_LDFLAGS="$(LDFLAGS)"; \
-	  export CGO_LDFLAGS; \
+	  export GOPATH CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS; \
+	  mkdir -p "gopath/$*/src/swigtests/$*"; \
+	  cp gopath/$*/src/$*/* gopath/$*/src/swigtests/$*/; \
 	  (cd gopath/$*/src/$* && \
-	    $(COMPILETOOL) $(GO) build `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme) && \
+	    $(COMPILETOOL) $(GO) build $(GOBUILDDBG) `if $(GOGCC); then echo -compiler=gccgo; fi` -o ../../../../$*_runme) && \
 	  env LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(RUNTOOL) ./$*_runme; \
 	fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -844,6 +844,12 @@ else
   GCCGOOPT=
   GOVERSIONOPTION=
   GOMINVER='1.20'
+  case $host in
+  *-*-cygwin* | *-*-mingw* | *-*-msys*)
+    AS_IF([test "$CYGPATH" != "false" ],
+        [AS_VAR_SET([GO_CYGPATH], ["$CYGPATH"])])
+    ;;
+  esac
 
   if test -n "$GO" ; then
     GOVERSIONOPTION=version
@@ -890,6 +896,7 @@ AC_SUBST(GOOPT)
 AC_SUBST(GCCGOOPT)
 AC_SUBST(GOVERSIONOPTION)
 AC_SUBST(GOMINVER)
+AC_SUBST(GO_CYGPATH)
 
 #----------------------------------------------------------------
 # Look for Guile


### PR DESCRIPTION
This PR is based on three PRs

1. <del> #3355 </del>
2. <del> #3357  </del>
3. <del> #3349 </del>

This PR commit:
Add Windows support of Golang tests

- Add 2 variant of Golang tests:
  - MingW64
  - MingW64 with UCRT
- Use `cygpath` to convert include pathes to windows format.
  Golang on windows, expect windows format.
- Use `BOOST_CPPFLAGS` directly, as we need to convert it using the `cygpath` tool.
- Improve Golang test syntax.
- Support building on same folder of source code,
  i.e. `SRCDIR` can be empty!
- Use `mkdir` with `-p`, it is supported by POSIX for more than 20 years,
  https://pubs.opengroup.org/onlinepubs/009695399/utilities/mkdir.html
 after all our minimum Golang version 1.20 is from 2023, https://go.dev/doc/devel/release.
  Remove the error avoidance `|| true` and error output dump `2>/dev/null1`.
  In case of error, we need to stop and find the proper location of the error!
  The use of `-p` will avoid the existing folder warning and
  also create all the parents folder needed.
- Use the `tr` to clean the multiple cpp test list records
  before calling the compiler helper.
- `ROOT_DIR` is NOT a Javascript parameter,
  move up to the main parameters list.
- Add optional debug flag `GOBUILDDBG` for `go build`,
  So we can add the `-x` flag to print actual commands.
- We need GNU extension to build Cgo windows GCC.
  Use `-std=gnu11` or newer.
  See used source code compiled for `cgo`:
  https://github.com/golang/go/tree/master/src/runtime/cgo/gcc_windows_amd64.c


Note for @wsfulton ,
Tests were added for testing new features and new ability to test.
Fill free to reduce the number of tests, and you may increase there diversity, using the available matrix variables :smile: 
Be ware that not all combinations works.
For example, go require the C gnu extension standards for the `cgo` source code compilation (yes, part of `go` deployment on windows).
