### PR TITLE
Parser: Add T_WCHAR to enum validation list

### DIFF
--- a/Examples/test-suite/errors/c_enum_badvalue.i
+++ b/Examples/test-suite/errors/c_enum_badvalue.i
@@ -7,3 +7,7 @@ enum stuff {
    BADOCTAL = 018118055
 };
 
+enum stuff2 {
+   WFOO = L'x',
+};
+

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -7244,6 +7244,7 @@ etype            : expr {
 		       ($$.type != T_SHORT) && ($$.type != T_USHORT) &&
 		       ($$.type != T_SCHAR) && ($$.type != T_UCHAR) &&
 		       ($$.type != T_CHAR) && ($$.type != T_BOOL) &&
+		       ($$.type != T_WCHAR) &&
 		       ($$.type != T_UNKNOWN) && ($$.type != T_USER)) {
 		     Swig_error(cparse_file,cparse_line,"Type error. Expecting an integral type\n");
 		   }


### PR DESCRIPTION
The original issue (regular char constant `'A'` in enum initializer) was already fixed in the current codebase. The `etype` validation rule in `Source/CParse/parser.y` includes `T_CHAR` in its allowed integral types list, so `'A'` is accepted without error.

However, a related gap existed: wide character literals (`L'A'`) were not accepted as enum initializers because `T_WCHAR` was missing from the validation list.

Closes #1026