### PR TITLE
[Python][Typing] Annotate std::vector

### DIFF
--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -590,6 +590,7 @@
 <li><a href="Typemaps.html#Typemaps_special_macro_descriptor">$descriptor(type)</a>
 <li><a href="Typemaps.html#Typemaps_special_macro_typemap">$typemap(method, typepattern)</a>
 <li><a href="Typemaps.html#Typemaps_special_macro_typemap_attribute">$typemap(method:attribute, typepattern)</a>
+<li><a href="Typemaps.html#Typemaps_special_macro_typemap_attribute_optional">$typemap(method:attribute?, typepattern)</a>
 </ul>
 <li><a href="Typemaps.html#Typemaps_special_variable_attributes">Special variables and typemap attributes</a>
 <li><a href="Typemaps.html#Typemaps_special_variables_and_macros">Special variables combined with special variable macros</a>

--- a/Doc/Manual/Typemaps.html
+++ b/Doc/Manual/Typemaps.html
@@ -53,6 +53,7 @@
 <li><a href="#Typemaps_special_macro_descriptor">$descriptor(type)</a>
 <li><a href="#Typemaps_special_macro_typemap">$typemap(method, typepattern)</a>
 <li><a href="#Typemaps_special_macro_typemap_attribute">$typemap(method:attribute, typepattern)</a>
+<li><a href="#Typemaps_special_macro_typemap_attribute_optional">$typemap(method:attribute?, typepattern)</a>
 </ul>
 <li><a href="#Typemaps_special_variable_attributes">Special variables and typemap attributes</a>
 <li><a href="#Typemaps_special_variables_and_macros">Special variables combined with special variable macros</a>
@@ -2261,6 +2262,14 @@ run-time type checker (described later).</td>
 </td>
 </tr>
 
+<tr>
+<td>$<em>n</em>_targ<em>m</em></td>
+<td>Typename of the <em>m</em>th C++ template argument on the <em>n</em>th type.
+For example in <tt>%typemap(foo) Bar &lt; T &gt; "$1_targ1"</tt>,
+the <tt>$1_targ1</tt> would refer to the type of <tt>T</tt>. For a <tt>Bar&lt;int&gt;</tt>, it would be <tt>int</tt>.
+</td>
+</tr>
+
 </table>
 </center>
 
@@ -2559,6 +2568,48 @@ which expands to
 <p>
 <b>Compatibility note: </b> Support for typemap attributes in <tt>$typemap</tt>
 was introduced in SWIG-4.1.0.
+</p>
+
+<H4><a name="Typemaps_special_macro_typemap_attribute_optional">14.4.4.4 $typemap(method:attribute?, typepattern)</a></H4>
+
+
+<p>
+This version of <tt>$typemap</tt> provides access to typemap attributes like
+<a href="#Typemaps_special_macro_typemap_attribute"><tt>$typemap(method:attribute, typepattern)</tt></a>
+but it falls back to <a href="#Typemaps_special_macro_typemap"><tt>$typemap(method, typepattern)</tt></a>
+if there's no entry with an attribute. Below is a slightly modified example from above.
+</p>
+
+<div class="code">
+<pre>
+%typemap(cstype, out="object") XClass "XClass"
+%typemap(cstype) YClass "YClass"
+%typemap(cscode) BarClass %{
+  $typemap(cstype:out?, XClass) baz()
+  {
+    return new $typemap(cstype:out?, YClass);
+  }
+</pre>
+</div>
+<p>
+which expands to
+</p>
+<div class="code">
+<pre>
+  object baz()
+  {
+    return new YClass;
+  }
+</pre>
+</div>
+
+<p>
+Without the fallback, <tt>$typemap(cstype:out, YClass)</tt> would fail, because the typemap entry for <tt>YClass</tt> has no <tt>out</tt> attribute.
+</p>
+
+<p>
+<b>Compatibility note: </b> Support for optional typemap attributes in <tt>$typemap</tt>
+was introduced in SWIG-UNRELEASED.
 </p>
 
 

--- a/Examples/test-suite/csharp/special_variable_macros_runme.cs
+++ b/Examples/test-suite/csharp/special_variable_macros_runme.cs
@@ -26,5 +26,9 @@ public class runme {
       throw new Exception("test failed");
     if (special_variable_macros.shortFunction(1, 1) != (200*2 + 200*3))
       throw new Exception("test failed");
+    if (OptionalAttrTest.OptionalAttrResult != "int")
+      throw new Exception("test failed");
+    if (OptionalAttrTest.OptionalAttrFallback != "NoAttrType")
+      throw new Exception("test failed");
   }
 }

