### PR TITLE
Add CI support for testing Swig on Windows ARM64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
   # - Microsoft Visual Studio compiler.
   # - MinGW-w64 GCC compiler with MSVCRT or UCRT C standard library.
   # We use 2 package managers
-  # - NuGet packages are compatible with Visual Studio compiler.
+  # - Vcpkg packages are compatible with Visual Studio compiler.
   # - MSYS2 pacman with MSYS2 packages and MING-w64 packages.
   #
   # We try to use already installed software on GitHub windows
@@ -140,6 +140,37 @@ jobs:
           COMPILER: gcc
           CSTD: gnu11
           MSYS2_ENV: ucrt64
+        - SWIGLANG: csharp
+          os: windows-11-arm
+        - SWIGLANG: csharp
+          os: windows-11-arm
+          COMPILER: clang
+          MSYS2_ENV: clangarm64
+        - SWIGLANG: java
+          COMPILER: clang
+          VER: 21
+          os: windows-11-arm
+          MSYS2_ENV: clangarm64
+        - SWIGLANG: java
+          VER: 21
+          os: windows-11-arm
+        - SWIGLANG: python
+          COMPILER: clang
+          VER: '3.14'
+          os: windows-11-arm
+          MSYS2_ENV: clangarm64
+        - SWIGLANG: python
+          VER: '3.14'
+          os: windows-11-arm
+        - SWIGLANG: ruby
+          COMPILER: clang
+          MSYS2_ENV: clangarm64
+          os: windows-11-arm
+        - SWIGLANG: go
+          COMPILER: clang
+          CSTD: gnu11
+          MSYS2_ENV: clangarm64
+          os: windows-11-arm
       # Run all of them, as opposed to aborting when one fails
       fail-fast: false
 
@@ -147,8 +178,8 @@ jobs:
       CFLAGS: '-O2'
       CXXFLAGS: '-O2'
       CCCL_OPTIONS: '--cccl-muffle /W3 /EHsc'
-      PCRE2_CCCL_LD: '-lpcre2-8-static --cccl-link /NODEFAULTLIB:MSVCRT'
-      CHECK_OPTIONS: 'CSHARPOPTIONS=-platform:x64'
+      PCRE2_CCCL_LD: '-lpcre2-8 --cccl-link /NODEFAULTLIB:MSVCRT'
+      CHECK_OPTIONS: ${{ matrix.os == 'windows-11-arm' && 'CSHARPOPTIONS=-platform:arm64' || 'CSHARPOPTIONS=-platform:x64' }}
       SWIGLANG: ${{ matrix.SWIGLANG }}
       VER: ${{ matrix.VER }}
       SWIG_FEATURES: ${{ matrix.SWIG_FEATURES }}
@@ -171,6 +202,17 @@ jobs:
 #  /NODEFAULTLIB:lib   Ignore library 'lib'
 
     steps:
+    # On windows-11-arm, MSYS2 is not pre-installed.
+    # Install it manually via the official installer into C:\msys64,
+    - name: Install MSYS2 (windows-11-arm)
+      if: ${{ matrix.os == 'windows-11-arm' }}
+      shell: powershell
+      run: |
+          $installer = "$env:TEMP\msys2-arm64.exe"
+          Invoke-WebRequest -Uri "https://github.com/msys2/msys2-installer/releases/download/2026-03-22/msys2-arm64-20260322.exe" -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "install --root C:\msys64 --confirm-command" -Wait -NoNewWindow
+          C:\msys64\usr\bin\bash -lc "pacman -Syu --noconfirm --needed"
+  
     - name: Machine Info
       shell: powershell
       run: |
@@ -186,28 +228,38 @@ jobs:
       with:
         key: ${{ matrix.os || 'windows-2025' }}-${{ matrix.COMPILER || 'msvc' }}
 
-    - name: Install NuGet Packages
+    - name: Install pcre2 via vcpkg
       if: ${{ env.COMPILER == '' }}
       shell: powershell
       run: |
-          # 'nuget build for .NET: https://www.nuget.org/packages'
-          nuget install PCRE2 -OutputDirectory C:\Tools
-          nuget install boost -OutputDirectory C:\Tools
+          $triplet = if ($env:OS -eq 'windows-11-arm') { 'arm64-windows-static' } else { 'x64-windows-static' }
+          vcpkg install pcre2:$triplet --triplet $triplet
+          $vcpkgInstalled = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet"
+          echo "VCPKG_INSTALLED=$vcpkgInstalled" >> $env:GITHUB_ENV
+          echo "VCPKG_TRIPLET=$triplet" >> $env:GITHUB_ENV
 
