### PR TITLE
Python: Add nspace support

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -4,6 +4,16 @@ See the RELEASENOTES file for a summary of changes in each release.
 Issue # numbers mentioned below can be found on Github. For more details, add
 the issue number to the end of the URL: https://github.com/swig/swig/issues/
 
+Version 4.6.0 (in progress)
+===========================
+
+2026-08-07: trittsv
+            [Python] Added support for the 'nspace' feature. C++ classes and enums
+            can now be exposed through Python namespace objects using '%nspace' and
+            moved into different namespace hierarchies using '%nspacemove'. This is
+            supported with proxy classes, built-in types, directors, nested classes,
+            inheritance and standard library template instantiations.
+
 Version 4.5.0 (06 Aug 2026)
 ===========================
 

--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -1504,7 +1504,7 @@
 <li><a href="Python.html#Python_nn22">Pointers, references, values, and arrays</a>
 <li><a href="Python.html#Python_nn23">C++ overloaded functions</a>
 <li><a href="Python.html#Python_nn24">C++ operators</a>
-<li><a href="Python.html#Python_nn25">C++ namespaces</a>
+<li><a href="Python.html#Python_namespaces">C++ namespaces</a>
 <li><a href="Python.html#Python_nn26">C++ templates</a>
 <li><a href="Python.html#Python_nn27">C++ Smart Pointers</a>
 <ul>

--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -37,7 +37,7 @@
 <li><a href="#Python_nn22">Pointers, references, values, and arrays</a>
 <li><a href="#Python_nn23">C++ overloaded functions</a>
 <li><a href="#Python_nn24">C++ operators</a>
-<li><a href="#Python_nn25">C++ namespaces</a>
+<li><a href="#Python_namespaces">C++ namespaces</a>
 <li><a href="#Python_nn26">C++ templates</a>
 <li><a href="#Python_nn27">C++ Smart Pointers</a>
 <ul>
@@ -1998,18 +1998,21 @@ instead of raising the usual <tt>TypeError</tt> exception when an incorrect type
 This follows the guidelines in <a href="https://www.python.org/dev/peps/pep-0207/">PEP 207 - Rich Comparisons</a> and <a href="https://docs.python.org/3/library/constants.html#NotImplemented">NotImplemented Python constant</a>.
 </p>
 
-<H3><a name="Python_nn25">33.3.12 C++ namespaces</a></H3>
+<H3><a name="Python_namespaces">33.3.12 C++ namespaces</a></H3>
 
 
 <p>
-SWIG is aware of C++ namespaces, but namespace names do not appear in
-the module nor do namespaces result in a module that is broken up into
-submodules or packages.  For example, if you have a file like this,
+SWIG is aware of C++ namespaces, but namespace names do not appear in the
+Python module by default. The <a href="SWIGPlus.html#SWIGPlus_nspace"><tt>nspace</tt>
+feature</a> can be used to expose classes and enums through namespace objects which
+mirror the C++ namespace hierarchy. For example:
 </p>
 
 <div class="code">
 <pre>
 %module example
+
+%nspace foo::Vector;
 
 namespace foo {
   int fact(int n);
@@ -2027,9 +2030,7 @@ it works in Python as follows:
 <div class="targetlang">
 <pre>
 &gt;&gt;&gt; import example
-&gt;&gt;&gt; example.fact(3)
-6
-&gt;&gt;&gt; v = example.Vector()
+&gt;&gt;&gt; v = example.foo.Vector()
 &gt;&gt;&gt; v.x = 3.4
 &gt;&gt;&gt; print(v.y)
 0.0
@@ -2038,31 +2039,41 @@ it works in Python as follows:
 </div>
 
 <p>
-If your program has more than one namespace, name conflicts (if any) can be resolved using <tt>%rename</tt>
-For example:
+As with the general <tt>nspace</tt> feature, namespace objects are created for
+classes and enums. Functions and variables declared directly in a namespace remain
+in the module's flat scope. Therefore, <tt>fact</tt> in the example above remains
+available as <tt>example.fact</tt>.
+</p>
+
+<p>
+The <tt>%nspace</tt>, <tt>%nonspace</tt>, <tt>%clearnspace</tt>, and
+<tt>%nspacemove</tt> directives are supported. <tt>%nspacemove</tt> can expose a
+C++ type through a completely different Python namespace hierarchy:
 </p>
 
 <div class="code">
 <pre>
-%rename(Bar_spam) Bar::spam;
+%nspacemove(api::geometry) implementation::Vector;
 
-namespace Foo {
-  int spam();
-}
-
-namespace Bar {
-  int spam();
+namespace implementation {
+  struct Vector {
+  };
 }
 </pre>
 </div>
 
+<div class="targetlang">
+<pre>
+&gt;&gt;&gt; v = example.api.geometry.Vector()
+</pre>
+</div>
+
 <p>
-If you have more than one namespace and your want to keep their
-symbols separate, consider wrapping them as separate SWIG modules.
-For example, make the module name the same as the namespace and create
-extension modules for each namespace separately.  If your program
-utilizes thousands of small deeply nested namespaces each with
-identical symbol names, well, then you get what you deserve.
+Namespace objects are attributes of the generated Python module; they are not
+independently importable Python packages or modules. The feature works with both
+the default proxy classes and the <tt>-builtin</tt> option, including directors,
+inheritance between namespaces, nested classes, and standard library template
+instantiations.
 </p>
 
 <H3><a name="Python_nn26">33.3.13 C++ templates</a></H3>

--- a/Examples/test-suite/director_nspace.i
+++ b/Examples/test-suite/director_nspace.i
@@ -39,7 +39,7 @@ namespace TopLevel
 %include <std_string.i>
 
 // nspace feature only supported by these languages
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT) || defined(SWIGPYTHON)
 %nspace TopLevel::Bar::Foo;
 %nspace TopLevel::Bar::FooBar;
 #else

--- a/Examples/test-suite/director_nspace_director_name_collision.i
+++ b/Examples/test-suite/director_nspace_director_name_collision.i
@@ -34,7 +34,7 @@ namespace TopLevel
 %include <std_string.i>
 
 // nspace feature only supported by these languages
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT) || defined(SWIGPYTHON)
 %nspace TopLevel::A::Foo;
 %nspace TopLevel::B::Foo;
 #else

