### PR TITLE
Fix JavaScript and Scilab examples build on Ubuntu 26.04

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -787,7 +787,7 @@ ifeq (node,$(JSENGINE))
 	MAKEFLAGS= $(NODEGYP) --loglevel=silent configure build 1>>/dev/null
 else ifeq (napi,$(JSENGINE))
 	sed -e 's|$$srcdir|./$(SRCDIR)|g' $(SRCDIR)binding.gyp.in > binding.gyp
-	MAKEFLAGS= CXXFLAGS="$(CXXFLAGS) -I$(NAPI_DIR)" $(NODEGYP) --loglevel=silent configure build 1>>/dev/null
+	MAKEFLAGS= CXXFLAGS="$(CXXFLAGS) $(if $(NAPI_DIR),-I$(NAPI_DIR))" $(NODEGYP) --loglevel=silent configure build 1>>/dev/null
 else ifeq (v8,$(JSENGINE))
 	$(CXX) -c $(CCSHARED) $(CPPFLAGS) $(CXXFLAGS) $(ICXXSRCS) $(SRCDIR_SRCS) $(INCLUDES) $(JSINCLUDES)
 	$(CXXSHARED) $(CXXFLAGS) $(LDFLAGS) $(OBJS) $(IOBJS) $(JSDYNAMICLINKING) $(LIBS) $(CPP_DLLIBS) -o $(LIBPREFIX)$(TARGET)$(SO)
@@ -799,7 +799,7 @@ endif
 javascript_build_cpp: $(SRCDIR_SRCS)
 ifeq ($(JSENGINE), $(filter $(JSENGINE), node napi))
 	sed -e 's|$$srcdir|./$(SRCDIR)|g' $(SRCDIR)binding.gyp.in > binding.gyp
-	MAKEFLAGS= CXXFLAGS="$(CXXFLAGS) -I$(NAPI_DIR)" $(NODEGYP) --loglevel=silent configure build 1>>/dev/null
+	MAKEFLAGS= CXXFLAGS="$(CXXFLAGS) $(if $(NAPI_DIR),-I$(NAPI_DIR))" $(NODEGYP) --loglevel=silent configure build 1>>/dev/null
 else
 	$(CXX) -c $(CCSHARED) $(CPPFLAGS) $(CXXFLAGS) $(ICXXSRCS) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS) $(INCLUDES) $(JSINCLUDES)
 	$(CXXSHARED) $(CXXFLAGS) $(LDFLAGS) $(OBJS) $(IOBJS) $(JSDYNAMICLINKING) $(LIBS) $(CPP_DLLIBS) -o $(LIBPREFIX)$(TARGET)$(SO)
@@ -1559,7 +1559,9 @@ SCILAB_LIBPREFIX = lib
 
 scilab:
 	$(SWIG) -scilab $(SWIGOPT) -o $(ISRCS) $(INTERFACEPATH)
-	$(CC) -g -c $(CCSHARED) $(CPPFLAGS) $(CFLAGS) $(SCILAB_INC) $(INCLUDES) $(ISRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS)
+# -std=gnu17 works around Scilab's system mex.h which uses 'typedef int bool;',
+# rejected as an error by C23 (the default from gcc 15 / Ubuntu 26.04 onwards).
+	$(CC) -std=gnu17 -g -c $(CCSHARED) $(CPPFLAGS) $(CFLAGS) $(SCILAB_INC) $(INCLUDES) $(ISRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS)
 	$(LDSHARED) $(CFLAGS) $(LDFLAGS) $(IOBJS) $(OBJS) $(LIBS) -o $(SCILAB_LIBPREFIX)$(TARGET)$(SO)
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
## Problem

On Ubuntu 26.04 LTS (gcc 15.2.0, node-gyp 12.1.0, Node 22) `make check-examples` aborts. Two toolchain changes are responsible:

1. **gcc 15 defaults C to C23**, where `bool`/`true`/`false` are keywords.
2. **node-gyp now propagates the `CXXFLAGS` environment variable** into its compile commands.

## Fixes (both in `Examples/Makefile.in`)

**JavaScript** — `javascript_build` / `javascript_build_cpp` set `CXXFLAGS="... -I$(NAPI_DIR)"`. For the default `node` engine `NAPI_DIR` is empty, leaving a trailing bare `-I` that (now that node-gyp forwards CXXFLAGS) swallowed node-gyp's `-c`. The compile turned into a link and failed with `undefined reference to 'main'`. The `-I` is now only emitted when `NAPI_DIR` is set.

**Scilab** — Scilab's system `mex.h` uses `typedef int bool;`, a hard error under C23. The Scilab example wrappers are now compiled with `-std=gnu17`.

## Verification (Ubuntu 26.04)

- JavaScript examples: 13/13 build and run (were all failing).
- Scilab examples: 14/14 build (9 were failing).
- No regression in other languages.

## Known issues left unaddressed (not SWIG bugs)

- OCaml `toplevel` static examples (`shapes`, `string_from_ptr`) fail because OCaml 5.x removed the `Stream` module that camlp4o depends on. The dynamic OCaml examples pass; OCaml is an experimental target.
- Cosmetic warnings from Ruby 3.3 (`<cstdbool>` deprecation) and Perl 5.40 (`cBOOL` pointer cast) system headers; builds succeed.