### PR TITLE
Python: Support multi-argument typemaps for pytyping

### DIFF
--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -45,7 +45,20 @@ if sys.version_info[0:2] >= (3, 2):
         anno = get_annotations(no_annotations)
         if anno != {}:
             raise RuntimeError("annotations mismatch: {}".format(anno))
-        
+
+        anno = get_annotations(take_argv)
+        if anno != {"argc": "typing.List[str]", "return": "None"}:
+            raise RuntimeError("annotations mismatch: {}".format(anno))
+
+        anno = get_annotations(take_argv_surround)
+        if anno != {
+            "before": "float",
+            "argc": "typing.List[str]",
+            "after": "int",
+            "return": "None",
+        }:
+            raise RuntimeError("annotations mismatch: {}".format(anno))
+
         def make_argcheck(exp, args):
             d = {arg: exp for arg in args}
             d["return"] = "None"

--- a/Examples/test-suite/python_annotations_typing.i
+++ b/Examples/test-suite/python_annotations_typing.i
@@ -4,21 +4,9 @@
 %include <std_wstring.i>
 
 // Tests the typing annotations
-%feature("python:annotations", "typing") mymethod;
-%feature("python:annotations", "typing") makeT<short>;
-%feature("python:annotations", "typing") global_ints;
-%feature("python:annotations", "typing") global_overloaded;
-%feature("python:annotations", "typing") argcheck_bool;
-%feature("python:annotations", "typing") argcheck_char;
-%feature("python:annotations", "typing") argcheck_int;
-%feature("python:annotations", "typing") argcheck_float;
-%feature("python:annotations", "typing") argcheck_str;
-%feature("python:annotations", "typing") argcheck_fnptr;
-%feature("python:annotations", "typing") argcheck_array;
-%feature("python:annotations", "typing") use_callable;
-%feature("python:annotations", "typing") return_callable;
-%feature("python:annotations", "typing") optional_square;
-%feature("python:annotations", "typing") docs_do_something_out_type;
+%feature("python:annotations", "typing");
+
+%feature("python:annotations", "0") no_annotations;
 
 %typemap(pytyping) OptionalInt "typing.Optional[int]";
 %typemap(pytyping, out = "$typemap(pytyping, short)") MyType "typing.Union[int, float]";
@@ -63,7 +51,39 @@ int is_python_fastproxy() { return 0; }
 #endif
 %}
 
+%typemap(in) (int argc, char **argv) {
+  /* Check if is a list */
+  if (PyList_Check($input)) {
+    int i;
+    $1 = PyList_Size($input);
+    $2 = (char **) malloc(($1+1)*sizeof(char *));
+    for (i = 0; i < $1; i++) {
+      PyObject *o = PyList_GetItem($input, i);
+      if (PyString_Check(o)) {
+        $2[i] = PyString_AsString(PyList_GetItem($input, i));
+      } else {
+        PyErr_SetString(PyExc_TypeError, "list must contain strings");
+        SWIG_fail;
+      }
+    }
+    $2[i] = 0;
+  } else {
+    PyErr_SetString(PyExc_TypeError, "not a list");
+    SWIG_fail;
+  }
+}
+
+%typemap(freearg) (int argc, char **argv) {
+  free((char *) $2);
+}
+
+%typemap(pytyping) (int argc, char **argv) "typing.List[str]"
+
 %inline %{
+
+void take_argv(int argc, char **argv) {}
+
+void take_argv_surround(double before, int argc, char **argv, short after) {}
 
 void argcheck_bool(bool a_bool) {}
 

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1792,6 +1792,7 @@ public:
     addMissingParameterNames(n, plist, arg_num);  // for $1_name substitutions done in Swig_typemap_attach_parms
     Swig_typemap_attach_parms("in", plist, 0);
     Swig_typemap_attach_parms("doc", plist, 0);
+    Swig_typemap_attach_parms("pytyping", plist, 0);
 
     if (Strcmp(ParmList_protostr(plist), "void") == 0) {
       // No parameters actually
@@ -2535,7 +2536,9 @@ public:
    * ------------------------------------------------------------ */
 
   String *lookupPytyping(Node *n, bool out = false) {
-    String *tm = Swig_typemap_lookup("pytyping", n, Swig_cresult_name(), 0);
+    String *tm = Getattr(n, "tmap:pytyping");
+    if (!tm)
+      tm = Swig_typemap_lookup("pytyping", n, Swig_cresult_name(), 0);
     if (tm && out) {
       String *outty = Getattr(n, "tmap:pytyping:out");
       if (outty)

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -1792,6 +1792,7 @@ public:
     addMissingParameterNames(n, plist, arg_num);  // for $1_name substitutions done in Swig_typemap_attach_parms
     Swig_typemap_attach_parms("in", plist, 0);
     Swig_typemap_attach_parms("doc", plist, 0);
+    Swig_typemap_attach_parms("pytyping", plist, 0);
 
     if (Strcmp(ParmList_protostr(plist), "void") == 0) {
       // No parameters actually
@@ -2544,7 +2545,9 @@ public:
    * ------------------------------------------------------------ */
 
   String *lookupPytyping(Node *n, bool out = false) {
-    String *tm = Swig_typemap_lookup("pytyping", n, Swig_cresult_name(), 0);
+    String *tm = Getattr(n, "tmap:pytyping");
+    if (!tm)
+      tm = Swig_typemap_lookup("pytyping", n, Swig_cresult_name(), 0);
     if (tm && out) {
       String *outty = Getattr(n, "tmap:pytyping:out");
       if (outty)


### PR DESCRIPTION
To support multi-argument typemaps for `pytyping`, we need to use `Swig_typemap_attach_parms` and lookup with `"tmap:pytyping"`. Before, only the parameter would receive the type of the first argument to the typemap. Users couldn't overwrite that type properly.

I added a test that uses the typemap described in the docs (https://www.swig.org/Doc4.4/Python.html#Python_nn60).