### PR TITLE
Fix the SWIG_LINK_RUNTIME type list and document it

### DIFF
--- a/Doc/Manual/Contents.html
+++ b/Doc/Manual/Contents.html
@@ -827,6 +827,7 @@
 <li><a href="Modules.html#Modules_nn1">Basics</a>
 <li><a href="Modules.html#Modules_nn2">The SWIG runtime code</a>
 <li><a href="Modules.html#Modules_external_run_time">External access to the runtime</a>
+<li><a href="Modules.html#Modules_link_runtime">Linking the type table into the application</a>
 <li><a href="Modules.html#Modules_nn4">A word of caution about static libraries</a>
 <li><a href="Modules.html#Modules_nn5">References</a>
 <li><a href="Modules.html#Modules_nn6">Reducing the wrapper file size</a>

--- a/Doc/Manual/Modules.html
+++ b/Doc/Manual/Modules.html
@@ -15,6 +15,7 @@
 <li><a href="#Modules_nn1">Basics</a>
 <li><a href="#Modules_nn2">The SWIG runtime code</a>
 <li><a href="#Modules_external_run_time">External access to the runtime</a>
+<li><a href="#Modules_link_runtime">Linking the type table into the application</a>
 <li><a href="#Modules_nn4">A word of caution about static libraries</a>
 <li><a href="#Modules_nn5">References</a>
 <li><a href="#Modules_nn6">Reducing the wrapper file size</a>
@@ -290,7 +291,43 @@ SWIG_TYPE_TABLE to be the same as the module whose types you are trying to
 access.
 </p>
 
-<H2><a name="Modules_nn4">22.5 A word of caution about static libraries</a></H2>
+<H2><a name="Modules_link_runtime">22.5 Linking the type table into the application</a></H2>
+
+
+<p>
+The shared type table described above is reached through a variable in the target language, so it is
+visible only to the interpreter that created it. An application that hosts the interpreter through the
+C API and links the generated wrappers into its own binary can keep the table in the binary instead.
+Compile every wrapper with <tt>-DSWIG_LINK_RUNTIME</tt> and <tt>SWIG_GetModule</tt> will obtain the
+table by calling
+</p>
+
+<div class="code"><pre>
+void *SWIG_ReturnGlobalTypeList(void *);
+</pre></div>
+
+<p>
+which the application must define and link. <tt>linkruntime.c</tt>, in the SWIG library directory
+reported by <tt>swig -swiglib</tt>, is a ready made implementation. It needs the
+<tt>swig_module_info</tt> declaration from the header described in
+<a href="#Modules_external_run_time">External access to the runtime</a>, so compile it with that header
+included:
+</p>
+
+<div class="shell"><pre>
+$ swig -python -external-runtime swigpyrun.h
+$ cc -c linkruntime.c -include Python.h -include swigpyrun.h
+</pre></div>
+
+<p>
+It returns an empty list which each module splices itself into as it initialises, so nothing has to be
+registered. Since no part of the table lives in the target language, modules share types from any
+sub-interpreter. The table is one symbol in one binary, so this suits an application that owns its
+wrappers; extension modules installed independently of each other must share types through the target
+language as described above. It also assumes the wrappers are never unloaded.
+</p>
+
+<H2><a name="Modules_nn4">22.6 A word of caution about static libraries</a></H2>
 
 
 <p>
@@ -301,7 +338,7 @@ into it. This is very often <b>NOT</b> what you want and it can lead to unexpect
 behavior. When working with dynamically loadable modules, you should try to work exclusively with shared libraries.
 </p>
 
-<H2><a name="Modules_nn5">22.6 References</a></H2>
+<H2><a name="Modules_nn5">22.7 References</a></H2>
 
 
 <p>
@@ -309,7 +346,7 @@ Due to the complexity of working with shared libraries and multiple modules, it 
 an outside reference.  John Levine's "Linkers and Loaders" is highly recommended.
 </p>
 
-<H2><a name="Modules_nn6">22.7 Reducing the wrapper file size</a></H2>
+<H2><a name="Modules_nn6">22.8 Reducing the wrapper file size</a></H2>
 
 
 <p>

--- a/Lib/linkruntime.c
+++ b/Lib/linkruntime.c
@@ -14,9 +14,11 @@
 # endif
 #endif
 
-static void *ptr = 0;
+/* Empty type table that modules splice themselves into; compile with the 'swig -external-runtime' header included. */
+static swig_module_info swig_global_type_list = { 0, 0, &swig_global_type_list, 0, 0, 0 };
+
 SWIGEXPORT void *
 SWIG_ReturnGlobalTypeList(void *t) {
- if (!ptr && !t) ptr = t;
- return ptr;
+  (void)t;
+  return &swig_global_type_list;
 }


### PR DESCRIPTION
`SWIG_LINK_RUNTIME` flag makes `SWIG_GetModule` call `SWIG_ReturnGlobalTypeList` instead of importing a capsule from the target language, so wrappers linked into a host application share types without per-interpreter state. Lib/linkruntime.c is the shipped implementation of that function and has never worked: it stores the list on the first call, but `SWIG_Python_GetModule` has passed a literal 0 since both were added in 2004.

Tested with two C++ modules, one deriving from the other, embedded with Py_Initialize and Py_NewInterpreter:

- SWIG_LINK_RUNTIME + linkruntime.c as shipped: TypeError: argument 1 of type 'Base *'
- SWIG_LINK_RUNTIME + this patch: passes
- capsule path, no SWIG_LINK_RUNTIME: passes

The fix returns a statically self-linked empty list; modules splice themselves in during SWIG_InitializeModule, so nothing
registers anything.

This has been in SWIG for 20+ years; document it finally. The Modules chapter gains a section covering it, including how to
compile linkruntime.c against the -external-runtime header.


Two C++ modules, one deriving from the other, embedded with Py_Initialize and Py_NewInterpreter:

- `SWIG_LINK_RUNTIME` + linkruntime.c as shipped: TypeError: argument 1 of type 'Base *'
- `SWIG_LINK_RUNTIME` + this patch: passes
- capsule path, no `SWIG_LINK_RUNTIME`: passes

The fix returns a statically self-linked empty list; modules splice themselves in during `SWIG_InitializeModule`, so nothing
registers anything.

This has been in SWIG for 20+ years; document it finally. The Modules chapter gains a section covering it, including how to
compile linkruntime.c against the -external-runtime header.

NOTE: Kodi is using SWIG_LINK_RUNTIME as part of its Python embedding, but with its own SwigRuntime wrapper. With this PR, Kodi will switch to using SWIG runtime wrapper natively.

Claude helped write the new doc entry.