### PR TITLE
Build and test CCache with MinGW-w64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,7 +69,7 @@ jobs:
 
     # The name of the test follow the tested language
     name: >
-      ${{ matrix.SWIGLANG }} ${{ matrix.VER }}
+      ${{ matrix.SWIGLANG || 'none' }} ${{ matrix.VER }}
       ${{ matrix.SWIG_FEATURES }}
       ${{ matrix.COMPILER || 'msvc' }}
       ${{ matrix.CPPSTD }}
@@ -83,6 +83,13 @@ jobs:
     strategy:
       matrix:
         include:
+        - SWIGLANG: ''
+          INSTALL: 'true'
+          COMPILER: gcc
+        - SWIGLANG: ''
+          INSTALL: 'true'
+          COMPILER: gcc
+          MSYS2_ENV: ucrt64
         - SWIGLANG: csharp
           INSTALL: 'true'
         - SWIGLANG: csharp
@@ -242,9 +249,12 @@ jobs:
             #  The MSYSTEM=MSYS, which supports 'Cygwin', uses the '/usr' path prefix.
             #  We do not use it at the moment.
 
+            # MinGW-w64 package list
+            ming_pkgs+=(binutils make autotools pcre2)
+
             case "$SWIGLANG" in
             python)
-              MORE_MSYS_PKGS+=" ${mingw_variant}python"
+              ming_pkgs+=(python)
               ;;
             ruby)
               if [[ -n "$VER" ]]; then
@@ -252,7 +262,7 @@ jobs:
                 RUBYDIR="$(cygpath -w $ruby_dir)"
                 echo "$RUBYDIR" >> $GITHUB_PATH
               else
-                MORE_MSYS_PKGS+=" ${mingw_variant}ruby"
+                ming_pkgs+=(ruby)
               fi
               ;;
             go)
@@ -267,8 +277,15 @@ jobs:
               ;;
             esac
 
-            # MinGW-w64 packages to install with MSYS2
-            for n in binutils make autotools pcre2 boost; do
+            # More MSYS2 packages to install
+            MORE_MSYS_PKGS+=" base-devel"
+
+            # Boost is needed with languages, we can skip for CCache tests
+            if [[ -n "$SWIGLANG" ]]; then
+              ming_pkgs+=(boost)
+            fi
+            # Add MinGW-w64 packages to MSYS2 packages list
+            for n in "${ming_pkgs[@]}"; do
               MORE_MSYS_PKGS+=" ${mingw_variant}$n"
             done
 
@@ -276,7 +293,7 @@ jobs:
             echo "PCRE2_CFLAGS=-I$mingw_dir/include -DPCRE2_STATIC" >> $GITHUB_ENV
             echo "PCRE2_LIBS=-L$mingw_dir/lib -lpcre2-8" >> $GITHUB_ENV
 
-            echo "MORE_MSYS_PKGS=base-devel $MORE_MSYS_PKGS" >> $GITHUB_ENV
+            echo "MORE_MSYS_PKGS=$MORE_MSYS_PKGS" >> $GITHUB_ENV
             echo "BOOST_PATH=/c/msys64$mingw_dir" >> $GITHUB_ENV
 
             # Set MSYS2 GCC compiler location
@@ -309,11 +326,16 @@ jobs:
             fi
           fi # COMPILER
 
+          # Extra tools for debugging, like hexdump, rev, hardlink.
+          # See 'Files:' in https://packages.msys2.org/packages/util-linux
+          # MORE_MSYS_PKGS+=" util-linux"
+
           if [[ "$SWIGLANG" = "java" ]] && [[ -n "$VER" ]]; then
             java_path="JAVA_HOME_${VER}_X64"
             echo "JAVA_HOME=${!java_path}" >> $GITHUB_ENV
           fi
 
+          echo "LIBS_CCACHE=-luserenv" >> $GITHUB_ENV
           echo "SWIGJOBS=-j$NUMBER_OF_PROCESSORS" >> $GITHUB_ENV
 
           echo 'C:\msys64\usr\bin' >> $GITHUB_PATH
@@ -321,6 +343,9 @@ jobs:
     - name: Install MSYS2 Packages
       shell: cmd
       run: |