--- a/Examples/test-suite/d/special_variable_macros_runme.2.d
+++ b/Examples/test-suite/d/special_variable_macros_runme.2.d
@@ -5,6 +5,7 @@ import special_variable_macros.special_variable_macros;
 import special_variable_macros.Name;
 import special_variable_macros.NewName;
 import special_variable_macros.PairIntBool;
+import special_variable_macros.OptionalAttrTest;
 
 void main() {
   auto name = new Name();
@@ -22,4 +23,7 @@ void main() {
   enforce(makeStringInt("stringint", 999) == "stringint");
   enforce(provideStringInt(999) == "1000");
   enforce(shortFunction(1, 1) == (200*2 + 200*3));
+
+  enforce(OptionalAttrTest.OptionalAttrResult == "int");
+  enforce(OptionalAttrTest.OptionalAttrFallback == "NoAttrType");
 }

--- a/Examples/test-suite/java/special_variable_macros_runme.java
+++ b/Examples/test-suite/java/special_variable_macros_runme.java
@@ -36,5 +36,9 @@ public class special_variable_macros_runme {
       throw new RuntimeException("test failed");
     if (special_variable_macros.shortFunction((short)1, (short)1) != (200*2 + 200*3))
       throw new RuntimeException("test failed");
+    if (!OptionalAttrTest.OptionalAttrResult.equals("int"))
+      throw new RuntimeException("test failed");
+    if (!OptionalAttrTest.OptionalAttrFallback.equals("NoAttrType"))
+      throw new RuntimeException("test failed");
   }
 }

--- a/Examples/test-suite/python/python_annotations_typing_runme.py
+++ b/Examples/test-suite/python/python_annotations_typing_runme.py
@@ -138,8 +138,46 @@ if annotations_supported:
     if anno != make_argcheck("typing.Optional[SWIGTYPE_p_float]", ["arr"]):
         raise RuntimeError("annotations mismatch: {}".format(anno))
 
-    anno = get_annotations(optional_square)
-    if anno != {"return": "typing.Optional[int]", "i": "typing.Optional[int]"}:
+    anno = get_annotations(identity_vector)
+    if anno != {
+        "return": "typing.Tuple[int, ...]",
+        "v": "collections.abc.Iterable[int]",
+    }:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(identity_vector([1, 2]), tuple))
+
+    anno = get_annotations(identity_vector_cref)
+    if anno != {
+        "return": "typing.Tuple[int, ...]",
+        "v": "collections.abc.Iterable[int]",
+    }:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    swig_assert(isinstance(identity_vector_cref([1, 2]), tuple))
+
+    anno = get_annotations(identity_nest_vector)
+    if anno != {
+        "return": "typing.Tuple[typing.Tuple[int, ...], ...]",
+        "v": "collections.abc.Iterable[collections.abc.Iterable[int]]",
+    }:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    res = identity_nest_vector([[1, 2], [3, 4]])
+    swig_assert(isinstance(res, tuple) and isinstance(res[0], tuple))
+
+    anno = get_annotations(identity_nest_vector_cref)
+    if anno != {
+        "return": "typing.Tuple[typing.Tuple[int, ...], ...]",
+        "v": "collections.abc.Iterable[collections.abc.Iterable[int]]",
+    }:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+    res = identity_nest_vector_cref([[1, 2], [3, 4]])
+    swig_assert(isinstance(res, tuple) and isinstance(res[0], tuple))
+
+    anno = get_annotations(identity_vector_ref)
+    if anno != {"return": "IntVector", "v": "IntVector"}:
+        raise RuntimeError("annotations mismatch: {}".format(anno))
+
+    anno = get_annotations(identity_vector_ptr)
+    if anno != {"return": "typing.Optional[IntVector]", "v": "typing.Optional[IntVector]"}:
         raise RuntimeError("annotations mismatch: {}".format(anno))
 
     swig_assert(optional_square(None) is None)