-    # Set MSVC compilers path and environment variables.
+    - name: Install Boost (MSVC)
+      if: ${{ env.COMPILER == '' }}
+      uses: MarkusJx/install-boost@v2
+      id: install-boost
+      with:
+        boost_version: 1.89.0
+        toolset: msvc
+        arch: ${{ matrix.os == 'windows-11-arm' && 'aarch64' || 'x86' }}
+   
+      # Set MSVC compilers path and environment variables.
     - name: Setup MSVC
       if: ${{ env.COMPILER == '' || env.SWIGLANG == 'csharp' }}
-      uses: TheMrMilchmann/setup-msvc-dev@v3
+      uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: x64
+        arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
 
     - name: Prepare Environment
       shell: bash
       run: |
           set -x
           uname --all
-
-          if [[ "$COMPILER" = "gcc" ]]; then
+          if [[ "$COMPILER" = "gcc" || "$COMPILER" = "clang" ]]; then
             # MinGW-w64 variant to use
             # See: https://www.msys2.org/docs/environments
             MSYS2_UENV="${MSYS2_ENV^^}" # Change to uppercase
@@ -228,6 +280,10 @@ jobs:
             CLANG64) # Use LLVM/Clang
               # The matched MSYS2 packages prefix
               mingw_variant=mingw-w64-clang-x86_64-
+              ;;
+            CLANGARM64) # Use LLVM/Clang for ARM64
+              # The matched MSYS2 packages prefix
+              mingw_variant=mingw-w64-clang-aarch64-
               ;;
             esac
             # The matched MSYS2 active environment path prefix
@@ -263,8 +319,15 @@ jobs:
               ;;
             esac
 
-            # MinGW-w64 packages to install with MSYS2
-            for n in binutils make autotools pcre2 boost; do
+            # MinGW-w64/CLANGARM64 packages to install with MSYS2
+            # For CLANGARM64 add 'toolchain' to get clang/clang++/lld.
+            # For MINGW64/UCRT64/CLANG64 gcc is already present via dependencies.
+            if [[ "$MSYSTEM" == "CLANGARM64" ]]; then
+              pkgs="toolchain binutils make autotools pcre2 boost"
+            else
+              pkgs="binutils make autotools pcre2 boost"
+            fi
+            for n in $pkgs; do
               MORE_MSYS_PKGS+=" ${mingw_variant}$n"
             done
 
@@ -283,16 +346,13 @@ jobs:
             chmod +x /usr/bin/cccl
             /usr/bin/cccl --version
             cp -p /usr/bin/cccl /c/msys64/usr/bin/cccl
-
-            # Using pcre2 installed with NuGet
-            PCRE2_PATH=$(ls -d /c/tools/PCRE2*)
-            echo "PCRE2_CFLAGS=-I$PCRE2_PATH/include -DPCRE2_STATIC" >> $GITHUB_ENV
-            echo "PCRE2_LIBS=-L$PCRE2_PATH/lib $PCRE2_CCCL_LD" >> $GITHUB_ENV
-
+            # Using pcre2 installed with vcpkg
+            VCPKG_INSTALLED_UNIX="$(cygpath -u "$VCPKG_INSTALLED")"
+            echo "PCRE2_CFLAGS=-I$VCPKG_INSTALLED_UNIX/include -DPCRE2_STATIC" >> $GITHUB_ENV
+            echo "PCRE2_LIBS=-L$VCPKG_INSTALLED_UNIX/lib $PCRE2_CCCL_LD" >> $GITHUB_ENV
             echo "CXX=/usr/bin/cccl" >> $GITHUB_ENV
             echo "CC=/usr/bin/cccl" >> $GITHUB_ENV
-            echo "BOOST_PATH=$(ls -d /c/tools/boost*)/lib/native" >> $GITHUB_ENV
-
+            echo "BOOST_PATH=$(cygpath -u "${{ steps.install-boost.outputs.BOOST_ROOT }}")/include/boost-1_89" >> $GITHUB_ENV            
             if [[ -n "$VER" ]]; then
               case "$SWIGLANG" in
               python)
