### PR TITLE
Fix #3553 - Fix cross-module std::vector<T> mangled-name mismatch

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -958,6 +958,7 @@ MULTI_CPP_TEST_CASES += \
 	clientdata_prop \
 	import_share \
 	import_stl \
+	import_vector_fwd \
 	imports \
 	mod \
 	multi_import \

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -189,6 +189,8 @@ clean:
 	rm -f import_stl_a.go import_stl_a.gox
 	rm -f import_stl_b.go import_stl_b.gox
 	rm -f import_stl_c.go import_stl_c.gox
+	rm -f import_vector_fwd_a.go import_vector_fwd_a.gox
+	rm -f import_vector_fwd_b.go import_vector_fwd_b.gox
 	rm -f imports_a.go imports_a.gox imports_b.go imports_b.gox
 	rm -f mod_a.go mod_a.gox mod_b.go mod_b.gox
 	rm -f multi_import_a.go multi_import_a.gox

--- a/Examples/test-suite/go/Makefile.in
+++ b/Examples/test-suite/go/Makefile.in
@@ -34,6 +34,14 @@ CPP_TEST_CASES = \
 MULTI_CPP_TEST_CASES = \
 	go_subdir_import \
 
+# import_vector_fwd_b.i only %imports import_vector_fwd_a.i for the sake of the
+# C++ runtime type registry (see import_vector_fwd_a.i); it never references any
+# of module a's wrapped Go types. SWIG's Go backend always emits a Go `import`
+# statement for every %import though, so the generated import_vector_fwd_b.go
+# ends up with an import that Go's compiler rejects as unused.
+FAILING_MULTI_CPP_TESTS += \
+	import_vector_fwd \
+
 include $(srcdir)/../common.mk
 
 INCLUDES = -I$(abs_top_srcdir)/$(EXAMPLES)/$(TEST_SUITE)
@@ -189,8 +197,6 @@ clean:
 	rm -f import_stl_a.go import_stl_a.gox
 	rm -f import_stl_b.go import_stl_b.gox
 	rm -f import_stl_c.go import_stl_c.gox
-	rm -f import_vector_fwd_a.go import_vector_fwd_a.gox
-	rm -f import_vector_fwd_b.go import_vector_fwd_b.gox
 	rm -f imports_a.go imports_a.gox imports_b.go imports_b.gox
 	rm -f mod_a.go mod_a.gox mod_b.go mod_b.gox
 	rm -f multi_import_a.go multi_import_a.gox

--- a/Examples/test-suite/import_vector_fwd.h
+++ b/Examples/test-suite/import_vector_fwd.h
@@ -1,0 +1,37 @@
+/* Shared by import_vector_fwd_a.i and import_vector_fwd_b.i.
+
+   Bar is only forward-declared in import_vector_fwd_a.i (which declares Container, using
+   std::vector<Bar> as a parameter/return type). Bar is fully defined, and
+   std::vector<Bar> is %template'd, in import_vector_fwd_b.i, which %imports
+   import_vector_fwd_a.i. */
+
+#ifndef SWIGTESTIMPORTVECTORFWD_H
+#define SWIGTESTIMPORTVECTORFWD_H
+
+#include <vector>
+#include <string>
+
+class Bar {
+public:
+  Bar() : name_("bar") {}
+  Bar(std::string name) : name_(name) {}
+  std::string name() const { return name_; }
+private:
+  std::string name_;
+};
+
+class Container {
+public:
+  Container() : count_(0) {}
+  bool addBars(const std::vector<Bar>& bars) {
+    count_ += bars.size();
+    return true;
+  }
+  std::vector<Bar> getBars() const {
+    return std::vector<Bar>(count_);
+  }
+private:
+  size_t count_;
+};
+
+#endif

--- a/Examples/test-suite/import_vector_fwd.h
+++ b/Examples/test-suite/import_vector_fwd.h
@@ -10,6 +10,8 @@
 
 #include <vector>
 #include <string>