--- a/Examples/test-suite/nspace.i
+++ b/Examples/test-suite/nspace.i
@@ -2,7 +2,7 @@
 %module nspace
 
 // nspace feature only supported by these languages
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT) || defined(SWIGPYTHON)
 
 #if defined(SWIGJAVA)
 SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
@@ -116,4 +116,3 @@ void test_classes(Outer::SomeClass c, Outer::Inner2::Color cc) {}
 #else
 //#warning nspace feature not yet supported in this target language
 #endif
-

--- a/Examples/test-suite/nspace_extend.i
+++ b/Examples/test-suite/nspace_extend.i
@@ -2,7 +2,7 @@
 %module nspace_extend
 
 // nspace feature only supported by these languages
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT) || defined(SWIGPYTHON)
 
 #if defined(SWIGJAVA)
 SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
@@ -52,4 +52,3 @@ namespace Outer {
 #else
 //#warning nspace feature not yet supported in this target language
 #endif
-

--- a/Examples/test-suite/nspacemove_nested.i
+++ b/Examples/test-suite/nspacemove_nested.i
@@ -3,7 +3,7 @@
 // Tests nested classes for badly configured %nspace, %nonspace, %nspacemove combinations
 // Based off Examples/test-suite/errors/swig_nspacemove.i
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT) || defined(SWIGPYTHON)
 
 #if !defined(SWIGCSHARP) && !defined(SWIGJAVA)
 %feature ("flatnested");

--- a/Examples/test-suite/nspacemove_stl.i
+++ b/Examples/test-suite/nspacemove_stl.i
@@ -1,6 +1,6 @@
 %module nspacemove_stl
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGD) || defined(SWIGLUA) || defined(SWIGJAVASCRIPT) || defined(SWIGPYTHON)
 
 #if defined(SWIGJAVA)
 SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)

--- a/Examples/test-suite/python/director_nspace_director_name_collision_runme.py
+++ b/Examples/test-suite/python/director_nspace_director_name_collision_runme.py
@@ -1,0 +1,17 @@
+from swig_test_utils import swig_check
+
+import director_nspace_director_name_collision as nspace
+
+
+class FooA(nspace.TopLevel.A.Foo):
+    def ping(self):
+        return "FooA.ping()"
+
+
+class FooB(nspace.TopLevel.B.Foo):
+    def ping(self):
+        return "FooB.ping()"
+
+
+swig_check(FooA().ping(), "FooA.ping()")
+swig_check(FooB().ping(), "FooB.ping()")

--- a/Examples/test-suite/python/director_nspace_runme.py
+++ b/Examples/test-suite/python/director_nspace_runme.py
@@ -1,0 +1,15 @@
+from swig_test_utils import swig_check
+
+import director_nspace
+
+
+class PythonFoo(director_nspace.TopLevel.Bar.Foo):
+    def ping(self):
+        return "PythonFoo.ping();"
+
+
+foo = PythonFoo()
+swig_check(foo.ping(), "PythonFoo.ping();")
+swig_check(foo.pong(), "Bar::Foo::pong();PythonFoo.ping();")
+swig_check(foo.fooBar(director_nspace.TopLevel.Bar.FooBar()), "Bar::Foo2::Foo2Bar()")
+swig_check(type(foo.makeFoo()), director_nspace.TopLevel.Bar.Foo)

--- a/Examples/test-suite/python/nspace_extend_runme.py
+++ b/Examples/test-suite/python/nspace_extend_runme.py
@@ -1,0 +1,13 @@
+from swig_test_utils import swig_assert
+
+import nspace_extend
+
+
+Color1 = nspace_extend.Outer.Inner1.Color
+Color2 = nspace_extend.Outer.Inner2.Color
+color1 = Color1()
+color2 = Color2.create()
+color1.colorInstanceMethod(1.0)
+Color2.colorStaticMethod(2.0)
+color2.colors(color1, color1, color2, color2, color2)
+swig_assert(isinstance(Color1(color1), Color1), "%extend copy constructor failed")

