### PR TITLE
Restore Lua 5.1 support / LuaJIT support, including directors

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -122,6 +122,8 @@ jobs:
           VER: '12'
           CPPSTD: c++11
         - SWIGLANG: lua
+          VER: '5.1'
+        - SWIGLANG: lua
           VER: '5.2'
         - SWIGLANG: lua
           VER: '5.3'

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,11 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.5.0 (in progress)
 ===========================
 
+2026-07-12: wsfulton
+            [Lua] Restore support for Lua 5.1 and LuaJIT (which implements the
+            Lua 5.1 API) for non-director wrapping. Reverts part of #3394 which
+            dropped Lua 5.1 support.
+
 2026-07-11: wsfulton
             Fixed a protected or private nested class deriving from a class used
             elsewhere in the wrapped API producing a runtime upcast helper function

--- a/CHANGES.current
+++ b/CHANGES.current
@@ -8,6 +8,13 @@ Version 4.5.0 (in progress)
 ===========================
 
 2026-07-12: wsfulton
+            [Lua] Directors now work with Lua 5.1 and LuaJIT, which do not have the
+            Lua 5.2 uservalue functions ('lua_getuservalue'/'lua_setuservalue') used
+            to store the table of Lua method overrides for a director object. The
+            userdata environment functions that uservalues replaced
+            ('lua_getfenv'/'lua_setfenv') are used instead when wrapping for Lua 5.1.
+
+2026-07-12: wsfulton
             [Lua] Restore support for Lua 5.1 and LuaJIT (which implements the
             Lua 5.1 API) for non-director wrapping. Reverts part of #3394 which
             dropped Lua 5.1 support.

--- a/Doc/Manual/Lua.html
+++ b/Doc/Manual/Lua.html
@@ -102,7 +102,7 @@ eLua stands for Embedded Lua (can be thought of as a flavor of Lua) and offers t
 
 
 <p>
-The current SWIG implementation is designed to work with Lua version 5.2 and above. It is possible to either static link or dynamic link a Lua module into the interpreter (normally Lua static links its libraries, as dynamic linking is not available on all platforms).
+The current SWIG implementation is designed to work with Lua version 5.1 and above, including LuaJIT (which implements the Lua 5.1 API - see the "Extensions from Lua 5.2" section of the <a href="https://luajit.org/extensions.html">LuaJIT Extensions</a> page: "LuaJIT is API+ABI-compatible with Lua 5.1, which prevents implementing features that would otherwise break the Lua/C API and ABI"). Directors (see <a href="#Lua_directors">Cross language polymorphism using directors</a>) additionally require Lua 5.2 or later. It is possible to either static link or dynamic link a Lua module into the interpreter (normally Lua static links its libraries, as dynamic linking is not available on all platforms).
 SWIG has experimental support for eLua from version 0.8 onwards.
 </p>
 
@@ -270,7 +270,7 @@ $ gcc -fPIC -c example.c -o example.o
 $ gcc -shared -I/usr/include/lua -L/usr/lib/lua example_wrap.o example.o -o example.so
 </pre></div>
 <p>
-The wrappers produced by SWIG can be compiled and linked with Lua 5.2 and later. The loading is extremely simple.
+The wrappers produced by SWIG can be compiled and linked with Lua 5.1 and later, including LuaJIT. The loading is extremely simple.
 </p>
 <div class="targetlang"><pre>
 require("example")
@@ -2131,6 +2131,9 @@ that make it easy to set up these overrides without needing to understand the un
 <H3><a name="Lua_directors_enabling">29.8.1 Enabling directors</a></H3>
 
 
