### PR TITLE
Python: Map more primitives for PEP 484 annotations

### DIFF
--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -52,26 +52,47 @@ if sys.version_info[0:2] >= (3, 2):
             return d
 
         anno = get_annotations(argcheck_bool)
-        if anno != make_argcheck("bool", ["a_bool"]):
+        if anno != make_argcheck("bool", ["a_bool", "a_bool_cref"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
-        anno = get_annotations( argcheck_char)
-        if anno != make_argcheck("str", ["a_char", "a_wchar"]):
+
+        anno = get_annotations(argcheck_char)
+        if anno != make_argcheck("str", ["a_char", "a_wchar", "a_char_cref"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))
         
         anno = get_annotations(argcheck_int)
-        if anno != make_argcheck("int", [
-            "a_schar", "a_uchar", "a_short", "a_ushort","a_int",
-            "a_uint", "a_long", "a_ulong", "a_llong", "a_ullong"
-        ]):
+        if anno != make_argcheck(
+            "int",
+            [
+                "a_schar",
+                "a_uchar",
+                "a_short",
+                "a_ushort",
+                "a_int",
+                "a_uint",
+                "a_long",
+                "a_ulong",
+                "a_llong",
+                "a_ullong",
+                "a_short_cref",
+                "a_int_cref",
+            ],
+        ):
             raise RuntimeError("annotations mismatch: {}".format(anno))
         
         anno = get_annotations(argcheck_float)
-        if anno != make_argcheck("float", ["a_float", "a_double"]):
+        if anno != make_argcheck("float", ["a_float", "a_double", "a_double_cref"]):
+            raise RuntimeError("annotations mismatch: {}".format(anno))
+
+        anno = get_annotations(argcheck_complex)
+        if anno != make_argcheck(
+            "complex", ["a_cfloat", "a_cdouble", "a_cdouble_cref"]
+        ):
             raise RuntimeError("annotations mismatch: {}".format(anno))
         
         anno = get_annotations(argcheck_str)
-        if anno != make_argcheck("str", ["a_cstr", "a_wcstr"]):
+        if anno != make_argcheck(
+            "str", ["a_cstr", "a_wcstr", "a_stdstr", "a_stdwstr", "a_stdstr_cref"]
+        ):
             raise RuntimeError("annotations mismatch: {}".format(anno))
         
         anno = get_annotations(argcheck_fnptr)

--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -65,32 +65,53 @@ if sys.version_info[0:2] >= (3, 2):
             return d
 
         anno = get_annotations(argcheck_bool)
-        if anno != make_argcheck("bool", ["a_bool"]):
+        if anno != make_argcheck("bool", ["a_bool", "a_bool_cref"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
-        anno = get_annotations( argcheck_char)
-        if anno != make_argcheck("str", ["a_char", "a_wchar"]):
+
+        anno = get_annotations(argcheck_char)
+        if anno != make_argcheck("str", ["a_char", "a_wchar", "a_char_cref"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
+
         anno = get_annotations(argcheck_int)
-        if anno != make_argcheck("int", [
-            "a_schar", "a_uchar", "a_short", "a_ushort","a_int",
-            "a_uint", "a_long", "a_ulong", "a_llong", "a_ullong"
-        ]):
+        if anno != make_argcheck(
+            "int",
+            [
+                "a_schar",
+                "a_uchar",
+                "a_short",
+                "a_ushort",
+                "a_int",
+                "a_uint",
+                "a_long",
+                "a_ulong",
+                "a_llong",
+                "a_ullong",
+                "a_short_cref",
+                "a_int_cref",
+            ],
+        ):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
+
         anno = get_annotations(argcheck_float)
-        if anno != make_argcheck("float", ["a_float", "a_double"]):
+        if anno != make_argcheck("float", ["a_float", "a_double", "a_double_cref"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
+
+        anno = get_annotations(argcheck_complex)
+        if anno != make_argcheck(
+            "complex", ["a_cfloat", "a_cdouble", "a_cdouble_cref"]
+        ):
+            raise RuntimeError("annotations mismatch: {}".format(anno))
+
         anno = get_annotations(argcheck_str)
-        if anno != make_argcheck("str", ["a_cstr", "a_wcstr"]):
+        if anno != make_argcheck(
+            "str", ["a_cstr", "a_wcstr", "a_stdstr", "a_stdwstr", "a_stdstr_cref"]
+        ):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
+
         anno = get_annotations(argcheck_fnptr)
         if anno != make_argcheck("typing.Any", ["f"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
+
         anno = get_annotations(argcheck_array)
         if anno != make_argcheck("typing.Any", ["arr"]):
             raise RuntimeError("annotations mismatch: {}".format(anno))

--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -103,9 +103,14 @@ if sys.version_info[0:2] >= (3, 2):
             raise RuntimeError("annotations mismatch: {}".format(anno))
 
         anno = get_annotations(argcheck_str)
-        if anno != make_argcheck(
-            "str", ["a_cstr", "a_wcstr", "a_stdstr", "a_stdwstr", "a_stdstr_cref"]
-        ):
+        if anno != {
+            "a_cstr": "typing.Optional[str]",
+            "a_wcstr": "typing.Optional[str]",
+            "a_stdstr": "str",
+            "a_stdwstr": "str",
+            "a_stdstr_cref": "str",
+            "return": "None",
+        }:
             raise RuntimeError("annotations mismatch: {}".format(anno))
 
         anno = get_annotations(argcheck_fnptr)

--- a/Examples/test-suite/python_annotations_typing.i
+++ b/Examples/test-suite/python_annotations_typing.i
@@ -2,23 +2,12 @@
 
 %include <std_string.i>
 %include <std_wstring.i>
+%include <std_complex.i>
 
 // Tests the typing annotations
-%feature("python:annotations", "typing") mymethod;
-%feature("python:annotations", "typing") makeT<short>;
-%feature("python:annotations", "typing") global_ints;
-%feature("python:annotations", "typing") global_overloaded;
-%feature("python:annotations", "typing") argcheck_bool;
-%feature("python:annotations", "typing") argcheck_char;
-%feature("python:annotations", "typing") argcheck_int;
-%feature("python:annotations", "typing") argcheck_float;
-%feature("python:annotations", "typing") argcheck_str;
-%feature("python:annotations", "typing") argcheck_fnptr;
-%feature("python:annotations", "typing") argcheck_array;
-%feature("python:annotations", "typing") use_callable;
-%feature("python:annotations", "typing") return_callable;
-%feature("python:annotations", "typing") optional_square;
-%feature("python:annotations", "typing") docs_do_something_out_type;
+%feature("python:annotations", "typing");
+
+%feature("python:annotations", "0") no_annotations;
 
 %typemap(pytyping) OptionalInt "typing.Optional[int]";
 %typemap(pytyping, out = "$typemap(pytyping, short)") MyType "typing.Union[int, float]";
@@ -65,11 +54,15 @@ int is_python_fastproxy() { return 0; }
 
 %inline %{
 
-void argcheck_bool(bool a_bool) {}
+void argcheck_bool(
+  bool a_bool,
+  const bool &a_bool_cref
+) {}
 
 void argcheck_char(
   char a_char,
-  wchar_t a_wchar
+  wchar_t a_wchar,
+  const char &a_char_cref
 ) {}
 
 void argcheck_int(
@@ -82,17 +75,29 @@ void argcheck_int(
   long a_long,
   unsigned long a_ulong,
   long long a_llong,
-  unsigned long long a_ullong
+  unsigned long long a_ullong,
+  const short &a_short_cref,
+  const int &a_int_cref
 ) {}
 
 void argcheck_float(
   float a_float,
-  double a_double
+  double a_double,
+  const double &a_double_cref
+) {}
+
+void argcheck_complex(
+  std::complex<float> a_cfloat,
+  std::complex<double> a_cdouble,
+  const std::complex<double> &a_cdouble_cref
 ) {}
 
 void argcheck_str(
   const char* a_cstr,
-  const wchar_t *a_wcstr
+  const wchar_t *a_wcstr,
+  std::string a_stdstr,
+  std::wstring a_stdwstr,
+  const std::string &a_stdstr_cref
 ) {}
 
 void argcheck_fnptr(int(*f)(char, bool)) {}

--- a/Examples/test-suite/python_annotations_typing.i
+++ b/Examples/test-suite/python_annotations_typing.i
@@ -2,6 +2,7 @@
 
 %include <std_string.i>
 %include <std_wstring.i>
+%include <std_complex.i>
 
 // Tests the typing annotations
 %feature("python:annotations", "typing");
@@ -85,11 +86,15 @@ void take_argv(int argc, char **argv) {}
 
 void take_argv_surround(double before, int argc, char **argv, short after) {}
 
-void argcheck_bool(bool a_bool) {}
+void argcheck_bool(
+  bool a_bool,
+  const bool &a_bool_cref
+) {}
 
 void argcheck_char(
   char a_char,
-  wchar_t a_wchar
+  wchar_t a_wchar,
+  const char &a_char_cref
 ) {}
 
 void argcheck_int(
@@ -102,17 +107,29 @@ void argcheck_int(
   long a_long,
   unsigned long a_ulong,
   long long a_llong,
-  unsigned long long a_ullong
+  unsigned long long a_ullong,
+  const short &a_short_cref,
+  const int &a_int_cref
 ) {}
 
 void argcheck_float(
   float a_float,
-  double a_double
+  double a_double,
+  const double &a_double_cref
+) {}
+
+void argcheck_complex(
+  std::complex<float> a_cfloat,
+  std::complex<double> a_cdouble,
+  const std::complex<double> &a_cdouble_cref
 ) {}
 
 void argcheck_str(
   const char* a_cstr,
-  const wchar_t *a_wcstr
+  const wchar_t *a_wcstr,
+  std::string a_stdstr,
+  std::wstring a_stdwstr,
+  const std::string &a_stdstr_cref
 ) {}
 
 void argcheck_fnptr(int(*f)(char, bool)) {}

--- a/Lib/python/pytyping.swg
+++ b/Lib/python/pytyping.swg
@@ -2,11 +2,47 @@
 
 %typemap(pytyping) bool "bool"
 
-%typemap(pytyping) signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long "int"
-%typemap(pytyping) size_t "int"
+/*
+    Map both 'T' and 'T const &' to 'PyType'.
+    Keep in sync with primtypes.swg.
+*/
+%define %_pytyping_primtype(Type, PyType)
+    %typemap(pytyping) Type, Type const & "PyType"
+%enddef
 
-%typemap(pytyping) float, double, long double "float"
+%_pytyping_primtype(bool, bool);
 
-%typemap(pytyping) char, wchar_t, char *, wchar_t * "str"
+%_pytyping_primtype(signed char       , int);
+%_pytyping_primtype(unsigned char     , int);
+%_pytyping_primtype(short             , int);
+%_pytyping_primtype(unsigned short    , int);
+%_pytyping_primtype(int               , int);
+%_pytyping_primtype(unsigned int      , int);
+%_pytyping_primtype(long              , int);
+%_pytyping_primtype(unsigned long     , int);
+%_pytyping_primtype(long long         , int);
+%_pytyping_primtype(unsigned long long, int);
+%_pytyping_primtype(size_t            , int);
+%_pytyping_primtype(std::size_t       , int);
+%_pytyping_primtype(ptrdiff_t         , int);
+%_pytyping_primtype(std::ptrdiff_t    , int);
+
+%_pytyping_primtype(float , float);
+%_pytyping_primtype(double, float);
+
+%_pytyping_primtype(std::complex< float > , complex);
+%_pytyping_primtype(std::complex< double >, complex);
+
+/* No 'T const &' maps for these */
+%typemap(pytyping) float _Complex, double _Complex, _Complex "complex"
+
+%_pytyping_primtype(char        , str);
+%_pytyping_primtype(wchar_t     , str);
+%_pytyping_primtype(std::string , str);
+%_pytyping_primtype(std::wstring, str);
+
+%typemap(pytyping) long double "float"
+
+%typemap(pytyping) char *, wchar_t * "str"
 
 %typemap(pytyping) void "None"

--- a/Lib/python/pytyping.swg
+++ b/Lib/python/pytyping.swg
@@ -1,12 +1,36 @@
 %typemap(pytyping) SWIGTYPE "typing.Any"
 
-%typemap(pytyping) bool "bool"
+%typemap(pytyping) bool, bool const & "bool"
 
-%typemap(pytyping) signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long "int"
-%typemap(pytyping) size_t "int"
+%typemap(pytyping)
+  signed char,        signed char const &,
+  unsigned char,      unsigned char const &,
+  short,              short const &,
+  unsigned short,     unsigned short const &,
+  int,                int const &,
+  unsigned int,       unsigned int const &,
+  long,               long const &,
+  unsigned long,      unsigned long const &,
+  long long,          long long const &,
+  unsigned long long, unsigned long long const &,
+  size_t,             size_t const &,
+  ptrdiff_t,          ptrdiff_t const &
+"int"
 
-%typemap(pytyping) float, double, long double "float"
+%typemap(pytyping)
+  float,       float const &,
+  double,      double const &,
+  long double, long double const &
+"float"
 
-%typemap(pytyping) char, wchar_t, char *, wchar_t * "str"
+/* No 'T const &' maps for these */
+%typemap(pytyping) float _Complex, double _Complex, _Complex "complex"
+
+%typemap(pytyping)
+    char,    char const &,
+    wchar_t, wchar_t const &
+    "str"
+
+%typemap(pytyping) char *, wchar_t * "str"
 
 %typemap(pytyping) void "None"

--- a/Lib/python/pytyping.swg
+++ b/Lib/python/pytyping.swg
@@ -31,6 +31,6 @@
     wchar_t, wchar_t const &
     "str"
 
-%typemap(pytyping) char *, wchar_t * "str"
+%typemap(pytyping) char *, wchar_t * "typing.Optional[str]"
 
 %typemap(pytyping) void "None"

--- a/Lib/python/std_complex.i
+++ b/Lib/python/std_complex.i
@@ -25,3 +25,6 @@ namespace std {
 %typemaps_primitive(%checkcode(CPLXDBL), std::complex<double>);
 %typemaps_primitive(%checkcode(CPLXFLT), std::complex<float>);
 
+%typemap(pytyping) std::complex< float >,  std::complex< float >  const & "complex"
+%typemap(pytyping) std::complex< double >, std::complex< double > const & "complex"
+

--- a/Lib/python/std_string.i
+++ b/Lib/python/std_string.i
@@ -1,1 +1,7 @@
 %include <typemaps/std_string.swg>
+
+#ifdef SWIG_STD_STRING
+%typemap(pytyping) std::string, std::string const & "str"
+#else
+%typemap(pytyping) std::string, std::string const & "typing.Union[str, typing.Any]"
+#endif

--- a/Lib/python/std_wstring.i
+++ b/Lib/python/std_wstring.i
@@ -1,3 +1,8 @@
 %include <pywstrings.swg>
 %include <typemaps/std_wstring.swg>
 
+#ifdef SWIG_STD_WSTRING
+%typemap(pytyping) std::wstring, std::wstring const & "str"
+#else
+%typemap(pytyping) std::wstring, std::wstring const & "typing.Union[str, typing.Any]"
+#endif


### PR DESCRIPTION
This is split from #3390 where I noticed that `T const &` wasn't mapped correctly for primitive types.

This PR maps all types that are included in https://github.com/swig/swig/blob/8b307eb27900a4375d4e7b6c5aaa852c62c54c5b/Lib/typemaps/primtypes.swg. Notably, this includes const-references.