@@ -306,15 +366,17 @@ jobs:
           fi # COMPILER
 
           if [[ "$SWIGLANG" = "java" ]] && [[ -n "$VER" ]]; then
-            java_path="JAVA_HOME_${VER}_X64"
+            if [[ "$OS" == "windows-11-arm" ]]; then
+              java_path="JAVA_HOME_${VER}_AARCH64"
+            else
+              java_path="JAVA_HOME_${VER}_X64"
+            fi
             echo "JAVA_HOME=${!java_path}" >> $GITHUB_ENV
           fi
-
           echo "SWIGJOBS=-j$NUMBER_OF_PROCESSORS" >> $GITHUB_ENV
-
           echo 'C:\msys64\usr\bin' >> $GITHUB_PATH
-
-    - name: Install MSYS2 Packages
+    - name: Install MSYS2 Packages for x64
+      if: ${{ matrix.os != 'windows-11-arm' }}
       shell: cmd
       run: |
           rem 'MSYS2 uses MinGW-w64 https://packages.msys2.org/'
@@ -322,7 +384,12 @@ jobs:
           if %ErrorLevel% NEQ 0 (exit 1)
           pacman -Syu --noconfirm --needed autoconf automake bison %MORE_MSYS_PKGS%
           if %ErrorLevel% NEQ 0 (exit 1)
-
+    - name: Install MSYS2 Packages for ARM64
+      if: ${{ matrix.os == 'windows-11-arm' }}
+      shell: bash
+      run: |
+          C:/msys64/usr/bin/pacman -S --noconfirm --needed autoconf automake bison $MORE_MSYS_PKGS
+  
     - name: Autoconf
       shell: bash
       run: |
@@ -331,12 +398,20 @@ jobs:
             which cl.exe
             cl.exe /? 2>&1 | head -n1
           else
-            which gcc
-            gcc --version | head -n1
-            which g++
-            g++ --version | head -n1
+            if [[ "$MSYS2_ENV" == "clangarm64" ]]; then
+              which clang
+              clang --version | head -n1
+              which clang++
+              clang++ --version | head -n1
+              echo "CC=clang" >> $GITHUB_ENV
+              echo "CXX=clang++" >> $GITHUB_ENV
+            else
+              which gcc
+              gcc --version | head -n1
+              which g++
+              g++ --version | head -n1
+            fi
           fi
-
           WITHLANG="$SWIGLANG"
           case "$SWIGLANG" in
           csharp)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,6 +79,7 @@ jobs:
     strategy:
       matrix:
         include:
+        # x64 builds
         - SWIGLANG: csharp
           INSTALL: 'true'
         - SWIGLANG: csharp
@@ -140,37 +141,46 @@ jobs:
           COMPILER: gcc
           CSTD: gnu11
           MSYS2_ENV: ucrt64
+        # arm64 builds
         - SWIGLANG: csharp
           os: windows-11-arm
+          arch: arm64
         - SWIGLANG: csharp
           os: windows-11-arm
+          arch: arm64
           COMPILER: clang
           MSYS2_ENV: clangarm64
         - SWIGLANG: java
           COMPILER: clang
           VER: 21
           os: windows-11-arm
+          arch: arm64
           MSYS2_ENV: clangarm64
         - SWIGLANG: java
           VER: 21
           os: windows-11-arm
+          arch: arm64
         - SWIGLANG: python
           COMPILER: clang
           VER: '3.14'
           os: windows-11-arm
+          arch: arm64
           MSYS2_ENV: clangarm64
         - SWIGLANG: python
           VER: '3.14'
           os: windows-11-arm
+          arch: arm64
         - SWIGLANG: ruby
           COMPILER: clang
           MSYS2_ENV: clangarm64
           os: windows-11-arm
+          arch: arm64
         - SWIGLANG: go
           COMPILER: clang
           CSTD: gnu11
           MSYS2_ENV: clangarm64
           os: windows-11-arm
+          arch: arm64
       # Run all of them, as opposed to aborting when one fails
       fail-fast: false
 
@@ -179,7 +189,7 @@ jobs:
       CXXFLAGS: '-O2'
       CCCL_OPTIONS: '--cccl-muffle /W3 /EHsc'
       PCRE2_CCCL_LD: '-lpcre2-8 --cccl-link /NODEFAULTLIB:MSVCRT'
