### PR TITLE
[Python] Fix stale Python error indicator with director

### DIFF
--- a/Examples/test-suite/director_stale_error.i
+++ b/Examples/test-suite/director_stale_error.i
@@ -1,0 +1,54 @@
+// Test that catching DirectorException in C++ and calling clearPythonError()
+// does not leave a stale Python error indicator (issue #2671).
+
+%module(directors="1") director_stale_error
+
+%feature("director") Handler;
+
+%warnfilter(SWIGWARN_TYPEMAP_DIRECTOROUT_PTR) return_const_char_star;
+
+%{
+#include <string>
+#ifndef SWIG_DIRECTORS
+namespace Swig {
+  class DirectorException {};
+  class DirectorMethodException: public Swig::DirectorException {};
+}
+#endif
+%}
+
+%feature("director:except") %{
+  if ($error != NULL) {
+    throw Swig::DirectorMethodException();
+  }
+%}
+
+%inline %{
+
+class Handler {
+public:
+    Handler() {}
+    virtual ~Handler() {}
+    virtual int handle(int value) {
+        return value * 2;
+    }
+};
+
+class Invoker {
+public:
+    Invoker(Handler *h) : handler(h) {}
+
+    int call(int value) {
+        try {
+            return handler->handle(value);
+        } catch (Swig::DirectorException &e) {
+            e.clearPythonError();
+            return -1;
+        }
+    }
+
+private:
+    Handler *handler;
+};
+
+%}

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -26,6 +26,7 @@ CPP_TEST_CASES += \
 	callback \
 	complextest \
 	director_guard \
+	director_stale_error \
 	director_stl \
 	director_wstring \
 	file_test \

--- a/Examples/test-suite/python/director_stale_error_runme.py
+++ b/Examples/test-suite/python/director_stale_error_runme.py
@@ -1,0 +1,30 @@
+# Test that catching DirectorException in C++ and calling clearPythonError()
+# does not leave a stale Python error indicator (issue #2671).
+
+from director_stale_error import *
+
+class MyHandler(Handler):
+    def handle(self, value):
+        raise RuntimeError("error from director")
+
+h = MyHandler()
+inv = Invoker(h)
+
+# The director method raises an exception. C++ catches DirectorException,
+# calls clearPythonError(), and returns -1. No stale error should remain.
+result = inv.call(42)
+assert result == -1, "Expected -1, got %d" % result
+
+# A second call should also work without SystemError.
+result = inv.call(99)
+assert result == -1, "Expected -1, got %d" % result
+
+# Test that non-director calls still work normally.
+class GoodHandler(Handler):
+    def handle(self, value):
+        return value + 1
+
+h2 = GoodHandler()
+inv2 = Invoker(h2)
+result = inv2.call(10)
+assert result == 11, "Expected 11, got %d" % result

--- a/Lib/python/director.swg
+++ b/Lib/python/director.swg
@@ -164,6 +164,11 @@ namespace Swig {
   class DirectorException : public std::exception {
   protected:
     std::string swig_msg;
+    PyObject *swig_error_type;
+    PyObject *saved_error_type;
+    PyObject *saved_error_value;
+    PyObject *saved_error_tb;
+    bool suppress;
   public:
     DirectorException(PyObject *error, const char *hdr ="", const char *msg ="") : swig_msg(hdr) {
       SWIG_PYTHON_THREAD_BEGIN_BLOCK;
@@ -171,13 +176,50 @@ namespace Swig {
         swig_msg += " ";
         swig_msg += msg;
       }
-      if (!PyErr_Occurred()) {
-        PyErr_SetString(error, swig_msg.c_str());
+      swig_error_type = error;
+      Py_XINCREF(swig_error_type);
+      saved_error_type = saved_error_value = saved_error_tb = NULL;
+      suppress = false;
+      if (PyErr_Occurred()) {
+        PyErr_Fetch(&saved_error_type, &saved_error_value, &saved_error_tb);
       }
       SWIG_PYTHON_THREAD_END_BLOCK;
     }
 
     virtual ~DirectorException() SWIG_NOEXCEPT {
+      SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+      if (suppress) {
+        Py_XDECREF(saved_error_type);
+        Py_XDECREF(saved_error_value);
+        Py_XDECREF(saved_error_tb);
+      } else if (saved_error_type) {
+        PyErr_Restore(saved_error_type, saved_error_value, saved_error_tb);
+      } else if (!PyErr_Occurred()) {
+        PyErr_SetString(swig_error_type, swig_msg.c_str());
+      }
+      saved_error_type = saved_error_value = saved_error_tb = NULL;
+      Py_XDECREF(swig_error_type);
+      swig_error_type = NULL;
+      SWIG_PYTHON_THREAD_END_BLOCK;
+    }
+
+    void restorePythonError() {
+      if (saved_error_type) {
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        PyErr_Restore(saved_error_type, saved_error_value, saved_error_tb);
+        saved_error_type = saved_error_value = saved_error_tb = NULL;
+        SWIG_PYTHON_THREAD_END_BLOCK;
+      }
+    }
+
+    void clearPythonError() {
+      SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+      Py_XDECREF(saved_error_type);
+      Py_XDECREF(saved_error_value);
+      Py_XDECREF(saved_error_tb);
+      saved_error_type = saved_error_value = saved_error_tb = NULL;
+      suppress = true;
+      SWIG_PYTHON_THREAD_END_BLOCK;
     }
 
     /* Deprecated, use what() instead */

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3489,7 +3489,11 @@ public:
     String *actioncode = emit_action(n);
 
     if (director_method) {
-      Append(actioncode, "} catch (Swig::DirectorException&) {\n");
+      Append(actioncode, "} catch (Swig::DirectorException& e) {\n");
+      Append(actioncode, "  e.restorePythonError();\n");
+      Append(actioncode, "  if (!PyErr_Occurred()) {\n");
+      Append(actioncode, "    PyErr_SetString(PyExc_RuntimeError, e.what());\n");
+      Append(actioncode, "  }\n");
       Append(actioncode, "  SWIG_fail;\n");
       Append(actioncode, "}\n");
     }


### PR DESCRIPTION
When a Python method invoked from a director upcall raises an exception, Swig::DirectorMethodException is thrown. The DirectorException constructor previously preserved the Python error indicator (via the if (!PyErr_Occurred()) guard) rather than clearing it. If the C++ code caught the DirectorException and continued normally, the wrapper would return a result to Python with the stale error indicator still set, causing SystemError ("returned a result with an error set").

Fix: always clear the Python error indicator in the DirectorException constructor via PyErr_Fetch, storing the original error in member variables. The destructor restores the saved error when the exception propagates (preserving the original Python exception for the default wrapper catch handler). When no Python error was set (e.g. DirectorTypeMismatchException), the destructor sets the appropriate SWIG error (TypeError, RuntimeError, etc.) from the exception's error type.

A new clearPythonError() method is provided for user code that catches DirectorException and continues without propagating the error.

Fixes #2671.

Assisted-by: opencode (deepseek-v4-flash)