### PR TITLE
Add `%pointer_dynamic_cast` to `cpointer.i`

### DIFF
--- a/Doc/Manual/Library.html
+++ b/Doc/Manual/Library.html
@@ -383,6 +383,41 @@ In this example,  the function <tt>int_to_uint()</tt> would be used to cast type
 <b>Note:</b> When working with simple pointers, typemaps can often be used to provide more seamless operation.
 </p>
 
+<br>
+
+<p>
+<b><tt>%pointer_dynamic_cast(type1, type2, name)</tt></b>
+</p>
+
+<div class="indent">
+
+<p>
+Creates a dynamic conversion of an object stored in a pointer typed <tt>type1</tt> to a pointer typed <tt>type2</tt> or return <b>null</b> if the object is <b>not</b> polymorphic of the class pointed by <tt>type2</tt>.
+The name of the function is <tt>name</tt>.<br>
+For example:
+</p>
+
+<div class="code">
+<pre>
+%pointer_dynamic_cast(Base *, Derive *, base_to_derive);
+</pre>
+</div>
+
+<p>
+In this example, the function <tt>base_to_derive()</tt> can be use to convert a pointer typed <tt>Based *</tt> pointing to a <tt>Derived</tt> object to a pointer typed <tt>Derived *</tt>.
+</p>
+
+</div>
+
+<P>
+<b>Note:</b> The dynamic casting is using C++ run-time type identification (RTTI), the decision to return converted pointer or null pointer is done in run-time.
+</p>
+
+<P>
+<b>Note:</b> The dynamic casting is a C++ casting, when used in C, the function will use an explicit type conversion.
+</p>
+
+
 <H3><a name="Library_carrays">12.2.3 carrays.i</a></H3>
 
 

--- a/Doc/Manual/Library.html
+++ b/Doc/Manual/Library.html
@@ -384,6 +384,41 @@ In this example,  the function <tt>int_to_uint()</tt> would be used to cast type
 <b>Note:</b> When working with simple pointers, typemaps can often be used to provide more seamless operation.
 </p>
 
+<br>
+
+<p>
+<b><tt>%pointer_dynamic_cast(type1, type2, name)</tt></b>
+</p>
+
+<div class="indent">
+
+<p>
+Creates a dynamic conversion of an object stored in a pointer typed <tt>type1</tt> to a pointer typed <tt>type2</tt> or return <b>null</b> if the object is <b>not</b> polymorphic of the class pointed by <tt>type2</tt>.
+The name of the function is <tt>name</tt>.<br>
+For example:
+</p>
+
+<div class="code">
+<pre>
+%pointer_dynamic_cast(Base *, Derive *, base_to_derive);
+</pre>
+</div>
+
+<p>
+In this example, the function <tt>base_to_derive()</tt> can be use to convert a pointer typed <tt>Based *</tt> pointing to a <tt>Derived</tt> object to a pointer typed <tt>Derived *</tt>.
+</p>
+
+</div>
+
+<P>
+<b>Note:</b> The dynamic casting is using C++ run-time type identification (RTTI), the decision to return converted pointer or null pointer is done in run-time.
+</p>
+
+<P>
+<b>Note:</b> The dynamic casting is a C++ casting, when used in C, the function will use an explicit type conversion.
+</p>
+
+
 <H3><a name="Library_carrays">14.2.3 carrays.i</a></H3>
 
 

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -310,6 +310,7 @@ CPP_TEST_CASES += \
 	li_carrays_cpp \
 	li_cdata_cpp \
 	li_cpointer_cpp \
+	li_cpointer_dynamic_cast \
 	li_std_auto_ptr \
 	li_stdint \
 	li_swigtype_inout \

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -315,6 +315,7 @@ CPP_TEST_CASES += \
 	li_cdata_cpp \
 	li_cdata_bytes_cpp \
 	li_cpointer_cpp \
+	li_cpointer_dynamic_cast \
 	li_std_auto_ptr \
 	li_stdint \
 	li_swigtype_inout \

--- a/Examples/test-suite/csharp/li_cpointer_dynamic_cast_runme.cs
+++ b/Examples/test-suite/csharp/li_cpointer_dynamic_cast_runme.cs
@@ -1,0 +1,73 @@
+using System;
+using li_cpointer_dynamic_castNamespace;
+
+public class runme
+{
+  public static void swig_assert(bool b, string msg) {
+    if (!b)
+      throw new Exception(msg);
+  }
+  static void Main()
+  {
+    // Get a Derived object using a Base pointer;
+    Base base_point_derived = Derived.NewDerived();
+    swig_assert(base_point_derived.val1() == 11, "base_point_derived fail calling Derived::val1()");
+    swig_assert(base_point_derived.val2() == 2, "base_point_derived fail calling Base::val2()");
+    // Dynamic cast to original Derived class;
+    Derived derived_dyn = li_cpointer_dynamic_cast.dynDerivedCast(base_point_derived);
+    swig_assert(derived_dyn != null, "dynamic cast to derived_dyn fail");
+    swig_assert(derived_dyn.val1() == 11, "derived_dyn fail calling Derived::val1()");
+    swig_assert(derived_dyn.val2() == 12, "derived_dyn fail calling Derived::val2()");
+    // Static cast work the same as dynamic cast, when used with the derived class!;
+    Derived derived_static = li_cpointer_dynamic_cast.staticDerivedCast(base_point_derived);
+    swig_assert(derived_static != null, "static cast to derived_static fail");
+    swig_assert(derived_static.val1() == 11, "derived_static fail calling Derived::val1()");
+    swig_assert(derived_static.val2() == 12, "derived_static fail calling Derived::val2()");
+
+    // Get an Other object using a Base pointer;
+    Base base_point_other = Other.NewOther();
+    swig_assert(base_point_other.val1() == 21, "base_point_other fail calling Other::val1()");
+    swig_assert(base_point_other.val2() == 2, "base_point_other fail calling Base::val2()");
+    // Dynamic cast to original Other class;
+    Other other_dyn = li_cpointer_dynamic_cast.dynOtherCast(base_point_other);
+    swig_assert(other_dyn != null, "dynamic cast to other_dyn fail");
+    swig_assert(other_dyn.val1() == 21, "other_dyn fail calling Other::val1()");
+    swig_assert(other_dyn.val2() == 22, "other_dyn fail calling Other::val2()");
+    // Static cast work the same as dynamic cast, when used with the other class!;
+    Other other_static = li_cpointer_dynamic_cast.staticOtherCast(base_point_other);
+    swig_assert(other_static != null, "static cast to other_static fail");
+    swig_assert(other_static.val1() == 21, "other_static fail calling Other::val1()");
+    swig_assert(other_static.val2() == 22, "other_static fail calling Other::val2()");
+
+    // Get a Base object;
+    Base baseObj = new Base();
+    swig_assert(baseObj.val1() == 1, "base fail calling Base::val1()");
+    swig_assert(baseObj.val2() == 2, "base fail calling Base::val2()");
+
+    // Dynamic cast gives NULL as expected;
+    swig_assert(li_cpointer_dynamic_cast.dynOtherCast(base_point_derived) == null, "'Derived' object can not cast to 'Other'");
+    swig_assert(li_cpointer_dynamic_cast.dynDerivedCast(base_point_other) == null, "'Other' object can not cast to 'Derived'");
+    swig_assert(li_cpointer_dynamic_cast.dynOtherCast(baseObj) == null, "'Base' object can not cast to 'Other'");
+    swig_assert(li_cpointer_dynamic_cast.dynDerivedCast(baseObj) == null, "'Base' object can not cast to 'Derived'");
+
+    // Static cast gives a hybrid result;
+    // The virtual method point to original object class, as we expect!;
+    // While the non-virtual method uses the new pointed class method!;
+    Other non_cpp_other_derived = li_cpointer_dynamic_cast.staticOtherCast(base_point_derived);
+    swig_assert(non_cpp_other_derived != null, "static cast to non_cpp_other_derived fail");
+    swig_assert(non_cpp_other_derived.val1() == 11, "non_cpp_other_derived fail calling Derived::val1()");
+    swig_assert(non_cpp_other_derived.val2() == 22, "non_cpp_other_derived fail calling Other::val2()");
+    Derived non_cpp_derived_other = li_cpointer_dynamic_cast.staticDerivedCast(base_point_other);
+    swig_assert(non_cpp_derived_other != null, "static cast to non_cpp_derived_other fail");
+    swig_assert(non_cpp_derived_other.val1() == 21, "non_cpp_derived_other fail calling Other::val1()");
+    swig_assert(non_cpp_derived_other.val2() == 12, "non_cpp_derived_other fail calling Derived::val2()");
+    Derived non_cpp_base_derived = li_cpointer_dynamic_cast.staticDerivedCast(baseObj);
+    swig_assert(non_cpp_base_derived != null, "static cast to non_cpp_base_derived fail");
+    swig_assert(non_cpp_base_derived.val1() == 1, "non_cpp_base_derived fail calling Base::val1()");
+    swig_assert(non_cpp_base_derived.val2() == 12, "non_cpp_base_derived fail calling Derived::val2()");
+    Other non_cpp_base_other = li_cpointer_dynamic_cast.staticOtherCast(baseObj);
+    swig_assert(non_cpp_base_other != null, "static cast to non_cpp_base_other fail");
+    swig_assert(non_cpp_base_other.val1() == 1, "non_cpp_base_other fail calling Base::val1()");
+    swig_assert(non_cpp_base_other.val2() == 22, "non_cpp_base_other fail calling Other::val2()");
+  }
+}

