### PR TITLE
[Lua] Fix apply_signed_char test

### DIFF
--- a/Examples/test-suite/apply_signed_char.i
+++ b/Examples/test-suite/apply_signed_char.i
@@ -12,6 +12,9 @@
 %apply const signed char & {const char &};
 
 %inline %{
+  /* Some languages wrapper are agnostic, some are sensitive and fails unless char is signed.
+     To test use: make apply_signed_char.cpptest CXXFLAGS="$CXXFLAGS -funsigned-char" */
+  int is_char_signed(void) { char c = -1; return c < 0; }
   char CharValFunction(char number) { return number; }
   const char CCharValFunction(const char number) { return number; }
   const char & CCharRefFunction(const char & number) { return number; }

--- a/Examples/test-suite/lua/apply_signed_char_runme.lua
+++ b/Examples/test-suite/lua/apply_signed_char_runme.lua
@@ -1,5 +1,11 @@
 local v=require("apply_signed_char")
 
+-- The test require char to be signed
+-- Skip the test if char is unsigned
+if v.is_char_signed() == 0 then
+  os.exit()
+end
+
 local smallnum = -127
 assert(v.CharValFunction(smallnum) == smallnum)
 assert(v.CCharValFunction(smallnum) == smallnum)


### PR DESCRIPTION
Follow #3499

Use @wsfulton solution.

Add is_char_signed() to skip the tests in Lua.
As test fails if char is unsigned.