### PR TITLE
Go: Fix wrapping of static constexpr const char* member variables

### DIFF
--- a/Examples/test-suite/cpp11_decltype.i
+++ b/Examples/test-suite/cpp11_decltype.i
@@ -73,6 +73,9 @@
 
     static constexpr decltype(&hidden_global_char) should_be_string = "xyzzy";
 
+    // Test wrapping of static constexpr const char * member variable (#2724)
+    static constexpr const char * plain_string = "hello";
+
     // SWIG < 4.2.0 incorrectly used int for the result of logical not in C++
     // so this would end up wrapped as int.
     decltype(!0) should_be_bool;

--- a/Examples/test-suite/go/cpp11_decltype_runme.go
+++ b/Examples/test-suite/go/cpp11_decltype_runme.go
@@ -1,0 +1,13 @@
+package main
+
+import "swigtests/cpp11_decltype"
+
+func main() {
+    if cpp11_decltype.BShould_be_string != "xyzzy" {
+        panic("BShould_be_string mismatch")
+    }
+
+    if cpp11_decltype.BPlain_string != "hello" {
+        panic("BPlain_string mismatch")
+    }
+}

--- a/Source/Modules/lang.cxx
+++ b/Source/Modules/lang.cxx
@@ -1644,10 +1644,8 @@ int Language::staticmembervariableHandler(Node *n) {
     }
 
     SwigType *t1 = SwigType_typedef_resolve_all(Getattr(n, "type"));
-    SwigType *t2 = SwigType_strip_qualifiers(t1);
-    Setattr(n, "type", t2);
+    Setattr(n, "type", t1);
     Delete(t1);
-    Delete(t2);
     SetFlag(n, "wrappedasconstant");
     memberconstantHandler(n);
     Delete(cname);

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -1582,7 +1582,14 @@ int Swig_VargetToFunction(Node *n, int flags) {
   int varcref = flags & CWRAP_NATURAL_VAR;
 
   name = Getattr(n, "name");
-  type = Getattr(n, "type");
+  type = Copy(Getattr(n, "type"));
+  /* Merge the declarator into the type to get the full type */
+  {
+    String *decl = Getattr(n, "decl");
+    if (decl) {
+      SwigType_push(type, decl);
+    }
+  }
   ty = Swig_wrapped_var_type(type, varcref);
 
   if (flags & CWRAP_EXTEND) {


### PR DESCRIPTION
Swig_VargetToFunction (Source/Swig/cwrap.c) now merges the declarator into the variable's type, so that non-constant variables get the full type including pointer/declarator.  In staticmembervariableHandler (Source/Modules/lang.cxx), qualifiers are no longer stripped from the type when a constexpr variable is wrapped as a constant, preserving the const qualifier for downstream type selection.

Previously a static constexpr const char* member generated C wrapper code using the stripped type "char", which also affected Go wrapper code generation.  The fix ensures the const qualifier is preserved.

Closes #2724