### PR TITLE
[Python] Fix segfault with -threads in exception handlers

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -28,6 +28,7 @@ CPP_TEST_CASES += \
 	director_guard \
 	director_stl \
 	director_wstring \
+	threads_exception \
 	file_test \
 	iadd \
 	implicittest \

--- a/Lib/python/pythreads.swg
+++ b/Lib/python/pythreads.swg
@@ -16,11 +16,28 @@
 #      endif
 #    endif
 #    ifdef __cplusplus /* C++ code */
+       /* Deferred error storage: when PyGILState_Ensure creates a temporary
+        * thread state inside a SWIG_PYTHON_THREAD_BEGIN_ALLOW block, errors
+        * set on that temporary state are lost when PyGILState_Release destroys
+        * it. These globals bridge the transition: Block::end() saves the error
+        * before release, and Allow::end() restores it after restore. */
+       static PyObject *_swig_deferred_error_type = NULL;
+       static PyObject *_swig_deferred_error_value = NULL;
+       static PyObject *_swig_deferred_error_tb = NULL;
+
        class SWIG_Python_Thread_Block {
          bool status;
          PyGILState_STATE state;
        public:
-         void end() { if (status) { PyGILState_Release(state); status = false;} }
+         void end() {
+           if (status) {
+             status = false;
+             if (state == PyGILState_UNLOCKED && PyErr_Occurred()) {
+               PyErr_Fetch(&_swig_deferred_error_type, &_swig_deferred_error_value, &_swig_deferred_error_tb);
+             }
+             PyGILState_Release(state);
+           }
+         }
          SWIG_Python_Thread_Block() : status(true), state(PyGILState_Ensure()) {}
          ~SWIG_Python_Thread_Block() { end(); }
        };
@@ -28,7 +45,16 @@
          bool status;
          PyThreadState *save;
        public:
-         void end() { if (status) { status = false; PyEval_RestoreThread(save); }}
+         void end() {
+           if (status) {
+             status = false;
+             PyEval_RestoreThread(save);
+             if (_swig_deferred_error_type) {
+               PyErr_Restore(_swig_deferred_error_type, _swig_deferred_error_value, _swig_deferred_error_tb);
+               _swig_deferred_error_type = _swig_deferred_error_value = _swig_deferred_error_tb = NULL;
+             }
+           }
+         }
          SWIG_Python_Thread_Allow() : status(true), save(PyEval_SaveThread()) {}
          ~SWIG_Python_Thread_Allow() { end(); }
        };


### PR DESCRIPTION
When -threads is active and a C++ function throws an exception that is caught by a %exception handler or %throws typemap, the SWIG-generated wrapper's try-catch block wraps the ALLOW/END_ALLOW GIL release. If an exception is thrown inside the ALLOW block, the END_ALLOW is skipped and the catch block runs without the GIL. The error-setting functions (SWIG_SetErrorObj, SWIG_SetErrorMsg) use PyGILState_Ensure/Release (BLOCK/END_BLOCK) which creates a temporary PyThreadState. The error is set on this temporary state, and PyGILState_Release then destroys or caches it separately from the original thread state restored by PyEval_RestoreThread in END_ALLOW, causing the error to be lost. The wrapper returns NULL without an exception set, resulting in a segfault.

Fix by saving any pending Python error from the temporary thread state in SWIG_Python_Thread_Block::end() before PyGILState_Release, and restoring it in SWIG_Python_Thread_Allow::end() after PyEval_RestoreThread restores the original thread state. This bridges the Deferred Error Storage across the two different CPython GIL APIs that SWIG must mix when nesting BLOCK inside ALLOW.

Fixes #3212.

Assisted-by: opencode (deepseek-v4-flash)