### PR TITLE
[R] Fix compilation with R 4.6.0 which removed non-API macros

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -275,6 +275,8 @@ jobs:
         - SWIGLANG: python
           CPPSTD: c++11
         - SWIGLANG: r
+          VER: 4.0.0
+        - SWIGLANG: r
           CPPSTD: c++11
         - SWIGLANG: ruby
           CPPSTD: c++11
@@ -319,6 +321,7 @@ jobs:
           CPPSTD: c++14
         - SWIGLANG: r
           CPPSTD: c++14
+          VER: 4.5.0
         - SWIGLANG: ruby
           CPPSTD: c++14
         - SWIGLANG: scilab
@@ -386,6 +389,10 @@ jobs:
         - SWIGLANG: python
           CPPSTD: c++17
           GCC: 13
+          os: ubuntu-24.04
+        - SWIGLANG: r
+          CPPSTD: c++17
+          VER: 4.6.0
           os: ubuntu-24.04
         - SWIGLANG: r
           CPPSTD: c++17

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,12 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.5.0 (in progress)
 ===========================
 
+2026-04-30: blowekamp
+            [R] #3407 Fix compilation with R 4.6.0 which removed the non-API macro
+            SET_S4_OBJECT and made CHARACTER_POINTER return a const pointer.
+            Use Rf_asS4, SET_STRING_ELT and STRING_ELT instead. These replacement
+            APIs have been available since R 2.x so no version guards are required.
+
 2026-04-25: wsfulton
             Advanced %rename fixes for templates. It is now possible to use %rename
 	    on instantiated templates for various corner cases, see "Template renaming"

--- a/Lib/r/argcargv.i
+++ b/Lib/r/argcargv.i
@@ -14,7 +14,6 @@
 %}
 %typemap(in) (int ARGC, char **ARGV) {
   $1_ltype i;
-  SEXP *pstr;
   if ($input == R_NilValue) {
     /* Empty array */
     $1 = 0;
@@ -22,14 +21,13 @@
     SWIG_exception_fail(SWIG_RuntimeError, "Wrong array type.");
   } else {
     $1 = Rf_length($input);
-    pstr = CHARACTER_POINTER($input);
   }
   $2 = ($2_ltype) malloc(($1+1)*sizeof($*2_ltype));
   if ($2 == NULL) {
     SWIG_exception_fail(SWIG_MemoryError, "Memory allocation failed.");
   }
   for (i = 0; i < $1; i++) {
-    $2[i] = ($*2_ltype)STRING_VALUE(pstr[i]);
+    $2[i] = ($*2_ltype)STRING_VALUE(STRING_ELT($input, i));
   }
   $2[i] = NULL;
 }

--- a/Lib/r/rrun.swg
+++ b/Lib/r/rrun.swg
@@ -267,7 +267,7 @@ SWIG_MakePtr(void *ptr, const char *typeName, int flags)
     R_RegisterCFinalizer(external, R_SWIG_ReferenceFinalizer);
 
   r_obj = SET_SLOT(r_obj, Rf_mkString((char *) "ref"), external);
-  SET_S4_OBJECT(r_obj);
+  r_obj = Rf_asS4(r_obj, TRUE, 0);
   Rf_unprotect(2);
 
   return(r_obj);
@@ -285,7 +285,7 @@ R_SWIG_create_SWIG_R_Array(const char *typeName, SEXP ref, int len)
    Rf_protect(arr = R_do_slot_assign(arr, Rf_mkString("dims"), Rf_ScalarInteger(len)));
 
    Rf_unprotect(3); 			   
-   SET_S4_OBJECT(arr);	
+   arr = Rf_asS4(arr, TRUE, 0);
    return arr;
 }
 
@@ -308,7 +308,7 @@ SWIG_R_NewPointerObj(void *ptr, swig_type_info *type, int flags) {
   }
   rptr = R_MakeExternalPtr(ptr, 
   R_MakeExternalPtr(type, R_NilValue, R_NilValue), R_NilValue); 
-  SET_S4_OBJECT(rptr);
+  rptr = Rf_asS4(rptr, TRUE, 0);
   return rptr;
 }
 

--- a/Lib/r/std_vector.i
+++ b/Lib/r/std_vector.i
@@ -203,7 +203,7 @@
          PROTECT(result = Rf_allocVector(STRSXP, val->size()));
          for (unsigned pos = 0; pos < val->size(); pos++)
            {
-             CHARACTER_POINTER(result)[pos] = Rf_mkChar(((*val)[pos]).c_str());
+             SET_STRING_ELT(result, pos, Rf_mkChar(((*val)[pos]).c_str()));
            }
         UNPROTECT(1);
         return(result);
@@ -669,7 +669,7 @@
             // Fill the R vector
             for (unsigned vpos = 0; vpos < val->at(pos).size(); ++vpos)
               {
-                CHARACTER_POINTER(VECTOR_ELT(result, pos))[vpos] = Rf_mkChar(val->at(pos).at(vpos).c_str());
+                SET_STRING_ELT(VECTOR_ELT(result, pos), vpos, Rf_mkChar(val->at(pos).at(vpos).c_str()));
               }
           }
         UNPROTECT(1);

