### PR TITLE
Fix null module dereference in the type query functions

### DIFF
--- a/Lib/swigrun.swg
+++ b/Lib/swigrun.swg
@@ -511,6 +511,8 @@ SWIG_MangledTypeQueryModule(swig_module_info *start,
                             swig_module_info *end,
 		            const char *name) {
   swig_module_info *iter = start;
+  if (!iter)
+    return 0;
   do {
     if (iter->size) {
       size_t l = 0;
@@ -563,6 +565,8 @@ SWIG_TypeQueryModule(swig_module_info *start,
     /* STEP 2: If the type hasn't been found, do a complete search
        of the str field (the human readable name) */
     swig_module_info *iter = start;
+    if (!iter)
+      return 0;
     do {
       size_t i = 0;
       for (; i < iter->size; ++i) {


### PR DESCRIPTION
Fix null module dereference in the type query functions

SWIG_GetModule can return null and two runtime functions dereference it unchecked. Reproduced on master, single interpreter: generate a header with swig -python -external-runtime swigpyrun.h, then call SWIG_TypeQuery before importing any wrapper module.

```
AddressSanitizer: SEGV on unknown address 0x000000000008 (READ)
    #0 SWIG_MangledTypeQueryModule
    #1 SWIG_TypeQueryModule
    #2 SWIG_TypeQuery
```
0x8 is the size member of a null swig_module_info; both functions read iter->size before testing anything. Null is a designed return: the Python runtime returns it when PyCapsule_Import fails, and the SWIG_LINK_RUNTIME stub in Lib/linkruntime.c returns it unconditionally.

The guard goes in swigrun.swg rather than at the Python call site because SWIG_Python_TypeQuery is not the only unchecked caller: Lib/runtime.swg has four more, and SWIG_Lua_init_base_class and several Octave sites do the same. Four lines cover all of them. 0 is what both functions already return for an unknown name.

Not a fix for #3535.
