### PR TITLE
Fix overload dispatch for classes with 'smartptr' feature

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -674,6 +674,7 @@ CPP11_TEST_CASES += \
 	cpp11_rvalue_reference3 \
 	cpp11_rvalue_reference_move \
 	cpp11_shared_ptr_const \
+	cpp11_shared_ptr_container \
 	cpp11_shared_ptr_crtp_upcast \
 	cpp11_shared_ptr_nullptr_in_containers \
 	cpp11_shared_ptr_overload \

--- a/Examples/test-suite/cpp11_shared_ptr_container.i
+++ b/Examples/test-suite/cpp11_shared_ptr_container.i
@@ -1,0 +1,19 @@
+%module cpp11_shared_ptr_container
+
+#if defined(SWIGC) || defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY) || defined(SWIGR) || defined(SWIGLUA)
+#define SHARED_PTR_WRAPPERS_IMPLEMENTED
+#endif
+
+#if defined(SHARED_PTR_WRAPPERS_IMPLEMENTED)
+%include <std_string.i>
+%include <std_vector.i>
+%include <std_shared_ptr.i>
+%shared_ptr(std::vector<std::string>)
+%template(StringVector) std::vector<std::string>;
+#endif
+
+%inline %{
+#include <string>
+#include <vector>
+#include <memory>
+%}

--- a/Examples/test-suite/python/cpp11_shared_ptr_container_runme.py
+++ b/Examples/test-suite/python/cpp11_shared_ptr_container_runme.py
@@ -1,0 +1,24 @@
+from cpp11_shared_ptr_container import StringVector
+from swig_test_utils import swig_check
+
+v = StringVector()
+
+v.append("hello")
+v.append("world")
+
+swig_check(v[0], "hello")
+swig_check(v[1], "world")
+
+v[0] = "foo"
+swig_check(v[0], "foo")
+
+v[1] = "bar"
+swig_check(v[1], "bar")
+
+v.append("baz")
+swig_check(v[2], "baz")
+
+x = v.pop()
+swig_check(x, "baz")
+
+swig_check(len(v), 2)

--- a/Source/Modules/emit.cxx
+++ b/Source/Modules/emit.cxx
@@ -216,6 +216,28 @@ void emit_attach_parmmaps(ParmList *l, Wrapper *f) {
       }
     }
   }
+
+  /* Override the typecheck typemap for the self parameter of a class
+   * that has a smart pointer. When %shared_ptr is used on a class, the
+   * target language proxy wraps the smart pointer rather than the
+   * underlying class, so the overload dispatch typecheck for self needs
+   * to use the smart pointer type descriptor. This is particularly
+   * important for STL container classes whose own typecheck typemaps
+   * (e.g. swig::asptr) take a higher precedence and would otherwise
+   * incorrectly check against the container type. */
+  {
+    Parm *p = l;
+    if (p && Getattr(p, "self") && Getattr(p, "smartptr")) {
+      SwigType *smart = Getattr(p, "smartptr");
+      SwigType *sp = Copy(smart);
+      SwigType_add_pointer(sp);
+      String *tm = NewStringf("int res = SWIG_ConvertPtr($input, 0, SWIGTYPE%s, 0);\n_v = SWIG_CheckState(res);", SwigType_manglestr(sp));
+      Setattr(p, "tmap:typecheck", tm);
+      Delattr(p, "tmap:typecheck:next");
+      Delete(tm);
+      Delete(sp);
+    }
+  }
 }
 
 /* -----------------------------------------------------------------------------

--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -944,6 +944,16 @@ int Swig_MethodToFunction(Node *n, const_String_or_char_ptr nspace, String *clas
   p = NewParm(type, "self", n);
   Setattr(p, "self", "1");
   Setattr(p, "hidden", "1");
+  /* If the class has a smart pointer, store the smart pointer type on
+   * the self parm so that emit_attach_parmmaps can generate a typecheck
+   * that uses the smart pointer descriptor for overload dispatch. */
+  {
+    Node *cls = parentNode(n);
+    if (cls && Strcmp(nodeType(cls), "extend") == 0)
+      cls = parentNode(cls);
+    if (cls && Getattr(cls, "smart"))
+      Setattr(p, "smartptr", Getattr(cls, "smart"));
+  }
   /*
      Disable the 'this' ownership in 'self' to manage inplace
      operations like:


### PR DESCRIPTION
When %shared_ptr wraps a class whose own typecheck typemaps (e.g. swig::asptr for STL containers) take higher precedence than the generic pointer typecheck, the overload dispatch incorrectly used the underlying class type rather than the smart pointer type for the 'self' parameter. This caused '__setitem__' (and similar) to fail with NotImplementedError.

Store the smart pointer type on the self parm node in Swig_MethodToFunction() and use it in emit_attach_parmmaps() to override the typecheck with SWIG_ConvertPtr using the correct smart pointer descriptor.

Closes #952