### PR TITLE
Compute qualified name for member variable matching

### DIFF
--- a/Examples/test-suite/python/typemap_variables_runme.py
+++ b/Examples/test-suite/python/typemap_variables_runme.py
@@ -1,0 +1,12 @@
+import typemap_variables
+
+# Regression test for issue #2056: %typemap(in) with struct qualification
+# matching member variable setters.
+a = typemap_variables.StructA()
+b = typemap_variables.StructB()
+
+# Setting member exercises the qualified 'in' typemap on the setter
+# parameter. If the typemap matches, the wrapper compiles and runs
+# without error (the in typemap forces arg2=0).
+a.member = 42
+b.member = 99

--- a/Examples/test-suite/typemap_variables.i
+++ b/Examples/test-suite/typemap_variables.i
@@ -48,10 +48,28 @@
 %typemap(in)  int Space::nspace             "/*int nspace in */ $1=0;"
 %typemap(out) int Space::nspace             "/*int nspace out*/ $result=OUT_NULL_VALUE;"
 %typemap(in)  int member                    "/*int member in */ $1=0;"
-#ifdef SWIGTCL
+#if defined(SWIGTCL) || defined(SWIGSCILAB)
 %typemap(out) int member                    "/*int member out*/"
+#elif defined(SWIGPYTHON)
+%typemap(out) int member                    "/*int member out*/ $result=Py_None; Py_INCREF(Py_None);"
 #else
 %typemap(out) int member                    "/*int member out*/ $result=OUT_NULL_VALUE;"
+#endif
+%typemap(in)  int StructA::member           "/*int StructA::member in */ $1=0;"
+#if defined(SWIGTCL) || defined(SWIGSCILAB)
+%typemap(out) int StructA::member           "/*int StructA::member out*/"
+#elif defined(SWIGPYTHON)
+%typemap(out) int StructA::member           "/*int StructA::member out*/ $result=Py_None; Py_INCREF(Py_None);"
+#else
+%typemap(out) int StructA::member           "/*int StructA::member out*/ $result=OUT_NULL_VALUE;"
+#endif
+%typemap(in)  int StructB::member           "/*int StructB::member in */ $1=0;"
+#if defined(SWIGTCL) || defined(SWIGSCILAB)
+%typemap(out) int StructB::member           "/*int StructB::member out*/"
+#elif defined(SWIGPYTHON)
+%typemap(out) int StructB::member           "/*int StructB::member out*/ $result=Py_None; Py_INCREF(Py_None);"
+#else
+%typemap(out) int StructB::member           "/*int StructB::member out*/ $result=OUT_NULL_VALUE;"
 #endif
 %typemap(in)  int Space::Struct::smember    "/*int smember in */ $1=0;"
 %typemap(out) int Space::Struct::smember    "/*int smember out*/ $result=OUT_NULL_VALUE;"
@@ -83,6 +101,14 @@
 %inline %{
 
 int globul;
+
+struct StructA {
+  int member;
+};
+
+struct StructB {
+  int member;
+};
 
 namespace Space {
   int nspace;

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -1383,6 +1383,7 @@ int Swig_MembersetToFunction(Node *n, String *classname, int flags) {
 
   ty = Swig_wrapped_member_var_type(type, varcref);
   p = NewParm(ty, name, n);
+  Setattr(p, "sym:symtab", Getattr(n, "sym:symtab"));
   Setattr(parms, "hidden", "1");
   set_nextSibling(parms, p);
 

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -821,6 +821,7 @@ static Hash *typemap_search_multi(const_String_or_char_ptr tmap_method, ParmList
   SwigType *type;
   SwigType *mtype = 0;
   String *name;
+  String *qpname = 0;
   String *multi_tmap_method;
   Hash *tm;
   Hash *tm1 = 0;
@@ -832,8 +833,19 @@ static Hash *typemap_search_multi(const_String_or_char_ptr tmap_method, ParmList
   type = Getattr(parms, "type");
   name = Getattr(parms, "name");
 
+  /* Compute qualified name for member variable setter parameter matching,
+   * e.g. %typemap(in) int * _A::v { ... } */
+  if (name && Getattr(parms, "sym:symtab")) {
+    String *qsn = Swig_symbol_qualified(parms);
+    if (qsn && Len(qsn)) {
+      qpname = NewStringf("%s::%s", qsn, name);
+      Delete(qsn);
+    }
+  }
+
   /* Try to find a match on the first type */
-  tm = typemap_search(tmap_method, type, name, 0, &mtype, parms);
+  tm = typemap_search(tmap_method, type, name, qpname, &mtype, parms);
+  Delete(qpname);
   if (tm) {
     if (mtype && SwigType_isarray(mtype)) {
       Setattr(parms, "tmap:match", mtype);


### PR DESCRIPTION
`%typemap(out) int * _A::v { ... }` matches for member variable getters, but `%typemap(in) int * _A::v { ... }` does NOT match for setters.

Two independent factors combine to prevent `in` (and `typecheck`, etc.) typemaps from matching qualified member names:

`Source/Swig/cwrap.c:1385` in `Swig_MembersetToFunction()`:

    p = NewParm(ty, name, n);

`NewParm()` copies only file/line info from `n`. It does NOT copy `sym:symtab`. Without `sym:symtab` the initial Parm later passed to `typemap_search_multi()` has no way to determine what struct/class the member belongs to.

Compare with the getter path (`out`): it uses `Swig_typemap_lookup_impl()` which retrieves `sym:symtab` directly from the original Node `n` — so the qualified name `_A::v` is available for matching.

`Source/Swig/typemap.c:836` in `typemap_search_multi()`:

    tm = typemap_search(tmap_method, type, name, 0, &mtype, parms);
                                               ^
                                   qualifiedname = NULL

Even if `sym:symtab` were present on the Parm, the qualified name is never computed from it; it is always passed as `0` (NULL). So `typemap_search()` → `typemap_search_helper()` never attempts the qualified name lookup.

1. **`cwrap.c`**: Add `Setattr(p, "sym:symtab", Getattr(n, "sym:symtab"))` after the `NewParm()` call so the Parm carries the struct/class scope.

2. **`typemap.c`**: Before the `typemap_search()` call, compute `qpname` from the Parm's `sym:symtab` via `Swig_symbol_qualified(parms)` and pass it instead of `0`.

Closes #2056