### PR TITLE
Ruby: Allocate the TypedData wrapper with TypedData_Make_Struct and use embedded data

### DIFF
--- a/Lib/ruby/rubyhead.swg
+++ b/Lib/ruby/rubyhead.swg
@@ -112,6 +112,9 @@
 #ifndef RTYPEDDATA_P
 # define RTYPEDDATA_P(x) (TYPE(x) != T_DATA)
 #endif
+#ifndef TYPED_DATA_EMBEDDED
+# define RTYPEDDATA_GET_DATA(x) RTYPEDDATA_DATA(x)
+#endif
 
 /* Wrapper attached to every SWIG TypedData object. It holds the wrapped pointer
    together with the per-object mark and free functions. The static rb_data_type_t

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -185,7 +185,9 @@ static void SWIG_Ruby_free_swig_type(void *data) {
   struct swig_ruby_wrapped_object *wrobj = (struct swig_ruby_wrapped_object *)data;
   if (wrobj->dfree)
     wrobj->dfree(wrobj->data);
-  free(wrobj);
+#ifndef RUBY_TYPED_EMBEDDABLE
+  ruby_xfree(wrobj);
+#endif
 }
 
 /* TypedData descriptor for the anonymous SWIG::TYPE* pointer wrappers (types
@@ -197,6 +199,9 @@ static const rb_data_type_t swig_type_data_type = {
   0, 0
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
   , RUBY_TYPED_FREE_IMMEDIATELY
+#ifdef RUBY_TYPED_EMBEDDABLE
+  || RUBY_TYPED_EMBEDDABLE
+#endif
 #endif
 };
 
@@ -238,11 +243,10 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
     }
 
     /* Create a new Ruby object */
-    wrobj = (struct swig_ruby_wrapped_object *)malloc(sizeof(struct swig_ruby_wrapped_object));
+    obj = TypedData_Make_Struct(sklass->klass, struct swig_ruby_wrapped_object, &sklass->cext_type, wrobj);
     wrobj->data = ptr;
     wrobj->dmark = sklass->mark;
     wrobj->dfree = own ? sklass->destroy : (track ? SWIG_RubyRemoveTracking : 0);
-    obj = TypedData_Wrap_Struct(sklass->klass, &sklass->cext_type, wrobj);
 
     /* If tracking is on for this class then track this object. */
     if (track) {
@@ -254,11 +258,11 @@ SWIG_Ruby_NewPointerObj(void *ptr, swig_type_info *type, int flags)
     SWIG_snprintf(klass_name, klass_len, "TYPE%s", type->name);
     klass = rb_const_get(_mSWIG, rb_intern(klass_name));
     free((void *) klass_name);
-    wrobj = (struct swig_ruby_wrapped_object *)malloc(sizeof(struct swig_ruby_wrapped_object));
+
+    obj = TypedData_Make_Struct(klass, struct swig_ruby_wrapped_object, &swig_type_data_type, wrobj);
     wrobj->data = ptr;
     wrobj->dmark = 0;
     wrobj->dfree = 0;
-    obj = TypedData_Wrap_Struct(klass, &swig_type_data_type, wrobj);
   }
   rb_iv_set(obj, "@__swigtype__", rb_str_new2(type->name));
 
@@ -270,12 +274,12 @@ SWIGRUNTIME VALUE
 SWIG_Ruby_NewClassInstance(VALUE klass, swig_type_info *type)
 {
   VALUE obj;
+  struct swig_ruby_wrapped_object *wrobj;
   swig_class *sklass = (swig_class *) type->clientdata;
-  struct swig_ruby_wrapped_object *wrobj = (struct swig_ruby_wrapped_object *)malloc(sizeof(struct swig_ruby_wrapped_object));
+  obj = TypedData_Make_Struct(klass, struct swig_ruby_wrapped_object, &sklass->cext_type, wrobj);
   wrobj->data = 0;
   wrobj->dmark = sklass->mark;
   wrobj->dfree = sklass->destroy;
-  obj = TypedData_Wrap_Struct(klass, &sklass->cext_type, wrobj);
   rb_iv_set(obj, "@__swigtype__", rb_str_new2(type->name));
   return obj;
 }
