### PR TITLE
Improvements to wrapping classes as interfaces in C#/Java/JS

### DIFF
--- a/Doc/Manual/Java.html
+++ b/Doc/Manual/Java.html
@@ -3649,9 +3649,17 @@ added to the interface; they are of course still available in the Java proxy cla
 </p>
 
 <p>
-<b>C# note:</b> the C# interface works the same way, except that member variables are exposed as C# properties
-rather than as accessor methods. Member variables were first added to the interface in SWIG-4.5.0; earlier
-versions only added instance methods.
+Any class nested directly in a class marked as an interface is generated inside the Java interface rather than
+inside the proxy class. As a Java class inherits the member types of the interfaces it implements, such a nested
+class is then accessible both as <tt>InterfaceName.Nested</tt> and through any class implementing the interface,
+for example <tt>DerivedClass.Nested</tt>.
+</p>
+
+<p>
+<b>C# note:</b> the C# interface works the same way for member variables, except that they are exposed as C#
+properties rather than as accessor methods. Nested classes, however, are kept in the C# proxy class, as a C#
+interface cannot be used to access the nested types of an implementing class. Member variables were first added
+to the interface in SWIG-4.5.0; earlier versions only added instance methods.
 </p>
 
 <p>

--- a/Doc/Manual/Java.html
+++ b/Doc/Manual/Java.html
@@ -3648,6 +3648,13 @@ They are of course still available in the Java proxy class.
 </p>
 
 <p>
+<b>C# note:</b> unlike Java, C# interfaces can declare properties, so for C# the non-static member variables
+of the wrapped C++ class are additionally exposed as properties in the generated interface and can be accessed
+through an interface reference. Static methods, static variables, enums and constants are still only available
+in the C# proxy class as for Java. This was first added in SWIG-4.5.0.
+</p>
+
+<p>
 Wherever a class marked as an interface is used, such as the <tt>UseBases</tt> method in the example,
 the interface name is used as the type in the Java layer:
 </p>

--- a/Doc/Manual/Java.html
+++ b/Doc/Manual/Java.html
@@ -3642,16 +3642,16 @@ added to the proxy class implementing that interface.
 </p>
 
 <p>
-The Java interface only ever contains virtual and non-virtual instance methods from the wrapped C++ class.
-Any static methods, enums or variables in the wrapped C++ class are not supported and are not added to the interface.
-They are of course still available in the Java proxy class.
+The Java interface contains the virtual and non-virtual instance methods from the wrapped C++ class, plus the
+accessor methods generated for its non-static member variables, so that these variables can be accessed through
+an interface reference. Any static methods, static variables, enums or constants in the wrapped C++ class are not
+added to the interface; they are of course still available in the Java proxy class.
 </p>
 
 <p>
-<b>C# note:</b> unlike Java, C# interfaces can declare properties, so for C# the non-static member variables
-of the wrapped C++ class are additionally exposed as properties in the generated interface and can be accessed
-through an interface reference. Static methods, static variables, enums and constants are still only available
-in the C# proxy class as for Java. This was first added in SWIG-4.5.0.
+<b>C# note:</b> the C# interface works the same way, except that member variables are exposed as C# properties
+rather than as accessor methods. Member variables were first added to the interface in SWIG-4.5.0; earlier
+versions only added instance methods.
 </p>
 
 <p>

--- a/Examples/test-suite/csharp/multiple_inheritance_interfaces_runme.cs
+++ b/Examples/test-suite/csharp/multiple_inheritance_interfaces_runme.cs
@@ -92,5 +92,12 @@ public class multiple_inheritance_interfaces_runme {
     d.ia("bye", false);
 
     UndesirablesSwigImpl.UndesiredStaticMethod(UndesirablesSwigImpl.UndesiredEnum.UndesiredEnum1);
+
+    // Non-static member variables are exposed as properties in the interface, so they are
+    // accessible through an interface reference to a derived class.
+    Undesirables undesirables = new UndesirablesDerived();
+    undesirables.UndesiredVariable = 42;
+    if (undesirables.UndesiredVariable != 42)
+      throw new Exception("UndesiredVariable not accessible via the Undesirables interface");
   }
 }