--- a/Examples/test-suite/d/li_cpointer_dynamic_cast_runme.2.d
+++ b/Examples/test-suite/d/li_cpointer_dynamic_cast_runme.2.d
@@ -1,0 +1,76 @@
+module li_cpointer_dynamic_cast_runme;
+
+// import std.conv;
+// import std.exception;
+import li_cpointer_dynamic_cast.Base;
+import li_cpointer_dynamic_cast.Derived;
+import li_cpointer_dynamic_cast.Other;
+import li_cpointer_dynamic_cast.li_cpointer_dynamic_cast;
+
+void swig_assert(bool b, string msg) {
+  if (!b)
+     throw new Exception(msg);
+}
+
+void main() {
+  // Get a Derived object using a Base pointer;
+  Base base_point_derived = Derived.NewDerived();
+  swig_assert(base_point_derived.val1() == 11, "base_point_derived fail calling Derived::val1()");
+  swig_assert(base_point_derived.val2() == 2, "base_point_derived fail calling Base::val2()");
+  // Dynamic cast to original Derived class;
+  Derived derived_dyn = dynDerivedCast(base_point_derived);
+  swig_assert(derived_dyn !is null, "dynamic cast to derived_dyn fail");
+  swig_assert(derived_dyn.val1() == 11, "derived_dyn fail calling Derived::val1()");
+  swig_assert(derived_dyn.val2() == 12, "derived_dyn fail calling Derived::val2()");
+  // Static cast work the same as dynamic cast, when used with the derived class!;
+  Derived derived_static = staticDerivedCast(base_point_derived);
+  swig_assert(derived_static !is null, "static cast to derived_static fail");
+  swig_assert(derived_static.val1() == 11, "derived_static fail calling Derived::val1()");
+  swig_assert(derived_static.val2() == 12, "derived_static fail calling Derived::val2()");
+
+  // Get an Other object using a Base pointer;
+  Base base_point_other = Other.NewOther();
+  swig_assert(base_point_other.val1() == 21, "base_point_other fail calling Other::val1()");
+  swig_assert(base_point_other.val2() == 2, "base_point_other fail calling Base::val2()");
+  // Dynamic cast to original Other class;
+  Other other_dyn = dynOtherCast(base_point_other);
+  swig_assert(other_dyn !is null, "dynamic cast to other_dyn fail");
+  swig_assert(other_dyn.val1() == 21, "other_dyn fail calling Other::val1()");
+  swig_assert(other_dyn.val2() == 22, "other_dyn fail calling Other::val2()");
+  // Static cast work the same as dynamic cast, when used with the other class!;
+  Other other_static = staticOtherCast(base_point_other);
+  swig_assert(other_static !is null, "static cast to other_static fail");
+  swig_assert(other_static.val1() == 21, "other_static fail calling Other::val1()");
+  swig_assert(other_static.val2() == 22, "other_static fail calling Other::val2()");
+
+  // Get a Base object;
+  Base baseObj = new Base();
+  swig_assert(baseObj.val1() == 1, "baseObj fail calling Base::val1()");
+  swig_assert(baseObj.val2() == 2, "baseObj fail calling Base::val2()");
+
+  // Dynamic cast gives NULL as expected;
+  swig_assert(dynOtherCast(base_point_derived) is null, "'Derived' object can not cast to 'Other'");
+  swig_assert(dynDerivedCast(base_point_other) is null, "'Other' object can not cast to 'Derived'");
+  swig_assert(dynOtherCast(baseObj) is null, "'Base' object can not cast to 'Other'");
+  swig_assert(dynDerivedCast(baseObj) is null, "'Base' object can not cast to 'Derived'");
+
+  // Static cast gives a hybrid result;
+  // The virtual method point to original object class, as we expect!;
+  // While the non-virtual method uses the new pointed class method!;
+  Other non_cpp_other_derived = staticOtherCast(base_point_derived);
+  swig_assert(non_cpp_other_derived !is null, "static cast to non_cpp_other_derived fail");
+  swig_assert(non_cpp_other_derived.val1() == 11, "non_cpp_other_derived fail calling Derived::val1()");
+  swig_assert(non_cpp_other_derived.val2() == 22, "non_cpp_other_derived fail calling Other::val2()");
+  Derived non_cpp_derived_other = staticDerivedCast(base_point_other);
+  swig_assert(non_cpp_derived_other !is null, "static cast to non_cpp_derived_other fail");
+  swig_assert(non_cpp_derived_other.val1() == 21, "non_cpp_derived_other fail calling Other::val1()");
+  swig_assert(non_cpp_derived_other.val2() == 12, "non_cpp_derived_other fail calling Derived::val2()");
+  Derived non_cpp_base_derived = staticDerivedCast(baseObj);
+  swig_assert(non_cpp_base_derived !is null, "static cast to non_cpp_base_derived fail");
+  swig_assert(non_cpp_base_derived.val1() == 1, "non_cpp_base_derived fail calling Base::val1()");
+  swig_assert(non_cpp_base_derived.val2() == 12, "non_cpp_base_derived fail calling Derived::val2()");
+  Other non_cpp_base_other = staticOtherCast(baseObj);
+  swig_assert(non_cpp_base_other !is null, "static cast to non_cpp_base_other fail");
+  swig_assert(non_cpp_base_other.val1() == 1, "non_cpp_base_other fail calling Base::val1()");
+  swig_assert(non_cpp_base_other.val2() == 22, "non_cpp_base_other fail calling Other::val2()");
+}

--- a/Examples/test-suite/go/li_cpointer_dynamic_cast_runme.go
+++ b/Examples/test-suite/go/li_cpointer_dynamic_cast_runme.go
@@ -1,0 +1,74 @@
+package main
+
+import "swigtests/li_cpointer_dynamic_cast"
+
+func swig_assert(b bool, msg string) {
+    if !b {
+        panic(msg)
+    }
+}
+func main() {
+    // Get a Derived object using a Base pointer
+    base_point_derived := li_cpointer_dynamic_cast.DerivedNewDerived()
+    defer li_cpointer_dynamic_cast.DeleteBase(base_point_derived)
+    swig_assert(base_point_derived.Val1() == 11, "base_point_derived fail calling Derived::val1()")
+    swig_assert(base_point_derived.Val2() == 2, "base_point_derived fail calling Base::val2()")
+    // Dynamic cast to original Derived class
+    derived_dyn := li_cpointer_dynamic_cast.DynDerivedCast(base_point_derived)
+    swig_assert(derived_dyn.Swigcptr() != 0, "dynamic cast to derived_dyn fail")
+    swig_assert(derived_dyn.Val1() == 11, "derived_dyn fail calling Derived::val1()")
+    swig_assert(derived_dyn.Val2() == 12, "derived_dyn fail calling Derived::val2()")
+    // Static cast work the same as dynamic cast, when used with the derived class!
+    derived_static := li_cpointer_dynamic_cast.StaticDerivedCast(base_point_derived)
+    swig_assert(derived_static.Swigcptr() != 0, "static cast to derived_static fail")
+    swig_assert(derived_static.Val1() == 11, "derived_static fail calling Derived::val1()")
+    swig_assert(derived_static.Val2() == 12, "derived_static fail calling Derived::val2()")
+
+    // Get an Other object using a Base pointer
+    base_point_other := li_cpointer_dynamic_cast.OtherNewOther()
+    defer li_cpointer_dynamic_cast.DeleteBase(base_point_other)
+    swig_assert(base_point_other.Val1() == 21, "base_point_other fail calling Other::val1()")
+    swig_assert(base_point_other.Val2() == 2, "base_point_other fail calling Base::val2()")
+    // Dynamic cast to original Other class
+    other_dyn := li_cpointer_dynamic_cast.DynOtherCast(base_point_other)
+    swig_assert(other_dyn.Swigcptr() != 0, "dynamic cast to other_dyn fail")
+    swig_assert(other_dyn.Val1() == 21, "other_dyn fail calling Other::val1()")
+    swig_assert(other_dyn.Val2() == 22, "other_dyn fail calling Other::val2()")
+    // Static cast work the same as dynamic cast, when used with the other class!
+    other_static := li_cpointer_dynamic_cast.StaticOtherCast(base_point_other)
+    swig_assert(other_static.Swigcptr() != 0, "static cast to other_static fail")
+    swig_assert(other_static.Val1() == 21, "other_static fail calling Other::val1()")
+    swig_assert(other_static.Val2() == 22, "other_static fail calling Other::val2()")
+
+    // Get a Base object
+    base := li_cpointer_dynamic_cast.NewBase()
+    defer li_cpointer_dynamic_cast.DeleteBase(base)
+    swig_assert(base.Val1() == 1, "base fail calling Base::val1()")
+    swig_assert(base.Val2() == 2, "base fail calling Base::val2()")
+
+    // Dynamic cast gives NULL as expected
+    swig_assert(li_cpointer_dynamic_cast.DynOtherCast(base_point_derived).Swigcptr() == 0, "'Derived' object can not cast to 'Other'")
+    swig_assert(li_cpointer_dynamic_cast.DynDerivedCast(base_point_other).Swigcptr() == 0, "'Other' object can not cast to 'Derived'")
+    swig_assert(li_cpointer_dynamic_cast.DynOtherCast(base).Swigcptr() == 0, "'Base' object can not cast to 'Other'")
+    swig_assert(li_cpointer_dynamic_cast.DynDerivedCast(base).Swigcptr() == 0, "'Base' object can not cast to 'Derived'")
+
+    // Static cast gives a hybrid result
+    // The virtual method point to original object class, as we expect!
+    // While the non-virtual method uses the new pointed class method!
+    non_cpp_other_derived := li_cpointer_dynamic_cast.StaticOtherCast(base_point_derived)
+    swig_assert(non_cpp_other_derived.Swigcptr() != 0, "static cast to non_cpp_other_derived fail")
+    swig_assert(non_cpp_other_derived.Val1() == 11, "non_cpp_other_derived fail calling Derived::val1()")
+    swig_assert(non_cpp_other_derived.Val2() == 22, "non_cpp_other_derived fail calling Other::val2()")
+    non_cpp_derived_other := li_cpointer_dynamic_cast.StaticDerivedCast(base_point_other)
+    swig_assert(non_cpp_derived_other.Swigcptr() != 0, "static cast to non_cpp_derived_other fail")
+    swig_assert(non_cpp_derived_other.Val1() == 21, "non_cpp_derived_other fail calling Other::val1()")
+    swig_assert(non_cpp_derived_other.Val2() == 12, "non_cpp_derived_other fail calling Derived::val2()")
+    non_cpp_base_derived := li_cpointer_dynamic_cast.StaticDerivedCast(base)
+    swig_assert(non_cpp_base_derived.Swigcptr() != 0, "static cast to non_cpp_base_derived fail")
+    swig_assert(non_cpp_base_derived.Val1() == 1, "non_cpp_base_derived fail calling Base::val1()")
+    swig_assert(non_cpp_base_derived.Val2() == 12, "non_cpp_base_derived fail calling Derived::val2()")
+    non_cpp_base_other := li_cpointer_dynamic_cast.StaticOtherCast(base)
+    swig_assert(non_cpp_base_other.Swigcptr() != 0, "static cast to non_cpp_base_other fail")
+    swig_assert(non_cpp_base_other.Val1() == 1, "non_cpp_base_other fail calling Base::val1()")
+    swig_assert(non_cpp_base_other.Val2() == 22, "non_cpp_base_other fail calling Other::val2()")
+}

--- a/Examples/test-suite/guile/li_cpointer_dynamic_cast_runme.scm
+++ b/Examples/test-suite/guile/li_cpointer_dynamic_cast_runme.scm
@@ -1,0 +1,5 @@
+;; The SWIG modules have "passive" Linkage, i.e., they don't generate
+;; Guile modules (namespaces) but simply put all the bindings into the
+;; current module.  That's enough for such a simple test.
+(dynamic-call "scm_init_li_cpointer_dynamic_cast_module" (dynamic-link "./libli_cpointer_dynamic_cast"))
+(load "../schemerunme/li_cpointer_dynamic_cast.scm")

