### PR TITLE
ci: Cancel in-progress jobs when pushing new commits

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cmake:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
   # The clang-format version used is slightly different for each OS workflow file

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
   # The clang-format version used is slightly different for each OS workflow file

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Code format checks, see https://github.com/marketplace/actions/clang-format-github-action
   # The clang-format version used is slightly different for each OS workflow file


### PR DESCRIPTION
The Swig repo runs a lot of GitHub Actions jobs on a PR to test many supported configurations/languages. When pushing commits to a PR, this will request another batch of jobs. When the previous jobs aren't done yet, they will still continue, even though their result isn't needed anymore.

With this change, any previous jobs are cancelled when pushing new commits. This follows the example from the [GitHub actions docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-concurrency-and-the-default-behavior).