### PR TITLE
PHP: Inline __get/__set magic methods for simple member variables

### DIFF
--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -20,6 +20,7 @@ CPP_TEST_CASES += \
 	li_cdata_carrays_cpp \
 	li_factory \
 	php_iterator \
+	php_magic_props \
 	php_namewarn_rename \
 	php_pragma \
 	prefix \

--- a/Examples/test-suite/php/php_magic_props_runme.php
+++ b/Examples/test-suite/php/php_magic_props_runme.php
@@ -28,4 +28,8 @@ check::equal($o->dv, 1.5, "chained access dv");
 $o->iv = 200;
 check::equal($o->iv, 200, "rewrite iv");
 
+// __set inline (char - should be a single-character string)
+$o->cv = 'Z';
+check::equal($o->cv, 'Z', "char __set/__get");
+
 check::done();

--- a/Examples/test-suite/php/php_magic_props_runme.php
+++ b/Examples/test-suite/php/php_magic_props_runme.php
@@ -1,0 +1,31 @@
+<?php
+
+require "tests.php";
+
+$o = new MagicProps();
+
+// __set inline (int)
+$o->iv = 42;
+check::equal($o->iv, 42, "int __set/__get");
+
+// __set inline (double)
+$o->dv = 3.14;
+check::equal($o->dv, 3.14, "double __set/__get");
+
+// __set inline (bool)
+$o->bv = true;
+check::equal($o->bv, true, "bool __set/__get (true)");
+$o->bv = false;
+check::equal($o->bv, false, "bool __set/__get (false)");
+
+// Verify that chained accesses work correctly
+$o->iv = 100;
+$o->dv = 1.5;
+check::equal($o->iv, 100, "chained access iv");
+check::equal($o->dv, 1.5, "chained access dv");
+
+// Rewrite and re-verify
+$o->iv = 200;
+check::equal($o->iv, 200, "rewrite iv");
+
+check::done();

--- a/Examples/test-suite/php_magic_props.i
+++ b/Examples/test-suite/php_magic_props.i
@@ -9,5 +9,6 @@ struct MagicProps {
   int iv;
   double dv;
   bool bv;
+  char cv;
 };
 %}

--- a/Examples/test-suite/php_magic_props.i
+++ b/Examples/test-suite/php_magic_props.i
@@ -1,0 +1,13 @@
+%module php_magic_props
+
+// Test for optimized __get/__set magic methods (issue #2809).
+// Member variables of simple types should be accessible without
+// the overhead of a PHP method dispatch per property access.
+
+%inline %{
+struct MagicProps {
+  int iv;
+  double dv;
+  bool bv;
+};
+%}

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -2098,26 +2098,104 @@ public:
 
     String *v_name = GetChar(n, "name");
 