--- a/Examples/test-suite/java/li_cpointer_dynamic_cast_runme.java
+++ b/Examples/test-suite/java/li_cpointer_dynamic_cast_runme.java
@@ -1,0 +1,79 @@
+import li_cpointer_dynamic_cast.*;
+
+public class li_cpointer_dynamic_cast_runme {
+
+  static {
+    try {
+      System.loadLibrary("li_cpointer_dynamic_cast");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("Native code library failed to load. See the chapter on Dynamic Linking Problems in the SWIG Java documentation for help.\n" + e);
+      System.exit(1);
+    }
+  }
+  public static void swig_assert(boolean b, String msg) {
+    if (!b)
+      throw new RuntimeException(msg);
+  }
+  public static void main(String argv[]) {
+    // Get a Derived object using a Base pointer;
+    Base base_point_derived = Derived.NewDerived();
+    swig_assert(base_point_derived.val1() == 11, "base_point_derived fail calling Derived::val1()");
+    swig_assert(base_point_derived.val2() == 2, "base_point_derived fail calling Base::val2()");
+    // Dynamic cast to original Derived class;
+    Derived derived_dyn = li_cpointer_dynamic_cast.dynDerivedCast(base_point_derived);
+    swig_assert(derived_dyn != null, "dynamic cast to derived_dyn fail");
+    swig_assert(derived_dyn.val1() == 11, "derived_dyn fail calling Derived::val1()");
+    swig_assert(derived_dyn.val2() == 12, "derived_dyn fail calling Derived::val2()");
+    // Static cast work the same as dynamic cast, when used with the derived class!;
+    Derived derived_static = li_cpointer_dynamic_cast.staticDerivedCast(base_point_derived);
+    swig_assert(derived_static != null, "static cast to derived_static fail");
+    swig_assert(derived_static.val1() == 11, "derived_static fail calling Derived::val1()");
+    swig_assert(derived_static.val2() == 12, "derived_static fail calling Derived::val2()");
+
+    // Get an Other object using a Base pointer;
+    Base base_point_other = Other.NewOther();
+    swig_assert(base_point_other.val1() == 21, "base_point_other fail calling Other::val1()");
+    swig_assert(base_point_other.val2() == 2, "base_point_other fail calling Base::val2()");
+    // Dynamic cast to original Other class;
+    Other other_dyn = li_cpointer_dynamic_cast.dynOtherCast(base_point_other);
+    swig_assert(other_dyn != null, "dynamic cast to other_dyn fail");
+    swig_assert(other_dyn.val1() == 21, "other_dyn fail calling Other::val1()");
+    swig_assert(other_dyn.val2() == 22, "other_dyn fail calling Other::val2()");
+    // Static cast work the same as dynamic cast, when used with the other class!;
+    Other other_static = li_cpointer_dynamic_cast.staticOtherCast(base_point_other);
+    swig_assert(other_static != null, "static cast to other_static fail");
+    swig_assert(other_static.val1() == 21, "other_static fail calling Other::val1()");
+    swig_assert(other_static.val2() == 22, "other_static fail calling Other::val2()");
+
+    // Get a Base object;
+    Base base = new Base();
+    swig_assert(base.val1() == 1, "base fail calling Base::val1()");
+    swig_assert(base.val2() == 2, "base fail calling Base::val2()");
+
+    // Dynamic cast gives NULL as expected;
+    swig_assert(li_cpointer_dynamic_cast.dynOtherCast(base_point_derived) == null, "'Derived' object can not cast to 'Other'");
+    swig_assert(li_cpointer_dynamic_cast.dynDerivedCast(base_point_other) == null, "'Other' object can not cast to 'Derived'");
+    swig_assert(li_cpointer_dynamic_cast.dynOtherCast(base) == null, "'Base' object can not cast to 'Other'");
+    swig_assert(li_cpointer_dynamic_cast.dynDerivedCast(base) == null, "'Base' object can not cast to 'Derived'");
+
+    // Static cast gives a hybrid result;
+    // The virtual method point to original object class, as we expect!;
+    // While the non-virtual method uses the new pointed class method!;
+    Other non_cpp_other_derived = li_cpointer_dynamic_cast.staticOtherCast(base_point_derived);
+    swig_assert(non_cpp_other_derived != null, "static cast to non_cpp_other_derived fail");
+    swig_assert(non_cpp_other_derived.val1() == 11, "non_cpp_other_derived fail calling Derived::val1()");
+    swig_assert(non_cpp_other_derived.val2() == 22, "non_cpp_other_derived fail calling Other::val2()");
+    Derived non_cpp_derived_other = li_cpointer_dynamic_cast.staticDerivedCast(base_point_other);
+    swig_assert(non_cpp_derived_other != null, "static cast to non_cpp_derived_other fail");
+    swig_assert(non_cpp_derived_other.val1() == 21, "non_cpp_derived_other fail calling Other::val1()");
+    swig_assert(non_cpp_derived_other.val2() == 12, "non_cpp_derived_other fail calling Derived::val2()");
+    Derived non_cpp_base_derived = li_cpointer_dynamic_cast.staticDerivedCast(base);
+    swig_assert(non_cpp_base_derived != null, "static cast to non_cpp_base_derived fail");
+    swig_assert(non_cpp_base_derived.val1() == 1, "non_cpp_base_derived fail calling Base::val1()");
+    swig_assert(non_cpp_base_derived.val2() == 12, "non_cpp_base_derived fail calling Derived::val2()");
+    Other non_cpp_base_other = li_cpointer_dynamic_cast.staticOtherCast(base);
+    swig_assert(non_cpp_base_other != null, "static cast to non_cpp_base_other fail");
+    swig_assert(non_cpp_base_other.val1() == 1, "non_cpp_base_other fail calling Base::val1()");
+    swig_assert(non_cpp_base_other.val2() == 22, "non_cpp_base_other fail calling Other::val2()");
+  }
+}

--- a/Examples/test-suite/javascript/li_cpointer_dynamic_cast_runme.js
+++ b/Examples/test-suite/javascript/li_cpointer_dynamic_cast_runme.js
@@ -1,0 +1,67 @@
+var li_cpointer_dynamic_cast = require("li_cpointer_dynamic_cast");
+
+var swig_assert = function(condition, msg) {
+  if (!condition)
+    throw new Error(msg);
+}
+
+// Get a Derived object using a Base pointer
+base_point_derived = li_cpointer_dynamic_cast.Derived.NewDerived();
+swig_assert(base_point_derived.val1() === 11, "base_point_derived fail calling Derived::val1()");
+swig_assert(base_point_derived.val2() === 2, "base_point_derived fail calling Base::val2()");
+// Dynamic cast to original Derived class
+derived_dyn = li_cpointer_dynamic_cast.dynDerivedCast(base_point_derived);
+swig_assert(derived_dyn !== null, "dynamic cast to derived_dyn fail");
+swig_assert(derived_dyn.val1() === 11, "derived_dyn fail calling Derived::val1()");
+swig_assert(derived_dyn.val2() === 12, "derived_dyn fail calling Derived::val2()");
+// Static cast work the same as dynamic cast, when used with the derived class!
+derived_static = li_cpointer_dynamic_cast.staticDerivedCast(base_point_derived);
+swig_assert(derived_static !== null, "static cast to derived_static fail");
+swig_assert(derived_static.val1() === 11, "derived_static fail calling Derived::val1()");
+swig_assert(derived_static.val2() === 12, "derived_static fail calling Derived::val2()");
+
+// Get an Other object using a Base pointer
+base_point_other = li_cpointer_dynamic_cast.Other.NewOther();
+swig_assert(base_point_other.val1() === 21, "base_point_other fail calling Other::val1()");
+swig_assert(base_point_other.val2() === 2, "base_point_other fail calling Base::val2()");
+// Dynamic cast to original Other class
+other_dyn = li_cpointer_dynamic_cast.dynOtherCast(base_point_other);
+swig_assert(other_dyn !== null, "dynamic cast to other_dyn fail");
+swig_assert(other_dyn.val1() === 21, "other_dyn fail calling Other::val1()");
+swig_assert(other_dyn.val2() === 22, "other_dyn fail calling Other::val2()");
+// Static cast work the same as dynamic cast, when used with the other class!
+other_static = li_cpointer_dynamic_cast.staticOtherCast(base_point_other);
+swig_assert(other_static !== null, "static cast to other_static fail");
+swig_assert(other_static.val1() === 21, "other_static fail calling Other::val1()");
+swig_assert(other_static.val2() === 22, "other_static fail calling Other::val2()");
+
+// Get a Base object
+base = new li_cpointer_dynamic_cast.Base;
+swig_assert(base.val1() === 1, "base fail calling Base::val1()");
+swig_assert(base.val2() === 2, "base fail calling Base::val2()");
+
+// Dynamic cast gives NULL as expected
+swig_assert(li_cpointer_dynamic_cast.dynOtherCast(base_point_derived) === null, "'Derived' object can not cast to 'Other'");
+swig_assert(li_cpointer_dynamic_cast.dynDerivedCast(base_point_other) === null, "'Other' object can not cast to 'Derived'");
+swig_assert(li_cpointer_dynamic_cast.dynOtherCast(base) === null, "'Base' object can not cast to 'Other'");
+swig_assert(li_cpointer_dynamic_cast.dynDerivedCast(base) === null, "'Base' object can not cast to 'Derived'");
+
+// Static cast gives a hybrid result
+// The virtual method point to original object class, as we expect!
+// While the non-virtual method uses the new pointed class method!
+non_cpp_other_derived = li_cpointer_dynamic_cast.staticOtherCast(base_point_derived);
+swig_assert(non_cpp_other_derived !== null, "static cast to non_cpp_other_derived fail");
+swig_assert(non_cpp_other_derived.val1() === 11, "non_cpp_other_derived fail calling Derived::val1()");
+swig_assert(non_cpp_other_derived.val2() === 22, "non_cpp_other_derived fail calling Other::val2()");
+non_cpp_derived_other = li_cpointer_dynamic_cast.staticDerivedCast(base_point_other);
+swig_assert(non_cpp_derived_other !== null, "static cast to non_cpp_derived_other fail");
+swig_assert(non_cpp_derived_other.val1() === 21, "non_cpp_derived_other fail calling Other::val1()");
+swig_assert(non_cpp_derived_other.val2() === 12, "non_cpp_derived_other fail calling Derived::val2()");
+non_cpp_base_derived = li_cpointer_dynamic_cast.staticDerivedCast(base);
+swig_assert(non_cpp_base_derived !== null, "static cast to non_cpp_base_derived fail");
+swig_assert(non_cpp_base_derived.val1() === 1, "non_cpp_base_derived fail calling Base::val1()");
+swig_assert(non_cpp_base_derived.val2() === 12, "non_cpp_base_derived fail calling Derived::val2()");
+non_cpp_base_other = li_cpointer_dynamic_cast.staticOtherCast(base);
+swig_assert(non_cpp_base_other !== null, "static cast to non_cpp_base_other fail");
+swig_assert(non_cpp_base_other.val1() === 1, "non_cpp_base_other fail calling Base::val1()");
+swig_assert(non_cpp_base_other.val2() === 22, "non_cpp_base_other fail calling Other::val2()");