+/* Some std_vector.i variants only #include this in a %{ %} block, a no-op for a module reached via %import. */
+#include <stdexcept>
 
 class Bar {
 public:

--- a/Examples/test-suite/import_vector_fwd.h
+++ b/Examples/test-suite/import_vector_fwd.h
@@ -10,7 +10,8 @@
 
 #include <vector>
 #include <string>
-/* Some std_vector.i variants only #include this in a %{ %} block, a no-op for a module reached via %import. */
+/* Some std_vector.i variants only #include these in a %{ %} block, a no-op for a module reached via %import. */
+#include <algorithm>
 #include <stdexcept>
 
 class Bar {

--- a/Examples/test-suite/import_vector_fwd.list
+++ b/Examples/test-suite/import_vector_fwd.list
@@ -1,0 +1,2 @@
+import_vector_fwd_a
+import_vector_fwd_b

--- a/Examples/test-suite/import_vector_fwd_a.i
+++ b/Examples/test-suite/import_vector_fwd_a.i
@@ -1,0 +1,33 @@
+/* This is a regression test for https://github.com/swig/swig/issues/3553
+
+   Bar is only forward-declared in this module. Container uses std::vector<Bar> as a
+   parameter and return type. Bar's real definition, and %template(BarVector)
+   std::vector<Bar>, live in import_vector_fwd_b.i, which %imports this module.
+
+   Since commit e3ccabbd4dc22a7e59a9d1b93308d96a97d35328 ("Simpler names when using
+   SwigType_manglestr for templates"), the mangled name SWIG generates for
+   std::vector<Bar> here (where Bar is incomplete) differs from the one generated in
+   import_vector_fwd_b.i (where Bar is complete): the default std::allocator<Bar>
+   template argument is dropped from the mangled name only when the full definition of
+   the argument type is visible. Because SWIG's cross-module runtime type registry
+   merges types by exact mangled-name match, the two modules' notions of
+   "std::vector<Bar>" never merge, and passing a BarVector (built in
+   import_vector_fwd_b.i) to Container::addBars (declared here) fails at runtime. See
+   import_vector_fwd_b.i and the *_runme scripts. */
+%module import_vector_fwd_a
+
+%{
+#include "import_vector_fwd.h"
+%}
+
+%include <std_vector.i>
+
+// Bar is intentionally only forward-declared here; see import_vector_fwd_b.i.
+class Bar;
+
+class Container {
+public:
+  Container();
+  bool addBars(const std::vector<Bar>& bars);
+  std::vector<Bar> getBars() const;
+};

--- a/Examples/test-suite/import_vector_fwd_b.i
+++ b/Examples/test-suite/import_vector_fwd_b.i
@@ -4,13 +4,17 @@
    supplies the real definition of Bar, plus %template(BarVector) std::vector<Bar>. */
 %module import_vector_fwd_b
 
-%import "import_vector_fwd_a.i"
-
 %{
 #include "import_vector_fwd.h"
 %}
 
+// %include <std_vector.i> must come before %import "import_vector_fwd_a.i": once a.i
+// (pulled in via %import) has %include'd std_vector.i, SWIG treats the file as already
+// processed and won't re-emit its raw runtime code (e.g. the SWIG_exception macro on
+// some targets) into this module's own wrapper, causing target-language compile errors.
 %include <std_vector.i>
+
+%import "import_vector_fwd_a.i"
 
 class Bar {
 public:

--- a/Examples/test-suite/import_vector_fwd_b.i
+++ b/Examples/test-suite/import_vector_fwd_b.i
@@ -1,0 +1,22 @@
+/* See import_vector_fwd_a.i for the full explanation of this regression test.
+
+   This module %imports import_vector_fwd_a.i (which only forward-declares Bar) and
+   supplies the real definition of Bar, plus %template(BarVector) std::vector<Bar>. */
+%module import_vector_fwd_b
+
+%import "import_vector_fwd_a.i"
+
+%{
+#include "import_vector_fwd.h"
+%}
+
+%include <std_vector.i>
+
+class Bar {
+public:
+  Bar();
+  Bar(std::string name);
+  std::string name() const;
+};
+
+%template(BarVector) std::vector<Bar>;

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -181,6 +181,7 @@ clean:
 		rm -f clientdata_prop_a$${ext} clientdata_prop_b$${ext}; \
 		rm -f import_share_a$${ext} import_share_b$${ext} import_share_c$${ext}; \
 		rm -f import_stl_a$${ext} import_stl_b$${ext} import_stl_c$${ext}; \
+		rm -f import_vector_fwd_a$${ext} import_vector_fwd_b$${ext}; \
 		rm -f imports_a$${ext} imports_b$${ext}; \
 		rm -f mod_a$${ext} mod_b$${ext}; \
 		rm -f multi_import_a$${ext} multi_import_b$${ext} multi_import_d$${ext}; \

--- a/Examples/test-suite/ocaml/Makefile.in
+++ b/Examples/test-suite/ocaml/Makefile.in
@@ -112,6 +112,7 @@ clean:
 	rm -f clientdata_prop_a.ml clientdata_prop_b.ml
 	rm -f import_share_a.ml import_share_b.ml import_share_c.ml
 	rm -f import_stl_a.ml import_stl_b.ml import_stl_c.ml
+	rm -f import_vector_fwd_a.ml import_vector_fwd_b.ml
 	rm -f imports_a.ml imports_b.ml
 	rm -f mod_a.ml mod_b.ml
 	rm -f multi_import_a.ml multi_import_b.ml multi_import_d.ml

--- a/Examples/test-suite/php/Makefile.in
+++ b/Examples/test-suite/php/Makefile.in
@@ -110,6 +110,7 @@ clean:
 	rm -f clientdata_prop_a.php clientdata_prop_b.php php_clientdata_prop_a.h php_clientdata_prop_b.h
 	rm -f import_share_a.php import_share_b.php import_share_c.php php_import_share_a.h php_import_share_b.h php_import_share_c.h
 	rm -f import_stl_a.php import_stl_b.php import_stl_c.php php_import_stl_a.h php_import_stl_b.h php_import_stl_c.h
+	rm -f import_vector_fwd_a.php import_vector_fwd_b.php php_import_vector_fwd_a.h php_import_vector_fwd_b.h
 	rm -f imports_a.php imports_b.php php_imports_a.h php_imports_b.h
 	rm -f mod_a.php mod_b.php php_mod_a.h php_mod_b.h
 	rm -f multi_import_a.php multi_import_b.php multi_import_d.php php_multi_import_a.h php_multi_import_b.h php_multi_import_d.h

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -26,6 +26,12 @@ top_builddir = @top_builddir@
 FAILING_CPP_TESTS = \
 	cpp17_map_no_default_ctor \
 
+# std::vector<T> cannot be used as a parameter/return type across an %import boundary when T is
+# only forward-declared in the importing module and fully defined (with %template) in the
+# imported module. See import_vector_fwd_a.i. Fails since SWIG 4.2.0 (still broken as of 4.4.1).
+FAILING_MULTI_CPP_TESTS = \
+	import_vector_fwd \
+
 CPP_TEST_CASES += \
 	callback \
 	complextest \

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -230,6 +230,7 @@ clean:
 	rm -f python_annotations_import_a.py* python_annotations_import_b.py*
 	rm -f import_share_a.py* import_share_b.py* import_share_c.py*
 	rm -f import_stl_a.py* import_stl_b.py* import_stl_c.py*
+	rm -f import_vector_fwd_a.py* import_vector_fwd_b.py*
 	rm -f imports_a.py* imports_b.py* mod_a.py* mod_b.py*
 	rm -f multi_import_a.py* multi_import_b.py* multi_import_d.py*
 	rm -f packageoption_a.py* packageoption_b.py* packageoption_c.py*

--- a/Examples/test-suite/python/Makefile.in
+++ b/Examples/test-suite/python/Makefile.in
@@ -26,12 +26,6 @@ top_builddir = @top_builddir@
 FAILING_CPP_TESTS = \
 	cpp17_map_no_default_ctor \
 
-# std::vector<T> cannot be used as a parameter/return type across an %import boundary when T is
-# only forward-declared in the importing module and fully defined (with %template) in the
-# imported module. See import_vector_fwd_a.i. Fails since SWIG 4.2.0 (still broken as of 4.4.1).
-FAILING_MULTI_CPP_TESTS = \
-	import_vector_fwd \
-
 CPP_TEST_CASES += \
 	callback \
 	complextest \

--- a/Examples/test-suite/python/import_vector_fwd_runme.py
+++ b/Examples/test-suite/python/import_vector_fwd_runme.py
@@ -1,0 +1,20 @@
+# Regression test for a SWIG bug where std::vector<T> cannot be used as a parameter or
+# return type across an %import boundary when T is only forward-declared in the
+# importing module, while T's real definition and %template(...) std::vector<T> live in
+# the imported module. See import_vector_fwd_a.i for the full explanation.
+
+import import_vector_fwd_a
+import import_vector_fwd_b
+
+bv = import_vector_fwd_b.BarVector()
+bv.append(import_vector_fwd_b.Bar())
+
+c = import_vector_fwd_a.Container()
+if not c.addBars(bv):
+    raise RuntimeError("addBars failed")
+
+bars = c.getBars()
+if not isinstance(bars, import_vector_fwd_b.BarVector):
+    raise RuntimeError("getBars returned wrong type: %s" % type(bars))
+if len(bars) != 1:
+    raise RuntimeError("getBars returned wrong size: %d" % len(bars))

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -20,6 +20,12 @@ SHELL_PATH_SEP = @SHELL_PATH_SEP@
 FAILING_CPP_TESTS = \
 	cpp17_map_no_default_ctor \
 
+# std::vector<T> cannot be used as a parameter/return type across an %import boundary when T is
+# only forward-declared in the importing module and fully defined (with %template) in the
+# imported module. See import_vector_fwd_a.i. Fails since SWIG 4.2.0 (still broken as of 4.4.1).
+FAILING_MULTI_CPP_TESTS = \
+	import_vector_fwd \
+
 CPP_TEST_CASES = \
 	li_cstring \
 	li_factory \

--- a/Examples/test-suite/ruby/Makefile.in
+++ b/Examples/test-suite/ruby/Makefile.in
@@ -20,12 +20,6 @@ SHELL_PATH_SEP = @SHELL_PATH_SEP@
 FAILING_CPP_TESTS = \
 	cpp17_map_no_default_ctor \
 
-# std::vector<T> cannot be used as a parameter/return type across an %import boundary when T is
-# only forward-declared in the importing module and fully defined (with %template) in the
-# imported module. See import_vector_fwd_a.i. Fails since SWIG 4.2.0 (still broken as of 4.4.1).
-FAILING_MULTI_CPP_TESTS = \
-	import_vector_fwd \
-
 CPP_TEST_CASES = \
 	li_cstring \
 	li_factory \

--- a/Examples/test-suite/ruby/import_vector_fwd_runme.rb
+++ b/Examples/test-suite/ruby/import_vector_fwd_runme.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+#
+# Regression test for a SWIG bug where std::vector<T> cannot be used as a parameter or
+# return type across an %import boundary when T is only forward-declared in the
+# importing module, while T's real definition and %template(...) std::vector<T> live in
+# the imported module. See import_vector_fwd_a.i for the full explanation.
+#
+
+require 'swig_assert'
+
+require 'import_vector_fwd_a'
+require 'import_vector_fwd_b'
+
+bv = Import_vector_fwd_b::BarVector.new
+bv.push(Import_vector_fwd_b::Bar.new)
+
+c = Import_vector_fwd_a::Container.new
+
+swig_assert("c.addBars(bv)", binding)
+
+bars = c.getBars
+swig_assert("bars.is_a?(Import_vector_fwd_b::BarVector)", binding)
+swig_assert_equal_simple(1, bars.size)

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -1224,8 +1224,22 @@ static String *manglestr_default(const SwigType *s) {
 
   if (SwigType_istemplate(ss)) {
     SwigType *dt = Swig_symbol_template_deftype(ss, 0);
-    String *ty = Swig_symbol_type_qualify(dt, 0);
+    SwigType *qt = Swig_symbol_type_qualify(dt, 0);
+    /* Swig_symbol_type_qualify() can collapse a template-id back down to a shorter spelling
+       (omitting default template arguments) when a %template-instantiated node happens to be
+       registered for it locally -- but whether that's the case depends on unrelated %template
+       calls elsewhere in this compilation, not on the type itself. Re-expand any defaults here
+       so the mangled name stays a stable function of the type, regardless of what's been
+       %template'd locally (see swig/swig#3553). */
+    String *ty = SwigType_istemplate(qt) ? Swig_symbol_template_deftype(qt, 0) : Copy(qt);
+    if (getenv("SWIG_TRACE_MANGLE") && strstr(Char(ss), "Bar")) {
+      Printf(stderr, "[manglestr_default] ss=%s\n", ss);
+      Printf(stderr, "[manglestr_default] dt=%s\n", dt);
+      Printf(stderr, "[manglestr_default] qt=%s\n", qt);
+      Printf(stderr, "[manglestr_default] ty=%s\n", ty);
+    }
     Delete(dt);
+    Delete(qt);
     Delete(ss);
     ss = ty;
     type = ss;

--- a/Source/Swig/stype.c
+++ b/Source/Swig/stype.c
@@ -1232,12 +1232,6 @@ static String *manglestr_default(const SwigType *s) {
        so the mangled name stays a stable function of the type, regardless of what's been
        %template'd locally (see swig/swig#3553). */
     String *ty = SwigType_istemplate(qt) ? Swig_symbol_template_deftype(qt, 0) : Copy(qt);
-    if (getenv("SWIG_TRACE_MANGLE") && strstr(Char(ss), "Bar")) {
-      Printf(stderr, "[manglestr_default] ss=%s\n", ss);
-      Printf(stderr, "[manglestr_default] dt=%s\n", dt);
-      Printf(stderr, "[manglestr_default] qt=%s\n", qt);
-      Printf(stderr, "[manglestr_default] ty=%s\n", ty);
-    }
     Delete(dt);
     Delete(qt);
     Delete(ss);


### PR DESCRIPTION
- Fix #3553

std::vector<T> cannot be used as a parameter or return type across an %import boundary when T is only forward-declared in the importing module while T's real definition and %template(...) live in the imported module. The two modules mangle std::vector<T> differently (the default std::allocator<T> argument is dropped only when T is fully visible, since e3ccabbd), so the cross-module runtime type registry never merges them, and passing the vector across the module boundary fails.

Added as import_vector_fwd_{a,b}.i (with a shared header) and wired into ruby and python as a known-failing multi-module test, since this is not yet fixed. Confirmed still broken on 4.4.1 and master.