### PR TITLE
Parser: emit char-valued enum items as integers, not strings

### DIFF
--- a/Examples/test-suite/char_enum_value.i
+++ b/Examples/test-suite/char_enum_value.i
@@ -1,0 +1,12 @@
+%module char_enum_value
+
+%inline %{
+
+enum color { RED, BLUE, GREEN = 'g' };
+enum escapes {
+  NEWLINE = '\n',
+  TAB = '\t',
+  CAP_A = 'A',
+};
+
+%}

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -248,6 +248,7 @@ CPP_TEST_CASES += \
 	enum_scope_template \
 	enum_template \
 	enum_thorough \
+	char_enum_value \
 	enum_var \
 	equality \
 	evil_diamond \

--- a/Examples/test-suite/python/char_enum_value_runme.py
+++ b/Examples/test-suite/python/char_enum_value_runme.py
@@ -1,0 +1,10 @@
+import char_enum_value
+from swig_test_utils import swig_check, swig_assert
+
+swig_check(char_enum_value.RED, 0)
+swig_check(char_enum_value.BLUE, 1)
+swig_check(char_enum_value.GREEN, 103)
+swig_check(char_enum_value.NEWLINE, 10)
+swig_check(char_enum_value.TAB, 9)
+swig_check(char_enum_value.CAP_A, 65)
+swig_assert(isinstance(char_enum_value.GREEN, int))

--- a/Source/CParse/parser.y
+++ b/Source/CParse/parser.y
@@ -7217,7 +7217,7 @@ edecl          :  identifier {
 		   Delete(type);
 		 }
                  | identifier EQUAL etype {
-		   SwigType *type = NewSwigType($etype.type == T_BOOL ? T_BOOL : ($etype.type == T_CHAR ? T_CHAR : T_INT));
+		   SwigType *type = NewSwigType(T_INT);
 		   $$ = new_node("enumitem");
 		   Setattr($$,"name",$identifier);
 		   Setattr($$,"type",type);
@@ -7244,6 +7244,7 @@ etype            : expr {
 		       ($$.type != T_SHORT) && ($$.type != T_USHORT) &&
 		       ($$.type != T_SCHAR) && ($$.type != T_UCHAR) &&
 		       ($$.type != T_CHAR) && ($$.type != T_BOOL) &&
+		       ($$.type != T_WCHAR) &&
 		       ($$.type != T_UNKNOWN) && ($$.type != T_USER)) {
 		     Swig_error(cparse_file,cparse_line,"Type error. Expecting an integral type\n");
 		   }
@@ -7444,12 +7445,14 @@ exprsimple     : exprnum
 		  $$.stringval = $CHARCONST;
 		  $$.val = NewStringf("'%(escape)s'", $CHARCONST);
 		  $$.type = T_CHAR;
+		  $$.numval = NewStringf("%d", (unsigned char)Char($CHARCONST)[0]);
 	       }
 	       | WCHARCONST {
 		  $$ = default_dtype;
 		  $$.stringval = $WCHARCONST;
 		  $$.val = NewStringf("L'%(escape)s'", $WCHARCONST);
 		  $$.type = T_WCHAR;
+		  $$.numval = NewStringf("%d", (unsigned char)Char($WCHARCONST)[0]);
 	       }
 
 	       /* In sizeof(X) X can be a type or expression.  We don't actually


### PR DESCRIPTION
When an enum item is initialized with a character literal (e.g. `GREEN = 'g'`), SWIG incorrectly propagated the initializer's type (T_CHAR) to the enum item's type attribute. This caused Python to call `SWIG_From_char()`, which returns a Python string via `SWIG_FromCharPtrAndSize()`, producing `GREEN = 'g'` instead of `GREEN = 103`. Passing such a value to a function expecting the enum type then fails with TypeError.

Changes in Source/CParse/parser.y:

1. edecl rule -- always use T_INT for enum items regardless of the initializer expression type. The underlying type of a C/C++ enumeration is an integral type, not the type of the initializer.
2. CHARCONST production -- compute `numval` (the integer value of the character) so that `enumnumval` is available to backends that use it (Java, C#, R, D).
3. WCHARCONST production -- same treatment for wide character literals.
4. etype validation -- add T_WCHAR to the allowed integral types list so that `L'x'` literals are accepted as enum initializers.

Closes #1026

Assisted-by: Claude Code