--- a/Examples/test-suite/li_cpointer_dynamic_cast.i
+++ b/Examples/test-suite/li_cpointer_dynamic_cast.i
@@ -1,0 +1,28 @@
+%module li_cpointer_dynamic_cast
+
+%include "cpointer.i"
+
+%inline %{
+struct Base {
+  virtual ~Base() {}
+  virtual int val1() { return 1; }
+  int val2() { return 2; }
+};
+struct Derived : Base {
+  virtual ~Derived() {}
+  virtual int val1() { return 11; }
+  int val2() { return 12; }
+  static Base* NewDerived() { return new Derived; }
+};
+struct Other : Base {
+  virtual ~Other() {}
+  virtual int val1() { return 21; }
+  int val2() { return 22; }
+  static Base* NewOther() { return new Other; }
+};
+%}
+
+%pointer_cast(Base*,Derived*,staticDerivedCast);
+%pointer_dynamic_cast(Base*,Derived*,dynDerivedCast);
+%pointer_cast(Base*,Other*,staticOtherCast);
+%pointer_dynamic_cast(Base*,Other*,dynOtherCast);

--- a/Examples/test-suite/lua/li_cpointer_dynamic_cast_runme.lua
+++ b/Examples/test-suite/lua/li_cpointer_dynamic_cast_runme.lua
@@ -1,0 +1,62 @@
+local v=require("li_cpointer_dynamic_cast")
+
+-- Get a Derived object using a Base pointer
+local base_point_derived = v.Derived.NewDerived()
+assert(base_point_derived:val1() == 11, "base_point_derived fail calling Derived::val1()")
+assert(base_point_derived:val2() == 2, "base_point_derived fail calling Base::val2()")
+-- Dynamic cast to original Derived class
+local derived_dyn = v.dynDerivedCast(base_point_derived)
+assert(derived_dyn ~= nil, "dynamic cast to derived_dyn fail")
+assert(derived_dyn:val1() == 11, "derived_dyn fail calling Derived::val1()")
+assert(derived_dyn:val2() == 12, "derived_dyn fail calling Derived::val2()")
+-- Static cast work the same as dynamic cast, when used with the derived class!
+local derived_static = v.staticDerivedCast(base_point_derived)
+assert(derived_static ~= nil, "static cast to derived_static fail")
+assert(derived_static:val1() == 11, "derived_static fail calling Derived::val1()")
+assert(derived_static:val2() == 12, "derived_static fail calling Derived::val2()")
+
+-- Get an Other object using a Base pointer
+local base_point_other = v.Other.NewOther()
+assert(base_point_other:val1() == 21, "base_point_other fail calling Other::val1()")
+assert(base_point_other:val2() == 2, "base_point_other fail calling Base::val2()")
+-- Dynamic cast to original Other class
+local other_dyn = v.dynOtherCast(base_point_other)
+assert(other_dyn ~= nil, "dynamic cast to other_dyn fail")
+assert(other_dyn:val1() == 21, "other_dyn fail calling Other::val1()")
+assert(other_dyn:val2() == 22, "other_dyn fail calling Other::val2()")
+-- Static cast work the same as dynamic cast, when used with the other class!
+local other_static = v.staticOtherCast(base_point_other)
+assert(other_static ~= nil, "static cast to other_static fail")
+assert(other_static:val1() == 21, "other_static fail calling Other::val1()")
+assert(other_static:val2() == 22, "other_static fail calling Other::val2()")
+
+-- Get a Base object
+local base = v.Base()
+assert(base:val1() == 1, "base fail calling Base::val1()")
+assert(base:val2() == 2, "base fail calling Base::val2()")
+
+-- Dynamic cast gives NULL as expected
+assert(v.dynOtherCast(base_point_derived) == nil, "'Derived' object can not cast to 'Other'")
+assert(v.dynDerivedCast(base_point_other) == nil, "'Other' object can not cast to 'Derived'")
+assert(v.dynOtherCast(base) == nil, "'Base' object can not cast to 'Other'")
+assert(v.dynDerivedCast(base) == nil, "'Base' object can not cast to 'Derived'")
+
+-- Static cast gives a hybrid result
+-- The virtual method point to original object class, as we expect!
+-- While the non-virtual method uses the new pointed class method!
+local non_cpp_other_derived = v.staticOtherCast(base_point_derived)
+assert(non_cpp_other_derived ~= nil, "static cast to non_cpp_other_derived fail")
+assert(non_cpp_other_derived:val1() == 11, "non_cpp_other_derived fail calling Derived::val1()")
+assert(non_cpp_other_derived:val2() == 22, "non_cpp_other_derived fail calling Other::val2()")
+local non_cpp_derived_other = v.staticDerivedCast(base_point_other)
+assert(non_cpp_derived_other ~= nil, "static cast to non_cpp_derived_other fail")
+assert(non_cpp_derived_other:val1() == 21, "non_cpp_derived_other fail calling Other::val1()")
+assert(non_cpp_derived_other:val2() == 12, "non_cpp_derived_other fail calling Derived::val2()")
+local non_cpp_base_derived = v.staticDerivedCast(base)
+assert(non_cpp_base_derived ~= nil, "static cast to non_cpp_base_derived fail")
+assert(non_cpp_base_derived:val1() == 1, "non_cpp_base_derived fail calling Base::val1()")
+assert(non_cpp_base_derived:val2() == 12, "non_cpp_base_derived fail calling Derived::val2()")
+local non_cpp_base_other = v.staticOtherCast(base)
+assert(non_cpp_base_other ~= nil, "static cast to non_cpp_base_other fail")
+assert(non_cpp_base_other:val1() == 1, "non_cpp_base_other fail calling Base::val1()")
+assert(non_cpp_base_other:val2() == 22, "non_cpp_base_other fail calling Other::val2()")

--- a/Examples/test-suite/ocaml/li_cpointer_dynamic_cast_runme.ml
+++ b/Examples/test-suite/ocaml/li_cpointer_dynamic_cast_runme.ml
@@ -1,0 +1,65 @@
+open Swig
+open Li_cpointer_dynamic_cast
+
+let _ =
+  let null = 0 in (* repeasent C++ null pointer *)
+  (* Get a Derived object using a Base pointer *)
+  let base_point_derived = _Derived_NewDerived '() in
+  let _ = assert '((base_point_derived -> val1 () as int) = 11) in
+  let _ = assert '((base_point_derived -> val2 () as int) = 2) in
+  (* Dynamic cast to original Derived class *)
+  let derived_dyn = _dynDerivedCast '(base_point_derived) in
+  let _ = assert '(derived_dyn as int != null) in
+  let _ = assert '((derived_dyn -> val1 () as int) = 11) in
+  let _ = assert '((derived_dyn -> val2 () as int) = 12) in
+  (* Static cast work the same as dynamic cast, when used with the derived class! *)
+  let derived_static = _staticDerivedCast '(base_point_derived) in
+  let _ = assert '(derived_static as int != null) in
+  let _ = assert '((derived_static -> val1 () as int) = 11) in
+  let _ = assert '((derived_static -> val2 () as int) = 12) in
+
+  (* Get an Other object using a Base pointer *)
+  let base_point_other = _Other_NewOther '() in
+  let _ = assert '((base_point_other -> val1 () as int) = 21) in
+  let _ = assert '((base_point_other -> val2 () as int) = 2) in
+  (* Dynamic cast to original Other class *)
+  let other_dyn = _dynOtherCast '(base_point_other) in
+  let _ = assert '(other_dyn as int != null) in
+  let _ = assert '((other_dyn -> val1 () as int) = 21) in
+  let _ = assert '((other_dyn -> val2 () as int) = 22) in
+  (* Static cast work the same as dynamic cast, when used with the other class! *)
+  let other_static = _staticOtherCast '(base_point_other) in
+  let _ = assert '(other_static as int != null) in
+  let _ = assert '((other_static -> val1 () as int) = 21) in
+  let _ = assert '((other_static -> val2 () as int) = 22) in
+
+  (* Get a Base object *)
+  let base = _new_Base '() in
+  let _ = assert '((base -> val1 () as int) = 1) in
+  let _ = assert '((base -> val2 () as int) = 2) in
+
+  (* Dynamic cast gives NULL as expected *)
+  let _ = assert '((_dynOtherCast '(base_point_derived) as int) = null) in
+  let _ = assert '((_dynDerivedCast(base_point_other) as int) = null) in
+  let _ = assert '((_dynOtherCast(base) as int) = null) in
+  let _ = assert '((_dynDerivedCast(base) as int) = null) in
+
+  (* Static cast gives a hybrid result *)
+  (* The virtual method point to original object class, as we expect! *)
+  (* While the non-virtual method uses the new pointed class method! *)
+  let non_cpp_other_derived = _staticOtherCast '(base_point_derived) in
+  let _ = assert '(non_cpp_other_derived as int != null) in
+  let _ = assert '((non_cpp_other_derived -> val1 () as int) = 11) in
+  let _ = assert '((non_cpp_other_derived -> val2 () as int) = 22) in
+  let non_cpp_derived_other = _staticDerivedCast '(base_point_other) in
+  let _ = assert '(non_cpp_derived_other as int != null) in
+  let _ = assert '((non_cpp_derived_other -> val1 () as int) = 21) in
+  let _ = assert '((non_cpp_derived_other -> val2 () as int) = 12) in
+  let non_cpp_base_derived = _staticDerivedCast '(base) in
+  let _ = assert '(non_cpp_base_derived as int != null) in
+  let _ = assert '((non_cpp_base_derived -> val1 () as int) = 1) in
+  let _ = assert '((non_cpp_base_derived -> val2 () as int) = 12) in
+  let non_cpp_base_other = _staticOtherCast '(base) in
+  let _ = assert '(non_cpp_base_other as int != null) in
+  let _ = assert '((non_cpp_base_other -> val1 () as int) = 1) in
+  assert '((non_cpp_base_other -> val2 () as int) = 22)

