### PR TITLE
Go: Fix director returning reference to local variable

### DIFF
--- a/Examples/test-suite/director_frob.i
+++ b/Examples/test-suite/director_frob.i
@@ -80,6 +80,10 @@
     virtual unsigned long long ull(unsigned long long i, unsigned long long j) { return i + j; }
     unsigned long long callull(int i, int j) { return ull(i, j); }
   };
+
+  int take_ops_intref(Ops& ops) {
+    return ops.operator int&();
+  }
 %}
 
 

--- a/Examples/test-suite/go/director_frob_runme.go
+++ b/Examples/test-suite/go/director_frob_runme.go
@@ -9,4 +9,12 @@ func main() {
 	if s != "Bravo::abs_method()" {
 		panic(s)
 	}
+
+	// Test take_ops_intref with a non-director Ops (no virtual dispatch)
+	ops := NewOps()
+	ret := Take_ops_intref(ops)
+	if ret != 0 {
+		panic(ret)
+	}
+	DeleteOps(ops)
 }

--- a/Lib/go/go.swg
+++ b/Lib/go/go.swg
@@ -592,8 +592,8 @@ rvrdeleter.reset($1); %}
 
 %typemap(directorout) int &
 %{
-  $*1_ltype f = ($*1_ltype)*$input;
-  $result = ($1_ltype)&f;
+  $result = new $*1_ltype(($*1_ltype)*$input);
+  swig_acquire_pointer(&swig_mem, $result);
 %}
 
 %typemap(directorargout) int &
@@ -630,8 +630,8 @@ rvrdeleter.reset($1); %}
 
 %typemap(directorout) int &&
 %{
-  $*1_ltype f = ($*1_ltype)*$input;
-  $result = ($1_ltype)&f;
+  $result = new $*1_ltype(($*1_ltype)*$input);
+  swig_acquire_pointer(&swig_mem, $result);
 %}
 
 %typemap(directorargout) int &&


### PR DESCRIPTION
The directorout typemaps for int& and int&& in Lib/go/go.swg created a local variable and returned its address:

  int f = (int)*result;
  c_result = (int *)&f;
  return *c_result;      // warning: function returns address of local variable

Fix by heap-allocating the value with 'new' and tracking it with swig_acquire_pointer, matching the existing pattern used by const int&.

  c_result = new int((int)*result);
  swig_acquire_pointer(&swig_mem, c_result);
  return *c_result;

Closes #3398