### PR TITLE
[Python] Fix compound assignment operators use-after-free/double-free

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -312,6 +312,7 @@ CPP_TEST_CASES += \
 	li_cdata_bytes_cpp \
 	li_cpointer_cpp \
 	li_std_auto_ptr \
+	li_std_iadd \
 	li_stdint \
 	li_swigtype_inout \
 	li_typemaps \

--- a/Examples/test-suite/li_std_iadd.i
+++ b/Examples/test-suite/li_std_iadd.i
@@ -1,0 +1,17 @@
+%module li_std_iadd
+
+#if defined(SWIGPYTHON)
+
+%inline %{
+class Counter {
+public:
+  int val;
+  Counter(int v = 0) : val(v) {}
+  int get() const { return val; }
+  Counter &operator+=(const Counter &o) { val += o.val; return *this; }
+  Counter &operator-=(const Counter &o) { val -= o.val; return *this; }
+  Counter &renamed_add_assign(const Counter &o) { val += o.val; return *this; }
+};
+%}
+
+#endif

--- a/Examples/test-suite/python/li_std_iadd_runme.py
+++ b/Examples/test-suite/python/li_std_iadd_runme.py
@@ -1,0 +1,32 @@
+from li_std_iadd import *
+
+def check(flag):
+    if not flag:
+        raise RuntimeError("Check failed")
+
+a = Counter(10)
+b = Counter(3)
+check(a.val == 10)
+
+# Direct += modifies the object in place
+a += b
+check(a.val == 13)
+
+# -= also works
+a -= b
+check(a.val == 10)
+
+# += inside a function (the #3309 scenario)
+def func(v):
+    v += b
+
+func(a)
+check(a.val == 13)
+
+# Calling func twice (would trigger use-after-free before the fix)
+func(a)
+check(a.val == 16)
+
+# renamed_add_assign behaves identically
+a.renamed_add_assign(b)
+check(a.val == 19)

--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -631,18 +631,24 @@ SwigPyBuiltin_getiterfunc_closure(SwigPyWrapperFunction wrapper, PyObject *a) {
 #define SWIGPY_BINARYFUNC_CLOSURE(wrapper)			\
 SWIGINTERN PyObject *						\
 wrapper##_binaryfunc_closure(PyObject *a, PyObject *b) {	\
-  return SwigPyBuiltin_binaryfunc_closure(wrapper, a, b);	\
+  return wrapper(a, b);						\
 }
-SWIGINTERN PyObject *
-SwigPyBuiltin_binaryfunc_closure(SwigPyWrapperFunction wrapper, PyObject *a, PyObject *b) {
-  PyObject *tuple, *result;
-  tuple = PyTuple_New(1);
-  assert(tuple);
-  SWIG_Py_INCREF(b);
-  PyTuple_SET_ITEM(tuple, 0, b);
-  result = wrapper(a, tuple);
-  SWIG_Py_DECREF(tuple);
-  return result;
+
+#define SWIGPY_INPLACE_BINARYFUNC_CLOSURE(wrapper)                      \
+SWIGINTERN PyObject *                                                    \
+wrapper##_inplace_binaryfunc_closure(PyObject *a, PyObject *b) {        \
+  PyObject *result;                                                      \
+  SwigPyObject *sobj;                                                    \
+  result = wrapper(a, b);                                                \
+  if (result) {                                                          \
+    sobj = SWIG_Python_GetSwigThis(result);                              \
+    if (sobj && sobj->ptr == ((SwigPyObject *)a)->ptr) {                 \
+      SWIG_Py_DECREF(result);                                            \
+      SWIG_Py_INCREF(a);                                                 \
+      return a;                                                          \
+    }                                                                    \
+  }                                                                      \
+  return result;                                                         \
 }
 
 typedef ternaryfunc ternarycallfunc;

--- a/Lib/python/pyopers.swg
+++ b/Lib/python/pyopers.swg
@@ -160,51 +160,43 @@ __div__ = __truediv__
   Inplace operator declarations.
 
   They translate the inplace C++ operators (+=, -=, ...)  into the
-  corresponding python equivalents(__iadd__,__isub__), etc,
-  disabling the ownership of the input 'this' pointer, and assigning
-  it to the returning object:  
+  corresponding python equivalents (__iadd__, __isub__), etc.
 
-     %feature("del") *::Operator; // disables ownership by generating SWIG_POINTER_DISOWN
-     %feature("new") *::Operator; // claims ownership by generating SWIG_POINTER_OWN
-  
-  This makes the most common case safe, ie:
+  These operators return a reference to *this, so the underlying C++
+  object is the same before and after the call.  SWIG therefore keeps
+  the input 'this' pointer owned by the original Python wrapper and
+  returns the same pointer without taking new ownership — both
+  %delobject and %newobject are deliberately omitted.
 