--- a/Examples/test-suite/octave/li_cpointer_dynamic_cast_runme.m
+++ b/Examples/test-suite/octave/li_cpointer_dynamic_cast_runme.m
@@ -1,0 +1,68 @@
+li_cpointer_dynamic_cast
+
+function swig_assert (b, msg)
+  if (!b)
+    error(msg);
+  end
+end
+
+% Get a Derived object using a Base pointer
+base_point_derived = Derived.NewDerived();
+swig_assert(base_point_derived.val1() == 11, "base_point_derived fail calling Derived::val1()");
+swig_assert(base_point_derived.val2() == 2, "base_point_derived fail calling Base::val2()");
+% Dynamic cast to original Derived class
+derived_dyn = dynDerivedCast(base_point_derived);
+swig_assert(!isempty(derived_dyn), "dynamic cast to derived_dyn fail");
+swig_assert(derived_dyn.val1() == 11, "derived_dyn fail calling Derived::val1()");
+swig_assert(derived_dyn.val2() == 12, "derived_dyn fail calling Derived::val2()");
+% Static cast work the same as dynamic cast, when used with the derived class!
+derived_static = staticDerivedCast(base_point_derived);
+swig_assert(!isempty(derived_static), "static cast to derived_static fail");
+swig_assert(derived_static.val1() == 11, "derived_static fail calling Derived::val1()");
+swig_assert(derived_static.val2() == 12, "derived_static fail calling Derived::val2()");
+
+% Get an Other object using a Base pointer
+base_point_other = Other.NewOther();
+swig_assert(base_point_other.val1() == 21, "base_point_other fail calling Other::val1()");
+swig_assert(base_point_other.val2() == 2, "base_point_other fail calling Base::val2()");
+% Dynamic cast to original Other class
+other_dyn = dynOtherCast(base_point_other);
+swig_assert(!isempty(other_dyn), "dynamic cast to other_dyn fail");
+swig_assert(other_dyn.val1() == 21, "other_dyn fail calling Other::val1()");
+swig_assert(other_dyn.val2() == 22, "other_dyn fail calling Other::val2()");
+% Static cast work the same as dynamic cast, when used with the other class!
+other_static = staticOtherCast(base_point_other);
+swig_assert(!isempty(other_static), "static cast to other_static fail");
+swig_assert(other_static.val1() == 21, "other_static fail calling Other::val1()");
+swig_assert(other_static.val2() == 22, "other_static fail calling Other::val2()");
+
+% Get a Base object
+base = Base();
+swig_assert(base.val1() == 1, "base fail calling Base::val1()");
+swig_assert(base.val2() == 2, "base fail calling Base::val2()");
+
+% Dynamic cast gives NULL as expected
+swig_assert(isempty(dynOtherCast(base_point_derived)), "'Derived' object can not cast to 'Other'");
+swig_assert(isempty(dynDerivedCast(base_point_other)), "'Other' object can not cast to 'Derived'");
+swig_assert(isempty(dynOtherCast(base)), "'Base' object can not cast to 'Other'");
+swig_assert(isempty(dynDerivedCast(base)), "'Base' object can not cast to 'Derived'");
+
+% Static cast gives a hybrid result
+% The virtual method point to original object class, as we expect!
+% While the non-virtual method uses the new pointed class method!
+non_cpp_other_derived = staticOtherCast(base_point_derived);
+swig_assert(!isempty(non_cpp_other_derived), "static cast to non_cpp_other_derived fail");
+swig_assert(non_cpp_other_derived.val1() == 11, "non_cpp_other_derived fail calling Derived::val1()");
+swig_assert(non_cpp_other_derived.val2() == 22, "non_cpp_other_derived fail calling Other::val2()");
+non_cpp_derived_other = staticDerivedCast(base_point_other);
+swig_assert(!isempty(non_cpp_derived_other), "static cast to non_cpp_derived_other fail");
+swig_assert(non_cpp_derived_other.val1() == 21, "non_cpp_derived_other fail calling Other::val1()");
+swig_assert(non_cpp_derived_other.val2() == 12, "non_cpp_derived_other fail calling Derived::val2()");
+non_cpp_base_derived = staticDerivedCast(base);
+swig_assert(!isempty(non_cpp_base_derived), "static cast to non_cpp_base_derived fail");
+swig_assert(non_cpp_base_derived.val1() == 1, "non_cpp_base_derived fail calling Base::val1()");
+swig_assert(non_cpp_base_derived.val2() == 12, "non_cpp_base_derived fail calling Derived::val2()");
+non_cpp_base_other = staticOtherCast(base);
+swig_assert(!isempty(non_cpp_base_other), "static cast to non_cpp_base_other fail");
+swig_assert(non_cpp_base_other.val1() == 1, "non_cpp_base_other fail calling Base::val1()");
+swig_assert(non_cpp_base_other.val2() == 22, "non_cpp_base_other fail calling Other::val2()");

--- a/Examples/test-suite/perl5/li_cpointer_dynamic_cast_runme.pl
+++ b/Examples/test-suite/perl5/li_cpointer_dynamic_cast_runme.pl
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+use Test::More tests => 36;
+BEGIN { use_ok('li_cpointer_dynamic_cast') }
+require_ok('li_cpointer_dynamic_cast');
+
+# Get a Derived object using a Base pointer
+my $base_point_derived = li_cpointer_dynamic_cast::Derived::NewDerived;
+ok($base_point_derived->val1() == 11, "base_point_derived fail calling Derived::val1()");
+ok($base_point_derived->val2() == 2, "base_point_derived fail calling Base::val2()");
+# Dynamic cast to original Derived class
+my $derived_dyn = li_cpointer_dynamic_cast::dynDerivedCast($base_point_derived);
+ok($derived_dyn != undef, "dynamic cast to derived_dyn fail");
+ok($derived_dyn->val1() == 11, "derived_dyn fail calling Derived::val1()");
+ok($derived_dyn->val2() == 12, "derived_dyn fail calling Derived::val2()");
+# Static cast work the same as dynamic cast, when used with the derived class!
+my $derived_static = li_cpointer_dynamic_cast::staticDerivedCast($base_point_derived);
+ok($derived_static != undef, "static cast to derived_static fail");
+ok($derived_static->val1() == 11, "derived_static fail calling Derived::val1()");
+ok($derived_static->val2() == 12, "derived_static fail calling Derived::val2()");
+
+# Get an Other object using a Base pointer
+my $base_point_other = li_cpointer_dynamic_cast::Other::NewOther;
+ok($base_point_other->val1() == 21, "base_point_other fail calling Other::val1()");
+ok($base_point_other->val2() == 2, "base_point_other fail calling Base::val2()");
+# Dynamic cast to original Other class
+my $other_dyn = li_cpointer_dynamic_cast::dynOtherCast($base_point_other);
+ok($other_dyn != undef, "dynamic cast to other_dyn fail");
+ok($other_dyn->val1() == 21, "other_dyn fail calling Other::val1()");
+ok($other_dyn->val2() == 22, "other_dyn fail calling Other::val2()");
+# Static cast work the same as dynamic cast, when used with the other class!
+my $other_static = li_cpointer_dynamic_cast::staticOtherCast($base_point_other);
+ok($other_static != undef, "static cast to other_static fail");
+ok($other_static->val1() == 21, "other_static fail calling Other::val1()");
+ok($other_static->val2() == 22, "other_static fail calling Other::val2()");
+
+# Get a Base object
+my $baseObj = li_cpointer_dynamic_cast::Base->new;
+ok($baseObj->val1() == 1, "base fail calling Base::val1()");
+ok($baseObj->val2() == 2, "base fail calling Base::val2()");
+
+# Dynamic cast gives NULL as expected
+ok(li_cpointer_dynamic_cast::dynOtherCast($base_point_derived) == undef, "'Derived' object can not cast to 'Other'");
+ok(li_cpointer_dynamic_cast::dynDerivedCast($base_point_other) == undef, "'Other' object can not cast to 'Derived'");
+ok(li_cpointer_dynamic_cast::dynOtherCast($baseObj) == undef, "'Base' object can not cast to 'Other'");
+ok(li_cpointer_dynamic_cast::dynDerivedCast($baseObj) == undef, "'Base' object can not cast to 'Derived'");
+
+# Static cast gives a hybrid result
+# The virtual method point to original object class, as we expect!
+# While the non-virtual method uses the new pointed class method!
+my $non_cpp_other_derived = li_cpointer_dynamic_cast::staticOtherCast($base_point_derived);
+ok($non_cpp_other_derived != undef, "static cast to non_cpp_other_derived fail");
+ok($non_cpp_other_derived->val1() == 11, "non_cpp_other_derived fail calling Derived::val1()");
+ok($non_cpp_other_derived->val2() == 22, "non_cpp_other_derived fail calling Other::val2()");
+my $non_cpp_derived_other = li_cpointer_dynamic_cast::staticDerivedCast($base_point_other);
+ok($non_cpp_derived_other != undef, "static cast to non_cpp_derived_other fail");
+ok($non_cpp_derived_other->val1() == 21, "non_cpp_derived_other fail calling Other::val1()");
+ok($non_cpp_derived_other->val2() == 12, "non_cpp_derived_other fail calling Derived::val2()");
+my $non_cpp_base_derived = li_cpointer_dynamic_cast::staticDerivedCast($baseObj);
+ok($non_cpp_base_derived != undef, "static cast to non_cpp_base_derived fail");
+ok($non_cpp_base_derived->val1() == 1, "non_cpp_base_derived fail calling Base::val1()");
+ok($non_cpp_base_derived->val2() == 12, "non_cpp_base_derived fail calling Derived::val2()");
+my $non_cpp_base_other = li_cpointer_dynamic_cast::staticOtherCast($baseObj);
+ok($non_cpp_base_other != undef, "static cast to non_cpp_base_other fail");
+ok($non_cpp_base_other->val1() == 1, "non_cpp_base_other fail calling Base::val1()");
+ok($non_cpp_base_other->val2() == 22, "non_cpp_base_other fail calling Other::val2()");

--- a/Examples/test-suite/php/li_cpointer_dynamic_cast_runme.php
+++ b/Examples/test-suite/php/li_cpointer_dynamic_cast_runme.php
@@ -1,0 +1,69 @@
+<?php
+
+require "tests.php";
+
+check::functions(array("staticDerivedCast", "dynDerivedCast", "staticOtherCast", "dynOtherCast"));
+check::classes(array("Base", "Derived", "Other", "li_cpointer_dynamic_cast"));
+check::globals(array());
+
+
+# Get a Derived object using a Base pointer
+$base_point_derived = Derived::NewDerived();
+check::equal($base_point_derived->val1(), 11, "base_point_derived fail calling Derived::val1()");
+check::equal($base_point_derived->val2(), 2, "base_point_derived fail calling Base::val2()");
+# Dynamic cast to original Derived class
+$derived_dyn = dynDerivedCast($base_point_derived);
+check::equal($derived_dyn !== NULL, true, "dynamic cast to derived_dyn fail");
+check::equal($derived_dyn->val1(), 11, "derived_dyn fail calling Derived::val1()");
+check::equal($derived_dyn->val2(), 12, "derived_dyn fail calling Derived::val2()");
+# Static cast work the same as dynamic cast, when used with the derived class!
+$derived_static = staticDerivedCast($base_point_derived);
+check::equal($derived_static !== NULL, true, "static cast to derived_static fail");
+check::equal($derived_static->val1(), 11, "derived_static fail calling Derived::val1()");
+check::equal($derived_static->val2(), 12, "derived_static fail calling Derived::val2()");
+
+# Get an Other object using a Base pointer
+$base_point_other = Other::NewOther();
+check::equal($base_point_other->val1(), 21, "base_point_other fail calling Other::val1()");
+check::equal($base_point_other->val2(), 2, "base_point_other fail calling Base::val2()");
+# Dynamic cast to original Other class
+$other_dyn = dynOtherCast($base_point_other);
+check::equal($other_dyn !== NULL, true, "dynamic cast to other_dyn fail");
+check::equal($other_dyn->val1(), 21, "other_dyn fail calling Other::val1()");
+check::equal($other_dyn->val2(), 22, "other_dyn fail calling Other::val2()");
+# Static cast work the same as dynamic cast, when used with the other class!
+$other_static = staticOtherCast($base_point_other);
+check::equal($other_static !== NULL, true, "static cast to other_static fail");
+check::equal($other_static->val1(), 21, "other_static fail calling Other::val1()");
+check::equal($other_static->val2(), 22, "other_static fail calling Other::val2()");
+
+# Get a Base object
+$baseObj = new Base;
+check::equal($baseObj->val1(), 1, "base fail calling Base::val1()");
+check::equal($baseObj->val2(), 2, "base fail calling Base::val2()");
+
+# Dynamic cast gives NULL as expected
+check::isnull(dynOtherCast($base_point_derived), "'Derived' object can not cast to 'Other'");
+check::isnull(dynDerivedCast($base_point_other), "'Other' object can not cast to 'Derived'");
+check::isnull(dynOtherCast($baseObj), "'Base' object can not cast to 'Other'");
+check::isnull(dynDerivedCast($baseObj), "'Base' object can not cast to 'Derived'");
+
+# Static cast gives a hybrid result
+# The virtual method point to original object class, as we expect!
+# While the non-virtual method uses the new pointed class method!
+$non_cpp_other_derived = staticOtherCast($base_point_derived);
+check::equal($non_cpp_other_derived !== NULL, true, "static cast to non_cpp_other_derived fail");
+check::equal($non_cpp_other_derived->val1(), 11, "non_cpp_other_derived fail calling Derived::val1()");
+check::equal($non_cpp_other_derived->val2(), 22, "non_cpp_other_derived fail calling Other::val2()");
+$non_cpp_derived_other = staticDerivedCast($base_point_other);
+check::equal($non_cpp_derived_other !== NULL, true, "static cast to non_cpp_derived_other fail");
+check::equal($non_cpp_derived_other->val1(), 21, "non_cpp_derived_other fail calling Other::val1()");
+check::equal($non_cpp_derived_other->val2(), 12, "non_cpp_derived_other fail calling Derived::val2()");
+$non_cpp_base_derived = staticDerivedCast($baseObj);
+check::equal($non_cpp_base_derived !== NULL, true, "static cast to non_cpp_base_derived fail");
+check::equal($non_cpp_base_derived->val1(), 1, "non_cpp_base_derived fail calling Base::val1()");
+check::equal($non_cpp_base_derived->val2(), 12, "non_cpp_base_derived fail calling Derived::val2()");
+$non_cpp_base_other = staticOtherCast($baseObj);
+check::equal($non_cpp_base_other !== NULL, true, "static cast to non_cpp_base_other fail");
+check::equal($non_cpp_base_other->val1(), 1, "non_cpp_base_other fail calling Base::val1()");
+check::equal($non_cpp_base_other->val2(), 22, "non_cpp_base_other fail calling Other::val2()");