--- a/Examples/test-suite/python/nspace_runme.py
+++ b/Examples/test-suite/python/nspace_runme.py
@@ -1,0 +1,71 @@
+from swig_test_utils import swig_assert, swig_check
+
+import nspace
+
+
+Color1 = nspace.Outer.Inner1.Color
+Color2 = nspace.Outer.Inner2.Color
+
+swig_assert(Color1 is not Color2, "same-named classes in different namespaces must be distinct")
+if hasattr(Color1, "__swig_destroy__"):
+    swig_check(Color1.__qualname__, "Outer.Inner1.Color")
+    swig_check(Color2.__qualname__, "Outer.Inner2.Color")
+
+color1 = Color1()
+color1_copy = Color1(color1)
+color1.colorInstanceMethod(20.0)
+Color1.colorStaticMethod(20.0)
+swig_assert(isinstance(Color1.create(), Color1), "factory returned the wrong namespaced class")
+
+color1_copy.instanceMemberVariable = 123
+swig_check(color1_copy.instanceMemberVariable, 123)
+Color1.staticMemberVariable = 789
+swig_check(Color1.staticMemberVariable, 789)
+swig_check(Color1.staticConstMemberVariable, 222)
+swig_check(Color1.staticConstEnumMemberVariable, Color1.Transmission)
+swig_check(Color1.Specular, 0x20)
+
+Color2.staticMemberVariable = 456
+swig_check(Color2.staticMemberVariable, 456)
+swig_check(Color2.staticConstMemberVariable, 333)
+swig_check(Color2.staticConstEnumMemberVariable, Color2.Transmission)
+swig_check(Color2.Specular, 0x40)
+swig_assert(Color1.staticConstEnumMemberVariable != Color2.staticConstEnumMemberVariable, "class enum values collided")
+
+color2 = Color2.create()
+swig_assert(isinstance(color2, Color2), "second factory returned the wrong namespaced class")
+color2.colors(color1, color1, color2, color2, color2)
+
+some_class = nspace.Outer.SomeClass()
+swig_check(some_class.GetInner1ColorChannel(), Color1.Transmission)
+swig_check(some_class.GetInner2ColorChannel(), Color2.Transmission)
+swig_check(some_class.GetInner1Channel(), nspace.Outer.Inner1.Transmission1)
+swig_check(some_class.GetInner2Channel(), nspace.Outer.Inner2.Transmission2)
+swig_check(nspace.Outer.Inner1.ColorEnumVal2, 0x11)
+swig_check(nspace.Outer.Inner2.Specular, 0x30)
+swig_check(nspace.Outer.Inner1.ColorEnumVal1, 0)
+swig_check(nspace.Outer.Inner1.ColorEnumVal3, 0x12)
+
+nspace.namespaceFunction(color1)
+nspace.cvar.namespaceVar = 111
+swig_check(nspace.cvar.namespaceVar, 111)
+
+swig_assert(isinstance(nspace.Outer.Inner3.Blue(), Color2), "namespaced base class was not resolved")
+swig_assert(isinstance(nspace.Outer.Inner4.Blue(), Color2), "second namespaced base class was not resolved")
+
+swig_assert(hasattr(nspace.Outer, "namespce"), "%nspace class missing")
+swig_assert(hasattr(nspace, "NoNSpacePlease"), "%nonspace class was moved")
+swig_assert(not hasattr(nspace.Outer.Inner2, "NoNSpacePlease"), "%nonspace class remained namespaced")
+swig_check(nspace.NoNSpacePlease.noNspaceStaticFunc(), 10)
+swig_check(nspace.NoNSpacePlease.NoNspace1, 1)
+swig_check(nspace.NoNSpacePlease.NoNspace2, 10)
+swig_check(nspace.NoNSpacePlease.ReallyNoNspace1, 1)
+swig_check(nspace.NoNSpacePlease.ReallyNoNspace2, 10)
+
+swig_assert(isinstance(nspace.Outer.MyWorldPart2(), nspace.Outer.MyWorldPart2), "reopened namespace class missing")
+
+global_class = nspace.GlobalClass()
+global_class.gmethod()
+swig_check(nspace.aaa, 0)
+swig_check(nspace.bbb, 1)
+nspace.takeGlobalEnum(nspace.ccc)

--- a/Examples/test-suite/python/nspacemove_nested_runme.py
+++ b/Examples/test-suite/python/nspacemove_nested_runme.py
@@ -1,0 +1,30 @@
+import nspacemove_nested as nspace
+
+
+cases = (
+    (nspace.Space, "1"),
+    (nspace.Space, "2"),
+    (nspace.NewSpace3, "3"),
+    (nspace.NewSpace4, "4"),
+    (nspace, "5"),
+    (nspace, "6"),
+    (nspace, "7"),
+    (nspace.Space, "10"),
+    (nspace.Space, "20"),
+    (nspace.NewOkay30, "30"),
+    (nspace.NewOkay40, "40"),
+    (nspace.NewOkay50, "50"),
+    (nspace, "60"),
+    (nspace, "70"),
+    (nspace.Space, "80"),
+)
+
+for scope, suffix in cases:
+    outer_type = getattr(scope, "OuterClass" + suffix)
+    inner_type = getattr(scope, "InnerClass" + suffix)
+    bottom_type = getattr(scope, "BottomClass" + suffix)
+    outer = outer_type()
+    inner = inner_type()
+    bottom = bottom_type()
+    enum_value = getattr(outer_type, "ie" + suffix + "a")
+    outer.take(enum_value, inner)

--- a/Examples/test-suite/python/nspacemove_runme.py
+++ b/Examples/test-suite/python/nspacemove_runme.py
@@ -1,0 +1,30 @@
+from swig_test_utils import swig_assert, swig_check
+
+import nspacemove
+
+
+Color1 = nspacemove.Ooter.Extra.Inner1.Color
+Color2 = nspacemove.Outer.Snner2.Color
+swig_assert(Color1 is not Color2, "%nspacemove classes collided")
+if hasattr(Color1, "__swig_destroy__"):
+    swig_check(Color1.__qualname__, "Ooter.Extra.Inner1.Color")
+    swig_check(Color2.__qualname__, "Outer.Snner2.Color")
+swig_assert(isinstance(Color1.create(), Color1), "first moved class factory failed")
+swig_assert(isinstance(Color2.create(), Color2), "second moved class factory failed")
+swig_check(nspacemove.Euter.Extra.Inner1.Specular, 0x10)
+swig_check(nspacemove.Outer.Enner2.Specular, 0x30)
+swig_check(nspacemove.Euter.Extra.Inner1.Transmission1, 0x11)
+swig_check(nspacemove.Outer.Enner2.Transmission2, 0x31)
+swig_check(Color1.Specular, 0x20)
+swig_check(Color2.Specular, 0x40)
+swig_check(Color1.ColorEnumVal2, 0x22)
+swig_check(Color2.ColorEnumVal2, 0x33)
+
+color1 = Color1.create()
+color2 = Color2.create()
+color2.colors(color1, color1, color2, color2, color2)
+
+swig_assert(isinstance(nspacemove.Additional.GlobalClass(), nspacemove.Additional.GlobalClass), "global class move failed")
+swig_check(nspacemove.More.aaa, 0)
+swig_check(nspacemove.More.bbb, 1)
+nspacemove.takeGlobalEnum(nspacemove.More.ccc)

