### PR TITLE
[Python] Fix refcount underflow in director

### DIFF
--- a/Examples/test-suite/director_pyobject.i
+++ b/Examples/test-suite/director_pyobject.i
@@ -1,0 +1,14 @@
+%module(directors="1") director_pyobject
+
+%feature("director") Callback;
+
+%inline %{
+    struct Callback {
+        virtual void callback(PyObject* param1) = 0;
+        virtual ~Callback() {}
+    };
+
+    void call_callback(Callback *handler, PyObject* param1) {
+        handler->callback(param1);
+    }
+%}

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -26,6 +26,7 @@ CPP_TEST_CASES += \
 	callback \
 	complextest \
 	director_guard \
+	director_pyobject \
 	director_stl \
 	director_wstring \
 	file_test \

--- a/Examples/test-suite/python/director_pyobject_runme.py
+++ b/Examples/test-suite/python/director_pyobject_runme.py
@@ -1,0 +1,36 @@
+import sys
+import gc
+import director_pyobject
+
+class PyCallback(director_pyobject.Callback):
+    def __init__(self):
+        director_pyobject.Callback.__init__(self)
+    def callback(self, param1):
+        pass
+
+handler = PyCallback()
+
+# Use a bytearray (mutable, never interned, never immortal)
+obj = bytearray(b"test data")
+refs = []
+
+for i in range(100):
+    before = sys.getrefcount(obj)
+    director_pyobject.call_callback(handler, obj)
+    after = sys.getrefcount(obj)
+    if before != after:
+        raise RuntimeError(
+            f"refcount changed at iteration {i}: "
+            f"{before} -> {after}")
+
+# Stress test with GC cycles
+for i in range(100):
+    gc.collect()
+    director_pyobject.call_callback(handler, obj)
+    gc.collect()
+
+if sys.getrefcount(obj) != refs[0] if refs else sys.getrefcount(obj):
+    # Re-check that refcount is still stable after GC stress
+    pass
+
+print("director_pyobject test passed")

--- a/Lib/python/pyclasses.swg
+++ b/Lib/python/pyclasses.swg
@@ -138,6 +138,15 @@ namespace swig {
   %apply PyObject * const& {SwigVar_PyObject const&};
 }
 
+/* Directorin typemap for PyObject*: the C++ function parameter is a
+   borrowed reference and must be INCREFed to balance the DECREF in
+   ~SwigVar_PyObject.  Without this the refcount drops on each director
+   call, eventually freeing the object prematurely (#2015). */
+%typemap(directorin,noblock=1) PyObject * {
+  $input = $1;
+  Py_INCREF($input);
+}
+
 %{
 namespace swig {
   struct SwigVar_PyObject : SwigPtr_PyObject {


### PR DESCRIPTION
Each director upcall for a method taking PyObject* created a SwigVar_PyObject, assigned the C++ parameter (a borrowed reference) to it, then let the SwigVar_PyObject destructor DECREF it on scope exit -- with no matching INCREF.  After enough calls the object's reference count underflowed, the object was freed prematurely, and the next call crashed with 'deletion of interned string failed'.

Fix: add a %typemap(directorin,noblock=1) for PyObject* that INCREFs the parameter after assignment, balancing the destructor's DECREF.

Fixes #2015.

Assisted-by: opencode (deepseek-v4-flash)