### PR TITLE
Support unique_ptr custom deleter

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -673,6 +673,7 @@ CPP11_TEST_CASES += \
 	cpp11_std_array \
 	cpp11_std_function \
 	cpp11_std_unique_ptr \
+	li_std_unique_ptr_deleter \
 	cpp11_strongly_typed_enumerations \
 	cpp11_thread_local \
 	cpp11_template_double_brackets \

--- a/Examples/test-suite/li_std_unique_ptr_deleter.i
+++ b/Examples/test-suite/li_std_unique_ptr_deleter.i
@@ -1,0 +1,36 @@
+%module li_std_unique_ptr_deleter
+
+#if defined(SWIGPYTHON)
+
+%include "std_unique_ptr.i"
+
+%inline %{
+#include <memory>
+
+struct Widget {
+  int value;
+  Widget(int v) : value(v) {}
+  ~Widget() {}
+};
+
+struct WidgetDeleter {
+  void operator()(Widget* w) const {
+    delete w;
+  }
+};
+%}
+
+%unique_ptr_custom_deleter(Widget, WidgetDeleter)
+
+%inline %{
+
+  std::unique_ptr<Widget, WidgetDeleter> make_widget(int val) {
+    return std::unique_ptr<Widget, WidgetDeleter>(new Widget(val));
+  }
+
+  int widget_value(std::unique_ptr<Widget, WidgetDeleter> w) {
+    return w ? w->value : -1;
+  }
+%}
+
+#endif

--- a/Examples/test-suite/python/li_std_unique_ptr_deleter_runme.py
+++ b/Examples/test-suite/python/li_std_unique_ptr_deleter_runme.py
@@ -1,0 +1,12 @@
+from li_std_unique_ptr_deleter import *
+
+def check(flag):
+    if not flag:
+        raise RuntimeError("Check failed")
+
+# Test creating and passing a unique_ptr with custom deleter
+w = make_widget(42)
+check(w is not None)
+
+val = widget_value(w)
+check(val == 42)

--- a/Lib/python/std_unique_ptr.i
+++ b/Lib/python/std_unique_ptr.i
@@ -18,7 +18,8 @@
 %include <unique_ptr.swg>
 
 %define %unique_ptr(TYPE)
