### PR TITLE
Ruby: Fix objects embedded data usage

### DIFF
--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -37,6 +37,7 @@ CPP_TEST_CASES = \
 	ruby_minherit_shared_ptr \
 	ruby_naming \
 	ruby_rdata \
+	ruby_typeddata_embedded \
 	ruby_track_objects \
 	ruby_track_objects_directors \
 	std_containers \

--- a/Examples/test-suite/ruby/ruby_typeddata_embedded_runme.rb
+++ b/Examples/test-suite/ruby/ruby_typeddata_embedded_runme.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+#
+# Verify that wrapped objects use Ruby's embedded TypedData slot on Ruby 3.3+.
+#
+
+require 'swig_assert'
+require 'ruby_typeddata_embedded'
+
+include Ruby_typeddata_embedded
+
+thing = Thing.new(42)
+swig_assert_equal(42, thing.value, binding)
+
+# From Ruby 3.3 the per-class descriptor enables RUBY_TYPED_EMBEDDABLE, so the
+# wrapper is embedded in the object slot. Without it the wrapper is malloc'd and
+# leaked, since the free callback no longer releases it.
+if RUBY_VERSION >= "3.3"
+  swig_assert(swig_wrapper_embedded(thing), binding, "wrapper should be embedded on Ruby >= 3.3")
+end

--- a/Examples/test-suite/ruby_typeddata_embedded.i
+++ b/Examples/test-suite/ruby_typeddata_embedded.i
@@ -1,0 +1,28 @@
+%module ruby_typeddata_embedded
+
+/* Regression test for the per-class TypedData wrapper using Ruby's embedded data
+   slot (RUBY_TYPED_EMBEDDABLE) on Ruby 3.3 and later. If the per-class cext_type
+   descriptor does not request embedding, the swig_ruby_wrapped_object is malloc'd
+   and, because the free callback skips ruby_xfree when embedding is compiled in,
+   leaked on every object. The runme checks that a wrapped object really is
+   embedded so the leak can not silently come back. */
+
+%inline %{
+class Thing {
+public:
+  int value;
+  Thing(int v) : value(v) {}
+};
+
+/* True when obj's TypedData wrapper is stored inside the Ruby object slot rather
+   than a separate allocation. Always false on Ruby older than 3.3, which has no
+   embedding support. */
+bool swig_wrapper_embedded(VALUE obj) {
+#ifdef TYPED_DATA_EMBEDDED
+  return RTYPEDDATA_EMBEDDED_P(obj) ? true : false;
+#else
+  (void)obj;
+  return false;
+#endif
+}
+%}

--- a/Lib/ruby/rubyhead.swg
+++ b/Lib/ruby/rubyhead.swg
@@ -118,18 +118,18 @@
 
 /* Flags shared by every rb_data_type_t that SWIG allocates with
    TypedData_Make_Struct, so the static descriptors and the per class cext_type
-   stay in step. RUBY_TYPED_FREE_IMMEDIATELY is a (self referential) macro back to
-   Ruby 2.1, hence the '#ifdef'. Ruby 3.3+ additionally defines TYPED_DATA_EMBEDDED
-   and can store the small, fixed size swig_ruby_wrapped_object inside the object
-   slot rather than a separate malloc; that embedding also needs FREE_IMMEDIATELY. */
+   stay in step. The rb_data_type_t flags member, and RUBY_TYPED_FREE_IMMEDIATELY,
+   only exist from Ruby 2.1, so this macro (and every use of it) is guarded by
+   '#ifdef RUBY_TYPED_FREE_IMMEDIATELY' and is simply absent on older Ruby. Ruby
+   3.3+ additionally defines TYPED_DATA_EMBEDDED and can store the small, fixed
+   size swig_ruby_wrapped_object inside the object slot rather than a separate
+   malloc; that embedding also needs FREE_IMMEDIATELY. */
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
 # ifdef TYPED_DATA_EMBEDDED
 #  define SWIG_RUBY_TYPED_DATA_FLAGS (RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_EMBEDDABLE)
 # else
 #  define SWIG_RUBY_TYPED_DATA_FLAGS (RUBY_TYPED_FREE_IMMEDIATELY)
 # endif
-#else
-# define SWIG_RUBY_TYPED_DATA_FLAGS 0
 #endif
 
 /* Wrapper attached to every SWIG TypedData object. It holds the wrapped pointer

--- a/Lib/ruby/rubyhead.swg
+++ b/Lib/ruby/rubyhead.swg
@@ -116,6 +116,22 @@
 # define RTYPEDDATA_GET_DATA(x) RTYPEDDATA_DATA(x)
 #endif
 
+/* Flags shared by every rb_data_type_t that SWIG allocates with
+   TypedData_Make_Struct, so the static descriptors and the per class cext_type
+   stay in step. RUBY_TYPED_FREE_IMMEDIATELY is a (self referential) macro back to
+   Ruby 2.1, hence the '#ifdef'. Ruby 3.3+ additionally defines TYPED_DATA_EMBEDDED
+   and can store the small, fixed size swig_ruby_wrapped_object inside the object
+   slot rather than a separate malloc; that embedding also needs FREE_IMMEDIATELY. */
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+# ifdef TYPED_DATA_EMBEDDED
+#  define SWIG_RUBY_TYPED_DATA_FLAGS (RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_EMBEDDABLE)
+# else
+#  define SWIG_RUBY_TYPED_DATA_FLAGS (RUBY_TYPED_FREE_IMMEDIATELY)
+# endif
+#else
+# define SWIG_RUBY_TYPED_DATA_FLAGS 0
+#endif
+
 /* Wrapper attached to every SWIG TypedData object. It holds the wrapped pointer
    together with the per-object mark and free functions. The static rb_data_type_t
    shared by a class can not carry per-object ownership, which changes as ownership

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -492,10 +492,13 @@ SWIG_Ruby_GetModule(void *SWIGUNUSEDPARM(clientdata))
 SWIGRUNTIME void 
 SWIG_Ruby_SetModule(swig_module_info *pointer)
 {
-  /* register a new class */
+  /* register a new class - undefine its allocator before wrapping an instance,
+     otherwise wrapping marks the class as a T_DATA class and Ruby 3.x warns when
+     the allocator is undefined afterwards. The class still can not be instantiated
+     from Ruby. */
   VALUE cl = rb_define_class("swig_runtime_data", rb_cObject);