--- a/Examples/test-suite/java/multiple_inheritance_interfaces_runme.java
+++ b/Examples/test-suite/java/multiple_inheritance_interfaces_runme.java
@@ -83,5 +83,12 @@ public class multiple_inheritance_interfaces_runme {
     d.ia("bye", false);
 
     UndesirablesSwigImpl.UndesiredStaticMethod(UndesirablesSwigImpl.UndesiredEnum.UndesiredEnum1);
+
+    // Member variable accessors are declared in the interface, so they are accessible through an
+    // interface reference to a derived class.
+    Undesirables undesirables = new UndesirablesDerived();
+    undesirables.setUndesiredVariable(42);
+    if (undesirables.getUndesiredVariable() != 42)
+      throw new RuntimeException("UndesiredVariable not accessible via the Undesirables interface");
   }
 }

--- a/Examples/test-suite/java/multiple_inheritance_interfaces_runme.java
+++ b/Examples/test-suite/java/multiple_inheritance_interfaces_runme.java
@@ -90,5 +90,11 @@ public class multiple_inheritance_interfaces_runme {
     undesirables.setUndesiredVariable(42);
     if (undesirables.getUndesiredVariable() != 42)
       throw new RuntimeException("UndesiredVariable not accessible via the Undesirables interface");
+
+    // A class nested in an interface class is emitted in the interface, so it is accessible through
+    // any class implementing the interface, e.g. as WithNestedDerived.Nested.
+    WithNestedDerived.Nested nested = new WithNestedDerived.Nested();
+    if (nested.getValue() != 42)
+      throw new RuntimeException("WithNested.Nested not accessible via the WithNested interface");
   }
 }

--- a/Examples/test-suite/javascript/multiple_inheritance_interfaces_runme.js
+++ b/Examples/test-suite/javascript/multiple_inheritance_interfaces_runme.js
@@ -1,0 +1,7 @@
+var mii = require("multiple_inheritance_interfaces");
+
+let undesirables = new mii.UndesirablesDerived();
+undesirables.UndesiredVariable = 42;
+if (undesirables.UndesiredVariable != 42) {
+    throw Error(`value=${undesirables.UndesiredVariable} instead of expected 42`);
+}

