### PR TITLE
Add new test `li_cdata_bytes`

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,32 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.5.0 (in progress)
 ===========================
 
+2026-05-24: wsfulton
+            Fixed a one-byte buffer overflow in the cdata.i memmove typemap that
+            occurred when the data length exactly matched the destination buffer size.
+
+2026-05-20: erezgeva
+            [Guile, JavaScript, Python, Scilab, Tcl] #3383 The cdata.i library
+            functions (cdata, memmove and similar) now use a binary data type
+            instead of a string, so that all byte values 0-255 round-trip
+            correctly.
+
+            The target language type used by the cdata.i functions has changed:
+
+              - Python:     bytes object (was str)
+              - JavaScript: Uint8Array (was string)
+              - Tcl:        list of integers (was string)
+              - Scilab:     list of uint8 values (was string)
+
+            In Python, passing a str now fails with:
+
+                TypeError: in method 'memmove', argument 2 of type 'void const *'
+
+            so pass a bytes object instead. Guile cdata now also handles all
+            byte values correctly.
+
+	    *** POTENTIAL INCOMPATIBILITY ***
+
 2026-05-19: jmarrec
             #3415 Fix segmentation fault when a class declares a public
             'using Base::method;' that names a base-class member template with
@@ -18,7 +44,7 @@ Version 4.5.0 (in progress)
             failure protection to the argcargv typemaps and to the string duplication paths
             in pystrings.swg, perlstrings.swg, rubystrings.swg and rfragments.swg.
 
-            *Potentially incompatible change*: the `%new_copy_array` macro
+            Potentially incompatible change: the `%new_copy_array` macro
             has been removed. User interface files calling `%new_copy_array(ptr, size, T)`
             will be passed through to the C/C++ compiler unchanged and fail with
             an error such as:
@@ -31,7 +57,7 @@ Version 4.5.0 (in progress)
                 T *p = %new_array(size, T);
                 if (p) memcpy(p, ptr, size * sizeof(T));
 
