### PR TITLE
R: ensure Rpackage and DllName are DOH strings

### DIFF
--- a/Source/Modules/r.cxx
+++ b/Source/Modules/r.cxx
@@ -2592,12 +2592,12 @@ void R::main(int argc, char *argv[]) {
       Swig_mark_arg(i);
       i++;
       Swig_mark_arg(i);
-      Rpackage = argv[i];
+      Rpackage = NewString(argv[i]);
     } else if (strcmp(argv[i], "-dll") == 0) {
       Swig_mark_arg(i);
       i++;
       Swig_mark_arg(i);
-      DllName = argv[i];
+      DllName = NewString(argv[i]);
     } else if (strcmp(argv[i], "-help") == 0) {
       showUsage();
     } else if (strcmp(argv[i], "-namespace") == 0) {


### PR DESCRIPTION
## Summary

Fixes `DohCopy()` exiting with error when running SWIG's R module with the `-package` command-line option.

When one runs the latest SWIG with the `-r` option and passes `-package mypkg`, one will get this error:

```
Internal error: Attempt to copy a non-DOH object.
```

Older versions of SWIG, e.g. SWIG 4.0.2, would emit the following error and abort:

```
swig: ../../Source/DOH/base.c:71: DohCopy: Assertion `0' failed.
Aborted (core dumped)
```

The `-dll` option has luckily avoided this issue by never being the target of `DohCopy()`.

## Fix

In `Source/Modules/r.cxx` we just need to ensure `RPackage` is assigned a DOH object, i.e. `NewString(argv[i])`. We do the same thing for `DllName` for correctness despite `DllName` luckily never being manipulated after assignment.

## Reproduction

Using `Examples/r/simple/example.i` and assuming the locally built SWIG is in `build/swig`:

```
$ SWIG_LIB=./Lib ./build/swig -r -Ibuild -package mypkg -outdir . Examples/r/simple/example.i
Internal error: Attempt to copy a non-DOH object.
```

With the aforementioned change in `Source/Modules/r.cxx` the above invocation works correctly and `mypkg.R` is generated.