+          # We must run in `cmd`.
+          # As the update will terminate all running bash terminals!
+          # Including the terminal that may be used to execute the 'pacman' itself.
           rem 'MSYS2 uses MinGW-w64 https://packages.msys2.org/'
           pacman -Syu --noconfirm --needed
           if %ErrorLevel% NEQ 0 (exit 1)
@@ -435,25 +460,30 @@ jobs:
       run: |
           set -x
           ./swig.exe -version
-          make check-$SWIGLANG-version
-          make check-$SWIGLANG-enabled
-          make -k check-$SWIGLANG-examples $SWIGJOBS $CHECK_OPTIONS
-          make -k check-$SWIGLANG-test-suite $SWIGJOBS $CHECK_OPTIONS
+          if [[ -z "$SWIGLANG" ]]; then
+            make $SWIGJOBS check-ccache NOSOFTLINKSTEST=skip
+            make $SWIGJOBS check-errors-test-suite
+          else
+            make check-$SWIGLANG-version
+            make check-$SWIGLANG-enabled
+            make -k check-$SWIGLANG-examples $SWIGJOBS $CHECK_OPTIONS
+            make -k check-$SWIGLANG-test-suite $SWIGJOBS $CHECK_OPTIONS
+          fi
 
     - name: Install
       if: ${{ env.INSTALL == 'true' }}
       shell: bash
       run: |
-          make -s install > /dev/null
+          set -x
+          make install
 
           which swig.exe
           swig.exe -version
 
-          # TODO: Make install of ccache-swig do not work on Windows
-          #if [[ "$COMPILER" = "gcc" ]]; then
-          #  which ccache-swig.exe
-          #  ccache-swig.exe -V
-          #fi
+          if [[ "$COMPILER" = "gcc" ]]; then
+            which ccache-swig.exe
+            ccache-swig.exe -V
+          fi
 
     # The test by itself is not related to the installation.
     # We just want to save testing time :-)

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,6 @@ CCache/ccache_swig_config.h
 CCache/config.h
 CCache/config.log
 CCache/config.status
-CCache/config_win32.h
 Examples/Makefile
 Examples/guile/Makefile
 Examples/test-suite/*/Makefile

--- a/CCache/Makefile.in
+++ b/CCache/Makefile.in
@@ -6,7 +6,10 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 bindir=@bindir@
 mandir=@mandir@
-INSTALLCMD=@INSTALL@
+INSTALL=@abs_srcdir@/../Tools/config/install-sh
+INSTALL_DATA    = ${INSTALL} -c -m 644
+INSTALL_PROGRAM = ${INSTALL} -c -m 755
+MKINSTDIRS      = ${INSTALL} -m 0755 -d
 PACKAGE_NAME=@PACKAGE_NAME@
 PROGRAM_NAME=@PROGRAM_NAME@
 # Soft link test can be skipped on systems that don't support soft linking
@@ -21,7 +24,7 @@ EXEEXT=@EXEEXT@
 LIBS= @LIBS@
 OBJS= ccache.o mdfour.o hash.o execute.o util.o args.o stats.o \
 	cleanup.o snprintf.o unify.o
-HEADERS = ccache.h mdfour.h config.h config_win32.h
+HEADERS = ccache.h mdfour.h config.h
 
 all: $(PACKAGE_NAME)$(EXEEXT)
 
@@ -44,13 +47,13 @@ $(srcdir)/web/$(PACKAGE_NAME)-man.html: $(srcdir)/ccache.yo
 install: $(PACKAGE_NAME)$(EXEEXT)
 	@echo "Installing $(PACKAGE_NAME)"
 	@echo "Installing $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)"
-	${INSTALLCMD} -d $(DESTDIR)${bindir}
-	${INSTALLCMD} -m 755 $(PACKAGE_NAME)$(EXEEXT) $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)
+	@$(MKINSTDIRS) $(DESTDIR)${bindir}
+	@$(INSTALL_PROGRAM) $(PACKAGE_NAME)$(EXEEXT) $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)
 
 install-docs: $(srcdir)/$(PACKAGE_NAME).1
 	@echo "Installing $(DESTDIR)${mandir}/man1/$(PROGRAM_NAME).1"
-	${INSTALLCMD} -d $(DESTDIR)${mandir}/man1
-	${INSTALLCMD} -m 644 $(srcdir)/$(PACKAGE_NAME).1 $(DESTDIR)${mandir}/man1/$(PROGRAM_NAME).1
+	@$(MKINSTDIRS) $(DESTDIR)${mandir}/man1
+	@$(INSTALL_DATA) $(srcdir)/$(PACKAGE_NAME).1 $(DESTDIR)${mandir}/man1/$(PROGRAM_NAME).1
 
 uninstall: $(PACKAGE_NAME)$(EXEEXT)
 	rm -f $(DESTDIR)${bindir}/$(PROGRAM_NAME)$(EXEEXT)
@@ -65,12 +68,12 @@ clean-docs:
 	rm -f $(srcdir)/$(PACKAGE_NAME).1 $(srcdir)/web/$(PACKAGE_NAME)-man.html
 
 test: test.sh
-	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='../$(PACKAGE_NAME)' CCACHE_PROG=$(PROGRAM_NAME) $(srcdir)/test.sh
+	SWIG_LIB='$(SWIG_LIB)' PATH=../..:$$PATH SWIG='$(SWIG)' CC='$(CC)' NOSOFTLINKSTEST='$(NOSOFTLINKSTEST)' CCACHE='$(PACKAGE_NAME)$(EXEEXT)' CCACHE_PROG='$(PROGRAM_NAME)$(EXEEXT)' $(srcdir)/test.sh
 
 check: test
 
 distclean: clean
-	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h config_win32.h
+	/bin/rm -f Makefile config.h config.sub config.log build-stamp config.status ccache_swig_config.h
 	/bin/rm -rf autom4te.cache
 
 maintainer-clean: distclean

--- a/CCache/ccache.c
+++ b/CCache/ccache.c
@@ -23,6 +23,17 @@
 
 #include "ccache.h"
 
+#ifndef HAVE_UNISTD_H
+__inline static unsigned __cdecl getpid()
+{
+#ifdef _WIN32
+	return (unsigned)GetCurrentProcessId();
+#else
+	return 0;
+#endif
+}
+#endif
+
 /* verbose mode */
 int ccache_verbose = 0;
 
