### PR TITLE
Fix -doxygen: @file block bleeds into first class docstring

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,12 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.5.0 (in progress)
 ===========================
 
+2026-04-17: jwuttke
+            #3403 Fix -doxygen: @file block bleeding into the first class
+            docstring. Single-line //! (or ///) comments forming a file-level
+            header (starting with @file) are now correctly discarded instead of
+            being concatenated into the next declaration's docstring.
+
 2026-03-26: Nerixyz
             [Python] #3389 Add missing C annotations and PEP 484 annotations to constants.
 

--- a/Examples/test-suite/doxygen_misc_constructs.i
+++ b/Examples/test-suite/doxygen_misc_constructs.i
@@ -190,5 +190,13 @@
 
     #include "doxygen_misc_constructs.h"
 
+    // @file block (single-line //! style) must not bleed into the next class doc (GitHub issue #3403).
+    //! @file      doxygen_misc_constructs.i
+    //! @brief     File-level brief description.
+    //! @authors   Someone
+
+    //! This is the real class description.
+    struct FileHeaderTestClass {};
+
 %}
     %include "doxygen_misc_constructs.h"

--- a/Examples/test-suite/java/doxygen_misc_constructs_runme.java
+++ b/Examples/test-suite/java/doxygen_misc_constructs_runme.java
@@ -270,6 +270,13 @@ public class doxygen_misc_constructs_runme {
                 "\n" +
                 " @param fileName name of the log file\n");
 
+    wantedComments.put("doxygen_misc_constructs.FileHeaderTestClass",
+    		"\n" +
+    		"\n" +
+    		" This is the real class description.\n" +
+    		"\n" +
+    		"");
+
     wantedComments.put("doxygen_misc_constructs.doxygen_misc_constructs.doc_ends_with_quote()",
             "This doc comment ends with a quote: \"and that's ok\"");
 

