### PR TITLE
Ruby: Fix crash in GC_register when obj is Qnil

### DIFF
--- a/Lib/ruby/rubyclasses.swg
+++ b/Lib/ruby/rubyclasses.swg
@@ -66,7 +66,7 @@ namespace swig {
       }
     }
     void GC_register(VALUE& obj) {
-      if (FIXNUM_P(obj) || SPECIAL_CONST_P(obj) || SYMBOL_P(obj))
+      if (NIL_P(obj) || FIXNUM_P(obj) || SPECIAL_CONST_P(obj) || SYMBOL_P(obj))
         return;
       if (_hash != Qnil) {
         VALUE val = rb_hash_aref(_hash, obj);
@@ -76,7 +76,7 @@ namespace swig {
       }
     }
     void GC_unregister(const VALUE& obj) {
-      if (FIXNUM_P(obj) || SPECIAL_CONST_P(obj) || SYMBOL_P(obj))
+      if (NIL_P(obj) || FIXNUM_P(obj) || SPECIAL_CONST_P(obj) || SYMBOL_P(obj))
         return;
       // this test should not be needed but I've noticed some very erratic
       // behavior of none being unregistered in some very rare situations.


### PR DESCRIPTION
The BinaryPredicate default constructor (VALUE obj = Qnil) passes Qnil to GC_VALUE, which calls GC_register(Qnil).  GC_register already guards against FIXNUM/SPECIAL_CONST/SYMBOL but not against NIL_P, so rb_hash_aref(_hash, Qnil) was called, causing a segfault in Ruby 3.3's GC.

Add NIL_P(obj) to the early-return checks in both GC_register and GC_unregister.

Closes #3385