### PR TITLE
Fix namespaces being appended twice in template arguments

### DIFF
--- a/Examples/test-suite/cpp11_using_typedef_struct.i
+++ b/Examples/test-suite/cpp11_using_typedef_struct.i
@@ -29,4 +29,27 @@ int fn1(AffineMatrix a) { return a.x; }
 int fn2(CacheView a) { return a.x; }
 int fn3(Abstract *a) { _internal(a); return 0; }
 int fn4(const Abstract *a) { _internal(a); return 0; }
+
+namespace ANamespace {
+  struct ControlPoint {
+    int abc;
+  };
+}
+
+namespace Another {
+  template <typename T>
+  struct Vec {
+    using size_type = int;
+    Vec(T v) {}
+  };
+}
+
+using InNamespaceInt = Another::Vec<ANamespace::ControlPoint>;
+using WrapAgain = Another::Vec<InNamespaceInt::size_type>;
+
+// This needs to use SwigValueWrapper because there's no default constructor.
+// Test that the name is correct (i.e. it compiles).
+WrapAgain identity(WrapAgain in) {
+  return in;
+}
 %}

--- a/Source/Swig/symbol.c
+++ b/Source/Swig/symbol.c
@@ -1907,15 +1907,17 @@ static SwigType *Swig_symbol_template_reduce(SwigType *qt, Symtab *ntab) {
     String *qp = Swig_symbol_type_qualify(tp, ntab);
     Node *n = Swig_symbol_clookup(qp, ntab);
     if (n) {
-      String *qual = Swig_symbol_qualified(n);
       np = Copy(Getattr(n, "name"));
       Delete(tp);
       tp = np;
-      if (qual && Len(qual)) {
-        Insert(np, 0, "::");
-        Insert(np, 0, qual);
+      if (!Swig_scopename_check(np)) {
+        String *qual = Swig_symbol_qualified(n);
+        if (qual && Len(qual)) {
+          Insert(np, 0, "::");
+          Insert(np, 0, qual);
+        }
+        Delete(qual);
       }
-      Delete(qual);
     } else {
       np = qp;
     }


### PR DESCRIPTION
From https://sourceforge.net/p/swig/mailman/message/59368160/: hugin failed to build with the latest master due to 

```
/builddir/build/BUILD/hugin-2025.0.1-build/hugin-2025.0.1/redhat-linux-build/src/hugin_script_interface/CMakeFiles/hsi.dir/hsiPYTHON_wrap.cxx: In function ‘PyObject* _wrap_Panorama_getCtrlPointsVectorForImage(PyObject*, PyObject*)’:
/builddir/build/BUILD/hugin-2025.0.1-build/hugin-2025.0.1/redhat-linux-build/src/hugin_script_interface/CMakeFiles/hsi.dir/hsiPYTHON_wrap.cxx:58265:69: error: ‘HuginBase’ is not a member of ‘HuginBase’; did you mean ‘HuginBase’?
58265 |   SwigValueWrapper< std::vector< std::pair< std::vector< HuginBase::HuginBase::ControlPoint,std::allocator< HuginBase::HuginBase::ControlPoint > >::size_type,HuginBase::ControlPoint >,std::allocator< std::pair< std::vector< HuginBase::HuginBase::ControlPoint,std::allocator< HuginBase::HuginBase::ControlPoint > >::size_type,HuginBase::ControlPoint > > > > result;
      |                                                                     ^~~~~~~~~
```

The namespace `HuginBase` was appended twice. I bisected the history and found c5bfe9766f3ad17caf5b378f78a8bdf517e3db94 to be the issue. It could be reduced to
```cpp
namespace ANamespace {
  struct ControlPoint { int abc; };
}
namespace Another {
  template <typename T>
  struct Vec {
    using size_type = int;
    Vec(T v) {}
  };
}
using InNamespaceInt = Another::Vec<ANamespace::ControlPoint>;
using WrapAgain = Another::Vec<InNamespaceInt::size_type>;
//                             ^~~~~~~~~~~~~~~~~~~~~~~~~
// was expanded to Another::Vec<ANamespace::ANamespace::ControlPoint>::size_type

WrapAgain identity(WrapAgain in) {
  return in;
}
```

Specifically the call to `Swig_symbol_typedef_reduce` is an issue. We get there in two cases. First when parsing and secondly in `TypePass::normalize_type` where the symbol name is prefixed with the namespace. The important difference is for the `ANamespace::ControlPoint` type. First, its `"name"` attribute is `"ControlPoint"`. After normalization, its `"name"` attribute is `"ANamespace::ControlPoint"`.

When the `InNamespaceInt` was encountered during normalization, it would call `Swig_symbol_typedef_reduce` on the `Another::Vec<ANamespace::ControlPoint>` type. That would try to normalize the template argument in `Swig_symbol_template_reduce` where the qualified name was constructed as `{Swig_symbol_qualified(n)}::{Getattr(n, "name")}`. `Swig_symbol_qualified(n)` returned `"ANamespace"`, so in the end, we'd get `"ANamespace::ANamespace::ControlPoint"`.

I added a `Swig_scopename_check`, so the scope is only prepended if that's not the case already.