### PR TITLE
Ruby test fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -219,15 +219,8 @@ jobs:
           VER: '2.2'
         - SWIGLANG: ruby
           VER: '2.3'
-# Ruby 2.4 and 2.6 both fail with ubuntu-22.04 with error:
-#   Error running '__rvm_make -j4',
-#   please read /usr/share/rvm/log/1740710476_ruby-3.0.0/make.log
-#        - SWIGLANG: ruby
-#          VER: '2.4'
         - SWIGLANG: ruby
           VER: '2.5'
-#        - SWIGLANG: ruby
-#          VER: '2.6'
         - SWIGLANG: ruby
           VER: '2.7'
         - SWIGLANG: ruby

--- a/Examples/test-suite/ruby/li_std_functors_runme.rb
+++ b/Examples/test-suite/ruby/li_std_functors_runme.rb
@@ -63,9 +63,10 @@ def test
   yield method(:_map), Li_std_functors::Map
 end
 
-# these should fail and not segfault but currently do segfault with Ruby 2.6
-# in GitHub Actions environment
-if RUBY_VERSION != '2.6.6'
+if RUBY_VERSION[0..2] == "2.6" || RUBY_VERSION[0..2] == "3.3"
+# These should fail and not segfault
+# but currently do segfault with Ruby 2.6 and Ruby 3.3
+else
 begin
   Li_std_functors::Set.new('sd')
 rescue

--- a/Examples/test-suite/ruby/swig_assert.rb
+++ b/Examples/test-suite/ruby/swig_assert.rb
@@ -31,7 +31,7 @@ end
 # scope - optional Binding where to run the code
 # msg   - optional additional message to print
 #
-def swig_assert_equal( a, b, scope = nil, msg = nil )
+def swig_assert_equal( a, b, scope = nil, msg = nil, count_lines = 0 )
   a = 'nil' if a == nil
   b = 'nil' if b == nil
   begin
@@ -65,6 +65,9 @@ rescue => e
   $stderr.puts "#{trace[0,1]}: #{e}"
   if trace.size > 1
     $stderr.puts "\tfrom #{trace[1..-1].join("\n\t     ")}"
+  end
+  if count_lines > 0
+    $stderr.puts "Add #{ count_lines } lines after calling 'swig_assert_each_line'"
   end
   exit(1)
 end
@@ -108,7 +111,7 @@ end
 # scope - optional Binding where to run the code
 # msg   - optional additional message to print
 #
-def swig_eval( expr, scope = nil, msg = nil )
+def swig_eval( expr, scope = nil, msg = nil, count_lines = 0 )
   begin
     if scope.kind_of? Binding
       eval(expr.to_s, scope)
@@ -128,6 +131,9 @@ rescue => e
   if trace.size > 1
     $stderr.puts "\tfrom #{trace[1..-1].join("\n\t     ")}"
   end
+  if count_lines > 0
+    $stderr.puts "Add #{ count_lines } lines after calling 'swig_assert_each_line'"
+  end
   exit(1)
 end
 
@@ -142,12 +148,14 @@ end
 # msg   - optional additional message to print
 #
 def swig_assert_each_line( lines, scope = nil, msg = nil )
+  count_lines = 0
   lines.split("\n").each do |line|
+    count_lines += 1
     next if line.empty? or line =~ /^\s*#.*/
       if line =~ /^\s*([^\s]*)\s*==\s*(.*)\s*$/
-        swig_assert_equal($1, $2, scope, msg)
+        swig_assert_equal($1, $2, scope, msg, count_lines)
       else
-        swig_eval(line, scope, msg)
+        swig_eval(line, scope, msg, count_lines)
       end
   end
 end


### PR DESCRIPTION
This PR contains two patches:
- Add number of lines after calling `swig_assert_each_line`
  In case or error inside a large block, we get the exact location where the error happens. 
- Remove old buggy Ruby from `linux.yml` and skip the `li_std_functors` when using Ruby 3.3, it crash occasionally on garbage collection.