### PR TITLE
[Python] Fix %feature("shadow") silently ignored

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -28,6 +28,7 @@ CPP_TEST_CASES += \
 	director_guard \
 	director_stl \
 	director_wstring \
+	test_shadow \
 	file_test \
 	iadd \
 	implicittest \

--- a/Examples/test-suite/python/test_shadow_runme.py
+++ b/Examples/test-suite/python/test_shadow_runme.py
@@ -1,0 +1,21 @@
+import test_shadow
+from swig_test_utils import swig_assert
+import inspect
+
+r = test_shadow.global_func(3, 4)
+swig_assert(r == 7)
+
+r = test_shadow.shadowed_func(5, 6)
+swig_assert(r == 30)
+
+r = test_shadow.plain_func(10, 3)
+swig_assert(r == 7)
+
+# inspect.getsource does not work with -builtin
+if not test_shadow.is_python_builtin():
+    src = inspect.getsource(test_shadow.global_func)
+    swig_assert("SHADOW WORKS" in src)
+    src = inspect.getsource(test_shadow.shadowed_func)
+    swig_assert("SHADOW WORKS" in src)
+    src = inspect.getsource(test_shadow.plain_func)
+    swig_assert("SHADOW WORKS" not in src)

--- a/Examples/test-suite/test_shadow.i
+++ b/Examples/test-suite/test_shadow.i
@@ -1,0 +1,25 @@
+%module test_shadow
+
+%feature("shadow") global_func %{
+def global_func(a, b):
+    print("SHADOW WORKS")
+    return $action(a, b)
+%}
+
+%feature("shadow") shadowed_func %{
+def shadowed_func(a, b):
+    print("SHADOW WORKS")
+    return $action(a, b)
+%}
+
+%inline %{
+int global_func(int a, int b) { return a + b; }
+int shadowed_func(int a, int b) { return a * b; }
+int plain_func(int a, int b) { return a - b; }
+
+#ifdef SWIGPYTHON_BUILTIN
+bool is_python_builtin() { return true; }
+#else
+bool is_python_builtin() { return false; }
+#endif
+%}

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2609,6 +2609,18 @@ public:
     String *parms = make_pyParmList(n, false, false, kw);
     String *callParms = make_pyParmList(n, false, true, kw);
 
+    // %feature("shadow") provides a complete replacement function body.
+    // Emit it directly and skip the standard wrapper generation.
+    if (!builtin && Getattr(n, "feature:shadow")) {
+      String *pycode = indent_pythoncode(Getattr(n, "feature:shadow"), "", Getfile(n), Getline(n), "%feature(\"shadow\")");
+      String *pyaction = NewStringf("%s.%s", module, name);
+      Replaceall(pycode, "$action", pyaction);
+      Delete(pyaction);
+      Printv(f_dest, pycode, "\n", NIL);
+      Delete(pycode);
+      return;
+    }
+
     // Callbacks need the C function in order to extract the pointer from the swig_ptr: string
     bool fast = (fastproxy && !have_addtofunc(n)) || Getattr(n, "feature:callback");
 


### PR DESCRIPTION
%feature("shadow") provides a complete Python function body that replaces the generated wrapper, with $action expanded to the C function call. It worked on class methods but was silently ignored on global functions because emitFunctionShadowHelper did not check for feature:shadow. The fast-proxy path (name = module.name) was always taken, bypassing the shadow code entirely.

Fix: check for Getattr(n, "feature:shadow") at the top of emitFunctionShadowHelper and emit the shadow code directly with $action replaced, then return early so the fast-proxy assignment is skipped.

Fixes #980.

Assisted-by: opencode (deepseek-v4-flash)