### PR TITLE
Lib/typemaps/strings.swg: restore the %typemaps_string_alloc macro

### DIFF
--- a/CHANGES.current
+++ b/CHANGES.current
@@ -7,6 +7,13 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 4.6.0 (in progress)
 ===========================
 
+2026-08-12: kwwette
+            Restore the `%typemaps_string_alloc` macro in `Lib/typemaps/strings.swg`
+            for custom string classes that implement a custom destructor.
+
+            Added example demonstrating `%typemaps_string_alloc` in
+            `Examples/perl5/xmlstring_alloc/` (copied from `Examples/perl5/xmlstring/`).
+
 2026-08-11: wsfulton
             Fix syntax error parsing a cv-qualified 'auto' placeholder. Both
             orderings of the qualifier are now accepted everywhere a placeholder

--- a/Examples/perl5/xmlstring_alloc/Makefile
+++ b/Examples/perl5/xmlstring_alloc/Makefile
@@ -1,0 +1,23 @@
+TOP        = ../..
+SWIGEXE    = $(TOP)/../swig
+SWIG_LIB_DIR = $(TOP)/../$(TOP_BUILDDIR_TO_TOP_SRCDIR)Lib
+CXXSRCS    = example.cxx
+TARGET     = example
+INTERFACE  = example.i
+LIBS       = -lxerces-c -lxerces-depdom -lm
+
+check: build
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' perl5_run
+
+build:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' \
+	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
+	TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' LIBS=$(LIBS) CXX="g++ -g3" perl5_cpp
+
+static:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' \
+	SWIG_LIB_DIR='$(SWIG_LIB_DIR)' SWIGEXE='$(SWIGEXE)' \
+	TARGET='myperl' INTERFACE='$(INTERFACE)' perl5_cpp_static
+
+clean:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' perl5_clean

--- a/Examples/perl5/xmlstring_alloc/example.cxx
+++ b/Examples/perl5/xmlstring_alloc/example.cxx
@@ -1,0 +1,1 @@
+#include "example.h"

--- a/Examples/perl5/xmlstring_alloc/example.h
+++ b/Examples/perl5/xmlstring_alloc/example.h
@@ -1,0 +1,36 @@
+#include <xercesc/util/XMLString.hpp>
+
+
+class XMLChTest 
+{
+  XMLCh *_val;
+  
+public:
+
+  XMLChTest() : _val(0)
+  {
+  }
+
+  void set(const XMLCh *v) 
+  {
+    size_t len = XERCES_CPP_NAMESPACE::XMLString::stringLen(v);
+    delete[] _val;
+    _val = new XMLCh[len + 1];
+    for (int i = 0; i < len; ++i) {
+      _val[i] = v[i];
+    }
+    _val[len] = 0;
+  }
+
+  const XMLCh *get() 
+  {
+    return _val;
+  }
+
+  XMLCh get_first() 
+  {
+    return _val[0];
+  }
+  
+};
+

--- a/Examples/perl5/xmlstring_alloc/example.i
+++ b/Examples/perl5/xmlstring_alloc/example.i
@@ -1,0 +1,10 @@
+%module example
+
+%include <xmlstring.i>
+
+%{
+#include "example.h"
+%}
+
+
+%include example.h

--- a/Examples/perl5/xmlstring_alloc/runme.pl
+++ b/Examples/perl5/xmlstring_alloc/runme.pl
@@ -1,0 +1,8 @@
+use example;
+
+
+$e1 = new example::XMLChTest();
+$e1->set("hello");
+print $e1->get(),"\n";
+print $e1->get_first(),"\n";
+

