### PR TITLE
Fix duplicate using declaration

### DIFF
--- a/Examples/test-suite/li_std_vector.i
+++ b/Examples/test-suite/li_std_vector.i
@@ -119,8 +119,14 @@ namespace aa {
     Holder(int n = 0) : number(n) {}
     int number;
   };
+
+  struct UsedFromNS {};
 }
 %}
+
+using aa::UsedFromNS;
+using aa::UsedFromNS; // Duplicate using declarations (regression test for #2933)
+%template(VectorUsedFromNS) std::vector< UsedFromNS >;
 
 #if !defined(SWIGOCTAVE)
 // To fix: something different in Octave is preventing this from working

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -607,6 +607,10 @@ void Swig_symbol_cadd(const_String_or_char_ptr name, Node *n) {
     Swig_error(Getfile(n), Getline(n), "Declaration of '%s' shadows template parameter,\n", name);
     Swig_error(Getfile(cn), Getline(cn), "previous template parameter declaration '%s'.\n", name);
     return;
+  } else if (cn && Checkattr(cn, "nodeType", "using") && Checkattr(n, "nodeType", "using") && Equal(Getattr(cn, "uname"), Getattr(n, "uname"))) {
+    /* Duplicate using declaration - skip to avoid creating a spurious csym:nextSibling chain
+     * that would cause Swig_symbol_clookup to bail out without resolving the using declaration. */
+    return;
   } else if (cn) {
     append = n;
   } else if (!cn) {


### PR DESCRIPTION
`Source/Swig/symbol.c:Swig_symbol_cadd()` chains duplicate `using` declarations (e.g., two `using aa::UsedFromNS;`) via `csym:nextSibling`. When `Swig_symbol_clookup()` later resolves the unqualified name `UsedFromNS`, it sees `csym:nextSibling` set and treats it as "overloaded using declarations", breaking out of the resolution loop and returning the `using` node itself instead of following `uname` to the underlying `aa::UsedFromNS` class node. The type qualification then fails, generating `std::vector< UsedFromNS >` instead of `std::vector< aa::UsedFromNS >` in wrapper code.

In **`Source/Swig/symbol.c:615`**, added a new `else if` clause in `Swig_symbol_cadd()` that detects when both the existing entry (`cn`) and the new node (`n`) are `using` declarations with identical `uname` attributes, and returns early without chaining. This prevents the spurious `csym:nextSibling` that confuses `Swig_symbol_clookup`.

Closes #2933