--- a/Examples/test-suite/python/special_variable_macros_runme.py
+++ b/Examples/test-suite/python/special_variable_macros_runme.py
@@ -26,3 +26,9 @@ if special_variable_macros.provideStringInt(999) != "1000":
     raise "test failed"
 if special_variable_macros.shortFunction(1, 1) != (200*2 + 200*3):
     raise "test failed"
+
+# Test $targ template arg substitution
+p = special_variable_macros.PairIntDouble(5, 6.5)
+r = special_variable_macros.testTargs(p)
+if r.first != 5 or r.second != 6.5:
+    raise "test failed"

--- a/Examples/test-suite/python_annotations_typing.i
+++ b/Examples/test-suite/python_annotations_typing.i
@@ -3,6 +3,7 @@
 %include <std_string.i>
 %include <std_wstring.i>
 %include <std_complex.i>
+%include <std_vector.i>
 
 // Tests the typing annotations
 %feature("python:annotations", "typing");
@@ -58,6 +59,8 @@ int *no_annotations(int &ri, const char *c) { return NULL; }
 %}
 %template(TemplateShort) Space::Template<short>;
 %template(MakeShort) makeT<short>;
+%template(IntVector) std::vector<int>;
+%template(IntNestVector) std::vector< std::vector<int> >;
 
 %inline %{
 #ifdef SWIGPYTHON_BUILTIN
@@ -171,6 +174,16 @@ void argcheck_str(
 
 void argcheck_fnptr(int(*f)(char, bool)) {}
 void argcheck_array(float arr[3]) {}
+
+std::vector<int> identity_vector(std::vector<int> v) { return v; }
+std::vector<std::vector<int> > identity_nest_vector(std::vector<std::vector<int> > v) { return v; }
+std::vector<int> const& identity_vector_cref(std::vector<int> const& v) { return v; }
+std::vector<std::vector<int> > const& identity_nest_vector_cref(std::vector<std::vector<int> > const& v) { return v; }
+std::vector<int> & identity_vector_ref(std::vector<int> & v) { return v; }
+std::vector<int> * identity_vector_ptr(std::vector<int> * v) { return v; }
+
+void vector_ref(std::vector<int> &v) { (void)v; }
+void vector_ptr(std::vector<int> *v) { (void)v; }
 
 struct OptionalInt {
   OptionalInt() : has_value(false) {}

--- a/Examples/test-suite/special_variable_macros.i
+++ b/Examples/test-suite/special_variable_macros.i
@@ -189,6 +189,16 @@ namespace Space {
 %}
 %template(PairIntBool) Space::Pair<int, bool>;
 
+// Test $targ special variable template arg substitution.
+// This will fail to compile if they refer to the incorrect values.
+%typemap(arginit) Space::Pair<int, double> {
+  $1 = Space::Pair<$targ1, $targ2>(Space::Pair<$1_targ1, $1_targ2>(1, 1.0));
+}
+%template(PairIntDouble) Space::Pair<int, double>;
+%inline %{
+Space::Pair<int, double> testTargs(Space::Pair<int, double> p) { return p; }
+%}
+
 //////////////////////////////////////////////////////////////////////////////////////
 // A real use case for $typemap()
 
@@ -331,4 +341,34 @@ short shortFunction(short x, short y) {
 %apply int MYINT { int myint1, int myint2 }
 %inline %{
 void intFunction(int myint1, int myint2) {}
+%}
+
+// Test $typemap(method:attribute?, typepattern) - optional typemap attribute fallback
+#if defined(SWIGCSHARP)
+%typemap(cstype, out="int") IntAttrType "IntAttrType"
+%typemap(cstype) NoAttrType "NoAttrType"
+%typemap(cscode) OptionalAttrTest %{
+  public const string OptionalAttrResult = "$typemap(cstype:out?, IntAttrType)";
+  public const string OptionalAttrFallback = "$typemap(cstype:out?, NoAttrType)";
+%}
+#elif defined(SWIGJAVA)
+%typemap(jstype, out="int") IntAttrType "IntAttrType"
+%typemap(jstype) NoAttrType "NoAttrType"
+%typemap(javacode) OptionalAttrTest %{
+  public static final String OptionalAttrResult = "$typemap(jstype:out?, IntAttrType)";
+  public static final String OptionalAttrFallback = "$typemap(jstype:out?, NoAttrType)";
+%}
+#elif defined(SWIGD)
+%typemap(dtype, out="int") IntAttrType "IntAttrType"
+%typemap(dtype) NoAttrType "NoAttrType"
+%typemap(dcode) OptionalAttrTest %{
+  static string OptionalAttrResult = "$typemap(dtype:out?, IntAttrType)";
+  static string OptionalAttrFallback = "$typemap(dtype:out?, NoAttrType)";
+%}
+#endif
+
+%inline %{
+struct IntAttrType { int val; };
+struct NoAttrType { float val; };
+struct OptionalAttrTest {};
 %}

--- a/Lib/python/std_vector.i
+++ b/Lib/python/std_vector.i
@@ -32,3 +32,5 @@
 #define %swig_vector_methods_val(Type...) %swig_sequence_methods_val(Type);
 
 %include <std/std_vector.i>
+
+%typemap(pytyping, out="typing.Tuple[$typemap(pytyping:out?, $targ1), ...]") std::vector< _Tp, _Alloc >, std::vector< _Tp, _Alloc > const & "collections.abc.Iterable[$typemap(pytyping, $targ1)]"

--- a/Source/Modules/python.cxx
+++ b/Source/Modules/python.cxx
@@ -930,6 +930,8 @@ public:
         Printv(f_shadow_py, "\n", f_shadow_begin, "\n", NIL);
 
       Printv(f_shadow_py, "\nimport typing\n", NULL);
+      Printv(f_shadow_py, "if typing.TYPE_CHECKING:\n", NULL);
+      Printv(f_shadow_py, tab4, "import collections.abc\n", NULL);
 
       if (Len(f_shadow_after_begin) > 0)
         Printv(f_shadow_py, f_shadow_after_begin, "\n", NIL);

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -1154,6 +1154,26 @@ static int typemap_replace_vars(String *s, ParmList *locals, SwigType *type, Swi
     Delete(amp_mangle);
     Delete(amp_type);
 
+    // ${n}_targ{m} and $targ{m}
+    if (SwigType_istemplate(ftype)) {
+      List *targs = SwigType_templateargslist(ftype);
+      Iterator targ;
+      int targ_idx = 1;
+      for (targ = First(targs); targ.item; ++targ_idx, targ = Next(targ)) {
+        ts = SwigType_str(targ.item, 0);
+        if (index == 1) {
+          sprintf(varname, "$targ%d", targ_idx);
+          Replace(s, varname, ts, DOH_REPLACE_ANY);
+          replace_local_types(locals, varname, targ.item);
+        }
+        sprintf(varname, "$%d_targ%d", index, targ_idx);
+        Replace(s, varname, ts, DOH_REPLACE_ANY);
+        replace_local_types(locals, varname, targ.item);
+        Delete(ts);
+      }
+      Delete(targs);
+    }
+
     /* Base type */
     if (SwigType_isarray(type)) {
       base_type = Copy(type);
@@ -2133,11 +2153,22 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
               Delete(dtypemap);
             }
             found_colon = Strchr(tmap_method, ':');
+
+            // Position of the '?' for queries such as "foo:bar?". In that case, "foo:bar" is searched.
+            // If this has no match, "foo" is searched.
+            char *found_questionmark = Strchr(tmap_method, '?');
+            if (found_questionmark && (found_questionmark[1] != '\0' || !found_colon))
+              found_questionmark = NULL;
+
+            // Typemap method without the keyword argument. For "foo:bar", this is "foo".
+            String *tmap_base_method = NULL;
             if (found_colon) {
               /* Substitute from a keyword argument to a typemap. Avoid emitting local variables from the attached typemap by passing NULL for the file. */
-              String *temp_tmap_method = NewStringWithSize(Char(tmap_method), (int)(found_colon - Char(tmap_method)));
-              typemap_attach_parms(temp_tmap_method, to_match_parms, NULL, override_vars);
-              Delete(temp_tmap_method);
+              tmap_base_method = NewStringWithSize(Char(tmap_method), (int)(found_colon - Char(tmap_method)));
+              typemap_attach_parms(tmap_base_method, to_match_parms, NULL, override_vars);
+
+              if (found_questionmark)
+                Delitem(tmap_method, (int)(found_questionmark - Char(tmap_method)));
             } else {
               typemap_attach_parms(tmap_method, to_match_parms, f, override_vars);
             }
@@ -2146,6 +2177,17 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
             /* Look for the typemap code */
             attr = NewStringf("tmap:%s", tmap_method);
             tm = Getattr(to_match_parms, attr);
+
+            // Look for the code without a keyword argument.
+            if (!tm && found_questionmark) {
+              Delete(attr);
+              attr = NewStringf("tmap:%s", tmap_base_method);
+              tm = Getattr(to_match_parms, attr);
+            }
+
+            if (tmap_base_method)
+              Delete(tmap_base_method);
+
             if (tm) {
               Printf(attr, "%s", ":next");
               /* fail if multi-argument lookup requested in $typemap(...) and the lookup failed */


### PR DESCRIPTION
This adds a PEP 484 (pytyping) annotation for `std::vector` and works
towards having annotations for all supported `std::` types. Before
this, `std::vector` was either annotated as `typing.Any` or as
`IntVector` (i.e. the proxy name), if
`%typemap(pytyping) SWIGTYPE "$&pytypename"` is used. The former is too
broad (we don't accept any object) and the latter is too restrictive
(any iterable is accepted).

With this, the annotation for `std::vector<T>` is
`collections.abc.Iterable[T]` and `typing.Tuple[T, ...]` as a return
value.

To be able to annotate `std::vector`, two changes were made:
- Added a special variable `${n}_targ{m}` to get the typename of the
  m-th template argument in the n-th type. This was required, because
  the vector type is declared in `std/std_vector.i`, so in
  `python/std_vector.i`, we don't have access to the value type.
  I experimented with passing the type through `%swig_vector_methods`.
  For simple types this works well, but if you have a
  `vector<vector<int, Alloc>, Alloc>`, the comments become a problem.
  Swig will wrap the type in parentheses, but then you can't pass it
  into `$typemap()` anymore.
- Added a new `$typemap(meth:attr?, ty)` syntax that looks up
  `$typemap(meth:att, ty)` and falls back to `$typemap(meth, ty)` if the
  former is undefined. This matches the behavior for the return value in
  `pytyping`.

The changes here are scoped to `std::vector` to get the direction
right. The other `std::` types will likely be similar.