### PR TITLE
[Python] Release the GIL before calling virtual director methods

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -230,6 +230,7 @@ CPP_TEST_CASES += \
 	director_simple \
 	director_shared_ptr \
 	director_template \
+	director_gil_release \
 	director_thread \
 	director_unroll \
 	director_unwrap_result \

--- a/Examples/test-suite/director_gil_release.i
+++ b/Examples/test-suite/director_gil_release.i
@@ -1,0 +1,33 @@
+#if defined(SWIGPYTHON)
+%module(directors="1", threads="1") director_gil_release
+#else
+%module(directors="1") director_gil_release
+#endif
+
+%{
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+%}
+
+%director Foo;
+
+%inline %{
+
+class Foo {
+public:
+  virtual ~Foo() {}
+  virtual void blocking_call(int ms) {
+#ifdef _WIN32
+    Sleep(ms);
+#else
+    usleep(ms * 1000);
+#endif
+  }
+  int ping() {
+    return 42;
+  }
+};
+%}

--- a/Examples/test-suite/python/director_gil_release_runme.py
+++ b/Examples/test-suite/python/director_gil_release_runme.py
@@ -1,0 +1,40 @@
+import threading
+import time
+from director_gil_release import Foo
+
+
+class PyFoo(Foo):
+    pass
+
+
+f = PyFoo()
+done = False
+
+
+def worker():
+    global done
+    f.blocking_call(300)
+    done = True
+
+
+t = threading.Thread(target=worker)
+start = time.time()
+t.start()
+time.sleep(0.05)
+
+# if GIL was released by blocking_call, ping() returns immediately
+# if not, ping() can't be called until blocking_call(300) finishes (~300ms)
+result = f.ping()
+elapsed = time.time() - start
+
+t.join()
+
+# elapsed from start includes:
+# - 50ms sleep (specified)
+# - GIL wait time only if GIL was NOT released by the director method
+# With GIL release: ~0.05s, without: ~0.30s
+if elapsed > 0.2:
+    raise RuntimeError("GIL was not released, total time %.3fs" % elapsed)
+
+if result != 42:
+    raise RuntimeError("Unexpected result: " + str(result))

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3296,6 +3296,15 @@ public:
         const char *self_parm = builtin_self ? "self" : "obj0";
         Printf(f->code, "upcall = (director && (director->swig_get_self()==%s));\n", self_parm);
       }
+      if (allow_thread) {
+        String *preaction = NewString("");
+        thread_begin_allow(n, preaction);
+        Setattr(n, "wrap:preaction", preaction);
+
+        String *postaction = NewString("");
+        thread_end_allow(n, postaction);
+        Setattr(n, "wrap:postaction", postaction);
+      }
     } else {
       if (allow_thread) {
         String *preaction = NewString("");


### PR DESCRIPTION
The Python wrapper for a non-virtual method releases the GIL (SWIG_PYTHON_THREAD_BEGIN_ALLOW / SWIG_PYTHON_THREAD_END_ALLOW) before entering C++ code, so other Python threads can make progress while the call is in flight.  Virtual (director) methods were missing this GIL release because the thread-allow setup was skipped in the director_method branch of functionWrapper().  This could cause a deadlock when a director method blocked in C++ while holding the GIL.

Add the same thread_begin_allow / thread_end_allow calls in the director_method path that already exist for non-director methods, so the action code (the if (upcall) / else branch emitted by cwrap.c's CWRAP_DIRECTOR_TWO_CALLS) is wrapped in GIL release.

Fixes #306.

Assisted-by: opencode (DeepSeek V4 Flash)