### PR TITLE
Python: Fix SWIG_NewPointerObj requiring 'self' in scope with -builtin

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -57,6 +57,7 @@ CPP_TEST_CASES += \
 	python_annotations_variable_typing \
 	python_append \
 	python_builtin \
+	python_swig_newpointerobj_builtin \
 	python_destructor_exception \
 	python_director \
 	python_docstring \
@@ -138,6 +139,7 @@ SWIGOPT += -Werror
 # Custom tests - tests with additional commandline options
 python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
 python_nokwargs_keyword.cpptest: SWIGOPT += -keyword
+python_swig_newpointerobj_builtin.cpptest: SWIGOPT += -builtin
 
 # Make sure just python_runtime_data_builtin.i uses the -builtin option. Note: does not use python_runtime_data.list for all steps.
 # PY_ABI_VER is unset for python_runtime_data_builtin because stable ABI is not supported by builtin

--- a/Examples/test-suite/python/python_swig_newpointerobj_builtin_runme.py
+++ b/Examples/test-suite/python/python_swig_newpointerobj_builtin_runme.py
@@ -1,0 +1,9 @@
+from python_swig_newpointerobj_builtin import *
+
+# SWIG_NewPointerObj used inside %inline C code should work without
+# 'self' when using -builtin (issue #2613).
+f = make_foo(42)
+if f is None:
+    raise RuntimeError("make_foo returned None")
+if f.n != 42:
+    raise RuntimeError("make_foo returned unexpected value")

--- a/Examples/test-suite/python_swig_newpointerobj_builtin.i
+++ b/Examples/test-suite/python_swig_newpointerobj_builtin.i
@@ -1,0 +1,16 @@
+%module python_swig_newpointerobj_builtin
+
+// This test checks that SWIG_NewPointerObj works in %inline code
+// when the -builtin option is used.  See issue #2613.
+
+%inline %{
+struct Foo {
+    int n;
+};
+
+PyObject *make_foo(int n) {
+    Foo *f = new Foo();
+    f->n = n;
+    return SWIG_NewPointerObj(f, SWIGTYPE_p_Foo, SWIG_POINTER_OWN);
+}
+%}

--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -128,6 +128,7 @@ SwigPyBuiltin_FunpackSetterClosure (PyObject *obj, PyObject *val, void *closure)
   return result ? 0 : -1;
 }
 
+#ifndef Py_LIMITED_API
 SWIGINTERN void
 SwigPyStaticVar_dealloc(PyDescrObject *descr) {
   PyObject_GC_UnTrack(descr);
@@ -164,6 +165,7 @@ SwigPyStaticVar_set(PyGetSetDescrObject *descr, PyObject *obj, PyObject *value) 
   PyErr_Format(PyExc_AttributeError, "attribute '%S' of '%s' objects is not writable", PyDescr_NAME(descr), PyDescr_TYPE(descr)->tp_name);
   return -1;
 }
