### PR TITLE
R: Fix non-class scoped enums

### DIFF
--- a/Examples/test-suite/r/cpp11_strongly_typed_enumerations_runme.R
+++ b/Examples/test-suite/r/cpp11_strongly_typed_enumerations_runme.R
@@ -1,0 +1,34 @@
+clargs <- commandArgs(trailing=TRUE)
+source(file.path(clargs[1], "unittest.R"))
+
+dyn.load(paste("cpp11_strongly_typed_enumerations", .Platform$dynlib.ext, sep=""))
+source("cpp11_strongly_typed_enumerations.R")
+cacheMetaData(1)
+
+# Check integer values of strongly typed enum values
+unittest(0, enumToInteger("Val1", "_Enum1"))
+unittest(1, enumToInteger("Val2", "_Enum1"))
+unittest(13, enumToInteger("Val3", "_Enum1"))
+unittest(14, enumToInteger("Val4", "_Enum1"))
+
+unittest(23, enumToInteger("Val3", "_Enum2"))
+unittest(43, enumToInteger("Val3", "_Enum4"))
+unittest(53, enumToInteger("Val3", "_Enum5"))
+unittest(63, enumToInteger("Val3", "_Enum6"))
+unittest(73, enumToInteger("Val3", "_Enum7"))
+unittest(83, enumToInteger("Val3", "_Enum8"))
+unittest(0, enumToInteger("Val1", "_Enum9"))
+
+unittest(1151, enumToInteger("Val1", "_Enum15"))
+unittest(1161, enumToInteger("Val1", "_Enum16"))
+unittest(1171, enumToInteger("Val1", "_Enum17"))
+
+# Test class-scoped strongly typed enums
+unittest(1121, enumToInteger("Val1", "_Class1__Enum12"))
+unittest(1131, enumToInteger("Val1", "_Class1__Enum13"))
+unittest(1141, enumToInteger("Val1", "_Class1__Enum14"))
+
+# Test enum class (the %rename changes the wrapper function name but
+# defineEnumeration still uses the original QVal1 name)
+unittest(1181, enumToInteger("QVal1", "_QEnum18"))
+unittest(1182, enumToInteger("Val2", "_QEnum18"))

--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -2749,7 +2749,13 @@ String *R::enumValue(Node *n) {
     newsymname = Swig_name_member(0, Getattr(parent, "sym:name"), symname);
     // Strange hack to change the name
     Setattr(n, "name", Getattr(n, "value"));
-    Setattr(n, "sym:name", newsymname);
+    if (GetFlag(parent, "scopedenum")) {
+      // Language::variableWrapper will prefix with EnumClassPrefix for scoped
+      // enums (non-class). Avoid double prefixing by not adding it here.
+      Setattr(n, "sym:name", Copy(symname));
+    } else {
+      Setattr(n, "sym:name", Copy(newsymname));
+    }
     variableWrapper(n);
     value = Swig_name_get(NSPACE_TODO, newsymname);
   } else {


### PR DESCRIPTION
In `R::enumValue()` (`Source/Modules/r.cxx:2749`), for **non-class scoped enums** (`enum class` at file scope), the enum value name was being prefixed **twice**:

1. `R::enumValue()` manually prefixes `sym:name` with the parent enum name via `Swig_name_member(0, parent_sym:name, symname)` -> `VarType_Discretized`
2. Then `Language::variableWrapper()` prefixes **again** via `EnumClassPrefix` (set by `Language::enumDeclaration` for scoped enums) -> `VarType_VarType_Discretized`

This caused the C wrapper function to be named `R_swig_VarType_VarType_Discretized_get` while the R `.Call` referenced `R_swig_VarType_Discretized_get` -> a mismatch that crashed at runtime.

In `R::enumValue()`, for scoped enums, skip the manual prefixing and let `Language::variableWrapper()` handle it through the `EnumClassPrefix` mechanism (which already exists for this purpose).

Closes #2984