### PR TITLE
[Python] Customize return annotation for multiple argout matches

### DIFF
--- a/Doc/Manual/Python.html
+++ b/Doc/Manual/Python.html
@@ -7149,9 +7149,19 @@ def do_something(t: "int|float") -&gt; "int":
 When <tt>argout</tt> typemaps are used, the return annotation is built from the wrapped return
 type and each matched <tt>pytyping</tt> typemap for the <tt>argout</tt> parameters. A single
 returned value keeps its type directly if the function signature returns void. Multiple returned values default to
-<tt>typing.List[typing.Union[...]]</tt>. There will be multiple returned values if the function signature returns non-void
-and there is at least one parameter that is an argout. This matches the behaviour when <tt>SWIG_AppendOutput</tt> is used.
+<tt>typing.List[typing.Union[...]]</tt>. This matches the behaviour when <tt>SWIG_AppendOutput</tt> is used.
 </p>
+
+<p>
+Use <tt>argoutaction="overwrite"</tt> in a <tt>pytyping</tt> typemap to replace the current
+annotation instead of appending to it. Use <tt>argoutprefix</tt>, <tt>argoutjoiner</tt>, and
+<tt>argoutsuffix</tt> to customize the formatting when multiple values are returned.
+</p>
+
+<div class="code"><pre>
+%typemap(pytyping, argoutaction="overwrite") short *OutReplace "int"
+%typemap(pytyping, argoutprefix="typing.Tuple[", argoutjoiner=",", argoutsuffix="]") double *OutTuple "float"
+</pre></div>
 
 <p>
 The following special variables can be used in a <tt>pytyping</tt> typemap. They are similar to Java's

--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -256,10 +256,20 @@ if annotations_supported:
     ]:
         swig_assert(not hasattr(python_annotations_typing, name))
 
