### PR TITLE
[Python] Return the original Python wrapper for methods returning *this

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -423,6 +423,7 @@ CPP_TEST_CASES += \
 	return_value_scope \
 	rname \
 	samename \
+	self_return \
 	sizet \
 	smart_pointer_const \
 	smart_pointer_const2 \

--- a/Examples/test-suite/python/self_return_runme.py
+++ b/Examples/test-suite/python/self_return_runme.py
@@ -1,0 +1,17 @@
+from self_return import Counter
+
+# Direct rebind: f = f.Inc() must not destroy the C++ object
+a = Counter(10)
+a = a.Inc()
+assert a.get_n() == 11, "direct rebind failed: " + str(a.get_n())
+
+# Chained calls: each returns *this
+b = Counter(1)
+b = b.Inc().Inc().Inc()
+assert b.get_n() == 4, "chained calls failed: " + str(b.get_n())
+
+# Method with argument returning *this
+c = Counter(5)
+d = Counter(3)
+c = c.Add(d)
+assert c.get_n() == 8, "Add rebind failed: " + str(c.get_n())

--- a/Examples/test-suite/self_return.i
+++ b/Examples/test-suite/self_return.i
@@ -1,0 +1,22 @@
+%module self_return
+
+%inline %{
+
+class Counter {
+public:
+  Counter(int n = 0) : n(n) {}
+  Counter& Inc() {
+    ++n;
+    return *this;
+  }
+  Counter& Add(const Counter& other) {
+    n += other.n;
+    return *this;
+  }
+  int get_n() const {
+    return n;
+  }
+private:
+  int n;
+};
+%}

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -3351,12 +3351,33 @@ public:
         }
       }
 
+      bool self_return = !constructor && !destructor && l && Getattr(l, "self") && !GetFlag(n, "feature:self:disown") &&
+                         (SwigType_isreference(returntype) || SwigType_ispointer(returntype)) &&
+                         Cmp(SwigType_base(returntype), SwigType_base(Getattr(l, "type"))) == 0;
+
       // Unwrap return values that are director classes so that the original Python object is returned instead.
       if (!constructor && Swig_director_can_unwrap(n)) {
-        Wrapper_add_local(f, "director", "Swig::Director *director = 0");
-        Printf(f->code, "director = SWIG_DIRECTOR_CAST(%s);\n", Swig_cresult_name());
+        const char *director_var = "director";
+        Wrapper_add_local(f, director_var, "Swig::Director *director = 0");
+        Printf(f->code, "%s = SWIG_DIRECTOR_CAST(%s);\n", director_var, Swig_cresult_name());
         Append(f->code, "if (director) {\n");
         Append(f->code, "  resultobj = director->swig_get_self();\n");
+        Append(f->code, "  SWIG_Py_INCREF(resultobj);\n");
+        if (self_return) {
+          const char *self_var = builtin_self ? "self" : (funpack ? "swig_obj[0]" : "obj0");
+          Printf(f->code, "} else if ((void *)arg1 == (void *)%s) {\n", Swig_cresult_name());
+          Printf(f->code, "  resultobj = %s;\n", self_var);
+          Append(f->code, "  SWIG_Py_INCREF(resultobj);\n");
+          Append(f->code, "} else {\n");
+        } else {
+          Append(f->code, "} else {\n");
+        }
+        Printf(f->code, "%s\n", tm);
+        Append(f->code, "}\n");
+      } else if (self_return) {
+        const char *self_var = builtin_self ? "self" : (funpack ? "swig_obj[0]" : "obj0");
+        Printf(f->code, "if ((void *)arg1 == (void *)%s) {\n", Swig_cresult_name());
+        Printf(f->code, "  resultobj = %s;\n", self_var);
         Append(f->code, "  SWIG_Py_INCREF(resultobj);\n");
         Append(f->code, "} else {\n");
         Printf(f->code, "%s\n", tm);


### PR DESCRIPTION
When a C++ member function returns a reference or pointer to *this (e.g. Foo& Inc() { ++n; return *this; }), the SWIG-generated wrapper creates a new Python object wrapping the same C++ pointer.  Python then sees two wrappers owning the same C++ object: the old one and the new one. When Python evaluates 'f = f.Inc()', it decrefs the old wrapper first (destroying the C++ object) before assigning the new wrapper, which now dangles.

Fix this by adding a runtime check in the out-typemap path: if the returned C++ pointer is identical to the 'this' pointer (arg1), return the original Python wrapper ('self') with an incremented reference count instead of creating a new object.  The check is inserted both in the director-unwrap path (for director classes) and as a standalone guard for non-director classes.

The check only fires for non-static member functions where both the self parameter and return type resolve to the same C++ type, and is skipped when %delobject is in effect (which would have already transferred ownership away from the input wrapper).

Fixes #764.

Assisted-by: opencode (DeepSeek V4 Flash)