### PR TITLE
[Python] Pass  `SWIG_FromCharPtrAndSize` from SWIG Preprocessing to compiler

### DIFF
--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -117,6 +117,7 @@ C_TEST_CASES += \
 	file_test \
 	li_cstring \
 	li_cwstring \
+	python_charptr_fragment \
 	python_nondynamic \
 	python_varargs_typemap \
 	python_weakref \

--- a/Examples/test-suite/python/python_charptr_fragment_runme.py
+++ b/Examples/test-suite/python/python_charptr_fragment_runme.py
@@ -1,0 +1,8 @@
+import python_charptr_fragment
+
+if python_charptr_fragment.getStr() != 'test1':
+    raise runtimeerror("wrong getstr value")
+
+t = python_charptr_fragment.tst_str2()
+if t.getStr() != 'test2':
+    raise runtimeerror("wrong tst_str2::getstr value")

--- a/Examples/test-suite/python_charptr_fragment.i
+++ b/Examples/test-suite/python_charptr_fragment.i
@@ -1,0 +1,31 @@
+%module python_charptr_fragment
+
+%typemap(out,noblock=1,fragment="SWIG_FromCharPtrAndSize") struct tst_str {
+  %set_output(SWIG_FromCharPtrAndSize($1.str,$1.len));
+}
+
+%extend tst_str2 {
+PyObject *getStr() {
+    return SWIG_FromCharPtrAndSize("test2", 5);
+}
+}
+
+%inline %{
+
+struct tst_str {
+    size_t len;
+    char* str;
+};
+
+struct tst_str2 {
+    int dummy;
+};
+
+
+struct tst_str getStr()
+{
+    static struct tst_str r = { 5, "test1" };
+    return r;
+}
+
+%}

--- a/Lib/python/pystrings.swg
+++ b/Lib/python/pystrings.swg
@@ -73,7 +73,7 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char **cptr, size_t *psize, int *alloc)
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
-#define SWIG_FromCharPtrAndSize(carray, size) SWIG_FromBinaryCharPtrAndSize(carray, size, 0)
+%#define SWIG_FromCharPtrAndSize(carray, size) SWIG_FromBinaryCharPtrAndSize(carray, size, 0)
 SWIGINTERNINLINE PyObject *
 SWIG_FromBinaryCharPtrAndSize(const char* carray, size_t size, int flags)
 {


### PR DESCRIPTION
Hi @wsfulton 
Follow Jitka finding.

Add test that verify the fix by adding an extend code that call  `SWIG_FromCharPtrAndSize` without explicit fragment.
That is allowed as we have a typemap above it which does use the fragment.