### PR TITLE
More lua directors testing

### DIFF
--- a/Examples/test-suite/lua/Makefile.in
+++ b/Examples/test-suite/lua/Makefile.in
@@ -17,6 +17,7 @@ top_builddir = @top_builddir@
 # sorry, currently very few test cases work/have been written
 
 CPP_TEST_CASES += \
+	director_stl \
 	li_std_set \
 	lua_no_module_global \
 	lua_inherit_getitem  \

--- a/Examples/test-suite/lua/director_protected_runme.lua
+++ b/Examples/test-suite/lua/director_protected_runme.lua
@@ -1,0 +1,75 @@
+require("import")	-- the import fn
+import("director_protected")	-- import lib
+
+-- Create test objects
+local b = director_protected.Bar()
+local f = b:create()
+
+-- FooBar: overrides ping
+local fb = director_protected.Bar()
+swig_override(fb, 'ping', function(self)
+  return "FooBar::ping();"
+end)
+
+-- FooBar2: overrides ping and pang
+local fb2 = director_protected.Bar()
+swig_derive(fb2, {
+  ping = function(self)
+    return "FooBar2::ping();"
+  end,
+  pang = function(self)
+    return "FooBar2::pang();"
+  end
+})
+
+-- FooBar3: overrides cheer
+local fb3 = director_protected.Bar()
+swig_override(fb3, 'cheer', function(self)
+  return "FooBar3::cheer();"
+end)
+
+-- Test overridden used() calls
+assert(fb:used() == "Foo::pang();Bar::pong();Foo::pong();FooBar::ping();",
+  "bad FooBar::used: " .. fb:used())
+assert(fb2:used() == "FooBar2::pang();Bar::pong();Foo::pong();FooBar2::ping();",
+  "bad FooBar2::used: " .. fb2:used())
+
+-- Test pong() calls
+assert(b:pong() == "Bar::pong();Foo::pong();Bar::ping();",
+  "bad Bar::pong: " .. b:pong())
+assert(f:pong() == "Bar::pong();Foo::pong();Bar::ping();",
+  "bad Foo::pong: " .. f:pong())
+assert(fb:pong() == "Bar::pong();Foo::pong();FooBar::ping();",
+  "bad FooBar::pong: " .. fb:pong())
+
+-- Test cheer override
+assert(fb3:cheer() == "FooBar3::cheer();",
+  "bad fb3::cheer: " .. fb3:cheer())
+
+-- Test callping/callcheer (call protected methods internally from C++)
+assert(fb2:callping() == "FooBar2::ping();",
+  "bad fb2:callping: " .. fb2:callping())
+assert(fb2:callcheer() == "FooBar2::pang();Bar::pong();Foo::pong();FooBar2::ping();",
+  "bad fb2:callcheer: " .. fb2:callcheer())
+assert(fb3:callping() == "Bar::ping();",
+  "bad fb3:callping: " .. fb3:callping())
+assert(fb3:callcheer() == "FooBar3::cheer();",
+  "bad fb3:callcheer: " .. fb3:callcheer())
+
+-- Note: In Lua, director objects CAN call protected methods (they go through the
+-- SwigDirector public accessor). This differs from Python where protected access
+-- is additionally restricted via swig_get_inner(). This is by design.
+-- Director objects (b, fb, fb2, fb3) can call protected methods:
+assert(b:ping() == "Bar::ping();", "bad b:ping")
+assert(b:cheer() == "Foo::pang();Bar::pong();Foo::pong();Bar::ping();", "bad b:cheer")
+
+-- Non-director objects (f, returned by Bar::create() which does new Bar() in C++)
+-- CANNOT call protected methods - the darg null check catches this:
+local ret, msg = pcall(function() f:ping() end)
+assert(not ret, "f:ping() should fail - f is not a director")
+
+ret, msg = pcall(function() f:pang() end)
+assert(not ret, "f:pang() should fail - f is not a director")
+
+ret, msg = pcall(function() f:cheer() end)
+assert(not ret, "f:cheer() should fail - f is not a director")

--- a/Examples/test-suite/lua/director_stl_runme.lua
+++ b/Examples/test-suite/lua/director_stl_runme.lua
@@ -1,0 +1,29 @@
+require("import")	-- the import fn
+import("director_stl")	-- import lib
+
+local a = director_stl.Foo()
+swig_derive(a, {
+  ping = function(self, s)
+    return "MyFoo::ping():" .. s
+  end,
+  pident = function(self, arg)
+    return arg
+  end,
+  vident = function(self, v)
+    return v
+  end,
+  vidents = function(self, v)
+    return v
+  end,
+  vsecond = function(self, v1, v2)
+    return v2
+  end
+})
+
+-- Test tping (calls virtual ping through C++)
+local r1 = a:tping("hello")
+assert(r1 == "MyFoo::ping():hello", "bad tping: " .. r1)
+
+-- Test tpong (calls pong which calls ping internally)
+local r2 = a:tpong("hello")
+assert(r2 == "Foo::pong:hello:MyFoo::ping():hello", "bad tpong: " .. r2)


### PR DESCRIPTION
Hi @christophe-calmejane,

After you add the Lua directors, I added some directors testing to check weather  the new feature works properly swig/swig@786931dc6f

During porting I notice two tests that fails and seems relevant:
the `director_protected` and `director_stl`.

<br>

In  `director_protected` I notice two wrong behaviours
- Bar::create() which create a new Bar object is called from Lua, but is not wrapped as director object. See the new `'self' is not a director` exception.
- Calling protected methods success. instead of generating proper exception. 

`director_stl` is more buzzard, calling Foo::tping() and Foo::tpong() from Lua fails.

I t would be nice if  you have a look.

Feel free to take charge and add these tests after proper fixing.