### PR TITLE
Allow easily ignoring clang-format commit when running git-blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,20 @@
+# This file can be used with git blame --ignore-revs-file option or used as
+# the value of blame.ignoreRevsFile in git config to ignore the changes done by
+# the following "not interesting" commits.
+#
+# It's supported by Git 2.23 or later and to use it by default for all the
+# future git-blame invocations, run the following command:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# When adding entries to this file, please keep them in reverse chronological
+# order (the newest ones are added at the top).
+#
+# You can use
+#
+#   $ git show -s --format='# %s, %cs%n%H%n'
+#
+# incantation to directly create an entry in the format used here.
+
+# Beautify using swig specific .clang-format, 2026-03-04
+bbdec1f77b3ccb0b85ecdf63cc45ab8117ae2081


### PR DESCRIPTION
Add the file which can be used to ignore the specified commits when running git-blame and add the commit corresponding to the Great Source Reformatting to it.

Put it in the location used by GitHub web UI so that it would also be used there.

[skip ci]

----

Please consider merging this trivial PR as it makes it much more convenient to use git-blame.