+#endif
 
 SWIGINTERN int
 SwigPyObjectType_setattro(PyObject *typeobject, PyObject *name, PyObject *value) {
@@ -172,10 +174,18 @@ SwigPyObjectType_setattro(PyObject *typeobject, PyObject *name, PyObject *value)
 
   assert(PyType_Check(typeobject));
   type = (PyTypeObject *)typeobject;
+#ifndef Py_LIMITED_API
   attribute = _PyType_Lookup(type, name);
+#else
+  attribute = SWIG_PyType_Lookup(type, name);
+#endif
   if (attribute != NULL) {
     /* Implement descriptor functionality, if any */
+#ifndef Py_LIMITED_API
     descrsetfunc local_set = Py_TYPE(attribute)->tp_descr_set;
+#else
+    descrsetfunc local_set = (descrsetfunc)PyType_GetSlot(Py_TYPE(attribute), Py_tp_descr_set);
+#endif
     if (local_set == NULL) {
       PyObject *tpname = SWIG_PyType_GetFullyQualifiedName(type);
       PyErr_Format(PyExc_AttributeError, "cannot modify read-only attribute '%S.%S'", tpname, name);
@@ -192,6 +202,7 @@ SwigPyObjectType_setattro(PyObject *typeobject, PyObject *name, PyObject *value)
   return -1;
 }
 
+#ifndef Py_LIMITED_API
 SWIGINTERN PyTypeObject*
 SwigPyStaticVar_TypeOnce(void) {
   static char SwigPyStaticVar_doc[] = "Swig member static variables";
@@ -312,10 +323,18 @@ SwigPyStaticVar_Type(void) {
   static PyTypeObject *SWIG_STATIC_POINTER(type) = SwigPyStaticVar_TypeOnce();
   return type;
 }
+#else
+SWIGRUNTIME PyTypeObject *
+SwigPyStaticVar_Type(void) {
+  return NULL;
+}
+#endif
 
 SWIGINTERN PyTypeObject*
 SwigPyObjectType_TypeOnce(void) {
+#if !defined(SWIG_HEAPTYPES) || !defined(Py_LIMITED_API)
   static char SwigPyObjectType_doc[] = "Metaclass for SWIG wrapped types";
+#endif
 #ifndef SWIG_HEAPTYPES
   static PyTypeObject swigpyobjecttype_type;
   static int type_init = 0;
@@ -403,7 +422,7 @@ SwigPyObjectType_TypeOnce(void) {
       SWIG_Py_INCREF((PyObject *)&swigpyobjecttype_type);
   }
   return &swigpyobjecttype_type;
-#else
+#elif !defined(Py_LIMITED_API)
   PyType_Slot slots[] = {
     { Py_tp_setattro, (void *)SwigPyObjectType_setattro },
     { Py_tp_doc, (void *)SwigPyObjectType_doc},
@@ -422,6 +441,12 @@ SwigPyObjectType_TypeOnce(void) {
   if (pytype && PyModule_AddObject(runtime_data_module, "SwigPyObjectType", pytype) == 0)
     SWIG_Py_INCREF(pytype);
   return (PyTypeObject *)pytype;
+#else
+  /* The limited API cannot create a subclass of PyType_Type because
+     PyType_Type's size is opaque.  Return a pointer to PyType_Type
+     itself - types will be dynamic (allow arbitrary type attributes),
+     which is acceptable in abi3 mode. */
+  return &PyType_Type;
 #endif
 }
 
@@ -431,6 +456,7 @@ SwigPyObjectType_Type(void) {
   return type;
 }
 
+#ifndef Py_LIMITED_API
 SWIGINTERN PyGetSetDescrObject *
 SwigPyStaticVar_new_getset(PyTypeObject *type, PyGetSetDef *getset) {
 
@@ -447,6 +473,7 @@ SwigPyStaticVar_new_getset(PyTypeObject *type, PyGetSetDef *getset) {
   }
   return descr;
 }
+#endif
 
 SWIGINTERN PyObject *
 SwigPyBuiltin_InitBases(PyTypeObject **bases) {

--- a/Lib/python/pyinit.swg
+++ b/Lib/python/pyinit.swg
@@ -225,6 +225,7 @@ SWIGINTERN int SWIG_mod_exec(PyObject *m) {
 
 #if defined(SWIGPYTHON_BUILTIN)
   static SwigPyClientData SwigPyObject_clientdata = {0, 0, 0, 0, 0, 0, 0};
+#ifndef Py_LIMITED_API
   static PyGetSetDef this_getset_def = {
     (char *)"this", &SwigPyBuiltin_ThisClosure, NULL, NULL, NULL
   };
@@ -235,17 +236,22 @@ SWIGINTERN int SWIG_mod_exec(PyObject *m) {
   static PyGetSetDef thisown_getset_def = {
     (char *)"thisown", SwigPyBuiltin_GetterClosure, SwigPyBuiltin_SetterClosure, NULL, &thisown_getset_closure
   };
+#endif
   PyTypeObject *builtin_pytype;
   int builtin_base_count;
   swig_type_info *builtin_basetype;
   PyObject *tuple;
+#ifndef Py_LIMITED_API
   PyGetSetDescrObject *static_getset;
+#endif
   PyTypeObject *metatype;
   PyTypeObject *swigpyobject;
   SwigPyClientData *cd;
   PyObject *public_interface, *public_symbol;
-  PyObject *this_descr;
-  PyObject *thisown_descr;
+#ifndef Py_LIMITED_API
+  PyObject *this_descr = NULL;
+  PyObject *thisown_descr = NULL;
+#endif
   PyObject *self = 0;
   int i;
 
@@ -253,7 +259,9 @@ SWIGINTERN int SWIG_mod_exec(PyObject *m) {
   (void)builtin_base_count;
   (void)builtin_basetype;
   (void)tuple;
+#ifndef Py_LIMITED_API
   (void)static_getset;
+#endif
   (void)self;
 
   /* Metaclass is used to implement static member variables */
@@ -298,18 +306,24 @@ SWIGINTERN int SWIG_mod_exec(PyObject *m) {
   if (!cd) {
     SwigPyObject_stype->clientdata = &SwigPyObject_clientdata;
     SwigPyObject_clientdata.pytype = swigpyobject;
+#ifndef Py_LIMITED_API
   } else if (swigpyobject->tp_basicsize != cd->pytype->tp_basicsize) {
     PyErr_SetString(PyExc_RuntimeError, "Import error: attempted to load two incompatible swig-generated modules.");
     return -1;
   }
+#else
+  }
+#endif
 
   /* All objects have a 'this' attribute */
+#ifndef Py_LIMITED_API
   this_descr = PyDescr_NewGetSet(SwigPyObject_Type(), &this_getset_def);
   (void)this_descr;
 
   /* All objects have a 'thisown' attribute */
   thisown_descr = PyDescr_NewGetSet(SwigPyObject_Type(), &thisown_getset_def);
   (void)thisown_descr;
+#endif
 
   public_interface = PyList_New(0);
   public_symbol = 0;

--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -18,11 +18,10 @@
 #define SWIG_ConvertPtr(obj, pptr, type, flags)         SWIG_Python_ConvertPtr(obj, pptr, type, flags)
 #define SWIG_ConvertPtrAndOwn(obj,pptr,type,flags,own)  SWIG_Python_ConvertPtrAndOwn(obj, pptr, type, flags, own)
 
-#ifdef SWIGPYTHON_BUILTIN
-#define SWIG_NewPointerObj(ptr, type, flags)            SWIG_Python_NewPointerObj(self, ptr, type, flags)
-#else
+/* always passes NULL for self -- user code (%inline, etc.) does not have
+   'self' in scope.  The tp_init path passes it via the SWIG_BUILTIN_INIT flag,
+   handled in SWIG_Python_NewPointerObj.  See issue #2613. */
 #define SWIG_NewPointerObj(ptr, type, flags)            SWIG_Python_NewPointerObj(NULL, ptr, type, flags)
-#endif
 
 #define SWIG_InternalNewPointerObj(ptr, type, flags)	SWIG_Python_NewPointerObj(NULL, ptr, type, flags)
 
@@ -1328,22 +1327,26 @@ SWIG_Python_GetSwigThis(PyObject *pyobj)
 #ifdef SWIGPYTHON_BUILTIN
   (void)obj;
   if (PyWeakref_CheckProxy(pyobj)) {
-#if PY_VERSION_HEX >= 0x030d0000
+#if PY_VERSION_HEX >= 0x030d0000 && (!defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030d0000)
     if (PyWeakref_GetRef(pyobj, &pyobj) > 0)
       Py_DECREF(pyobj);
     else
       pyobj = NULL;
 #else
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     pyobj = PyWeakref_GetObject(pyobj);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #endif
     if (pyobj && SwigPyObject_Check(pyobj))
       return (SwigPyObject*) pyobj;
   }
   return NULL;
 #else
-
-  obj = 0;
-
   obj = PyObject_GetAttr(pyobj, SWIG_This());
   if (obj) {
     SWIG_Py_DECREF(obj);
@@ -1630,7 +1633,7 @@ SWIG_Python_NewPointerObj(PyObject *self, void *ptr, swig_type_info *type, int f
   own = (flags & SWIG_POINTER_OWN) ? SWIG_POINTER_OWN : 0;
   if (clientdata && clientdata->pytype) {
     SwigPyObject *newobj;
-    if (flags & SWIG_BUILTIN_TP_INIT) {
+    if ((flags & SWIG_BUILTIN_TP_INIT) && self) {
       newobj = (SwigPyObject*) self;
       if (newobj->ptr) {
 #ifndef Py_LIMITED_API
@@ -1663,7 +1666,13 @@ SWIG_Python_NewPointerObj(PyObject *self, void *ptr, swig_type_info *type, int f
     return SWIG_Py_Void();
   }
 
-  assert(!(flags & SWIG_BUILTIN_TP_INIT));
+  /* When self is NULL (call from user code via %inline) the BUILTIN_TP_INIT
+   * flag is meaningless - just create a new object.  See issue #2613. */
+  if (!(flags & SWIG_BUILTIN_TP_INIT) || !self) {
+    flags &= ~SWIG_BUILTIN_TP_INIT;
+  } else {
+    assert(0);
+  }
 
   robj = SwigPyObject_New(ptr, type, own);
   if (robj && clientdata && !(flags & SWIG_POINTER_NOSHADOW)) {
@@ -1868,6 +1877,25 @@ SWIG_Python_MustGetPtr(PyObject *obj, swig_type_info *ty, int SWIGUNUSEDPARM(arg
 }
 
 #ifdef SWIGPYTHON_BUILTIN
+
+#ifndef Py_LIMITED_API
+#define SWIG_PyType_Lookup(tp, name) _PyType_Lookup(tp, name)
+#else
+/* Look up name in the type's MRO using only limited API calls.
+   Returns a borrowed reference (NULL if not found), with any
+   AttributeError cleared (matching _PyType_Lookup behaviour). */
+SWIGINTERN PyObject *
+SWIG_PyType_Lookup(PyTypeObject *type, PyObject *name) {
+  PyObject *result = PyObject_GetAttr((PyObject *)type, name);
+  if (result) {
+    Py_DECREF(result);
+  } else {
+    PyErr_Clear();
+  }
+  return result;
+}
+#endif
+
 SWIGRUNTIME int
 SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
   PyTypeObject *tp = Py_TYPE(obj);
@@ -1894,15 +1922,25 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
     SWIG_Py_INCREF(name);
   }
 
+#ifndef Py_LIMITED_API
   if (!tp->tp_dict) {
     if (PyType_Ready(tp) != 0)
       goto done;
   }
-
   descr = _PyType_Lookup(tp, name);
+#else
+  if (PyType_Ready(tp) != 0)
+    goto done;
+  descr = SWIG_PyType_Lookup(tp, name);
+#endif
   f = NULL;
-  if (descr != NULL)
+  if (descr != NULL) {
+#ifndef Py_LIMITED_API
     f = Py_TYPE(descr)->tp_descr_set;
+#else
+    f = (descrsetfunc)PyType_GetSlot(Py_TYPE(descr), Py_tp_descr_set);
+#endif
+  }
   if (!f) {
     if (PyBytes_Check(name)) {
       encoded_name = name;

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3341,6 +3341,12 @@ public:
       Replaceall(tm, "$result", "resultobj");
       if (builtin_ctor) {
         Replaceall(tm, "$owner", "SWIG_BUILTIN_INIT");
+        /* Bypass the SWIG_NewPointerObj macro so that 'self' (the
+           tp_init argument) is passed directly to the underlying
+           function.  The macro now passes NULL (for user %inline code)
+           but tp_init must pass self to reuse the pre-allocated object.
+           See issue #2613. */
+        Replaceall(tm, "SWIG_NewPointerObj(", "SWIG_Python_NewPointerObj(self, ");
       } else if (handled_as_init) {
         Replaceall(tm, "$owner", "SWIG_POINTER_NEW");
       } else {
@@ -4189,8 +4195,10 @@ public:
     Printf(getset_def, "SWIGINTERN PyGetSetDef %s[] = {\n", getset_name);
 
     // All objects have 'this' and 'thisown' attributes
+    Printv(f_init, "#ifndef Py_LIMITED_API\n", NIL);
     Printv(f_init, "PyDict_SetItemString(d, \"this\", this_descr);\n", NIL);
     Printv(f_init, "PyDict_SetItemString(d, \"thisown\", thisown_descr);\n", NIL);
+    Printv(f_init, "#endif\n", NIL);
 
     // Now, the rest of the attributes
     for (Iterator member_iter = First(builtin_getset); member_iter.item; member_iter = Next(member_iter)) {
@@ -4673,12 +4681,27 @@ public:
       Printv(f, "#endif\n", NIL);
     }
     Printf(f, "  if (pytype) {\n");
+    Printv(f, "#ifndef Py_LIMITED_API\n", NIL);
     Printf(f, "    if (PyDict_Merge(pytype->tp_dict, dict, 1) == 0) {\n");
+    Printv(f, "#else\n", NIL);
+    Printf(f, "    {\n");
+    Printf(f, "      PyObject *key, *value;\n");
+    Printf(f, "      Py_ssize_t pos = 0;\n");
+    Printf(f, "      while (PyDict_Next(dict, &pos, &key, &value)) {\n");
+    Printf(f, "        if (PyObject_SetAttr((PyObject *)pytype, key, value) < 0) {\n");
+    Printf(f, "          pytype = 0;\n");
+    Printf(f, "          break;\n");
+    Printf(f, "        }\n");
+    Printf(f, "      }\n");
+    Printf(f, "    }\n");
+    Printv(f, "#endif\n", NIL);
     Printv(f, "      SwigPyBuiltin_SetMetaType(pytype, type);\n", NIL);
     Printf(f, "      PyType_Modified(pytype);\n");
+    Printv(f, "#ifndef Py_LIMITED_API\n", NIL);
     Printf(f, "    } else {\n");
     Printf(f, "      pytype = 0;\n");
     Printf(f, "    }\n");
+    Printv(f, "#endif\n", NIL);
     Printf(f, "  }\n");
     Printf(f, "  Py_DECREF(dict);\n");
     Printf(f, "  return pytype;\n");


### PR DESCRIPTION
In builtin mode the SWIG_NewPointerObj macro passed 'self' to SWIG_Python_NewPointerObj, requiring 'self' to be in scope at the call site.  This broke user code in %inline blocks that called SWIG_NewPointerObj, because 'self' only exists in the generated tp_init wrapper, not in arbitrary C functions.

1. Change the builtin macro to pass NULL instead of self.
2. Guard the BUILTIN_TP_INIT code path with a self != NULL check, so tp_init still works (self is provided by the generated wrapper) while user code calling SWIG_NewPointerObj gets a normal new object.

Closes #2613