--- a/Examples/test-suite/python/nspacemove_stl_runme.py
+++ b/Examples/test-suite/python/nspacemove_stl_runme.py
@@ -1,0 +1,17 @@
+from swig_test_utils import swig_assert
+
+import nspacemove_stl
+
+
+vector_int = nspacemove_stl.CPlusPlus.Standard.Ints.VectorInt()
+vector_int.push_back(10)
+nspacemove_stl.test_vector_int(vector_int)
+
+vector_string = nspacemove_stl.CPlusPlus.Standard.Strings.VectorString()
+vector_string.push_back("value")
+nspacemove_stl.test_vector_string(vector_string)
+
+map_int = nspacemove_stl.CPlusPlus.Maps.MapIntInt()
+map_int[1] = 2
+nspacemove_stl.test_map_int(map_int)
+swig_assert(map_int[1] == 2, "moved STL map failed")

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -50,6 +50,8 @@ static String *f_shadow_begin = 0;
 static Hash *f_shadow_imports = 0;
 static String *f_shadow_after_begin = 0;
 static String *f_shadow_stubs = 0;
+static String *f_shadow_nspaces = 0;
+static Hash *python_nspaces = 0;
 static Hash *builtin_getset = 0;
 static Hash *builtin_closures = 0;
 static Hash *class_members = 0;
@@ -105,6 +107,15 @@ static int nogil = 0;
 static int pyi_stub = 0;
 static String *pyi_filename = 0;
 static int typehints = 0;
+
+static String *python_nspace_mangle(const String *nspace, const String *name) {
+  if (!nspace)
+    return Copy(name);
+  String *mangled = Copy(nspace);
+  Replaceall(mangled, NSPACE_SEPARATOR, "_");
+  Printv(mangled, "_", name, NIL);
+  return mangled;
+}
 
 /* flags for the make_autodoc function */
 namespace {
@@ -773,6 +784,8 @@ public:
       f_shadow_imports = NewHash();
       f_shadow_after_begin = NewString("");
       f_shadow_stubs = NewString("");
+      f_shadow_nspaces = NewString("");
+      python_nspaces = NewHash();
 
       Swig_register_filebyname("shadow", f_shadow);
       Swig_register_filebyname("python", f_shadow);
@@ -958,6 +971,9 @@ public:
         Printv(f_shadow_py, default_import_code, NIL);
       }
 
+      if (Len(f_shadow_nspaces) > 0)
+        Printv(f_shadow_py, "\n", f_shadow_nspaces, "\n", NIL);
+
       if (Len(f_shadow) > 0)
         Printv(f_shadow_py, "\n", f_shadow, "\n", NIL);
       if (Len(f_shadow_stubs) > 0)
@@ -1013,6 +1029,8 @@ public:
 
     Delete(default_import_code);
     Delete(f_shadow_after_begin);
+    Delete(f_shadow_nspaces);
+    Delete(python_nspaces);
     Delete(f_shadow_imports);
     Delete(f_shadow_begin);
     Delete(f_shadow);
@@ -3361,7 +3379,7 @@ public:
     if (!have_constructor && (constructor || Getattr(n, "handled_as_constructor")) && ((shadow & PYSHADOW_MEMBER))) {
       String *nname = Getattr(n, "sym:name");
       String *sname = Getattr(getCurrentClass(), "sym:name");
-      String *cname = Swig_name_construct(NSPACE_TODO, sname);
+      String *cname = Swig_name_construct(getNSpace(), sname);
       handled_as_init = (Strcmp(nname, sname) == 0) || (Strcmp(nname, cname) == 0);
       Delete(cname);
     }
@@ -3387,7 +3405,7 @@ public:
     if (Getattr(n, "sym:overloaded")) {
       overname = Getattr(n, "sym:overname");
     } else {
-      if (!addSymbol(iname, n))
+      if (!addSymbol(iname, n, getNSpace()))
         return SWIG_ERROR;
     }
 
@@ -4079,7 +4097,7 @@ public:
     String *tm;
     Wrapper *getf, *setf;
 
-    if (!addSymbol(iname, n))
+    if (!addSymbol(iname, n, getNSpace()))
       return SWIG_ERROR;
 
     getf = NewWrapper();
@@ -4107,8 +4125,8 @@ public:
     if (!builtin && shadow && !assignable && !in_class)
       Printf(f_shadow_stubs, "%s = %s.%s\n", iname, global_name, iname);
 
-    String *getname = Swig_name_get(NSPACE_TODO, iname);
-    String *setname = Swig_name_set(NSPACE_TODO, iname);
+    String *getname = Swig_name_get(getNSpace(), iname);
+    String *setname = Swig_name_set(getNSpace(), iname);
     String *vargetname = NewStringf("Swig_var_%s", getname);
     String *varsetname = NewStringf("Swig_var_%s", setname);
 
@@ -4220,15 +4238,20 @@ public:
 
   virtual int constantWrapper(Node *n) {
     String *name = Getattr(n, "name");
-    String *iname = Getattr(n, "sym:name");
+    String *symname = Getattr(n, "sym:name");
+    String *iname = python_nspace_mangle(getNSpace(), symname);
     SwigType *type = Getattr(n, "type");
     String *value = Getattr(n, "value");
     String *tm;
     int have_tm = 0;
     int have_builtin_symname = 0;
 
-    if (!addSymbol(iname, n))
+    if (!addSymbol(symname, n, getNSpace())) {
+      Delete(iname);
       return SWIG_ERROR;
+    }
+    Swig_save("python:nspace_constantWrapper", n, "sym:name", NIL);
+    Setattr(n, "sym:name", iname);
 
     /* Special hook for member pointer */
     if (SwigType_type(type) == T_MPOINTER) {
@@ -4289,6 +4312,8 @@ public:
 
     if (!have_tm) {
       Swig_warning(WARN_TYPEMAP_CONST_UNDEF, input_file, line_number, "Unsupported constant value.\n");
+      Swig_restore(n);
+      Delete(iname);
       return SWIG_NOWRAP;
     }
 
@@ -4306,10 +4331,19 @@ public:
           Printv(f_s, module, ".", iname, "_swigconstant(", module, ")\n", NIL);
         }
         String *annotation = variableAnnotation(n);
-        Printv(f_s, iname, annotation, " = ", module, ".", iname, "\n", NIL);
+        if (getNSpace() && !in_class) {
+          require_python_nspace(getNSpace());
+          Printv(f_s, "_swig_create_namespace(\"", getNSpace(), "\").", symname, annotation, " = ", module, ".", iname, "\n", NIL);
+        } else {
+          Printv(f_s, symname, annotation, " = ", module, ".", iname, "\n", NIL);
+        }
         if (have_docstring(n))
           Printv(f_s, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
       }
+    }
+    if (builtin && shadow && getNSpace() && !in_class) {
+      require_python_nspace(getNSpace());
+      Printv(f_shadow_stubs, "_swig_create_namespace(\"", getNSpace(), "\").", symname, " = ", iname, "\n", NIL);
     }
 
     if (pyi_stub && !in_class) {
@@ -4320,6 +4354,8 @@ public:
       Delete(annotation);
     }
 