--- a/Examples/test-suite/multiple_inheritance_interfaces.i
+++ b/Examples/test-suite/multiple_inheritance_interfaces.i
@@ -66,7 +66,8 @@ struct V3 : IV1, IV2 {};
 #endif
 
 %inline %{
-// Don't put variables and enums into interface
+// Non-static member variables are exposed in the interface (as properties for C#), but static
+// members, enums and constants are not and remain available only via the proxy class.
 class Undesirables
 {
 public:

--- a/Examples/test-suite/multiple_inheritance_interfaces.i
+++ b/Examples/test-suite/multiple_inheritance_interfaces.i
@@ -178,3 +178,24 @@ struct IAdditional2 { virtual ~IAdditional2() {} };
 struct IAdditional3 : IAdditional1, IAdditional2 {};
 struct AdditionalConcrete : IAdditional1, IAdditional2 {};
 %}
+
+// A class nested in a class wrapped as an interface is emitted into the interface itself for Java, so
+// that it can be used through any class implementing the interface, e.g. WithNestedDerived.Nested.
+#if defined(SWIGJAVA)
+%interface_impl(WithNested);
+
+%inline %{
+struct WithNested {
+  struct Nested {
+    int getValue() { return 42; }
+  };
+  virtual ~WithNested() {}
+  virtual void withNestedMethod() {}
+};
+
+struct WithNestedDerived : WithNested {
+  virtual void withNestedMethod() {}
+};
+%}
+
+#endif

--- a/Examples/test-suite/multiple_inheritance_interfaces.i
+++ b/Examples/test-suite/multiple_inheritance_interfaces.i
@@ -66,8 +66,9 @@ struct V3 : IV1, IV2 {};
 #endif
 
 %inline %{
-// Non-static member variables are exposed in the interface (as properties for C#), but static
-// members, enums and constants are not and remain available only via the proxy class.
+// Non-static member variables are exposed in the interface (as properties for C# and as accessor
+// methods for Java), but static members, enums and constants are not and remain available only via
+// the proxy class.
 class Undesirables
 {
 public:

--- a/Lib/csharp/swiginterface.i
+++ b/Lib/csharp/swiginterface.i
@@ -36,7 +36,7 @@
 %typemap(csdirectorin) CTYPE *, CTYPE [] "($iminput == global::System.IntPtr.Zero) ? null : ($csinterfacename)new $csclassname($iminput, false)"
 %typemap(csdirectorin) CTYPE *const& "($iminput == global::System.IntPtr.Zero) ? null : ($*csinterfacename)new $*csclassname($iminput, false)"
 %typemap(csdirectorout) CTYPE, CTYPE *, CTYPE *const&, CTYPE [], CTYPE & "$cscall.GetInterfaceCPtr()"
-%typemap(csinterfacecode, declaration="  [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]\n  global::System.Runtime.InteropServices.HandleRef GetInterfaceCPtr();\n", cptrmethod="$interfacename_GetInterfaceCPtr") CTYPE %{
+%typemap(csinterfacecode, declaration="  [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]\n  $interfacenewglobal::System.Runtime.InteropServices.HandleRef GetInterfaceCPtr();\n", cptrmethod="$interfacename_GetInterfaceCPtr") CTYPE %{
   [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
   global::System.Runtime.InteropServices.HandleRef $csinterfacename.GetInterfaceCPtr() {
     return new global::System.Runtime.InteropServices.HandleRef(this, $imclassname.$csclazzname$interfacename_GetInterfaceCPtr(swigCPtr.Handle));

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -1919,9 +1919,9 @@ public:
              "(",
              classname,
              " *jarg1) {\n",
-             "    return (",
+             "    return static_cast<",
              baseclassname,
-             " *)jarg1;\n"
+             " *>(jarg1);\n"
              "}\n",
              "\n",
              NIL);

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -304,6 +304,8 @@ public:
 
     allow_overloading();
     Swig_interface_feature_enable();
+    // C# interfaces can declare properties, so expose member variables in them too.
+    Swig_interface_propagate_variables_enable();
   }
 
   /* ---------------------------------------------------------------------
@@ -2565,6 +2567,9 @@ public:
     String *terminator_code = NewString("");
     bool is_interface =
       GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable") && !static_flag && Getattr(n, "interface:owner") == 0;
+    // Non-static member variables of an interface class are declared as properties in the generated interface.
+    bool is_interface_variable = interface_class_code && GetFlag(parentNode(n), "feature:interface") && checkAttribute(n, "kind", "variable") && !static_flag &&
+                                 Getattr(n, "interface:owner") == 0;
 
     if (!proxy_flag)
       return;
@@ -2863,6 +2868,8 @@ public:
 
         // Start property declaration
         Printf(proxy_class_code, "  %s %s%s %s {", methodmods, static_flag ? "static " : "", variable_type, variable_name);
+        if (is_interface_variable)
+          Printf(interface_class_code, "  %s %s {", variable_type, variable_name);
       }
       generate_property_declaration_flag = false;
 
@@ -2881,6 +2888,8 @@ public:
         } else {
           Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(cvariable_type, 0));
         }
+        if (is_interface_variable)
+          Printf(interface_class_code, " set;");
       } else {
         // Getter method
         if ((tm = Swig_typemap_lookup("csvarout", n, "", 0))) {
@@ -2896,6 +2905,8 @@ public:
         } else {
           Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarout typemap defined for %s\n", SwigType_str(t, 0));
         }
+        if (is_interface_variable)
+          Printf(interface_class_code, " get;");
       }
     } else {
       // Normal function call
@@ -3182,6 +3193,8 @@ public:
 
     // End property declaration
     Printf(proxy_class_code, "\n  }\n\n");
+    if (interface_class_code && GetFlag(parentNode(n), "feature:interface") && Getattr(n, "interface:owner") == 0)
+      Printf(interface_class_code, " }\n");
 
     return SWIG_OK;
   }

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -2264,6 +2264,7 @@ public:
 
     String *additional = Getattr(n, "feature:interface:additional");
     String *bases = additional ? NewStringf(" : %s", additional) : 0;
+    bool has_interface_bases = false;
     if (List *baselist = Getattr(n, "bases")) {
       for (Iterator base = First(baselist); base.item; base = Next(base)) {
         if (GetFlag(base.item, "feature:ignore") || !GetFlag(base.item, "feature:interface"))
@@ -2275,6 +2276,7 @@ public:
           Append(bases, ", ");
           Append(bases, base_iname);
         }
+        has_interface_bases = true;
       }
     }
     if (bases) {
@@ -2288,7 +2290,9 @@ public:
     if (interface_code) {
       String *interface_declaration = Copy(Getattr(attributes, "tmap:csinterfacecode:declaration"));
       if (interface_declaration) {
+        // $interfacenew is a hack which gets replaced with "new" if the interface has a base interface and nothing otherwise.
         Replaceall(interface_declaration, "$interfacename", interface_name);
+        Replaceall(interface_declaration, "$interfacenew", has_interface_bases ? "new " : "");
         Printv(f_interface, interface_declaration, NIL);
         Delete(interface_declaration);
       }

--- a/Source/Modules/interface.cxx
+++ b/Source/Modules/interface.cxx
@@ -19,12 +19,20 @@
 
 static bool interface_feature_enabled = false;
 
+/* Whether member variables should be propagated to derived classes alongside methods. This is only
+ * wanted for languages whose interfaces can declare instance variables (e.g. C# properties), so it
+ * is enabled separately from the interface feature itself. */
+static bool interface_variables_enabled = false;
+
 /* -----------------------------------------------------------------------------
  * collect_interface_methods()
  *
  * Create a list of all the methods from the base classes of class n that are
  * marked as an interface. The resulting list is thus the list of methods that
  * need to be implemented in order for n to be non-abstract.
+ *
+ * When variable propagation is enabled, non-static member variables are
+ * collected too, so that derived classes can implement the interface property.
  * ----------------------------------------------------------------------------- */
 
 static List *collect_interface_methods(Node *n) {
@@ -38,7 +46,9 @@ static List *collect_interface_methods(Node *n) {
         if (Cmp(nodeType(child), "cdecl") == 0) {
           if (GetFlag(child, "feature:ignore") || Getattr(child, "interface:owner"))
             continue;  // skip methods propagated to bases
-          if (!checkAttribute(child, "kind", "function"))
+          bool is_function = checkAttribute(child, "kind", "function");
+          bool is_variable = interface_variables_enabled && checkAttribute(child, "kind", "variable");
+          if (!is_function && !is_variable)
             continue;
           if (checkAttribute(child, "storage", "static"))
             continue;  // accept virtual methods, non-virtual methods too... mmm??. Warn that the interface class has something that is not a virtual method?
@@ -211,4 +221,16 @@ void Swig_interface_propagate_methods(Node *n) {
 
 void Swig_interface_feature_enable() {
   interface_feature_enabled = true;
+}
+
+/* -----------------------------------------------------------------------------
+ * Swig_interface_propagate_variables_enable()
+ *
+ * Turn on propagation of member variables to derived classes so that they can
+ * be exposed as part of the interface. Only meaningful when the interface
+ * feature is also enabled.
+ * ----------------------------------------------------------------------------- */
+
+void Swig_interface_propagate_variables_enable() {
+  interface_variables_enabled = true;
 }

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -327,6 +327,8 @@ public:
 
     allow_overloading();
     Swig_interface_feature_enable();
+    // Member variables are wrapped as accessor methods which can be declared in a Java interface too.
+    Swig_interface_propagate_variables_enable();
   }
 
   /* ---------------------------------------------------------------------
@@ -2532,8 +2534,9 @@ public:
     bool setter_flag = false;
     String *pre_code = NewString("");
     String *post_code = NewString("");
-    bool is_interface =
-      GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable") && !static_flag && Getattr(n, "interface:owner") == 0;
+    // Member variables are wrapped as accessor methods, so they are declared in the interface like any other
+    // instance method (unlike C# where they are exposed as properties).
+    bool is_interface = GetFlag(parentNode(n), "feature:interface") && !static_flag && Getattr(n, "interface:owner") == 0;
 
     if (!proxy_flag)
       return;

--- a/Source/Modules/java.cxx
+++ b/Source/Modules/java.cxx
@@ -2403,13 +2403,20 @@ public:
       Replaceall(proxy_class_constants_code, "$imclassname", full_imclass_name);
       Replaceall(interface_class_code, "$imclassname", full_imclass_name);
 
+      // A class nested directly inside a class wrapped as an interface is emitted into the interface
+      // rather than the proxy class, so that it can be used as InterfaceName.Nested as well as via any
+      // class implementing the interface (a Java class inherits the member types of its interfaces).
+      String *outer_class_code = old_proxy_class_code;
+      if (has_outerclass && GetFlag(Getattr(n, "nested:outer"), "feature:interface"))
+        outer_class_code = old_interface_class_code;
+
       if (!has_outerclass)
         Printv(f_proxy, proxy_class_def, proxy_class_code, NIL);
       else {
         Swig_offset_string(proxy_class_def, nesting_depth);
-        Append(old_proxy_class_code, proxy_class_def);
+        Append(outer_class_code, proxy_class_def);
         Swig_offset_string(proxy_class_code, nesting_depth);
-        Append(old_proxy_class_code, proxy_class_code);
+        Append(outer_class_code, proxy_class_code);
       }
 
       // Write out all the constants
@@ -2418,7 +2425,7 @@ public:
           Printv(f_proxy, proxy_class_constants_code, NIL);
         else {
           Swig_offset_string(proxy_class_constants_code, nesting_depth);
-          Append(old_proxy_class_code, proxy_class_constants_code);
+          Append(outer_class_code, proxy_class_constants_code);
         }
       }
 
@@ -2428,8 +2435,8 @@ public:
         f_proxy = NULL;
       } else {
         for (int i = 0; i < nesting_depth; ++i)
-          Append(old_proxy_class_code, "  ");
-        Append(old_proxy_class_code, "}\n\n");
+          Append(outer_class_code, "  ");
+        Append(outer_class_code, "}\n\n");
         --nesting_depth;
       }
 

--- a/Source/Modules/javascript.cxx
+++ b/Source/Modules/javascript.cxx
@@ -625,6 +625,9 @@ void JAVASCRIPT::main(int argc, char *argv[]) {
   SWIG_config_file("javascript.swg");
 
   allow_overloading();
+  Swig_interface_feature_enable();
+  // JavaScript objects can declare properties, so expose member variables in them too.
+  Swig_interface_propagate_variables_enable();
 }
 
 /* -----------------------------------------------------------------------------

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -440,6 +440,7 @@ void Swig_nested_name_unnamed_c_structs(Node *n);
 
 /* Interface feature */
 void Swig_interface_feature_enable();
+void Swig_interface_propagate_variables_enable();
 void Swig_interface_propagate_methods(Node *n);
 
 /* Miscellaneous */


### PR DESCRIPTION
The main change here is to make any variables defined in the C++ base classes accessible via the interface in C#/Java when they were just completely lost before. For Java, any nested classes defined in these base classes are exported from the interface as well, but this is not done for C# because:

1. This is "only" available since C# 8 and so would require an option allowing to generate code requiring it.
2. Unlike Java, C# doesn't allow to refer to the nested classes defined in an interface using the derived class scope, which makes this much less useful, at least for my purposes.

Seeing that most of the recent changes in SWIG have been done by Claude, I've decided to use it for these changes too. FWIW I've reviewed all the changes in the first 3 commits but made only minor corrections to them, i.e. LLM-generated code looks fine to me.