### PR TITLE
Parser: Fix Pointer as default template argument

### DIFF
--- a/Examples/test-suite/template_default_pointer.i
+++ b/Examples/test-suite/template_default_pointer.i
@@ -7,6 +7,42 @@ class B
 {
 };
 
+template <class T = int*>
+class C
+{
+};
+
+template <class T = void*>
+class D
+{
+};
+
+template <class T = const int*>
+class E
+{
+};
+
+template <class T = int**>
+class F
+{
+};
+
+template <class T = int&>
+class G
+{
+};
+
+template <class T = int&&>
+class H
+{
+};
+
 %}
 
 %template(B_d) B<double>;
+%template(C_i) C<int>;
+%template(D_v) D<void>;
+%template(E_ci) E<const int>;
+%template(F_i) F<int>;
+%template(G_i) G<int>;
+%template(H_i) H<int>;

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -22,7 +22,7 @@
    you really have no choice but to do it, make sure you clearly document each
    new conflict in this file.
  */
-%expect 7
+%expect 10
 
 /* Make the internal token numbers the same as the external token numbers
  * which saves Bison generating a lookup table to map between them, giving
@@ -7100,7 +7100,28 @@ type_specifier : TYPE_INT {
 
 definetype     : expr
                | default_delete
-               ;
+               | type pointer {
+		 SwigType *t = Copy($type);
+		 SwigType_push(t, $pointer);
+		 $$ = default_dtype;
+		 $$.val = t;
+		 $$.type = T_UNKNOWN;
+               }
+               | type AND {
+		 SwigType *t = Copy($type);
+		 SwigType_add_reference(t);
+		 $$ = default_dtype;
+		 $$.val = t;
+		 $$.type = T_UNKNOWN;
+               }
+               | type LAND {
+		 SwigType *t = Copy($type);
+		 SwigType_add_rvalue_reference(t);
+		 $$ = default_dtype;
+		 $$.val = t;
+		 $$.type = T_UNKNOWN;
+               }
+	       ;
 
 default_delete : deleted_definition
                 | explicit_default


### PR DESCRIPTION
Root cause: `def_args` -> `definetype` -> `expr` only matched the base type (int, void, etc.) without pointer/reference declarators (`*`, `&`, `&&`). The `type` production in `expr` stops at the base type name.

Fix (Source/CParse/parser.y): Added three alternatives to `definetype`:
  - `type pointer`  -- handles int*, int**, const int*, etc.
  - `type AND`      -- handles int& (lvalue reference)
  - `type LAND`     -- handles int&& (rvalue reference)

3 new shift/reduce conflicts (resolved correctly by Bison's default shift preference: type interpretation wins over binary operators). Updated %expect 7 -> %expect 10.

Closes #543