### PR TITLE
Skip Ubuntu Toolchain PPA if versioned GCC already installed

### DIFF
--- a/Tools/CI-linux-install.sh
+++ b/Tools/CI-linux-install.sh
@@ -9,11 +9,15 @@ if [[ "$compiler" = 'clang' ]]; then
 	CC="clang"
 	CXX="clang++"
 elif [[ -n "$GCC" ]]; then
-	$RETRY sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-	$RETRY sudo apt-get -qq update
-	$RETRY sudo apt-get -qq install g++-$GCC
 	CC="gcc-$GCC"
 	CXX="g++-$GCC"
+	if ! dpkg -l 'g++*' | grep "^ii  $CXX " > /dev/null; then
+		$RETRY sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+		$RETRY sudo apt-get -qq update
+		$RETRY sudo apt-get -qq install g++-$GCC
+	else
+		$RETRY sudo apt-get -qq update
+	fi
 else
 	$RETRY sudo apt-get -qq update
 	CC="gcc"


### PR DESCRIPTION
Most versioned GCC are already installed on GitHub Ubuntu images. 

Although we only spare ~10 seconds of adding the PPA repository.
We skip potential errors in case the PPA is not reachable.