### PR TITLE
Python: Allow keyword arguments with overloaded functions

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -380,6 +380,7 @@ CPP_TEST_CASES += \
 	overload_complicated \
 	overload_copy \
 	overload_extend \
+	overload_kwargs \
 	overload_method \
 	overload_numeric \
 	overload_null \

--- a/Examples/test-suite/overload_kwargs.i
+++ b/Examples/test-suite/overload_kwargs.i
@@ -1,0 +1,18 @@
+%module overload_kwargs
+
+%nocopyctor;
+%feature("kwargs");
+
+%inline %{
+  struct MyStruct {
+    MyStruct() : a_(0.0), b_(0.0) {}
+    MyStruct(double a, double b) : a_(a), b_(b) {}
+    double foo() { return 0.0; }
+    double foo(double x, double y) { return x + y; }
+    double getA() { return a_; }
+    double getB() { return b_; }
+  private:
+    double a_;
+    double b_;
+  };
+%}

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -151,6 +151,10 @@ SWIGOPT += -Werror
 python_flatstaticmethod.cpptest: SWIGOPT += -flatstaticmethod
 python_nokwargs_keyword.cpptest: SWIGOPT += -keyword
 
+# overload_kwargs tests kwargs with overloaded functions, which is not supported in -builtin mode.
+overload_kwargs.cpptest: override SWIG_FEATURES := $(filter-out -builtin,$(SWIG_FEATURES))
+overload_kwargs.cpptest: override SWIGOPT := $(filter-out -builtin,$(SWIGOPT))
+
 # Make sure just python_runtime_data_builtin.i uses the -builtin option. Note: does not use python_runtime_data.list for all steps.
 # PY_ABI_VER is unset for python_runtime_data_builtin because stable ABI is not supported by builtin
 python_runtime_data.multicpptest: override SWIG_FEATURES := $(filter-out -builtin,$(SWIG_FEATURES))

--- a/Examples/test-suite/python/overload_kwargs_runme.py
+++ b/Examples/test-suite/python/overload_kwargs_runme.py
@@ -1,0 +1,27 @@
+from overload_kwargs import MyStruct
+from swig_test_utils import *
+
+# Constructor with zero args (no kwargs)
+s = MyStruct()
+swig_assert(s.getA() == 0.0 and s.getB() == 0.0)
+
+# Constructor with kwargs (2-overload case: zero-arg + two-arg)
+s = MyStruct(a=3.0, b=4.0)
+swig_assert(s.getA() == 3.0 and s.getB() == 4.0)
+
+# Constructor with positional args still works
+s = MyStruct(5.0, 6.0)
+swig_assert(s.getA() == 5.0 and s.getB() == 6.0)
+
+# Method with kwargs (2-overload case: zero-arg + two-arg)
+swig_assert(s.foo(x=10.0, y=20.0) == 30.0)
+
+# Method with no args
+swig_assert(s.foo() == 0.0)
+
+# Method with positional args still works
+swig_assert(s.foo(1.0, 2.0) == 3.0)
+
+# Unknown kwargs should raise TypeError
+with swig_assert_raises(TypeError):
+    MyStruct(nonexistent=10)

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2682,7 +2682,17 @@ public:
     String *tmp = NewString("");
     String *dispatch;
 
