### PR TITLE
[Python] Fix metaclass conflict under -builtin

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -123,6 +123,7 @@ C_TEST_CASES += \
 
 MULTI_CPP_TEST_CASES += \
 	import_callback \
+	python_crossmod \
 	python_pyiterator_rename \
 	python_runtime_data \
 
@@ -193,6 +194,7 @@ clean:
 	rm -f ../hugemod.h ../hugemod_a.i ../hugemod_b.i hugemod_a.py hugemod_b.py $(hugemod_runme)
 	rm -f clientdata_prop_a.py clientdata_prop_b.py
 	rm -f import_callback_x.py import_callback_y.py
+	rm -f python_crossmod_a.py python_crossmod_b.py
 	rm -f import_share_a.py import_share_b.py import_share_c.py
 	rm -f import_stl_a.py import_stl_b.py
 	rm -f imports_a.py imports_b.py mod_a.py mod_b.py

--- a/Examples/test-suite/python/python_crossmod_runme.py
+++ b/Examples/test-suite/python/python_crossmod_runme.py
@@ -1,0 +1,10 @@
+import python_crossmod_a
+import python_crossmod_b
+
+c = python_crossmod_b.C()
+if c.methA() != 1:
+    raise RuntimeError("methA got {}".format(c.methA()))
+if c.methB() != 2:
+    raise RuntimeError("methB got {}".format(c.methB()))
+if c.methC() != 3:
+    raise RuntimeError("methC got {}".format(c.methC()))

--- a/Examples/test-suite/python_crossmod.h
+++ b/Examples/test-suite/python_crossmod.h
@@ -1,0 +1,17 @@
+class A {
+public:
+    A() {}
+    int methA() { return 1; }
+};
+
+class B {
+public:
+    B() {}
+    int methB() { return 2; }
+};
+
+class C : public A, public B {
+public:
+    C() {}
+    int methC() { return 3; }
+};

--- a/Examples/test-suite/python_crossmod.list
+++ b/Examples/test-suite/python_crossmod.list
@@ -1,0 +1,2 @@
+python_crossmod_a
+python_crossmod_b

--- a/Examples/test-suite/python_crossmod_a.i
+++ b/Examples/test-suite/python_crossmod_a.i
@@ -1,0 +1,11 @@
+%module python_crossmod_a
+
+%{
+#include "python_crossmod.h"
+%}
+
+class A {
+public:
+    A();
+    int methA();
+};

--- a/Examples/test-suite/python_crossmod_b.i
+++ b/Examples/test-suite/python_crossmod_b.i
@@ -1,0 +1,19 @@
+%module python_crossmod_b
+
+%{
+#include "python_crossmod.h"
+%}
+
+%import(module="python_crossmod_a") "python_crossmod_a.i"
+
+class B {
+public:
+    B();
+    int methB();
+};
+
+class C : public A, public B {
+public:
+    C();
+    int methC();
+};

--- a/Lib/python/builtin.swg
+++ b/Lib/python/builtin.swg
@@ -299,8 +299,13 @@ SwigPyStaticVar_TypeOnce(void) {
     Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE,
     slots
   };
-  PyObject *pytype = PyType_FromSpec(&spec);
   PyObject *runtime_data_module = SWIG_runtime_data_module();
+  PyObject *pytype = PyObject_GetAttrString(runtime_data_module, "SwigPyStaticVar");
+  if (pytype) {
+    return (PyTypeObject *)pytype;
+  }
+  PyErr_Clear();
+  pytype = PyType_FromSpec(&spec);
   if (pytype && PyModule_AddObject(runtime_data_module, "SwigPyStaticVar", pytype) == 0)
     SWIG_Py_INCREF(pytype);
   return (PyTypeObject *)pytype;
@@ -417,8 +422,13 @@ SwigPyObjectType_TypeOnce(void) {
     Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,
     slots
   };
-  PyObject *pytype = PyType_FromSpec(&spec);
   PyObject *runtime_data_module = SWIG_runtime_data_module();
+  PyObject *pytype = PyObject_GetAttrString(runtime_data_module, "SwigPyObjectType");
+  if (pytype) {
+    return (PyTypeObject *)pytype;
+  }
+  PyErr_Clear();
+  pytype = PyType_FromSpec(&spec);
   if (pytype && PyModule_AddObject(runtime_data_module, "SwigPyObjectType", pytype) == 0)
     SWIG_Py_INCREF(pytype);
   return (PyTypeObject *)pytype;


### PR DESCRIPTION
The SwigPyObjectType metaclass and SwigPyStaticVar type created via PyType_FromSpec in the heap types path of builtin.swg were allocated as distinct heap type instances in each compiled module's copy of the TypeOnce functions. When a class inherited from types defined in different SWIG extension modules -- such as a director class from module A and a non-director class from module B -- PyType_FromSpecWithBases detected incompatible metaclasses and raised:

  TypeError: metaclass conflict

Both TypeOnce functions now check the shared runtime data module for an existing instance before creating a new one, so all modules share a single metaclass. This regression was introduced when SWIG_HEAPTYPES was enabled by default (SWIG 4.4) and only manifests on Python 3.12+.

Fixes #3315.

Assisted-by: opencode (deepseek-v4-flash)