--- a/Examples/test-suite/python/li_cpointer_dynamic_cast_runme.py
+++ b/Examples/test-suite/python/li_cpointer_dynamic_cast_runme.py
@@ -1,0 +1,66 @@
+from li_cpointer_dynamic_cast import *
+
+def swig_assert(condition, msg):
+  if not condition:
+    raise AssertionError(msg)
+
+# Get a Derived object using a Base pointer
+base_point_derived = Derived.NewDerived()
+swig_assert(base_point_derived.val1() == 11, "base_point_derived fail calling Derived::val1()")
+swig_assert(base_point_derived.val2() == 2, "base_point_derived fail calling Base::val2()")
+# Dynamic cast to original Derived class
+derived_dyn = dynDerivedCast(base_point_derived)
+swig_assert(derived_dyn != None, "dynamic cast to derived_dyn fail")
+swig_assert(derived_dyn.val1() == 11, "derived_dyn fail calling Derived::val1()")
+swig_assert(derived_dyn.val2() == 12, "derived_dyn fail calling Derived::val2()")
+# Static cast work the same as dynamic cast, when used with the derived class!
+derived_static = staticDerivedCast(base_point_derived)
+swig_assert(derived_static != None, "static cast to derived_static fail")
+swig_assert(derived_static.val1() == 11, "derived_static fail calling Derived::val1()")
+swig_assert(derived_static.val2() == 12, "derived_static fail calling Derived::val2()")
+
+# Get an Other object using a Base pointer
+base_point_other = Other.NewOther()
+swig_assert(base_point_other.val1() == 21, "base_point_other fail calling Other::val1()")
+swig_assert(base_point_other.val2() == 2, "base_point_other fail calling Base::val2()")
+# Dynamic cast to original Other class
+other_dyn = dynOtherCast(base_point_other)
+swig_assert(other_dyn != None, "dynamic cast to other_dyn fail")
+swig_assert(other_dyn.val1() == 21, "other_dyn fail calling Other::val1()")
+swig_assert(other_dyn.val2() == 22, "other_dyn fail calling Other::val2()")
+# Static cast work the same as dynamic cast, when used with the other class!
+other_static = staticOtherCast(base_point_other)
+swig_assert(other_static != None, "static cast to other_static fail")
+swig_assert(other_static.val1() == 21, "other_static fail calling Other::val1()")
+swig_assert(other_static.val2() == 22, "other_static fail calling Other::val2()")
+
+# Get a Base object
+base = Base()
+swig_assert(base.val1() == 1, "base fail calling Base::val1()")
+swig_assert(base.val2() == 2, "base fail calling Base::val2()")
+
+# Dynamic cast gives NULL as expected
+swig_assert(dynOtherCast(base_point_derived) == None, "'Derived' object can not cast to 'Other'")
+swig_assert(dynDerivedCast(base_point_other) == None, "'Other' object can not cast to 'Derived'")
+swig_assert(dynOtherCast(base) == None, "'Base' object can not cast to 'Other'")
+swig_assert(dynDerivedCast(base) == None, "'Base' object can not cast to 'Derived'")
+
+# Static cast gives a hybrid result
+# The virtual method point to original object class, as we expect!
+# While the non-virtual method uses the new pointed class method!
+non_cpp_other_derived = staticOtherCast(base_point_derived)
+swig_assert(non_cpp_other_derived != None, "static cast to non_cpp_other_derived fail")
+swig_assert(non_cpp_other_derived.val1() == 11, "non_cpp_other_derived fail calling Derived::val1()")
+swig_assert(non_cpp_other_derived.val2() == 22, "non_cpp_other_derived fail calling Other::val2()")
+non_cpp_derived_other = staticDerivedCast(base_point_other)
+swig_assert(non_cpp_derived_other != None, "static cast to non_cpp_derived_other fail")
+swig_assert(non_cpp_derived_other.val1() == 21, "non_cpp_derived_other fail calling Other::val1()")
+swig_assert(non_cpp_derived_other.val2() == 12, "non_cpp_derived_other fail calling Derived::val2()")
+non_cpp_base_derived = staticDerivedCast(base)
+swig_assert(non_cpp_base_derived != None, "static cast to non_cpp_base_derived fail")
+swig_assert(non_cpp_base_derived.val1() == 1, "non_cpp_base_derived fail calling Base::val1()")
+swig_assert(non_cpp_base_derived.val2() == 12, "non_cpp_base_derived fail calling Derived::val2()")
+non_cpp_base_other = staticOtherCast(base)
+swig_assert(non_cpp_base_other != None, "static cast to non_cpp_base_other fail")
+swig_assert(non_cpp_base_other.val1() == 1, "non_cpp_base_other fail calling Base::val1()")
+swig_assert(non_cpp_base_other.val2() == 22, "non_cpp_base_other fail calling Other::val2()")

--- a/Examples/test-suite/ruby/li_cpointer_dynamic_cast_runme.rb
+++ b/Examples/test-suite/ruby/li_cpointer_dynamic_cast_runme.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+require 'swig_assert'
+require 'li_cpointer_dynamic_cast'
+
+# Get a Derived object using a Base pointer
+base_point_derived = Li_cpointer_dynamic_cast::Derived.NewDerived()
+swig_assert_equal(base_point_derived.val1(), 11, binding, "base_point_derived fail calling Derived::val1()")
+swig_assert_equal(base_point_derived.val2(), 2, binding, "base_point_derived fail calling Base::val2()")
+# Dynamic cast to original Derived class
+derived_dyn = Li_cpointer_dynamic_cast::dynDerivedCast(base_point_derived)
+swig_assert(derived_dyn != nil, binding, "dynamic cast to derived_dyn fail")
+swig_assert_equal(derived_dyn.val1(), 11, binding, "derived_dyn fail calling Derived::val1()")
+swig_assert_equal(derived_dyn.val2(), 12, binding, "derived_dyn fail calling Derived::val2()")
+# Static cast work the same as dynamic cast, when used with the derived class!
+derived_static = Li_cpointer_dynamic_cast::staticDerivedCast(base_point_derived)
+swig_assert(derived_static != nil, binding, "static cast to derived_static fail")
+swig_assert_equal(derived_static.val1(), 11, binding, "derived_static fail calling Derived::val1()")
+swig_assert_equal(derived_static.val2(), 12, binding, "derived_static fail calling Derived::val2()")
+
+# Get an Other object using a Base pointer
+base_point_other = Li_cpointer_dynamic_cast::Other.NewOther()
+swig_assert_equal(base_point_other.val1(), 21, binding, "base_point_other fail calling Other::val1()")
+swig_assert_equal(base_point_other.val2(), 2, binding, "base_point_other fail calling Base::val2()")
+# Dynamic cast to original Other class
+other_dyn = Li_cpointer_dynamic_cast::dynOtherCast(base_point_other)
+swig_assert(other_dyn != nil, binding, "dynamic cast to other_dyn fail")
+swig_assert_equal(other_dyn.val1(), 21, binding, "other_dyn fail calling Other::val1()")
+swig_assert_equal(other_dyn.val2(), 22, binding, "other_dyn fail calling Other::val2()")
+# Static cast work the same as dynamic cast, when used with the other class!
+other_static = Li_cpointer_dynamic_cast::staticOtherCast(base_point_other)
+swig_assert(other_static != nil, binding, "static cast to other_static fail")
+swig_assert_equal(other_static.val1(), 21, binding, "other_static fail calling Other::val1()")
+swig_assert_equal(other_static.val2(), 22, binding, "other_static fail calling Other::val2()")
+
+# Get a Base object
+base = Li_cpointer_dynamic_cast::Base.new
+swig_assert_equal(base.val1(), 1, binding, "base fail calling Base::val1()")
+swig_assert_equal(base.val2(), 2, binding, "base fail calling Base::val2()")
+
+# Dynamic cast gives NULL as expected
+swig_assert_equal(Li_cpointer_dynamic_cast::dynOtherCast(base_point_derived), nil, binding, "'Derived' object can not cast to 'Other'")
+swig_assert_equal(Li_cpointer_dynamic_cast::dynDerivedCast(base_point_other), nil, binding, "'Other' object can not cast to 'Derived'")
+swig_assert_equal(Li_cpointer_dynamic_cast::dynOtherCast(base), nil, binding, "'Base' object can not cast to 'Other'")
+swig_assert_equal(Li_cpointer_dynamic_cast::dynDerivedCast(base), nil, binding, "'Base' object can not cast to 'Derived'")
+
+# Static cast gives a hybrid result
+# The virtual method point to original object class, as we expect!
+# While the non-virtual method uses the new pointed class method!
+non_cpp_other_derived = Li_cpointer_dynamic_cast::staticOtherCast(base_point_derived)
+swig_assert(non_cpp_other_derived != nil, binding, "static cast to non_cpp_other_derived fail")
+swig_assert_equal(non_cpp_other_derived.val1(), 11, binding, "non_cpp_other_derived fail calling Derived::val1()")
+swig_assert_equal(non_cpp_other_derived.val2(), 22, binding, "non_cpp_other_derived fail calling Other::val2()")
+non_cpp_derived_other = Li_cpointer_dynamic_cast::staticDerivedCast(base_point_other)
+swig_assert(non_cpp_derived_other != nil, binding, "static cast to non_cpp_derived_other fail")
+swig_assert_equal(non_cpp_derived_other.val1(), 21, binding, "non_cpp_derived_other fail calling Other::val1()")
+swig_assert_equal(non_cpp_derived_other.val2(), 12, binding, "non_cpp_derived_other fail calling Derived::val2()")
+non_cpp_base_derived = Li_cpointer_dynamic_cast::staticDerivedCast(base)
+swig_assert(non_cpp_base_derived != nil, binding, "static cast to non_cpp_base_derived fail")
+swig_assert_equal(non_cpp_base_derived.val1(), 1, binding, "non_cpp_base_derived fail calling Base::val1()")
+swig_assert_equal(non_cpp_base_derived.val2(), 12, binding, "non_cpp_base_derived fail calling Derived::val2()")
+non_cpp_base_other = Li_cpointer_dynamic_cast::staticOtherCast(base)
+swig_assert(non_cpp_base_other != nil, binding, "static cast to non_cpp_base_other fail")
+swig_assert_equal(non_cpp_base_other.val1(), 1, binding, "non_cpp_base_other fail calling Base::val1()")
+swig_assert_equal(non_cpp_base_other.val2(), 22, binding, "non_cpp_base_other fail calling Other::val2()")

