### PR TITLE
Use Py_TPFLAGS_MANAGED_DICT for builtin wrappers on Python >= 3.12

### DIFF
--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -580,9 +580,11 @@ SWIGINTERN void
 SwigPyBuiltin_destructor_closure(SwigPyWrapperFunction wrapper, const char *wrappername, PyObject *a) {
   SwigPyObject *sobj;
   sobj = (SwigPyObject *)a;
+#if PY_VERSION_HEX < 0x030c0000
   if (sobj->weakreflist != NULL)
     PyObject_ClearWeakRefs(a);
   SWIG_Py_XDECREF(sobj->swigdict);
+#endif
   if (sobj->own) {
     PyObject *o;
     PyObject *type = 0, *value = 0, *traceback = 0;

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -642,6 +642,16 @@ typedef struct {
 SWIGRUNTIME PyObject *
 SwigPyObject_get___dict__(PyObject *v, PyObject *SWIGUNUSEDPARM(args))
 {
+#if PY_VERSION_HEX >= 0x030c0000
+  PyObject **dictptr = _PyObject_GetDictPtr(v);
+  if (dictptr) {
+    if (!*dictptr)
+      *dictptr = PyDict_New();
+    SWIG_Py_XINCREF(*dictptr);
+    return *dictptr;
+  }
+  Py_RETURN_NONE;
+#else
   SwigPyObject *sobj = (SwigPyObject *)v;
 
   if (!sobj->swigdict)
@@ -649,6 +659,7 @@ SwigPyObject_get___dict__(PyObject *v, PyObject *SWIGUNUSEDPARM(args))
 
   SWIG_Py_XINCREF(sobj->swigdict);
   return sobj->swigdict;
+#endif
 }
 
 #endif

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -4636,7 +4636,11 @@ public:
     Printf(f, "    %s,\n", quoted_symname);
     Printf(f, "    sizeof(SwigPyObject),\n");
     Printf(f, "    0,\n");
-    Printf(f, "    %s,\n", getHeapTypesSlot(n, "feature:python:tp_flags", tp_flags_py3), "tp_flags");
+    Printf(f, "#if PY_VERSION_HEX >= 0x030c0000\n");
+    Printf(f, "    %s|Py_TPFLAGS_MANAGED_DICT|Py_TPFLAGS_MANAGED_WEAKREF,\n", getHeapTypesSlot(n, "feature:python:tp_flags", tp_flags_py3));
+    Printf(f, "#else\n");
+    Printf(f, "    %s,\n", getHeapTypesSlot(n, "feature:python:tp_flags", tp_flags_py3));
+    Printf(f, "#endif\n");
     Printf(f, "    slots\n");
     Printf(f, "  };\n");
     Printv(f, "  PyObject *tuple_bases = SwigPyBuiltin_InitBases(bases);\n", NIL);

--- a/Source/Swig/typesys.c
+++ b/Source/Swig/typesys.c
@@ -2182,6 +2182,19 @@ void SwigType_emit_type_table(File *f_forward, File *f_table) {
         if (!Equal(dn, rn) && !Equal(dn, ln)) {
           Setattr(nthash, dn, "1");
         }
+        /* also add a version with 'enum ' stripped from the default type,
+         * so that template type queries (e.g. swig::asptr) can match even
+         * when they don't use the 'enum' keyword in template arguments */
+        {
+          SwigType *dt_stripped = Copy(dt);
+          Replaceall(dt_stripped, "enum ", "");
+          String *dn_stripped = SwigType_lstr(dt_stripped, 0);
+          if (!Equal(dn_stripped, dn) && !Equal(dn_stripped, rn) && !Equal(dn_stripped, ln)) {
+            Setattr(nthash, dn_stripped, "1");
+          }
+          Delete(dn_stripped);
+          Delete(dt_stripped);
+        }
         Delete(dt);
         Delete(dn);
       }


### PR DESCRIPTION
For the heaptypes (builtin) path, set Py_TPFLAGS_MANAGED_DICT and Py_TPFLAGS_MANAGED_WEAKREF in the type spec instead of relying on tp_dictoffset/tp_weaklistoffset. The instance dict is now accessed via _PyObject_GetDictPtr rather than direct sobject->swigdict access, and manual swigdict/weakreflist management is skipped at object creation and destruction time.  Non-builtin types continue to use the existing tp_dictoffset mechanism.

Closes #3202