+    Swig_restore(n);
+    Delete(iname);
     return SWIG_OK;
   }
 
@@ -4373,9 +4409,7 @@ public:
     Node *parent = Getattr(n, "parentNode");
     String *sub = NewString("");
     String *decl = Getattr(n, "decl");
-    String *supername = Swig_class_name(parent);
-    String *classname = NewString("");
-    Printf(classname, "SwigDirector_%s", supername);
+    String *classname = Copy(Getattr(parent, "director:classname"));
 
     /* insert self parameter */
     Parm *p;
@@ -4414,7 +4448,6 @@ public:
 
     Delete(sub);
     Delete(classname);
-    Delete(supername);
     Delete(parms);
     return Language::classDirectorConstructor(n);
   }
@@ -4424,18 +4457,18 @@ public:
    * ------------------------------------------------------------ */
 
   int classDirectorDefaultConstructor(Node *n) {
-    String *classname = Swig_class_name(n);
+    String *classname = Copy(Getattr(n, "director:classname"));
     {
       Node *parent = Swig_methodclass(n);
       String *basetype = Getattr(parent, "classtype");
       Wrapper *w = NewWrapper();
-      Printf(w->def, "SwigDirector_%s::SwigDirector_%s(PyObject *self) : Swig::Director(self) { \n", classname, classname);
+      Printf(w->def, "%s::%s(PyObject *self) : Swig::Director(self) { \n", classname, classname);
       Printf(w->def, "   SWIG_DIRECTOR_RGTR((%s *)this, this); \n", basetype);
       Append(w->def, "}\n");
       Wrapper_print(w, f_directors);
       DelWrapper(w);
     }
-    Printf(f_directors_h, "    SwigDirector_%s(PyObject *self);\n", classname);
+    Printf(f_directors_h, "    %s(PyObject *self);\n", classname);
     Delete(classname);
     return Language::classDirectorDefaultConstructor(n);
   }