--- a/Tools/CI-linux-install.sh
+++ b/Tools/CI-linux-install.sh
@@ -181,7 +181,25 @@ case "$SWIGLANG" in
 		fi
 		;;
 	"r")
-		$RETRY sudo apt-get -qq install r-base
+		if [[ -n "$VER" ]]; then
+			# Should helps with old version, but do not work
+			#$RETRY sudo apt-get -qq remove r-base r-base-core r-base-dev r-base-html r-doc-html r-recommended
+			sudo sed -i 's%^# deb-src %deb-src %' /etc/apt/sources.list
+			sudo sed -i 's%^Types: deb$%Types: deb deb-src%' /etc/apt/sources.list.d/*
+			$RETRY sudo apt-get -qq update
+			$RETRY sudo apt-get -qq build-dep r-base
+			r_build=`mktemp -d`
+			r_tarball=R-$VER.tar.gz
+			URL=https://cran.r-project.org/src/base/R-${VER:0:1}
+			$RETRY wget $URL/$r_tarball
+			tar -xf "$r_tarball" --strip-components=1 -C "$r_build"
+			cd "$r_build"
+			./configure
+			make
+			sudo make install
+		else
+			$RETRY sudo apt-get -qq install r-base
+		fi
 		;;
 	"ruby")
 		if [[ "$VER" ]]; then

--- a/configure.ac
+++ b/configure.ac
@@ -2292,6 +2292,17 @@ else
 if test "x$RBIN" = xyes; then
    AC_PATH_PROG(RBIN, R)
 fi
+if test -n "$RBIN" && test -x "$RBIN"; then
+   r_min_version=2.4.0
+   AC_MSG_CHECKING([for R version])
+   r_version=`R --version | grep 'R version' | sed 's%^R version %%;s% (.*%%'`
+   AS_VERSION_COMPARE(["$r_version"], ["$r_min_version"],
+                  [AC_MSG_RESULT([older then $r_min_version])
+                   AS_UNSET([RBIN])],        dnl bellow r_min_version
+                  [AC_MSG_RESULT([$r_version])],   dnl equal r_min_version
+                  [AC_MSG_RESULT([$r_version])])   dnl above r_min_version
+fi
+
 fi
 
 AC_SUBST(RBIN)


### PR DESCRIPTION
R 4.6.0 (released April 2025) removed several non-API C macros from its
public headers, breaking compilation of SWIG-generated R wrapper code.
This PR replaces them with the proper stable R API equivalents which have
been available since R 2.x, so no version guards are needed.

Fixes #3407.

### Changes

**`Lib/r/rrun.swg`** — 3 sites where `SET_S4_OBJECT(x)` was used to mark
an R object as an S4 instance. Replaced with `x = Rf_asS4(x, TRUE, 0)`,
which is the documented API equivalent (available since R 2.4.0).

**`Lib/r/std_vector.i`** — 2 sites in `traits_from_ptr` specialisations
for `std::vector<std::string>` and `std::vector<std::vector<std::string>>`
that wrote into a character vector via `CHARACTER_POINTER(v)[i] = ...`.
`CHARACTER_POINTER` now returns a `const SEXP *` in R 4.6.0, making write
access illegal. Replaced with `SET_STRING_ELT(v, i, ...)`.

**`Lib/r/argcargv.i`** — The `(int ARGC, char **ARGV)` typemap used
`CHARACTER_POINTER` to obtain a pointer to the string array and then
indexed through it. Replaced the pointer variable with direct calls to
`STRING_ELT($input, i)`.

### Testing

The full R test suite was run both before and after the change using the
existing SWIG binary with the modified `Lib/` files
(`SWIG_LIB=... make -k check-r-test-suite`). Both runs processed 691 test
cases with identical results: the only failures were 6 boost-related tests
(`li_boost_shared_ptr*`, `director_shared_ptr`,
`multiple_inheritance_shared_ptr`) that fail due to missing boost headers
in the test environment and are unrelated to this change.

Key tests that exercise the affected code paths all passed:
- `argcargvtest` (with run test) — exercises `argcargv.i`
- `li_std_vector` (with run test) — exercises `std_vector.i` string path
- `li_std_vector_vector` (with run test) — exercises nested string vector path
- All `smart_pointer_*` and `pointer_*` tests — exercise `rrun.swg` S4 marking

<details>
<summary>AI assistance</summary>

- Tool: GitHub Copilot (Claude Sonnet 4.6)
- Role: root-cause analysis, identification of all affected code sites, and implementation of fixes
- Contribution: researched R 4.6.0 API removals, located all 6 affected sites across 3 files, identified backward-compatible replacement APIs, implemented changes, ran test suite to verify no regressions
- All code was reviewed and tested locally before committing

</details>