### PR TITLE
added pointer initializations in a format supported in C

### DIFF
--- a/Lib/csharp/std_wstring.i
+++ b/Lib/csharp/std_wstring.i
@@ -23,8 +23,8 @@ static std::wstring Swig_csharp_UTF16ToWString(const unsigned short *str) {
   if (sizeof(wchar_t) == 2) {
     return std::wstring((wchar_t *)str);
   } else {
-    const unsigned short *pBegin(str);
-    const unsigned short *ptr(pBegin);
+    const unsigned short *pBegin = str;
+    const unsigned short *ptr = pBegin;
 
     while (*ptr != 0)
       ++ptr;

--- a/Lib/csharp/wchar.i
+++ b/Lib/csharp/wchar.i
@@ -159,8 +159,8 @@ static wchar_t * Swig_csharp_UTF16ToWCharPtr(const unsigned short *str) {
     wchar_t *result = 0;
 
     if (str) {
-      const unsigned short *pBegin(str);
-      const unsigned short *pEnd(pBegin);
+      const unsigned short *pBegin = str;
+      const unsigned short *pEnd = pBegin;
       wchar_t *ptr = 0;
 
       while (*pEnd != 0)


### PR DESCRIPTION
These C# typemaps produced .c code that did not compile due to the now corrected pointer initializations using C++ syntax.