--- a/Examples/test-suite/python/doxygen_misc_constructs_runme.py
+++ b/Examples/test-suite/python/doxygen_misc_constructs_runme.py
@@ -141,3 +141,7 @@ comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.doc_with_triple_qu
 
     """How quaint"""'''
 );
+
+comment_verifier.check(inspect.getdoc(doxygen_misc_constructs.FileHeaderTestClass),
+    r"""This is the real class description."""
+)

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -426,6 +426,7 @@ static int yylook(void) {
       {
         typedef enum { DOX_COMMENT_PRE = -1, DOX_COMMENT_NONE, DOX_COMMENT_POST } comment_kind_t;
         comment_kind_t existing_comment = DOX_COMMENT_NONE;
+        int in_structural_block = 0; /* True when a @file (or similar) block is being skipped */
 
         /* Concatenate or skip all consecutive comments at once. */
         do {
@@ -462,7 +463,12 @@ static int yylook(void) {
                 break;
               }
 
-              if (this_comment == DOX_COMMENT_POST || !isStructuralDoxygen(loc)) {
+              if (this_comment == DOX_COMMENT_PRE && existing_comment == DOX_COMMENT_NONE && isStructuralDoxygen(loc)) {
+                /* @file and similar commands mark the whole block as file-scope documentation.
+                   Set a flag to discard all subsequent lines until a blank line separates
+                   this block from the next declaration's doc comment. */
+                in_structural_block = 1;
+              } else if (!in_structural_block && (this_comment == DOX_COMMENT_POST || !isStructuralDoxygen(loc))) {
                 String *str;
 
                 int begin = this_comment == DOX_COMMENT_POST ? 4 : 3;
@@ -492,10 +498,19 @@ static int yylook(void) {
               }
             }
           }
-          do {
-            tok = Scanner_token(scan);
-          } while (tok == SWIG_TOKEN_ENDLINE);
-          Delete(cmt_modified);
+          {
+            int endlines = 0;
+            do {
+              tok = Scanner_token(scan);
+              if (tok == SWIG_TOKEN_ENDLINE)
+                endlines++;
+            } while (tok == SWIG_TOKEN_ENDLINE);
+            Delete(cmt_modified);
+            /* A blank line (2+ newlines) ends a structural block, ensuring the next
+               declaration's doc comment is not bleed into the discarded file-level doc. */
+            if (in_structural_block && endlines >= 2)
+              break;
+          }
         } while (tok == SWIG_TOKEN_COMMENT);
 
         Scanner_pushtoken(scan, tok, Scanner_text(scan));

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -464,11 +464,13 @@ static int yylook(void) {
               }
 
               if (this_comment == DOX_COMMENT_PRE && existing_comment == DOX_COMMENT_NONE && isStructuralDoxygen(loc)) {
-                /* @file and similar commands mark the whole block as file-scope documentation.
-                   Set a flag to discard all subsequent lines until a blank line separates
-                   this block from the next declaration's doc comment. */
+                /* @file and similar page-level commands mark the whole block as file-scope
+                   documentation.  Set a flag; if a blank line follows, the accumulated
+                   content will be discarded so it does not bleed into the next declaration's
+                   docstring.  If no blank line follows (e.g. @name/@{), the content is
+                   returned as usual — only the structural line itself is not accumulated. */
                 in_structural_block = 1;
-              } else if (!in_structural_block && (this_comment == DOX_COMMENT_POST || !isStructuralDoxygen(loc))) {
+              } else if (this_comment == DOX_COMMENT_POST || !isStructuralDoxygen(loc)) {
                 String *str;
 
                 int begin = this_comment == DOX_COMMENT_POST ? 4 : 3;
@@ -506,10 +508,15 @@ static int yylook(void) {
                 endlines++;
             } while (tok == SWIG_TOKEN_ENDLINE);
             Delete(cmt_modified);
-            /* A blank line (2+ newlines) ends a structural block, ensuring the next
-               declaration's doc comment is not bleed into the discarded file-level doc. */
-            if (in_structural_block && endlines >= 2)
+            /* A blank line (2+ newlines) after a structural block (@file, @page, ...) means
+               all accumulated content is file-scope and must be discarded, so that the next
+               declaration's own doc comment is not polluted. */
+            if (in_structural_block && endlines >= 2) {
+              Delete(yylval.str);
+              yylval.str = 0;
+              existing_comment = DOX_COMMENT_NONE;
               break;
+            }
           }
         } while (tok == SWIG_TOKEN_COMMENT);
 


### PR DESCRIPTION
When a header uses consecutive \`//!\` (or \`///\`) single-line comments for a
file-level block starting with \`@file\`, SWIG's comment accumulation loop was
concatenating the file-header content into the following class or function
docstring.

Two bugs conspired:
- Only the \`@file\` line itself was recognised as structural and skipped;
  subsequent lines (\`@brief\`, \`@authors\`, ...) are not in \`structuralTags[]\`
  and so were accumulated into \`yylval.str\`.
- Blank lines between comment groups do not break the accumulation loop
  (all \`SWIG_TOKEN_ENDLINE\` tokens are consumed silently), so the next
  declaration's own doc comment was appended to the same string.

Fix: introduce an \`in_structural_block\` flag. When the first comment in a
group contains a structural command (\`@file\`, \`@page\`, ...), set the flag but
continue accumulating content normally. Count newlines in the inner do-while;
when \`in_structural_block\` is set and two or more consecutive newlines are seen
(a blank line), discard all accumulated content and break, so the following
declaration's doc comment is processed fresh.

Not breaking the loop on a natural exit (no blank line) is deliberate: it
correctly handles the \`@name\`/\`@{\` member-grouping pattern, where \`@{\`
immediately follows \`@name\` without a blank line and must still be attached to
the next member.

The block-comment style (\`/*! @file ... */\`) was already handled correctly
because the entire block is one scanner token and \`isStructuralDoxygen()\`
would see \`@file\` in it.

Fixes #3403