-      CHECK_OPTIONS: ${{ matrix.os == 'windows-11-arm' && 'CSHARPOPTIONS=-platform:arm64' || 'CSHARPOPTIONS=-platform:x64' }}
+      CHECK_OPTIONS: ${{ (matrix.arch == 'arm64') && 'CSHARPOPTIONS=-platform:arm64' || 'CSHARPOPTIONS=-platform:x64' }}
       SWIGLANG: ${{ matrix.SWIGLANG }}
       VER: ${{ matrix.VER }}
       SWIG_FEATURES: ${{ matrix.SWIG_FEATURES }}
@@ -187,7 +197,7 @@ jobs:
       CSTD: ${{ matrix.CSTD }}
       CPPSTD: ${{ matrix.CPPSTD }}
       COMPILER: ${{ matrix.COMPILER }}
-      OS: ${{ matrix.os }}
+      ARCH: ${{ matrix.arch || 'x64' }}
       INSTALL: ${{ matrix.INSTALL }}
 
 # cl.exe:
@@ -202,17 +212,17 @@ jobs:
 #  /NODEFAULTLIB:lib   Ignore library 'lib'
 
     steps:
-    # On windows-11-arm, MSYS2 is not pre-installed.
-    # Install it manually via the official installer into C:\msys64,
-    - name: Install MSYS2 (windows-11-arm)
-      if: ${{ matrix.os == 'windows-11-arm' }}
+    # On arm64 runners, MSYS2 is not pre-installed.
+    # Install it manually via the official installer into C:\msys64.
+    - name: Install MSYS2 (arm64)
+      if: ${{ env.ARCH == 'arm64' }}
       shell: powershell
       run: |
           $installer = "$env:TEMP\msys2-arm64.exe"
           Invoke-WebRequest -Uri "https://github.com/msys2/msys2-installer/releases/download/2026-03-22/msys2-arm64-20260322.exe" -OutFile $installer
           Start-Process -FilePath $installer -ArgumentList "install --root C:\msys64 --confirm-command" -Wait -NoNewWindow
           C:\msys64\usr\bin\bash -lc "pacman -Syu --noconfirm --needed"
-  
+
     - name: Machine Info
       shell: powershell
       run: |
@@ -232,7 +242,7 @@ jobs:
       if: ${{ env.COMPILER == '' }}
       shell: powershell
       run: |
-          $triplet = if ($env:OS -eq 'windows-11-arm') { 'arm64-windows-static' } else { 'x64-windows-static' }
+          $triplet = "$env:ARCH-windows-static"
           vcpkg install pcre2:$triplet --triplet $triplet
           $vcpkgInstalled = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet"
           echo "VCPKG_INSTALLED=$vcpkgInstalled" >> $env:GITHUB_ENV
@@ -245,14 +255,14 @@ jobs:
       with:
         boost_version: 1.89.0
         toolset: msvc
-        arch: ${{ matrix.os == 'windows-11-arm' && 'aarch64' || 'x86' }}
-   
+        arch: ${{ env.ARCH == 'arm64' && 'aarch64' || 'x86' }}
+
       # Set MSVC compilers path and environment variables.
     - name: Setup MSVC
       if: ${{ env.COMPILER == '' || env.SWIGLANG == 'csharp' }}
       uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
+        arch: ${{ env.ARCH }}
 
     - name: Prepare Environment
       shell: bash
@@ -352,7 +362,7 @@ jobs:
             echo "PCRE2_LIBS=-L$VCPKG_INSTALLED_UNIX/lib $PCRE2_CCCL_LD" >> $GITHUB_ENV
             echo "CXX=/usr/bin/cccl" >> $GITHUB_ENV
             echo "CC=/usr/bin/cccl" >> $GITHUB_ENV
-            echo "BOOST_PATH=$(cygpath -u "${{ steps.install-boost.outputs.BOOST_ROOT }}")/include/boost-1_89" >> $GITHUB_ENV            
+            echo "BOOST_PATH=$(cygpath -u "${{ steps.install-boost.outputs.BOOST_ROOT }}")/include/boost-1_89" >> $GITHUB_ENV
             if [[ -n "$VER" ]]; then
               case "$SWIGLANG" in
               python)
@@ -366,7 +376,7 @@ jobs:
           fi # COMPILER
 
           if [[ "$SWIGLANG" = "java" ]] && [[ -n "$VER" ]]; then
