### PR TITLE
Fix li_stdint test

### DIFF
--- a/Examples/test-suite/li_stdint.i
+++ b/Examples/test-suite/li_stdint.i
@@ -18,10 +18,10 @@
   int16_t  int16_td(int16_t i) { return i; }
   int32_t  int32_td(int32_t i) { return i; }
   int64_t  int64_td(int64_t i) { return i; }
-  uint8_t  uint8_td (int8_t  i) { return i; }
-  uint16_t uint16_td(int16_t i) { return i; }
-  uint32_t uint32_td(int32_t i) { return i; }
-  uint64_t uint64_td(int64_t i) { return i; }
+  uint8_t  uint8_td(uint8_t  i) { return i; }
+  uint16_t uint16_td(uint16_t i) { return i; }
+  uint32_t uint32_td(uint32_t i) { return i; }
+  uint64_t uint64_td(uint64_t i) { return i; }
 
   struct StdIf {
     int_fast8_t   int_fast8_member;
@@ -38,10 +38,10 @@
   int_fast16_t  int_fast16_td(int_fast16_t i) { return i; }
   int_fast32_t  int_fast32_td(int_fast32_t i) { return i; }
   int_fast64_t  int_fast64_td(int_fast64_t i) { return i; }
-  uint_fast8_t  uint_fast8_td (int_fast8_t  i) { return i; }
-  uint_fast16_t uint_fast16_td(int_fast16_t i) { return i; }
-  uint_fast32_t uint_fast32_td(int_fast32_t i) { return i; }
-  uint_fast64_t uint_fast64_td(int_fast64_t i) { return i; }
+  uint_fast8_t  uint_fast8_td(uint_fast8_t  i) { return i; }
+  uint_fast16_t uint_fast16_td(uint_fast16_t i) { return i; }
+  uint_fast32_t uint_fast32_td(uint_fast32_t i) { return i; }
+  uint_fast64_t uint_fast64_td(uint_fast64_t i) { return i; }
 
   struct StdIl {
     int_least8_t   int_least8_member;
@@ -58,10 +58,10 @@
   int_least16_t  int_least16_td(int_least16_t i) { return i; }
   int_least32_t  int_least32_td(int_least32_t i) { return i; }
   int_least64_t  int_least64_td(int_least64_t i) { return i; }
-  uint_least8_t  uint_least8_td (int_least8_t  i) { return i; }
-  uint_least16_t uint_least16_td(int_least16_t i) { return i; }
-  uint_least32_t uint_least32_td(int_least32_t i) { return i; }
-  uint_least64_t uint_least64_td(int_least64_t i) { return i; }
+  uint_least8_t  uint_least8_td (uint_least8_t  i) { return i; }
+  uint_least16_t uint_least16_td(uint_least16_t i) { return i; }
+  uint_least32_t uint_least32_td(uint_least32_t i) { return i; }
+  uint_least64_t uint_least64_td(uint_least64_t i) { return i; }
 
 %}
 


### PR DESCRIPTION
Converting signed to unsigned may change the value.

The test need to pass values unchanged.
As long as the values are in the type range!
Converting signed to unsigned we may convert the value to a different one if the value is outside the range.
Though the test fails.
For example on `i386`
`uint16_td(0xffff) => 0x7fff + 1`

@wsfulton 
This should solve the failure, Jitka from Red Hat found on  `i386` with `li_stdint_runme.lua`.

The reason we did not see it before is that the test was exist on PHP only, while Fedora on `i386` do not use PHP.
See:
https://kojipkgs.fedoraproject.org//work/tasks/5365/147615365/build.log

````
The SWIG test-suite and examples are configured for the following languages:
c lua octave perl5 python ruby tcl 
````