### PR TITLE
Fix PHP `%typemap(directorin)` for pointers

### DIFF
--- a/Examples/test-suite/csharp/director_classes_runme.cs
+++ b/Examples/test-suite/csharp/director_classes_runme.cs
@@ -102,6 +102,7 @@ public class runme
     if (myCaller.ValCall(dh).val != dh.val) throw new Exception("failed");
     if (myCaller.RefCall(dh).val != dh.val) throw new Exception("failed");
     if (myCaller.PtrCall(dh).val != dh.val) throw new Exception("failed");
+    if (myCaller.ConstPtrCall(dh).val != dh.val) throw new Exception("failed");
     if (myCaller.ConstPtrRefCall(dh).val != dh.val) throw new Exception("failed");
 
     // Fully overloaded method test (all methods in base class are overloaded)
@@ -144,6 +145,11 @@ public class CSharpDerived : Base
   public override DoubleHolder Ptr(DoubleHolder x)
   {
     if (director_classes.PrintDebug) Console.WriteLine("CSharpDerived - Ptr({0})", x.val);
+    return x;
+  }
+  public override DoubleHolder ConstPtr(DoubleHolder x)
+  {
+    if (director_classes.PrintDebug) Console.WriteLine("CSharpDerived - ConstPtr({0})", x.val);
     return x;
   }
   public override DoubleHolder ConstPtrRef(DoubleHolder x)

