### PR TITLE
Fix:  `nspace_interface` to use c++17

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -363,7 +363,6 @@ CPP_TEST_CASES += \
 	newobject3 \
 	nspace \
 	nspace_extend \
-	nspace_interface \
 	nspacemove \
 	nspacemove_nested \
 	nspacemove_stl \
@@ -699,6 +698,7 @@ CPP17_TEST_CASES += \
 	cpp17_hex_floating_literals \
 	cpp17_map_no_default_ctor \
 	cpp17_nested_namespaces \
+	cpp17_nspace_interface \
 	cpp17_nspace_nested_namespaces \
 	cpp17_string_view \
 	cpp17_u8_char_literals \

--- a/Examples/test-suite/cpp17_nspace_interface.i
+++ b/Examples/test-suite/cpp17_nspace_interface.i
@@ -1,4 +1,4 @@
-%module nspace_interface
+%module cpp17_nspace_interface
 
 // nspace feature only supported by these languages
 #if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)

--- a/Examples/test-suite/csharp/cpp17_nspace_interface_runme.cs
+++ b/Examples/test-suite/csharp/cpp17_nspace_interface_runme.cs
@@ -1,5 +1,5 @@
 using System;
-using nspace_interfaceNamespace.A;
+using cpp17_nspace_interfaceNamespace.A;
 
 public class runme
 {

--- a/Examples/test-suite/java/Makefile.in
+++ b/Examples/test-suite/java/Makefile.in
@@ -87,6 +87,7 @@ SWIGOPT += -Werror
 inherit_target_language.%: JAVAC_OPTIONS=
 
 # Custom tests - tests with additional commandline options
+cpp17_nspace_interface.%: JAVA_PACKAGE = $*Package
 cpp17_nspace_nested_namespaces.%: JAVA_PACKAGE = $*Package
 director_nspace.%: JAVA_PACKAGE = $*Package
 director_nspace_director_name_collision.%: JAVA_PACKAGE = $*Package
@@ -95,7 +96,6 @@ java_nspacewithoutpackage.%: JAVA_PACKAGEOPT =
 multiple_inheritance_nspace.%: JAVA_PACKAGE = $*Package
 nspace.%: JAVA_PACKAGE = $*Package
 nspace_extend.%: JAVA_PACKAGE = $*Package
-nspace_interface.%: JAVA_PACKAGE = $*Package
 nspacemove.%: JAVA_PACKAGE = $*Package
 nspacemove_nested.%: JAVA_PACKAGE = $*Package
 nspacemove_stl.%: JAVA_PACKAGE = $*Package

--- a/Examples/test-suite/java/cpp17_nspace_interface_runme.java
+++ b/Examples/test-suite/java/cpp17_nspace_interface_runme.java
@@ -1,9 +1,9 @@
-// This tests changes the package name from nspace_interface to nspace_interfacePackage as javac can't seem to resolve classes and packages having the same name
-public class nspace_interface_runme {
+// This tests changes the package name from cpp17_nspace_interface to cpp17_nspace_interfacePackage as javac can't seem to resolve classes and packages having the same name
+public class cpp17_nspace_interface_runme {
 
   static {
     try {
-	System.loadLibrary("nspace_interface");
+	System.loadLibrary("cpp17_nspace_interface");
     } catch (UnsatisfiedLinkError e) {
       System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
       System.exit(1);
@@ -11,7 +11,7 @@ public class nspace_interface_runme {
   }
 
   public static void main(String argv[]) {
-    nspace_interfacePackage.A.Implementer impl = new nspace_interfacePackage.A.Implementer();
+    cpp17_nspace_interfacePackage.A.Implementer impl = new cpp17_nspace_interfacePackage.A.Implementer();
 
     Assert(impl.Method(), "Implemented A::B::Interface::Method");
   }


### PR DESCRIPTION
@wsfulton,

Fix 7588b7bba3f300223bdbc0f455585adbffeede4b
Tests on MacOS fail, as test require C++17.

<br>

Rename `nspace_interface` to `cpp17_nspace_interface`.

The test uses nested namespace which are a C++17 extension. See `(8)` at: https://en.cppreference.com/w/cpp/language/namespace.html