### PR TITLE
Ensure configured `CXXSHARED` uses `CXX`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,7 +261,8 @@ AC_MSG_RESULT($LDSHARED)
 AC_MSG_CHECKING(CXXSHARED)
 if test -z "$CXXSHARED"
 then
-	CXXSHARED="$LDSHARED"
+	# Ensure we use CXX for C++
+	CXXSHARED="$(echo "$LDSHARED" | sed 's%\$(CC)%\$(CXX)%')"
 fi
 AC_MSG_RESULT($CXXSHARED)
 


### PR DESCRIPTION
Ensure configured `CXXSHARED` uses `CXX`

Configure `CC` with MSVC yield  `/usr/bin/cccl -std:c11`
Which is proper for C compilation.
But improper for C++.

In any case, linking of C++ should be done with C++ compiler.
GCC as well should link with `g++`.