### PR TITLE
[Python] Support INOUT/INPUT/OUTPUT for pytyping

### DIFF
--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -261,3 +261,15 @@ if annotations_supported:
         "SWIGTYPE_p_ForwardOnly",
     ]:
         swig_assert(not hasattr(python_annotations_typing, name))
+
+    anno = get_annotations(singleOutput)
+    if anno != {"x": "int", "y": "int", "return": "int"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+
+    anno = get_annotations(twoInputs)
+    if anno != {"IN1": "int", "IN2": "int", "return": "bool"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+
+    anno = get_annotations(inout)
+    if anno != {"x": "int", "INOUT": "int", "return": "int"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))

--- a/Examples/test-suite/python_annotations_typing.i
+++ b/Examples/test-suite/python_annotations_typing.i
@@ -275,3 +275,13 @@ void use_forward_only(ForwardOnly *fp) { (void)fp; }
 
 // A class-typed %constant is annotated at module level.
 %constant MyStruct *CONST_STRUCT = 0;
+
+%apply int *INPUT { short *IN1, short *IN2 };
+
+%inline %{
+
+void singleOutput(int x, int y, int *OUTPUT) {}
+bool twoInputs(short *IN1, short *IN2) { return true; }
+void inout(int x, int *INOUT) {}
+
+%}

--- a/Lib/python/pytypemaps.swg
+++ b/Lib/python/pytypemaps.swg
@@ -68,6 +68,17 @@
 /* Include the Unified Typemap Library */
 %include <typemaps/swigtypemaps.swg>
 
+#ifndef SWIG_INOUT_NODEF
+/* Add INOUT/INPUT/OUTPUT support for the pytyping typemap */
+%define %_pytyping_inout_define(Code, Type)
+  %typemap(pytyping)
+    Type *OUTPUT, Type &OUTPUT,
+    Type *INPUT, Type &INPUT,
+    Type *INOUT, Type &INOUT
+  "$typemap(pytyping, Type)"
+%enddef
+%apply_checkctypes(%_pytyping_inout_define)
+#endif
 
 /*  ------------------------------------------------------------
  *  Python extra typemaps / typemap overrides


### PR DESCRIPTION
This fixes the annotations when using the INOUT/INPUT/OUTPUT typemaps. Before, this would use the name for `Type*` or `Type&`. With this PR, the name for `Type` is used.