+<p>
+Directors require Lua 5.2 or later (unlike the rest of SWIG's Lua support, which works with Lua 5.1 and later); they are not supported with Lua 5.1 or LuaJIT, since LuaJIT is API+ABI-compatible with Lua 5.1 only (see <a href="https://luajit.org/extensions.html">luajit.org</a>) and does not provide the Lua 5.2 <code>lua_setuservalue()</code> function that directors rely on.
+</p>
 <p>
 The director feature is disabled by default. To use directors you must make two changes to the interface file.
 First, add the "directors" option to the %module directive:

--- a/Doc/Manual/Lua.html
+++ b/Doc/Manual/Lua.html
@@ -102,7 +102,11 @@ eLua stands for Embedded Lua (can be thought of as a flavor of Lua) and offers t
 
 
 <p>
-The current SWIG implementation is designed to work with Lua version 5.1 and above, including LuaJIT (which implements the Lua 5.1 API - see the "Extensions from Lua 5.2" section of the <a href="https://luajit.org/extensions.html">LuaJIT Extensions</a> page: "LuaJIT is API+ABI-compatible with Lua 5.1, which prevents implementing features that would otherwise break the Lua/C API and ABI"). Directors (see <a href="#Lua_directors">Cross language polymorphism using directors</a>) additionally require Lua 5.2 or later. It is possible to either static link or dynamic link a Lua module into the interpreter (normally Lua static links its libraries, as dynamic linking is not available on all platforms).
+The current SWIG implementation is designed to work with Lua version 5.1 and above, including LuaJIT (which implements the Lua 5.1 API - see the
+"Extensions from Lua 5.2" section of the <a href="https://luajit.org/extensions.html">LuaJIT Extensions</a> page: "LuaJIT is API+ABI-compatible
+with Lua 5.1, which prevents implementing features that would otherwise break the Lua/C API and ABI").
+It is possible to either static link or dynamic link a Lua module into the interpreter (normally Lua static links its libraries, as dynamic linking
+is not available on all platforms).
 SWIG has experimental support for eLua from version 0.8 onwards.
 </p>
 
@@ -2131,9 +2135,6 @@ that make it easy to set up these overrides without needing to understand the un
 <H3><a name="Lua_directors_enabling">29.8.1 Enabling directors</a></H3>
 
 
-<p>
-Directors require Lua 5.2 or later (unlike the rest of SWIG's Lua support, which works with Lua 5.1 and later); they are not supported with Lua 5.1 or LuaJIT, since LuaJIT is API+ABI-compatible with Lua 5.1 only (see <a href="https://luajit.org/extensions.html">luajit.org</a>) and does not provide the Lua 5.2 <code>lua_setuservalue()</code> function that directors rely on.
-</p>
 <p>
 The director feature is disabled by default. To use directors you must make two changes to the interface file.
 First, add the "directors" option to the %module directive:

--- a/Examples/lua/embed/embed.c
+++ b/Examples/lua/embed/embed.c
@@ -25,7 +25,8 @@ extern int luaopen_example(lua_State*L);
 */
 int dostring(lua_State *L, char* str) {
   int ok = luaL_dostring(L,str);
-  if (ok != LUA_OK)
+  /* luaL_dostring() returns 0 on success in all Lua versions; LUA_OK is Lua 5.2 and later only */
+  if (ok != 0)
     printf("[C] ERROR in dostring: %s\n",lua_tostring(L,-1));
   return ok;
 }

--- a/Examples/test-suite/lua/helpers.lua
+++ b/Examples/test-suite/lua/helpers.lua
@@ -1,6 +1,7 @@
 -- The following global functions are available for all tests in the test-suite
 function catch_undef_globs() -- catch "undefined" global variables
-setmetatable(_ENV, {__index=function (t,i) error("undefined global variable `"..i.."'",2) end})
+-- use _G rather than _ENV, as _ENV is Lua 5.2 and later only; both name the same table here
+setmetatable(_G, {__index=function (t,i) error("undefined global variable `"..i.."'",2) end})
 end
 function require_to_globs(name)
 local module = require(name)

--- a/Examples/test-suite/lua/li_cdata_bytes_cpp_runme.lua
+++ b/Examples/test-suite/lua/li_cdata_bytes_cpp_runme.lua
@@ -10,7 +10,9 @@ for i=0,0xff do
 end
 local s2=''
 for i=1,0x100 do
-  local d = string.format("%c", 0x100 - i)
+  -- use string.char rather than string.format("%c", ...), as the latter yields an
+  -- empty string for a NUL byte in Lua 5.1 (it applies strlen() to the formatted result)
+  local d = string.char(0x100 - i)
   s2 = s2 .. d
 end
 s = s2 .. s2

--- a/Examples/test-suite/lua/li_cdata_bytes_runme.lua
+++ b/Examples/test-suite/lua/li_cdata_bytes_runme.lua
@@ -10,7 +10,9 @@ for i=0,0xff do
 end
 local s2=''
 for i=1,0x100 do
-  local d = string.format("%c", 0x100 - i)
+  -- use string.char rather than string.format("%c", ...), as the latter yields an
+  -- empty string for a NUL byte in Lua 5.1 (it applies strlen() to the formatted result)
+  local d = string.char(0x100 - i)
   s2 = s2 .. d
 end
 s = s2 .. s2

--- a/Lib/lua/director.swg
+++ b/Lib/lua/director.swg
@@ -15,6 +15,68 @@
 /* Macro to cast a pointer to a director class */
 #define SWIG_DIRECTOR_CAST(PTR) (dynamic_cast<Swig::Director*>(PTR))
 
+/* -----------------------------------------------------------------------------
+ * uservalue compatibility
+ *
+ * A director object stores the table of Lua method overrides for the object in the userdata's
+ * uservalue. Uservalues were added in Lua 5.2, replacing the userdata environments of Lua 5.1, so use
+ * the environment functions when wrapping for Lua 5.1 (this includes LuaJIT, which implements the Lua
+ * 5.1 API).
+ *
+ * The two are not quite interchangeable though. A new userdata has no uservalue (nil) in Lua 5.2 and
+ * later, but in Lua 5.1 it inherits the environment of the C function creating it, which is a table
+ * shared by every userdata the module creates (Lua's 'package' table, as it happens, inherited via the
+ * loader that ran luaopen_). Storing the overrides in that table would share them between all objects
+ * and corrupt the table. Mark the tables created here so that they can be told apart from an inherited
+ * environment, and report an unmarked environment as no uservalue, that is nil, matching Lua 5.2.
+ * ----------------------------------------------------------------------------- */
+#if LUA_VERSION_NUM >= 502
+# define SWIG_lua_getuservalue(L, idx) lua_getuservalue(L, idx)
+# define SWIG_lua_setuservalue(L, idx) lua_setuservalue(L, idx)
+#else
+/* Key marking a table as one created below. Not a valid C++ method name, so it cannot clash with an override. */
+# define SWIG_LUA_DIRECTOR_USERVALUE_KEY ".swig_director_overrides"
+
+SWIGINTERN SWIGUNUSED void SWIG_lua_getuservalue(lua_State *L, int idx) {
+  lua_getfenv(L, idx);
+  if (!lua_istable(L, -1)) {
+    lua_pop(L, 1);
+    lua_pushnil(L);
+    return;
+  }
+  lua_pushliteral(L, SWIG_LUA_DIRECTOR_USERVALUE_KEY);
+  lua_rawget(L, -2);
+  if (lua_isnil(L, -1)) {
+    lua_pop(L, 2); /* an inherited environment, not a table of overrides */
+    lua_pushnil(L);
+  } else {
+    lua_pop(L, 1); /* drop the marker, leaving the table of overrides */
+  }
+}
+
+SWIGINTERN SWIGUNUSED void SWIG_lua_setuservalue(lua_State *L, int idx) {
+  /* mark the table, so that SWIG_lua_getuservalue() can tell it apart from an inherited environment */
+  lua_pushliteral(L, SWIG_LUA_DIRECTOR_USERVALUE_KEY);
+  lua_pushboolean(L, 1);
+  lua_rawset(L, -3);
+  lua_setfenv(L, idx);
+}
+#endif
+
+/* Push the Lua override function for the named method of the director object at obj_idx,
+   or nil if the object has no override for the method. */
+SWIGINTERN SWIGUNUSED void SWIG_Lua_get_director_override(lua_State *L, int obj_idx, const char *method_name) {
+  SWIG_lua_getuservalue(L, obj_idx);
+  if (lua_istable(L, -1)) {
+    lua_pushstring(L, method_name);
+    lua_rawget(L, -2);
+    lua_remove(L, -2); /* remove the uservalue table, leaving the override or nil */
+  } else {
+    lua_pop(L, 1);
+    lua_pushnil(L);
+  }
+}
+
 namespace Swig {
 
   /* memory handler */
@@ -376,12 +438,12 @@ SWIGINTERN int SWIG_Lua_director_override(lua_State *L) {
   }
   
   /* Get or create the uservalue table */
-  lua_getuservalue(L, 1);
+  SWIG_lua_getuservalue(L, 1);
   if (lua_isnil(L, -1)) {
     lua_pop(L, 1);
     lua_newtable(L);
-    lua_pushvalue(L, -1); /* duplicate for setuservalue */
-    lua_setuservalue(L, 1);
+    lua_pushvalue(L, -1); /* duplicate for SWIG_lua_setuservalue */
+    SWIG_lua_setuservalue(L, 1);
   }
   
   /* Set the method override in the uservalue table */
@@ -407,7 +469,7 @@ SWIGINTERN int SWIG_Lua_director_get_override(lua_State *L) {
   }
   
   /* Get the uservalue table */
-  lua_getuservalue(L, 1);
+  SWIG_lua_getuservalue(L, 1);
   if (lua_isnil(L, -1)) {
     /* No uservalue, return nil */
     return 1;
@@ -433,12 +495,12 @@ SWIGINTERN int SWIG_Lua_director_derive(lua_State *L) {
   }
   
   /* Get or create the uservalue table */
-  lua_getuservalue(L, 1);
+  SWIG_lua_getuservalue(L, 1);
   if (lua_isnil(L, -1)) {
     lua_pop(L, 1);
     lua_newtable(L);
-    lua_pushvalue(L, -1); /* duplicate for setuservalue */
-    lua_setuservalue(L, 1);
+    lua_pushvalue(L, -1); /* duplicate for SWIG_lua_setuservalue */
+    SWIG_lua_setuservalue(L, 1);
   }
   
   /* Iterate over the overrides table and copy to uservalue */

--- a/Lib/lua/director.swg
+++ b/Lib/lua/director.swg
@@ -340,67 +340,6 @@ namespace Swig {
       return own;
     }
   };
-
-  /* helper function to check if a method exists in a Lua table/userdata */
-  inline bool SWIG_Lua_director_has_method(lua_State *L, int idx, const char *method_name) {
-    bool has_method = false;
-    int top = lua_gettop(L);
-    
-    lua_pushvalue(L, idx);
-    lua_pushstring(L, method_name);
-    lua_gettable(L, -2);
-    
-    if (lua_isfunction(L, -1)) {
-      has_method = true;
-    }
-    
-    lua_settop(L, top);
-    return has_method;
-  }
-
-  /* helper function to call a Lua method on an object */
-  inline int SWIG_Lua_director_call_method(lua_State *L, int obj_idx, const char *method_name, int nargs, int nresults) {
-    /* Get the method from the object */
-    lua_pushvalue(L, obj_idx);
-    lua_pushstring(L, method_name);
-    lua_gettable(L, -2);
-    
-    if (!lua_isfunction(L, -1)) {
-      lua_pop(L, 2); /* pop nil/non-function and object copy */
-      std::string msg = "Method '";
-      msg += method_name;
-      msg += "' not found in Lua object";
-      DirectorMethodException::raise(msg.c_str());
-      return 0;
-    }
-    
-    /* Remove the extra object copy, keep the function */
-    lua_remove(L, -2);
-    
-    /* Push self (the object) as first argument */
-    lua_pushvalue(L, obj_idx);
-    
-    /* Move the additional arguments below self */
-    if (nargs > 0) {
-      /* Move self after the arguments */
-      lua_insert(L, -(nargs + 1));
-      /* Move function before self and arguments */
-      lua_insert(L, -(nargs + 2));
-    }
-    
-    /* Call the method with nargs + 1 (including self) */
-    if (lua_pcall(L, nargs + 1, nresults, 0) != 0) {
-      std::string error = "Error calling director method '";
-      error += method_name;
-      error += "': ";
-      error += lua_tostring(L, -1);
-      lua_pop(L, 1);
-      DirectorMethodException::raise(error.c_str());
-      return 0;
-    }
-    
-    return 1;
-  }
 }
 
 /* director disown support for classes */

--- a/Lib/lua/luarun.swg
+++ b/Lib/lua/luarun.swg
@@ -132,6 +132,37 @@ typedef struct swig_elua_entry {
 #endif
 #endif /* SWIG_LUA_ELUA_EMULATE*/
 
+/* -----------------------------------------------------------------------------
+ * Compatibility defines for supporting Lua 5.1.
+ *
+ * Note that LuaJIT, which implements the Lua 5.1 API and does not define Lua 5.2
+ * additions. See the "Extensions from Lua 5.2" section of
+ * https://luajit.org/extensions.html: "LuaJIT is API+ABI-compatible with Lua 5.1 ..."
+ * ----------------------------------------------------------------------------- */
+
+/* lua_rawlen() was named lua_objlen() in Lua 5.1. */
+#if LUA_VERSION_NUM == 501
+# define lua_rawlen lua_objlen
+#endif
+
+/* lua_pushglobaltable is the recommended "future-proof" way to get the global
+   table for Lua 5.2 and later; define it for Lua 5.1. */
+#if LUA_VERSION_NUM < 502
+# define lua_pushglobaltable(L) lua_pushvalue(L, LUA_GLOBALSINDEX)
+#endif
+
+/* lua_rawsetp/lua_rawgetp were introduced in Lua 5.2; define them for Lua 5.1. */
+#if LUA_VERSION_NUM < 502
+#define lua_rawsetp(L,index,ptr)\
+  lua_pushlightuserdata(L,(void*)(ptr));\
+  lua_insert(L,-2);\
+  lua_rawset(L,index);
+
+#define lua_rawgetp(L,index,ptr)\
+  lua_pushlightuserdata(L,(void*)(ptr));\
+  lua_rawget(L,index);
+#endif
+
 /* --------------------------------------------------------------------------
  * Helper functions for error handling
  * -------------------------------------------------------------------------- */
@@ -1865,7 +1896,7 @@ SWIG_Lua_dostring(lua_State *L, const char *str) {
   if (str==0 || str[0]==0) return 0; /* nothing to do */
   top=lua_gettop(L); /* save stack */
   ok=luaL_dostring(L,str);
-  if (ok!=LUA_OK) {
+  if (ok!=0) {
     SWIG_DOSTRING_FAIL(lua_tostring(L,-1));
   }
   lua_settop(L,top); /* restore the stack */

--- a/Source/Modules/lua.cxx
+++ b/Source/Modules/lua.cxx
@@ -2742,21 +2742,8 @@ public:
       Printf(w->code, "}\n");
       Printf(w->code, "int obj_idx = lua_gettop(L);\n");
 
-      /* Get method from object - first try uservalue table, then metatable */
-      Printf(w->code, "lua_getuservalue(L, obj_idx);\n");
-      Printf(w->code, "if (lua_istable(L, -1)) {\n");
-      Printf(w->code, "  lua_pushstring(L, \"%s\");\n", symname);
-      Printf(w->code, "  lua_rawget(L, -2);\n");
-      Printf(w->code, "  if (!lua_isfunction(L, -1)) {\n");
-      Printf(w->code, "    lua_pop(L, 2); /* pop nil and uservalue table */\n");
-      Printf(w->code, "    lua_pushnil(L); /* placeholder for consistency */\n");
-      Printf(w->code, "  } else {\n");
-      Printf(w->code, "    lua_remove(L, -2); /* remove uservalue table, keep function */\n");
-      Printf(w->code, "  }\n");
-      Printf(w->code, "} else {\n");
-      Printf(w->code, "  lua_pop(L, 1); /* pop non-table uservalue */\n");
-      Printf(w->code, "  lua_pushnil(L); /* placeholder */\n");
-      Printf(w->code, "}\n");
+      /* Get the Lua method override for this object, or nil if there is none */
+      Printf(w->code, "SWIG_Lua_get_director_override(L, obj_idx, \"%s\");\n", symname);
       Printf(w->code, "if (!lua_isfunction(L, -1)) {\n");
       Printf(w->code, "  lua_pop(L, 1); /* pop placeholder */\n");
       Printf(w->code, "  lua_settop(L, top);\n");

--- a/Tools/CI-linux-install.sh
+++ b/Tools/CI-linux-install.sh
@@ -117,7 +117,12 @@ case "$SWIGLANG" in
 		$RETRY sudo apt-get -qq install guile-${VER:-2.2}-dev
 		;;
 	"lua")
-		$RETRY sudo apt-get -qq install lua${VER} liblua${VER}-dev
+		if [[ "$VER" = "5.1" ]]; then
+			# Ubuntu names the Lua 5.1 dev package irregularly, unlike every other version
+			$RETRY sudo apt-get -qq install lua5.1 liblua5.1-0-dev
+		else
+			$RETRY sudo apt-get -qq install lua${VER} liblua${VER}-dev
+		fi
 		;;
 	"ocaml")
 		$RETRY sudo apt-get -qq install ocaml camlp4

--- a/configure.ac
+++ b/configure.ac
@@ -1493,7 +1493,6 @@ if test "x$LUABIN" = xyes; then
 fi
 
 # Check version of Lua found and only accept the supported versions - 5.1 and later.
-# Directors are the exception, requiring Lua 5.2 or later as they use lua_setuservalue().
 LUA_MINVER='5.1'
 if test -n "$LUABIN"; then
   AC_MSG_CHECKING([Lua version])

--- a/configure.ac
+++ b/configure.ac
@@ -1489,11 +1489,12 @@ else
 if test "x$LUABIN" = xyes; then
    # We look for a versioned Lua binary first, as there can be
    # multiple versions of Lua installed on some systems (like Debian).
-   AC_PATH_PROGS(LUABIN, [lua5.5 lua5.4 lua5.3 lua5.2 lua])
+   AC_PATH_PROGS(LUABIN, [lua5.5 lua5.4 lua5.3 lua5.2 lua5.1 lua])
 fi
 
-# check version: we need Lua 5.2 or above
-LUA_MINVER='5.2'
+# Check version of Lua found and only accept the supported versions - 5.1 and later.
+# Directors are the exception, requiring Lua 5.2 or later as they use lua_setuservalue().
+LUA_MINVER='5.1'
 if test -n "$LUABIN"; then
   AC_MSG_CHECKING([Lua version])
   AS_VAR_SET([LUA_VERSION], [`$LUABIN -e 'print(string.match(_VERSION, "%d+[.]%d+"))'`])


### PR DESCRIPTION
Restores Lua 5.1 and LuaJIT support, which #3394 dropped, and extends it to directors,
which have never worked with Lua 5.1. Lua 5.1 is now tested in CI so this cannot regress
silently again.

## Why

74ff929bd (#3394) removed the compatibility defines for `lua_rawlen`,
`lua_pushglobaltable` and `lua_rawsetp`/`lua_rawgetp` from `Lib/lua/luarun.swg`. These are
in the runtime compiled into **every** generated Lua wrapper, not just those using
directors, so any SWIG generated Lua module now fails to compile against Lua 5.1 or
LuaJIT:

```
swigluarun.h:1555:19: error: implicit declaration of function 'lua_rawlen'
```

Found by a Fedora COPR mass rebuild against SWIG master: obs-studio's Lua bindings, which
are compiled against LuaJIT, failed to build.

#3394 removed more than its actual blocker, which was that directors use
`lua_setuservalue()`, added in Lua 5.2. Dropping Lua 5.1 was accepted on the grounds it
was old and untestable; both turn out to be avoidable. LuaJIT will not grow these
functions - it is
[API+ABI-compatible with Lua 5.1](https://luajit.org/extensions.html), and
`LUAJIT_ENABLE_LUA52COMPAT` only adds Lua level features, never Lua/C API additions.

## What

1. **Restore the compatibility defines**, for Lua 5.1 and later only (the Lua 5.0 shims
   are not restored). `configure.ac` accepts Lua 5.1 again - this only governs which Lua
   the test-suite and examples run against, as Lua is not needed to build SWIG itself.
   Also fixes the examples and test-suite where they themselves used Lua 5.2 only features
   (`LUA_OK`, `_ENV`, and `string.format("%c", ...)`, which drops NUL bytes in Lua 5.1).

2. **Director support for Lua 5.1**, using the userdata environments that uservalues
   replaced. Note `lua_getuservalue` cannot simply be defined to `lua_getfenv`: a new
   userdata has no uservalue in Lua 5.2, but in Lua 5.1 it inherits its creator's
   environment - Lua's `package` table, shared by every userdata the module creates - so
   the overrides would be shared between all objects and corrupt that table. The override
   tables are therefore marked, and an unmarked environment reported as nil.

3. **Remove two unused director helpers**. No change to generated code.

## Testing

- New Lua 5.1 job in the Linux GHA matrix.
- Not covered: running the test-suite under LuaJIT itself. That needs build system work
  (Ubuntu's `libluajit-5.1-dev` ships only a static, non-PIC library, so a shared module
  cannot link it) so we rely on the Lua 5.1 only testing.

@erezgeva, could you please review before I merge.