### PR TITLE
Fix leftover of convertpath removal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2710,8 +2710,7 @@ AC_DEFINE_DIR(SWIG_LIB, swig_lib, [Directory for SWIG system-independent librari
 
 case $build in
   # Windows does not understand unix directories. Convert into a windows directory with drive letter.
-  *-*-mingw*) SWIG_LIB_WIN_UNIX=`${srcdir}/Tools/convertpath -m $SWIG_LIB`;;
-  *-*-cygwin*) SWIG_LIB_WIN_UNIX=`cygpath --mixed "$SWIG_LIB"`;;
+  *-*-cygwin* | *-*-mingw*) SWIG_LIB_WIN_UNIX=`$CYGPATH -m $SWIG_LIB`;;
   *) SWIG_LIB_WIN_UNIX="";;
 esac
 AC_DEFINE_UNQUOTED(SWIG_LIB_WIN_UNIX, ["$SWIG_LIB_WIN_UNIX"], [Directory for SWIG system-independent libraries (Unix install on native Windows)])


### PR DESCRIPTION
Tools/convertpath was removed in favour of cygpath in commit:
  https://github.com/swig/swig/commit/f8d198bf675bfec02680335e7d7aa375372d5831

But there was one leftover which shows this error while running configure:
```
  ../swig-4.5.0/configure: line 15476: ../swig-4.5.0/Tools/convertpath: No such file or directory
```