@@ -300,7 +304,7 @@ SWIGRUNTIME swig_ruby_owntype
 SWIG_Ruby_AcquirePtr(VALUE obj, swig_ruby_owntype own) {
   swig_ruby_owntype oldown = {0, 0};
   if (RB_TYPE_P(obj, RUBY_T_DATA) && RTYPEDDATA_P(obj)) {
-    struct swig_ruby_wrapped_object *wrobj = (struct swig_ruby_wrapped_object *)RTYPEDDATA_DATA(obj);
+    struct swig_ruby_wrapped_object *wrobj = (struct swig_ruby_wrapped_object *)RTYPEDDATA_GET_DATA(obj);
     oldown.datafree = wrobj->dfree;
     wrobj->dfree = own.datafree;
   }
@@ -322,7 +326,7 @@ SWIG_Ruby_ConvertPtrAndOwn(VALUE obj, void **ptr, swig_type_info *ty, int flags,
       *ptr = 0;
     return (flags & SWIG_POINTER_NO_NULL) ? SWIG_NullReferenceError : SWIG_OK;
   } else if (RB_TYPE_P(obj, RUBY_T_DATA) && RTYPEDDATA_P(obj)) {
-    wrobj = (struct swig_ruby_wrapped_object *)RTYPEDDATA_DATA(obj);
+    wrobj = (struct swig_ruby_wrapped_object *)RTYPEDDATA_GET_DATA(obj);
     vptr = wrobj->data;
   } else {
     return SWIG_ERROR;
@@ -453,7 +457,7 @@ SWIG_Ruby_ConvertPacked(VALUE obj, void *ptr, int sz, swig_type_info *ty) {
    SWIG version. */
 static const rb_data_type_t swig_runtime_data_type = {
   "swig_runtime_data" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME,
-  { 0, SWIG_Ruby_free_swig_type, 0, 0 },
+  { 0, 0, 0, 0 },
   0, 0
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
   , RUBY_TYPED_FREE_IMMEDIATELY
@@ -476,7 +480,8 @@ SWIG_Ruby_GetModule(void *SWIGUNUSEDPARM(clientdata))
     /* Each module defines its own swig_runtime_data_type, so the data is read
        directly rather than through TypedData_Get_Struct, which would reject a
        wrapper created by another module's (equivalent) descriptor. */
-    ret = (swig_module_info *)((struct swig_ruby_wrapped_object *)RTYPEDDATA_DATA(pointer))->data;
+    if (!RB_TYPE_P(pointer, RUBY_T_DATA)) rb_check_typeddata(pointer, &swig_runtime_data_type);
+    ret = (swig_module_info *)RTYPEDDATA_GET_DATA(pointer);
   }
 
   /* reinstate warnings */
@@ -489,13 +494,9 @@ SWIG_Ruby_SetModule(swig_module_info *pointer)
 {
   /* register a new class */
   VALUE cl = rb_define_class("swig_runtime_data", rb_cObject);
-  struct swig_ruby_wrapped_object *wrobj = (struct swig_ruby_wrapped_object *)malloc(sizeof(struct swig_ruby_wrapped_object));
+  swig_runtime_data_type_pointer = TypedData_Wrap_Struct(cl, &swig_runtime_data_type, pointer);
   rb_undef_alloc_func(cl);
   /* create and store the structure pointer to a global variable */
-  wrobj->data = pointer;
-  wrobj->dmark = 0;
-  wrobj->dfree = 0;
-  swig_runtime_data_type_pointer = TypedData_Wrap_Struct(cl, &swig_runtime_data_type, wrobj);
   rb_define_readonly_variable("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME, &swig_runtime_data_type_pointer);
 }
 

--- a/Lib/ruby/rubytracking.swg
+++ b/Lib/ruby/rubytracking.swg
@@ -111,7 +111,7 @@ SWIGRUNTIME void SWIG_RubyUnlinkObjects(void* ptr) {
     // object might have the T_ZOMBIE type, but that's just
     // because the GC has flagged it as such for a deferred
     // destruction. Until then, it's still a T_DATA object.
-    ((struct swig_ruby_wrapped_object *)RTYPEDDATA_DATA(object))->data = 0;
+    ((struct swig_ruby_wrapped_object *)RTYPEDDATA_GET_DATA(object))->data = 0;
   }
 }
 

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -1803,7 +1803,7 @@ public:
             Wrapper_add_local(f, result_name, result_var);
             Printf(action, "\n%s = new %s(%s);", result_name, SwigType_namestr(smart), Swig_cresult_name());
           }
-          Printf(action, "\n((struct swig_ruby_wrapped_object *)RTYPEDDATA_DATA(self))->data = %s;", result_name);
+          Printf(action, "\n((struct swig_ruby_wrapped_object *)RTYPEDDATA_GET_DATA(self))->data = %s;", result_name);
           if (GetFlag(pn, "feature:trackobjects")) {
             Printf(action, "\nSWIG_RubyAddTracking(%s, self);", result_name);
           }


### PR DESCRIPTION
Ruby-3.3+ allows to embed the wrapper data into the objects memory slot.
This is particular useful for SWIG since the `struct swig_ruby_wrapped_object` is a small and fixed size piece of memory.
Also the rest of the restrictions apply: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#c-struct-to-ruby-object

This commit reverts several changes of commit 98ea4cdf2db28dded4b365c4d984ab79453c2106 :

1. Revert allocation of `struct swig_ruby_wrapped_object` per `malloc`:

When using `TypedData_Make_Struct` the corresponding deallocation should call `ruby_xfree` instead of `free`.
That's the better fix than changing to `malloc` allocation.

2. RTYPEDDATA_DATA is reverted back to RTYPEDDATA_GET_DATA

Because RTYPEDDATA_GET_DATA was in preparation of using RUBY_TYPED_EMBEDDABLE.

3. Revert back to use plain pointer for `$swig_runtime_data_type_pointer`

Because there's no need an no advantage in using `struct swig_ruby_wrapped_object` for this object.
It's makes things only more complicated and needs more memory.

4. The simple type check of `$swig_runtime_data_type_pointer` was removed

It should be re-added as it protects for accident changes or GC issues.
