### PR TITLE
Fix deleting invalid string when parsing Doxygen grouping comments

### DIFF
--- a/Examples/test-suite/doxygen_misc_constructs.i
+++ b/Examples/test-suite/doxygen_misc_constructs.i
@@ -209,6 +209,13 @@
     // @name/@{ member grouping: @{ must not be discarded as part of the structural block,
     // and the member's own doc comment must still attach (regression guard for GitHub #3403 fix).
     struct GroupedMembers {
+      /// @name constants and types
+      //@{
+
+      enum WeekFlags { Sunday_First, Monday_First };
+
+      //@}
+
       //! @name Logging
       //! @{
 

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -753,9 +753,11 @@ static int yylook(void) {
                all accumulated content is file-scope and must be discarded, so that the next
                declaration's own doc comment is not polluted. */
             if (in_structural_block && endlines >= 2) {
-              Delete(yylval.str);
-              yylval.str = 0;
-              existing_comment = DOX_COMMENT_NONE;
+              if (existing_comment != DOX_COMMENT_NONE) {
+                Delete(yylval.str);
+                yylval.str = 0;
+                existing_comment = DOX_COMMENT_NONE;
+              }
               break;
             }
           }

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -739,11 +739,13 @@ static int yylook(void) {
           }
 
           int endlines = 0;
-          do {
+          for (;;) {
             tok = Scanner_token(scan);
-            if (tok == SWIG_TOKEN_ENDLINE)
-              endlines++;
-          } while (tok == SWIG_TOKEN_ENDLINE);
+            if (tok != SWIG_TOKEN_ENDLINE)
+              break;
+
+            endlines++;
+          }
 
           if (scan_doxygen_comments) {
             Delete(cmt_modified);

--- a/Source/CParse/cscanner.c
+++ b/Source/CParse/cscanner.c
@@ -737,13 +737,15 @@ static int yylook(void) {
               }
             }
           }
-          {
-            int endlines = 0;
-            do {
-              tok = Scanner_token(scan);
-              if (tok == SWIG_TOKEN_ENDLINE)
-                endlines++;
-            } while (tok == SWIG_TOKEN_ENDLINE);
+
+          int endlines = 0;
+          do {
+            tok = Scanner_token(scan);
+            if (tok == SWIG_TOKEN_ENDLINE)
+              endlines++;
+          } while (tok == SWIG_TOKEN_ENDLINE);
+
+          if (scan_doxygen_comments) {
             Delete(cmt_modified);
             /* A blank line (2+ newlines) after a structural block (@file, @page, ...) means
                all accumulated content is file-scope and must be discarded, so that the next


### PR DESCRIPTION
This fixes a fatal regression, see https://github.com/swig/swig/issues/3403