+    anno = get_annotations(argoutVoidSingleReplace)
+    if anno != {"arg": "bool", "return": "int"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(argoutVoidSingleReplace(True), int))
+
     anno = get_annotations(argoutVoidSingleAppend)
     if anno != {"arg": "bool", "return": "int"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_assert(isinstance(argoutVoidSingleAppend(True), int))
+
+    anno = get_annotations(argoutBoolSingleReplace)
+    if anno != {"arg": "bool", "return": "int"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(argoutBoolSingleReplace(True), int))
 
     anno = get_annotations(argoutBoolSingleAppend)
     if anno != {"arg": "bool", "return": "typing.List[typing.Union[bool, int]]"}:
@@ -275,8 +285,27 @@ if annotations_supported:
     if anno != {"arg": "bool", "return": "typing.List[typing.Union[bool, int, int]]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_assert(isinstance(argoutBoolAppendTwice(True), list))
+    anno = get_annotations(argoutVoidReplaceTwice)
+    if anno != {"arg": "bool", "return": "int"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(argoutVoidReplaceTwice(True), int))
+
+    anno = get_annotations(argoutBoolTuple)
+    if anno != {"arg": "bool", "return": "typing.Tuple[bool,float]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(argoutBoolTuple(True), tuple))
+
+    anno = get_annotations(argoutBoolTupleTwice)
+    if anno != {"arg": "bool", "return": "typing.Tuple[bool,float,float]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(argoutBoolTupleTwice(True), tuple))
 
     anno = get_annotations(argoutMultiarg)
+    if anno != {"return": "typing.List[int]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(argoutMultiarg(), list))
+
+    anno = get_annotations(argoutMultiargReplace)
     if anno != {"return": "typing.List[int]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_assert(isinstance(argoutMultiarg(), list))
@@ -286,22 +315,47 @@ if annotations_supported:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_check(argoutBoolMultiarg(True), [True, []])
 
+    anno = get_annotations(argoutBoolMultiargReplace)
+    if anno != {"arg": "bool", "return": "typing.List[int]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_check(argoutBoolMultiargReplace(True), [])
+
     anno = get_annotations(argoutMultiargAfterFirst)
     if anno != {"first": "int", "return": "typing.List[int]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_check(argoutMultiargAfterFirst(1), [])
+
+    anno = get_annotations(argoutMultiargReplaceAfterFirst)
+    if anno != {"first": "int", "return": "typing.List[int]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_check(argoutMultiargReplaceAfterFirst(1), [])
 
     anno = get_annotations(argoutBoolMultiargAfterFirst)
     if anno != {"first": "int", "return": "typing.List[typing.Union[bool, typing.List[int]]]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_check(argoutBoolMultiargAfterFirst(2), [True, []])
 
+    anno = get_annotations(argoutBoolMultiargReplaceAfterFirst)
+    if anno != {"first": "int", "return": "typing.List[int]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_check(argoutBoolMultiargReplaceAfterFirst(2), [])
+
     anno = get_annotations(argoutMultiargBetweenFirstLast)
     if anno != {"first": "int", "last": "float", "return": "typing.List[int]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_check(argoutMultiargBetweenFirstLast(3, 4.0), [])
 
+    anno = get_annotations(argoutMultiargReplaceBetweenFirstLast)
+    if anno != {"first": "int", "last": "float", "return": "typing.List[int]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_check(argoutMultiargReplaceBetweenFirstLast(3, 4.0), [])
+
     anno = get_annotations(argoutBoolMultiargBetweenFirstLast)
     if anno != {"first": "int", "last": "float", "return": "typing.List[typing.Union[bool, typing.List[int]]]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
     swig_check(argoutBoolMultiargBetweenFirstLast(5, 6.0), [True, []])
+
+    anno = get_annotations(argoutBoolMultiargReplaceBetweenFirstLast)
+    if anno != {"first": "int", "last": "float", "return": "typing.List[int]"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_check(argoutBoolMultiargReplaceBetweenFirstLast(5, 6.0), [])

--- a/Examples/test-suite/python_annotations_typing.i
+++ b/Examples/test-suite/python_annotations_typing.i
@@ -101,12 +101,44 @@ int is_python_fastproxy() { return 0; }
 
 %typemap(pytyping) (int argc, char **argv) "typing.List[str]"
 
+%typemap(in, numinputs=0) short *OutReplace (short temp) { $1 = &temp; }
+%typemap(argout) (short *OutReplace) {
+  Py_XDECREF($result);
+  $result = PyLong_FromLong(*$1);
+}
+%typemap(pytyping, argoutaction="overwrite") short *OutReplace "int"
+
 %typemap(in, numinputs=0) short *OutAppend (short temp) { $1 = &temp; }
 %typemap(argout) (short *OutAppend) {
   $result = SWIG_AppendOutput($result, PyLong_FromLong(*$1));
 }
 %typemap(pytyping) short *OutAppend "int"
+
+%typemap(in, numinputs=0) double *OutTuple (double temp) { $1 = &temp; }
+%typemap(argout) double *OutTuple {
+  PyObject *o, *o2, *o3;
+  o = PyFloat_FromDouble(*$1);
+  if ((!$result) || ($result == Py_None)) {
+    $result = o;
+  } else {
+    if (!PyTuple_Check($result)) {
+      PyObject *o2 = $result;
+      $result = PyTuple_New(1);
+      PyTuple_SetItem($result, 0, o2);
+    }
+    o3 = PyTuple_New(1);
+    PyTuple_SetItem(o3, 0, o);
+    o2 = $result;
+    $result = PySequence_Concat(o2, o3);
+    Py_DecRef(o2);
+    Py_DecRef(o3);
+  }
+}
+%typemap(pytyping, argoutprefix="typing.Tuple[", argoutjoiner=",", argoutsuffix="]") double *OutTuple "float"
+
+%apply short *OutReplace { short *OutReplace2 };
 %apply short *OutAppend { short *OutAppend2 };
+%apply double *OutTuple { double *OutTuple2 };
 
 %typemap(in, numinputs=0) (short **short_list)(short*temp) { $1 = &temp; }
 %typemap(in, numinputs=0) (size_t *short_list_len)(size_t temp) { $1 = &temp; }
@@ -118,6 +150,18 @@ int is_python_fastproxy() { return 0; }
   $result = SWIG_AppendOutput($result, list);
 }
 %typemap(pytyping) (short **short_list, size_t *short_list_len) "typing.List[int]"
+
+// Like (short **short_list, size_t *short_list_len) except that it replaces the return value.
+%typemap(in, numinputs=0) (short **short_list_replace)(short*temp) { $1 = &temp; }
+%typemap(in, numinputs=0) (size_t *short_list_len)(size_t temp) { $1 = &temp; }
+%typemap(freearg) (short **short_list_replace) { free(*$1); }
+%typemap(argout) (short **short_list_replace, size_t *short_list_len) {
+  Py_XDECREF($result);
+  $result = PyList_New(*$2);
+  for (size_t i = 0; i < *$2; i++)
+    PyList_SetItem($result, i, PyLong_FromLong((*$1)[i]));
+}
+%typemap(pytyping, argoutaction="overwrite") (short **short_list_replace, size_t *short_list_len) "typing.List[int]"
 
 %inline %{
 #include <cstddef>
@@ -289,8 +333,13 @@ struct HasClassMembers {
 struct ForwardOnly;
 void use_forward_only(ForwardOnly *fp) { (void)fp; }
 
+void argoutVoidSingleReplace(bool arg, short *OutReplace) { *OutReplace = 42; }
 void argoutVoidSingleAppend(bool arg, short *OutAppend) { *OutAppend = 42; }
 
+bool argoutBoolSingleReplace(bool arg, short *OutReplace) {
+  *OutReplace = 42;
+  return arg;
+}
 bool argoutBoolSingleAppend(bool arg, short *OutAppend) {
   *OutAppend = 42;
   return arg;
@@ -300,10 +349,31 @@ void argoutVoidAppendTwice(bool arg, short *OutAppend, short *OutAppend2) {
   *OutAppend = 42;
   *OutAppend2 = 43;
 }
+void argoutVoidReplaceTwice(bool arg, short *OutReplace, short *OutReplace2) {
+  *OutReplace = 42;
+  *OutReplace2 = 43;
+}
 
 bool argoutBoolAppendTwice(bool arg, short *OutAppend, short *OutAppend2) {
   *OutAppend = 42;
   *OutAppend2 = 43;
+  return arg;
+}
+
+bool argoutBoolReplaceAppend(bool arg, short *OutReplace, short *OutAppend) {
+  *OutReplace = 42;
+  *OutAppend = 43;
+  return arg;
+}
+
+bool argoutBoolTuple(bool arg, double *OutTuple) {
+  *OutTuple = 42.0;
+  return arg;
+}
+
+bool argoutBoolTupleTwice(bool arg, double *OutTuple, double *OutTuple2) {
+  *OutTuple = 42.0;
+  *OutTuple2 = 43.0;
   return arg;
 }
 
@@ -312,8 +382,19 @@ void argoutMultiarg(short **short_list, size_t *short_list_len) {
   *short_list_len = 0;
 }
 
+void argoutMultiargReplace(short **short_list_replace, size_t *short_list_len) {
+  *short_list_replace = NULL;
+  *short_list_len = 0;
+}
+
 bool argoutBoolMultiarg(bool arg, short **short_list, size_t *short_list_len) {
   *short_list = NULL;
+  *short_list_len = 0;
+  return arg;
+}
+
+bool argoutBoolMultiargReplace(bool arg, short **short_list_replace, size_t *short_list_len) {
+  *short_list_replace = NULL;
   *short_list_len = 0;
   return arg;
 }
@@ -324,8 +405,20 @@ void argoutMultiargAfterFirst(int first, short **short_list, size_t *short_list_
   *short_list_len = 0;
 }
 
+void argoutMultiargReplaceAfterFirst(int first, short **short_list_replace, size_t *short_list_len) {
+  (void)first;
+  *short_list_replace = NULL;
+  *short_list_len = 0;
+}
+
 bool argoutBoolMultiargAfterFirst(int first, short **short_list, size_t *short_list_len) {
   *short_list = NULL;
+  *short_list_len = 0;
+  return first != 0;
+}
+
+bool argoutBoolMultiargReplaceAfterFirst(int first, short **short_list_replace, size_t *short_list_len) {
+  *short_list_replace = NULL;
   *short_list_len = 0;
   return first != 0;
 }
@@ -337,8 +430,21 @@ void argoutMultiargBetweenFirstLast(int first, short **short_list, size_t *short
   *short_list_len = 0;
 }
 
+void argoutMultiargReplaceBetweenFirstLast(int first, short **short_list_replace, size_t *short_list_len, double last) {
+  (void)first;
+  (void)last;
+  *short_list_replace = NULL;
+  *short_list_len = 0;
+}
+
 bool argoutBoolMultiargBetweenFirstLast(int first, short **short_list, size_t *short_list_len, double last) {
   *short_list = NULL;
+  *short_list_len = 0;
+  return first != 0 && last != 0.0;
+}
+
+bool argoutBoolMultiargReplaceBetweenFirstLast(int first, short **short_list_replace, size_t *short_list_len, double last) {
+  *short_list_replace = NULL;
   *short_list_len = 0;
   return first != 0 && last != 0.0;
 }

--- a/Source/Include/swigwarn.h
+++ b/Source/Include/swigwarn.h
@@ -269,6 +269,7 @@
 
 #define WARN_PYTHON_INDENT_MISMATCH                  740
 #define WARN_PYTHON_TYPEMAP_PYTYPING_UNDEF           741
+#define WARN_PYTHON_PYTYPING_ARGOUT_MISMATCH         742
 
 /* please leave 740-749 free for Python */
 

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -2596,10 +2596,47 @@ public:
   }
 
   /* ------------------------------------------------------------
+   * updateArgoutTypingFormat()
+   *
+   * Get the user specified formatting for typing annotations when argout typemaps are used.
+   * Issue warnings if they don't match existing ones.
+   * ------------------------------------------------------------ */
+
+  void updateArgoutTypingFormat(ParmList *p, const String **prefix, const String **joiner, const String **suffix) {
+    // Assume all argout parameters are returned in a list (SWIG_AppendOutput).
+    const char *default_prefix = "typing.List[typing.Union[";
+    const char *default_joiner = ", ";
+    const char *default_suffix = "]]";
+
+    const String *user_prefix = Getattr(p, "tmap:pytyping:argoutprefix");
+    if (!*prefix) {
+      *prefix = user_prefix ? user_prefix : default_prefix;
+    } else if (user_prefix && !Equal(*prefix, user_prefix)) {
+      Swig_warning(
+        WARN_PYTHON_PYTYPING_ARGOUT_MISMATCH, input_file, line_number, "Found different argout prefixes for pytyping. Prefix '%s' will be used.\n", *prefix);
+    }
+
+    const String *user_joiner = Getattr(p, "tmap:pytyping:argoutjoiner");
+    if (!*joiner) {
+      *joiner = user_joiner ? user_joiner : default_joiner;
+    } else if (user_joiner && !Equal(*joiner, user_joiner)) {
+      Swig_warning(WARN_PYTHON_PYTYPING_ARGOUT_MISMATCH, input_file, line_number, "Found different argout joiners for pytyping. '%s' will be used.\n", *joiner);
+    }
+
+    const String *user_suffix = Getattr(p, "tmap:pytyping:argoutsuffix");
+    if (!*suffix) {
+      *suffix = user_suffix ? user_suffix : default_suffix;
+    } else if (user_suffix && !Equal(*suffix, user_suffix)) {
+      Swig_warning(
+        WARN_PYTHON_PYTYPING_ARGOUT_MISMATCH, input_file, line_number, "Found different argout suffixes for pytyping. '%s' will be used.\n", *suffix);
+    }
+  }
+
+  /* ------------------------------------------------------------
    * argoutReturnTypeAnnotation()
    *
-   * Get the return type annotation for functions with argout
-   * parameters. Return NULL if there are no argout parameters.
+   * Gets the return type annotation for functions with argout
+   * parameters. Returns NULL if there are no argout parameters.
    * The annotation mode must not be NONE.
    * ------------------------------------------------------------ */
 
@@ -2616,16 +2653,20 @@ public:
 
     while (p) {
       if ((tm = Getattr(p, "tmap:argout:match_type"))) {
-        if (anno == TYPE_ANNOTATION_TYPING)
+        if (anno == TYPE_ANNOTATION_TYPING) {
+          // To allow multi-argument typemaps to specify an out parameter,
+          // we clone the list and attach the pytyping info.
+          p = CopyParmList(root);
           break;
+        }
 
+        // C annotations - concatenate all with a comma
         tm = SwigType_str(tm, 0);
         if (ret) {
           Printv(ret, ", ", tm, NULL);
-          Delete(tm);
-        } else {
+          Free(tm);
+        } else
           ret = tm;
-        }
 
         p = Getattr(p, "tmap:argout:next");
       } else {
@@ -2637,16 +2678,23 @@ public:
 
     assert(anno == TYPE_ANNOTATION_TYPING);
 
-    ParmList *copied_parms = CopyParmList(root);
-    Swig_typemap_attach_parms("pytyping", copied_parms, 0);
+    Swig_typemap_attach_parms("pytyping", p, 0);
 
-    size_t num_results = 0;
+    size_t n_ret = 0;
+    // If there are multiple return types, the annotation will be formatted as
+    // "{prefix}{type}{joiner}{type}...{suffix}".
+    const String *prefix = NULL;
+    const String *joiner = NULL;
+    const String *suffix = NULL;
+
+    // Intialize with the return type by default.
+    // Users can overwrite this in the pytyping typemap by using argoutaction="overwrite".
     if (!Equal(Getattr(n, "type"), "void")) {
       ret = lookupPytyping(n, true);
-      num_results = 1;
+      n_ret = 1;
     }
 
-    for (p = copied_parms; p; p = nextSibling(p)) {
+    while (p != NULL) {
       if (Getattr(p, "tmap:argout:match_type")) {
         tm = lookupPytyping(p, true);
         if (!tm) {
@@ -2658,26 +2706,43 @@ public:
           tm = NewString("typing.Any");
         }
 
-        if (ret) {
-          if (num_results == 1) {
-            String *combined = NewStringf("typing.List[typing.Union[%s, %s", ret, tm);
+        String *action = Getattr(p, "tmap:pytyping:argoutaction");
+        bool overwrite = Equal(action, "overwrite");
+
+        if (overwrite) {
+          n_ret = 0;  // incremented later
+          Delete(ret);
+          ret = tm;
+        } else if (ret) {
+          updateArgoutTypingFormat(p, &prefix, &joiner, &suffix);
+
+          if (n_ret == 1) {
+            String *tmp = NewStringf("%s%s%s%s", prefix, ret, joiner, tm);
             Delete(ret);
-            ret = combined;
+            ret = tmp;
           } else {
-            Printv(ret, ", ", tm, NULL);
+            Printv(ret, joiner, tm, NULL);
           }
+
           Delete(tm);
         } else {
           ret = tm;
         }
-        num_results++;
+
+        ++n_ret;
+
+        if (ParmList *next = Getattr(p, "tmap:argout:next")) {
+          p = next;
+          continue;
+        }
       }
+
+      p = nextSibling(p);
     }
 
-    if (num_results > 1)
-      Printv(ret, "]]", NULL);
+    if (n_ret > 1)
+      Printv(ret, suffix, NULL);
 
-    Delete(copied_parms);
     return ret;
   }
 
@@ -2693,7 +2758,6 @@ public:
       return NewStringEmpty();
 
     String *ret = argoutReturnTypeAnnotation(n, anno);
-
     /* If no argout typemap, then get the returning type from
      * the function prototype. */
     if (!ret) {


### PR DESCRIPTION
When multiple argout matches are in a function or there is one argout match and one return type, Swig would previously concatenate them with `, `. This annotation is invalid. Furthermore, multi-argument pytyping typemaps weren't respected.

With this PR, both are fixed. By default, it's assumed the argout typemaps use `SWIG_AppendOutput` which creates a list. So by default, the annotation will look like `typing.List[typing.Union[A, B, C]]`. The prefix, joiner, and suffix can be customized. Furthermore, you can specify that the return value is discarded.

Fixes #3469.