-  swig_runtime_data_type_pointer = TypedData_Wrap_Struct(cl, &swig_runtime_data_type, pointer);
   rb_undef_alloc_func(cl);
+  swig_runtime_data_type_pointer = TypedData_Wrap_Struct(cl, &swig_runtime_data_type, pointer);
   /* create and store the structure pointer to a global variable */
   rb_define_readonly_variable("$swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME, &swig_runtime_data_type_pointer);
 }

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -185,7 +185,7 @@ static void SWIG_Ruby_free_swig_type(void *data) {
   struct swig_ruby_wrapped_object *wrobj = (struct swig_ruby_wrapped_object *)data;
   if (wrobj->dfree)
     wrobj->dfree(wrobj->data);
-#ifndef RUBY_TYPED_EMBEDDABLE
+#ifndef TYPED_DATA_EMBEDDED
   ruby_xfree(wrobj);
 #endif
 }
@@ -199,8 +199,8 @@ static const rb_data_type_t swig_type_data_type = {
   0, 0
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
   , RUBY_TYPED_FREE_IMMEDIATELY
-#ifdef RUBY_TYPED_EMBEDDABLE
-  || RUBY_TYPED_EMBEDDABLE
+#ifdef TYPED_DATA_EMBEDDED
+  | RUBY_TYPED_EMBEDDABLE
 #endif
 #endif
 };

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -196,13 +196,8 @@ static void SWIG_Ruby_free_swig_type(void *data) {
 static const rb_data_type_t swig_type_data_type = {
   "swig_type",
   { 0, SWIG_Ruby_free_swig_type, 0, 0 },
-  0, 0
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
-  , RUBY_TYPED_FREE_IMMEDIATELY
-#ifdef TYPED_DATA_EMBEDDED
-  | RUBY_TYPED_EMBEDDABLE
-#endif
-#endif
+  0, 0,
+  SWIG_RUBY_TYPED_DATA_FLAGS
 };
 
 /* Create a new pointer object */

--- a/Lib/ruby/rubyrun.swg
+++ b/Lib/ruby/rubyrun.swg
@@ -196,8 +196,10 @@ static void SWIG_Ruby_free_swig_type(void *data) {
 static const rb_data_type_t swig_type_data_type = {
   "swig_type",
   { 0, SWIG_Ruby_free_swig_type, 0, 0 },
-  0, 0,
-  SWIG_RUBY_TYPED_DATA_FLAGS
+  0, 0
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+  , SWIG_RUBY_TYPED_DATA_FLAGS
+#endif
 };
 
 /* Create a new pointer object */

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -2429,11 +2429,13 @@ public:
 
   /* Set up the per-class TypedData descriptor: named after the C++ class (so it is
      recognisable in Ruby heap dumps and ObjectSpace statistics) with the shared mark
-     and free callbacks. */
+     and free callbacks. The flags enable embedding of the wrapper on Ruby 3.3+, the
+     same as the anonymous swig_type_data_type descriptor. */
   void handleClassName(Node *) {
     Printf(klass->init, "SwigClass%s.cext_type.wrap_struct_name = \"C++ class %s\";\n", klass->name, klass->cname);
     Printf(klass->init, "SwigClass%s.cext_type.function.dmark = SWIG_Ruby_mark_swig_type;\n", klass->name);
     Printf(klass->init, "SwigClass%s.cext_type.function.dfree = SWIG_Ruby_free_swig_type;\n", klass->name);
+    Printf(klass->init, "SwigClass%s.cext_type.flags = SWIG_RUBY_TYPED_DATA_FLAGS;\n", klass->name);
   }
 
   /*

--- a/Source/Modules/ruby.cxx
+++ b/Source/Modules/ruby.cxx
@@ -2435,7 +2435,9 @@ public:
     Printf(klass->init, "SwigClass%s.cext_type.wrap_struct_name = \"C++ class %s\";\n", klass->name, klass->cname);
     Printf(klass->init, "SwigClass%s.cext_type.function.dmark = SWIG_Ruby_mark_swig_type;\n", klass->name);
     Printf(klass->init, "SwigClass%s.cext_type.function.dfree = SWIG_Ruby_free_swig_type;\n", klass->name);
+    Printf(klass->init, "#ifdef RUBY_TYPED_FREE_IMMEDIATELY\n");
     Printf(klass->init, "SwigClass%s.cext_type.flags = SWIG_RUBY_TYPED_DATA_FLAGS;\n", klass->name);
+    Printf(klass->init, "#endif\n");
   }
 
   /*


### PR DESCRIPTION
Sorry, I made a mistake in the last merge request!

Two things disabled objects embedded data usage:

1. RUBY_TYPED_EMBEDDABLE is no `define`, but only an `enum` in ruby-3.3 to 4.0. It will be a define in ruby-4.1, but to enable the feature we better check for TYPED_DATA_EMBEDDED which is defined in all rubies 3.3 and following. The ruby docs are a bit misleading about this: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#c-struct-to-ruby-object

2. RUBY_TYPED_EMBEDDABLE should be OR'ed bitwise to have an effect.