--- a/Examples/test-suite/schemerunme/li_cpointer_dynamic_cast.scm
+++ b/Examples/test-suite/schemerunme/li_cpointer_dynamic_cast.scm
@@ -1,0 +1,76 @@
+(define (swig_assert b msg)
+  (unless b
+    (begin
+    (display msg)
+    (newline)
+    (exit 1))))
+(define (swig_assert_equal a b msg)
+  (swig_assert (equal? a b) msg))
+(define null '())
+(define (swig_assert_isnotnull o msg)
+  (swig_assert (not (equal? o null)) msg))
+(define (swig_assert_isnull o msg)
+  (swig_assert_equal o null msg))
+
+;; Get a Derived object using a Base pointer
+(define base_point_derived (Derived-NewDerived))
+(swig_assert_equal (Base-val1 base_point_derived) 11 "base_point_derived fail calling Derived::val1()")
+(swig_assert_equal (Base-val2 base_point_derived) 2 "base_point_derived fail calling Base::val2()")
+;; Dynamic cast to original Derived class
+(define derived_dyn (dynDerivedCast base_point_derived))
+(swig_assert_isnotnull derived_dyn "dynamic cast to derived_dyn fail")
+(swig_assert_equal (Derived-val1 derived_dyn) 11 "derived_dyn fail calling Derived::val1()")
+(swig_assert_equal (Derived-val2 derived_dyn) 12 "derived_dyn fail calling Derived::val2()")
+;; Static cast work the same as dynamic cast, when used with the derived class!
+(define derived_static (staticDerivedCast base_point_derived))
+(swig_assert_isnotnull derived_static "static cast to derived_static fail")
+(swig_assert_equal (Derived-val1 derived_static) 11 "derived_static fail calling Derived::val1()")
+(swig_assert_equal (Derived-val2 derived_static) 12 "derived_static fail calling Derived::val2()")
+
+;; Get an Other object using a Base pointer
+(define base_point_other (Other-NewOther))
+(swig_assert_equal (Base-val1 base_point_other) 21 "base_point_other fail calling Other::val1()")
+(swig_assert_equal (Base-val2 base_point_other) 2 "base_point_other fail calling Base::val2()")
+;; Dynamic cast to original Other class
+(define other_dyn (dynOtherCast base_point_other))
+(swig_assert_isnotnull other_dyn "dynamic cast to other_dyn fail")
+(swig_assert_equal (Other-val1 other_dyn) 21 "other_dyn fail calling Other::val1()")
+(swig_assert_equal (Other-val2 other_dyn) 22 "other_dyn fail calling Other::val2()")
+;; Static cast work the same as dynamic cast, when used with the other class!
+(define other_static (staticOtherCast base_point_other))
+(swig_assert_isnotnull other_static "static cast to other_static fail")
+(swig_assert_equal (Other-val1 other_static) 21 "other_static fail calling Other::val1()")
+(swig_assert_equal (Other-val2 other_static) 22 "other_static fail calling Other::val2()")
+
+;; Get a Base object
+(define base (new-Base))
+(swig_assert_equal (Base-val1 base) 1 "base fail calling Base::val1()")
+(swig_assert_equal (Base-val2 base) 2 "base fail calling Base::val2()")
+
+;; Dynamic cast gives NULL as expected
+(swig_assert_isnull (dynOtherCast base_point_derived) "'Derived' object can not cast to 'Other'")
+(swig_assert_isnull (dynDerivedCast base_point_other) "'Other' object can not cast to 'Derived'")
+(swig_assert_isnull (dynOtherCast base) "'Base' object can not cast to 'Other'")
+(swig_assert_isnull (dynDerivedCast base) "'Base' object can not cast to 'Derived'")
+
+;; Static cast gives a hybrid result
+;; The virtual method point to original object class, as we expect!
+;; While the non-virtual method uses the new pointed class method!
+(define non_cpp_other_derived (staticOtherCast base_point_derived))
+(swig_assert_isnotnull non_cpp_other_derived "static cast to non_cpp_other_derived fail")
+(swig_assert_equal (Other-val1 non_cpp_other_derived) 11 "non_cpp_other_derived fail calling Derived::val1()")
+(swig_assert_equal (Other-val2 non_cpp_other_derived) 22 "non_cpp_other_derived fail calling Other::val2()")
+(define non_cpp_derived_other (staticDerivedCast base_point_other))
+(swig_assert_isnotnull non_cpp_derived_other "static cast to non_cpp_derived_other fail")
+(swig_assert_equal (Derived-val1 non_cpp_derived_other) 21 "non_cpp_derived_other fail calling Other::val1()")
+(swig_assert_equal (Derived-val2 non_cpp_derived_other) 12 "non_cpp_derived_other fail calling Derived::val2()")
+(define non_cpp_base_derived (staticDerivedCast base))
+(swig_assert_isnotnull non_cpp_base_derived "static cast to non_cpp_base_derived fail")
+(swig_assert_equal (Derived-val1 non_cpp_base_derived) 1 "non_cpp_base_derived fail calling Base::val1()")
+(swig_assert_equal (Derived-val2 non_cpp_base_derived) 12 "non_cpp_base_derived fail calling Derived::val2()")
+(define non_cpp_base_other (staticOtherCast base))
+(swig_assert_isnotnull non_cpp_base_other "static cast to non_cpp_base_other fail")
+(swig_assert_equal (Other-val1 non_cpp_base_other) 1 "non_cpp_base_other fail calling Base::val1()")
+(swig_assert_equal (Other-val2 non_cpp_base_other) 22 "non_cpp_base_other fail calling Other::val2()")
+
+(exit 0)

--- a/Examples/test-suite/scilab/li_cpointer_dynamic_cast_runme.sci
+++ b/Examples/test-suite/scilab/li_cpointer_dynamic_cast_runme.sci
@@ -1,0 +1,73 @@
+exec("swigtest.start", -1);
+
+function checknotnull(o, msg)
+  if isequal(SWIG_this(o), 0) then
+    swigtesterror(msg);
+  end
+endfunction
+function checknull(o, msg)
+  checkequal(SWIG_this(o), 0);
+endfunction
+
+// Get a Derived object using a Base pointer
+base_point_derived = Derived_NewDerived();
+checkequal(Base_val1(base_point_derived), 11, "base_point_derived fail calling Derived::val1()");
+checkequal(Base_val2(base_point_derived), 2, "base_point_derived fail calling Base::val2()");
+// Dynamic cast to original Derived class
+derived_dyn = dynDerivedCast(base_point_derived);
+checknotnull(derived_dyn, "dynamic cast to derived_dyn fail");
+checkequal(Derived_val1(derived_dyn), 11, "derived_dyn fail calling Derived::val1()");
+checkequal(Derived_val2(derived_dyn), 12, "derived_dyn fail calling Derived::val2()");
+// Static cast work the same as dynamic cast, when used with the derived class!
+derived_static = staticDerivedCast(base_point_derived);
+checknotnull(derived_static, "static cast to derived_static fail");
+checkequal(Derived_val1(derived_static), 11, "derived_static fail calling Derived::val1()");
+checkequal(Derived_val2(derived_static), 12, "derived_static fail calling Derived::val2()");
+
+// Get an Other object using a Base pointer
+base_point_other = Other_NewOther();
+checkequal(Base_val1(base_point_other), 21, "base_point_other fail calling Other::val1()");
+checkequal(Base_val2(base_point_other), 2, "base_point_other fail calling Base::val2()");
+// Dynamic cast to original Other class
+other_dyn = dynOtherCast(base_point_other);
+checknotnull(other_dyn, "dynamic cast to other_dyn fail");
+checkequal(Other_val1(other_dyn), 21, "other_dyn fail calling Other::val1()");
+checkequal(Other_val2(other_dyn), 22, "other_dyn fail calling Other::val2()");
+// Static cast work the same as dynamic cast, when used with the other class!
+other_static = staticOtherCast(base_point_other);
+checknotnull(other_static, "static cast to other_static fail");
+checkequal(Other_val1(other_static), 21, "other_static fail calling Other::val1()");
+checkequal(Other_val2(other_static), 22, "other_static fail calling Other::val2()");
+
+// Get a Base object
+base = new_Base();
+checkequal(Base_val1(base), 1, "base fail calling Base::val1()");
+checkequal(Base_val2(base), 2, "base fail calling Base::val2()");
+
+// Dynamic cast gives NULL as expected
+checknull(dynOtherCast(base_point_derived), "''Derived'' object can not cast to ''Other''");
+checknull(dynDerivedCast(base_point_other), "''Other'' object can not cast to ''Derived''");
+checknull(dynOtherCast(base), "''Base'' object can not cast to ''Other''");
+checknull(dynDerivedCast(base), "''Base'' object can not cast to ''Derived''");
+
+// Static cast gives a hybrid result
+// The virtual method point to original object class, as we expect!
+// While the non-virtual method uses the new pointed class method!
+non_cpp_other_derived = staticOtherCast(base_point_derived);
+checknotnull(non_cpp_other_derived, "static cast to non_cpp_other_derived fail");
+checkequal(Other_val1(non_cpp_other_derived), 11, "non_cpp_other_derived fail calling Derived::val1()");
+checkequal(Other_val2(non_cpp_other_derived), 22, "non_cpp_other_derived fail calling Other::val2()");
+non_cpp_derived_other = staticDerivedCast(base_point_other);
+checknotnull(non_cpp_derived_other, "static cast to non_cpp_derived_other fail");
+checkequal(Derived_val1(non_cpp_derived_other), 21, "non_cpp_derived_other fail calling Other::val1()");
+checkequal(Derived_val2(non_cpp_derived_other), 12, "non_cpp_derived_other fail calling Derived::val2()");
+non_cpp_base_derived = staticDerivedCast(base);
+checknotnull(non_cpp_base_derived, "static cast to non_cpp_base_derived fail");
+checkequal(Derived_val1(non_cpp_base_derived), 1, "non_cpp_base_derived fail calling Base::val1()");
+checkequal(Derived_val2(non_cpp_base_derived), 12, "non_cpp_base_derived fail calling Derived::val2()");
+non_cpp_base_other = staticOtherCast(base);
+checknotnull(non_cpp_base_other, "static cast to non_cpp_base_other fail");
+checkequal(Other_val1(non_cpp_base_other), 1, "non_cpp_base_other fail calling Base::val1()");
+checkequal(Other_val2(non_cpp_base_other), 22, "non_cpp_base_other fail calling Other::val2()");
+
+exec("swigtest.quit", -1);

--- a/Examples/test-suite/tcl/li_cpointer_dynamic_cast_runme.tcl
+++ b/Examples/test-suite/tcl/li_cpointer_dynamic_cast_runme.tcl
@@ -1,0 +1,78 @@
+if [ catch { load ./li_cpointer_dynamic_cast[info sharedlibextension] Li_cpointer_dynamic_cast} err_msg ] {
+	puts stderr "Could not load shared object:\n$err_msg"
+}
+
+proc swig_assert_equal { a b msg } {
+	if { $a != $b } {
+		puts stderr $msg
+		exit 1
+	}
+}
+proc swig_assert_not_null {o msg} {
+	if { $o == "NULL" } {
+		puts stderr $msg
+		exit 1
+	}
+}
+proc swig_assert_is_null {o msg} { swig_assert_equal $o "NULL" $msg }
+
+# Get a Derived object using a Base pointer
+set base_point_derived [ Derived_NewDerived ]
+swig_assert_equal [ $base_point_derived val1 ] 11 "base_point_derived fail calling Derived::val1()"
+swig_assert_equal [ $base_point_derived val2 ] 2 "base_point_derived fail calling Base::val2()"
+# Dynamic cast to original Derived class
+set derived_dyn [ dynDerivedCast $base_point_derived ]
+swig_assert_not_null $derived_dyn "dynamic cast to derived_dyn fail"
+swig_assert_equal [ $derived_dyn val1 ] 11 "derived_dyn fail calling Derived::val1()"
+swig_assert_equal [ $derived_dyn val2 ] 12 "derived_dyn fail calling Derived::val2()"
+# Static cast work the same as dynamic cast, when used with the derived class!
+set derived_static [ staticDerivedCast $base_point_derived ]
+swig_assert_not_null $derived_static "static cast to derived_static fail"
+swig_assert_equal [ $derived_static val1 ] 11 "derived_static fail calling Derived::val1()"
+swig_assert_equal [ $derived_static val2 ] 12 "derived_static fail calling Derived::val2()"
+
+# Get an Other object using a Base pointer
+set base_point_other [ Other_NewOther ]
+swig_assert_equal [ $base_point_other val1 ] 21 "base_point_other fail calling Other::val1()"
+swig_assert_equal [ $base_point_other val2 ] 2 "base_point_other fail calling Base::val2()"
+# Dynamic cast to original Other class
+set other_dyn [ dynOtherCast $base_point_other ]
+swig_assert_not_null $other_dyn "dynamic cast to other_dyn fail"
+swig_assert_equal [ $other_dyn val1 ] 21 "other_dyn fail calling Other::val1()"
+swig_assert_equal [ $other_dyn val2 ] 22 "other_dyn fail calling Other::val2()"
+# Static cast work the same as dynamic cast, when used with the other class!
+set other_static [ staticOtherCast $base_point_other ]
+swig_assert_not_null $other_static "static cast to other_static fail"
+swig_assert_equal [ $other_static val1 ] 21 "other_static fail calling Other::val1()"
+swig_assert_equal [ $other_static val2 ] 22 "other_static fail calling Other::val2()"
+
+# Get a Base object
+set base [ Base ]
+swig_assert_equal [ $base val1 ] 1 "base fail calling Base::val1()"
+swig_assert_equal [ $base val2 ] 2 "base fail calling Base::val2()"
+
+# Dynamic cast gives NULL as expected
+swig_assert_is_null [ dynOtherCast $base_point_derived ] "'Derived' object can not cast to 'Other'"
+swig_assert_is_null [ dynDerivedCast $base_point_other ] "'Other' object can not cast to 'Derived'"
+swig_assert_is_null [ dynOtherCast $base ] "'Base' object can not cast to 'Other'"
+swig_assert_is_null [ dynDerivedCast $base ] "'Base' object can not cast to 'Derived'"
+
+# Static cast gives a hybrid result
+# The virtual method point to original object class, as we expect!
+# While the non-virtual method uses the new pointed class method!
+set non_cpp_other_derived [ staticOtherCast $base_point_derived ]
+swig_assert_not_null $non_cpp_other_derived "static cast to non_cpp_other_derived fail"
+swig_assert_equal [ $non_cpp_other_derived val1 ] 11 "non_cpp_other_derived fail calling Derived::val1()"
+swig_assert_equal [ $non_cpp_other_derived val2 ] 22 "non_cpp_other_derived fail calling Other::val2()"
+set non_cpp_derived_other [ staticDerivedCast $base_point_other ]
+swig_assert_not_null $non_cpp_derived_other "static cast to non_cpp_derived_other fail"
+swig_assert_equal [ $non_cpp_derived_other val1 ] 21 "non_cpp_derived_other fail calling Other::val1()"
+swig_assert_equal [ $non_cpp_derived_other val2 ] 12 "non_cpp_derived_other fail calling Derived::val2()"
+set non_cpp_base_derived [ staticDerivedCast $base ]
+swig_assert_not_null $non_cpp_base_derived "static cast to non_cpp_base_derived fail"
+swig_assert_equal [ $non_cpp_base_derived val1 ] 1 "non_cpp_base_derived fail calling Base::val1()"
+swig_assert_equal [ $non_cpp_base_derived val2 ] 12 "non_cpp_base_derived fail calling Derived::val2()"
+set non_cpp_base_other [ staticOtherCast $base ]
+swig_assert_not_null $non_cpp_base_other "static cast to non_cpp_base_other fail"
+swig_assert_equal [ $non_cpp_base_other val1 ] 1 "non_cpp_base_other fail calling Base::val1()"
+swig_assert_equal [ $non_cpp_base_other val2 ] 22 "non_cpp_base_other fail calling Other::val2()"

--- a/Lib/cpointer.i
+++ b/Lib/cpointer.i
@@ -177,10 +177,24 @@ TYPE2 NAME(TYPE1 x) {
 %}
 %enddef
 
+/* -----------------------------------------------------------------------------
+ * %pointer_dynamic_cast(type1,type2,name)
+ *
+ * Generates a polymorphic conversion function.
+ * ----------------------------------------------------------------------------- */
 
-
-
-
-
-
-
+%define %pointer_dynamic_cast(TYPE1,TYPE2,NAME)
+#if defined(__cplusplus) && !defined(SWIG_NO_CPLUSPLUS_CAST)
+%inline %{
+TYPE2 NAME(TYPE1 x) {
+   return dynamic_cast<TYPE2>(x);
+}
+%}
+#else /* C case */
+%inline %{
+TYPE2 NAME(TYPE1 x) {
+   return (Type)(x);
+}
+%}
+#endif /* __cplusplus */
+%enddef

--- a/Lib/d/cpointer.i
+++ b/Lib/d/cpointer.i
@@ -169,3 +169,25 @@ TYPE2 NAME(TYPE1 x) {
 }
 %}
 %enddef
