### PR TITLE
Python: Annotate types of constants

### DIFF
--- a/Examples/test-suite/python/python_annotations_variable_c_runme.py
+++ b/Examples/test-suite/python/python_annotations_variable_c_runme.py
@@ -15,12 +15,20 @@ def get_annotations(cls):
 
 # Variable annotations for properties is only supported in python-3.6 and later (PEP 526)
 if sys.version_info[0:2] >= (3, 6):
+    import python_annotations_variable_c
     from python_annotations_variable_c import *
 
     # No SWIG __annotations__ support with -builtin or -fastproxy
     annotations_supported = not(is_python_builtin() or is_python_fastproxy())
 
     if annotations_supported:
+        anno = get_annotations(python_annotations_variable_c)
+        if anno != {
+            "A_CONSTANT_INT": "int",
+            "A_CONSTANT_SHORT": "short",
+        }:
+            raise RuntimeError("annotations mismatch: {}".format(anno))
+
         anno = get_annotations(TemplateShort)
         if anno != {'member_variable': 'int'}:
             raise RuntimeError("annotations mismatch: {}".format(anno))

--- a/Examples/test-suite/python/python_annotations_variable_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_variable_typing_runme.py
@@ -15,12 +15,20 @@ def get_annotations(cls):
 
 # Variable annotations for properties is only supported in python-3.6 and later (PEP 526)
 if sys.version_info[0:2] >= (3, 6):
+    import python_annotations_variable_typing
     from python_annotations_variable_typing import *
 
     # No SWIG __annotations__ support with -builtin or -fastproxy
     annotations_supported = not(is_python_builtin() or is_python_fastproxy())
 
     if annotations_supported:
+        anno = get_annotations(python_annotations_variable_typing)
+        if anno != {
+            "A_CONSTANT_INT": "int",
+            "A_CONSTANT_SHORT": "int",
+        }:
+            raise RuntimeError("annotations mismatch: {}".format(anno))
+
         anno = get_annotations(TemplateShort)
         if anno != {'member_variable': 'int'}:
             raise RuntimeError("annotations mismatch: {}".format(anno))

--- a/Examples/test-suite/python_annotations_variable_c.i
+++ b/Examples/test-suite/python_annotations_variable_c.i
@@ -8,6 +8,7 @@
 
 %feature("python:annotations", "c");
 %feature("python:annotations:novar") member_variable_not_annotated;
+%feature("python:annotations:novar") A_CONSTANT_NOVAR;
 
 
 %inline %{
@@ -42,3 +43,6 @@ int is_python_fastproxy() { return 0; }
 #endif
 %}
 
+%constant int A_CONSTANT_INT = 42;
+%constant int A_CONSTANT_NOVAR = 42;
+%constant short A_CONSTANT_SHORT = 42;

--- a/Examples/test-suite/python_annotations_variable_typing.i
+++ b/Examples/test-suite/python_annotations_variable_typing.i
@@ -5,7 +5,7 @@
 
 %feature("python:annotations", "typing");
 %feature("python:annotations:novar") member_variable_not_annotated;
-
+%feature("python:annotations:novar") A_CONSTANT_NOVAR;
 
 %inline %{
 namespace Space {
@@ -39,3 +39,6 @@ int is_python_fastproxy() { return 0; }
 #endif
 %}
 
+%constant int A_CONSTANT_INT = 42;
+%constant int A_CONSTANT_NOVAR = 42;
+%constant short A_CONSTANT_SHORT = 42;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3809,7 +3809,8 @@ public:
           Printv(f_s, "\n", NIL);
           Printv(f_s, module, ".", iname, "_swigconstant(", module, ")\n", NIL);
         }
-        Printv(f_s, iname, " = ", module, ".", iname, "\n", NIL);
+        String *annotation = variableAnnotation(n);
+        Printv(f_s, iname, annotation, " = ", module, ".", iname, "\n", NIL);
         if (have_docstring(n))
           Printv(f_s, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
       }


### PR DESCRIPTION
Constants in modules did not have type annotations. With this PR, they're added. It uses the same functionality as for annotating variables and thus respects `python:annotations:novar` too.