### PR TITLE
Add support for Ubuntu ARM64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -222,6 +222,9 @@ jobs:
           CSTD: gnu99
           SWIG_FEATURES: -builtin -pyi -typehints
         - SWIGLANG: python
+          VER: '3.14'
+          os: ubuntu-24.04-arm
+        - SWIGLANG: python
           VER: '3.14-dbg'
           CSTD: gnu99
         - SWIGLANG: python

--- a/Tools/GHA-linux-install.sh
+++ b/Tools/GHA-linux-install.sh
@@ -22,7 +22,7 @@ update_path()
 probe_cached_tool()
 {
 	if [[ -z "$SKIP_CACHED_TOOLS" ]]; then
-		tool_path=$(ls -d $RUNNER_TOOL_CACHE/$1/$VER.*/x64/bin 2> /dev/null | head -1 || true)
+		tool_path=$(ls -d $RUNNER_TOOL_CACHE/$1/$VER.*/*/bin 2> /dev/null | head -1 || true)
 	fi
 }
 


### PR DESCRIPTION
This is a very small PR.
Not much is needed to use Ubuntu arm 64.

I think by adding a single task, so we can ensure we do work properly on Linux arm 64.
And can add more tests on Linux arm 64 if we need them.
The speed is of the same scale, the only reason not to use more, is that in most cases the result will be the same as using x86-64.