### PR TITLE
[Ruby] Migrate from Data_* to TypedData_* API

### DIFF
--- a/Lib/ruby/rubyclasses.swg
+++ b/Lib/ruby/rubyclasses.swg
@@ -6,11 +6,11 @@
   of the underlying Ruby object with the GC.
 
   It can be used if you want to create STL containers of VALUEs, such as:
-  
+
      std::vector< GC_VALUE >;
 
   or as a member variable:
-  
+
      struct A {
        GC_VALUE _obj;
        A(VALUE o) : _obj(o) {
@@ -34,62 +34,88 @@
    
 */
 
-%fragment("GC_VALUE_definition","header") {
+
+%fragment("GC_VALUE_definition","header") %{
+#include <map>
 namespace swig {
   class SwigGCReferences {
-    VALUE _hash;
+    VALUE _self;
 
-    SwigGCReferences() : _hash(Qnil) {
+    SwigGCReferences() : _self(Qnil) {
     }
     ~SwigGCReferences() {
-      if (_hash != Qnil)
-        rb_gc_unregister_address(&_hash);
+      if (_self != Qnil)
+        rb_gc_unregister_address(&_self);
     }
     static void EndProcHandler(VALUE) {
-      // Ruby interpreter ending - _hash can no longer be accessed.
+      // Ruby interpreter ending - _self can no longer be accessed.
       SwigGCReferences &s_references = instance();
-      s_references._hash = Qnil;
+      s_references._self = Qnil;
     }
+
+    typedef std::map<VALUE, unsigned> ref_map_t;
+
+    static void gcrefs_mark(void *ptr) {
+      ref_map_t *refs = static_cast<ref_map_t *>(ptr);
+      for (ref_map_t::iterator it = refs->begin(); it != refs->end(); ++it) {
+        rb_gc_mark(it->first);
+      }
+    }
+    static void gcrefs_free(void *ptr) {
+      delete static_cast<ref_map_t *>(ptr);
+    }
+    static size_t gcrefs_size(const void *ptr) {
+      return sizeof(ref_map_t);
+    }
+
   public:
     static SwigGCReferences& instance() {
-      // Hash of all GC_VALUE's currently in use
+      // Map of all GC_VALUE's currently in use
       static SwigGCReferences s_references;
 
       return s_references;
     }
     static void initialize() {
       SwigGCReferences &s_references = instance();
-      if (s_references._hash == Qnil) {
+      if (s_references._self == Qnil) {
         rb_set_end_proc(&EndProcHandler, Qnil);
-        s_references._hash = rb_hash_new();
-        rb_gc_register_address(&s_references._hash);
+        ref_map_t *refs = new ref_map_t();
+        static const rb_data_type_t swig_gcrefs_type = {
+          "SwigGCReferences",
+          { SwigGCReferences::gcrefs_mark, SwigGCReferences::gcrefs_free, SwigGCReferences::gcrefs_size, 0 },
+          0, 0
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+          , RUBY_TYPED_FREE_IMMEDIATELY
+#endif
+        };
+        s_references._self = TypedData_Wrap_Struct(rb_cObject, &swig_gcrefs_type, refs);
+        rb_gc_register_address(&s_references._self);
       }
     }
     void GC_register(VALUE& obj) {
       if (FIXNUM_P(obj) || SPECIAL_CONST_P(obj) || SYMBOL_P(obj))
         return;
-      if (_hash != Qnil) {
-        VALUE val = rb_hash_aref(_hash, obj);
-        unsigned n = FIXNUM_P(val) ? NUM2UINT(val) : 0;
-        ++n;
-        rb_hash_aset(_hash, obj, INT2NUM(n));
+      if (_self == Qnil) return;
+      ref_map_t *refs = static_cast<ref_map_t *>(RTYPEDDATA_DATA(_self));
+      ref_map_t::iterator it = refs->find(obj);
+      if (it != refs->end()) {
+        it->second++;
+      } else {
+        (*refs)[obj] = 1;
       }
     }
     void GC_unregister(const VALUE& obj) {
       if (FIXNUM_P(obj) || SPECIAL_CONST_P(obj) || SYMBOL_P(obj))
         return;
-      // this test should not be needed but I've noticed some very erratic
-      // behavior of none being unregistered in some very rare situations.
       if (BUILTIN_TYPE(obj) == T_NONE)
         return;
-      if (_hash != Qnil) {
-        VALUE val = rb_hash_aref(_hash, obj);
-        unsigned n = FIXNUM_P(val) ? NUM2UINT(val) : 1;
-        --n;
-        if (n)
-          rb_hash_aset(_hash, obj, INT2NUM(n));
-        else
-          rb_hash_delete(_hash, obj);
+      if (_self == Qnil) return;
+      ref_map_t *refs = static_cast<ref_map_t *>(RTYPEDDATA_DATA(_self));
+      ref_map_t::iterator it = refs->find(obj);
+      if (it != refs->end()) {
+        if (--it->second == 0) {
+          refs->erase(it);
+        }
       }
     }
   };
@@ -308,7 +334,7 @@ namespace swig {
 
 } // namespace swig
 
-} // %fragment(GC_VALUE_definition)
+%} // %fragment(GC_VALUE_definition)
 
 
 

--- a/Lib/ruby/rubyhead.swg
+++ b/Lib/ruby/rubyhead.swg
@@ -135,8 +135,8 @@
  *
  * VOIDFUNC(f) is used to typecast a C function that implements either
  * the "mark" or "free" stuff for a Ruby Data object, so that it can be
- * passed as an argument to Ruby C API functions like Data_Wrap_Struct()
- * and Data_Make_Struct().
+ * passed as an argument to Ruby C API functions like TypedData_Wrap_Struct()
+ * and TypedData_Make_Struct().
  *
  * SWIG_RUBY_VOID_ANYARGS_FUNC(f) is used for the function pointer
  * argument(s) of Ruby C API functions like rb_define_virtual_variable().
@@ -182,5 +182,46 @@
 #define rb_define_alloc_func(klass, func) rb_define_singleton_method((klass), "new", VALUEFUNC((func)), -1)
 #define rb_undef_alloc_func(klass) rb_undef_method(CLASS_OF((klass)), "new")
 #endif
+
+/* Wrapper struct for TypedData API.
+ * Stores the wrapped pointer alongside the mark and free functions
+ * so that ownership can be transferred dynamically (which the
+ * static rb_data_type_t does not allow). */
+typedef struct {
+  void *ptr;
+  RUBY_DATA_FUNC mark;
+  RUBY_DATA_FUNC free;
+} swig_ruby_data;
+
+/* Generic mark/free for TypedData wrappers -- delegates to per-object
+ * handlers stored in the swig_ruby_data wrapper. */
+static void swig_ruby_data_mark(void *ptr) {
+  swig_ruby_data *d = (swig_ruby_data *)ptr;
+  if (d->mark && d->mark != (RUBY_DATA_FUNC)RUBY_DEFAULT_FREE)
+    d->mark(d->ptr);
+}
+
+static void swig_ruby_data_free(void *ptr) {
+  swig_ruby_data *d = (swig_ruby_data *)ptr;
+  if (d->free && d->free != (RUBY_DATA_FUNC)RUBY_DEFAULT_FREE)
+    d->free(d->ptr);
+  free(d);
+}
+
+static size_t swig_ruby_data_size(const void *ptr) {
+  return sizeof(swig_ruby_data);
+}
+
+static const rb_data_type_t swig_ruby_data_type = {
+  "SWIG",
+  { swig_ruby_data_mark, swig_ruby_data_free, swig_ruby_data_size, 0 },
+  0, 0
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+  , RUBY_TYPED_FREE_IMMEDIATELY
+#endif
+};
+
+#undef DATA_PTR
+#define DATA_PTR(obj)  (((swig_ruby_data *)RTYPEDDATA_DATA(obj))->ptr)
 
 static VALUE _mSWIG = Qnil;

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -199,10 +199,14 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
     }
 
     /* Create a new Ruby object */
-    obj = Data_Wrap_Struct(sklass->klass, VOIDFUNC(sklass->mark), 
-			   ( own ? VOIDFUNC(sklass->destroy) : 
-			     (track ? VOIDFUNC(SWIG_RubyRemoveTracking) : 0 )
-			     ), ptr);
+    {
+      swig_ruby_data *d = (swig_ruby_data *)malloc(sizeof(swig_ruby_data));
+      d->ptr = ptr;
+      d->mark = (RUBY_DATA_FUNC)sklass->mark;
+      d->free = own ? (RUBY_DATA_FUNC)sklass->destroy
+                    : (track ? (RUBY_DATA_FUNC)SWIG_RubyRemoveTracking : 0);
+      obj = TypedData_Wrap_Struct(sklass->klass, &swig_ruby_data_type, d);
+    }
 
     /* If tracking is on for this class then track this object. */
     if (track) {
@@ -214,7 +218,13 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
     SWIG_snprintf(klass_name, klass_len, "TYPE%s", type->name);
     klass = rb_const_get(_mSWIG, rb_intern(klass_name));
     free((void *) klass_name);
-    obj = Data_Wrap_Struct(klass, 0, 0, ptr);
+    {
+      swig_ruby_data *d = (swig_ruby_data *)malloc(sizeof(swig_ruby_data));
+      d->ptr = ptr;
+      d->mark = 0;
+      d->free = 0;
+      obj = TypedData_Wrap_Struct(klass, &swig_ruby_data_type, d);
+    }
   }
   rb_iv_set(obj, "@__swigtype__", rb_str_new2(type->name));
 
@@ -227,7 +237,13 @@ SWIG_Ruby_NewClassInstance(VALUE klass, swig_type_info *type)
 {
   VALUE obj;
   swig_class *sklass = (swig_class *) type->clientdata;
-  obj = Data_Wrap_Struct(klass, VOIDFUNC(sklass->mark), VOIDFUNC(sklass->destroy), 0);
+  {
+    swig_ruby_data *d = (swig_ruby_data *)malloc(sizeof(swig_ruby_data));
+    d->ptr = 0;
+    d->mark = (RUBY_DATA_FUNC)sklass->mark;
+    d->free = (RUBY_DATA_FUNC)sklass->destroy;
+    obj = TypedData_Wrap_Struct(klass, &swig_ruby_data_type, d);
+  }
   rb_iv_set(obj, "@__swigtype__", rb_str_new2(type->name));
   return obj;
 }
@@ -251,9 +267,10 @@ typedef struct {
 SWIGRUNTIME swig_ruby_owntype
 SWIG_Ruby_AcquirePtr(VALUE obj, swig_ruby_owntype own) {
   swig_ruby_owntype oldown = {0, 0};
-  if (TYPE(obj) == T_DATA && !RTYPEDDATA_P(obj)) {
-    oldown.datafree = RDATA(obj)->dfree;
-    RDATA(obj)->dfree = own.datafree;
+  if (TYPE(obj) == T_DATA && RTYPEDDATA_P(obj)) {
+    swig_ruby_data *d = (swig_ruby_data *)RTYPEDDATA_DATA(obj);
+    oldown.datafree = d->free;
+    d->free = own.datafree;
   }
   return oldown;
 }
@@ -272,49 +289,51 @@ SWIG_Ruby_ConvertPtrAndOwn(VALUE obj, void **ptr, swig_type_info *ty, int flags,
       *ptr = 0;
     return (flags & SWIG_POINTER_NO_NULL) ? SWIG_NullReferenceError : SWIG_OK;
   } else {
-    if (TYPE(obj) != T_DATA || (TYPE(obj) == T_DATA && RTYPEDDATA_P(obj))) {
+    swig_ruby_data *d;
+    if (TYPE(obj) != T_DATA || !RTYPEDDATA_P(obj)) {
       return SWIG_ERROR;
     }
-    Data_Get_Struct(obj, void, vptr);
-  }
-  
-  if (own) {
-    own->datafree = RDATA(obj)->dfree;
-    own->own = 0;
-  }
-    
-  if (((flags & SWIG_POINTER_RELEASE) == SWIG_POINTER_RELEASE)) {
-    if (!RDATA(obj)->dfree)
-      return SWIG_ERROR_RELEASE_NOT_OWNED;
-  }
+    d = (swig_ruby_data *)RTYPEDDATA_DATA(obj);
+    vptr = d->ptr;
 
-  /* Check to see if the input object is giving up ownership
-     of the underlying C struct or C++ object.  If so then we
-     need to reset the destructor since the Ruby object no 
-     longer owns the underlying C++ object.*/ 
-  if (flags & SWIG_POINTER_DISOWN) {
-    /* Is tracking on for this class? */
-    int track = 0;
-    if (ty && ty->clientdata) {
-      swig_class *sklass = (swig_class *) ty->clientdata;
-      track = sklass->trackObjects;
+    if (own) {
+      own->datafree = d->free;
+      own->own = 0;
     }
 
-    if (track) {
-      /* We are tracking objects for this class.  Thus we change the destructor
-       * to SWIG_RubyRemoveTracking.  This allows us to
-       * remove the mapping from the C++ to Ruby object
-       * when the Ruby object is garbage collected.  If we don't
-       * do this, then it is possible we will return a reference 
-       * to a Ruby object that no longer exists thereby crashing Ruby. */
-      RDATA(obj)->dfree = SWIG_RubyRemoveTracking;
-    } else {    
-      RDATA(obj)->dfree = 0;
+    if (((flags & SWIG_POINTER_RELEASE) == SWIG_POINTER_RELEASE)) {
+      if (!d->free)
+        return SWIG_ERROR_RELEASE_NOT_OWNED;
     }
-  }
 
-  if (flags & SWIG_POINTER_CLEAR) {
-    DATA_PTR(obj) = 0;
+    /* Check to see if the input object is giving up ownership
+       of the underlying C struct or C++ object.  If so then we
+       need to reset the destructor since the Ruby object no
+       longer owns the underlying C++ object.*/
+    if (flags & SWIG_POINTER_DISOWN) {
+      /* Is tracking on for this class? */
+      int track = 0;
+      if (ty && ty->clientdata) {
+        swig_class *sklass = (swig_class *) ty->clientdata;
+        track = sklass->trackObjects;
+      }
+
+      if (track) {
+        /* We are tracking objects for this class.  Thus we change the destructor
+         * to SWIG_RubyRemoveTracking.  This allows us to
+         * remove the mapping from the C++ to Ruby object
+         * when the Ruby object is garbage collected.  If we don't
+         * do this, then it is possible we will return a reference
+         * to a Ruby object that no longer exists thereby crashing Ruby. */
+        d->free = SWIG_RubyRemoveTracking;
+      } else {
+        d->free = 0;
+      }
+    }
+
+    if (flags & SWIG_POINTER_CLEAR) {
+      d->ptr = 0;
+    }
   }
 
   /* Do type-checking if type info was provided */
@@ -411,7 +430,8 @@ SWIG_Ruby_GetModule(void *SWIGUNUSEDPARM(clientdata))
   /* first check if pointer already created */
   pointer = rb_gv_get("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME);
   if (pointer != Qnil) {
-    Data_Get_Struct(pointer, swig_module_info, ret);
+    swig_ruby_data *d = (swig_ruby_data *)RTYPEDDATA_DATA(pointer);
+    ret = (swig_module_info *)d->ptr;
   }
 
   /* reinstate warnings */
@@ -426,7 +446,13 @@ SWIG_Ruby_SetModule(swig_module_info *pointer)
   VALUE cl = rb_define_class("swig_runtime_data", rb_cObject);
   rb_undef_alloc_func(cl);
   /* create and store the structure pointer to a global variable */
-  swig_runtime_data_type_pointer = Data_Wrap_Struct(cl, 0, 0, pointer);
+  {
+    swig_ruby_data *d = (swig_ruby_data *)malloc(sizeof(swig_ruby_data));
+    d->ptr = pointer;
+    d->mark = 0;
+    d->free = 0;
+    swig_runtime_data_type_pointer = TypedData_Wrap_Struct(cl, &swig_ruby_data_type, d);
+  }
   rb_define_readonly_variable("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME, &swig_runtime_data_type_pointer);
 }
 

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -2434,6 +2434,8 @@ public:
     String *markfunc = Getattr(n, "feature:markfunc");
     if (markfunc) {
       Printf(klass->init, "SwigClass%s.mark = (void (*)(void *)) %s;\n", klass->name, markfunc);
+    } else if (Swig_directorclass(n)) {
+      Printf(klass->init, "SwigClass%s.mark = (void (*)(void *)) swig_mark_%s;\n", klass->name, klass->name);
     } else {
       Printf(klass->init, "SwigClass%s.mark = 0;\n", klass->name);
     }
@@ -2829,6 +2831,43 @@ public:
   }
 
   virtual int classDirectorEnd(Node *n) {
+    String *classname = Swig_class_name(n);
+    validate_const_name(Char(classname), "class");
+    String *classtype = SwigType_namestr(Getattr(n, "classtype"));
+
+    SwigType *smart = Getattr(n, "smart");
+    if (smart) {
+      String *smartnamestr = SwigType_namestr(smart);
+      Printf(f_directors_helpers,
+             "static void swig_mark_%s(void *ptr) {\n"
+             "  if (ptr) {\n"
+             "    %s *smartptr = reinterpret_cast<%s *>(ptr);\n"
+             "    %s *d = smartptr->get();\n"
+             "    if (d) {\n"
+             "      Swig::Director *dir = SWIG_DIRECTOR_CAST(d);\n"
+             "      if (dir) rb_gc_mark(dir->swig_get_self());\n"
+             "    }\n"
+             "  }\n"
+             "}\n\n",
+             classname,
+             smartnamestr,
+             smartnamestr,
+             classtype);
+      Delete(smartnamestr);
+    } else {
+      Printf(f_directors_helpers,
+             "static void swig_mark_%s(void *ptr) {\n"
+             "  %s *d = reinterpret_cast<%s *>(ptr);\n"
+             "  Swig::Director *dir = SWIG_DIRECTOR_CAST(d);\n"
+             "  if (dir) rb_gc_mark(dir->swig_get_self());\n"
+             "}\n\n",
+             classname,
+             classtype,
+             classtype);
+    }
+
+    Delete(classtype);
+    Delete(classname);
     Printf(f_directors_h, "};\n\n");
     return Language::classDirectorEnd(n);
   }


### PR DESCRIPTION
Ruby 3.4 marks the legacy Data_Wrap_Struct / Data_Get_Struct API as deprecated (via RUBY_UNTYPED_DATA_WARNING), generating compiler warnings that become errors under -Werror.

Replace all uses with the TypedData API:

- Add a swig_ruby_data wrapper struct that stores the wrapped pointer alongside per-object mark/free function pointers, since TypedData's static rb_data_type_t does not allow dynamic ownership transfers.
- Introduce a shared swig_ruby_data_type descriptor with generic mark/free/size callbacks that delegate through the wrapper.
- Redefine DATA_PTR to transparently unwrap through the wrapper so existing generated code and user typemaps using DATA_PTR continue to work unchanged.

Assisted-by: Claude Code (deepseek-v4-flash)