-            *Potentially incompatible change*: the `%typemaps_string` macro in
+            Potentially incompatible change: the `%typemaps_string` macro in
             `Lib/typemaps/strings.swg` now takes an additional argument naming a
             `SWIG_NewCopyCharArray` style fragment, and the related
             `%typemaps_string_alloc` macro has been removed (its allocator

--- a/Doc/Manual/Library.html
+++ b/Doc/Manual/Library.html
@@ -728,14 +728,35 @@ Now, in a script:
 
 
 <p>
-The <tt>cdata.i</tt> module defines functions for converting raw C data to and from a target language type.
-The target language type is either:
+The <tt>cdata.i</tt> module defines functions for converting raw C data to and from a target language.
 </p>
 
-<ul>
-  <li> A string for the scripting languages. The scripting language must support strings with embedded binary data in order for this to work.</li>
-  <li> A byte array for the statically typed languages; namely, <tt>byte[]</tt> for C# and Java, <tt>ubyte[]</tt> for D, <tt>[]byte</tt> for Go.</li>
-</ul>
+<p>
+The following table descripbe the specific type per language:
+</p>
+
+<table BORDER summary="cdata types">
+<tr VALIGN=TOP>
+<td><b>Langause</b></td>
+<td><b>cdata type</b></td>
+<td><b>mutability</b></td>
+</tr>
+<tr> <td>Ruby</td>       <td>string</td>                 <td>yes</td> </tr>
+<tr> <td>PHP</td>        <td>string</td>                 <td>yes</td> </tr>
+<tr> <td>Guile</td>      <td>string</td>                 <td>yes</td> </tr>
+<tr> <td>Lua</td>        <td>string</td>                 <td>none</td> </tr>
+<tr> <td>Perl5</td>      <td>string</td>                 <td>none</td> </tr>
+<tr> <td>OCaml</td>      <td>string</td>                 <td>none</td> </tr>
+<tr> <td>Octave</td>     <td>string</td>                 <td>none</td> </tr>
+<tr> <td>Python</td>     <td>binary string</td>          <td>none</td> </tr>
+<tr> <td>C#</td>         <td><tt>byte[]</tt></td>        <td>yes</td> </tr>
+<tr> <td>Java</td>       <td><tt>byte[]</tt></td>        <td>yes</td> </tr>
+<tr> <td>D</td>          <td><tt>ubyte[]</tt></td>       <td>yes</td> </tr>
+<tr> <td>Go</td>         <td><tt>[]byte</tt></td>        <td>yes</td> </tr>
+<tr> <td>Javascript</td> <td><tt>Uint8Array</tt></td>    <td>yes</td> </tr>
+<tr> <td>Scilab</td>     <td>list of <tt>uint8</tt></td> <td>yes</td> </tr>
+<tr> <td>Tcl</td>        <td>list of integers</td>       <td>yes</td> </tr>
+</table>
 
 <p>
 The primary applications of this module would be packing/unpacking of
@@ -796,7 +817,7 @@ Python example:
 ...    a[i] = i
 &gt;&gt;&gt; b = cdata(a, 40)
 &gt;&gt;&gt; b
-'\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04
+b'\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04
 \x00\x00\x00\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08\x00\x00\x00\t'
 &gt;&gt;&gt; c = intArray(10)
 &gt;&gt;&gt; memmove(c, b)

--- a/Doc/Manual/Library.html
+++ b/Doc/Manual/Library.html
@@ -732,12 +732,12 @@ The <tt>cdata.i</tt> module defines functions for converting raw C data to and f
 </p>
 
 <p>
-The following table descripbe the specific type per language:
+The following table describes the specific type per language:
 </p>
 
 <table BORDER summary="cdata types">
 <tr VALIGN=TOP>
-<td><b>Langause</b></td>
+<td><b>Language</b></td>
 <td><b>cdata type</b></td>
 <td><b>mutability</b></td>
 </tr>

--- a/Examples/test-suite/c/Makefile.in
+++ b/Examples/test-suite/c/Makefile.in
@@ -23,6 +23,7 @@ FAILING_C_TESTS := \
     function_typedef \
     lextype \
     li_carrays \
+    li_cdata_bytes \
     nested \
     nested_extend_c \
     nested_structs \
@@ -56,6 +57,7 @@ FAILING_CPP_TESTS := \
     li_attribute \
     li_attribute_template \
     li_boost_shared_ptr_attribute \
+    li_cdata_bytes_cpp \
     li_std_auto_ptr \
     li_std_deque \
     li_std_wstring \

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -309,6 +309,7 @@ CPP_TEST_CASES += \
 	li_boost_shared_ptr_template \
 	li_carrays_cpp \
 	li_cdata_cpp \
+	li_cdata_bytes_cpp \
 	li_cpointer_cpp \
 	li_std_auto_ptr \
 	li_stdint \
@@ -853,6 +854,7 @@ C_TEST_CASES += \
 	lextype \
 	li_carrays \
 	li_cdata \
+	li_cdata_bytes \
 	li_cmalloc \
 	li_constraints \
 	li_cpointer \

--- a/Examples/test-suite/csharp/li_cdata_bytes_cpp_runme.cs
+++ b/Examples/test-suite/csharp/li_cdata_bytes_cpp_runme.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text;
+using li_cdata_bytes_cppNamespace;
+
+public class li_cdata_bytes_cpp_runme {
+
+  public static void Main() {
+    SWIGTYPE_p_void m = li_cdata_bytes_cpp.predefStr();
+    byte[] s = li_cdata_bytes_cpp.cdata(m, 0x200);
+    for (uint i = 0; i < 0x100; i++) {
+      uint val = Convert.ToUInt32(s[i]);
+      if (val != i)
+        throw new Exception("Wrong value " + val + " at index " + i);
+      val = Convert.ToUInt32(s[i + 0x100]);
+      if (val != i)
+        throw new Exception("Wrong value " + val + " at index " + (i + 0x100));
+    }
+    for (uint i = 0; i < 0x100; i++) {
+      byte v = (byte)(0x100 - 1 - i);
+      s[i] = v;
+      s[i + 0x100] = v;
+    }
+    SWIGTYPE_p_void m2 = li_cdata_bytes_cpp.malloc(0x200);
+    li_cdata_bytes_cpp.memmove(m2, s);
+    if (li_cdata_bytes_cpp.verifyBytes(m2) != 0)
+      throw new Exception("verifyBytes fails");
+    li_cdata_bytes_cpp.free(m2);
+  }
+}

--- a/Examples/test-suite/csharp/li_cdata_bytes_runme.cs
+++ b/Examples/test-suite/csharp/li_cdata_bytes_runme.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text;
+using li_cdata_bytesNamespace;
+
+public class li_cdata_bytes_runme {
+
+  public static void Main() {
+    SWIGTYPE_p_void m = li_cdata_bytes.predefStr();
+    byte[] s = li_cdata_bytes.cdata(m, 0x200);
+    for (uint i = 0; i < 0x100; i++) {
+      uint val = Convert.ToUInt32(s[i]);
+      if (val != i)
+        throw new Exception("Wrong value " + val + " at index " + i);
+      val = Convert.ToUInt32(s[i + 0x100]);
+      if (val != i)
+        throw new Exception("Wrong value " + val + " at index " + (i + 0x100));
+    }
+    for (uint i = 0; i < 0x100; i++) {
+      byte v = (byte)(0x100 - 1 - i);
+      s[i] = v;
+      s[i + 0x100] = v;
+    }
+    SWIGTYPE_p_void m2 = li_cdata_bytes.malloc(0x200);
+    li_cdata_bytes.memmove(m2, s);
+    if (li_cdata_bytes.verifyBytes(m2) != 0)
+      throw new Exception("verifyBytes fails");
+    li_cdata_bytes.free(m2);
+  }
+}

--- a/Examples/test-suite/d/li_cdata_bytes_cpp_runme.2.d
+++ b/Examples/test-suite/d/li_cdata_bytes_cpp_runme.2.d
@@ -1,0 +1,25 @@
+module li_cdata_bytes_cpp_runme;
+
+import li_cdata_bytes_cpp.li_cdata_bytes_cpp;
+import std.conv;
+
+void main() {
+  auto m = predefStr();
+  ubyte[] s = cdata(m, 0x200);
+  for (uint i = 0; i < 0x100; i++) {
+    if (s[i] != i)
+      throw new Exception("Wrong value " ~ to!string(s[i]) ~ " at index " ~ to!string(i));
+    if (s[i + 0x100] != i)
+      throw new Exception("Wrong value " ~ to!string(s[i + 0x100]) ~ " at index " ~ to!string(i + 0x100));
+  }
+  for (uint i = 0; i < 0x100; i++) {
+      ubyte v = cast(ubyte)(0x100 - 1 - i);
+      s[i] = v;
+      s[i + 0x100] = v;
+  }
+  auto m2 = malloc(0x200);
+  memmove(m2, s);
+  if (verifyBytes(m2) != 0)
+      throw new Exception("verifyBytes fails");
+  free(m2);
+}

--- a/Examples/test-suite/d/li_cdata_bytes_runme.2.d
+++ b/Examples/test-suite/d/li_cdata_bytes_runme.2.d
@@ -1,0 +1,25 @@
+module li_cdata_bytes_runme;
+
+import li_cdata_bytes.li_cdata_bytes;
+import std.conv;
+
+void main() {
+  auto m = predefStr();
+  ubyte[] s = cdata(m, 0x200);
+  for (uint i = 0; i < 0x100; i++) {
+    if (s[i] != i)
+      throw new Exception("Wrong value " ~ to!string(s[i]) ~ " at index " ~ to!string(i));
+    if (s[i + 0x100] != i)
+      throw new Exception("Wrong value " ~ to!string(s[i + 0x100]) ~ " at index " ~ to!string(i + 0x100));
+  }
+  for (uint i = 0; i < 0x100; i++) {
+      ubyte v = cast(ubyte)(0x100 - 1 - i);
+      s[i] = v;
+      s[i + 0x100] = v;
+  }
+  auto m2 = malloc(0x200);
+  memmove(m2, s);
+  if (verifyBytes(m2) != 0)
+      throw new Exception("verifyBytes fails");
+  free(m2);
+}

--- a/Examples/test-suite/go/li_cdata_bytes_cpp_runme.go
+++ b/Examples/test-suite/go/li_cdata_bytes_cpp_runme.go
@@ -1,0 +1,28 @@
+package main
+
+import "strconv"
+import . "swigtests/li_cdata_bytes_cpp"
+
+func main() {
+    m := PredefStr()
+    s := Cdata(m, int64(0x200))
+    for i := 0; i < 0x100; i++ {
+      if int(s[i]) != i {
+        panic("Wrong value " + strconv.Itoa(int(s[i])) + " at index " + strconv.Itoa(i))
+      }
+      if int(s[i + 0x100]) != i {
+        panic("Wrong value " + strconv.Itoa(int(s[i])) + " at index " + strconv.Itoa(i + 0x100))
+      }
+    }
+    for i := 0; i < 0x100; i++ {
+        v := byte(0x100 - 1 - i)
+        s[i] = v
+        s[i + 0x100] = v
+    }
+    m2 := Malloc(0x200)
+    Memmove(m2, s)
+    if (VerifyBytes(m2) != 0) {
+        panic("verifyBytes fails")
+    }
+    Free(m2)
+}

--- a/Examples/test-suite/go/li_cdata_bytes_runme.go
+++ b/Examples/test-suite/go/li_cdata_bytes_runme.go
@@ -1,0 +1,28 @@
+package main
+
+import "strconv"
+import . "swigtests/li_cdata_bytes"
+
+func main() {
+    m := PredefStr()
+    s := Cdata(m, int64(0x200))
+    for i := 0; i < 0x100; i++ {
+      if int(s[i]) != i {
+        panic("Wrong value " + strconv.Itoa(int(s[i])) + " at index " + strconv.Itoa(i))
+      }
+      if int(s[i + 0x100]) != i {
+        panic("Wrong value " + strconv.Itoa(int(s[i])) + " at index " + strconv.Itoa(i + 0x100))
+      }
+    }
+    for i := 0; i < 0x100; i++ {
+        v := byte(0x100 - 1 - i)
+        s[i] = v
+        s[i + 0x100] = v
+    }
+    m2 := Malloc(0x200)
+    Memmove(m2, s)
+    if (VerifyBytes(m2) != 0) {
+        panic("verifyBytes fails")
+    }
+    Free(m2)
+}

--- a/Examples/test-suite/guile/li_cdata_bytes_cpp_runme.scm
+++ b/Examples/test-suite/guile/li_cdata_bytes_cpp_runme.scm
@@ -1,0 +1,6 @@
+;; The SWIG modules have "passive" Linkage, i.e., they don't generate
+;; Guile modules (namespaces) but simply put all the bindings into the
+;; current module.  That's enough for such a simple test.
+(dynamic-call "scm_init_li_cdata_bytes_cpp_module" (dynamic-link "./libli_cdata_bytes_cpp"))
+(load "testsuite.scm")
+(load "../schemerunme/li_cdata_bytes_cpp.scm")

--- a/Examples/test-suite/guile/li_cdata_bytes_runme.scm
+++ b/Examples/test-suite/guile/li_cdata_bytes_runme.scm
@@ -1,0 +1,6 @@
+;; The SWIG modules have "passive" Linkage, i.e., they don't generate
+;; Guile modules (namespaces) but simply put all the bindings into the
+;; current module.  That's enough for such a simple test.
+(dynamic-call "scm_init_li_cdata_bytes_module" (dynamic-link "./libli_cdata_bytes"))
+(load "testsuite.scm")
+(load "../schemerunme/li_cdata_bytes.scm")

--- a/Examples/test-suite/java/li_cdata_bytes_cpp_runme.java
+++ b/Examples/test-suite/java/li_cdata_bytes_cpp_runme.java
@@ -1,0 +1,37 @@
+import li_cdata_bytes_cpp.*;
+
+public class li_cdata_bytes_cpp_runme {
+
+  static {
+    try {
+        System.loadLibrary("li_cdata_bytes_cpp");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) throws Throwable
+  {
+    SWIGTYPE_p_void m = li_cdata_bytes_cpp.predefStr();
+    byte[] s = li_cdata_bytes_cpp.cdata(m, 0x200);
+    for (int i = 0; i < 0x100; i++) {
+      int val = Byte.toUnsignedInt(s[i]);
+      if (val != i)
+        throw new RuntimeException("Wrong value " + val + " at index " + i);
+      val = Byte.toUnsignedInt(s[i + 0x100]);
+      if (val != i)
+        throw new RuntimeException("Wrong value " + val + " at index " + (i + 0x100));
+    }
+    for (int i = 0; i < 0x100; i++) {
+        byte v = (byte)(0x100 - 1 - i);
+        s[i] = v;
+        s[i + 0x100] = v;
+    }
+    SWIGTYPE_p_void m2 = li_cdata_bytes_cpp.malloc(0x200);
+    li_cdata_bytes_cpp.memmove(m2, s);
+    if (li_cdata_bytes_cpp.verifyBytes(m2) != 0)
+        throw new RuntimeException("verifyBytes fails");
+    li_cdata_bytes_cpp.free(m2);
+  }
+}

--- a/Examples/test-suite/java/li_cdata_bytes_runme.java
+++ b/Examples/test-suite/java/li_cdata_bytes_runme.java
@@ -1,0 +1,37 @@
+import li_cdata_bytes.*;
+
+public class li_cdata_bytes_runme {
+
+  static {
+    try {
+        System.loadLibrary("li_cdata_bytes");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+
+  public static void main(String argv[]) throws Throwable
+  {
+    SWIGTYPE_p_void m = li_cdata_bytes.predefStr();
+    byte[] s = li_cdata_bytes.cdata(m, 0x200);
+    for (int i = 0; i < 0x100; i++) {
+      int val = Byte.toUnsignedInt(s[i]);
+      if (val != i)
+        throw new RuntimeException("Wrong value " + val + " at index " + i);
+      val = Byte.toUnsignedInt(s[i + 0x100]);
+      if (val != i)
+        throw new RuntimeException("Wrong value " + val + " at index " + (i + 0x100));
+    }
+    for (int i = 0; i < 0x100; i++) {
+        byte v = (byte)(0x100 - 1 - i);
+        s[i] = v;
+        s[i + 0x100] = v;
+    }
+    SWIGTYPE_p_void m2 = li_cdata_bytes.malloc(0x200);
+    li_cdata_bytes.memmove(m2, s);
+    if (li_cdata_bytes.verifyBytes(m2) != 0)
+        throw new RuntimeException("verifyBytes fails");
+    li_cdata_bytes.free(m2);
+  }
+}

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -8,7 +8,8 @@ NODEJS = @NODEJS@
 SCRIPTSUFFIX = _runme.js
 OBJEXT = @OBJEXT@
 SO = @SO@
-GYP_CXXFLAGS = @BOOST_CPPFLAGS@ @PLATCXXFLAGS@ -I$(shell npm config get prefix)/lib/node_modules/node-addon-api
+NAPI_DIR = @NODENAPI_DIR@
+GYP_CXXFLAGS = @BOOST_CPPFLAGS@ @PLATCXXFLAGS@ -I$(shell npm config get prefix)/lib/node_modules/node-addon-api -I $(NAPI_DIR)
 
 HAVE_CXX11   = @HAVE_CXX11@
 HAVE_CXX14   = @HAVE_CXX14@
@@ -23,9 +24,13 @@ CPP_TEST_CASES += \
 	inplaceadd \
 	input \
 	javascript_lib_arrays \
+	li_cdata_carrays_cpp \
 	li_factory \
 	li_std_containers_int \
 	li_std_map_member
+
+C_TEST_CASES += \
+	li_cdata_carrays \
 
 # napi fails
 FAILING_CPP_TESTS += \

--- a/Examples/test-suite/javascript/li_cdata_bytes_cpp_runme.js
+++ b/Examples/test-suite/javascript/li_cdata_bytes_cpp_runme.js
@@ -1,0 +1,29 @@
+var li_cdata_bytes_cpp = require("li_cdata_bytes_cpp");
+
+m = li_cdata_bytes_cpp.predefStr();
+s = li_cdata_bytes_cpp.cdata(m, 512);
+// 's' is Uint8Array, verify its property
+if (!ArrayBuffer.isView(s) || s.byteLength != 512 ||
+    s.length != 512 || s.BYTES_PER_ELEMENT != 1) {
+  throw new Error("'s' do not have proper properties");
+}
+// verify 's' content
+for (i = 0; i < 256; i++) {
+  if (s[i] != i)
+    throw new Error("Wrong value " + s[i] + " at index " + i);
+  if (s[i + 256] != i)
+    throw new Error("Wrong value " + s[i + 256] + " at index " + (i + 256));
+}
+// Fill 's' with new content
+for (i = 0; i < 256; i++) {
+  v = 256 - 1 - i;
+  s[i] = v;
+  s[i + 256] = v;
+}
+m2 = li_cdata_bytes_cpp.malloc(512);
+// Copy 's' into a new allocated memory
+li_cdata_bytes_cpp.memmove(m2, s);
+if (li_cdata_bytes_cpp.verifyBytes(m2) != 0) {
+  throw new Error("verifyBytes fails");
+}
+li_cdata_bytes_cpp.free(m2);

--- a/Examples/test-suite/javascript/li_cdata_bytes_runme.js
+++ b/Examples/test-suite/javascript/li_cdata_bytes_runme.js
@@ -1,0 +1,29 @@
+var li_cdata_bytes = require("li_cdata_bytes");
+
+m = li_cdata_bytes.predefStr();
+s = li_cdata_bytes.cdata(m, 512);
+// 's' is Uint8Array, verify its property
+if (!ArrayBuffer.isView(s) || s.byteLength != 512 ||
+    s.length != 512 || s.BYTES_PER_ELEMENT != 1) {
+  throw new Error("'s' do not have proper properties");
+}
+// verify 's' content
+for (i = 0; i < 256; i++) {
+  if (s[i] != i)
+    throw new Error("Wrong value " + s[i] + " at index " + i);
+  if (s[i + 256] != i)
+    throw new Error("Wrong value " + s[i + 256] + " at index " + (i + 256));
+}
+// Fill 's' with new content
+for (i = 0; i < 256; i++) {
+  v = 256 - 1 - i;
+  s[i] = v;
+  s[i + 256] = v;
+}
+m2 = li_cdata_bytes.malloc(512);
+// Copy 's' into a new allocated memory
+li_cdata_bytes.memmove(m2, s);
+if (li_cdata_bytes.verifyBytes(m2) != 0) {
+  throw new Error("verifyBytes fails");
+}
+li_cdata_bytes.free(m2);

--- a/Examples/test-suite/javascript/li_cdata_carrays_cpp_runme.js
+++ b/Examples/test-suite/javascript/li_cdata_carrays_cpp_runme.js
@@ -1,0 +1,21 @@
+var li_cdata_carrays_cpp = require("li_cdata_carrays_cpp");
+
+ia = new li_cdata_carrays_cpp.intArray(5);
+for(i = 0; i < 5; i++) {
+  ia.setitem(i, i * i);
+}
+
+y = li_cdata_carrays_cpp.cdata_int(ia.cast(), 5);
+
+const INT_SIZE = 4; // We assume int uses 4 bytes
+// The numbers are smaller than 256
+// so we can simply sum and skip endian issues
+a = [0, 0, 0, 0, 0];
+for(j = 0; j < 5; j++) {
+  for(i = 0; i < INT_SIZE; i++) {
+    a[j] += 0 + y[j * INT_SIZE + i];
+  }
+}
+if (a[0] !== 0 || a[1] !== 1 || a[2] !== 4 || a[3] !== 9 || a[4] !== 16) {
+  throw new Error("failed");
+}

--- a/Examples/test-suite/javascript/li_cdata_carrays_runme.js
+++ b/Examples/test-suite/javascript/li_cdata_carrays_runme.js
@@ -1,0 +1,21 @@
+var li_cdata_carrays = require("li_cdata_carrays");
+
+ia = new li_cdata_carrays.intArray(5);
+for(i = 0; i < 5; i++) {
+  ia.setitem(i, i * i);
+}
+
+y = li_cdata_carrays.cdata_int(ia.cast(), 5);
+
+const INT_SIZE = 4; // We assume int uses 4 bytes
+// The numbers are smaller than 256
+// so we can simply sum and skip endian issues
+a = [0, 0, 0, 0, 0];
+for(j = 0; j < 5; j++) {
+  for(i = 0; i < INT_SIZE; i++) {
+    a[j] += 0 + y[j * INT_SIZE + i];
+  }
+}
+if (a[0] !== 0 || a[1] !== 1 || a[2] !== 4 || a[3] !== 9 || a[4] !== 16) {
+  throw new Error("failed");
+}

--- a/Examples/test-suite/javascript/li_cdata_cpp_runme.js
+++ b/Examples/test-suite/javascript/li_cdata_cpp_runme.js
@@ -1,14 +1,13 @@
 
 var li_cdata_cpp = require("li_cdata_cpp");
 
-/* FIXME:
- * Use null in middle of string
- * Apple JSC JSStringCreateWithUTF8CString()
- * usses null terminated string without length */
-s = "ABC abc";
+// Set "ABC abc"
+s = new Uint8Array([65, 66, 67, 32, 97, 98, 99]);
 m = li_cdata_cpp.malloc(256);
 li_cdata_cpp.memmove(m, s);
 ss = li_cdata_cpp.cdata(m, 7);
-if (ss !== "ABC abc") {
-    throw new Error("failed");
+// Translate Uint8Array to string
+a = ""; ss.forEach((i) => a += String.fromCharCode(i));
+if (a !== "ABC abc") {
+  throw new Error("failed");
 }

--- a/Examples/test-suite/javascript/li_cdata_runme.js
+++ b/Examples/test-suite/javascript/li_cdata_runme.js
@@ -1,14 +1,13 @@
 
 var li_cdata = require("li_cdata");
 
-/* FIXME:
- * Use null in middle of string
- * Apple JSC JSStringCreateWithUTF8CString()
- * usses null terminated string without length */
-s = "ABC abc";
+// Set "ABC abc"
+s = new Uint8Array([65, 66, 67, 32, 97, 98, 99]);
 m = li_cdata.malloc(256);
 li_cdata.memmove(m, s);
 ss = li_cdata.cdata(m, 7);
-if (ss !== "ABC abc") {
-    throw new Error("failed");
+// Translate Uint8Array to string
+a = ""; ss.forEach((i) => a += String.fromCharCode(i));
+if (a !== "ABC abc") {
+  throw new Error("failed");
 }

--- a/Examples/test-suite/li_cdata_bytes.i
+++ b/Examples/test-suite/li_cdata_bytes.i
@@ -1,0 +1,34 @@
+%module li_cdata_bytes
+
+%include <cdata.i>
+
+%{
+#include <stdlib.h>
+static unsigned char _pre_bug[0x200];
+void *predefStr(void) {
+  unsigned i;
+  for (i = 0; i < 0x100; i++) {
+    _pre_bug[i] = (unsigned char)i;
+    _pre_bug[i + 0x100] = (unsigned char)i;
+  }
+  return _pre_bug;
+}
+int verifyBytes(void *ptr) {
+  unsigned i;
+  unsigned char *p;
+  if (ptr == NULL)
+    return -1;
+  p = (unsigned char *)ptr;
+  for (i = 0; i < 0x100; i++) {
+    unsigned char v = (unsigned char)(0x100 - 1 - i);
+    if (p[i] != v || p[i + 0x100] != v)
+      return -1;
+  }
+  return 0;
+}
+%}
+
+void *malloc(size_t size);
+void free(void *);
+void *predefStr(void);
+int verifyBytes(void *ptr);

--- a/Examples/test-suite/li_cdata_bytes.i
+++ b/Examples/test-suite/li_cdata_bytes.i
@@ -4,14 +4,14 @@
 
 %{
 #include <stdlib.h>
-static unsigned char _pre_bug[0x200];
+static unsigned char predef_buf[0x200];
 void *predefStr(void) {
   unsigned i;
   for (i = 0; i < 0x100; i++) {
-    _pre_bug[i] = (unsigned char)i;
-    _pre_bug[i + 0x100] = (unsigned char)i;
+    predef_buf[i] = (unsigned char)i;
+    predef_buf[i + 0x100] = (unsigned char)i;
   }
-  return _pre_bug;
+  return predef_buf;
 }
 int verifyBytes(void *ptr) {
   unsigned i;

--- a/Examples/test-suite/li_cdata_bytes_cpp.i
+++ b/Examples/test-suite/li_cdata_bytes_cpp.i
@@ -1,0 +1,34 @@
+%module li_cdata_bytes_cpp
+
+%include <cdata.i>
+
+%{
+#include <stdlib.h>
+static unsigned char _pre_bug[0x200];
+void *predefStr(void) {
+  unsigned i;
+  for (i = 0; i < 0x100; i++) {
+    _pre_bug[i] = (unsigned char)i;
+    _pre_bug[i + 0x100] = (unsigned char)i;
+  }
+  return _pre_bug;
+}
+int verifyBytes(void *ptr) {
+  unsigned i;
+  unsigned char *p;
+  if (ptr == NULL)
+    return -1;
+  p = (unsigned char *)ptr;
+  for (i = 0; i < 0x100; i++) {
+    unsigned char v = (unsigned char)(0x100 - 1 - i);
+    if (p[i] != v || p[i + 0x100] != v)
+      return -1;
+  }
+  return 0;
+}
+%}
+
+void *malloc(size_t size);
+void free(void *);
+void *predefStr(void);
+int verifyBytes(void *ptr);

--- a/Examples/test-suite/li_cdata_bytes_cpp.i
+++ b/Examples/test-suite/li_cdata_bytes_cpp.i
@@ -4,14 +4,14 @@
 
 %{
 #include <stdlib.h>
-static unsigned char _pre_bug[0x200];
+static unsigned char predef_buf[0x200];
 void *predefStr(void) {
   unsigned i;
   for (i = 0; i < 0x100; i++) {
-    _pre_bug[i] = (unsigned char)i;
-    _pre_bug[i + 0x100] = (unsigned char)i;
+    predef_buf[i] = (unsigned char)i;
+    predef_buf[i + 0x100] = (unsigned char)i;
   }
-  return _pre_bug;
+  return predef_buf;
 }
 int verifyBytes(void *ptr) {
   unsigned i;

--- a/Examples/test-suite/lua/li_cdata_bytes_cpp_runme.lua
+++ b/Examples/test-suite/lua/li_cdata_bytes_cpp_runme.lua
@@ -1,0 +1,25 @@
+require("import")
+local v=require("li_cdata_bytes_cpp")
+
+local m = v.predefStr()
+local s = v.cdata(m, 0x200)
+for i=0,0x99 do
+  if string.byte(s, i + 1) ~= i then
+    error("value " ..  s:byte(i + 1) .. " should be " .. i .. " at index " .. i)
+  end
+  if string.byte(s, i + 0x101) ~= i then
+    error("value " ..  s:byte(i + 0x101) .. " should be " .. i .. " at index " .. i)
+  end
+end
+local s2=''
+for i=1,0x100 do
+  local d = string.format("%c", 0x100 - i)
+  s2 = s2 .. d
+end
+s = s2 .. s2
+local m2 = v.malloc(0x200)
+v.memmove(m2, s)
+if v.verifyBytes(m2) < 0 then
+  error("verifyBytes fails")
+end
+v.free(m2)

--- a/Examples/test-suite/lua/li_cdata_bytes_cpp_runme.lua
+++ b/Examples/test-suite/lua/li_cdata_bytes_cpp_runme.lua
@@ -3,7 +3,7 @@ local v=require("li_cdata_bytes_cpp")
 
 local m = v.predefStr()
 local s = v.cdata(m, 0x200)
-for i=0,0x99 do
+for i=0,0xff do
   if string.byte(s, i + 1) ~= i then
     error("value " ..  s:byte(i + 1) .. " should be " .. i .. " at index " .. i)
   end

--- a/Examples/test-suite/lua/li_cdata_bytes_runme.lua
+++ b/Examples/test-suite/lua/li_cdata_bytes_runme.lua
@@ -1,0 +1,25 @@
+require("import")
+local v=require("li_cdata_bytes")
+
+local m = v.predefStr()
+local s = v.cdata(m, 0x200)
+for i=0,0x99 do
+  if string.byte(s, i + 1) ~= i then
+    error("value " ..  s:byte(i + 1) .. " should be " .. i .. " at index " .. i)
+  end
+  if string.byte(s, i + 0x101) ~= i then
+    error("value " ..  s:byte(i + 0x101) .. " should be " .. i .. " at index " .. i)
+  end
+end
+local s2=''
+for i=1,0x100 do
+  local d = string.format("%c", 0x100 - i)
+  s2 = s2 .. d
+end
+s = s2 .. s2
+local m2 = v.malloc(0x200)
+v.memmove(m2, s)
+if v.verifyBytes(m2) < 0 then
+  error("verifyBytes fails")
+end
+v.free(m2)

--- a/Examples/test-suite/lua/li_cdata_bytes_runme.lua
+++ b/Examples/test-suite/lua/li_cdata_bytes_runme.lua
@@ -3,7 +3,7 @@ local v=require("li_cdata_bytes")
 
 local m = v.predefStr()
 local s = v.cdata(m, 0x200)
-for i=0,0x99 do
+for i=0,0xff do
   if string.byte(s, i + 1) ~= i then
     error("value " ..  s:byte(i + 1) .. " should be " .. i .. " at index " .. i)
   end

--- a/Examples/test-suite/ocaml/li_cdata_bytes_cpp_runme.ml
+++ b/Examples/test-suite/ocaml/li_cdata_bytes_cpp_runme.ml
@@ -1,0 +1,33 @@
+open Swig
+open Li_cdata_bytes_cpp
+
+let m = _predefStr '();;
+let s = _cdata '(m, 512) as string;;
+
+for i = 0 to 255 do
+  let c = (String.get s i) in
+  let v = (Char.code c) in
+  assert (v = i);
+  let i2 = i + 256 in
+  let c2 = (String.get s i2) in
+  let v2 = (Char.code c2) in
+  assert (v2 = i);
+done;;
+
+let s2 = ref ("");;
+
+for i = 0 to 255 do
+  let d = 255 - i in
+  let c = (Char.chr d) in
+  let s0 = (String.make 1 c) in
+  s2 := (String.cat !s2 s0);
+done;;
+
+let _ =
+  let s3 = (String.cat !s2 !s2) in
+  let m2 = _malloc '(512) in
+  let _ = _memmove '(m2, (C_string s3)) in
+  let r = _verifyBytes '(m2) as int in
+  let _ = _free '(m2) in
+  assert (r = 0);
+;;

--- a/Examples/test-suite/ocaml/li_cdata_bytes_runme.ml
+++ b/Examples/test-suite/ocaml/li_cdata_bytes_runme.ml
@@ -1,0 +1,33 @@
+open Swig
+open Li_cdata_bytes
+
+let m = _predefStr '();;
+let s = _cdata '(m, 512) as string;;
+
+for i = 0 to 255 do
+  let c = (String.get s i) in
+  let v = (Char.code c) in
+  assert (v = i);
+  let i2 = i + 256 in
+  let c2 = (String.get s i2) in
+  let v2 = (Char.code c2) in
+  assert (v2 = i);
+done;;
+
+let s2 = ref ("");;
+
+for i = 0 to 255 do
+  let d = 255 - i in
+  let c = (Char.chr d) in
+  let s0 = (String.make 1 c) in
+  s2 := (String.cat !s2 s0);
+done;;
+
+let _ =
+  let s3 = (String.cat !s2 !s2) in
+  let m2 = _malloc '(512) in
+  let _ = _memmove '(m2, (C_string s3)) in
+  let r = _verifyBytes '(m2) as int in
+  let _ = _free '(m2) in
+  assert (r = 0);
+;;

--- a/Examples/test-suite/octave/li_cdata_bytes_cpp_runme.m
+++ b/Examples/test-suite/octave/li_cdata_bytes_cpp_runme.m
@@ -1,0 +1,24 @@
+li_cdata_bytes_cpp
+
+m = li_cdata_bytes_cpp.predefStr();
+s = li_cdata_bytes_cpp.cdata(m, 0x200);
+for i = 0:255
+  if (double(s(i + 1)) != i)
+    error(strcat("Value ", string(double(s(i + 1))), " should be ", string(i), " at index ", string(i)));
+  end
+  if (double(s(i + 1 + 256)) != i)
+    error(strcat("Value ", string(double(s(i + 1 + 256))), " should be ", string(i), " at index ", string(i + 256)));
+  end
+end
+s2 = "";
+for i = 1:256
+  d = char(256 - i);
+  s2 = [s2 d];
+end
+s = [s2 s2];
+m2 = li_cdata_bytes_cpp.malloc(0x200);
+li_cdata_bytes_cpp.memmove(m2, s);
+if (li_cdata_bytes_cpp.verifyBytes(m2) < 0)
+  error("verifyBytes fail");
+end
+li_cdata_bytes_cpp.free(m2);

--- a/Examples/test-suite/octave/li_cdata_bytes_runme.m
+++ b/Examples/test-suite/octave/li_cdata_bytes_runme.m
@@ -1,0 +1,24 @@
+li_cdata_bytes
+
+m = li_cdata_bytes.predefStr();
+s = li_cdata_bytes.cdata(m, 0x200);
+for i = 0:255
+  if (double(s(i + 1)) != i)
+    error(strcat("Value ", string(double(s(i + 1))), " should be ", string(i), " at index ", string(i)));
+  end
+  if (double(s(i + 1 + 256)) != i)
+    error(strcat("Value ", string(double(s(i + 1 + 256))), " should be ", string(i), " at index ", string(i + 256)));
+  end
+end
+s2 = "";
+for i = 1:256
+  d = char(256 - i);
+  s2 = [s2 d];
+end
+s = [s2 s2];
+m2 = li_cdata_bytes.malloc(0x200);
+li_cdata_bytes.memmove(m2, s);
+if (li_cdata_bytes.verifyBytes(m2) < 0)
+  error("verifyBytes fail");
+end
+li_cdata_bytes.free(m2);

--- a/Examples/test-suite/perl5/li_cdata_bytes_cpp_runme.pl
+++ b/Examples/test-suite/perl5/li_cdata_bytes_cpp_runme.pl
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+
+sub test
+{
+  my $m = li_cdata_bytes_cpp::predefStr();
+  my $s = li_cdata_bytes_cpp::cdata($m, 0x200);
+  my $p = sprintf 'C[%d]', 0x200;
+  # convert binary string to octets array
+  my @v = unpack $p, $s;
+  my $emsg = '';
+  for (0..(0x100 - 1)) {
+    if ($v[$_] != $_) {
+      $emsg = "test value $_ at index $_";
+      last;
+    }
+    my $i = $_ + 0x100;
+    if ($v[$i] != $_) {
+      $emsg = "test value $_ at index $i";
+      last;
+    }
+  }
+  is($emsg, '', "Check values ($emsg)");
+  for (0..(0x100 - 1)) {
+    my $d = 0x100 - 1 - $_;
+    $v[$_] = $d;
+    $v[$_ + 0x100] = $d;
+  }
+  $s = pack $p, @v;
+  my $m2 = li_cdata_bytes_cpp::malloc(0x200);
+  li_cdata_bytes_cpp::memmove($m2, $s);
+  my $a = li_cdata_bytes_cpp::verifyBytes($m2);
+  is(li_cdata_bytes_cpp::verifyBytes($m2), 0, 'verifyBytes');
+  # Somehow the free() is too 'heavy' for macos
+  li_cdata_bytes_cpp::free($m2);
+}
+# The test work on macos, but seemed a bit heavy.
+# The test breaks occasionally, simply skip it.
+if ($^O ne 'darwin') {
+  eval <<"END_TXT";
+  use Test::More tests => 4;
+  require_ok('li_cdata_bytes_cpp');
+  BEGIN { use_ok('li_cdata_bytes_cpp') }
+  test;
+END_TXT
+}

--- a/Examples/test-suite/perl5/li_cdata_bytes_cpp_runme.pl
+++ b/Examples/test-suite/perl5/li_cdata_bytes_cpp_runme.pl
@@ -29,18 +29,12 @@ sub test
   $s = pack $p, @v;
   my $m2 = li_cdata_bytes_cpp::malloc(0x200);
   li_cdata_bytes_cpp::memmove($m2, $s);
-  my $a = li_cdata_bytes_cpp::verifyBytes($m2);
   is(li_cdata_bytes_cpp::verifyBytes($m2), 0, 'verifyBytes');
-  # Somehow the free() is too 'heavy' for macos
   li_cdata_bytes_cpp::free($m2);
 }
-# The test work on macos, but seemed a bit heavy.
-# The test breaks occasionally, simply skip it.
-if ($^O ne 'darwin') {
-  eval <<"END_TXT";
-  use Test::More tests => 4;
-  require_ok('li_cdata_bytes_cpp');
-  BEGIN { use_ok('li_cdata_bytes_cpp') }
-  test;
+eval <<"END_TXT";
+use Test::More tests => 4;
+require_ok('li_cdata_bytes_cpp');
+BEGIN { use_ok('li_cdata_bytes_cpp') }
+test;
 END_TXT
-}

--- a/Examples/test-suite/perl5/li_cdata_bytes_cpp_runme.pl
+++ b/Examples/test-suite/perl5/li_cdata_bytes_cpp_runme.pl
@@ -1,6 +1,10 @@
 use strict;
 use warnings;
 
+use Test::More tests => 4;
+require_ok('li_cdata_bytes_cpp');
+BEGIN { use_ok('li_cdata_bytes_cpp') }
+
 sub test
 {
   my $m = li_cdata_bytes_cpp::predefStr();
@@ -32,9 +36,4 @@ sub test
   is(li_cdata_bytes_cpp::verifyBytes($m2), 0, 'verifyBytes');
   li_cdata_bytes_cpp::free($m2);
 }
-eval <<"END_TXT";
-use Test::More tests => 4;
-require_ok('li_cdata_bytes_cpp');
-BEGIN { use_ok('li_cdata_bytes_cpp') }
 test;
-END_TXT

--- a/Examples/test-suite/perl5/li_cdata_bytes_runme.pl
+++ b/Examples/test-suite/perl5/li_cdata_bytes_runme.pl
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+
+sub test
+{
+  my $m = li_cdata_bytes::predefStr();
+  my $s = li_cdata_bytes::cdata($m, 0x200);
+  my $p = sprintf 'C[%d]', 0x200;
+  # convert binary string to octets array
+  my @v = unpack $p, $s;
+  my $emsg = '';
+  for (0..(0x100 - 1)) {
+    if ($v[$_] != $_) {
+      $emsg = "test value $_ at index $_";
+      last;
+    }
+    my $i = $_ + 0x100;
+    if ($v[$i] != $_) {
+      $emsg = "test value $_ at index $i";
+      last;
+    }
+  }
+  is($emsg, '', "Check values ($emsg)");
+  for (0..(0x100 - 1)) {
+    my $d = 0x100 - 1 - $_;
+    $v[$_] = $d;
+    $v[$_ + 0x100] = $d;
+  }
+  $s = pack $p, @v;
+  my $m2 = li_cdata_bytes::malloc(0x200);
+  li_cdata_bytes::memmove($m2, $s);
+  my $a = li_cdata_bytes::verifyBytes($m2);
+  is(li_cdata_bytes::verifyBytes($m2), 0, 'verifyBytes');
+  # Somehow the free() is too 'heavy' for macos
+  li_cdata_bytes::free($m2);
+}
+# The test work on macos, but seemed a bit heavy.
+# The test breaks occasionally, simply skip it.
+if ($^O ne 'darwin') {
+  eval <<"END_TXT";
+  use Test::More tests => 4;
+  require_ok('li_cdata_bytes');
+  BEGIN { use_ok('li_cdata_bytes') }
+  test;
+END_TXT
+}

--- a/Examples/test-suite/perl5/li_cdata_bytes_runme.pl
+++ b/Examples/test-suite/perl5/li_cdata_bytes_runme.pl
@@ -1,6 +1,10 @@
 use strict;
 use warnings;
 
+use Test::More tests => 4;
+require_ok('li_cdata_bytes');
+BEGIN { use_ok('li_cdata_bytes') }
+
 sub test
 {
   my $m = li_cdata_bytes::predefStr();
@@ -32,9 +36,4 @@ sub test
   is(li_cdata_bytes::verifyBytes($m2), 0, 'verifyBytes');
   li_cdata_bytes::free($m2);
 }
-eval <<"END_TXT";
-use Test::More tests => 4;
-require_ok('li_cdata_bytes');
-BEGIN { use_ok('li_cdata_bytes') }
 test;
-END_TXT

--- a/Examples/test-suite/perl5/li_cdata_bytes_runme.pl
+++ b/Examples/test-suite/perl5/li_cdata_bytes_runme.pl
@@ -29,18 +29,12 @@ sub test
   $s = pack $p, @v;
   my $m2 = li_cdata_bytes::malloc(0x200);
   li_cdata_bytes::memmove($m2, $s);
-  my $a = li_cdata_bytes::verifyBytes($m2);
   is(li_cdata_bytes::verifyBytes($m2), 0, 'verifyBytes');
-  # Somehow the free() is too 'heavy' for macos
   li_cdata_bytes::free($m2);
 }
-# The test work on macos, but seemed a bit heavy.
-# The test breaks occasionally, simply skip it.
-if ($^O ne 'darwin') {
-  eval <<"END_TXT";
-  use Test::More tests => 4;
-  require_ok('li_cdata_bytes');
-  BEGIN { use_ok('li_cdata_bytes') }
-  test;
+eval <<"END_TXT";
+use Test::More tests => 4;
+require_ok('li_cdata_bytes');
+BEGIN { use_ok('li_cdata_bytes') }
+test;
 END_TXT
-}

--- a/Examples/test-suite/php/li_cdata_bytes_cpp_runme.php
+++ b/Examples/test-suite/php/li_cdata_bytes_cpp_runme.php
@@ -1,0 +1,28 @@
+<?php
+
+require "tests.php";
+
+check::functions(array('predefStr', 'cdata', 'malloc', 'memmove', 'verifyBytes', 'free'));
+check::classes(array('li_cdata_bytes_cpp'));
+// No new vars
+check::globals(array());
+
+$m = predefStr();
+$s = cdata($m, 0x200);
+
+for($i = 0; $i < 0x100; ++$i) {
+  $v = ord($s[$i]);
+  check::equal($v, $i, "Value $v should be $i at index $i");
+  $i2 = $i + 0x100;
+  $v = ord($s[$i2]);
+  check::equal($v, $i, "Value $v should be $i at index $i2");
+}
+for($i = 0; $i < 0x100; ++$i) {
+  $d = chr(0x100 - 1 - $i);
+  $s[$i] = $d;
+  $s[$i + 0x100] = $d;
+}
+$m2 = malloc(0x200);
+memmove($m2, $s);
+check::equal(verifyBytes($m2), 0, "verifyBytes fail");
+free($m2);

--- a/Examples/test-suite/php/li_cdata_bytes_runme.php
+++ b/Examples/test-suite/php/li_cdata_bytes_runme.php
@@ -1,0 +1,28 @@
+<?php
+
+require "tests.php";
+
+check::functions(array('predefStr', 'cdata', 'malloc', 'memmove', 'verifyBytes', 'free'));
+check::classes(array('li_cdata_bytes'));
+// No new vars
+check::globals(array());
+
+$m = predefStr();
+$s = cdata($m, 0x200);
+
+for($i = 0; $i < 0x100; ++$i) {
+  $v = ord($s[$i]);
+  check::equal($v, $i, "Value $v should be $i at index $i");
+  $i2 = $i + 0x100;
+  $v = ord($s[$i2]);
+  check::equal($v, $i, "Value $v should be $i at index $i2");
+}
+for($i = 0; $i < 0x100; ++$i) {
+  $d = chr(0x100 - 1 - $i);
+  $s[$i] = $d;
+  $s[$i + 0x100] = $d;
+}
+$m2 = malloc(0x200);
+memmove($m2, $s);
+check::equal(verifyBytes($m2), 0, "verifyBytes fail");
+free($m2);

--- a/Examples/test-suite/python/li_cdata_bytes_cpp_runme.py
+++ b/Examples/test-suite/python/li_cdata_bytes_cpp_runme.py
@@ -1,0 +1,27 @@
+import sys
+import platform
+
+# The test work on macos, but seemed a bit heavy.
+# The test breaks occasionally, simply skip it.
+if sys.version_info[0] >= 3 and platform.system() != 'Darwin':
+  from li_cdata_bytes_cpp import *
+
+  m = predefStr()
+  s = cdata(m, 0x200)
+  for i in range(0x100):
+    if s[i] != i:
+      msg = "Value " + str(s[i]) + " should be " + str(i) + " at index " + str(i)
+      raise Exception(msg)
+    if s[i + 0x100] != i:
+      msg = "Value " + str(s[i + 0x100]) + " should be " + str(i) + " at index " + str(i + 0x100)
+      raise Exception(msg)
+  s2 = b''
+  for i in range(0x100):
+    d = 255 - i
+    s2 += bytes([d])
+  s = s2 + s2
+  m2 = malloc(0x200)
+  memmove(m2, s)
+  if verifyBytes(m2) < 0:
+    raise Exception("verifyBytes fail")
+  free(m2)

--- a/Examples/test-suite/python/li_cdata_bytes_cpp_runme.py
+++ b/Examples/test-suite/python/li_cdata_bytes_cpp_runme.py
@@ -1,27 +1,27 @@
 import sys
-import platform
 
-# The test work on macos, but seemed a bit heavy.
-# The test breaks occasionally, simply skip it.
-if sys.version_info[0] >= 3 and platform.system() != 'Darwin':
-  from li_cdata_bytes_cpp import *
+# cdata returns a bytes object; indexing it yields ints only on Python 3.
+if sys.version_info[0] < 3:
+  sys.exit(0)
 
-  m = predefStr()
-  s = cdata(m, 0x200)
-  for i in range(0x100):
-    if s[i] != i:
-      msg = "Value " + str(s[i]) + " should be " + str(i) + " at index " + str(i)
-      raise Exception(msg)
-    if s[i + 0x100] != i:
-      msg = "Value " + str(s[i + 0x100]) + " should be " + str(i) + " at index " + str(i + 0x100)
-      raise Exception(msg)
-  s2 = b''
-  for i in range(0x100):
-    d = 255 - i
-    s2 += bytes([d])
-  s = s2 + s2
-  m2 = malloc(0x200)
-  memmove(m2, s)
-  if verifyBytes(m2) < 0:
-    raise Exception("verifyBytes fail")
-  free(m2)
+from li_cdata_bytes_cpp import *
+
+m = predefStr()
+s = cdata(m, 0x200)
+for i in range(0x100):
+  if s[i] != i:
+    msg = "Value " + str(s[i]) + " should be " + str(i) + " at index " + str(i)
+    raise Exception(msg)
+  if s[i + 0x100] != i:
+    msg = "Value " + str(s[i + 0x100]) + " should be " + str(i) + " at index " + str(i + 0x100)
+    raise Exception(msg)
+s2 = b''
+for i in range(0x100):
+  d = 255 - i
+  s2 += bytes([d])
+s = s2 + s2
+m2 = malloc(0x200)
+memmove(m2, s)
+if verifyBytes(m2) < 0:
+  raise Exception("verifyBytes fail")
+free(m2)

--- a/Examples/test-suite/python/li_cdata_bytes_runme.py
+++ b/Examples/test-suite/python/li_cdata_bytes_runme.py
@@ -1,0 +1,27 @@
+import sys
+import platform
+
+# The test work on macos, but seemed a bit heavy.
+# The test breaks occasionally, simply skip it.
+if sys.version_info[0] >= 3 and platform.system() != 'Darwin':
+  from li_cdata_bytes import *
+
+  m = predefStr()
+  s = cdata(m, 0x200)
+  for i in range(0x100):
+    if s[i] != i:
+      msg = "Value " + str(s[i]) + " should be " + str(i) + " at index " + str(i)
+      raise Exception(msg)
+    if s[i + 0x100] != i:
+      msg = "Value " + str(s[i + 0x100]) + " should be " + str(i) + " at index " + str(i + 0x100)
+      raise Exception(msg)
+  s2 = b''
+  for i in range(0x100):
+    d = 255 - i
+    s2 += bytes([d])
+  s = s2 + s2
+  m2 = malloc(0x200)
+  memmove(m2, s)
+  if verifyBytes(m2) < 0:
+    raise Exception("verifyBytes fail")
+  free(m2)

--- a/Examples/test-suite/python/li_cdata_bytes_runme.py
+++ b/Examples/test-suite/python/li_cdata_bytes_runme.py
@@ -1,27 +1,27 @@
 import sys
-import platform
 
-# The test work on macos, but seemed a bit heavy.
-# The test breaks occasionally, simply skip it.
-if sys.version_info[0] >= 3 and platform.system() != 'Darwin':
-  from li_cdata_bytes import *
+# cdata returns a bytes object; indexing it yields ints only on Python 3.
+if sys.version_info[0] < 3:
+  sys.exit(0)
 
-  m = predefStr()
-  s = cdata(m, 0x200)
-  for i in range(0x100):
-    if s[i] != i:
-      msg = "Value " + str(s[i]) + " should be " + str(i) + " at index " + str(i)
-      raise Exception(msg)
-    if s[i + 0x100] != i:
-      msg = "Value " + str(s[i + 0x100]) + " should be " + str(i) + " at index " + str(i + 0x100)
-      raise Exception(msg)
-  s2 = b''
-  for i in range(0x100):
-    d = 255 - i
-    s2 += bytes([d])
-  s = s2 + s2
-  m2 = malloc(0x200)
-  memmove(m2, s)
-  if verifyBytes(m2) < 0:
-    raise Exception("verifyBytes fail")
-  free(m2)
+from li_cdata_bytes import *
+
+m = predefStr()
+s = cdata(m, 0x200)
+for i in range(0x100):
+  if s[i] != i:
+    msg = "Value " + str(s[i]) + " should be " + str(i) + " at index " + str(i)
+    raise Exception(msg)
+  if s[i + 0x100] != i:
+    msg = "Value " + str(s[i + 0x100]) + " should be " + str(i) + " at index " + str(i + 0x100)
+    raise Exception(msg)
+s2 = b''
+for i in range(0x100):
+  d = 255 - i
+  s2 += bytes([d])
+s = s2 + s2
+m2 = malloc(0x200)
+memmove(m2, s)
+if verifyBytes(m2) < 0:
+  raise Exception("verifyBytes fail")
+free(m2)

--- a/Examples/test-suite/python/li_cdata_cpp_runme.py
+++ b/Examples/test-suite/python/li_cdata_cpp_runme.py
@@ -1,9 +1,9 @@
 
 from li_cdata_cpp import *
 
-s = "ABC\x00abc"
+s = b"ABC\x00abc"
 m = malloc(256)
 memmove(m, s)
 ss = cdata(m, 7)
-if ss != "ABC\x00abc":
+if ss != b"ABC\x00abc":
     raise "failed"

--- a/Examples/test-suite/python/li_cdata_runme.py
+++ b/Examples/test-suite/python/li_cdata_runme.py
@@ -1,9 +1,9 @@
 
 from li_cdata import *
 
-s = "ABC\x00abc"
+s = b"ABC\x00abc"
 m = malloc(256)
 memmove(m, s)
 ss = cdata(m, 7)
-if ss != "ABC\x00abc":
+if ss != b"ABC\x00abc":
     raise "failed"

--- a/Examples/test-suite/ruby/li_cdata_bytes_cpp_runme.rb
+++ b/Examples/test-suite/ruby/li_cdata_bytes_cpp_runme.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+#
+# Put description here
+#
+
+require 'swig_assert'
+require 'li_cdata_bytes_cpp'
+
+include Li_cdata_bytes_cpp
+
+def test
+  m = predefStr()
+  s = cdata(m, 512)
+  for i in (0..255) do
+    swig_assert(s[i].ord == i, binding, "Value #{ s[i].ord } should be #{ i } at index #{ i }")
+    i2 = i + 256
+    swig_assert(s[i2].ord == i, binding, "Value #{ s[i2].ord } should be #{ i } at index #{ i2 }")
+  end
+  for i in (0..255) do
+    d = (255 - i).chr
+    s[i] = d
+    s[i + 256] = d
+  end
+  m2 = malloc(512)
+  memmove(m2, s)
+  swig_assert(verifyBytes(m2) == 0, binding, "verifyBytes fail")
+  free(m2)
+end
+
+# The test work on macos, but seemed a bit heavy.
+# The test breaks occasionally, simply skip it.
+test unless /darwin/ =~ RUBY_PLATFORM and RUBY_VERSION[0..2] == "3.2"

--- a/Examples/test-suite/ruby/li_cdata_bytes_cpp_runme.rb
+++ b/Examples/test-suite/ruby/li_cdata_bytes_cpp_runme.rb
@@ -27,6 +27,4 @@ def test
   free(m2)
 end
 
-# The test work on macos, but seemed a bit heavy.
-# The test breaks occasionally, simply skip it.
-test unless /darwin/ =~ RUBY_PLATFORM and RUBY_VERSION[0..2] == "3.2"
+test

--- a/Examples/test-suite/ruby/li_cdata_bytes_runme.rb
+++ b/Examples/test-suite/ruby/li_cdata_bytes_runme.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+#
+# Put description here
+#
+
+require 'swig_assert'
+require 'li_cdata_bytes'
+
+include Li_cdata_bytes
+
+def test
+  m = predefStr()
+  s = cdata(m, 512)
+  for i in (0..255) do
+    swig_assert(s[i].ord == i, binding, "Value #{ s[i].ord } should be #{ i } at index #{ i }")
+    i2 = i + 256
+    swig_assert(s[i2].ord == i, binding, "Value #{ s[i2].ord } should be #{ i } at index #{ i2 }")
+  end
+  for i in (0..255) do
+    d = (255 - i).chr
+    s[i] = d
+    s[i + 256] = d
+  end
+  m2 = malloc(512)
+  memmove(m2, s)
+  swig_assert(verifyBytes(m2) == 0, binding, "verifyBytes fail")
+  free(m2)
+end
+
+# The test work on macos, but seemed a bit heavy.
+# The test breaks occasionally, simply skip it.
+test unless /darwin/ =~ RUBY_PLATFORM and RUBY_VERSION[0..2] == "3.2"

--- a/Examples/test-suite/ruby/li_cdata_bytes_runme.rb
+++ b/Examples/test-suite/ruby/li_cdata_bytes_runme.rb
@@ -27,6 +27,4 @@ def test
   free(m2)
 end
 
-# The test work on macos, but seemed a bit heavy.
-# The test breaks occasionally, simply skip it.
-test unless /darwin/ =~ RUBY_PLATFORM and RUBY_VERSION[0..2] == "3.2"
+test

--- a/Examples/test-suite/schemerunme/li_cdata_bytes.scm
+++ b/Examples/test-suite/schemerunme/li_cdata_bytes.scm
@@ -1,0 +1,41 @@
+;; Fetch predefined vector
+(define m (predefStr))
+;; Convert it to binary string
+(define s (cdata m  512))
+;; Temporary varibale
+(define val 0)
+(define i2 0)
+(define c 'a)
+
+;; Verify binary string content is correct
+(map (lambda (i)
+  (set! c (string-ref s i))
+  (set! val (char->integer c))
+  (if (not (= val i))
+      (error (format #f "Wrong value ~A for index ~A ~%" val i)))
+  (set! i2 (+ i 256))
+  (set! c (string-ref s i2))
+  (set! val (char->integer c))
+  (if (not (= val i))
+      (error (format #f "Wrong value ~A for index ~A ~%" val i2))))
+  (iota 256))
+
+;; Set binary string content for verifying
+(map (lambda (i)
+  (set! val (- 256 (+ 1 i)))
+  (set! c (integer->char val))
+  (string-set! s i c)
+  (set! i2 (+ i 256))
+  (string-set! s i2 c))
+   (iota 256))
+
+;; Copy binary string into another C buffer
+(define m2 (malloc 512))
+(memmove m2 s)
+;; Verfy the other C buffer have the proper content
+(if (< (verifyBytes m2) 0)
+    (error "failed verifyBytes"))
+;; Release the other buffer
+(free m2)
+
+(exit 0)

--- a/Examples/test-suite/schemerunme/li_cdata_bytes.scm
+++ b/Examples/test-suite/schemerunme/li_cdata_bytes.scm
@@ -2,7 +2,7 @@
 (define m (predefStr))
 ;; Convert it to binary string
 (define s (cdata m  512))
-;; Temporary varibale
+;; Temporary variable
 (define val 0)
 (define i2 0)
 (define c 'a)
@@ -32,7 +32,7 @@
 ;; Copy binary string into another C buffer
 (define m2 (malloc 512))
 (memmove m2 s)
-;; Verfy the other C buffer have the proper content
+;; Verify the other C buffer has the proper content
 (if (< (verifyBytes m2) 0)
     (error "failed verifyBytes"))
 ;; Release the other buffer

--- a/Examples/test-suite/schemerunme/li_cdata_bytes_cpp.scm
+++ b/Examples/test-suite/schemerunme/li_cdata_bytes_cpp.scm
@@ -1,0 +1,41 @@
+;; Fetch predefined vector
+(define m (predefStr))
+;; Convert it to binary string
+(define s (cdata m  512))
+;; Temporary varibale
+(define val 0)
+(define i2 0)
+(define c 'a)
+
+;; Verify binary string content is correct
+(map (lambda (i)
+  (set! c (string-ref s i))
+  (set! val (char->integer c))
+  (if (not (= val i))
+      (error (format #f "Wrong value ~A for index ~A ~%" val i)))
+  (set! i2 (+ i 256))
+  (set! c (string-ref s i2))
+  (set! val (char->integer c))
+  (if (not (= val i))
+      (error (format #f "Wrong value ~A for index ~A ~%" val i2))))
+  (iota 256))
+
+;; Set binary string content for verifying
+(map (lambda (i)
+  (set! val (- 256 (+ 1 i)))
+  (set! c (integer->char val))
+  (string-set! s i c)
+  (set! i2 (+ i 256))
+  (string-set! s i2 c))
+   (iota 256))
+
+;; Copy binary string into another C buffer
+(define m2 (malloc 512))
+(memmove m2 s)
+;; Verfy the other C buffer have the proper content
+(if (< (verifyBytes m2) 0)
+    (error "failed verifyBytes"))
+;; Release the other buffer
+(free m2)
+
+(exit 0)

--- a/Examples/test-suite/schemerunme/li_cdata_bytes_cpp.scm
+++ b/Examples/test-suite/schemerunme/li_cdata_bytes_cpp.scm
@@ -2,7 +2,7 @@
 (define m (predefStr))
 ;; Convert it to binary string
 (define s (cdata m  512))
-;; Temporary varibale
+;; Temporary variable
 (define val 0)
 (define i2 0)
 (define c 'a)
@@ -32,7 +32,7 @@
 ;; Copy binary string into another C buffer
 (define m2 (malloc 512))
 (memmove m2 s)
-;; Verfy the other C buffer have the proper content
+;; Verify the other C buffer has the proper content
 (if (< (verifyBytes m2) 0)
     (error "failed verifyBytes"))
 ;; Release the other buffer

--- a/Examples/test-suite/scilab/li_cdata_bytes_cpp_runme.sci
+++ b/Examples/test-suite/scilab/li_cdata_bytes_cpp_runme.sci
@@ -1,0 +1,25 @@
+exec("swigtest.start", -1);
+
+m = predefStr();
+s = cdata(m, 512);
+for i = 0:255
+  if s(i + 1) <> i then
+    swigtesterror("Value " + string(s(i + 1)) + " should be " + string(i) + " at index " + string(i));
+  end
+  if s(i + 1 + 256) <> i then
+    swigtesterror("Value " + string(s(i + 1 + 256)) + " should be " + string(i) + " at index " + string(i + 256));
+  end
+end
+for i = 1:256
+  d = 256 - i
+  s(i) = d;
+  s(i + 256) = d;
+end
+m2 = malloc(512);
+memmove(m2, s);
+if verifyBytes(m2) < 0 then
+  swigtesterror("verifyBytes fail");
+end
+free(m2);
+
+exec("swigtest.quit", -1);

--- a/Examples/test-suite/scilab/li_cdata_bytes_runme.sci
+++ b/Examples/test-suite/scilab/li_cdata_bytes_runme.sci
@@ -1,0 +1,25 @@
+exec("swigtest.start", -1);
+
+m = predefStr();
+s = cdata(m, 512);
+for i = 0:255
+  if s(i + 1) <> i then
+    swigtesterror("Value " + string(s(i + 1)) + " should be " + string(i) + " at index " + string(i));
+  end
+  if s(i + 1 + 256) <> i then
+    swigtesterror("Value " + string(s(i + 1 + 256)) + " should be " + string(i) + " at index " + string(i + 256));
+  end
+end
+for i = 1:256
+  d = 256 - i
+  s(i) = d;
+  s(i + 256) = d;
+end
+m2 = malloc(512);
+memmove(m2, s);
+if verifyBytes(m2) < 0 then
+  swigtesterror("verifyBytes fail");
+end
+free(m2);
+
+exec("swigtest.quit", -1);

--- a/Examples/test-suite/scilab/li_cdata_cpp_runme.sci
+++ b/Examples/test-suite/scilab/li_cdata_cpp_runme.sci
@@ -1,11 +1,21 @@
 exec("swigtest.start", -1);
 
-// Strings in Scilab can not contain null character same as C
-s = "ABC abc";
+// Typed list of ascii codes of "ABC\0abc"
+s = list(65, 66, 67, 32, 97, 98, 99);
 m = malloc(256);
 memmove(m, s);
 ss = cdata(m, 7);
-if ss <> "ABC abc" then
+a = ascii(ss(1)) + ascii(ss(2)) + ascii(ss(3)) + ascii(ss(4)) + ascii(ss(5)) + ascii(ss(6)) + ascii(ss(7));
+if a <> "ABC abc" then
+  swigtesterror("failed");
+end
+
+// Same list using uint8 values
+s = list(uint8(65), uint8(66), uint8(67), uint8(32), uint8(97), uint8(98), uint8(99));
+memmove(m, s);
+ss = cdata(m, 7);
+a = ascii(ss(1)) + ascii(ss(2)) + ascii(ss(3)) + ascii(ss(4)) + ascii(ss(5)) + ascii(ss(6)) + ascii(ss(7));
+if a <> "ABC abc" then
   swigtesterror("failed");
 end
 

--- a/Examples/test-suite/scilab/li_cdata_runme.sci
+++ b/Examples/test-suite/scilab/li_cdata_runme.sci
@@ -1,11 +1,21 @@
 exec("swigtest.start", -1);
 
-// Strings in Scilab can not contain null character same as C
-s = "ABC abc";
+// Typed list of ascii codes of "ABC\0abc"
+s = list(65, 66, 67, 32, 97, 98, 99);
 m = malloc(256);
 memmove(m, s);
 ss = cdata(m, 7);
-if ss <> "ABC abc" then
+a = ascii(ss(1)) + ascii(ss(2)) + ascii(ss(3)) + ascii(ss(4)) + ascii(ss(5)) + ascii(ss(6)) + ascii(ss(7));
+if a <> "ABC abc" then
+  swigtesterror("failed");
+end
+
+// Same list using uint8 values
+s = list(uint8(65), uint8(66), uint8(67), uint8(32), uint8(97), uint8(98), uint8(99));
+memmove(m, s);
+ss = cdata(m, 7);
+a = ascii(ss(1)) + ascii(ss(2)) + ascii(ss(3)) + ascii(ss(4)) + ascii(ss(5)) + ascii(ss(6)) + ascii(ss(7));
+if a <> "ABC abc" then
   swigtesterror("failed");
 end
 

--- a/Examples/test-suite/tcl/li_cdata_bytes_cpp_runme.tcl
+++ b/Examples/test-suite/tcl/li_cdata_bytes_cpp_runme.tcl
@@ -1,0 +1,33 @@
+
+if [ catch { load ./li_cdata_bytes_cpp[info sharedlibextension] Li_cdata_bytes_cpp} err_msg ] {
+	puts stderr "Could not load shared object:\n$err_msg"
+}
+
+set m [predefStr]
+set s [cdata $m 512]
+for { set i 0 } { $i < 256 } { incr i } {
+  set v [lindex $s $i]
+  if { $i != $v } {
+    puts stderr "Value $v should be $i at index $i"
+    exit 1
+  }
+  set i2 [expr $i + 256]
+  set v2 [lindex $s $i2]
+  if { $i != $v2 } {
+    puts stderr "Value $v2 should be $i at index $i2"
+    exit 1
+  }
+}
+for { set i 0 } { $i < 256 } { incr i } {
+  set v [expr 255 - $i]
+  set i2 [expr $i + 256]
+  lset s $i $v
+  lset s $i2 $v
+}
+set m2 [malloc 512]
+memmove $m2 $s
+if { [verifyBytes $m2] < 0 } {
+  puts stderr "verifyBytes fail"
+  exit 1
+}
+free $m2

--- a/Examples/test-suite/tcl/li_cdata_bytes_runme.tcl
+++ b/Examples/test-suite/tcl/li_cdata_bytes_runme.tcl
@@ -1,0 +1,33 @@
+
+if [ catch { load ./li_cdata_bytes[info sharedlibextension] Li_cdata_bytes} err_msg ] {
+	puts stderr "Could not load shared object:\n$err_msg"
+}
+
+set m [predefStr]
+set s [cdata $m 512]
+for { set i 0 } { $i < 256 } { incr i } {
+  set v [lindex $s $i]
+  if { $i != $v } {
+    puts stderr "Value $v should be $i at index $i"
+    exit 1
+  }
+  set i2 [expr $i + 256]
+  set v2 [lindex $s $i2]
+  if { $i != $v2 } {
+    puts stderr "Value $v2 should be $i at index $i2"
+    exit 1
+  }
+}
+for { set i 0 } { $i < 256 } { incr i } {
+  set v [expr 255 - $i]
+  set i2 [expr $i + 256]
+  lset s $i $v
+  lset s $i2 $v
+}
+set m2 [malloc 512]
+memmove $m2 $s
+if { [verifyBytes $m2] < 0 } {
+  puts stderr "verifyBytes fail"
+  exit 1
+}
+free $m2

--- a/Examples/test-suite/tcl/li_cdata_cpp_runme.tcl
+++ b/Examples/test-suite/tcl/li_cdata_cpp_runme.tcl
@@ -3,12 +3,17 @@ if [ catch { load ./li_cdata_cpp[info sharedlibextension] Li_cdata_cpp} err_msg 
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 
-# The universal character Escape Sequence is 2 bytes
-set s "ABC\u0000bc"
+# Ascii codes of "ABC\0abc"
+set s { 65 66 67 0 97 98 99 }
 set m [ malloc 256 ]
 memmove $m $s
 set ss [ cdata $m 7 ]
-if {$ss != "ABC\u0000bc"} {
+# Convert list of integers to string
+set a ""
+foreach i $ss {
+    append a "[format %c $i]"
+}
+if {$a != "ABC\u0000abc"} {
     puts stderr "failed"
     exit 1
 }

--- a/Examples/test-suite/tcl/li_cdata_runme.tcl
+++ b/Examples/test-suite/tcl/li_cdata_runme.tcl
@@ -3,12 +3,17 @@ if [ catch { load ./li_cdata[info sharedlibextension] Li_cdata} err_msg ] {
 	puts stderr "Could not load shared object:\n$err_msg"
 }
 
-# The universal character Escape Sequence is 2 bytes
-set s "ABC\u0000bc"
+# Ascii codes of "ABC\0abc"
+set s { 65 66 67 0 97 98 99 }
 set m [ malloc 256 ]
 memmove $m $s
 set ss [ cdata $m 7 ]
-if {$ss != "ABC\u0000bc"} {
+# Convert list of integers to string
+set a ""
+foreach i $ss {
+    append a "[format %c $i]"
+}
+if {$a != "ABC\u0000abc"} {
     puts stderr "failed"
     exit 1
 }

--- a/Lib/cdata.i
+++ b/Lib/cdata.i
@@ -4,7 +4,7 @@
  * SWIG library file containing macros for manipulating raw C data.
  * ----------------------------------------------------------------------------- */
 
-%typemap(in,noblock=0,fragment="SWIG_AsCharPtrAndSize") (const void *BYTES, size_t LENGTH) (int res, void *buf = 0, size_t len = 0, int alloc = 0) {
+%typemap(in,noblock=0,fragment="SWIG_AsCharPtrAndSize") (const void *BYTES, size_t LENGTH) (int res, void *buf = 0, size_t len = 0, int alloc = SWIG_BINSTR) {
   res = SWIG_AsCharPtrAndSize($input, (char **)&buf, &len, &alloc);
   if (!SWIG_IsOK(res)) {
     %argument_fail(res,"$type",$symname, $argnum);
@@ -21,9 +21,9 @@
 
 %typemap(directorin,noblock=1,fragment="SWIG_FromCharPtrAndSize") (const void *BYTES, size_t LENGTH) {
   if ($1 && $2 > 0) {
-    $input = SWIG_FromCharPtrAndSize((const char*)$1, (size_t)$2);
+    $input = SWIG_FromBinCharPtrAndSize((const char*)$1, (size_t)$2, SWIG_BINSTR);
   } else {
-    $input = SWIG_FromCharPtrAndSize("", 0);
+    $input = SWIG_FromBinCharPtrAndSize("", 0, SWIG_BINSTR);
   }
 }
 
@@ -44,7 +44,7 @@
 %include <typemaps/cdata_begin.swg>
 
 %typemap(out,noblock=1,fragment="SWIG_FromCharPtrAndSize") SWIGCDATA {
-  %set_output(SWIG_FromCharPtrAndSize($1.data,(size_t)($1.len)));
+  %set_output(SWIG_FromBinCharPtrAndSize($1.data,(size_t)($1.len), SWIG_BINSTR));
 }
 
 %include <typemaps/cdata_end.swg>

--- a/Lib/cdata.i
+++ b/Lib/cdata.i
@@ -4,6 +4,8 @@
  * SWIG library file containing macros for manipulating raw C data.
  * ----------------------------------------------------------------------------- */
 
+/* 'alloc' is seeded with 'SWIG_BINARYSTR' so 'SWIG_AsCharPtrAndSize' treats the input as
+   raw bytes (no Unicode translation, exact length); it overwrites 'alloc' on return. */
 %typemap(in,noblock=0,fragment="SWIG_AsCharPtrAndSize") (const void *BYTES, size_t LENGTH) (int res, void *buf = 0, size_t len = 0, int alloc = SWIG_BINARYSTR) {
   res = SWIG_AsCharPtrAndSize($input, (char **)&buf, &len, &alloc);
   if (!SWIG_IsOK(res)) {

--- a/Lib/cdata.i
+++ b/Lib/cdata.i
@@ -4,7 +4,7 @@
  * SWIG library file containing macros for manipulating raw C data.
  * ----------------------------------------------------------------------------- */
 
-%typemap(in,noblock=0,fragment="SWIG_AsCharPtrAndSize") (const void *BYTES, size_t LENGTH) (int res, void *buf = 0, size_t len = 0, int alloc = SWIG_BINSTR) {
+%typemap(in,noblock=0,fragment="SWIG_AsCharPtrAndSize") (const void *BYTES, size_t LENGTH) (int res, void *buf = 0, size_t len = 0, int alloc = SWIG_BINARYSTR) {
   res = SWIG_AsCharPtrAndSize($input, (char **)&buf, &len, &alloc);
   if (!SWIG_IsOK(res)) {
     %argument_fail(res,"$type",$symname, $argnum);
@@ -21,9 +21,9 @@
 
 %typemap(directorin,noblock=1,fragment="SWIG_FromCharPtrAndSize") (const void *BYTES, size_t LENGTH) {
   if ($1 && $2 > 0) {
-    $input = SWIG_FromBinCharPtrAndSize((const char*)$1, (size_t)$2, SWIG_BINSTR);
+    $input = SWIG_FromBinaryCharPtrAndSize((const char*)$1, (size_t)$2, SWIG_BINARYSTR);
   } else {
-    $input = SWIG_FromBinCharPtrAndSize("", 0, SWIG_BINSTR);
+    $input = SWIG_FromBinaryCharPtrAndSize("", 0, SWIG_BINARYSTR);
   }
 }
 
@@ -44,7 +44,7 @@
 %include <typemaps/cdata_begin.swg>
 
 %typemap(out,noblock=1,fragment="SWIG_FromCharPtrAndSize") SWIGCDATA {
-  %set_output(SWIG_FromBinCharPtrAndSize($1.data,(size_t)($1.len), SWIG_BINSTR));
+  %set_output(SWIG_FromBinaryCharPtrAndSize($1.data,(size_t)($1.len), SWIG_BINARYSTR));
 }
 
 %include <typemaps/cdata_end.swg>

--- a/Lib/guile/cdata.i
+++ b/Lib/guile/cdata.i
@@ -10,7 +10,7 @@
 
 %typemap(in) (const void *BYTES, size_t LENGTH) {
   size_t temp;
-  $1 = ($1_ltype) SWIG_Guile_scm2newstr($input, &temp);
+  $1 = ($1_ltype) scm_to_stringn($input, &temp,"latin1",SCM_FAILED_CONVERSION_ESCAPE_SEQUENCE);
   $2 = ($2_ltype) temp;
 }
 %apply (const void *BYTES, size_t LENGTH) { (void *BYTES, size_t LENGTH) }
@@ -18,7 +18,7 @@
 %include <typemaps/cdata_begin.swg>
 
 %typemap(out) SWIGCDATA {
-  $result = scm_from_locale_stringn($1.data,$1.len);
+  $result = scm_from_stringn($1.data,$1.len,"latin1",SCM_FAILED_CONVERSION_ESCAPE_SEQUENCE);
 }
 
 %include <typemaps/cdata_end.swg>

--- a/Lib/javascript/cdata.i
+++ b/Lib/javascript/cdata.i
@@ -1,0 +1,38 @@
+/* -----------------------------------------------------------------------------
+ * cdata.i
+ *
+ * SWIG library file containing macros for manipulating raw C data.
+ * ----------------------------------------------------------------------------- */
+
+%include <javascriptuint8array.swg>
+
+%typemap(in,noblock=0,fragment="SWIG_FromUint8Array") (const void *BYTES, size_t LENGTH) (void *buf = 0, int alloc = 0) {
+  size_t len;
+  int res = SWIG_FromUint8Array($input, &buf, &len, &alloc);
+  if (!SWIG_IsOK(res)) {
+    %argument_fail(res,"$type",$symname, $argnum);
+  }
+  $1 = %reinterpret_cast(buf, $1_ltype);
+  $2 = %numeric_cast(len, $2_ltype);
+}
+
+/* buffer is allocated with 'unsigned char' type! */
+%typemap(freearg,noblock=1,match="in") (const void *BYTES, size_t LENGTH) {
+  if (alloc$argnum == SWIG_NEWOBJ) {
+    %delete_array((%reinterpret_cast(buf$argnum, unsigned char *)));
+  }
+}
+
+%typemap(directorin,noblock=1,fragment="SWIG_ToUint8Array") (const void *BYTES, size_t LENGTH) {
+  $input = SWIG_ToUint8Array($1, $2);
+}
+
+%apply (const void *BYTES, size_t LENGTH) { (void *BYTES, size_t LENGTH) }
+
+%include <typemaps/cdata_begin.swg>
+
+%typemap(out,noblock=1,fragment="SWIG_ToUint8Array") SWIGCDATA {
+  %set_output(SWIG_ToUint8Array($1.data, $1.len));
+}
+
+%include <typemaps/cdata_end.swg>

--- a/Lib/javascript/jsc/cdata.i
+++ b/Lib/javascript/jsc/cdata.i
@@ -1,0 +1,1 @@
+%include <javascript/cdata.i>

--- a/Lib/javascript/jsc/javascriptuint8array.swg
+++ b/Lib/javascript/jsc/javascriptuint8array.swg
@@ -1,0 +1,55 @@
+
+/* ------------------------------------------------------------
+ *  utility methods for Uint8Array
+ * ------------------------------------------------------------ */
+
+%fragment("SWIG_FromUint8Array", "header") {
+#define SWIG_FromUint8Array(valRef, cptr, psize, alloc) SWIG_ContextFromUint8Array(context, valRef, cptr, psize, alloc)
+SWIGINTERN int
+SWIG_ContextFromUint8Array(JSContextRef context, JSValueRef valRef, void** cptr, size_t* psize, int *alloc)
+{
+  if (alloc == NULL || psize == NULL || cptr == NULL)
+    return SWIG_TypeError;
+  *alloc = 0;
+  *cptr = NULL;
+  *psize = 0;
+  if (JSValueGetTypedArrayType(context, valRef, NULL) == kJSTypedArrayTypeUint8Array) {
+    JSObjectRef arr = JSValueToObject(context, valRef, NULL);
+    size_t len = (size_t)SWIGJSC_ArrayLength(context, arr);
+    if (len > 0) {
+      size_t i;
+      unsigned char *cbuf = %new_array(len, unsigned char);
+      if (cbuf == NULL) {
+        return SWIG_TypeError;
+      }
+      *alloc = SWIG_NEWOBJ;
+      *cptr = (void*)cbuf;
+      *psize = len;
+      for (i = 0; i < len; i++) {
+        JSValueRef val = JSObjectGetPropertyAtIndex(context, arr, i, NULL);
+        cbuf[i] = (unsigned char)JSValueToNumber(context, val, NULL);
+      }
+    }
+    return SWIG_OK;
+  }
+  return JSValueIsNull(context, valRef) || JSValueIsUndefined(context, valRef) ? SWIG_OK : SWIG_TypeError;
+}
+}
+
+%fragment("SWIG_ToUint8Array", "header") {
+#define SWIG_ToUint8Array(buf, len) SWIG_ContextToUint8Array(context, buf, len)
+SWIGINTERN JSValueRef SWIG_ContextToUint8Array(JSContextRef context, void* buf, size_t len)
+{
+  if (buf != NULL && len > 0) {
+    size_t i;
+    unsigned char* cbuf = (unsigned char*)buf;
+    JSObjectRef arr = JSObjectMakeTypedArray(context, kJSTypedArrayTypeUint8Array, len, NULL);
+    for (i = 0; i < len; i++) {
+      JSValueRef val = JSValueMakeNumber(context, cbuf[i]);
+      JSObjectSetPropertyAtIndex(context, arr, i, val, NULL);
+    }
+    return arr;
+  }
+  return JSValueMakeUndefined(context);
+}
+}

--- a/Lib/javascript/napi/cdata.i
+++ b/Lib/javascript/napi/cdata.i
@@ -1,0 +1,1 @@
+%include <javascript/cdata.i>

--- a/Lib/javascript/napi/javascriptuint8array.swg
+++ b/Lib/javascript/napi/javascriptuint8array.swg
@@ -1,0 +1,58 @@
+
+/* ------------------------------------------------------------
+ *  utility methods for Uint8Array
+ * ------------------------------------------------------------ */
+
+%fragment("SWIG_FromUint8Array", "header") {
+SWIGINTERN int
+SWIG_FromUint8Array(Napi::Value valRef, void** cptr, size_t* psize, int *alloc)
+{
+  if (alloc == NULL || psize == NULL || cptr == NULL)
+    return SWIG_TypeError;
+  *alloc = 0;
+  *cptr = NULL;
+  *psize = 0;
+  if (valRef.IsTypedArray()) {
+    Napi::Number num;
+    size_t len = 0;
+    Napi::TypedArray arr = valRef.As<Napi::TypedArray>();
+    if (arr.TypedArrayType() != napi_uint8_array) {
+      return SWIG_TypeError;
+    }
+    len = arr.ElementLength();
+    if (len > 0) {
+      size_t i;
+      unsigned char *cbuf = %new_array(len, unsigned char);
+      if (cbuf == NULL) {
+        return SWIG_TypeError;
+      }
+      *alloc = SWIG_NEWOBJ;
+      *cptr = (void*)cbuf;
+      *psize = len;
+      for (i = 0; i < len; i++) {
+        NAPI_CHECK_RESULT(arr.Get(i).ToNumber(), num);
+        cbuf[i] = (unsigned char)num.Uint32Value();
+      }
+    }
+    return SWIG_OK;
+  }
+  return valRef.IsNull() || valRef.IsUndefined() ? SWIG_OK : SWIG_TypeError;
+}
+}
+
+%fragment("SWIG_ToUint8Array", "header") {
+#define SWIG_ToUint8Array(buf, len) SWIG_EnvToUint8Array(env, buf, len)
+SWIGINTERN Napi::Value SWIG_EnvToUint8Array(Napi::Env env, void* buf, size_t len)
+{
+  if (buf != NULL && len > 0) {
+    size_t i;
+    unsigned char* cbuf = (unsigned char*)buf;
+    Napi::Uint8Array arr = Napi::Uint8Array::New(env, len);
+    for (i = 0; i < len; i++) {
+      arr.Set(i, cbuf[i]);
+    }
+    return arr;
+  }
+  return env.Undefined();
+}
+}

--- a/Lib/javascript/v8/cdata.i
+++ b/Lib/javascript/v8/cdata.i
@@ -1,0 +1,1 @@
+%include <javascript/cdata.i>

--- a/Lib/javascript/v8/javascriptuint8array.swg
+++ b/Lib/javascript/v8/javascriptuint8array.swg
@@ -1,0 +1,56 @@
+
+/* ------------------------------------------------------------
+ *  utility methods for Uint8Array
+ * ------------------------------------------------------------ */
+
+#define SWIGV8_UINT8ARRAY v8::Local<v8::Uint8Array>
+
+%fragment("SWIG_FromUint8Array", "header") {
+SWIGINTERN int
+SWIG_FromUint8Array(SWIGV8_VALUE valRef, void** cptr, size_t* psize, int *alloc)
+{
+  if (alloc == NULL || psize == NULL || cptr == NULL)
+    return SWIG_TypeError;
+  *alloc = 0;
+  *cptr = NULL;
+  *psize = 0;
+  if (valRef->IsUint8Array()) {
+    SWIGV8_UINT8ARRAY arr = SWIGV8_UINT8ARRAY::Cast(valRef);
+    size_t len = (size_t)arr->Length();
+    if (len > 0) {
+      size_t i;
+      unsigned char *cbuf = %new_array(len, unsigned char);
+      if (cbuf == NULL) {
+        return SWIG_TypeError;
+      }
+      *alloc = SWIG_NEWOBJ;
+      *cptr = (void*)cbuf;
+      *psize = len;
+      for (i = 0; i < len; i++) {
+        SWIGV8_VALUE val = SWIGV8_ARRAY_GET(arr, i);
+        cbuf[i] = (unsigned char)SWIGV8_NUMBER_VALUE(val);
+      }
+    }
+    return SWIG_OK;
+  }
+  return valRef->IsNull() || valRef->IsUndefined() ? SWIG_OK : SWIG_TypeError;
+}
+}
+
+%fragment("SWIG_ToUint8Array", "header") {
+SWIGINTERN SWIGV8_VALUE SWIG_ToUint8Array(void* buf, size_t len)
+{
+  if (buf != NULL && len > 0) {
+    size_t i;
+    unsigned char* cbuf = (unsigned char*)buf;
+    v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), len);
+    SWIGV8_UINT8ARRAY arr = v8::Uint8Array::New(ab, 0, len);
+    for (i = 0; i < len; i++) {
+      SWIGV8_VALUE val = SWIGV8_INTEGER_NEW_UNS(cbuf[i]);
+      SWIGV8_ARRAY_SET(arr, i, val);
+    }
+    return arr;
+  }
+  return SWIGV8_UNDEFINED();
+}
+}

--- a/Lib/octave/octprimtypes.swg
+++ b/Lib/octave/octprimtypes.swg
@@ -239,6 +239,7 @@ SWIG_AsCharPtrAndSize(octave_value ov, char** cptr, size_t* psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
+#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERNINLINE octave_value
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {

--- a/Lib/octave/octprimtypes.swg
+++ b/Lib/octave/octprimtypes.swg
@@ -239,7 +239,7 @@ SWIG_AsCharPtrAndSize(octave_value ov, char** cptr, size_t* psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
-#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
+#define SWIG_FromBinaryCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERNINLINE octave_value
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {

--- a/Lib/octave/octprimtypes.swg
+++ b/Lib/octave/octprimtypes.swg
@@ -214,6 +214,7 @@ SWIG_AsVal_dec(bool)(const octave_value& ov, bool *val)
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(octave_value ov, char** cptr, size_t* psize, int *alloc)
 {
+  int is_binary = (alloc != NULL) && SWIG_IsBinaryStr(*alloc);
   if (ov.iscell() && ov.rows() == 1 && ov.columns() == 1)
     ov = ov.cell_value()(0);
 
@@ -227,7 +228,7 @@ SWIG_AsCharPtrAndSize(octave_value ov, char** cptr, size_t* psize, int *alloc)
     } else if (cptr)
       *cptr = cstr;
     if (psize)
-      *psize = len + 1;
+      *psize = is_binary ? len : len + 1;
   } else if (!ov.is_defined() || (ov.is_matrix_type() && ov.rows() == 0 && ov.columns() == 0) ) {
     if (cptr)
       *cptr = 0;

--- a/Lib/perl5/perlstrings.swg
+++ b/Lib/perl5/perlstrings.swg
@@ -6,6 +6,7 @@
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(SV *obj, char** cptr, size_t* psize, int *alloc)
 {
+  int is_binary = (alloc != NULL) && SWIG_IsBinaryStr(*alloc);
   if (SvMAGICAL(obj)) {
      SV *tmp = sv_newmortal();
      SvSetSV(tmp, obj);
@@ -13,8 +14,8 @@ SWIG_AsCharPtrAndSize(SV *obj, char** cptr, size_t* psize, int *alloc)
   }
   if (SvPOK(obj)) {
     STRLEN len = 0;
-    char *cstr = SvPV(obj, len); 
-    size_t size = len + 1;
+    char *cstr = SvPV(obj, len);
+    size_t size = is_binary ? len : len + 1;
     if (cptr) {
       if (alloc) {
 	if (*alloc == SWIG_NEWOBJ) {

--- a/Lib/perl5/perlstrings.swg
+++ b/Lib/perl5/perlstrings.swg
@@ -18,7 +18,7 @@ SWIG_AsCharPtrAndSize(SV *obj, char** cptr, size_t* psize, int *alloc)
     size_t size = is_binary ? len : len + 1;
     if (cptr) {
       if (alloc) {
-	if (*alloc == SWIG_NEWOBJ) {
+	if (SWIG_IsNewObj(*alloc)) {
 	  char* p = %new_array(size, char);
 	  if (p == NULL) {
 	    return SWIG_MemoryError;

--- a/Lib/perl5/perlstrings.swg
+++ b/Lib/perl5/perlstrings.swg
@@ -49,6 +49,7 @@ SWIG_AsCharPtrAndSize(SV *obj, char** cptr, size_t* psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header") {
+#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERNINLINE SV *
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {

--- a/Lib/perl5/perlstrings.swg
+++ b/Lib/perl5/perlstrings.swg
@@ -49,7 +49,7 @@ SWIG_AsCharPtrAndSize(SV *obj, char** cptr, size_t* psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header") {
-#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
+#define SWIG_FromBinaryCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERNINLINE SV *
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {

--- a/Lib/python/pystrings.swg
+++ b/Lib/python/pystrings.swg
@@ -7,47 +7,52 @@
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 {
+  int useBin = 0;
+  if (alloc != NULL) {
+    useBin = SWIG_IsBinStr(*alloc);
+    *alloc = 0;
+  }
 %#if PY_VERSION_HEX >= 0x03000000
 %#if defined(SWIG_PYTHON_STRICT_BYTE_CHAR)
-  if (PyBytes_Check(obj))
-%#else
-  if (PyUnicode_Check(obj))
+  useBin = 1;
 %#endif
-%#else  
+  if (useBin ? PyBytes_Check(obj) : PyUnicode_Check(obj))
+%#else
   if (PyString_Check(obj))
 %#endif
   {
-    char *cstr; Py_ssize_t len;
+    char *cstr = NULL;
+    Py_ssize_t len = 0;
     PyObject *bytes = NULL;
     int ret = SWIG_OK;
     if (alloc)
       *alloc = SWIG_OLDOBJ;
-%#if PY_VERSION_HEX >= 0x03000000 && defined(SWIG_PYTHON_STRICT_BYTE_CHAR)
-    if (PyBytes_AsStringAndSize(obj, &cstr, &len) == -1)
-      return SWIG_TypeError;
-%#else
-    cstr = (char *)SWIG_PyUnicode_AsUTF8AndSize(obj, &len, &bytes);
-    if (!cstr)
-      return SWIG_TypeError;
-    /* The returned string is only duplicated if the char * returned is not owned and memory managed by obj */
-    if (bytes && cptr) {
-      if (alloc) {
-        size_t alen = (size_t)(len + 1);
-        char *p = %new_array(alen, char);
-        if (p == NULL) {
+    if (useBin) {
+      if (PyBytes_AsStringAndSize(obj, &cstr, &len) == -1)
+        return SWIG_TypeError;
+    } else {
+      cstr = (char *)SWIG_PyUnicode_AsUTF8AndSize(obj, &len, &bytes);
+      if (!cstr)
+        return SWIG_TypeError;
+      /* The returned string is only duplicated if the char * returned is not owned and memory managed by obj */
+      if (bytes && cptr) {
+        if (alloc) {
+          size_t alen = (size_t)(len + 1);
+          char *p = %new_array(alen, char);
+          if (p == NULL) {
+            SWIG_Py_XDECREF(bytes);
+            return SWIG_MemoryError;
+          }
+          memcpy(p, cstr, alen);
+          cstr = p;
+          *alloc = SWIG_NEWOBJ;
+        } else {
+          /* alloc must be set in order to clean up allocated memory */
           SWIG_Py_XDECREF(bytes);
-          return SWIG_MemoryError;
+          return SWIG_RuntimeError;
         }
-        memcpy(p, cstr, alen);
-        cstr = p;
-        *alloc = SWIG_NEWOBJ;
-      } else {
-        /* alloc must be set in order to clean up allocated memory */
-        SWIG_Py_XDECREF(bytes);
-        return SWIG_RuntimeError;
       }
     }
-%#endif
     if (cptr) *cptr = cstr;
     if (psize) *psize = (size_t)(len + 1);
     SWIG_Py_XDECREF(bytes);
@@ -59,7 +64,8 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 %#endif
 %#if PY_VERSION_HEX < 0x03000000
     if (PyUnicode_Check(obj)) {
-      char *cstr; Py_ssize_t len;
+      char *cstr = NULL;
+      Py_ssize_t len = 0;
       if (!alloc && cptr) {
         return SWIG_RuntimeError;
       }
@@ -104,8 +110,9 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
+#define SWIG_FromCharPtrAndSize(carray, size) SWIG_FromBinCharPtrAndSize(carray, size, 0)
 SWIGINTERNINLINE PyObject *
-SWIG_FromCharPtrAndSize(const char* carray, size_t size)
+SWIG_FromBinCharPtrAndSize(const char* carray, size_t size, int flags)
 {
   if (carray) {
     if (size > (size_t)PY_SSIZE_T_MAX) {
@@ -117,6 +124,8 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 %#if defined(SWIG_PYTHON_STRICT_BYTE_CHAR)
       return PyBytes_FromStringAndSize(carray, %numeric_cast(size, Py_ssize_t));
 %#else
+      if (SWIG_IsBinStr(flags))
+        return PyBytes_FromStringAndSize(carray, %numeric_cast(size, Py_ssize_t));
       return PyUnicode_DecodeUTF8(carray, %numeric_cast(size, Py_ssize_t), "surrogateescape");
 %#endif
 %#else

--- a/Lib/python/pystrings.swg
+++ b/Lib/python/pystrings.swg
@@ -7,9 +7,11 @@
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 {
-  int use_binary = 0;
+  int use_binary = 0;       /* extract the value as raw bytes rather than as UTF-8 text */
+  int is_binary = 0;        /* SWIG_BINARYSTR was passed: report the exact byte count */
   if (alloc != NULL) {
-    use_binary = SWIG_IsBinaryStr(*alloc);
+    is_binary = SWIG_IsBinaryStr(*alloc);
+    use_binary = is_binary;
     *alloc = 0;
   }
 %#if PY_VERSION_HEX >= 0x03000000
@@ -54,7 +56,7 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
       }
     }
     if (cptr) *cptr = cstr;
-    if (psize) *psize = (size_t)(len + 1);
+    if (psize) *psize = is_binary ? (size_t)len : (size_t)(len + 1);
     SWIG_Py_XDECREF(bytes);
     return ret;
   } else {

--- a/Lib/python/pystrings.swg
+++ b/Lib/python/pystrings.swg
@@ -7,16 +7,16 @@
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 {
-  int useBin = 0;
+  int use_binary = 0;
   if (alloc != NULL) {
-    useBin = SWIG_IsBinStr(*alloc);
+    use_binary = SWIG_IsBinaryStr(*alloc);
     *alloc = 0;
   }
 %#if PY_VERSION_HEX >= 0x03000000
 %#if defined(SWIG_PYTHON_STRICT_BYTE_CHAR)
-  useBin = 1;
+  use_binary = 1;
 %#endif
-  if (useBin ? PyBytes_Check(obj) : PyUnicode_Check(obj))
+  if (use_binary ? PyBytes_Check(obj) : PyUnicode_Check(obj))
 %#else
   if (PyString_Check(obj))
 %#endif
@@ -27,7 +27,7 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
     int ret = SWIG_OK;
     if (alloc)
       *alloc = SWIG_OLDOBJ;
-    if (useBin) {
+    if (use_binary) {
       if (PyBytes_AsStringAndSize(obj, &cstr, &len) == -1)
         return SWIG_TypeError;
     } else {
@@ -110,9 +110,9 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
-#define SWIG_FromCharPtrAndSize(carray, size) SWIG_FromBinCharPtrAndSize(carray, size, 0)
+#define SWIG_FromCharPtrAndSize(carray, size) SWIG_FromBinaryCharPtrAndSize(carray, size, 0)
 SWIGINTERNINLINE PyObject *
-SWIG_FromBinCharPtrAndSize(const char* carray, size_t size, int flags)
+SWIG_FromBinaryCharPtrAndSize(const char* carray, size_t size, int flags)
 {
   if (carray) {
     if (size > (size_t)PY_SSIZE_T_MAX) {
@@ -124,7 +124,7 @@ SWIG_FromBinCharPtrAndSize(const char* carray, size_t size, int flags)
 %#if defined(SWIG_PYTHON_STRICT_BYTE_CHAR)
       return PyBytes_FromStringAndSize(carray, %numeric_cast(size, Py_ssize_t));
 %#else
-      if (SWIG_IsBinStr(flags))
+      if (SWIG_IsBinaryStr(flags))
         return PyBytes_FromStringAndSize(carray, %numeric_cast(size, Py_ssize_t));
       return PyUnicode_DecodeUTF8(carray, %numeric_cast(size, Py_ssize_t), "surrogateescape");
 %#endif

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -129,6 +129,7 @@ SWIG_AsVal_dec(double)(SEXP obj, double *val)
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(SEXP obj, char** cptr, size_t* psize, int *alloc)
 {
+  int is_binary = (alloc != NULL) && SWIG_IsBinaryStr(*alloc);
   if (cptr && Rf_isString(obj)) {
     char *cstr = %const_cast(CHAR(STRING_ELT(obj, 0)), char *);
     int len = strlen(cstr);
@@ -149,7 +150,7 @@ SWIG_AsCharPtrAndSize(SEXP obj, char** cptr, size_t* psize, int *alloc)
       *cptr = %reinterpret_cast(malloc(len + 1), char *);
       *cptr = strcpy(*cptr, cstr);
     }
-    if (psize) *psize = (size_t)(len + 1);
+    if (psize) *psize = is_binary ? (size_t)len : (size_t)(len + 1);
     return SWIG_OK;
   }
   return SWIG_TypeError;

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -170,6 +170,7 @@ SWIG_strdup(const char *str)
 
 %fragment("SWIG_FromCharPtrAndSize","header") 
 {
+#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERN SEXP
 SWIG_FromCharPtrAndSize(const char* carray, size_t size) 
 {

--- a/Lib/r/rfragments.swg
+++ b/Lib/r/rfragments.swg
@@ -170,7 +170,7 @@ SWIG_strdup(const char *str)
 
 %fragment("SWIG_FromCharPtrAndSize","header") 
 {
-#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
+#define SWIG_FromBinaryCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERN SEXP
 SWIG_FromCharPtrAndSize(const char* carray, size_t size) 
 {

--- a/Lib/ruby/rubystrings.swg
+++ b/Lib/ruby/rubystrings.swg
@@ -43,7 +43,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
-#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
+#define SWIG_FromBinaryCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERNINLINE VALUE 
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {

--- a/Lib/ruby/rubystrings.swg
+++ b/Lib/ruby/rubystrings.swg
@@ -6,9 +6,10 @@
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 {
+  int is_binary = (alloc != NULL) && SWIG_IsBinaryStr(*alloc);
   if (TYPE(obj) == T_STRING) {
-    char *cstr = StringValuePtr(obj); 
-    size_t size = RSTRING_LEN(obj) + 1;
+    char *cstr = StringValuePtr(obj);
+    size_t size = RSTRING_LEN(obj) + (is_binary ? 0 : 1);
     if (cptr)  {
       if (alloc) {
 	if (*alloc == SWIG_NEWOBJ) {

--- a/Lib/ruby/rubystrings.swg
+++ b/Lib/ruby/rubystrings.swg
@@ -12,7 +12,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
     size_t size = RSTRING_LEN(obj) + (is_binary ? 0 : 1);
     if (cptr)  {
       if (alloc) {
-	if (*alloc == SWIG_NEWOBJ) {
+	if (SWIG_IsNewObj(*alloc)) {
 	  char *p = %new_array(size, char);
 	  if (p == NULL) {
 	    return SWIG_MemoryError;

--- a/Lib/ruby/rubystrings.swg
+++ b/Lib/ruby/rubystrings.swg
@@ -43,6 +43,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
+#define SWIG_FromBinCharPtrAndSize(carray, size, flags) SWIG_FromCharPtrAndSize(carray, size)
 SWIGINTERNINLINE VALUE 
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {

--- a/Lib/scilab/cdata.i
+++ b/Lib/scilab/cdata.i
@@ -1,0 +1,144 @@
+/* -----------------------------------------------------------------------------
+ * cdata.i
+ *
+ * SWIG library file containing macros for manipulating raw C data.
+ * ----------------------------------------------------------------------------- */
+
+%typemap(in) (const void *BYTES, size_t LENGTH) (void *buf = 0, int alloc = 0) {
+  int len = 0, *piAddrVar = NULL;
+  SciErr sciErr = getVarAddressFromPosition(pvApiCtx, $input, &piAddrVar);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+  }
+  if (!isListType(pvApiCtx, piAddrVar)) {
+    %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+  }
+  sciErr = getListItemNumber(pvApiCtx, piAddrVar, &len);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+  }
+  if (len > 0) {
+    int i, typ = 0, iRows = 0, iCols = 0, iPrec = 0;
+    int* iItemAddress = NULL;
+    unsigned char *iVal = NULL;
+    double *dVal = NULL;
+    unsigned char* cbuf = %new_array(len, unsigned char);
+    if (cbuf == NULL) {
+      %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+    }
+    buf = cbuf;
+    alloc = SWIG_NEWOBJ;
+    for (i = 0; i < len; i++) {
+      sciErr = getListItemAddress(pvApiCtx, piAddrVar, i + 1, &iItemAddress);
+      if (sciErr.iErr) {
+        printError(&sciErr, 0);
+        %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+      }
+      sciErr = getVarType(pvApiCtx, iItemAddress, &typ);
+      if (sciErr.iErr) {
+        printError(&sciErr, 0);
+        %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+      }
+      switch(typ) {
+        case sci_matrix:
+          sciErr = getMatrixOfDouble(pvApiCtx, iItemAddress, &iRows, &iCols, &dVal);
+          if (sciErr.iErr) {
+            printError(&sciErr, 0);
+            %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+          }
+          if (iRows * iCols != 1) {
+            Scierror(SCILAB_API_ARGUMENT_ERROR, _("%s: Wrong size for input argument #%d: A 8-bit unsigned integer or a double expected.\n"), fname, $argnum);
+            %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+          }
+          if (*dVal != floor(*dVal)) {
+            Scierror(SCILAB_API_ARGUMENT_ERROR, _("%s: Incorrect value for input argument #%d: The double value cannot be converted to a 8-bit unsigned integer.\n"), fname, $argnum);
+            %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+          }
+          if (*dVal < 0 || *dVal > UCHAR_MAX) {
+            Scierror(SCILAB_API_ARGUMENT_ERROR, _("%s: Overflow error for input argument #%d: The double value cannot be converted to a 8-bit unsigned integer.\n"), fname, $argnum);
+            %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+          }
+          cbuf[i] = (unsigned char)(*dVal);
+          break;
+        case sci_ints:
+          sciErr = getMatrixOfIntegerPrecision(pvApiCtx, iItemAddress, &iPrec);
+          if (sciErr.iErr) {
+            printError(&sciErr, 0);
+            %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+          }
+          if (iPrec != SCI_UINT8) {
+            Scierror(SCILAB_API_ARGUMENT_ERROR, _("%s: Wrong type for input argument #%d: A 8-bit unsigned integer or a double expected.\n"), fname, $argnum);
+            %argument_fail(SWIG_ERROR,"$type",$symname, $argnum);
+          }
+          sciErr = getMatrixOfUnsignedInteger8(pvApiCtx, iItemAddress, &iRows, &iCols, &iVal);
+          if (sciErr.iErr) {
+            printError(&sciErr, 0);
+            return SWIG_ERROR;
+          }
+          if (iRows * iCols != 1) {
+            Scierror(SCILAB_API_ARGUMENT_ERROR, _("%s: Wrong size for input argument #%d: A 8-bit unsigned integer or a double expected.\n"), fname, $argnum);
+            return SWIG_ERROR;
+          }
+          cbuf[i] = *iVal;
+          break;
+        default:
+          %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+          break;
+      }
+    }
+  }
+  $1 = %reinterpret_cast(buf, $1_ltype);
+  $2 = %numeric_cast(len, $2_ltype);
+}
+
+%typemap(freearg,noblock=1,match="in") (const void *BYTES, size_t LENGTH) {
+  if (alloc$argnum == SWIG_NEWOBJ) {
+    %delete_array((%reinterpret_cast(buf$argnum, unsigned char *)));
+  }
+}
+
+%{
+SWIGINTERN int SWIG_setUint8List(void *pvApiCtx, const void *buf, size_t len) {
+  int iVarOut = SWIG_NbInputArgument(pvApiCtx) + SWIG_Scilab_GetOutputPosition();
+  const unsigned char *cbuf = NULL;
+  int *piAddrVar = NULL;
+  SciErr sciErr;
+  if (buf != NULL) {
+    cbuf = (unsigned char *)buf;
+  } else {
+    len = 0;
+  }
+  sciErr = createList(pvApiCtx, iVarOut, len, &piAddrVar);
+  if (sciErr.iErr) {
+    printError(&sciErr, 0);
+    return SWIG_ERROR;
+  }
+  if (len > 0) {
+    size_t i;
+    for (i = 0; i < len; i++) {
+      sciErr = createMatrixOfUnsignedInteger8InList(pvApiCtx, iVarOut, piAddrVar, (int)(i + 1), 1, 1, cbuf + i);
+      if (sciErr.iErr) {
+        printError(&sciErr, 0);
+        return SWIG_ERROR;
+      }
+    }
+  }
+  return SWIG_OK;
+}
+%}
+
+%typemap(directorin,noblock=1,fragment="SWIG_FromCharPtrAndSize") (const void *BYTES, size_t LENGTH) {
+  $input = SWIG_setUint8List(pvApiCtx, $1, (size_t)$2);
+}
+
+%apply (const void *BYTES, size_t LENGTH) { (void *BYTES, size_t LENGTH) }
+
+%include <typemaps/cdata_begin.swg>
+
+%typemap(out,noblock=1,fragment="SWIG_FromCharPtrAndSize") SWIGCDATA {
+  %set_output(SWIG_setUint8List(pvApiCtx, $1.data, (size_t)($1.len)));
+}
+
+%include <typemaps/cdata_end.swg>

--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -145,11 +145,14 @@
 #define SWIG_NEWOBJMASK            (SWIG_CASTRANKLIMIT  << 1)
 /* The TmpMask is for in/out typemaps that use temporary objects */
 #define SWIG_TMPOBJMASK            (SWIG_NEWOBJMASK << 1)
+/* The Binary string mask denotes using string without unicode */
+#define SWIG_BINSTRMASK            (SWIG_TMPOBJMASK << 1)
 /* Simple returning values */
 #define SWIG_BADOBJ                (SWIG_ERROR)
 #define SWIG_OLDOBJ                (SWIG_OK)
 #define SWIG_NEWOBJ                (SWIG_OK | SWIG_NEWOBJMASK)
 #define SWIG_TMPOBJ                (SWIG_OK | SWIG_TMPOBJMASK)
+#define SWIG_BINSTR                (SWIG_OK | SWIG_BINSTRMASK)
 /* Check, add and del object mask methods */
 #define SWIG_AddNewMask(r)         (SWIG_IsOK(r) ? (r | SWIG_NEWOBJMASK) : r)
 #define SWIG_DelNewMask(r)         (SWIG_IsOK(r) ? (r & ~SWIG_NEWOBJMASK) : r)
@@ -157,6 +160,9 @@
 #define SWIG_AddTmpMask(r)         (SWIG_IsOK(r) ? (r | SWIG_TMPOBJMASK) : r)
 #define SWIG_DelTmpMask(r)         (SWIG_IsOK(r) ? (r & ~SWIG_TMPOBJMASK) : r)
 #define SWIG_IsTmpObj(r)           (SWIG_IsOK(r) && (r & SWIG_TMPOBJMASK))
+#define SWIG_AddBinMask(r)         (SWIG_IsOK(r) ? (r | SWIG_BINSTRMASK) : r)
+#define SWIG_DelBinMask(r)         (SWIG_IsOK(r) ? (r & ~SWIG_BINSTRMASK) : r)
+#define SWIG_IsBinStr(r)           (SWIG_IsOK(r) && (r & SWIG_BINSTRMASK))
 
 /* Cast-Rank Mode */
 #if defined(SWIG_CASTRANK_MODE)

--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -145,14 +145,14 @@
 #define SWIG_NEWOBJMASK            (SWIG_CASTRANKLIMIT  << 1)
 /* The TmpMask is for in/out typemaps that use temporary objects */
 #define SWIG_TMPOBJMASK            (SWIG_NEWOBJMASK << 1)
-/* The Binary string mask denotes using string without unicode */
-#define SWIG_BINSTRMASK            (SWIG_TMPOBJMASK << 1)
+/* The binary string mask denotes using string without unicode */
+#define SWIG_BINARYSTRMASK         (SWIG_TMPOBJMASK << 1)
 /* Simple returning values */
 #define SWIG_BADOBJ                (SWIG_ERROR)
 #define SWIG_OLDOBJ                (SWIG_OK)
 #define SWIG_NEWOBJ                (SWIG_OK | SWIG_NEWOBJMASK)
 #define SWIG_TMPOBJ                (SWIG_OK | SWIG_TMPOBJMASK)
-#define SWIG_BINSTR                (SWIG_OK | SWIG_BINSTRMASK)
+#define SWIG_BINARYSTR             (SWIG_OK | SWIG_BINARYSTRMASK)
 /* Check, add and del object mask methods */
 #define SWIG_AddNewMask(r)         (SWIG_IsOK(r) ? (r | SWIG_NEWOBJMASK) : r)
 #define SWIG_DelNewMask(r)         (SWIG_IsOK(r) ? (r & ~SWIG_NEWOBJMASK) : r)
@@ -160,9 +160,9 @@
 #define SWIG_AddTmpMask(r)         (SWIG_IsOK(r) ? (r | SWIG_TMPOBJMASK) : r)
 #define SWIG_DelTmpMask(r)         (SWIG_IsOK(r) ? (r & ~SWIG_TMPOBJMASK) : r)
 #define SWIG_IsTmpObj(r)           (SWIG_IsOK(r) && (r & SWIG_TMPOBJMASK))
-#define SWIG_AddBinMask(r)         (SWIG_IsOK(r) ? (r | SWIG_BINSTRMASK) : r)
-#define SWIG_DelBinMask(r)         (SWIG_IsOK(r) ? (r & ~SWIG_BINSTRMASK) : r)
-#define SWIG_IsBinStr(r)           (SWIG_IsOK(r) && (r & SWIG_BINSTRMASK))
+#define SWIG_AddBinaryStrMask(r)   (SWIG_IsOK(r) ? (r | SWIG_BINARYSTRMASK) : r)
+#define SWIG_DelBinaryStrMask(r)   (SWIG_IsOK(r) ? (r & ~SWIG_BINARYSTRMASK) : r)
+#define SWIG_IsBinaryStr(r)        (SWIG_IsOK(r) && (r & SWIG_BINARYSTRMASK))
 
 /* Cast-Rank Mode */
 #if defined(SWIG_CASTRANK_MODE)

--- a/Lib/tcl/cdata.i
+++ b/Lib/tcl/cdata.i
@@ -1,0 +1,68 @@
+/* -----------------------------------------------------------------------------
+ * cdata.i
+ *
+ * SWIG library file containing macros for manipulating raw C data.
+ * ----------------------------------------------------------------------------- */
+
+%typemap(in) (const void *BYTES, size_t LENGTH) (void *buf = NULL, int alloc = 0) {
+  Tcl_Size len = 0;
+  Tcl_Obj **listobjv;
+  if (Tcl_ListObjGetElements(interp, $input, &len, &listobjv) == TCL_ERROR) {
+    %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+  }
+  if (len > 0) {
+    Tcl_Size i;
+    unsigned char *cbuf = %new_array(len, unsigned char);
+    if (cbuf == NULL) {
+      %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+    }
+    for (i = 0; i < len; i++) {
+      int val;
+      if (Tcl_GetSizeIntFromObj(interp, listobjv[i], &val) == TCL_ERROR) {
+        %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+      }
+      cbuf[i] = (unsigned char)val;
+    }
+    alloc = SWIG_NEWOBJ;
+    buf = (void *)cbuf;
+  }
+  $1 = %reinterpret_cast(buf, $1_ltype);
+  $2 = %numeric_cast(len, $2_ltype);
+}
+
+%typemap(freearg,noblock=1,match="in") (const void *BYTES, size_t LENGTH) {
+  if (alloc$argnum == SWIG_NEWOBJ) {
+    %delete_array((%reinterpret_cast(buf$argnum, unsigned char *)));
+  }
+}
+
+%{
+SWIGINTERNINLINE Tcl_Obj *SWIG_CreateIntList(Tcl_Interp *interp, const void *bytes, size_t len) {
+  size_t i;
+  unsigned char *cbuf = NULL;
+  Tcl_Obj *ret = Tcl_GetObjResult(interp);
+  if (bytes != NULL) {
+    cbuf = (unsigned char *)bytes;
+  } else {
+    len = 0;
+  }
+  for (i = 0; i < len; i++) {
+    Tcl_ListObjAppendElement(interp, ret, Tcl_NewSizeIntObj(cbuf[i]));
+  }
+  return ret;
+}
+%}
+
+%typemap(directorin,noblock=1) (const void *BYTES, size_t LENGTH) {
+  $input = SWIG_CreateIntList(interp, $1, $2);
+}
+
+%apply (const void *BYTES, size_t LENGTH) { (void *BYTES, size_t LENGTH) }
+
+%include <typemaps/cdata_begin.swg>
+
+%typemap(out,noblock=1) SWIGCDATA {
+  %set_output(SWIG_CreateIntList(interp, $1.data, (size_t)($1.len)));
+}
+
+%include <typemaps/cdata_end.swg>

--- a/Lib/tcl/cdata.i
+++ b/Lib/tcl/cdata.i
@@ -17,8 +17,11 @@
       %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
     }
     for (i = 0; i < len; i++) {
-      int val;
+      Tcl_Size val;
       if (Tcl_GetSizeIntFromObj(interp, listobjv[i], &val) == TCL_ERROR) {
+        %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
+      }
+      if (val < 0 || val > 0xff) {
         %argument_fail(SWIG_ERROR, "$type", $symname, $argnum);
       }
       cbuf[i] = (unsigned char)val;

--- a/configure.ac
+++ b/configure.ac
@@ -1302,6 +1302,15 @@ else
           AC_SUBST(NODENAPI_DIR)
         fi
       fi
+      # Try Debian/Ubuntu 'node-addon-api' package location
+      if test -z "$JSNAPIENABLED" && which dpkg > /dev/null 2>&1; then
+        napi_dir="$(dpkg -L node-addon-api 2> /dev/null | grep '\/napi.h$' | head -1 | sed 's%/napi.h%%')"
+        if test -n "$napi_dir" && test -f "$napi_dir/napi.h"; then
+          NODENAPI_DIR="$napi_dir"
+          JSNAPIENABLED=1
+          AC_SUBST(NODENAPI_DIR)
+        fi
+      fi
       if test -n "$JSNAPIENABLED"; then
         AC_MSG_RESULT([$NODENAPI_DIR])
       else


### PR DESCRIPTION
This new `cdata` test focus on two aspects
- Ensure we can receive proper data from C/C++ and pass proper data back to C/C++.
- Use all byte values , i.e. the full range of 0 to 255.

<br>

Fix guile `cdata`

<br>

There are two potential issues:
- Some languages treat value 0 as string null terminator.
- Treat strings as Unicode, i.e. values 128-255 do not pass as is.

<br><br>

#### Other languages issues:
See  #3380
The `SWIG_AsCharPtrAndSize` and `SWIG_FromCharPtrAndSize` of some languages need support of raw data versa using Unicode encoding (UTF-8).
I think we need to add new flag to select raw data coping.
### Tcl
receive proper data from C/C++ 
But building  data to pass to C/C++ fails, Tcl uses Unicode by default however converted string to ISO 8859-1/Latin-1 fail too, further investigation required.
### scilab
Language uses Unicode by default.
The `SWIG_AsCharPtrAndSize` and `SWIG_FromCharPtrAndSize` may need updating.
### javascript
Language uses Unicode by default.
The `SWIG_AsCharPtrAndSize` and `SWIG_FromCharPtrAndSize` may need updating.
Alternativly we can switch and use [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)  
@mmomtchev What do you think of using `cdata.i` with `Uint8Array`?
**Update** After switching to `Uint8Array` all test pass :smile: 
### python
The `SWIG_AsCharPtrAndSize` and `SWIG_FromCharPtrAndSize` need updating.
For python 3, we can use the new [bytes](https://docs.python.org/3.0/reference/lexical_analysis.html#strings) type.
@wsfulton what do you think on using `cdata.i` with python3 `bytes`
Is python3 `bytes` storage different that strings storage?
### <del>ocaml</del>
<del>There is a basic test `li_cdata`. I do not know how to translate the `li_cdata_bytes` to ocaml. This language syntax requires more learning.
@wsfulton do we have any active developer capable writing test scripts in ocaml?
</del>
### R
There are no `cdata` tests in this language.
Perhaps we will get there?
### c
The generated code of `cdata.i` does not pass compilation.
The tests were added to `FAILING_C_TESTS` and `FAILING_CPP_TESTS`