+
+/* -----------------------------------------------------------------------------
+ * %pointer_dynamic_cast(type1,type2,name)
+ *
+ * Generates a polymorphic conversion function.
+ * ----------------------------------------------------------------------------- */
+
+%define %pointer_dynamic_cast(TYPE1,TYPE2,NAME)
+#if defined(__cplusplus) && !defined(SWIG_NO_CPLUSPLUS_CAST)
+%inline %{
+TYPE2 NAME(TYPE1 x) {
+   return dynamic_cast<TYPE2>(x);
+}
+%}
+#else /* C case */
+%inline %{
+TYPE2 NAME(TYPE1 x) {
+   return (Type)(x);
+}
+%}
+#endif /* __cplusplus */
+%enddef

--- a/Lib/typemaps/cpointer.swg
+++ b/Lib/typemaps/cpointer.swg
@@ -148,10 +148,16 @@ TYPE2 NAME(TYPE1 x) {
 %}
 %enddef
 
+/* -----------------------------------------------------------------------------
+ * %pointer_dynamic_cast(type1,type2,name)
+ *
+ * Generates a polymorphic conversion function.
+ * ----------------------------------------------------------------------------- */
 
-
-
-
-
-
-
+%define %pointer_dynamic_cast(TYPE1,TYPE2,NAME)
+%inline %{
+TYPE2 NAME(TYPE1 x) {
+   return %dynamic_cast(x,TYPE2);
+}
+%}
+%enddef

--- a/Lib/typemaps/swigmacros.swg
+++ b/Lib/typemaps/swigmacros.swg
@@ -118,11 +118,13 @@ nocppval
 # define %static_cast(a,Type...)      static_cast< Type >(a)
 # define %reinterpret_cast(a,Type...) reinterpret_cast< Type >(a)
 # define %numeric_cast(a,Type...)     static_cast< Type >(a)
+# define %dynamic_cast(a,Type...)     dynamic_cast< Type >(a)
 #else /* C case */
 # define %const_cast(a,Type...)       (Type)(a)
 # define %static_cast(a,Type...)      (Type)(a)
 # define %reinterpret_cast(a,Type...) (Type)(a)
 # define %numeric_cast(a,Type...)     (Type)(a)
+# define %dynamic_cast(a,Type...)     (Type)(a)
 #endif /* __cplusplus */
 
 

--- a/Lib/typemaps/swigmacros.swg
+++ b/Lib/typemaps/swigmacros.swg
@@ -117,11 +117,13 @@ nocppval
 # define %static_cast(a,Type...)      static_cast< Type >(a)
 # define %reinterpret_cast(a,Type...) reinterpret_cast< Type >(a)
 # define %numeric_cast(a,Type...)     static_cast< Type >(a)
+# define %dynamic_cast(a,Type...)     dynamic_cast< Type >(a)
 #else /* C case */
 # define %const_cast(a,Type...)       (Type)(a)
 # define %static_cast(a,Type...)      (Type)(a)
 # define %reinterpret_cast(a,Type...) (Type)(a)
 # define %numeric_cast(a,Type...)     (Type)(a)
+# define %dynamic_cast(a,Type...)     (Type)(a)
 #endif /* __cplusplus */
 
 


### PR DESCRIPTION
Add support for polymorphic conversion
 using run-time type identification (RTTI)
See:
https://en.cppreference.com/w/cpp/language/dynamic_cast.html