### PR TITLE
improve CCache types

### DIFF
--- a/CCache/ccache.c
+++ b/CCache/ccache.c
@@ -201,7 +201,7 @@ static const char *tmp_string(void)
 }
 
 /* update cached file sizes and count helper function for to_cache() */
-static void to_cache_stats_helper(struct stat *pstat, char *cached_filename, char *tmp_outfiles, int *files_size, int *cached_files_count)
+static void to_cache_stats_helper(struct stat *pstat, char *cached_filename, char *tmp_outfiles, size_t *files_size, int *cached_files_count)
 {
 #if ENABLE_ZLIB
 	/* do an extra stat on the cache file for the size statistics */
@@ -229,7 +229,7 @@ static void to_cache(ARGS *args)
 	struct stat st1;
 	int status;
 	int cached_files_count = 0;
-	int files_size = 0;
+	size_t files_size = 0;
 
 	x_asprintf(&tmp_stdout, "%s/tmp.stdout.%s", temp_dir, tmp_string());
 	x_asprintf(&tmp_stderr, "%s/tmp.stderr.%s", temp_dir, tmp_string());
@@ -496,8 +496,8 @@ static void find_hash(ARGS *args)
 		free(path);
 	}
 
-	hash_int(st.st_size);
-	hash_int(st.st_mtime);
+	hash_int((int)st.st_size);
+	hash_int((int)st.st_mtime);
 
 	/* possibly hash the current working directory */
 	if (getenv("CCACHE_HASHDIR")) {
@@ -1092,7 +1092,7 @@ static void process_args(int argc, char **argv)
 				*p = 0;
 			}
 			else {
-				int len = p - default_depfile_name;
+				int len = (int)(p - default_depfile_name);
 				
 				p = x_malloc(len + 3);
 				strncpy(default_depfile_name, p, len - 1);
@@ -1269,7 +1269,7 @@ static int ccache_main(int argc, char *argv[])
 		case 'F':
 			check_cache_dir();
 			v = atoi(optarg);
-			if (stats_set_limits(v, -1) == 0) {
+			if (stats_set_limits((long)v, -1) == 0) {
 				printf("Set cache file limit to %u\n", (unsigned)v);
 			} else {
 				printf("Could not set cache file limit.\n");
@@ -1280,7 +1280,7 @@ static int ccache_main(int argc, char *argv[])
 		case 'M':
 			check_cache_dir();
 			v = value_units(optarg);
-			if (stats_set_limits(-1, v) == 0) {
+			if (stats_set_limits(-1, (long)v) == 0) {
 				printf("Set cache size limit to %uk\n", (unsigned)v);
 			} else {
 				printf("Could not set cache size limit.\n");

--- a/CCache/ccache.h
+++ b/CCache/ccache.h
@@ -53,7 +53,7 @@
 
 #define MYNAME PROGRAM_NAME
 
-#define LIMIT_MULTIPLE 0.8
+#define LIMIT_MULTIPLE(n) ((n) * 4 / 5) // 0.8
 
 /* default maximum cache size */
 #ifndef DEFAULT_MAXSIZE
@@ -104,7 +104,7 @@ void hash_string(const char *s);
 void hash_int(int x);
 void hash_file(const char *fname);
 char *hash_result(void);
-void hash_buffer(const char *s, int len);
+void hash_buffer(const char *s, size_t len);
 
 void cc_log(const char *format, ...);
 void fatal(const char *msg);

--- a/CCache/cleanup.c
+++ b/CCache/cleanup.c
@@ -26,8 +26,8 @@ static struct files {
 	time_t mtime;
 	size_t size;
 } **files;
-static unsigned allocated;
-static unsigned num_files;
+static size_t allocated;
+static size_t num_files;
 static size_t total_size;
 static size_t total_files;
 static size_t size_threshold;
@@ -91,7 +91,7 @@ static void sort_and_clean(size_t minfiles)
 	   cached files have an identical time stamp, they will also be kept -
 	   this approach would not be needed if the cleanup was done at exit. */
 	if (minfiles != 0 && minfiles < num_files) {
-		unsigned minfiles_index = num_files - minfiles;
+		unsigned minfiles_index = (unsigned)(num_files - minfiles);
 		time_t minfiles_time = files[minfiles_index]->mtime;
 		for (i=1; i<=minfiles_index; i++) {
 			if (files[minfiles_index-i]->mtime == minfiles_time)
@@ -126,8 +126,8 @@ void cleanup_dir(const char *dir, size_t maxfiles, size_t maxsize, size_t minfil
 {
 	unsigned i;
 
-	size_threshold = maxsize * LIMIT_MULTIPLE;
-	files_threshold = maxfiles * LIMIT_MULTIPLE;
+	size_threshold = LIMIT_MULTIPLE(maxsize);
+	files_threshold = LIMIT_MULTIPLE(maxfiles);
 
 	num_files = 0;
 	total_size = 0;

--- a/CCache/execute.c
+++ b/CCache/execute.c
@@ -21,7 +21,7 @@
 #ifdef _WIN32
 char *argvtos(char **argv)
 {
-	int i, len;
+	size_t i, len;
 	char *ptr, *str;
 
 	for (i = 0, len = 0; argv[i]; i++) {

--- a/CCache/hash.c
+++ b/CCache/hash.c
@@ -23,7 +23,7 @@
 
 static struct mdfour md;
 
-void hash_buffer(const char *s, int len)
+void hash_buffer(const char *s, size_t len)
 {
 	mdfour_update(&md, (unsigned char *)s, len);
 }
@@ -47,7 +47,8 @@ void hash_int(int x)
 void hash_file(const char *fname)
 {
 	char buf[1024];
-	int fd, n;
+	int fd;
+	size_t n;
 
 	fd = open(fname, O_RDONLY|O_BINARY);
 	if (fd == -1) {

--- a/CCache/mdfour.c
+++ b/CCache/mdfour.c
@@ -109,13 +109,13 @@ void mdfour_begin(struct mdfour *md)
 }
 
 
-static void mdfour_tail(struct mdfour *md, const unsigned char *in, int n)
+static void mdfour_tail(struct mdfour *md, const unsigned char *in, size_t n)
 {
 	unsigned char buf[128];
 	uint32 M[16];
 	uint32 b;
 
-	md->totalN += n;
+	md->totalN += (uint32)n;
 
 	b = md->totalN * 8;
 
@@ -136,7 +136,7 @@ static void mdfour_tail(struct mdfour *md, const unsigned char *in, int n)
 	}
 }
 
-void mdfour_update(struct mdfour *md, const unsigned char *in, int n)
+void mdfour_update(struct mdfour *md, const unsigned char *in, size_t n)
 {
 	uint32 M[16];
 
@@ -146,7 +146,7 @@ void mdfour_update(struct mdfour *md, const unsigned char *in, int n)
 	}
 
 	if (md->tail_len) {
-		int len = 64 - md->tail_len;
+		size_t len = 64 - md->tail_len;
 		if (len > n) len = n;
 		memcpy(md->tail+md->tail_len, in, len);
 		md->tail_len += len;
@@ -184,7 +184,7 @@ void mdfour_result(struct mdfour *md, unsigned char *out)
 }
 
 
-void mdfour(unsigned char *out, const unsigned char *in, int n)
+void mdfour(unsigned char *out, const unsigned char *in, size_t n)
 {
 	struct mdfour md;
 	mdfour_begin(&md);
@@ -212,7 +212,7 @@ static void file_checksum1(char *fname)
 	mdfour_begin(&md);
 
 	while (1) {
-		int n = read(fd, buf, chunk);
+		size_t n = read(fd, buf, chunk);
 		if (n >= 0) {
 			mdfour_update(&md, buf, n);
 		}

--- a/CCache/mdfour.h
+++ b/CCache/mdfour.h
@@ -23,13 +23,13 @@ struct mdfour {
 	uint32 A, B, C, D;
 	uint32 totalN;
 	unsigned char tail[64];
-	unsigned tail_len;	
+	size_t tail_len;
 };
 
 void mdfour_begin(struct mdfour *md);
-void mdfour_update(struct mdfour *md, const unsigned char *in, int n);
+void mdfour_update(struct mdfour *md, const unsigned char *in, size_t n);
 void mdfour_result(struct mdfour *md, unsigned char *out);
-void mdfour(unsigned char *out, const unsigned char *in, int n);
+void mdfour(unsigned char *out, const unsigned char *in, size_t n);
 
 
 

--- a/CCache/snprintf.c
+++ b/CCache/snprintf.c
@@ -259,7 +259,7 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 				if (cflags == DP_C_SHORT) 
 					value = va_arg (args, int);
 				else if (cflags == DP_C_LONG)
-					value = va_arg (args, long int);
+					value = va_arg (args, long);
 				else if (cflags == DP_C_LLONG)
 					value = va_arg (args, LLONG);
 				else
@@ -269,25 +269,25 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 			case 'o':
 				flags |= DP_F_UNSIGNED;
 				if (cflags == DP_C_SHORT)
-					value = va_arg (args, unsigned int);
+					value = va_arg (args, unsigned);
 				else if (cflags == DP_C_LONG)
-					value = (long)va_arg (args, unsigned long int);
+					value = (long)va_arg (args, unsigned long);
 				else if (cflags == DP_C_LLONG)
 					value = (long)va_arg (args, unsigned LLONG);
 				else
-					value = (long)va_arg (args, unsigned int);
+					value = (long)va_arg (args, unsigned);
 				fmtint (buffer, &currlen, maxlen, value, 8, min, max, flags);
 				break;
 			case 'u':
 				flags |= DP_F_UNSIGNED;
 				if (cflags == DP_C_SHORT)
-					value = va_arg (args, unsigned int);
+					value = va_arg (args, unsigned);
 				else if (cflags == DP_C_LONG)
-					value = (long)va_arg (args, unsigned long int);
+					value = (long)va_arg (args, unsigned long);
 				else if (cflags == DP_C_LLONG)
 					value = (LLONG)va_arg (args, unsigned LLONG);
 				else
-					value = (long)va_arg (args, unsigned int);
+					value = (long)va_arg (args, unsigned);
 				fmtint (buffer, &currlen, maxlen, value, 10, min, max, flags);
 				break;
 			case 'X':
@@ -296,13 +296,13 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 			case 'x':
 				flags |= DP_F_UNSIGNED;
 				if (cflags == DP_C_SHORT)
-					value = va_arg (args, unsigned int);
+					value = va_arg (args, unsigned);
 				else if (cflags == DP_C_LONG)
-					value = (long)va_arg (args, unsigned long int);
+					value = (long)va_arg (args, unsigned long);
 				else if (cflags == DP_C_LLONG)
 					value = (LLONG)va_arg (args, unsigned LLONG);
 				else
-					value = (long)va_arg (args, unsigned int);
+					value = (long)va_arg (args, unsigned);
 				fmtint (buffer, &currlen, maxlen, value, 16, min, max, flags);
 				break;
 			case 'f':
@@ -338,7 +338,7 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 				strvalue = va_arg (args, char *);
 				if (!strvalue) strvalue = "(NULL)";
 				if (max == -1) {
-					max = strlen(strvalue);
+					max = (int)strlen(strvalue);
 				}
 				if (min > 0 && max >= 0 && min > max) max = min;
 				fmtstr (buffer, &currlen, maxlen, strvalue, flags, min, max);
@@ -349,13 +349,13 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 				break;
 			case 'n':
 				if (cflags == DP_C_SHORT) {
-					short int *num;
+					short *num;
 					num = va_arg (args, short int *);
-					*num = currlen;
+					*num = (short)currlen;
 				} else if (cflags == DP_C_LONG) {
-					long int *num;
-					num = va_arg (args, long int *);
-					*num = (long int)currlen;
+					long *num;
+					num = va_arg (args, long *);
+					*num = (long)currlen;
 				} else if (cflags == DP_C_LLONG) {
 					LLONG *num;
 					num = va_arg (args, LLONG *);
@@ -363,7 +363,7 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 				} else {
 					int *num;
 					num = va_arg (args, int *);
-					*num = currlen;
+					*num = (int)currlen;
 				}
 				break;
 			case '%':
@@ -756,7 +756,7 @@ static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c)
 #if !defined(HAVE_VSNPRINTF) || !defined(HAVE_C99_VSNPRINTF)
  int vsnprintf (char *str, size_t count, const char *fmt, va_list args)
 {
-	return dopr(str, count, fmt, args);
+	return (int)dopr(str, count, fmt, args);
 }
 #endif
 

--- a/CCache/stats.c
+++ b/CCache/stats.c
@@ -151,8 +151,8 @@ static void stats_update_size(enum stats stat, size_t size, size_t numfiles)
 
 	/* on a cache miss we up the file count and size */
 	if (stat == STATS_TOCACHE) {
-		counters[STATS_NUMFILES] += numfiles;
-		counters[STATS_TOTALSIZE] += size;
+		counters[STATS_NUMFILES] += (unsigned)numfiles;
+		counters[STATS_TOTALSIZE] += (unsigned)size;
 	}
 
 	/* and write them out */
@@ -355,8 +355,8 @@ void stats_set_sizes(const char *dir, size_t num_files, size_t total_size)
 	if (fd != -1) {
 		lock_fd(fd);
 		stats_read_fd(fd, counters);
-		counters[STATS_NUMFILES] = num_files;
-		counters[STATS_TOTALSIZE] = total_size;
+		counters[STATS_NUMFILES] = (unsigned)num_files;
+		counters[STATS_TOTALSIZE] = (unsigned)total_size;
 		write_stats(fd, counters);
 		close(fd);
 	}

--- a/CCache/unify.c
+++ b/CCache/unify.c
@@ -97,7 +97,7 @@ static void build_table(void)
 static void pushchar(unsigned char c)
 {
 	static unsigned char buf[64];
-	static int len;
+	static size_t len = 0;
 
 	if (c == 0) {
 		if (len > 0) {
@@ -209,7 +209,7 @@ static void unify(unsigned char *p, size_t size)
 			q = p[ofs];
 			for (i=0;i<tokens[q].num_toks;i++) {
 				unsigned char *s = (unsigned char *)tokens[q].toks[i];
-				int len = strlen((char *)s);
+				size_t len = strlen((char *)s);
 				if (size >= ofs+len && memcmp(&p[ofs], s, len) == 0) {
 					int j;
 					for (j=0;s[j];j++) {


### PR DESCRIPTION
During testing of CCache on windows (not functional at the moment).
I found some types improvements.

<br>

- Use `size_t` to represent sizes.
  As most of C functions return a size uses this type.
- Use explicit casting on types change.
- Avoid float type for expression result an integer result value.
- remove `int` from `long` , `short` and `unsigned`.