-     A&  A::operator+=(int i) { ...; return *this; }
-    ^^^^                                    ^^^^^^
+  The old behaviour (SWIG 4.x and earlier) used %delobject and
+  %newobject, which disabled ownership on the input and claimed
+  ownership on the output.  Since both wrappers pointed at the same
+  C++ object this caused use-after-free / double-free when the
+  original wrapper outlived the returned wrapper (issue #3309).
+  If you relied on the old behaviour you can restore it per class:
 
-  will work fine, even when the resulting python object shares the
-  'this' pointer with the input one. The input object is usually
-  deleted after the operation, including the shared 'this' pointer,
-  producing 'strange' seg faults, as reported by Lucriz
-  (lucriz@sitilandia.it).
+    %feature("del","1") A::operator+=;
+    %feature("new","1") A::operator+=;
 
-  If you have an interface that already takes care of that, ie, you
-  already are using inplace operators and you are not getting
-  seg. faults, with the new scheme you could end with 'free' elements
-  that never get deleted (maybe, not sure, it depends). But if that is
-  the case, you could recover the old behaviour using
+  or globally for a given operator:
 
-     %feature("del","0") A::operator+=;
-     %feature("new","0") A::operator+=;
-
-  which recovers the old behaviour for the class 'A', or if you are
-  100% sure your entire system works fine in the old way, use:
-
-    %feature("del","") *::operator+=;
-    %feature("new","") *::operator+=;
-
-  The default behaviour assumes that the 'this' pointer's memory is
-  already owned by the SWIG object; it relinquishes ownership then
-  takes it back. This may not be the case though as the SWIG object
-  might be owned by memory managed elsewhere, eg after calling a
-  function that returns a C++ reference. In such case you will need
-  to use the features above to recover the old behaviour too.
+    %feature("del","1") *::operator+=;
+    %feature("new","1") *::operator+=;
 */
 
+/*
+ * Inplace operator macros.
+ *
+ * For builtin mode: rename the C++ operator and register its Python slot.
+ * For non-builtin mode: rename and add a shadow that calls the C wrapper
+ * then returns self, keeping the original Python wrapper alive and owning.
+ * Without this, the returned wrapper (no ownership) would leave the C++
+ * object orphaned when the original wrapper gets rebound (issue #3309).
+ */
 #if defined(SWIGPYTHON_BUILTIN)
-#define %pyinplaceoper(SwigPyOper, Oper, functp, slt) %delobject Oper; %newobject Oper; %feature("python:slot", #slt, functype=#functp) Oper; %rename(SwigPyOper) Oper
+#define %pyinplaceoper(SwigPyOper, Oper, functp, slt) %feature("python:slot", #slt, functype=#functp) Oper; %rename(SwigPyOper) Oper
 #else
-#define %pyinplaceoper(SwigPyOper, Oper, functp, slt) %delobject Oper; %newobject Oper; %rename(SwigPyOper) Oper
+#define %pyinplaceoper(SwigPyOper, Oper, functp, slt) %rename(SwigPyOper) Oper
 #endif
 
 %pyinplaceoper(__iadd__   , *::operator +=,	binaryfunc, nb_inplace_add);
@@ -217,17 +209,65 @@ __div__ = __truediv__
 %pyinplaceoper(__ilshift__, *::operator <<=,	binaryfunc, nb_inplace_lshift);
 %pyinplaceoper(__irshift__, *::operator >>=,	binaryfunc, nb_inplace_rshift);
 
-/* Special cases */
+#ifndef SWIGPYTHON_BUILTIN
+/* Shadow features for inplace operators: call the C wrapper and return self.
+   The __idiv__ / __itruediv__ aliases are kept for backward compatibility. */
+%feature("shadow") *::operator += %{
+def __iadd__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator -= %{
+def __isub__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator *= %{
+def __imul__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator %= %{
+def __imod__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator &= %{
+def __iand__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator |= %{
+def __ior__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator ^= %{
+def __ixor__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator <<= %{
+def __ilshift__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator >>= %{
+def __irshift__(self, *args):
+    $action(self, *args)
+    return self
+%};
+%feature("shadow") *::operator /= %{
+def __itruediv__(self, *args):
+    $action(self, *args)
+    return self
+__idiv__ = __itruediv__
+%};
+#endif
+
 #if defined(SWIGPYTHON_BUILTIN)
 %pyinplaceoper(__itruediv__   , *::operator /=,	binaryfunc, nb_inplace_divide);
 #else
-%delobject *::operator /=;
-%newobject *::operator /=;
-%feature("shadow")      *::operator /= %{
-def __itruediv__(self, *args):
-    return $action(self, *args)
-__idiv__ = __itruediv__
-%};
 %rename(__itruediv__)    *::operator /=;
 #endif
 

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -179,6 +179,7 @@ static String *getClosure(String *functype, String *wrapper, int funpack = 0) {
     {"inquiry",              "SWIGPY_INQUIRY_CLOSURE"             },
     {"getiterfunc",          "SWIGPY_GETITERFUNC_CLOSURE"         },
     {"binaryfunc",           "SWIGPY_BINARYFUNC_CLOSURE"          },
+    {"inplace_binaryfunc",   "SWIGPY_INPLACE_BINARYFUNC_CLOSURE"  },
     {"ternaryfunc",          "SWIGPY_TERNARYFUNC_CLOSURE"         },
     {"ternarycallfunc",      "SWIGPY_TERNARYCALLFUNC_CLOSURE"     },
     {"lenfunc",              "SWIGPY_LENFUNC_CLOSURE"             },
@@ -198,6 +199,8 @@ static String *getClosure(String *functype, String *wrapper, int funpack = 0) {
     {"destructor",           "SWIGPY_DESTRUCTOR_CLOSURE"          },
     {"inquiry",              "SWIGPY_INQUIRY_CLOSURE"             },
     {"getiterfunc",          "SWIGPY_GETITERFUNC_CLOSURE"         },
+    {"binaryfunc",           "SWIGPY_BINARYFUNC_CLOSURE"          },
+    {"inplace_binaryfunc",   "SWIGPY_INPLACE_BINARYFUNC_CLOSURE"  },
     {"ternaryfunc",          "SWIGPY_TERNARYFUNC_CLOSURE"         },
     {"ternarycallfunc",      "SWIGPY_TERNARYCALLFUNC_CLOSURE"     },
     {"lenfunc",              "SWIGPY_LENFUNC_CLOSURE"             },
@@ -3521,11 +3524,18 @@ public:
       String *slot = Getattr(n, "feature:python:slot");
       if (slot && !isfriend) {
         String *func_type = Getattr(n, "feature:python:slot:functype");
-        String *closure_decl = getClosure(func_type, wrapper_name, overname ? 0 : funpack);
+        String *closure_functype = func_type;
+        /* In-place number slots (nb_inplace_*) need a specialised closure
+           that returns the original PyObject when the C++ pointer hasn't
+           changed, keeping ownership intact (issue #3309). */
+        if (slot && func_type && Equal(func_type, "binaryfunc") && Len(slot) > 10 && Strncmp(slot, "nb_inplace", 10) == 0) {
+          closure_functype = NewString("inplace_binaryfunc");
+        }
+        String *closure_decl = getClosure(closure_functype, wrapper_name, overname ? 0 : funpack);
         String *feature_name = NewStringf("feature:python:%s", slot);
         String *closure_name = 0;
         if (closure_decl) {
-          closure_name = NewStringf("%s_%s_closure", wrapper_name, func_type);
+          closure_name = NewStringf("%s_%s_closure", wrapper_name, closure_functype);
           if (!GetFlag(builtin_closures, closure_name))
             Printf(builtin_closures_code, "%s /* defines %s */\n\n", closure_decl, closure_name);
           SetFlag(builtin_closures, closure_name);
@@ -3541,6 +3551,8 @@ public:
         Setattr(parent, feature_name, closure_name);
         Delete(feature_name);
         Delete(closure_name);
+        if (closure_functype != func_type)
+          Delete(closure_functype);
       }
 
       /* Handle comparison operators for builtin types */


### PR DESCRIPTION
Compound assignment operators (+=, -=, *=, /=, %=, &=, |=, ^=, <<=, >>=) return a reference to *this, so the input and output wrap the same C++ object.  The old code applied %delobject/%newobject which generated SWIG_POINTER_DISOWN on the input and SWIG_POINTER_OWN on the output. When the returned wrapper was discarded (e.g. inside a function: v += b), the C++ object was freed, leaving the original wrapper dangling — use-after-free on the next access.

Fix two things in pyopers.swg:

 1. Remove %delobject/%newobject so the C wrapper uses 0 flags (no ownership transfer).
 2. Add a %feature("shadow") for each inplace operator that calls the C wrapper then returns self, keeping the original Python wrapper alive and owning the C++ object.

Also add a regression test (li_std_iadd) that exercises direct +=, -=, and += inside a function called twice.

Closes #3309