### PR TITLE
More improvements on using cached tools in Linux GHA

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -475,6 +475,7 @@ jobs:
       CPPSTD: ${{ matrix.CPPSTD }}
       CPPFLAGS: ${{ matrix.CPPFLAGS }}
       PY_ABI_VER: ${{ matrix.PY_ABI_VER }}
+      SKIP_CACHED_TOOLS: ${{ matrix.SKIP_CACHED_TOOLS }}
 
     steps:
     - name: Machine Info

--- a/Tools/CI-linux-install.sh
+++ b/Tools/CI-linux-install.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 # Expected to be called from elsewhere with certain variables set
 # e.g. RETRY=travis-retry SWIGLANG=python GCC=7
-# Also provide update_env() and update_path()
+# And provide update_env(), update_path(), probe_cached_tool()
 set -e # exit on failure (same as -o errexit)
-
-# See list of cached tools in:
-# https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cached-tools
-probe_cached_tool()
-{
-	tool_path=$(ls -d /opt/hostedtoolcache/$1/$VER.*/x64/bin 2> /dev/null | head -1 || true)
-}
 
 if [[ "$compiler" = 'clang' ]]; then
 	$RETRY sudo apt-get -qq update

--- a/Tools/GHA-linux-install.sh
+++ b/Tools/GHA-linux-install.sh
@@ -16,6 +16,15 @@ update_path()
 	# Add new directory to 'PATH'
 	echo "$@" >> $GITHUB_PATH
 }
+# See list of cached tools in:
+# https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cached-tools
+# Use 'SKIP_CACHED_TOOLS' to skip the cached tools
+probe_cached_tool()
+{
+	if [[ -z "$SKIP_CACHED_TOOLS" ]]; then
+		tool_path=$(ls -d $RUNNER_TOOL_CACHE/$1/$VER.*/x64/bin 2> /dev/null | head -1 || true)
+	fi
+}
 
 #lsb_release -a
 # find location of current script (only works in bash)


### PR DESCRIPTION
Add matrix variable `SKIP_CACHED_TOOLS` which prevent using a cached tools and forced installing from network.

Can be used in case a cached tool is malfunction, or we want to use the installing from network in addition to the cached tool.