@@ -4529,7 +4562,7 @@ public:
         Delete(rname);
       } else {
         String *symname = Getattr(n, "sym:name");
-        String *mrename = Swig_name_disown(NSPACE_TODO, symname);  // Getattr(n, "name"));
+        String *mrename = Swig_name_disown(getNSpace(), symname);  // Getattr(n, "name"));
         Printv(f_shadow, tab4, "def __disown__(self):\n", NIL);
         Printv(f_shadow, tab8, "self.this.disown()\n", NIL);
         Printv(f_shadow, tab8, module, ".", mrename, "(self)\n", NIL);
@@ -4548,6 +4581,31 @@ public:
    * classDeclaration()
    * ------------------------------------------------------------ */
 
+  void require_python_nspace(String *nspace) {
+    if (!nspace || Getattr(python_nspaces, nspace))
+      return;
+
+    if (Len(python_nspaces) == 0) {
+      Printv(f_shadow_nspaces,
+             "class _SwigNamespace:\n",
+             "    pass\n\n",
+             "def _swig_create_namespace(path):\n",
+             "    scope = globals()\n",
+             "    namespace = None\n",
+             "    for name in path.split(\".\"):\n",
+             "        namespace = scope.get(name)\n",
+             "        if namespace is None:\n",
+             "            namespace = _SwigNamespace()\n",
+             "            namespace.__name__ = name\n",
+             "            scope[name] = namespace\n",
+             "        scope = vars(namespace)\n",
+             "    return namespace\n\n",
+             NIL);
+    }
+    Printf(f_shadow_nspaces, "_swig_create_namespace(\"%s\")\n", nspace);
+    Setattr(python_nspaces, nspace, "1");
+  }
+
   virtual int classDeclaration(Node *n) {
     if (shadow && !Getattr(n, "feature:onlychildren")) {
       Node *mod = Getattr(n, "module");
@@ -4557,6 +4615,11 @@ public:
         String *pkg = options ? Getattr(options, "package") : 0;
         String *sym = Getattr(n, "sym:name");
         String *importname = import_name_string(package, mainmodule, pkg, modname, sym);
+        String *nspace = Getattr(n, "sym:nspace");
+        if (nspace) {
+          Delslice(importname, Len(importname) - Len(sym), DOH_END);
+          Printv(importname, nspace, ".", sym, NIL);
+        }
         Setattr(n, "python:proxy", importname);
         Delete(importname);
       }
@@ -4595,6 +4658,7 @@ public:
     SwigType *pname = Copy(name);
     SwigType_add_pointer(pname);
     String *symname = Getattr(n, "sym:name");
+    String *export_name = python_nspace_mangle(Getattr(n, "sym:nspace"), symname);
     SwigType *sname = add_explicit_scope(name);
     String *rname = SwigType_namestr(sname);
     String *mname = SwigType_manglestr(sname);
@@ -4656,7 +4720,7 @@ public:
       String *setter = Getattr(mgetset, "setter");
       const char *getter_closure = getter ? funpack ? "SwigPyBuiltin_FunpackGetterClosure" : "SwigPyBuiltin_GetterClosure" : "0";
       const char *setter_closure = setter ? funpack ? "SwigPyBuiltin_FunpackSetterClosure" : "SwigPyBuiltin_SetterClosure" : "0";
-      String *gspair = NewStringf("%s_%s_getset", symname, memname);
+      String *gspair = NewStringf("%s_%s_getset", export_name, memname);
       Printf(f, "static SwigPyGetSet %s = { %s, %s };\n", gspair, getter ? getter : "0", setter ? setter : "0");
       String *doc = Getattr(mgetset, "doc");
       if (!doc)
@@ -4743,18 +4807,26 @@ public:
 
     Node *mod = Getattr(n, "module");
     String *modname = mod ? Getattr(mod, "name") : 0;
+    String *nspace = Getattr(n, "sym:nspace");
+    String *qualified_symname = python_nspace_mangle(0, symname);
+    if (nspace) {
+      String *nspace_prefix = NewStringf("%s.", nspace);
+      Insert(qualified_symname, 0, nspace_prefix);
+      Delete(nspace_prefix);
+    }
     String *quoted_symname;
     if (package) {
       if (modname)
-        quoted_symname = NewStringf("\"%s.%s.%s\"", package, modname, symname);
+        quoted_symname = NewStringf("\"%s.%s.%s\"", package, modname, qualified_symname);
       else
-        quoted_symname = NewStringf("\"%s.%s\"", package, symname);
+        quoted_symname = NewStringf("\"%s.%s\"", package, qualified_symname);
     } else {
       if (modname)
-        quoted_symname = NewStringf("\"%s.%s\"", modname, symname);
+        quoted_symname = NewStringf("\"%s.%s\"", modname, qualified_symname);
       else
-        quoted_symname = NewStringf("\"%s\"", symname);
+        quoted_symname = NewStringf("\"%s\"", qualified_symname);
     }
+    Delete(qualified_symname);
     String *user_tp_doc = Getattr(n, "feature:python:tp_doc");
     // Empty string, not NULL: when tp_doc is NULL, inspect.getdoc() walks the MRO and picks up
     // the SwigPyObject base's docstring instead of returning "" like the non-builtin proxy does.
@@ -5168,11 +5240,11 @@ public:
       Printf(f_init, "    SwigPyBuiltin_%s_clientdata.klass = (PyObject *)builtin_pytype;\n", mname);
     }
     Printv(f_init, "    SWIG_Py_INCREF((PyObject *)builtin_pytype);\n", NIL);
-    Printf(f_init, "    if (PyModule_AddObject(m, \"%s\", (PyObject *)builtin_pytype) != 0) {\n", symname);
+    Printf(f_init, "    if (PyModule_AddObject(m, \"%s\", (PyObject *)builtin_pytype) != 0) {\n", export_name);
     Printf(f_init, "      SWIG_Py_DECREF((PyObject *)builtin_pytype);\n");
     Printv(f_init, "      return -1;\n", NIL);
     Printf(f_init, "    }\n", symname);
-    Printf(f_init, "    SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", symname);
+    Printf(f_init, "    SwigPyBuiltin_AddPublicSymbol(public_interface, \"%s\");\n", export_name);
     if (Getattr(n, "python:tp_init_doc")) {
       /* Replace the default tp_init slot wrapper for __init__ with a method descriptor that carries
          the doxygen docstring. type.__call__ still uses the tp_init slot for instantiation. */
@@ -5208,18 +5280,25 @@ public:
     Delete(richcompare_func);
     Delete(getset_name);
     Delete(methods_name);
+    Delete(export_name);
   }
 
   virtual int classHandler(Node *n) {
     File *f_shadow_file = f_shadow;
+    String *nspace = Getattr(n, "sym:nspace");
+    String *public_class_name = Getattr(n, "sym:name");
+    String *registration_name = python_nspace_mangle(nspace, public_class_name);
 
     if (shadow || pyi_stub) {
-      class_name = Getattr(n, "sym:name");
+      class_name = public_class_name;
       real_classname = Getattr(n, "name");
 
-      if (!addSymbol(class_name, n))
+      if (!addSymbol(public_class_name, n, nspace))
         return SWIG_ERROR;
     }
+
+    if (shadow)
+      require_python_nspace(nspace);
 
     if (builtin) {
       List *baselist = Getattr(n, "bases");
@@ -5314,13 +5393,13 @@ public:
         builtin_closures_code = NewString("");
         Clear(builtin_closures);
       } else {
-        Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
+        Printv(f_wrappers, "SWIGINTERN PyObject *", registration_name, "_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
         Printv(f_wrappers, "  PyObject *obj = NULL;\n", NIL);
         Printv(f_wrappers, "  if (!SWIG_Python_UnpackTuple(args, \"swigregister\", 1, 1, &obj)) return NULL;\n", NIL);
 
         Printv(
           f_wrappers, "  SWIG_TypeNewClientData(SWIGTYPE", SwigType_manglestr(ct), ", SWIG_NewClientData(obj));\n", "  return SWIG_Py_Void();\n", "}\n\n", NIL);
-        String *cname = NewStringf("%s_swigregister", class_name);
+        String *cname = NewStringf("%s_swigregister", registration_name);
         add_method(cname, cname, 0, 0, 1, 1, 1);
         Delete(cname);
       }
@@ -5340,9 +5419,9 @@ public:
                  NIL);
       } else if (!builtin) {
 
-        Printv(f_wrappers, "SWIGINTERN PyObject *", class_name, "_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
+        Printv(f_wrappers, "SWIGINTERN PyObject *", registration_name, "_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {\n", NIL);
         Printv(f_wrappers, "  return SWIG_Python_InitShadowInstance(args);\n", "}\n\n", NIL);
-        String *cname = NewStringf("%s_swiginit", class_name);
+        String *cname = NewStringf("%s_swiginit", registration_name);
         add_method(cname, cname, 0);
         Delete(cname);
       }
@@ -5366,7 +5445,13 @@ public:
         Printv(f_shadow_file, f_shadow, NIL);
         Printf(f_shadow_file, "\n");
         Printf(f_shadow_file, "# Register %s in %s:\n", class_name, module);
-        Printf(f_shadow_file, "%s.%s_swigregister(%s)\n", module, class_name, class_name);
+        Printf(f_shadow_file, "%s.%s_swigregister(%s)\n", module, registration_name, class_name);
+      }
+
+      if (nspace) {
+        if (!builtin)
+          Printf(f_shadow_file, "%s.__qualname__ = \"%s.%s\"\n", class_name, nspace, public_class_name);
+        Printf(f_shadow_file, "_swig_create_namespace(\"%s\").%s = %s\n", nspace, public_class_name, builtin ? registration_name : class_name);
       }
 
       shadow_indent = 0;
@@ -5384,6 +5469,7 @@ public:
     /* Restore shadow file back to original version */
     Delete(f_shadow);
     f_shadow = f_shadow_file;
+    Delete(registration_name);
 
     return SWIG_OK;
   }