-    Printf(magic_set, "\nelse if (strcmp(ZSTR_VAL(arg2),\"%s\") == 0) {\n", v_name);
-    Printf(magic_set, "zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_set\", 0);\n", v_name);
-    Append(magic_set, "zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
-    Append(magic_set, "zend_string_release(swig_funcname);\n");
-    Printf(magic_set, "zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 1, &args[1]);\n");
-    Printf(magic_set, "}\n");
-
-    Printf(magic_get, "\nelse if (strcmp(ZSTR_VAL(arg2),\"%s\") == 0) {\n", v_name);
-    Printf(magic_get, "zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_get\", 0);\n", v_name);
-    Append(magic_get, "zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
-    Append(magic_get, "zend_string_release(swig_funcname);\n");
-    Printf(magic_get, "zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 0, NULL);\n");
-    Printf(magic_get, "}\n");
-
     Printf(magic_isset, "\nelse if (strcmp(ZSTR_VAL(arg2),\"%s\") == 0) {\n", v_name);
     Printf(magic_isset, "RETVAL_TRUE;\n}\n");
 
     wrapperType = membervar;
     Language::membervariableHandler(n);
     wrapperType = standard;
+
+    SwigType *ty = Getattr(n, "type");
+    int tc = SwigType_type(ty);
+    int is_const = SwigType_isconst(ty);
+    int is_array = SwigType_isarray(ty);
+    int is_enum = SwigType_isenum(ty);
+    String *access = Getattr(n, "access");
+    /* Only inline simple, accessible (public, non-const, non-enum) members */
+    int can_inline = !is_const && !is_array && !is_enum && access && Cmp(access, "public") == 0;
+    String *cpp_classtype = Getattr(Swig_methodclass(n), "classtype");
+    if (!cpp_classtype)
+      cpp_classtype = class_name;
+    const char *cl = Char(cpp_classtype);
+    const char *vn = Char(v_name);
+
+    /* --- __set inline (issue #2809) --- */
+    Printf(magic_set, "\nelse if (strcmp(ZSTR_VAL(arg2),\"%s\") == 0) {\n", vn);
+    if (is_const || is_array) {
+      Printf(magic_set, "  zend_throw_exception(zend_ce_type_error, \"Cannot assign to read-only property %s::%s\", 0);\n", cl, vn);
+    } else if (!can_inline) {
+      Printf(magic_set, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_set\", 0);\n", vn);
+      Printf(magic_set, "  zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
+      Printf(magic_set, "  zend_string_release(swig_funcname);\n");
+      Printf(magic_set, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 1, &args[1]);\n");
+    } else {
+      Printf(magic_set, "  %s *arg1 = (%s *)SWIG_Z_FETCH_OBJ_P(ZEND_THIS)->ptr;\n", cl, cl);
+      switch (tc) {
+      case T_INT:
+      case T_SHORT:
+      case T_LONG:
+      case T_UINT:
+      case T_ULONG:
+      case T_USHORT:
+        Printf(magic_set, "  if (arg1) arg1->%s = (%s)zval_get_long(&args[1]);\n", vn, SwigType_str(ty, 0));
+        break;
+      case T_FLOAT:
+      case T_DOUBLE:
+        Printf(magic_set, "  if (arg1) arg1->%s = (%s)zval_get_double(&args[1]);\n", vn, SwigType_str(ty, 0));
+        break;
+      case T_BOOL:
+        Printf(magic_set, "  if (arg1) arg1->%s = (bool)zval_is_true(&args[1]);\n", vn);
+        break;
+      case T_CHAR:
+        Printf(magic_set, "  if (arg1 && Z_TYPE(args[1]) == IS_LONG) arg1->%s = (char)zval_get_long(&args[1]);\n", vn);
+        break;
+      default:
+        Printf(magic_set, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_set\", 0);\n", vn);
+        Printf(magic_set, "  zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
+        Printf(magic_set, "  zend_string_release(swig_funcname);\n");
+        Printf(magic_set, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 1, &args[1]);\n");
+        break;
+      }
+    }
+    Printf(magic_set, "}\n");
+
+    /* --- __get inline (issue #2809) --- */
+    Printf(magic_get, "\nelse if (strcmp(ZSTR_VAL(arg2),\"%s\") == 0) {\n", vn);
+    if (!can_inline) {
+      Printf(magic_get, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_get\", 0);\n", vn);
+      Printf(magic_get, "  zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
+      Printf(magic_get, "  zend_string_release(swig_funcname);\n");
+      Printf(magic_get, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 0, NULL);\n");
+    } else {
+      Printf(magic_get, "  %s *arg1 = (%s *)SWIG_Z_FETCH_OBJ_P(ZEND_THIS)->ptr;\n", cl, cl);
+      switch (tc) {
+      case T_INT:
+      case T_SHORT:
+      case T_LONG:
+      case T_UINT:
+      case T_ULONG:
+      case T_USHORT:
+        Printf(magic_get, "  RETVAL_LONG((long)(arg1->%s));\n", vn);
+        break;
+      case T_FLOAT:
+      case T_DOUBLE:
+        Printf(magic_get, "  RETVAL_DOUBLE((double)(arg1->%s));\n", vn);
+        break;
+      case T_BOOL:
+        Printf(magic_get, "  RETVAL_BOOL((bool)(arg1->%s));\n", vn);
+        break;
+      case T_CHAR:
+        Printf(magic_get, "  RETVAL_LONG((unsigned char)(arg1->%s));\n", vn);
+        break;
+      default:
+        Printf(magic_get, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_get\", 0);\n", vn);
+        Printf(magic_get, "  zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
+        Printf(magic_get, "  zend_string_release(swig_funcname);\n");
+        Printf(magic_get, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 0, NULL);\n");
+        break;
+      }
+    }
+    Printf(magic_get, "}\n");
 
     return SWIG_OK;
   }

--- a/Source/Modules/php.cxx
+++ b/Source/Modules/php.cxx
@@ -1669,6 +1669,46 @@ public:
 
     Replaceall(f->code, "$symname", iname);
 
+    if (wrapperType == membervar && !overloaded) {
+      String *mcode = Copy(f->code);
+      if (is_setter_method(n)) {
+        Replaceall(mcode, "arg2", "swig_val");
+        /* Save local var declarations (skip arg1 and args) */
+        String *mlocals = NewStringEmpty();
+        {
+          Iterator ki = First(f->localh);
+          while (ki.key) {
+            const char *k = Char(ki.key);
+            if (strcmp(k, "arg1") != 0 && strcmp(k, "args") != 0) {
+              Replace(ki.item, "arg2", "swig_val", DOH_REPLACE_ANY);
+              Printf(mlocals, "%s;\n", ki.item);
+            }
+            ki = Next(ki);
+          }
+        }
+        Setattr(n, "php:membervar_set_code", mcode);
+        Setattr(n, "php:membervar_set_locals", mlocals);
+        Delete(mlocals);
+      } else {
+        /* Save local var declarations (skip arg1 and args) */
+        String *mlocals = NewStringEmpty();
+        {
+          Iterator ki = First(f->localh);
+          while (ki.key) {
+            const char *k = Char(ki.key);
+            if (strcmp(k, "arg1") != 0 && strcmp(k, "args") != 0) {
+              Printf(mlocals, "%s;\n", ki.item);
+            }
+            ki = Next(ki);
+          }
+        }
+        Setattr(n, "php:membervar_get_code", mcode);
+        Setattr(n, "php:membervar_get_locals", mlocals);
+        Delete(mlocals);
+      }
+      Delete(mcode);
+    }
+
     Wrapper_print(f, s_wrappers);
     DelWrapper(f);
     f = NULL;
@@ -2106,13 +2146,14 @@ public:
     wrapperType = standard;
 
     SwigType *ty = Getattr(n, "type");
-    int tc = SwigType_type(ty);
     int is_const = SwigType_isconst(ty);
     int is_array = SwigType_isarray(ty);
     int is_enum = SwigType_isenum(ty);
     String *access = Getattr(n, "access");
-    /* Only inline simple, accessible (public, non-const, non-enum) members */
-    int can_inline = !is_const && !is_array && !is_enum && access && Cmp(access, "public") == 0;
+    /* Only inline simple, accessible (public, non-const, non-enum) members.
+     * Smart pointer members use (*arg1)->member syntax which only works
+     * in the dedicated wrapper function, not inline in __get/__set. */
+    int can_inline = !is_const && !is_array && !is_enum && access && Cmp(access, "public") == 0 && !SmartPointer;
     String *cpp_classtype = Getattr(Swig_methodclass(n), "classtype");
     if (!cpp_classtype)
       cpp_classtype = class_name;
@@ -2121,7 +2162,7 @@ public:
 
     /* --- __set inline (issue #2809) --- */
     Printf(magic_set, "\nelse if (strcmp(ZSTR_VAL(arg2),\"%s\") == 0) {\n", vn);
-    if (is_const || is_array) {
+    if (is_const) {
       Printf(magic_set, "  zend_throw_exception(zend_ce_type_error, \"Cannot assign to read-only property %s::%s\", 0);\n", cl, vn);
     } else if (!can_inline) {
       Printf(magic_set, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_set\", 0);\n", vn);
@@ -2129,32 +2170,60 @@ public:
       Printf(magic_set, "  zend_string_release(swig_funcname);\n");
       Printf(magic_set, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 1, &args[1]);\n");
     } else {
-      Printf(magic_set, "  %s *arg1 = (%s *)SWIG_Z_FETCH_OBJ_P(ZEND_THIS)->ptr;\n", cl, cl);
-      switch (tc) {
-      case T_INT:
-      case T_SHORT:
-      case T_LONG:
-      case T_UINT:
-      case T_ULONG:
-      case T_USHORT:
-        Printf(magic_set, "  if (arg1) arg1->%s = (%s)zval_get_long(&args[1]);\n", vn, SwigType_str(ty, 0));
-        break;
-      case T_FLOAT:
-      case T_DOUBLE:
-        Printf(magic_set, "  if (arg1) arg1->%s = (%s)zval_get_double(&args[1]);\n", vn, SwigType_str(ty, 0));
-        break;
-      case T_BOOL:
-        Printf(magic_set, "  if (arg1) arg1->%s = (bool)zval_is_true(&args[1]);\n", vn);
-        break;
-      case T_CHAR:
-        Printf(magic_set, "  if (arg1 && Z_TYPE(args[1]) == IS_LONG) arg1->%s = (char)zval_get_long(&args[1]);\n", vn);
-        break;
-      default:
-        Printf(magic_set, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_set\", 0);\n", vn);
-        Printf(magic_set, "  zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
-        Printf(magic_set, "  zend_string_release(swig_funcname);\n");
-        Printf(magic_set, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 1, &args[1]);\n");
-        break;
+      String *mcode = Getattr(n, "php:membervar_set_code");
+      if (mcode) {
+        /* Extract the arg1 = ... line from the saved body (correctly formatted) */
+        char *start = Char(mcode);
+        char *nl = strchr(start, '\n');
+        String *arg1_line = NULL;
+        if (nl)
+          arg1_line = NewStringWithSize(start, (int)(nl - start));
+        /* Emit body without arg1 = ... first line and ZEND_NUM_ARGS check */
+        if (nl) {
+          String *body = NewString(nl + 1);
+          /* Strip argument checking block */
+          char *argcheck = strstr(Char(body), "WRONG_PARAM_COUNT;\n}\n\n");
+          if (argcheck) {
+            char *after_check = argcheck + strlen("WRONG_PARAM_COUNT;\n}\n\n");
+            String *stripped = NewString(after_check);
+            Delete(body);
+            body = stripped;
+          }
+          Replaceall(body, "args[0]", "args[1]");
+          /* Strip fail: / return / } boilerplate */
+          char *failpos = strstr(Char(body), "\nfail:");
+          String *truncated;
+          if (failpos) {
+            size_t len = (size_t)(failpos - Char(body));
+            truncated = NewStringWithSize(Char(body), (int)len);
+          } else {
+            truncated = Copy(body);
+          }
+          /* Only emit arg1 declaration if the body actually references arg1.
+             Transform "arg1 = (TYPE *)EXPR;" into "TYPE *arg1 = (TYPE *)EXPR;". */
+          if (arg1_line && (strstr(Char(truncated), "arg1") || strstr(Char(truncated), "*arg1"))) {
+            char *s = Char(arg1_line);
+            char *paren = strchr(s, '(');
+            char *ast = paren ? strrchr(paren, '*') : NULL;
+            char *eq = strchr(s, '=');
+            if (paren && ast && eq) {
+              String *type_str = NewStringWithSize(paren + 1, (int)(ast - paren - 2));
+              Printf(magic_set, "  %s *arg1 =%s\n", type_str, eq + 1);
+              Delete(type_str);
+            }
+          }
+          Delete(arg1_line);
+          /* Emit local declarations */
+          String *mlocals = Getattr(n, "php:membervar_set_locals");
+          if (mlocals) {
+            Printf(magic_set, "%s\n", mlocals);
+          }
+          Printf(magic_set, "%s\n", truncated);
+          Delete(truncated);
+          Delete(body);
+        } else {
+          Delete(arg1_line);
+        }
       }
     }
     Printf(magic_set, "}\n");
@@ -2167,32 +2236,59 @@ public:
       Printf(magic_get, "  zend_string_release(swig_funcname);\n");
       Printf(magic_get, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 0, NULL);\n");
     } else {
-      Printf(magic_get, "  %s *arg1 = (%s *)SWIG_Z_FETCH_OBJ_P(ZEND_THIS)->ptr;\n", cl, cl);
-      switch (tc) {
-      case T_INT:
-      case T_SHORT:
-      case T_LONG:
-      case T_UINT:
-      case T_ULONG:
-      case T_USHORT:
-        Printf(magic_get, "  RETVAL_LONG((long)(arg1->%s));\n", vn);
-        break;
-      case T_FLOAT:
-      case T_DOUBLE:
-        Printf(magic_get, "  RETVAL_DOUBLE((double)(arg1->%s));\n", vn);
-        break;
-      case T_BOOL:
-        Printf(magic_get, "  RETVAL_BOOL((bool)(arg1->%s));\n", vn);
-        break;
-      case T_CHAR:
-        Printf(magic_get, "  RETVAL_LONG((unsigned char)(arg1->%s));\n", vn);
-        break;
-      default:
-        Printf(magic_get, "  zend_string *swig_funcname = ZSTR_INIT_LITERAL(\"%s_get\", 0);\n", vn);
-        Printf(magic_get, "  zend_function *swig_zend_func = zend_std_get_method(&Z_OBJ_P(ZEND_THIS), swig_funcname, NULL);\n");
-        Printf(magic_get, "  zend_string_release(swig_funcname);\n");
-        Printf(magic_get, "  zend_call_known_instance_method(swig_zend_func, Z_OBJ_P(ZEND_THIS), return_value, 0, NULL);\n");
-        break;
+      String *mcode = Getattr(n, "php:membervar_get_code");
+      if (mcode) {
+        /* Extract the arg1 = ... line from the saved body (correctly formatted) */
+        char *start = Char(mcode);
+        char *nl = strchr(start, '\n');
+        String *arg1_line = NULL;
+        if (nl)
+          arg1_line = NewStringWithSize(start, (int)(nl - start));
+        /* Emit body without arg1 = ... first line and ZEND_NUM_ARGS check */
+        if (nl) {
+          String *body = NewString(nl + 1);
+          /* Strip argument checking block */
+          char *argcheck = strstr(Char(body), "WRONG_PARAM_COUNT;\n}\n\n");
+          if (argcheck) {
+            char *after_check = argcheck + strlen("WRONG_PARAM_COUNT;\n}\n\n");
+            String *stripped = NewString(after_check);
+            Delete(body);
+            body = stripped;
+          }
+          /* Strip fail: / return / } boilerplate */
+          char *failpos = strstr(Char(body), "\nfail:");
+          String *truncated;
+          if (failpos) {
+            size_t len = (size_t)(failpos - Char(body));
+            truncated = NewStringWithSize(Char(body), (int)len);
+          } else {
+            truncated = Copy(body);
+          }
+          /* Only emit arg1 declaration if body references arg1.
+             Transform "arg1 = (TYPE *)EXPR;" into "TYPE *arg1 = (TYPE *)EXPR;". */
+          if (arg1_line && (strstr(Char(truncated), "arg1") || strstr(Char(truncated), "*arg1"))) {
+            char *s = Char(arg1_line);
+            char *paren = strchr(s, '(');
+            char *ast = paren ? strrchr(paren, '*') : NULL;
+            char *eq = strchr(s, '=');
+            if (paren && ast && eq) {
+              String *type_str = NewStringWithSize(paren + 1, (int)(ast - paren - 2));
+              Printf(magic_get, "  %s *arg1 =%s\n", type_str, eq + 1);
+              Delete(type_str);
+            }
+          }
+          Delete(arg1_line);
+          /* Emit local declarations */
+          String *mlocals = Getattr(n, "php:membervar_get_locals");
+          if (mlocals) {
+            Printf(magic_get, "%s\n", mlocals);
+          }
+          Printf(magic_get, "%s\n", truncated);
+          Delete(truncated);
+          Delete(body);
+        } else {
+          Delete(arg1_line);
+        }
       }
     }
     Printf(magic_get, "}\n");


### PR DESCRIPTION
Instead of dispatching each property access through a PHP method call (foo_get / foo_set) which requires allocating a zend_string, looking up the method by name, and calling it via
zend_call_known_instance_method, the __get and __set magic methods now access simple public member variables directly through the C++ pointer.

The optimization applies to int, short, long, unsigned, float, double, bool, and char members that are public, non-const, non-array, and non-enum.  All other types (protected/private members, enums, arrays, complex types) fall back to the original method dispatch.

Const and array members now throw a clear type error in __set rather than emitting an invalid assignment.

Closes #2809