-    const char *dispatch_call = funpack ? "%s(self, argc, argv);" : (builtin_ctor ? "%s(self, args, NULL);" : "%s(self, args);");
+    bool enable_kwargs = !builtin && !builtin_ctor && check_kwargs(n);
+    const char *dispatch_call;
+    if (funpack) {
+      dispatch_call = "%s(self, argc, argv);";
+    } else if (builtin_ctor) {
+      dispatch_call = "%s(self, args, NULL);";
+    } else if (enable_kwargs) {
+      dispatch_call = "%s(self, args, kwargs);";
+    } else {
+      dispatch_call = "%s(self, args);";
+    }
     String *dispatch_code = NewStringf("return %s", dispatch_call);
 
     if (castmode) {
@@ -2707,8 +2717,11 @@ public:
     String *symname = Getattr(n, "sym:name");
     String *wname = Swig_name_wrapper(symname);
 
-    const char *builtin_kwargs = builtin_ctor ? ", PyObject *kwargs" : "";
+    String *builtin_kwargs = NewString("");
+    if (builtin_ctor || enable_kwargs)
+      Printf(builtin_kwargs, ", PyObject *kwargs");
     Printv(f->def, linkage, builtin_ctor ? "int " : "PyObject *", wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
+    Delete(builtin_kwargs);
 
     if (builtin) {
       /* Avoid warning if the self parameter is not used. */
@@ -2751,6 +2764,29 @@ public:
 
     Replaceall(dispatch, "$args", "self, args");
 
+    /* When kwargs are enabled and present, bypass argc/argv-based dispatch and
+     * try each overload individually. Each overload's wrapper uses
+     * PyArg_ParseTupleAndKeywords which correctly handles keyword arguments --
+     * if the keywords don't match the overload's parameter names, it fails with
+     * TypeError, which is caught and cleared before trying the next overload. */
+    if (enable_kwargs) {
+      Node *sibl = n;
+      while (Getattr(sibl, "sym:previousSibling"))
+        sibl = Getattr(sibl, "sym:previousSibling");
+      Printf(f->code, "if (kwargs && PyDict_Size(kwargs) > 0) {\n");
+      while (sibl) {
+        String *wrap_name = Getattr(sibl, "wrap:name");
+        Printf(f->code, "  {\n");
+        Printf(f->code, "    PyObject *retobj = %s(self, args, kwargs);\n", wrap_name);
+        Printf(f->code, "    if (!SWIG_Python_TypeErrorOccurred(retobj)) return retobj;\n");
+        Printf(f->code, "    PyErr_Clear();\n");
+        Printf(f->code, "  }\n");
+        sibl = Getattr(sibl, "sym:nextSibling");
+      }
+      Printf(f->code, "  goto fail;\n");
+      Printf(f->code, "}\n");
+    }
+
     Printv(f->code, dispatch, "\n", NIL);
 
     if (GetFlag(n, "feature:python:maybecall")) {
@@ -2780,7 +2816,7 @@ public:
     Printv(f->code, "}\n", NIL);
     Wrapper_print(f, f_wrappers);
     if (!builtin_self && (use_static_method || !builtin))
-      add_method(symname, wname, 0, Getattr(n, "sym:previousSibling") ? n : NULL);
+      add_method(symname, wname, enable_kwargs ? 1 : 0, Getattr(n, "sym:previousSibling") ? n : NULL);
 
     /* Create a shadow for this function (if enabled and not in a member function) */
     if (!builtin && shadow && !(shadow & PYSHADOW_MEMBER) && use_static_method) {
@@ -2927,9 +2963,15 @@ public:
 
     // builtin handles/checks kwargs by default except in constructor wrappers so we need to explicitly handle them in the C constructor wrapper
     // The check below is for zero arguments. Sometimes (eg directors) self is the first argument for a method with zero arguments.
-    if (((num_arguments == 0) && (num_required == 0)) || ((num_arguments == 1) && (num_required == 1) && Getattr(l, "self")))
-      if (!builtin_ctor)
+    // When the function is overloaded, keep kwargs enabled for the individual wrappers since
+    // the dispatch function passes kwargs to each overload.
+    // For builtin mode, the dispatch function does not pass kwargs to overloads, so disable them.
+    if (overname && builtin) {
+      allow_kwargs = 0;
+    } else if (((num_arguments == 0) && (num_required == 0)) || ((num_arguments == 1) && (num_required == 1) && Getattr(l, "self"))) {
+      if (!builtin_ctor && !overname)
         allow_kwargs = 0;
+    }
     varargs = emit_isvarargs(l);
 
     String *wname = Copy(wrapper_name);
@@ -2938,15 +2980,11 @@ public:
     }
 
     const char *builtin_kwargs = builtin_ctor ? ", PyObject *kwargs" : "";
-    if (!allow_kwargs || overname) {
+    if (!allow_kwargs) {
       if (!varargs) {
         Printv(f->def, linkage, wrap_return, wname, "(PyObject *self, PyObject *args", builtin_kwargs, ") {", NIL);
       } else {
         Printv(f->def, linkage, wrap_return, wname, "__varargs__", "(PyObject *self, PyObject *args, PyObject *varargs", builtin_kwargs, ") {", NIL);
-      }
-      if (allow_kwargs) {
-        Swig_warning(WARN_LANG_OVERLOAD_KEYWORD, input_file, line_number, "Can't use keyword arguments with overloaded functions (%s).\n", Swig_name_decl(n));
-        allow_kwargs = 0;
       }
     } else {
       if (varargs) {
@@ -2961,7 +2999,7 @@ public:
       Append(f->code, "(void)self;\n");
     }
 
-    if (!builtin || !in_class || tuple_arguments > 0 || builtin_ctor) {
+    if (!builtin || !in_class || tuple_arguments > 0 || builtin_ctor || allow_kwargs) {
       if (!allow_kwargs) {
         Append(parse_args, "    if (!PyArg_ParseTuple(args, \"");
       } else {
@@ -5070,7 +5108,7 @@ public:
           Delete(pycode);
           fproxy = 0;
         } else {
-          int allow_kwargs = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
+          int allow_kwargs = check_kwargs(n) ? 1 : 0;
           String *parms = make_pyParmList(n, true, false, allow_kwargs);
           String *callParms = make_pyParmList(n, true, true, allow_kwargs);
           if (!have_addtofunc(n)) {
@@ -5236,7 +5274,7 @@ public:
 
     if (!Getattr(n, "sym:nextSibling")) {
       if (shadow) {
-        int allow_kwargs = (check_kwargs(n) && (!Getattr(n, "sym:overloaded"))) ? 1 : 0;
+        int allow_kwargs = check_kwargs(n) ? 1 : 0;
         int handled_as_init = 0;
         if (!have_constructor) {
           String *nname = Getattr(n, "sym:name");


### PR DESCRIPTION
When -keyword or %feature("kwargs") was used, keyword arguments were silently disabled for all overloaded functions and constructors. The dispatch wrapper used PyArg_ParseTuple instead of
PyArg_ParseTupleAndKeywords and the individual overload wrappers dropped kwargs support when overname was set.

Fix by removing the overname check as a condition for disabling kwargs in the individual overload wrappers and by adding a kwargs dispatch loop to the dispatch function that tries each overload sequentially, relying on PyArg_ParseTupleAndKeywords to reject mismatched keywords with TypeError (cleared between attempts). The Python proxy __init__ and method helpers now pass **kwargs through to the dispatch function.

The overloaded kwargs path is always active when -keyword / %feature("kwargs") is used. If performance with many overloads becomes a concern, a separate %feature("kwargs:overloaded") could be added later as an opt-in, but the runtime cost only applies when kwargs are actually passed (a PyDict_Size check); without kwargs, the existing argc-based fast path is unchanged.

Closes #2703

Assisted-by: Claude Code (deepseek-v4-flash)