@@ -5430,7 +5516,7 @@ public:
       // Can't use checkAttribute(n, "access", "public") because
       // "access" attr isn't set on %extend methods
       if (!checkAttribute(n, "access", "private") && strncmp(Char(symname), "operator ", 9) && !Getattr(class_members, symname)) {
-        String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *fullname = Swig_name_member(getNSpace(), class_name, symname);
         String *wname = Swig_name_wrapper(fullname);
         Setattr(class_members, symname, n);
         int argcount = Getattr(n, "python:argcount") ? atoi(Char(Getattr(n, "python:argcount"))) : 2;
@@ -5463,7 +5549,7 @@ public:
 
       if (shadow && !builtin) {
         int fproxy = fastproxy;
-        String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *fullname = Swig_name_member(getNSpace(), class_name, symname);
         if (Strcmp(symname, "__repr__") == 0) {
           have_repr = 1;
         }
@@ -5505,7 +5591,7 @@ public:
         }
         if (fproxy) {
           Printf(f_shadow, tab4);
-          Printf(f_shadow, "%s = _swig_new_instance_method(%s.%s)\n", symname, module, Swig_name_member(NSPACE_TODO, class_name, symname));
+          Printf(f_shadow, "%s = _swig_new_instance_method(%s.%s)\n", symname, module, Swig_name_member(getNSpace(), class_name, symname));
         }
 
         Delete(fullname);
@@ -5540,7 +5626,7 @@ public:
     int kw = (check_kwargs(n) && !Getattr(n, "sym:overloaded")) ? 1 : 0;
     if (builtin && in_class) {
       if ((GetFlagAttr(n, "feature:extend") || checkAttribute(n, "access", "public")) && !Getattr(class_members, symname)) {
-        String *fullname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *fullname = Swig_name_member(getNSpace(), class_name, symname);
         String *wname = Swig_name_wrapper(fullname);
         Setattr(class_members, symname, n);
         int funpack = fastunpack && !Getattr(n, "sym:overloaded");
@@ -5593,18 +5679,18 @@ public:
         if (have_pythonprepend(n))
           Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
         if (have_pythonappend(n)) {
-          Printv(f_shadow, tab8, "val = ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n", NIL);
+          Printv(f_shadow, tab8, "val = ", funcCall(Swig_name_member(getNSpace(), class_name, symname), callParms), "\n", NIL);
           Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n", NIL);
           Printv(f_shadow, tab8, "return val\n", NIL);
         } else {
-          Printv(f_shadow, tab8, "return ", funcCall(Swig_name_member(NSPACE_TODO, class_name, symname), callParms), "\n", NIL);
+          Printv(f_shadow, tab8, "return ", funcCall(Swig_name_member(getNSpace(), class_name, symname), callParms), "\n", NIL);
         }
       }
 
       // Below may result in a 2nd definition of the method when -olddefs is used. The Python interpreter will use the second definition as it overwrites the
       // first.
       if (fast) {
-        Printv(f_shadow, tab4, symname, " = ", staticfunc_name, "(", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname), ")\n", NIL);
+        Printv(f_shadow, tab4, symname, " = ", staticfunc_name, "(", module, ".", Swig_name_member(getNSpace(), class_name, symname), ")\n", NIL);
       }
       Delete(staticfunc_name);
     }