-%typemap(in, noblock=1) std::unique_ptr< TYPE > (void *argp = 0, int res = 0) {
+
+%typemap(in, noblock=1) std::unique_ptr< TYPE, std::default_delete< TYPE > > (void *argp = 0, int res = 0) {
   res = SWIG_ConvertPtr($input, &argp, $descriptor(TYPE *), SWIG_POINTER_RELEASE | %convertptr_flags);
   if (!SWIG_IsOK(res)) {
     if (res == SWIG_ERROR_RELEASE_NOT_OWNED) {
@@ -30,7 +31,7 @@
   $1.reset((TYPE *)argp);
 }
 
-%typemap(in, noblock=1) std::unique_ptr< TYPE > & (void *argp = 0, int res = 0, std::unique_ptr< TYPE > uptr), std::unique_ptr< TYPE > && (void *argp = 0, int res = 0, std::unique_ptr< TYPE > uptr) {
+%typemap(in, noblock=1) std::unique_ptr< TYPE, std::default_delete< TYPE > > & (void *argp = 0, int res = 0, std::unique_ptr< TYPE, std::default_delete< TYPE > > uptr), std::unique_ptr< TYPE, std::default_delete< TYPE > > && (void *argp = 0, int res = 0, std::unique_ptr< TYPE, std::default_delete< TYPE > > uptr) {
   res = SWIG_ConvertPtr($input, &argp, $descriptor(TYPE *), SWIG_POINTER_RELEASE | %convertptr_flags);
   if (!SWIG_IsOK(res)) {
     if (res == SWIG_ERROR_RELEASE_NOT_OWNED) {
@@ -43,7 +44,7 @@
   $1 = &uptr;
 }
 
-%typemap(in, noblock=1, fragment="SwigNoDeleteUniquePtr") const std::unique_ptr< TYPE > & (void *argp = 0, int res = 0, swig::NoDeleteUniquePtr< TYPE > ndup) {
+%typemap(in, noblock=1, fragment="SwigNoDeleteUniquePtr") const std::unique_ptr< TYPE, std::default_delete< TYPE > > & (void *argp = 0, int res = 0, swig::NoDeleteUniquePtr< TYPE > ndup) {
   res = SWIG_ConvertPtr($input, &argp, $descriptor(TYPE *), 0);
   if (!SWIG_IsOK(res)) {
     %argument_fail(res, "TYPE *", $symname, $argnum);
@@ -52,18 +53,70 @@
   $1 = &ndup.uptr;
 }
 
-%typemap (out) std::unique_ptr< TYPE > %{
+%typemap (out) std::unique_ptr< TYPE, std::default_delete< TYPE > > %{
   %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
 %}
-%typemap (out) std::unique_ptr< TYPE > &, std::unique_ptr< TYPE > && %{
+%typemap (out) std::unique_ptr< TYPE, std::default_delete< TYPE > > &, std::unique_ptr< TYPE, std::default_delete< TYPE > > && %{
   %set_output(SWIG_NewPointerObj($1->get(), $descriptor(TYPE *), $owner | %newpointer_flags));
 %}
 
-%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER, equivalent="TYPE *", noblock=1) std::unique_ptr< TYPE >, std::unique_ptr< TYPE > &, std::unique_ptr< TYPE > && {
+%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER, equivalent="TYPE *", noblock=1) std::unique_ptr< TYPE, std::default_delete< TYPE > >, std::unique_ptr< TYPE, std::default_delete< TYPE > > &, std::unique_ptr< TYPE, std::default_delete< TYPE > > && {
   void *vptr = 0;
   int res = SWIG_ConvertPtr($input, &vptr, $descriptor(TYPE *), 0);
   $1 = SWIG_CheckState(res);
 }
 
-%template() std::unique_ptr< TYPE >;
+%template() std::unique_ptr< TYPE, std::default_delete< TYPE > >;
+%enddef
+
+%define %unique_ptr_custom_deleter(TYPE, DELETER)
+
+%typemap(in, noblock=1) std::unique_ptr< TYPE, DELETER > (void *argp = 0, int res = 0) {
+  res = SWIG_ConvertPtr($input, &argp, $descriptor(TYPE *), SWIG_POINTER_RELEASE | %convertptr_flags);
+  if (!SWIG_IsOK(res)) {
+    if (res == SWIG_ERROR_RELEASE_NOT_OWNED) {
+      %releasenotowned_fail(res, "TYPE *", $symname, $argnum);
+    } else {
+      %argument_fail(res, "TYPE *", $symname, $argnum);
+    }
+  }
+  $1.reset((TYPE *)argp);
+}
+
+%typemap(in, noblock=1) std::unique_ptr< TYPE, DELETER > & (void *argp = 0, int res = 0, std::unique_ptr< TYPE, DELETER > uptr), std::unique_ptr< TYPE, DELETER > && (void *argp = 0, int res = 0, std::unique_ptr< TYPE, DELETER > uptr) {
+  res = SWIG_ConvertPtr($input, &argp, $descriptor(TYPE *), SWIG_POINTER_RELEASE | %convertptr_flags);
+  if (!SWIG_IsOK(res)) {
+    if (res == SWIG_ERROR_RELEASE_NOT_OWNED) {
+      %releasenotowned_fail(res, "TYPE *", $symname, $argnum);
+    } else {
+      %argument_fail(res, "TYPE *", $symname, $argnum);
+    }
+  }
+  uptr.reset((TYPE *)argp);
+  $1 = &uptr;
+}
+
+%typemap(in, noblock=1, fragment="SwigNoDeleteUniquePtr") const std::unique_ptr< TYPE, DELETER > & (void *argp = 0, int res = 0, swig::NoDeleteUniquePtr< TYPE > ndup) {
+  res = SWIG_ConvertPtr($input, &argp, $descriptor(TYPE *), 0);
+  if (!SWIG_IsOK(res)) {
+    %argument_fail(res, "TYPE *", $symname, $argnum);
+  }
+  ndup.uptr.reset((TYPE *)argp);
+  $1 = &ndup.uptr;
+}
+
+%typemap (out) std::unique_ptr< TYPE, DELETER > %{
+  %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
+%}
+%typemap (out) std::unique_ptr< TYPE, DELETER > &, std::unique_ptr< TYPE, DELETER > && %{
+  %set_output(SWIG_NewPointerObj($1->get(), $descriptor(TYPE *), $owner | %newpointer_flags));
+%}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER, equivalent="TYPE *", noblock=1) std::unique_ptr< TYPE, DELETER >, std::unique_ptr< TYPE, DELETER > &, std::unique_ptr< TYPE, DELETER > && {
+  void *vptr = 0;
+  int res = SWIG_ConvertPtr($input, &vptr, $descriptor(TYPE *), 0);
+  $1 = SWIG_CheckState(res);
+}
+
+%template() std::unique_ptr< TYPE, DELETER >;
 %enddef

--- a/Lib/unique_ptr.swg
+++ b/Lib/unique_ptr.swg
@@ -18,5 +18,5 @@ namespace swig {
 }
 
 namespace std {
-  template <class T> class unique_ptr {};
+  template <class T, class D = std::default_delete<T>> class unique_ptr {};
 }


### PR DESCRIPTION
std::unique_ptr is actually a 2-parameter template (`unique_ptr<T, D>` where `D = default_delete<T>` by default). SWIG only declared `template <class T> class unique_ptr`, so `unique_ptr<TYPE>` typemaps couldn't match `unique_ptr<int, MyDeleter>`.

1. `%unique_ptr(TYPE)` now generates typemaps matching `std::unique_ptr<TYPE, std::default_delete<TYPE>>` (macro-expanded concrete type, verified matching works)
2. New `%unique_ptr_custom_deleter(TYPE, DELETER)` macro generates the same typemaps matching `std::unique_ptr<TYPE, DELETER>` for custom deleter types

See #2411