### PR TITLE
Add `windows-11-arm` to `cmake.yml`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -111,7 +111,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-2025-vs2026]
+        os: [windows-11-arm, windows-2022, windows-2025-vs2026]
       # Run all of them, as opposed to aborting when one fails
       fail-fast: false
 
@@ -131,16 +131,30 @@ jobs:
     - name: Install NuGet Packages
       shell: powershell
       run: |
-          nuget install PCRE2 -OutputDirectory C:\Tools
           nuget install Bison -OutputDirectory C:\Tools
+          switch ( $env:RUNNER_ARCH ) {
+          'X64' {
+             nuget install PCRE2 -OutputDirectory C:\Tools
+          }
+          'ARM64' {
+             $triplet = 'arm64-windows-static'
+             vcpkg install pcre2:$triplet --triplet $triplet
+          }
+          }
 
     # https://cygwin.com/cygwin-ug-net/cygpath.html
     - name: Prepare Environment
       shell: bash
       run: |
-          cat << EOF >> $GITHUB_ENV
-          PCRE2_PATH=$(cygpath -w "$(ls -d /C/Tools/PCRE2*)")
-          EOF
+          case "$RUNNER_ARCH" in
+          X64)
+            PCRE2_PATH="$(cygpath -w "$(ls -d /C/Tools/PCRE2*)")"
+            ;;
+          ARM64)
+            PCRE2_PATH="$VCPKG_INSTALLATION_ROOT\installed\arm64-windows-static"
+            ;;
+          esac
+          echo "PCRE2_PATH=$PCRE2_PATH" >> $GITHUB_ENV
           BISON_PATH=$(cygpath -w "$(ls -d /C/Tools/Bison*)/bin")
           echo "$BISON_PATH" >> $GITHUB_PATH
 
@@ -152,7 +166,7 @@ jobs:
       shell: powershell
       run: |
           cmake --version
-          cmake -S . -B . -A x64 `
+          cmake -S . -B . -A $env:RUNNER_ARCH `
           -DCMAKE_INSTALL_PREFIX="C:\Tools\swig" `
           -DCMAKE_C_FLAGS="/W3 /EHsc" `
           -DCMAKE_CXX_FLAGS="/W3 /EHsc" `


### PR DESCRIPTION
Use #3412 as reference

But more simple
- As  `windows-11-arm`  lack `MSYS2`, `cmake.yml` seems a proper place, as it does not use `MSYS2`.
- We use `vcpkg` with `pcre2` on `arm64` only. `NuGet` is much faster, but lack libraries for `arm64`.
- Use GitHub variable `RUNNER_ARCH` to determine architecture, we can keep the matrix with images names only.