--- a/Examples/perl5/xmlstring_alloc/xmlstring.i
+++ b/Examples/perl5/xmlstring_alloc/xmlstring.i
@@ -1,0 +1,140 @@
+%include <perlstrings.swg>
+
+%fragment("<XMLCh.h>","header") 
+%{
+#include <xercesc/util/XMLString.hpp>
+#include <xercesc/util/TransService.hpp>
+#include <xercesc/util/XMLUTF8Transcoder.hpp>
+%}
+
+%fragment("SWIG_UTF8Transcoder","header",fragment="<XMLCh.h>") {
+SWIGINTERN XERCES_CPP_NAMESPACE::XMLTranscoder* 
+SWIG_UTF8Transcoder() {
+  using namespace XERCES_CPP_NAMESPACE;
+  static int init = 0;
+  static XMLTranscoder* UTF8_TRANSCODER  = NULL;
+  static XMLCh* UTF8_ENCODING = NULL;  
+  if (!init) {
+    XMLTransService::Codes failReason;
+    XMLPlatformUtils::Initialize(); // first we must create the transservice
+    UTF8_ENCODING = XMLString::transcode("UTF-8");
+    UTF8_TRANSCODER = XMLPlatformUtils::fgTransService->makeNewTranscoderFor(UTF8_ENCODING,
+									     failReason,
+									     1024);
+    init = 1;
+  }
+  return UTF8_TRANSCODER;
+}
+}
+   
+%fragment("SWIG_AsXMLChPtrAndSize","header",fragment="SWIG_AsCharPtrAndSize",fragment="SWIG_UTF8Transcoder") {
+SWIGINTERN int
+SWIG_AsXMLChPtrAndSize(SV *obj, XMLCh **val, size_t* psize, int *alloc)
+{
+  if (!val) {
+    return SWIG_AsCharPtrAndSize(obj, 0,  0, 0);
+  } else {
+    size_t size;
+    char *cptr = 0;
+    int calloc = SWIG_OLDOBJ;
+    int res = SWIG_AsCharPtrAndSize(obj, &cptr, &size, &calloc);
+    if (SWIG_IsOK(res)) {
+      STRLEN length = size - 1;
+      if (SvUTF8(obj)) {
+	unsigned int charsEaten = 0;
+	unsigned char* sizes = %new_array(size, unsigned char);
+	*val = %new_array(size, XMLCh);
+	unsigned int chars_stored = 
+	  SWIG_UTF8Transcoder()->transcodeFrom((const XMLByte*) cptr,
+					       (unsigned int) length,
+					       (XMLCh*) *val, 
+					       (unsigned int) length,
+					       charsEaten,
+					       (unsigned char*)sizes
+					       );
+	%delete_array(sizes);
+	// indicate the end of the string
+	(*val)[chars_stored] = '\0';
+      } else {
+	*val = XERCES_CPP_NAMESPACE::XMLString::transcode(cptr);
+      }
+      if (psize) *psize = size;
+      if (alloc) *alloc = SWIG_NEWOBJ;
+      if (calloc == SWIG_NEWOBJ) %delete_array(cptr);
+      return SWIG_NEWOBJ;    
+    } else {
+      return res;
+    }
+  }
+}
+}
+
+%fragment("SWIG_FromXMLChPtrAndSize","header",fragment="SWIG_UTF8Transcoder") {
+SWIGINTERNINLINE SV *
+SWIG_FromXMLChPtrAndSize(const XMLCh* input, size_t size)
+{
+  SV *output = sv_newmortal();
+  unsigned int charsEaten = 0;
+  int length  = size;                                        // string length
+  XMLByte* res = %new_array(length * UTF8_MAXLEN, XMLByte);          // output string
+  unsigned int total_chars =
+    SWIG_UTF8Transcoder()->transcodeTo((const XMLCh*) input, 
+				       (unsigned int) length,
+				       (XMLByte*) res,
+				       (unsigned int) length*UTF8_MAXLEN,
+				       charsEaten,
+				       XERCES_CPP_NAMESPACE::XMLTranscoder::UnRep_Throw
+				       );
+  res[total_chars] = '\0';
+  sv_setpv((SV*)output, (char *)res );
+  SvUTF8_on((SV*)output);
+  %delete_array(res);
+  return output;
+}
+}
+
+%fragment("SWIG_XMLStringNLen","header") {
+size_t
+SWIG_XMLStringNLen(const XMLCh* s, size_t maxlen)
+{
+  const XMLCh *p;
+  for (p = s; maxlen-- && *p; p++)
+    ;
+  return p - s;
+}
+}
+
+%fragment("SWIG_NewCopyXMLChArray","header") {
+SWIGINTERNINLINE XMLCh *SWIG_NewCopyXMLChArray(const XMLCh *cptr, size_t size)
+{
+  XMLCh *ret = NULL;
+  if (size > 0 && cptr != NULL) {
+    ret = %new_array(size, XMLCh);
+    if (ret != NULL) {
+      memcpy(ret, cptr, size * sizeof(XMLCh));
+    }
+  }
+  return ret;
+}
+}
+
+%init {
+  if (!SWIG_UTF8Transcoder()) {
+    croak("ERROR: XML::Xerces: INIT: Could not create UTF-8 transcoder");
+  }
+}
+
+
+%include <typemaps/strings.swg>
+%typemaps_string_alloc(%checkcode(UNISTRING), %checkcode(UNICHAR),
+		 SWIGWARN_TYPEMAP_WCHARLEAK_MSG,
+		 XMLCh, XMLCh,
+		 SWIG_AsXMLChPtrAndSize,
+		 SWIG_FromXMLChPtrAndSize,
+		 XERCES_CPP_NAMESPACE::XMLString::stringLen,
+		 SWIG_XMLStringNLen,
+		 SWIG_NewCopyXMLChArray,
+		 %delete_array,
+		 "<XMLCh.h>", INT_MIN, INT_MAX);
+
+

--- a/Lib/typemaps/strings.swg
+++ b/Lib/typemaps/strings.swg
@@ -640,3 +640,29 @@ SWIG_AsVal_dec(Char)(SWIG_Object obj, Char *val)
 		  %delete_array,
 		  FragLimits, CHAR_MIN, CHAR_MAX)
 %enddef
+
+/* ------------------------------------------------------------
+ *  String typemaps and fragments, with custom destructor
+ * ------------------------------------------------------------ */
+
+%define %typemaps_string_alloc(StringCode, CharCode,
+			       WarningLeakMsg,
+			       Char, CharName,
+			       SWIG_AsCharPtrAndSize,
+			       SWIG_FromCharPtrAndSize,
+			       SWIG_CharPtrLen,
+			       SWIG_CharBufLen,
+			       SWIG_NewCopyCharArray,
+			       SWIG_DeleteCharArray,
+			       FragLimits, CHAR_MIN, CHAR_MAX)
+%_typemap2_string(StringCode, CharCode,
+		  WarningLeakMsg,
+		  Char, CharName,
+		  SWIG_AsCharPtrAndSize,
+		  SWIG_FromCharPtrAndSize,
+		  SWIG_CharPtrLen,
+		  SWIG_CharBufLen,
+		  SWIG_NewCopyCharArray,
+		  SWIG_DeleteCharArray,
+		  FragLimits, CHAR_MIN, CHAR_MAX)
+%enddef


### PR DESCRIPTION
Restore the `%typemaps_string_alloc` macro in `Lib/typemaps/strings.swg` for custom string classes that implement a custom destructor.

Added example demonstrating `%typemaps_string_alloc` in `Examples/perl5/xmlstring_alloc/` (copied from `Examples/perl5/xmlstring/`).

Note: as none of the other `%typemaps_...` macros in the SWIG library appear to have any documentation under `Doc/`, I have not added anything for `%typemaps_string_alloc`.

Closes #3531 