--- a/Examples/test-suite/d/director_classes_runme.2.d
+++ b/Examples/test-suite/d/director_classes_runme.2.d
@@ -97,25 +97,26 @@ void makeCalls(Caller myCaller, Base myBase) {
   DoubleHolder dh = new DoubleHolder(444.555);
 
   // Class pointer, reference and pass by value tests
-  enforce(myCaller.ValCall(dh).val == dh.val, "[1] failed");
-  enforce(myCaller.RefCall(dh).val == dh.val, "[2] failed");
-  enforce(myCaller.PtrCall(dh).val == dh.val, "[3] failed");
-  enforce(myCaller.ConstPtrRefCall(dh).val == dh.val, "[3] failed");
+  enforce(myCaller.ValCall(dh).val == dh.val, "ValCall failed");
+  enforce(myCaller.RefCall(dh).val == dh.val, "RefCall failed");
+  enforce(myCaller.PtrCall(dh).val == dh.val, "PtrCall failed");
+  enforce(myCaller.ConstPtrCall(dh).val == dh.val, "ConstPtrCall failed");
+  enforce(myCaller.ConstPtrRefCall(dh).val == dh.val, "ConstPtrRefCall failed");
 
   // Fully overloaded method test (all methods in base class are overloaded)
-  enforce(myCaller.FullyOverloadedCall(10) == myBaseType ~ "::FullyOverloaded(int)", "[4] failed");
-  enforce(myCaller.FullyOverloadedCall(true) == myBaseType ~ "::FullyOverloaded(bool)", "[5] failed");
+  enforce(myCaller.FullyOverloadedCall(10) == myBaseType ~ "::FullyOverloaded(int)", "FullyOverloaded(int) failed");
+  enforce(myCaller.FullyOverloadedCall(true) == myBaseType ~ "::FullyOverloaded(bool)", "FullyOverloaded(bool) failed");
 
   // Semi overloaded method test (some methods in base class are overloaded)
-  enforce(myCaller.SemiOverloadedCall(-678) == myBaseType ~ "::SemiOverloaded(int)", "[6] failed");
-  enforce(myCaller.SemiOverloadedCall(true) == "Base" ~ "::SemiOverloaded(bool)", "[7] failed");
+  enforce(myCaller.SemiOverloadedCall(-678) == myBaseType ~ "::SemiOverloaded(int)", "SemiOverloaded(int) failed");
+  enforce(myCaller.SemiOverloadedCall(true) == "Base" ~ "::SemiOverloaded(bool)", "SemiOverloaded(bool) failed");
 
   // Default parameters methods test
-  enforce(myCaller.DefaultParmsCall(10, 2.25) == myBaseType ~ "::DefaultParms(int, double)", "[8] failed");
+  enforce(myCaller.DefaultParmsCall(10, 2.25) == myBaseType ~ "::DefaultParms(int, double)", "DefaultParms(int, double) failed");
   if (myBase.classinfo == DDerived.classinfo) { // special handling for D derived classes, there is no other way to do this
-    enforce(myCaller.DefaultParmsCall(10) == myBaseType ~ "::DefaultParms(int, double)", "[9] failed");
+    enforce(myCaller.DefaultParmsCall(10) == myBaseType ~ "::DefaultParms(int, double)", "DefaultParms(int, double) failed");
   } else {
-    enforce(myCaller.DefaultParmsCall(10) == myBaseType ~ "::DefaultParms(int)", "[10] failed");
+    enforce(myCaller.DefaultParmsCall(10) == myBaseType ~ "::DefaultParms(int)", "DefaultParms(int) failed");
   }
 
   myCaller.reset();
@@ -138,6 +139,11 @@ public class DDerived : Base {
 
   public override DoubleHolder Ptr(DoubleHolder x) {
     if (PrintDebug) writefln("DDerived - Ptr(%s)", x.val);
+    return x;
+  }
+
+  public override DoubleHolder ConstPtr(DoubleHolder x) {
+    if (PrintDebug) writefln("DDerived - ConstPtr(%s)", x.val);
     return x;
   }
 

--- a/Examples/test-suite/director_classes.i
+++ b/Examples/test-suite/director_classes.i
@@ -3,6 +3,7 @@
 
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Base::Ref;
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Base::Ptr;
+%warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Base::ConstPtr;
 %warnfilter(SWIGWARN_TYPEMAP_THREAD_UNSAFE,SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) Base::ConstPtrRef;
 
 #ifdef SWIGOCAML
@@ -48,6 +49,7 @@ public:
   virtual DoubleHolder Val(DoubleHolder x) { if (PrintDebug) std::cout << "Base - Val(" << x.val << ")" << std::endl; return x; }
   virtual DoubleHolder& Ref(DoubleHolder& x) { if (PrintDebug) std::cout << "Base - Ref(" << x.val << ")" << std::endl; return x; }
   virtual DoubleHolder* Ptr(DoubleHolder* x) { if (PrintDebug) std::cout << "Base - Ptr(" << x->val << ")" << std::endl; return x; }
+  virtual const DoubleHolder* ConstPtr(const DoubleHolder* x) { if (PrintDebug) std::cout << "Base - ConstPtr(" << x->val << ")" << std::endl; return x; }
   virtual DoubleHolder *const& ConstPtrRef(DoubleHolder *const& cprx) { if (PrintDebug) std::cout << "Base - ConstPtrRef(" << cprx->val << ")" << std::endl; return cprx; }
 
   virtual std::string FullyOverloaded(int x) { if (PrintDebug) std::cout << "Base - FullyOverloaded(int " << x << ")" << std::endl; return "Base::FullyOverloaded(int)"; }
@@ -74,6 +76,7 @@ public:
   virtual DoubleHolder Val(DoubleHolder x) { if (PrintDebug) std::cout << "Derived - Val(" << x.val << ")" << std::endl; return x; }
   virtual DoubleHolder& Ref(DoubleHolder& x) { if (PrintDebug) std::cout << "Derived - Ref(" << x.val << ")" << std::endl; return x; }
   virtual DoubleHolder* Ptr(DoubleHolder* x) { if (PrintDebug) std::cout << "Derived - Ptr(" << x->val << ")" << std::endl; return x; }
+  virtual const DoubleHolder* ConstPtr(const DoubleHolder* x) { if (PrintDebug) std::cout << "Derived - ConstPtr(" << x->val << ")" << std::endl; return x; }
   virtual DoubleHolder *const& ConstPtrRef(DoubleHolder *const& cprx) { if (PrintDebug) std::cout << "Derived - ConstPtrRef(" << cprx->val << ")" << std::endl; return cprx; }
 
   virtual std::string FullyOverloaded(int x) { if (PrintDebug) std::cout << "Derived - FullyOverloaded(int " << x << ")" << std::endl; return "Derived::FullyOverloaded(int)"; }
@@ -106,6 +109,7 @@ public:
   DoubleHolder ValCall(DoubleHolder x) { return m_base->Val(x); }
   DoubleHolder& RefCall(DoubleHolder& x) { return m_base->Ref(x); }
   DoubleHolder* PtrCall(DoubleHolder* x) { return m_base->Ptr(x); }
+  const DoubleHolder* ConstPtrCall(const DoubleHolder* x) { return m_base->ConstPtr(x); }
   DoubleHolder *const& ConstPtrRefCall(DoubleHolder *const& cprx) { return m_base->ConstPtrRef(cprx); }
   std::string FullyOverloadedCall(int x) { return m_base->FullyOverloaded(x); }
   std::string FullyOverloadedCall(bool x) { return m_base->FullyOverloaded(x); }

--- a/Examples/test-suite/java/director_classes_runme.java
+++ b/Examples/test-suite/java/director_classes_runme.java
@@ -114,6 +114,7 @@ public class director_classes_runme {
     if (myCaller.ValCall(dh).getVal() != dh.getVal()) throw new RuntimeException("failed");
     if (myCaller.RefCall(dh).getVal() != dh.getVal()) throw new RuntimeException("failed");
     if (myCaller.PtrCall(dh).getVal() != dh.getVal()) throw new RuntimeException("failed");
+    if (myCaller.ConstPtrCall(dh).getVal() != dh.getVal()) throw new RuntimeException("failed");
     if (myCaller.ConstPtrRefCall(dh).getVal() != dh.getVal()) throw new RuntimeException("failed");
 
     // Fully overloaded method test (all methods in base class are overloaded)
@@ -172,6 +173,11 @@ class JavaDerived extends Base
   public DoubleHolder Ptr(DoubleHolder x)
   {
     if (director_classes.getPrintDebug()) System.out.println("JavaDerived - Ptr(" + x.getVal() + ")");
+    return x;
+  }
+  public DoubleHolder ConstPtr(DoubleHolder x)
+  {
+    if (director_classes.getPrintDebug()) System.out.println("JavaDerived - ConstPtr(" + x.getVal() + ")");
     return x;
   }
   public DoubleHolder ConstPtrRef(DoubleHolder x)

--- a/Examples/test-suite/perl5/director_classes_runme.pl
+++ b/Examples/test-suite/perl5/director_classes_runme.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 32;
+use Test::More tests => 35;
 BEGIN { use_ok 'director_classes' }
 require_ok 'director_classes';
 
@@ -10,6 +10,7 @@ require_ok 'director_classes';
   sub Val { $_[1] }
   sub Ref { $_[1] }
   sub Ptr { $_[1] }
+  sub ConstPtr { $_[1] }
   sub ConstPtrRef { $_[1] }
   sub FullyOverloaded {
     my $rv = shift->SUPER::FullyOverloaded(@_);
@@ -17,11 +18,20 @@ require_ok 'director_classes';
     return $rv;
   }
   sub SemiOverloaded {
-    # this is going to be awkward because we can't really
-    # semi-overload in Perl, but we can sort of fake it.
-    return shift->SUPER::SemiOverloaded(@_) unless $_[0] =~ /^\d+/;
-    my $rv = shift->SUPER::SemiOverloaded(@_);
-    $rv =~ s/Base/__PACKAGE__/sge;
+    my $self = shift;
+    my $val = shift;
+    # Perl use one callback for both SemiOverloaded() methods.
+    # Usually we use the values type and number of values to distinguish.
+    # But as Perl tread boolean as number (as old C does),
+    # We fake it by detecting the value itself.
+    my $rv = $self->SUPER::SemiOverloaded($val);
+    if($val eq "") { # detect SemiOverloaded(bool)
+        # Convert SemiOverloaded(int) to SemiOverloaded(bool)
+        $rv =~ s/int/bool/;
+    } else { # detect SemiOverloaded(int)
+        # Convert Base::SemiOverloaded(int) to PerlDerived::SemiOverloaded(int)
+        $rv =~ s/Base/__PACKAGE__/se;
+    }
     return $rv;
   }
   sub DefaultParms {
@@ -46,6 +56,7 @@ sub makeCalls { my($caller, $base) = @_;
   is($caller->ValCall($dh)->{val}, $dh->{val}, "$bname.Val");
   is($caller->RefCall($dh)->{val}, $dh->{val}, "$bname.Ref");
   is($caller->PtrCall($dh)->{val}, $dh->{val}, "$bname.Ptr");
+  is($caller->ConstPtrCall($dh)->{val}, $dh->{val}, "$bname.ConstPtr");
   is($caller->ConstPtrRefCall($dh)->{val}, $dh->{val}, "$bname.ConstPtrRef");
   is($caller->FullyOverloadedCall(1),
       "${bname}::FullyOverloaded(int)",
@@ -53,12 +64,9 @@ sub makeCalls { my($caller, $base) = @_;
   is($caller->FullyOverloadedCall(''),
       "${bname}::FullyOverloaded(bool)",
       "$bname.FullyOverloaded(bool)");
-TODO: {
-  local $TODO = 'investigation needed here' if $bname eq 'PerlDerived';
   is($caller->SemiOverloadedCall(-678),
       "${bname}::SemiOverloaded(int)",
       "$bname.SemiOverloaded(int)");
-}
   is($caller->SemiOverloadedCall(''),
       "Base::SemiOverloaded(bool)",
       "$bname.SemiOverloaded(bool)");

--- a/Examples/test-suite/php/director_classes_runme.php
+++ b/Examples/test-suite/php/director_classes_runme.php
@@ -12,55 +12,45 @@ class PHPDerived extends Base {
   function Val(DoubleHolder $x) { return $x; }
   function Ref(DoubleHolder $x) { return $x; }
   function Ptr(?DoubleHolder $x) { return $x; }
+  function ConstPtr(?DoubleHolder $x) { return $x; }
   function ConstPtrRef(?DoubleHolder $x) { return $x; }
   function FullyOverloaded($x) {
-    $rv = parent::FullyOverloaded($x);
-    $rv = preg_replace('/Base/', 'PHPDerived', $rv);
-    return $rv;
+    return preg_replace('/Base/', 'PHPDerived', parent::FullyOverloaded($x));
   }
   function SemiOverloaded($x) {
-    # this is going to be awkward because we can't really
-    # semi-overload in PHP, but we can sort of fake it.
-    if (!is_int($x)) {
-      return parent::SemiOverloaded($x);
+    # PHP use one callback for both types!
+    if (is_int($x)) {
+        # PHPDerived::SemiOverloaded(int) overload
+        return preg_replace('/Base/', 'PHPDerived', parent::SemiOverloaded($x));
     }
-    $rv = parent::SemiOverloaded($x);
-    $rv = preg_replace('/Base/', 'PHPDerived', $rv);
-    return $rv;
+    # Call Base::SemiOverloaded(bool)
+    return parent::SemiOverloaded($x);
   }
-  function DefaultParms(int $x, float $y = 1.125) {
-    $rv = parent::DefaultParms($x, $y);
-    $rv = preg_replace('/Base/', 'PHPDerived', $rv);
-    return $rv;
+  function DefaultParms(int $x, float $y = 1.125) { /* Same default as C++! */
+    return preg_replace('/Base/', 'PHPDerived', parent::DefaultParms($x, $y));
   }
 }
 
-{
-  $c = new Caller();
-  makeCalls($c, new Base(100.0));
-  makeCalls($c, new Derived(200.0));
-  makeCalls($c, new PHPDerived(300.0));
-}
 
-function makeCalls($caller, $base) {
+function makeCalls($caller, $base, $TODO) {
   $bname = get_class($base);
-  if ($bname == 'PHPDerived') {
-      // TODO: Debug and make this work:
-      return;
-  }
   $caller->set($base);
   $dh = new DoubleHolder(444.555);
   check::equal($caller->ValCall($dh)->val, $dh->val, "$bname.Val");
   check::equal($caller->RefCall($dh)->val, $dh->val, "$bname.Ref");
   check::equal($caller->PtrCall($dh)->val, $dh->val, "$bname.Ptr");
+  check::equal($caller->ConstPtrCall($dh)->val, $dh->val, "$bname.ConstPtr");
+  if (!$TODO) {
+  # TODO Need fixing!
+  # Use SWIGTYPE_p_p_DoubleHolder instead of SWIGTYPE_p_DoubleHolder!
   check::equal($caller->ConstPtrRefCall($dh)->val, $dh->val, "$bname.ConstPtrRef");
+  }
   check::equal($caller->FullyOverloadedCall(1),
 	       "{$bname}::FullyOverloaded(int)",
 	       "$bname.FullyOverloaded(int)");
   check::equal($caller->FullyOverloadedCall(false),
 	       "{$bname}::FullyOverloaded(bool)",
 	       "$bname.FullyOverloaded(bool)");
-  // This next one is TODO for Perl with PerlDerived.
   check::equal($caller->SemiOverloadedCall(-678),
 	       "{$bname}::SemiOverloaded(int)",
 	       "$bname.SemiOverloaded(int)");
@@ -75,5 +65,10 @@ function makeCalls($caller, $base) {
 	       "$bname.DefaultParms(int)");
   $caller->reset();
 }
+
+$c = new Caller();
+makeCalls($c, new Base(100.0), false);
+makeCalls($c, new Derived(200.0), false);
+makeCalls($c, new PHPDerived(300.0), true);
 
 check::done();

--- a/Examples/test-suite/python/director_classes_runme.py
+++ b/Examples/test-suite/python/director_classes_runme.py
@@ -1,0 +1,65 @@
+import director_classes
+import re
+
+class PyDerived(director_classes.Base):
+    def __init__(self, v):
+        director_classes.Base.__init__(self, v)
+    def Val(self, x):
+        return x
+    def Ref(self, x):
+        return x
+    def Ptr(self, x):
+        return x
+    def ConstPtr(self, x):
+        return x
+    def ConstPtrRef(self, x):
+        return x
+    def FullyOverloaded(self, x):
+        rv = director_classes.Base.FullyOverloaded(self, x)
+        me = type(self).__name__
+        return re.sub(r'^Base', me, rv)
+    def SemiOverloaded(self, x):
+        # TODO: override 'int' only fails!
+        rv = director_classes.Base.SemiOverloaded(self, x)
+        # (x: bool) should not be overloaded
+        if type(x).__name__ == 'bool':
+            return rv
+        # (x: int) is overloaded
+        me = type(self).__name__
+        return re.sub(r'^Base', me, rv)
+    def DefaultParms(self, x, y):
+        rv = director_classes.Base.DefaultParms(self, x, y)
+        me = type(self).__name__
+        return re.sub(r'^Base', me, rv)
+
+def check_equal(a, b, msg):
+    if a != b:
+        raise RuntimeError("{}: {} != {}".format(msg, a, b))
+
+def makeCalls(caller, base):
+  bname = type(base).__name__
+  caller.set(base)
+  dh = director_classes.DoubleHolder(444.555)
+  check_equal(caller.ValCall(dh).val, dh.val, bname + "Val")
+  check_equal(caller.RefCall(dh).val, dh.val, bname + "Ref")
+  check_equal(caller.PtrCall(dh).val, dh.val, bname + "Ptr")
+  check_equal(caller.ConstPtrCall(dh).val, dh.val, bname + "ConstPtr")
+  check_equal(caller.ConstPtrRefCall(dh).val, dh.val, bname + "ConstPtrRef")
+  check_equal(caller.FullyOverloadedCall(1),
+      bname + "::FullyOverloaded(int)", bname + "FullyOverloaded(int)")
+  check_equal(caller.FullyOverloadedCall(False),
+      bname + "::FullyOverloaded(bool)", bname + "FullyOverloaded(bool)")
+  check_equal(caller.SemiOverloadedCall(-678),
+      bname + "::SemiOverloaded(int)", bname + "SemiOverloaded(int)")
+  check_equal(caller.SemiOverloadedCall(False),
+      "Base::SemiOverloaded(bool)", bname + "SemiOverloaded(bool)")
+  check_equal(caller.DefaultParmsCall(10, 2.2),
+      bname + "::DefaultParms(int, double)", bname + "DefaultParms(int, double)")
+  check_equal(caller.DefaultParmsCall(10),
+      bname + "::DefaultParms(int)", bname + "DefaultParms(int)")
+  caller.reset()
+
+caller = director_classes.Caller()
+makeCalls(caller, director_classes.Base(100.0))
+makeCalls(caller, director_classes.Derived(200.0))
+makeCalls(caller, PyDerived(300.0))

--- a/Examples/test-suite/ruby/director_classes_runme.rb
+++ b/Examples/test-suite/ruby/director_classes_runme.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+require 'director_classes'
+
+class RbDerived < Director_classes::Base
+  def Val(x)
+    return x
+  end
+  def Ref(x)
+    return x
+  end
+  def Ptr(x)
+    return x
+  end
+  def ConstPtr(x)
+    return x
+  end
+  def ConstPtrRef(x)
+    return x
+  end
+  def FullyOverloaded(x)
+    return super(x).gsub(/^Base/, 'RbDerived')
+  end
+  def SemiOverloaded(x)
+    ret = super(x)
+    # Ruvy does not have types!
+    if(!!x == x) # SemiOverloaded(bool)
+      return ret # Not overload
+    end
+    # SemiOverloaded(int)
+    return ret.gsub(/^Base/, 'RbDerived')
+  end
+  def DefaultParms(x, y)
+    return super(x, y).gsub(/^Base/, 'RbDerived')
+  end
+end
+
+def assert_equal(a, b, msg)
+    if a != b
+        raise SwigRubyError.new("#{msg}: #{a} != #{b}")
+    end
+end
+
+def makeCalls(callerObj, base)
+  bname = base.class.name.gsub(/^Director_classes::/,'')
+  callerObj.set(base)
+  dh = Director_classes::DoubleHolder.new(444.555)
+  assert_equal(callerObj.ValCall(dh).val, dh.val, bname + "Val")
+  assert_equal(callerObj.RefCall(dh).val, dh.val, bname + "Ref")
+  assert_equal(callerObj.PtrCall(dh).val, dh.val, bname + "Ptr")
+  assert_equal(callerObj.ConstPtrCall(dh).val, dh.val, bname + "ConstPtr")
+  assert_equal(callerObj.ConstPtrRefCall(dh).val, dh.val, bname + "ConstPtrRef")
+  assert_equal(callerObj.FullyOverloadedCall(1),
+      bname + "::FullyOverloaded(int)", bname + "FullyOverloaded(int)")
+  assert_equal(callerObj.FullyOverloadedCall(false),
+      bname + "::FullyOverloaded(bool)", bname + "FullyOverloaded(bool)")
+  assert_equal(callerObj.SemiOverloadedCall(-678),
+      bname + "::SemiOverloaded(int)", bname + "SemiOverloaded(int)")
+  assert_equal(callerObj.SemiOverloadedCall(false),
+      "Base::SemiOverloaded(bool)", bname + "SemiOverloaded(bool)")
+  assert_equal(callerObj.DefaultParmsCall(10, 2.2),
+      bname + "::DefaultParms(int, double)", bname + "DefaultParms(int, double)")
+  assert_equal(callerObj.DefaultParmsCall(10),
+      bname + "::DefaultParms(int)", bname + "DefaultParms(int)")
+  callerObj.reset()
+end
+
+callerObj = Director_classes::Caller.new
+makeCalls(callerObj, Director_classes::Base.new(100.0))
+makeCalls(callerObj, Director_classes::Derived.new(200.0))
+makeCalls(callerObj, RbDerived.new(300.0))

--- a/Lib/php/php.swg
+++ b/Lib/php/php.swg
@@ -461,13 +461,21 @@
   SWIG_SetPointerZval($result, (void *)*$1, $*1_descriptor, $owner);
 %}
 
-%typemap(directorin) SWIGTYPE *,
-                     SWIGTYPE [],
-                     SWIGTYPE &,
-                     SWIGTYPE &&
+/* map C++ reference to SWIG pointer and C++ reference of pointer to SWIG pointer of pointer */
+%typemap(directorin) SWIGTYPE &,
+                     SWIGTYPE &&,
+                     SWIGTYPE *const&
 %{
   ZVAL_UNDEF($input);
-  SWIG_SetPointerZval($input, (void *)&$1, $1_descriptor, $owner);
+  SWIG_SetPointerZval($input, (void *)&($1), $1_descriptor, $owner);
+%}
+
+/* map C/C++ pointer to SWIG pointer */
+%typemap(directorin) SWIGTYPE *,
+                     SWIGTYPE []
+%{
+  ZVAL_UNDEF($input);
+  SWIG_SetPointerZval($input, (void *)($1), $1_descriptor, $owner);
 %}
 
 %typemap(out, phptype="SWIGTYPE") SWIGTYPE (CLASS::*)


### PR DESCRIPTION
- `director_classes`
  - Add `ConstPtrCall()` method and add it to tests
  - Remove numbering from `D`, it is easier to use function names. And easier to modify in future.
  - Fix PHP test
  - Fix Perl test
  - Add Python and Ruby tests