@@ -5659,13 +5745,13 @@ public:
       if (!have_constructor) {
         String *nname = Getattr(n, "sym:name");
         String *sname = Getattr(getCurrentClass(), "sym:name");
-        String *cname = Swig_name_construct(NSPACE_TODO, sname);
+        String *cname = Swig_name_construct(getNSpace(), sname);
         handled_as_init = (Strcmp(nname, sname) == 0) || (Strcmp(nname, cname) == 0);
         Delete(cname);
       }
       const int add_init = !have_constructor && handled_as_init;
       if (shadow) {
-        String *subfunc = Swig_name_construct(NSPACE_TODO, symname);
+        String *subfunc = Swig_name_construct(getNSpace(), symname);
         if (add_init) {
           if (!builtin) {
             if (Getattr(n, "feature:shadow")) {
@@ -5700,7 +5786,9 @@ public:
               if (have_pythonprepend(n))
                 Printv(f_shadow, indent_pythoncode(pythonprepend(n), tab8, Getfile(n), Getline(n), "%pythonprepend or %feature(\"pythonprepend\")"), "\n", NIL);
               Printv(f_shadow, pass_self, NIL);
-              Printv(f_shadow, tab8, module, ".", class_name, "_swiginit(self, ", funcCall(subfunc, callParms), ")\n", NIL);
+              String *registration_name = python_nspace_mangle(getNSpace(), class_name);
+              Printv(f_shadow, tab8, module, ".", registration_name, "_swiginit(self, ", funcCall(subfunc, callParms), ")\n", NIL);
+              Delete(registration_name);
               if (have_pythonappend(n))
                 Printv(f_shadow, indent_pythoncode(pythonappend(n), tab8, Getfile(n), Getline(n), "%pythonappend or %feature(\"pythonappend\")"), "\n\n", NIL);
               Delete(pass_self);
@@ -5790,13 +5878,13 @@ public:
     if (shadow) {
       if (Getattr(n, "feature:shadow")) {
         String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), tab4, Getfile(n), Getline(n), "%feature(\"shadow\")");
-        String *pyaction = NewStringf("%s.%s", module, Swig_name_destroy(NSPACE_TODO, symname));
+        String *pyaction = NewStringf("%s.%s", module, Swig_name_destroy(getNSpace(), symname));
         Replaceall(pycode, "$action", pyaction);
         Delete(pyaction);
         Printv(f_shadow, pycode, "\n", NIL);
         Delete(pycode);
       } else {
-        Printv(f_shadow, tab4, "__swig_destroy__ = ", module, ".", Swig_name_destroy(NSPACE_TODO, symname), "\n", NIL);
+        Printv(f_shadow, tab4, "__swig_destroy__ = ", module, ".", Swig_name_destroy(getNSpace(), symname), "\n", NIL);
         if (!have_pythonprepend(n) && !have_pythonappend(n)) {
           return SWIG_OK;
         }
@@ -5828,9 +5916,9 @@ public:
     shadow = oldshadow;
 
     if (shadow && !builtin) {
-      String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
-      String *setname = Swig_name_set(NSPACE_TODO, mname);
-      String *getname = Swig_name_get(NSPACE_TODO, mname);
+      String *mname = Swig_name_member(getNSpace(), class_name, symname);
+      String *setname = Swig_name_set(0, mname);
+      String *getname = Swig_name_get(0, mname);
       int assignable = !is_immutable(n);
       String *variable_annotation = variableAnnotation(n);
       Printv(f_shadow, tab4, symname, variable_annotation, " = property(", module, ".", getname, NIL);
@@ -5878,15 +5966,15 @@ public:
 
     if (shadow) {
       if (!builtin && GetFlag(n, "hasconsttype")) {
-        String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
+        String *mname = Swig_name_member(getNSpace(), class_name, symname);
         Printf(f_shadow_stubs, "%s.%s = %s.%s.%s\n", class_name, symname, module, global_name, mname);
         Delete(mname);
       } else {
-        String *mname = Swig_name_member(NSPACE_TODO, class_name, symname);
-        String *getname = Swig_name_get(NSPACE_TODO, mname);
+        String *mname = Swig_name_member(getNSpace(), class_name, symname);
+        String *getname = Swig_name_get(0, mname);
         String *wrapgetname = Swig_name_wrapper(getname);
         String *vargetname = NewStringf("Swig_var_%s", getname);
-        String *setname = Swig_name_set(NSPACE_TODO, mname);
+        String *setname = Swig_name_set(0, mname);
         String *wrapsetname = Swig_name_wrapper(setname);
         String *varsetname = NewStringf("Swig_var_%s", setname);
 
@@ -5973,7 +6061,7 @@ public:
     if (builtin && in_class) {
       Swig_restore(n);
     } else if (shadow) {
-      Printv(f_shadow, tab4, symname, " = ", module, ".", Swig_name_member(NSPACE_TODO, class_name, symname), "\n", NIL);
+      Printv(f_shadow, tab4, symname, " = ", module, ".", Swig_name_member(getNSpace(), class_name, symname), "\n", NIL);
       if (have_docstring(n))
         Printv(f_shadow, tab4, docstring(n, AUTODOC_CONST, tab4), "\n", NIL);
     }
@@ -6200,7 +6288,7 @@ int PYTHON::classDirectorMethod(Node *n, Node *parent, String *super) {
 
   /* virtual method definition */
   String *target;
-  String *pclassname = NewStringf("SwigDirector_%s", classname);
+  String *pclassname = Copy(Getattr(parent, "director:classname"));
   String *qualified_name = NewStringf("%s::%s", pclassname, name);
   SwigType *rtype = Getattr(n, "conversion_operator") ? 0 : Getattr(n, "classDirectorMethods:type");
   target = Swig_method_decl(rtype, decl, qualified_name, l, 0);


### PR DESCRIPTION
## Summary
Add Python support for SWIG’s nspace feature.

C++ classes and enums can now be exposed through nested Python namespace objects:

`%nspace Outer::Inner::Color;`

`color = example.Outer.Inner.Color()`

The implementation also supports %nspacemove for exposing a type through a different Python namespace hierarchy.
## Supported functionality
- %nspace, %nonspace, %clearnspace and %nspacemove
- Default proxy classes and -builtin
- Same-named classes in different namespaces
- Constructors, methods, members, constants and enums
- Cross-namespace inheritance
- Nested classes
- %extend
- Directors and director-name collisions
- STL template instantiations
- Reopened C++ namespaces
- Namespace-aware proxy references and class __qualname__

Namespace objects are attributes of the generated Python module. They are not independently importable Python -packages or modules. Functions and variables declared directly in a C++ namespace remain in the module’s flat scope, consistent with the general limitations of the nspace feature.
## Implementation
The Python backend now:

- Uses namespace-aware target-language symbol scopes.
- Mangles internal wrapper, accessor, constant, registration and director names to prevent collisions.
- Creates nested namespace objects in generated Python code.
- Publishes proxy and built-in classes through the appropriate namespace objects.
- Generates namespace-aware references for inheritance and imported types.

## Testing

Added or expanded Python runtime coverage for:

- nspace
- nspace_extend
- nspacemove
- nspacemove_nested
- nspacemove_stl
- director_nspace
- director_nspace_director_name_collision

The tests cover proxy and built-in modes, duplicate class names, enums, static state, namespace moves, all nested namespace conflict combinations, STL containers and directors.