### PR TITLE
[C#] Support setting the namespace via %module(csnamespace="...")

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,19 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.6.0 (in progress)
 ===========================
 
+2026-09-11: sparcyu
+            [C#] Add support for setting the C# namespace via the 'csnamespace' option of
+            the %module directive, as an alternative to the -namespace command line
+            option. This is convenient for build system integration where the interface
+            file is the natural place to keep the module settings, eg:
+
+              %module(csnamespace="Example.Net") example
+
+            The -namespace command line option takes precedence over the csnamespace
+            module option when both are specified.
+
+            Fixes #3495.
+
 2026-09-03: larskanis, wsfulton
             #3534 Fix configure error "Tools/convertpath: No such file or directory" on
             MinGW. The removed convertpath tool was still used to compute the SWIG library

--- a/Doc/Manual/CSharp.html
+++ b/Doc/Manual/CSharp.html
@@ -197,6 +197,17 @@ Note that by default, the generated C# classes have no namespace and the module 
 </li>
 
 <li>
+The namespace can alternatively be specified in the interface file itself using the <tt>csnamespace</tt> option of the <a href="CSharp.html#CSharp_module_directive"><tt>%module</tt> directive</a>, avoiding the need to pass <tt>-namespace</tt> on the command line. This is convenient for build systems where the interface file is the natural place to keep the module settings. For example:
+
+<div class="code">
+<pre>
+%module(csnamespace="com.bloggs.widget") widget
+</pre>
+</div>
+generates code into the same namespaces as the <tt>-namespace com.bloggs.widget</tt> command line option above. If both are specified, the <tt>-namespace</tt> command line option takes precedence over the <tt>csnamespace</tt> module option.
+</li>
+
+<li>
 The <a href="SWIGPlus.html#SWIGPlus_nspace">nspace feature</a> is also supported as described in this general section with a C# example.
 Unlike Java which requires the use of the -package option when using the <tt>nspace</tt> feature, the -namespace option is not mandatory for C#.
 </li>

--- a/Examples/test-suite/csharp/Makefile.in
+++ b/Examples/test-suite/csharp/Makefile.in
@@ -27,6 +27,7 @@ CPP_TEST_CASES = \
 	csharp_features \
 	csharp_lib_arrays \
 	csharp_lib_arrays_bool \
+	csharp_module_namespace \
 	csharp_namespace_system_collision \
 	csharp_prepost \
 	csharp_swig2_compatibility \
@@ -49,7 +50,11 @@ include $(srcdir)/../common.mk
 
 # Overridden variables here
 SRCDIR       = ../$(srcdir)/
-SWIGOPT += -namespace $*Namespace
+# Every testcase is generated into a namespace named after the testcase. Kept in a
+# separate variable so individual testcases can clear it (see csharp_module_namespace,
+# which sets its namespace via %module(csnamespace="...") in the interface file instead).
+CSHARP_NAMESPACE_OPT = -namespace $*Namespace
+SWIGOPT += $(CSHARP_NAMESPACE_OPT)
 
 CSHARPFLAGSSPECIAL =
 
@@ -61,6 +66,8 @@ complextest.cpptest: CSHARPFLAGSSPECIAL = -r:System.Numerics.dll
 csharp_lib_arrays.cpptest: CSHARPFLAGSSPECIAL = -unsafe
 csharp_lib_arrays_bool.cpptest: CSHARPFLAGSSPECIAL = -unsafe
 csharp_swig2_compatibility.cpptest: SWIGOPT += -DSWIG2_CSHARP
+# Namespace is set via %module(csnamespace="...") in the .i file, so clear the global -namespace option.
+csharp_module_namespace.cpptest: CSHARP_NAMESPACE_OPT =
 # Doxygen tests have specific flags to generate XML documentation and deactivate warnings about XML generation
 doxygen_%.cpptest: CSHARPFLAGSSPECIAL = -doc:./$*/$*.xml -nowarn:"CS0419,CS1572,CS1573,CS1574,CS1584,CS1591"
 doxygen_%.cpptest: CSHARPSRCS_EXTRA_RUN = `$(CSHARPCONVERTPATH) $(SCRIPTDIR)/doxygen_checker.cs`

--- a/Examples/test-suite/csharp/csharp_module_namespace_runme.cs
+++ b/Examples/test-suite/csharp/csharp_module_namespace_runme.cs
@@ -1,0 +1,19 @@
+// Test the C# namespace set via %module(csnamespace="...") in the interface file
+// (issue #3495). The types below are only accessible via the SwigModuleNamespace
+// namespace, which was set in csharp_module_namespace.i, not on the commandline.
+
+using System;
+using SwigModuleNamespace;
+
+public class runme
+{
+  static void Main()
+  {
+    if (csharp_module_namespace.add(3, 4) != 7)
+      throw new Exception("add failed");
+
+    Number n = new Number(42);
+    if (n.get() != 42)
+      throw new Exception("Number failed");
+  }
+}

--- a/Examples/test-suite/csharp_module_namespace.i
+++ b/Examples/test-suite/csharp_module_namespace.i
@@ -1,0 +1,21 @@
+/* This tests setting the C# namespace via the 'csnamespace' option of the %module
+   directive in the interface file, instead of the -namespace commandline option.
+   See GitHub issue #3495.
+
+   The C# test-suite normally passes -namespace <testcase>Namespace on the
+   commandline to every testcase; the Makefile clears that option for this
+   testcase (target-specific CSHARP_NAMESPACE_OPT) so that the namespace set
+   here via %module is the one actually used. */
+
+%module(csnamespace="SwigModuleNamespace") csharp_module_namespace
+
+%inline %{
+int add(int a, int b) { return a + b; }
+
+class Number {
+  int val;
+public:
+  Number(int v) : val(v) {}
+  int get() const { return val; }
+};
+%}

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -319,6 +319,15 @@ public:
     if (optionsnode) {
       if (Getattr(optionsnode, "imclassname"))
         imclass_name = Copy(Getattr(optionsnode, "imclassname"));
+      /* The C# namespace can be specified with either the -namespace commandline
+       * option or the 'csnamespace' module option, eg:
+       *   %module(csnamespace="Example.Net") example
+       * The commandline option takes precedence when both are specified. */
+      if (!namespce) {
+        String *namespace_option = Getattr(optionsnode, "csnamespace");
+        if (namespace_option && Len(namespace_option) > 0)
+          namespce = Copy(namespace_option);
+      }
       /* check if directors are enabled for this module.  note: this
        * is a "master" switch, without which no director code will be
        * emitted.  %feature("director") statements are also required


### PR DESCRIPTION
Fixes #3495.

Allows the C# namespace to be specified via the `csnamespace` option of the `%module` directive in the interface file, as an alternative to the `-namespace` command line option. This is convenient for build system / IDE integration (e.g. MSBuild) where the `.i` file is the natural place to keep module settings:

```swig
%module(csnamespace="Example.Net") example
```

generates code into `namespace Example.Net { ... }`, exactly as `-namespace Example.Net` does. When both are specified, the `-namespace` command line option takes precedence.

Updated after review: this now uses the existing mechanism for target language custom options passed to `%module`, as already used for `imclassname` and `csbegin`, so the change is confined to `csharp.cxx`. **`parser.y` is untouched.**

The option is named `csnamespace` rather than `namespace` because `namespace` is a C++ keyword (`Source/CParse/cscanner.c` only treats it as one when `cparse_cplusplus` is set), so `%module(namespace=...)` is a syntax error in `-c++` mode — which is the common case — and would have required a grammar change. `csnamespace` also matches the existing naming convention for target language options (`imclassname`, `csbegin`, `ruby_minherit`, `jniclassname`).

### Changes

- **`Source/Modules/csharp.cxx`**: read the `csnamespace` option from the module `options` node in `top()`, only when `-namespace` was not passed so the command line wins. Mirrors the existing handling of `imclassname`, `directors`, etc.
- **Test**: `Examples/test-suite/csharp_module_namespace.i` + runme. The C# test Makefile passes `-namespace <testcase>Namespace` to every testcase, so the global option is factored into a `CSHARP_NAMESPACE_OPT` variable and cleared for this testcase (target-specific override) so the `%module` namespace is the one exercised.
- **Docs**: documented in `Doc/Manual/CSharp.html`.
- **`CHANGES.current`** updated.

### Testing

Built swig with CMake and verified:
- `%module(csnamespace="Example.Net")` → `namespace Example.Net { ... }`, in both C and C++ mode
- `-namespace` on the command line overrides the `csnamespace` module option
- `csnamespace=""` → no namespace emitted
- no option set → unchanged (global namespace, no regression)
- the new testcase's generated C# compiles together with its runme