-            if [[ "$OS" == "windows-11-arm" ]]; then
+            if [[ "$ARCH" == "arm64" ]]; then
               java_path="JAVA_HOME_${VER}_AARCH64"
             else
               java_path="JAVA_HOME_${VER}_X64"
@@ -375,8 +385,9 @@ jobs:
           fi
           echo "SWIGJOBS=-j$NUMBER_OF_PROCESSORS" >> $GITHUB_ENV
           echo 'C:\msys64\usr\bin' >> $GITHUB_PATH
+
     - name: Install MSYS2 Packages for x64
-      if: ${{ matrix.os != 'windows-11-arm' }}
+      if: ${{ env.ARCH != 'arm64' }}
       shell: cmd
       run: |
           rem 'MSYS2 uses MinGW-w64 https://packages.msys2.org/'
@@ -384,12 +395,13 @@ jobs:
           if %ErrorLevel% NEQ 0 (exit 1)
           pacman -Syu --noconfirm --needed autoconf automake bison %MORE_MSYS_PKGS%
           if %ErrorLevel% NEQ 0 (exit 1)
+
     - name: Install MSYS2 Packages for ARM64
-      if: ${{ matrix.os == 'windows-11-arm' }}
+      if: ${{ env.ARCH == 'arm64' }}
       shell: bash
       run: |
           C:/msys64/usr/bin/pacman -S --noconfirm --needed autoconf automake bison $MORE_MSYS_PKGS
-  
+
     - name: Autoconf
       shell: bash
       run: |

--- a/configure.ac
+++ b/configure.ac
@@ -729,8 +729,15 @@ fi
 case $host in
 *-*-cygwin* | *-*-mingw* | *-*-msys*)
     if test "$GCC" = yes; then
-        CSHARPDYNAMICLINKING="$GCC_MNO_CYGWIN -mthreads -Wl,--add-stdcall-alias"
-        CSHARPCFLAGS="$GCC_MNO_CYGWIN -mthreads"
+        if $CC -Wl,--version 2>&1 | grep -q "LLD"; then
+            # Clang/LLD: --add-stdcall-alias and -mthreads not supported
+            CSHARPDYNAMICLINKING=""
+            CSHARPCFLAGS=""
+        else
+            # GCC/GNU ld
+            CSHARPDYNAMICLINKING="$GCC_MNO_CYGWIN -mthreads -Wl,--add-stdcall-alias"
+            CSHARPCFLAGS="$GCC_MNO_CYGWIN -mthreads"
+        fi
     else
         CSHARPDYNAMICLINKING=""
         CSHARPCFLAGS=""
@@ -1179,8 +1186,15 @@ esac
 case $host in
 *-*-cygwin* | *-*-mingw* | *-*-msys*)
     if test "$GCC" = yes; then
-        JAVADYNAMICLINKING="$GCC_MNO_CYGWIN -mthreads -Wl,--add-stdcall-alias"
-        JAVACFLAGS="$GCC_MNO_CYGWIN -mthreads"
+        if $CC -Wl,--version 2>&1 | grep -q "LLD"; then
+            # Clang/LLD: --add-stdcall-alias and -mthreads not supported
+            JAVADYNAMICLINKING=""
+            JAVACFLAGS=""
+        else
+            # GCC/GNU ld
+            JAVADYNAMICLINKING="$GCC_MNO_CYGWIN -mthreads -Wl,--add-stdcall-alias"
+            JAVACFLAGS="$GCC_MNO_CYGWIN -mthreads"
+        fi
     else
         JAVADYNAMICLINKING=""
         JAVACFLAGS=""


### PR DESCRIPTION
PR Description:
 
* This PR introduces CI support for building and testing Swig on Windows ARM64 using the MSYS2/MSVC toolchain.
 
Changes Proposed:
 
* Updated the windows.yml workflow to include ARM64 build configurations.
* Replaced NuGet with VCPKG, as NuGet packages are currently available only for Windows x64, while VCPKG supports both Windows x64 and ARM64.
* Switched to using prebuilt Boost libraries in GitHub Actions.
* Added a step to manually install MSYS2 on Windows ARM64 runners, since it is not pre-installed.
* Excluded add-stdcall-alias and mthreads options for Windows ARM64, as they are not supported by the MSYS2 CLANGARM64 compiler.