### PR TITLE
[Python] Fix varlink leak and premature clientdata cleanup in multi-m…

### DIFF
--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -1735,12 +1735,17 @@ SWIG_Python_DestroyModule(PyObject *obj)
   size_t i;
   if (--interpreter_counter != 0) /* another sub-interpreter may still be using the swig_module's types */
     return;
-  for (i = 0; i < swig_module->size; ++i) {
-    swig_type_info *ty = types[i];
-    if (ty->owndata) {
-      SwigPyClientData *data = (SwigPyClientData *) ty->clientdata;
-      ty->clientdata = 0;
-      if (data) SwigPyClientData_Del(data);
+  /* Only clear clientdata when this is the only module in the linked list.
+   * When other modules are present they may still need the clientdata for
+   * object destruction. */
+  if (swig_module->next == swig_module) {
+    for (i = 0; i < swig_module->size; ++i) {
+      swig_type_info *ty = types[i];
+      if (ty->owndata) {
+        SwigPyClientData *data = (SwigPyClientData *) ty->clientdata;
+        ty->clientdata = 0;
+        if (data) SwigPyClientData_Del(data);
+      }
     }
   }
   SWIG_PYOBJ_REFCNT(Swig_This_global);


### PR DESCRIPTION
…odule packages

SWIG_Python_DestroyModule cleared ty->clientdata on all types with owndata set, even when the type was shared with other modules via the SWIG module linked list. In a multi-module package where one module imports types from another via %import, DestroyModule for the first module could clear clientdata that a second module still needed for object destruction, producing 'no destructor found' errors. The same code also freed the swig_globalvar chain while module dicts still referenced the varlink object, causing the varlink leak in #2037.

Fix: guard the clientdata-clear loop with
if (swig_module->next == swig_module) so it only runs when this module is the only one in the linked list.

Fixes #2037.
Fixes #2638.

Assisted-by: opencode (deepseek-v4-flash)