@@ -795,7 +806,11 @@ static void find_compiler(int argc, char **argv)
 	base = str_basename(argv[0]);
 
 	/* we might be being invoked like "ccache gcc -c foo.c" */
-	if (strcmp(base, MYNAME) == 0) {
+	if (strcmp(base, MYNAME) == 0
+#ifdef _WIN32 /* can be invoked without the `.exe` extension */
+	    || strcmp(base, PROGRAM_NAME) == 0
+#endif
+	    ) {
 		args_remove_first(orig_args);
 		free(base);
 		if (strchr(argv[1],'/')
@@ -1159,7 +1174,8 @@ static void process_args(int argc, char **argv)
 static void detect_swig(void)
 {
 	char *basename = str_basename(orig_args->argv[0]);
-	if (strstr(basename, "swig") || getenv("CCACHE_SWIG")) {
+	char *ccache_swig = getenv("CCACHE_SWIG");
+	if (strstr(basename, "swig") || (ccache_swig != NULL && ccache_swig[0] != 0)) {
 		swig = 1;
 	}
 	free(basename);

--- a/CCache/ccache.h
+++ b/CCache/ccache.h
@@ -2,45 +2,67 @@
 
 #define CCACHE_VERSION SWIG_VERSION
 
-#ifndef _WIN32
 #include "config.h"
-#else
-#include <sys/locking.h>
-#include "config_win32.h"
-#endif
 
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-
-#ifndef _WIN32
- #include <sys/wait.h>
- #include <sys/mman.h>
-#else
-#ifndef _WIN32_WINNT
- #define _WIN32_WINNT 0x0500
-#endif
+#ifdef _WIN32
+ #ifndef _WIN32_WINNT
+ /* minimum Windows OS SDK */
+ #define _WIN32_WINNT _WIN32_WINNT_WIN2K /* 0x0500 Windows 2000 */
+ #endif
  #include <windows.h>
  #include <shlobj.h>
-#endif
+ #include <io.h>
+ #include <direct.h>
+ #include <sys/locking.h>
+ #include <sys/utime.h>
+ #ifndef S_ISREG
+ #define S_ISREG(mode) (((mode) & S_IFREG) == S_IFREG)
+ #endif
+ #ifndef S_ISDIR
+ #define S_ISDIR(mode) (((mode) & S_IFDIR) == S_IFDIR)
+ #endif
+ void perror_win32(LPTSTR pszFunction);
+ char *argvtos(char **argv);
+ #define MYNAME PROGRAM_NAME ".exe"
+#else /* _WIN32 */
+ #define MYNAME PROGRAM_NAME
+#endif /* _WIN32 */
 
-#include <sys/file.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <time.h>
 #include <string.h>
-#include <ctype.h>
-#include <utime.h>
 #include <stdarg.h>
-#include <dirent.h>
 #include <limits.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_CTYPE_H
+#include <ctype.h>
+#endif
+#ifdef HAVE_DIRENT_H
+#include <dirent.h>
+#endif
 #ifdef HAVE_PWD_H
 #include <pwd.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+#ifdef HAVE_SYS_MMAN_H
+#include <sys/mman.h>
 #endif
 
 #ifdef ENABLE_ZLIB
@@ -50,8 +72,6 @@
 #define STATUS_NOTFOUND 3
 #define STATUS_FATAL 4
 #define STATUS_NOCACHE 5
-
-#define MYNAME PROGRAM_NAME
 
 #define LIMIT_MULTIPLE 0.8
 
@@ -134,9 +154,6 @@ char *gnu_getcwd(void);
 int create_empty_file(const char *fname);
 const char *get_home_directory(void);
 int x_utimes(const char *filename);
-#ifdef _WIN32
-void perror_win32(LPTSTR pszFunction);
-#endif
 
 void stats_update(enum stats stat);
 void stats_zero(void);
@@ -165,9 +182,6 @@ void cleanup_dir(const char *dir, size_t maxfiles, size_t maxsize, size_t minfil
 void cleanup_all(const char *dir);
 void wipe_all(const char *dir);
 
-#ifdef _WIN32
-char *argvtos(char **argv);
-#endif
 int execute(char **argv, 
 	    const char *path_stdout,
 	    const char *path_stderr);
@@ -199,11 +213,3 @@ typedef int (*COMPAR_FN_T)(const void *, const void *);
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif
-
-/* mkstemp() on some versions of cygwin don't handle binary files, so
-   override */
-/* Seems okay in Cygwin 1.7.0
-#ifdef __CYGWIN__
-#undef HAVE_MKSTEMP
-#endif
-*/

--- a/CCache/config_win32.h.in
+++ b/CCache/config_win32.h.in
@@ -1,3 +1,0 @@
-#if !defined(PROGRAM_NAME)
-#define PROGRAM_NAME "@PROGRAM_NAME@.exe"
-#endif

--- a/CCache/configure.ac
+++ b/CCache/configure.ac
@@ -7,12 +7,10 @@ AC_CONFIG_SRCDIR([ccache.h])
 AC_MSG_NOTICE([Configuring ccache])
 
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_FILES([config_win32.h])
 
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CPP
-AC_PROG_INSTALL
 AC_ARG_PROGRAM # for program_transform_name
 
 AC_SUBST(PROGRAM_NAME)
@@ -41,14 +39,12 @@ else
 fi
 
 AC_HEADER_DIRENT
-
 AC_HEADER_SYS_WAIT
+AC_CHECK_HEADERS([ctype.h strings.h stdlib.h string.h pwd.h sys/time.h
+   sys/mman.h])
 
-AC_CHECK_HEADERS(ctype.h strings.h stdlib.h string.h pwd.h sys/time.h)
-
-AC_CHECK_FUNCS(realpath snprintf vsnprintf vasprintf asprintf mkstemp)
-AC_CHECK_FUNCS(gethostname getpwuid)
-AC_CHECK_FUNCS(utimes)
+AC_CHECK_FUNCS([realpath snprintf vsnprintf vasprintf asprintf mkstemp
+   gethostname getpwuid utimes])
 
 AC_CACHE_CHECK([for compar_fn_t in stdlib.h],ccache_cv_COMPAR_FN_T, [
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]], [[
@@ -86,6 +82,8 @@ if test x"$ccache_cv_HAVE_C99_VSNPRINTF" = x"yes"; then
     AC_DEFINE(HAVE_C99_VSNPRINTF, 1, [ ])
 fi
 
+dnl Get libraries from environment
+LIBS="$LIBS $LIBS_CCACHE"
 dnl Check for zlib.
 dnl Note: This could be replaced by CHECK_ZLIB() in the autoconf macro archive
 AC_ARG_ENABLE([zlib],

--- a/CCache/test.sh
+++ b/CCache/test.sh
@@ -137,7 +137,7 @@ basetests() {
     checkstat 'bad compiler arguments' 1
 
     testname="c/c++"
-    ln -f test1.c test1.ccc
+    cp -f test1.c test1.ccc
     $CCACHE_COMPILE -c test1.ccc 2> /dev/null
     checkstat 'not a C/C++ file' 1
 
@@ -412,7 +412,7 @@ swigtests() {
 rm -rf $TESTDIR
 mkdir $TESTDIR
 if test -n "$CCACHE_PROG"; then
-  ln -s $CCACHE $TESTDIR/$CCACHE_PROG
+  cp "$CCACHE" $TESTDIR
   CCACHE=./$CCACHE_PROG
 fi
 cd $TESTDIR || exit 1

--- a/CCache/util.c
+++ b/CCache/util.c
@@ -18,6 +18,31 @@
 
 #include "ccache.h"
 
+#ifdef _WIN32
+#include <userenv.h> /* For GetUserProfileDirectoryA() */
+__inline static int link(const char *oldpath, const char *newpath)
+{
+	if(CreateHardLinkA(newpath, oldpath, NULL)) {
+		return 0;
+	}
+	if(GetLastError() == ERROR_ALREADY_EXISTS) {
+		errno = EEXIST;
+	}
+	return -1;
+}
+#endif /* _WIN32 */
+/* get perms right on the tmp file */
+__inline static void l_fchmod(int fd)
+{
+#ifndef _WIN32
+	mode_t mask = umask(0);
+	fchmod(fd, 0666 & ~mask);
+	umask(mask);
+#else
+	(void)fd;
+#endif
+}
+
 static FILE *logfile;
 
 /* log a message to the CCACHE_LOGFILE location */
@@ -50,13 +75,8 @@ int safe_rename(const char* oldpath, const char* newpath)
 
 	   Works like rename(), but it never overwrites an existing
 	   cache entry. This avoids corruption on NFS. */
-#ifndef _WIN32
 	int status = link(oldpath, newpath);
 	if( status == 0 || errno == EEXIST )
-#else
-	int status = CreateHardLinkA(newpath, oldpath, NULL) ? 0 : -1;
-	if( status == 0 || GetLastError() == ERROR_ALREADY_EXISTS )
-#endif
 	{
 		return unlink( oldpath );
 	}
@@ -103,7 +123,6 @@ static int copy_file(const char *src, const char *dest)
 	char buf[10240];
 	int n;
 	char *tmp_name;
-	mode_t mask;
 
 	x_asprintf(&tmp_name, "%s.XXXXXX", dest);
 
@@ -133,13 +152,7 @@ static int copy_file(const char *src, const char *dest)
 	close(fd1);
 
 	/* get perms right on the tmp file */
-#ifndef _WIN32
-	mask = umask(0);
-	fchmod(fd2, 0666 & ~mask);
-	umask(mask);
-#else
-	(void)mask;
-#endif
+	l_fchmod(fd2);
 
 	/* the close can fail on NFS if out of space */
 	if (close(fd2) == -1) {
@@ -202,7 +215,6 @@ static int _copy_file(const char *src, const char *dest, int mode) {
 	char buf[10240];
 	int n, ret;
 	char *tmp_name;
-	mode_t mask;
 	struct stat st;
 
 	x_asprintf(&tmp_name, "%s.XXXXXX", dest);
@@ -285,9 +297,7 @@ static int _copy_file(const char *src, const char *dest, int mode) {
 	}
 
 	/* get perms right on the tmp file */
-	mask = umask(0);
-	fchmod(fd_out, 0666 & ~mask);
-	umask(mask);
+	l_fchmod(fd_out);
 
 	/* the close can fail on NFS if out of space */
 	if (close(fd_out) == -1) {
@@ -357,11 +367,7 @@ int commit_to_cache(const char *src, const char *dest, int hardlink)
 	if (stat(src, &st) == 0) {
 		unlink(dest);
 		if (hardlink) {
-#ifdef _WIN32
-			ret = CreateHardLinkA(dest, src, NULL) ? 0 : -1;
-#else
 			ret = link(src, dest);
-#endif
 		}
 		if (ret == -1) {
 			ret = copy_file_to_cache(src, dest);
@@ -390,11 +396,7 @@ int retrieve_from_cache(const char *src, const char *dest, int hardlink)
 		unlink(dest);
 		/* only make a hardlink if the cache file is uncompressed */
 		if (hardlink && test_if_compressed(src) == 0) {
-#ifdef _WIN32
-			ret = CreateHardLinkA(dest, src, NULL) ? 0 : -1;
-#else
 			ret = link(src, dest);
-#endif
 		} else {
 			ret = copy_file_from_cache(src, dest);
 		}
@@ -825,22 +827,26 @@ const char *get_home_directory(void)
 {
 #ifdef _WIN32
 	static char home_path[MAX_PATH] = {0};
-	HRESULT ret;
+	HANDLE token;
 
 	/* we already have the path */
 	if (home_path[0] != 0) {
 		return home_path;
 	}
 
-	/* get the path to "Application Data" folder */
-	ret = SHGetFolderPathA(NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, home_path);
-	if (SUCCEEDED(ret)) {
-		return home_path;
+    /* As we already use minimum Windows 2000 SDK,
+     * we can use GetUserProfileDirectoryA() */
+	if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+		DWORD len = MAX_PATH - 1;
+		if(GetUserProfileDirectoryA(token, (LPSTR)&home_path, &len)) {
+			home_path[MAX_PATH - 1] = 0;
+			CloseHandle(token);
+			return home_path;
+		}
+		CloseHandle(token);
 	}
-
 	fprintf(stderr, "ccache: Unable to determine home directory\n");
-	return NULL;
-#else
+#else /* _WIN32 */
 	const char *p = getenv("HOME");
 	if (p) {
 		return p;
@@ -854,8 +860,8 @@ const char *get_home_directory(void)
 	}
 #endif
 	fatal("Unable to determine home directory");
+#endif /* _WIN32 */
 	return NULL;
-#endif
 }
 
 int x_utimes(const char *filename)

--- a/Examples/test-suite/errors/Makefile.in
+++ b/Examples/test-suite/errors/Makefile.in
@@ -27,49 +27,40 @@ top_builddir = @top_builddir@
 SWIG_LIB_SET = @SWIG_LIB_SET@
 SWIGINVOKE   = $(SWIG_LIB_SET) $(SWIGTOOL) $(SWIGEXE)
 
-# All .i files with prefix 'cpp_' will be treated as C++ input and remaining .i files as C input
-ALL_ERROR_TEST_CASES := $(sort $(patsubst %.i,%, $(notdir $(wildcard $(srcdir)/*.i))))
+# All .i files with prefix 'cpp_' will be treated as C++ input
+# All .i files with prefix 'doxygen_' will be treated as Doxygen input
+# the remaining .i files as C input
+ALL_ERROR_TEST_CASES := $(patsubst %.i,%, $(notdir $(wildcard $(srcdir)/*.i)))
 CPP_ERROR_TEST_CASES := $(sort $(filter cpp_%, $(ALL_ERROR_TEST_CASES)))
-C_ERROR_TEST_CASES := $(sort $(filter-out $(CPP_ERROR_TEST_CASES), $(ALL_ERROR_TEST_CASES)))
-DOXYGEN_ERROR_TEST_CASES := $(sort $(filter doxygen_%, $(C_ERROR_TEST_CASES)))
-C_ERROR_TEST_CASES := $(sort $(filter-out $(DOXYGEN_ERROR_TEST_CASES), $(C_ERROR_TEST_CASES)))
-
-# Always use C++ for Doxygen tests, there doesn't seem to be any need to
-# distinguish between C and C++ Doxygen tests.
-DOXYGEN_ERROR_TEST_CASES := $(DOXYGEN_ERROR_TEST_CASES:=.cpptest)
+DOXYGEN_ERROR_TEST_CASES := $(sort $(filter doxygen_%, $(ALL_ERROR_TEST_CASES)))
+C_ERROR_TEST_CASES := $(sort $(filter-out $(CPP_ERROR_TEST_CASES) $(DOXYGEN_ERROR_TEST_CASES), $(ALL_ERROR_TEST_CASES)))
 
 ERROR_TEST_CASES := $(CPP_ERROR_TEST_CASES:=.cpptest) \
 		    $(C_ERROR_TEST_CASES:=.ctest) \
-		    $(DOXYGEN_ERROR_TEST_CASES)
+		    $(DOXYGEN_ERROR_TEST_CASES:=.cpptest)
 
 include $(srcdir)/../common.mk
 
-# This is tricky: we need to let common.mk define SWIGOPT before appending to
-# it, if we do it before including it, its defining of SWIGOPT would override
-# whatever we do here.
-$(DOXYGEN_ERROR_TEST_CASES): SWIGOPT += -doxygen
+$(DOXYGEN_ERROR_TEST_CASES:=.cpptest): SWIGOPT += -doxygen
 
 # Unique module names are obtained from the .i file name (required for parallel make).
 # Note: -module overrides %module in the .i file.
 MODULE_OPTION=-module $*
 nomodule.ctest: MODULE_OPTION =
 
-# Portable dos2unix / fromdos for stripping CR
-FROMDOS       = tr -d '\r'
-
 # strip source directory from output, so that diffs compare
-STRIP_SRCDIR = sed -e 's|\\|/|g' -e 's|^$(SRCDIR)||'
+STRIP_SRCDIR:= sed 's%\\%/%g;s%^$(SRCDIR)%%'
 
 # Rules for the different types of tests
 %.cpptest:
 	$(ECHO_PROGRESS) "$(ACTION)ing errors testcase $*"
-	-$(SWIGINVOKE) -c++ -python -Wall -Fstandard $(MODULE_OPTION) $(SWIGOPT) $(SRCDIR)$*.i 2>&1 | $(FROMDOS) | $(STRIP_SRCDIR) > $*.$(ERROR_EXT)
-	$(COMPILETOOL) diff -c $(SRCDIR)$*.stderr $*.$(ERROR_EXT)
+	-$(SWIGINVOKE) -c++ -python -Wall -Fstandard $(MODULE_OPTION) $(SWIGOPT) $(SRCDIR)$*.i 2>&1 | $(STRIP_SRCDIR) > $*.$(ERROR_EXT)
+	$(COMPILETOOL) diff -cw $(SRCDIR)$*.stderr $*.$(ERROR_EXT)
 
 %.ctest:
 	$(ECHO_PROGRESS) "$(ACTION)ing errors testcase $*"
-	-$(SWIGINVOKE) -python -Wall -Fstandard $(MODULE_OPTION) $(SWIGOPT) $(SRCDIR)$*.i 2>&1 | $(FROMDOS) | $(STRIP_SRCDIR) > $*.$(ERROR_EXT)
-	$(COMPILETOOL) diff -c $(SRCDIR)$*.stderr $*.$(ERROR_EXT)
+	-$(SWIGINVOKE) -python -Wall -Fstandard $(MODULE_OPTION) $(SWIGOPT) $(SRCDIR)$*.i 2>&1 | $(STRIP_SRCDIR) > $*.$(ERROR_EXT)
+	$(COMPILETOOL) diff -cw $(SRCDIR)$*.stderr $*.$(ERROR_EXT)
 
 %.clean:
 	@exit 0


### PR DESCRIPTION
- Update `ccache-swig` to build with MinGW-w64 under windows.
- Update `CCache/test.sh` to properly support the `NOSOFTLINKSTEST`, i.e. work on system lacking symbolic links.
- Update `Examples/test-suite/errors/Makefile.in`.
  - remove the "dos" filter. The `checkout` on GHA add windows line feed to text files. The filter is useless.
  - Adding `--ignore-all-space` to `diff` solve the problem, no further filters are needed.
  - Improve `XXX_TEST_CASES` macros.  Follow `common.mk`, `XXX_TEST_CASES` should not store the extension. Update the comments and use one definition to each `XXX_TEST_CASES`. `SWIGOPT += -doxygen` is defined in `common.mk` for `DOXYGEN_TEST_CASES`, we do the same, no trick!