### PR TITLE
Fix enum type handling in template type aliases

### DIFF
--- a/Examples/test-suite/li_std_map_enum.i
+++ b/Examples/test-suite/li_std_map_enum.i
@@ -1,0 +1,16 @@
+%module li_std_map_enum
+
+%include "std_map.i"
+
+%inline %{
+  class MapEnum {
+  public:
+    MapEnum() {}
+
+    enum numbers {ten=10, twenty=20, thirty=30};
+
+    std::map<numbers, int> nums;
+  };
+%}
+
+%template(MapNumbersInt) std::map<MapEnum::numbers, int>;

--- a/Examples/test-suite/python/li_std_map_enum_runme.py
+++ b/Examples/test-suite/python/li_std_map_enum_runme.py
@@ -1,0 +1,27 @@
+import li_std_map_enum
+
+
+def check(a, b):
+    if (a != b):
+        raise RuntimeError("Not equal: ", a, b)
+
+
+me = li_std_map_enum.MapEnum()
+
+# Test __setitem__ and __getitem__
+me.nums[li_std_map_enum.MapEnum.ten] = 100
+me.nums[li_std_map_enum.MapEnum.twenty] = 200
+me.nums[li_std_map_enum.MapEnum.thirty] = 300
+
+check(me.nums[li_std_map_enum.MapEnum.ten], 100)
+check(me.nums[li_std_map_enum.MapEnum.twenty], 200)
+check(me.nums[li_std_map_enum.MapEnum.thirty], 300)
+
+# Test has_key and erase
+check(me.nums.has_key(li_std_map_enum.MapEnum.ten), True)
+me.nums.erase(li_std_map_enum.MapEnum.ten)
+check(me.nums.has_key(li_std_map_enum.MapEnum.ten), False)
+
+# Test non-overloaded methods still work
+check(me.nums.count(li_std_map_enum.MapEnum.twenty), 1)
+check(me.nums.count(li_std_map_enum.MapEnum.ten), 0)

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -2182,6 +2182,19 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
         if (!Equal(dn, rn) && !Equal(dn, ln)) {
           Setattr(nthash, dn, "1");
         }
+        /* also add a version with 'enum ' stripped from the default type,
+         * so that template type queries (e.g. swig::asptr) can match even
+         * when they don't use the 'enum' keyword in template arguments */
+        {
+          SwigType *dt_stripped = Copy(dt);
+          Replaceall(dt_stripped, "enum ", "");
+          String *dn_stripped = SwigType_lstr(dt_stripped, 0);
+          if (!Equal(dn_stripped, dn) && !Equal(dn_stripped, rn) && !Equal(dn_stripped, ln)) {
+            Setattr(nthash, dn_stripped, "1");
+          }
+          Delete(dn_stripped);
+          Delete(dt_stripped);
+        }
         Delete(dt);
         Delete(dn);
       }


### PR DESCRIPTION
Source/Swig/typesys.c: When generating the type alias table for template types that contain enum arguments, also include an "enum"-stripped variant of the default-expanded template type. This allows the overload dispatch's swig::asptr type query to match, fixing NotImplementedError when using std::map (and other overloaded containers) with an enum as the key.

Closes #1226